### PR TITLE
fix: enable LLM architecture review for all file types

### DIFF
--- a/.github/workflows/pr-architecture-review.yml
+++ b/.github/workflows/pr-architecture-review.yml
@@ -3,11 +3,8 @@ name: PR Architecture Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - '!tests/**/bin/**'
-      - '!tests/**/obj/**'
+    # LLM review checks acceptance criteria and issue linking for ALL changes
+    # No path restrictions - Docker configs, docs, CI changes all need validation
 
 env:
   DOTNET_VERSION: '10.0.x'
@@ -33,23 +30,32 @@ jobs:
       - name: Get Changed Files
         id: changed-files
         run: |
-          # Get list of changed .cs files
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...${{ github.sha }} | grep -E '\.(cs|csproj)$' || echo "")
+          # Get ALL changed files for comprehensive review (acceptance criteria, issue linking)
+          ALL_CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...${{ github.sha }})
 
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "No C# files changed, skipping architecture review"
+          # Get C# files separately for architecture-specific analysis
+          CS_CHANGED_FILES=$(echo "$ALL_CHANGED_FILES" | grep -E '\.(cs|csproj)$' || echo "")
+
+          if [ -z "$ALL_CHANGED_FILES" ]; then
+            echo "No files changed, skipping review"
             echo "skip_review=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           echo "changed_files<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
+          echo "$ALL_CHANGED_FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "cs_files<<EOF" >> $GITHUB_OUTPUT
+          echo "$CS_CHANGED_FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           echo "skip_review=false" >> $GITHUB_OUTPUT
 
           # Show what we found
-          echo "Changed C# files:"
-          echo "$CHANGED_FILES"
+          echo "All changed files:"
+          echo "$ALL_CHANGED_FILES"
+          echo ""
+          echo "C# files (for architecture analysis):"
+          echo "$CS_CHANGED_FILES"
 
       - name: Get File Contents and Diff
         if: steps.changed-files.outputs.skip_review == 'false'
@@ -74,7 +80,20 @@ jobs:
           while IFS= read -r file; do
             if [ -f "$file" ]; then
               echo "### File: $file" >> /tmp/architecture-review/context.md
-              echo '```csharp' >> /tmp/architecture-review/context.md
+
+              # Determine syntax highlighting based on file extension
+              case "$file" in
+                *.cs) syntax="csharp" ;;
+                *.csproj) syntax="xml" ;;
+                *.yml|*.yaml) syntax="yaml" ;;
+                *.json) syntax="json" ;;
+                *.md) syntax="markdown" ;;
+                *.sh) syntax="bash" ;;
+                Dockerfile*) syntax="dockerfile" ;;
+                *) syntax="text" ;;
+              esac
+
+              echo "\`\`\`$syntax" >> /tmp/architecture-review/context.md
               cat "$file" >> /tmp/architecture-review/context.md
               echo '```' >> /tmp/architecture-review/context.md
               echo "" >> /tmp/architecture-review/context.md


### PR DESCRIPTION
## Problem

The LLM architecture review was only running on changes to `src/**` and `tests/**`, but it should check **acceptance criteria and issue linking** for ALL changes including:

- 🐳 Docker configurations
- 🔄 CI/CD workflows  
- 📚 Documentation
- 📁 Project configuration

This meant PR #76 (Docker work) didn't get LLM review to validate it met Issue #2 acceptance criteria.

## Solution

✅ **Remove path restrictions** - LLM review now runs on ALL PR changes  
✅ **Support all file types** - proper syntax highlighting for .cs, .yml, .json, .md, Dockerfile, etc.  
✅ **Comprehensive validation** - checks acceptance criteria for infrastructure changes  
✅ **Proper issue linking** - validates all changes are properly linked to issues  

## Changes

- **Removed `paths:` filter** from workflow trigger
- **Enhanced file analysis** to handle all file types with proper syntax highlighting  
- **Expanded scope** to validate acceptance criteria for non-code changes
- **Maintained C# focus** for architecture-specific analysis when relevant

## Testing

After merge, PR #76 should automatically get LLM review to validate Issue #2 acceptance criteria.

## Impact

- ✅ **Better coverage** - Infrastructure changes get proper review
- ✅ **Issue linking** - All changes validated against acceptance criteria  
- ✅ **Quality gates** - No more missed requirements for non-code changes
- ⚡ **Minimal cost** - LLM review still efficient for all change types

This ensures comprehensive quality control across all types of changes, not just C# code.