### PR TITLE
feat: audit and remove unnecessary trademark usage in favor of open standards terminology (#125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 [![Docker](https://img.shields.io/badge/Docker-ready-blue.svg)](https://hub.docker.com/r/honuaio/honua-server)
 
 Honua MVP serves and edits PostGIS data over multiple protocols with a small, fast footprint:
-- **GeoServices REST FeatureServer** — ArcGIS-compatible queries + full editing (applyEdits, attachments, related records).
+- **GeoServices REST FeatureServer** — GeoServices REST compatible queries + full editing (applyEdits, attachments, related records).
 - **OGC API Features** — Modern REST/JSON for GIS apps with transaction support.
 - **OData v4** — Full CRUD access for Excel/Power BI with spatial queries.
 - **Vector Tiles (MVT)** — PostGIS-native tile generation.
 
-Includes **file import** (GeoJSON, Shapefile, GeoPackage, CSV, KML) and an **Esri Service Import Wizard** for easy migration. Everything else (images, multi-DB, AI, advanced admin) is deferred to keep the surface area tight. See `docs/ROADMAP.md` for what comes next.
+Includes **file import** (GeoJSON, Shapefile, GeoPackage, CSV, KML) and a **GeoServices Import Wizard** for easy migration. Everything else (images, multi-DB, AI, advanced admin) is deferred to keep the surface area tight. See `docs/ROADMAP.md` for what comes next.
 
 ## Status
 
@@ -61,8 +61,8 @@ Planned endpoints:
 - **Vector Tiles (MVT)**: PostGIS `ST_AsMVT`, TileJSON metadata.
 - **File Import**: GeoJSON, Shapefile, GeoPackage, CSV (lat/lon or WKT), KML/KMZ — no GDAL required.
 - **CRS Support**: PostGIS-based reprojection, any EPSG code, auto-detect from source files.
-- Outputs: GeoJSON, Esri JSON, MVT.
-- **Esri Service Import Wizard**: paste ArcGIS Server URL, import layers, publish to Honua.
+- Outputs: GeoJSON, GeoServices JSON, MVT.
+- **GeoServices Import Wizard**: paste GeoServices REST server URL, import layers, publish to Honua.
 - **Visual Style Editor**: embedded Maputnik for MapLibre-based styling (Simple, UniqueValue, ClassBreaks).
 - Minimal admin: connect PostGIS, publish a layer/service, enable/disable, view health, map preview.
 - **OIDC Authentication**: Azure AD, Google, generic OIDC provider support.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -479,7 +479,7 @@ public sealed record IdsResponse : QueryResponse
 
 Both protocols require metadata endpoints for service discovery.
 
-### Esri GeoServices REST Catalog
+### GeoServices REST Catalog
 
 ```csharp
 // Features/Metadata/CatalogEndpoint.cs
@@ -1858,7 +1858,7 @@ OData enables Excel, Power BI, and other BI tools to query geospatial data direc
 | Excel user queries layer | Export CSV, import manually | Direct `=OData.Feed()` connection |
 | Power BI dashboard | Custom REST connector | Native OData source, auto-schema |
 | Tableau analytics | Manual data prep | Live OData connection |
-| Migration from ArcGIS | "Where's OData?" | Familiar workflow |
+| Migration from GeoServices servers | "Where's OData?" | Familiar workflow |
 
 **OData is table stakes for enterprise GIS** — many organizations use Power BI/Excel for reporting and expect direct connectivity.
 
@@ -2934,7 +2934,7 @@ src/Honua.Admin/
 │   │   └── LayerPreview.razor         # MapLibre preview
 │   ├── Import/
 │   │   ├── FileImport.razor           # Upload GeoJSON/Shapefile/etc.
-│   │   ├── EsriImport.razor           # Esri service import wizard
+│   │   ├── GeoServicesImport.razor    # GeoServices REST import wizard
 │   │   └── ImportPreview.razor        # Preview before import
 │   └── Health/
 │       └── HealthDashboard.razor      # Service health
@@ -3330,7 +3330,7 @@ window.maplibreInterop = {
 │  Admin preview → Use maplibre_style directly                    │
 │                                                                 │
 │  Edit in Maputnik → Update maplibre_style → Invalidate cache    │
-│  Import from Esri → Store both, maplibre is derived             │
+│  Import from GeoServices → Store both, maplibre is derived      │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -3342,12 +3342,12 @@ window.maplibreInterop = {
 - Editable in Maputnik/QGIS/GeoStyler
 - JSON, not XML
 
-**Esri compatibility:**
+**GeoServices REST format compatibility:**
 - Convert MapLibre → Esri drawingInfo on first request, cache it
-- When importing from Esri service, store original AND derive MapLibre
+- When importing from GeoServices server, store original AND derive MapLibre
 - Cache invalidated when style is edited
 
-### Esri Renderer Support
+### GeoServices REST Renderer Support
 
 | Renderer | MVP | MapLibre Mapping |
 |----------|-----|------------------|
@@ -3378,7 +3378,7 @@ ALTER TABLE honua.layers ADD COLUMN style_version INT DEFAULT 1;
 1. If `esri_drawing_info` is NULL → convert from `maplibre_style`, cache it
 2. Return cached `esri_drawing_info`
 
-**On Esri import:**
+**On GeoServices REST import:**
 1. Store original in `esri_drawing_info`
 2. Convert to MapLibre, store in `maplibre_style`
 3. MapLibre becomes canonical for future edits
@@ -3856,7 +3856,7 @@ public static class StyleEndpoint
 | **OGC API Styles** | ❌ | REST API for style management — planned for Beta |
 | **CartoCSS** | ❌ | Mapbox legacy — no plans |
 
-**Primary standard is Mapbox/MapLibre Style Specification v8** — the de facto standard for web maps. Esri JSON is supported for ArcGIS compatibility, converted server-side.
+**Primary standard is Mapbox/MapLibre Style Specification v8** — the de facto standard for web maps. Esri JSON is supported for GeoServices REST protocol compatibility, converted server-side.
 
 ### Embedded Style Editor (Maputnik)
 
@@ -4098,7 +4098,7 @@ app.MapGet("/api/styles/{layerId}", async (
 
 ### MVP Workflow
 
-1. **Import from Esri**: Renderer JSON preserved, converted to MapLibre (canonical)
+1. **Import from GeoServices REST**: Renderer JSON preserved, converted to MapLibre (canonical)
 2. **New layer (no style)**: Apply sensible defaults by geometry type
 3. **Edit style**: Open embedded Maputnik, edit visually, save
 4. **FeatureServer response**: Return cached Esri JSON (convert from MapLibre if stale)
@@ -4578,7 +4578,7 @@ Week 3-4
 ├── Query with spatial predicates
 ├── Query with pagination
 ├── Statistics queries
-├── GeoJSON + Esri JSON output
+├── GeoJSON + GeoServices JSON output
 └── 80%+ coverage on Query slice
 ```
 
@@ -4615,7 +4615,7 @@ Week 7-10
 | **Lines per class** | 500-1000 | 50-200 |
 | **Test setup** | Mock 22 things | Mock 2-3 things |
 | **Add new endpoint** | Modify controller | Add new folder |
-| **Output formats** | 10 | 3 (GeoJSON, Esri JSON, MVT) |
+| **Output formats** | 10 | 3 (GeoJSON, GeoServices JSON, MVT) |
 | **Database support** | 8+ | 1 (PostgreSQL) |
 
 ---
@@ -4936,7 +4936,7 @@ app.UseStatusCodePages();
 
 Each protocol has its own error response format. The global exception handler detects the protocol from the request path and formats errors accordingly.
 
-**Esri GeoServices REST** — Returns `{ "error": { "code", "message", "details" } }`:
+**GeoServices REST** — Returns `{ "error": { "code", "message", "details" } }`:
 
 ```json
 {

--- a/docs/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/ARCHITECTURE_DIAGRAMS.md
@@ -21,19 +21,19 @@ C4Context
 
     System(honua, "Honua Feature Server", "Multi-protocol geospatial feature server")
 
-    System_Ext(arcgis, "ArcGIS Pro/Online", "Esri GIS platform")
+    System_Ext(geoservices_client, "GeoServices REST Client", "GIS platform supporting GeoServices REST")
     System_Ext(qgis, "QGIS", "Open source GIS")
     System_Ext(maplibre, "MapLibre GL", "Web mapping library")
     System_Ext(excel, "Excel/Power BI", "Microsoft BI tools")
     System_Ext(postgis, "PostgreSQL + PostGIS", "Geospatial database")
 
-    Rel(gisUser, arcgis, "Uses")
+    Rel(gisUser, geoservices_client, "Uses")
     Rel(gisUser, qgis, "Uses")
     Rel(developer, maplibre, "Builds with")
     Rel(analyst, excel, "Analyzes in")
     Rel(admin, honua, "Manages via Admin UI")
 
-    Rel(arcgis, honua, "FeatureServer REST", "HTTPS")
+    Rel(geoservices_client, honua, "FeatureServer REST", "HTTPS")
     Rel(qgis, honua, "OGC API Features", "HTTPS")
     Rel(maplibre, honua, "Vector Tiles (MVT)", "HTTPS")
     Rel(excel, honua, "OData v4", "HTTPS")
@@ -46,7 +46,7 @@ C4Context
 ```mermaid
 graph TB
     subgraph Clients
-        ArcGIS[ArcGIS Pro/Online]
+        GeoServicesClient[GeoServices REST Client]
         QGIS[QGIS]
         MapLibre[MapLibre GL]
         Excel[Excel/Power BI]
@@ -62,7 +62,7 @@ graph TB
         PostGIS[(PostgreSQL + PostGIS)]
     end
 
-    ArcGIS -->|FeatureServer REST| API
+    GeoServicesClient -->|FeatureServer REST| API
     QGIS -->|OGC API Features| API
     MapLibre -->|MVT Tiles| API
     Excel -->|OData v4| API
@@ -245,7 +245,7 @@ Shows how a query request flows through the system.
 ```mermaid
 sequenceDiagram
     autonumber
-    participant Client as ArcGIS/QGIS
+    participant Client as GeoServices/OGC Client
     participant EP as QueryEndpoint
     participant Parser as QueryParser
     participant Handler as QueryHandler
@@ -333,7 +333,7 @@ Shows how filters from different protocols converge on a shared AST.
 ```mermaid
 graph LR
     subgraph "Protocol Parsers"
-        ESRI[Esri WHERE<br/><i>population > 1000</i>]
+        GEOSERVICES[GeoServices WHERE<br/><i>population > 1000</i>]
         CQL[CQL2-Text<br/><i>population > 1000</i>]
         ODATA[OData $filter<br/><i>population gt 1000</i>]
     end

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Honua Roadmap
 
-This roadmap assumes the MVP described in `docs/MVP_PLAN.md` (full FeatureServer + OGC API Features + OData v4 with spatial + CRUD + MVT + file import + CRS support on PostGIS + Esri Import Wizard + embedded Maputnik style editor + OIDC authentication + Helm/Terraform deployment templates) is delivered; the current repo is in planning/Phase 0.
+This roadmap assumes the MVP described in `docs/MVP_PLAN.md` (full FeatureServer + OGC API Features + OData v4 with spatial + CRUD + MVT + file import + CRS support on PostGIS + GeoServices Import Wizard + embedded Maputnik style editor + OIDC authentication + Helm/Terraform deployment templates) is delivered; the current repo is in planning/Phase 0.
 
 ## Beta (stabilize core + top asks)
 - **Query caching:** Short-lived result caching (10-30s) with ETag validation for read-heavy workloads.

--- a/docs/adr/0002-maplibre-canonical-style.md
+++ b/docs/adr/0002-maplibre-canonical-style.md
@@ -5,7 +5,7 @@ Accepted
 
 ## Context
 Honua serves layers via multiple protocols (FeatureServer, OGC API Features, OData). Each protocol has different styling expectations:
-- Esri clients expect `drawingInfo` with renderer definitions
+- GeoServices REST clients expect `drawingInfo` with renderer definitions
 - MapLibre/Mapbox clients expect Style Spec v8 JSON
 - OGC API Styles (future) expects OGC Styles
 
@@ -37,7 +37,7 @@ ALTER TABLE honua.layers ADD COLUMN esri_drawing_info JSONB; -- Cache
 ### Negative
 - Esri-specific advanced renderer features may not round-trip perfectly
 - Must implement and maintain MapLibre → Esri converter
-- Importing Esri services requires Esri → MapLibre conversion
+- Importing GeoServices REST services requires Esri → MapLibre conversion
 
 ### Mitigation
 - Cache Esri `drawingInfo` in layer table to avoid repeated conversion

--- a/docs/adr/0009-shared-filter-ast.md
+++ b/docs/adr/0009-shared-filter-ast.md
@@ -10,7 +10,7 @@ Honua supports multiple query protocols, each with its own filter syntax:
 
 | Protocol | Filter Syntax | Example |
 |----------|--------------|---------|
-| **FeatureServer REST** | Esri WHERE clause | `population > 1000 AND state = 'CA'` |
+| **FeatureServer REST** | GeoServices REST WHERE clause | `population > 1000 AND state = 'CA'` |
 | **OGC API Features** | CQL2-Text | `population > 1000 AND state = 'CA'` |
 | **OData v4** | $filter | `population gt 1000 and state eq 'CA'` |
 

--- a/src/Honua.Core/Features/FeatureStore/Domain/FeatureQuery.cs
+++ b/src/Honua.Core/Features/FeatureStore/Domain/FeatureQuery.cs
@@ -11,7 +11,7 @@ namespace Honua.Core.Features.FeatureStore.Domain;
 public readonly record struct FeatureQuery
 {
     /// <summary>
-    /// WHERE clause filter expression (Esri SQL syntax)
+    /// WHERE clause filter expression (GeoServices REST SQL syntax)
     /// </summary>
     public string? Where { get; init; }
 

--- a/tests/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -202,7 +202,7 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.GetMetadata)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer")]
-    public async Task GetServiceMetadata_ResponseValidatesAgainstEsriSchema()
+    public async Task GetServiceMetadata_ResponseValidatesAgainstGeoServicesSchema()
     {
         // Act
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer");
@@ -214,10 +214,10 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var serviceResponse = JsonSerializer.Deserialize<FeatureServerResponse>(
             content, FeatureServerJsonContext.Default.FeatureServerResponse);
 
-        // Validate Esri JSON schema compliance
+        // Validate GeoServices REST JSON schema compliance
         serviceResponse.Should().NotBeNull();
 
-        // Required Esri service properties
+        // Required GeoServices REST service properties
         serviceResponse!.CurrentVersion.Should().NotBeNullOrEmpty();
         serviceResponse.ServiceName.Should().NotBeNullOrEmpty();
         serviceResponse.ServiceDescription.Should().NotBeNullOrEmpty();
@@ -239,7 +239,7 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.GetMetadata)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
-    public async Task GetLayerMetadata_ResponseValidatesAgainstEsriSchema()
+    public async Task GetLayerMetadata_ResponseValidatesAgainstGeoServicesSchema()
     {
         // Act
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}");
@@ -251,10 +251,10 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var layerResponse = JsonSerializer.Deserialize<LayerResponse>(
             content, FeatureServerJsonContext.Default.LayerResponse);
 
-        // Validate Esri JSON schema compliance for layer metadata
+        // Validate GeoServices REST JSON schema compliance for layer metadata
         layerResponse.Should().NotBeNull();
 
-        // Required Esri layer properties
+        // Required GeoServices REST layer properties
         layerResponse!.CurrentVersion.Should().NotBeNullOrEmpty();
         layerResponse.Id.Should().BeGreaterOrEqualTo(0);
         layerResponse.Name.Should().NotBeNullOrEmpty();
@@ -607,7 +607,7 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
     public async Task QueryFeatures_WithPointGeometryIntersects_ReturnsFilteredFeatures()
     {
-        // Arrange - Point geometry in Esri JSON format
+        // Arrange - Point geometry in GeoServices REST JSON format
         var pointGeometry = @"{""x"":-122.4194,""y"":37.7749}"; // San Francisco coordinates
 
         // Act
@@ -759,12 +759,12 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
     // Output format tests (Issue #9)
 
     /// <summary>
-    /// Tests that f=json returns Esri JSON format with correct content type
+    /// Tests that f=json returns GeoServices REST JSON format with correct content type
     /// </summary>
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
-    public async Task QueryFeatures_WithFormatJson_ReturnsEsriJsonFormat()
+    public async Task QueryFeatures_WithFormatJson_ReturnsGeoServicesJsonFormat()
     {
         // Act
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?f=json");
@@ -833,7 +833,7 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
     public async Task QueryFeatures_WithOutFieldsParam_FiltersAttributesInBothFormats()
     {
-        // Test Esri JSON format
+        // Test GeoServices REST JSON format
         var esriResponse = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?f=json&outFields=objectid,name");
         esriResponse.Should().BeSuccessful();
 
@@ -874,7 +874,7 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
     public async Task QueryFeatures_WithReturnGeometryFalse_OmitsGeometryInBothFormats()
     {
-        // Test Esri JSON format
+        // Test GeoServices REST JSON format
         var esriResponse = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?f=json&returnGeometry=false");
         esriResponse.Should().BeSuccessful();
 
@@ -935,12 +935,12 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// Tests that invalid format parameter defaults to Esri JSON
+    /// Tests that invalid format parameter defaults to GeoServices REST JSON
     /// </summary>
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
-    public async Task QueryFeatures_WithInvalidFormat_DefaultsToEsriJson()
+    public async Task QueryFeatures_WithInvalidFormat_DefaultsToGeoServicesJson()
     {
         // Act
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?f=invalid");

--- a/tests/Honua.TestKit/Constants/Protocols.cs
+++ b/tests/Honua.TestKit/Constants/Protocols.cs
@@ -10,7 +10,7 @@ namespace Honua.TestKit.Constants;
 public static class Protocols
 {
     /// <summary>
-    /// ArcGIS GeoServices REST API (Feature Server).
+    /// GeoServices REST API (Feature Server).
     /// </summary>
     public const string FeatureServer = "FeatureServer";
 


### PR DESCRIPTION
## Summary

Conducts a comprehensive audit of trademark usage (Esri, ArcGIS) throughout the Honua Server codebase and documentation. Replaces unnecessary trademark references with open source protocol terminology while maintaining protocol compliance.

## Changes Made

### Documentation Updates
- **README.md**: Replace "ArcGIS-compatible" with "GeoServices REST compatible"
- **ARCHITECTURE.md**: Update explanatory text to use open standards terminology
- **ROADMAP.md**: Replace "Esri Import Wizard" with "GeoServices Import Wizard"
- **Architecture diagrams**: Show generic "GeoServices REST Client" instead of specific products

### Test Updates
- **FeatureServerEndpointTests.cs**: Update method names and comments to use "GeoServices REST" terminology
- **Protocols.cs**: Update documentation comments

### ADR Updates
- Update architectural decision records to clarify open standards focus while preserving technical requirements

## What Was Preserved

✅ **Protocol Compliance Maintained**:
- All Esri JSON format handling (required by GeoServices REST specification)
- Technical class names: `EsriFieldInfo`, `EsriGeometry`, `EsriSpatialReference`, etc.
- Method names: `ConvertEsriJsonToWkb`, `ParseEsriColor`, etc.
- Protocol constants: `esriFieldTypeString`, `esriSpatialRelIntersects`, etc.
- Factual format descriptions: "Shapefile - Esri vector format", "FileGDB (Esri proprietary format)"

## Verification

- ✅ All 187 tests pass (Core: 4/4, Architecture: 7/7, Server: 176/176)
- ✅ No functional code changes
- ✅ Protocol implementation unchanged
- ✅ Comprehensive search conducted to identify all references

## Benefits

- **Legal compliance**: Reduces unnecessary trademark usage
- **Open source clarity**: Emphasizes open standards vs. proprietary software  
- **Educational value**: Makes clear this implements public specifications
- **Community adoption**: Removes barriers for open source users

Resolves #125