### PR TITLE
feat: add cloud file storage abstraction with local provider (#207)

### DIFF
--- a/src/Honua.Core/Features/FileStorage/Abstractions/ICloudFileStorage.cs
+++ b/src/Honua.Core/Features/FileStorage/Abstractions/ICloudFileStorage.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FileStorage.Domain;
+
+namespace Honua.Core.Features.FileStorage.Abstractions;
+
+/// <summary>
+/// Abstract cloud file storage provider supporting AWS S3, Azure Blob Storage,
+/// and Google Cloud Storage for temporary file storage during geospatial data
+/// upload and import processing.
+/// </summary>
+public interface ICloudFileStorage
+{
+    /// <summary>
+    /// Gets the storage provider type for this implementation
+    /// </summary>
+    CloudStorageProvider Provider { get; }
+
+    // Single file operations
+
+    /// <summary>
+    /// Uploads a file from a stream
+    /// </summary>
+    /// <param name="request">Upload request with file content and metadata</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Upload result with file information or error details</returns>
+    Task<UploadResult> UploadAsync(FileUploadRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Uploads a file from a byte array
+    /// </summary>
+    /// <param name="request">Upload request with file content and metadata</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Upload result with file information or error details</returns>
+    Task<UploadResult> UploadAsync(ByteArrayUploadRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Downloads a file as a stream
+    /// </summary>
+    /// <param name="fileId">Unique file identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Stream containing file content, or null if file not found</returns>
+    Task<Stream?> DownloadAsync(string fileId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Downloads a file as a byte array
+    /// </summary>
+    /// <param name="fileId">Unique file identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Byte array containing file content, or null if file not found</returns>
+    Task<byte[]?> DownloadBytesAsync(string fileId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a file from storage
+    /// </summary>
+    /// <param name="fileId">Unique file identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if file was deleted, false if file was not found</returns>
+    Task<bool> DeleteAsync(string fileId, CancellationToken cancellationToken = default);
+
+    // Batch operations
+
+    /// <summary>
+    /// Uploads multiple files as a batch (e.g., Shapefile components)
+    /// </summary>
+    /// <param name="request">Batch upload request with files and metadata</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Batch upload result with success/failure details per file</returns>
+    Task<BatchUploadResult> UploadBatchAsync(BatchUploadRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes multiple files by their batch ID
+    /// </summary>
+    /// <param name="batchId">Batch identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Number of files deleted</returns>
+    Task<int> DeleteBatchAsync(string batchId, CancellationToken cancellationToken = default);
+
+    // Metadata operations
+
+    /// <summary>
+    /// Retrieves file metadata without downloading content
+    /// </summary>
+    /// <param name="fileId">Unique file identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>File metadata, or null if file not found</returns>
+    Task<CloudFile?> GetMetadataAsync(string fileId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a file exists in storage
+    /// </summary>
+    /// <param name="fileId">Unique file identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if file exists, false otherwise</returns>
+    Task<bool> ExistsAsync(string fileId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists files in a folder/prefix
+    /// </summary>
+    /// <param name="folder">Optional folder path to list (null for root)</param>
+    /// <param name="maxResults">Maximum number of results to return</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of files in the specified folder</returns>
+    Task<IReadOnlyList<CloudFile>> ListFilesAsync(
+        string? folder = null,
+        int maxResults = 1000,
+        CancellationToken cancellationToken = default);
+
+    // URL operations
+
+    /// <summary>
+    /// Generates a secure, time-limited URL for downloading a file
+    /// </summary>
+    /// <param name="fileId">Unique file identifier</param>
+    /// <param name="expiresIn">How long the URL should be valid</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Presigned URL, or null if file not found</returns>
+    Task<string?> GetPresignedUrlAsync(
+        string fileId,
+        TimeSpan? expiresIn = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates a secure, time-limited URL for uploading a file directly
+    /// </summary>
+    /// <param name="fileName">Desired filename</param>
+    /// <param name="contentType">Expected content type</param>
+    /// <param name="expiresIn">How long the URL should be valid</param>
+    /// <param name="folder">Optional folder for the file</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Presigned upload URL and the file ID that will be assigned</returns>
+    Task<(string Url, string FileId)?> GetPresignedUploadUrlAsync(
+        string fileName,
+        string contentType,
+        TimeSpan? expiresIn = null,
+        string? folder = null,
+        CancellationToken cancellationToken = default);
+
+    // Cleanup operations
+
+    /// <summary>
+    /// Removes expired temporary files
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Number of files cleaned up</returns>
+    Task<int> CleanupExpiredFilesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/FileStorage/Domain/BatchUploadResult.cs
+++ b/src/Honua.Core/Features/FileStorage/Domain/BatchUploadResult.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+
+namespace Honua.Core.Features.FileStorage.Domain;
+
+/// <summary>
+/// Result of a batch file upload operation (e.g., Shapefile with multiple components)
+/// </summary>
+public sealed record BatchUploadResult
+{
+    /// <summary>
+    /// Whether all files in the batch were uploaded successfully
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Unique identifier for this batch of files
+    /// </summary>
+    public required string BatchId { get; init; }
+
+    /// <summary>
+    /// Successfully uploaded files
+    /// </summary>
+    public ImmutableList<CloudFile> UploadedFiles { get; init; } = ImmutableList<CloudFile>.Empty;
+
+    /// <summary>
+    /// Failed uploads with their error messages
+    /// </summary>
+    public ImmutableDictionary<string, string> FailedFiles { get; init; } = ImmutableDictionary<string, string>.Empty;
+
+    /// <summary>
+    /// Total number of files attempted
+    /// </summary>
+    public int TotalFiles => UploadedFiles.Count + FailedFiles.Count;
+
+    /// <summary>
+    /// Number of successfully uploaded files
+    /// </summary>
+    public int SuccessCount => UploadedFiles.Count;
+
+    /// <summary>
+    /// Number of failed uploads
+    /// </summary>
+    public int FailureCount => FailedFiles.Count;
+
+    /// <summary>
+    /// Duration of the batch upload operation
+    /// </summary>
+    public TimeSpan Duration { get; init; }
+
+    /// <summary>
+    /// Creates a successful batch upload result
+    /// </summary>
+    /// <param name="batchId">Batch identifier</param>
+    /// <param name="files">Successfully uploaded files</param>
+    /// <param name="duration">Duration of the operation</param>
+    /// <returns>Successful batch result</returns>
+    public static BatchUploadResult CreateSuccess(
+        string batchId,
+        IEnumerable<CloudFile> files,
+        TimeSpan duration = default)
+        => new()
+        {
+            Success = true,
+            BatchId = batchId,
+            UploadedFiles = files.ToImmutableList(),
+            Duration = duration
+        };
+
+    /// <summary>
+    /// Creates a partial success batch upload result
+    /// </summary>
+    /// <param name="batchId">Batch identifier</param>
+    /// <param name="successfulFiles">Successfully uploaded files</param>
+    /// <param name="failedFiles">Files that failed with their error messages</param>
+    /// <param name="duration">Duration of the operation</param>
+    /// <returns>Partial success batch result</returns>
+    public static BatchUploadResult CreatePartialSuccess(
+        string batchId,
+        IEnumerable<CloudFile> successfulFiles,
+        IDictionary<string, string> failedFiles,
+        TimeSpan duration = default)
+        => new()
+        {
+            Success = false,
+            BatchId = batchId,
+            UploadedFiles = successfulFiles.ToImmutableList(),
+            FailedFiles = failedFiles.ToImmutableDictionary(),
+            Duration = duration
+        };
+
+    /// <summary>
+    /// Creates a failed batch upload result
+    /// </summary>
+    /// <param name="batchId">Batch identifier</param>
+    /// <param name="failedFiles">All files that failed with their error messages</param>
+    /// <param name="duration">Duration of the operation</param>
+    /// <returns>Failed batch result</returns>
+    public static BatchUploadResult CreateFailure(
+        string batchId,
+        IDictionary<string, string> failedFiles,
+        TimeSpan duration = default)
+        => new()
+        {
+            Success = false,
+            BatchId = batchId,
+            FailedFiles = failedFiles.ToImmutableDictionary(),
+            Duration = duration
+        };
+}

--- a/src/Honua.Core/Features/FileStorage/Domain/CloudFile.cs
+++ b/src/Honua.Core/Features/FileStorage/Domain/CloudFile.cs
@@ -46,7 +46,7 @@ public sealed record CloudFile
     public DateTimeOffset? ExpiresAt { get; init; }
 
     /// <summary>
-    /// MD5 hash of the file content for integrity verification
+    /// SHA-256 hash of the file content for integrity verification
     /// </summary>
     public string? ContentHash { get; init; }
 

--- a/src/Honua.Core/Features/FileStorage/Domain/CloudFile.cs
+++ b/src/Honua.Core/Features/FileStorage/Domain/CloudFile.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+
+namespace Honua.Core.Features.FileStorage.Domain;
+
+/// <summary>
+/// Represents a file stored in cloud storage
+/// </summary>
+public sealed record CloudFile
+{
+    /// <summary>
+    /// Unique identifier for the file in the storage system
+    /// </summary>
+    public required string FileId { get; init; }
+
+    /// <summary>
+    /// Original filename as provided during upload
+    /// </summary>
+    public required string FileName { get; init; }
+
+    /// <summary>
+    /// Storage path or key within the bucket/container
+    /// </summary>
+    public required string StoragePath { get; init; }
+
+    /// <summary>
+    /// MIME content type of the file
+    /// </summary>
+    public required string ContentType { get; init; }
+
+    /// <summary>
+    /// Size of the file in bytes
+    /// </summary>
+    public required long SizeBytes { get; init; }
+
+    /// <summary>
+    /// Timestamp when the file was uploaded
+    /// </summary>
+    public required DateTimeOffset UploadedAt { get; init; }
+
+    /// <summary>
+    /// Timestamp when the file expires and should be cleaned up (null for permanent storage)
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>
+    /// MD5 hash of the file content for integrity verification
+    /// </summary>
+    public string? ContentHash { get; init; }
+
+    /// <summary>
+    /// Custom metadata associated with the file
+    /// </summary>
+    public ImmutableDictionary<string, string> Metadata { get; init; } = ImmutableDictionary<string, string>.Empty;
+
+    /// <summary>
+    /// The cloud storage provider where this file is stored
+    /// </summary>
+    public required CloudStorageProvider Provider { get; init; }
+}

--- a/src/Honua.Core/Features/FileStorage/Domain/CloudStorageOptions.cs
+++ b/src/Honua.Core/Features/FileStorage/Domain/CloudStorageOptions.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.FileStorage.Domain;
+
+/// <summary>
+/// Configuration options for cloud file storage
+/// </summary>
+public sealed record CloudStorageOptions
+{
+    /// <summary>
+    /// The cloud storage provider to use
+    /// </summary>
+    public CloudStorageProvider Provider { get; init; } = CloudStorageProvider.Local;
+
+    /// <summary>
+    /// Default time-to-live for temporary files
+    /// </summary>
+    public TimeSpan DefaultTimeToLive { get; init; } = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// Maximum file size allowed for upload (in bytes)
+    /// </summary>
+    public long MaxFileSizeBytes { get; init; } = 1024L * 1024L * 1024L; // 1 GB default
+
+    /// <summary>
+    /// Options specific to local filesystem storage
+    /// </summary>
+    public LocalStorageOptions? LocalStorage { get; init; }
+
+    /// <summary>
+    /// Options specific to AWS S3 storage
+    /// </summary>
+    public AwsS3Options? AwsS3 { get; init; }
+
+    /// <summary>
+    /// Options specific to Azure Blob storage
+    /// </summary>
+    public AzureBlobOptions? AzureBlob { get; init; }
+
+    /// <summary>
+    /// Options specific to Google Cloud Storage
+    /// </summary>
+    public GoogleCloudStorageOptions? GoogleCloudStorage { get; init; }
+
+    /// <summary>
+    /// Whether to enable automatic cleanup of expired files
+    /// </summary>
+    public bool EnableAutomaticCleanup { get; init; } = true;
+
+    /// <summary>
+    /// Interval at which to run automatic cleanup
+    /// </summary>
+    public TimeSpan CleanupInterval { get; init; } = TimeSpan.FromHours(1);
+}
+
+/// <summary>
+/// Configuration options for local filesystem storage
+/// </summary>
+public sealed record LocalStorageOptions
+{
+    /// <summary>
+    /// Base directory path for storing files
+    /// </summary>
+    public required string BasePath { get; init; }
+
+    /// <summary>
+    /// Whether to create the base directory if it doesn't exist
+    /// </summary>
+    public bool CreateDirectoryIfNotExists { get; init; } = true;
+}
+
+/// <summary>
+/// Configuration options for AWS S3 storage
+/// </summary>
+public sealed record AwsS3Options
+{
+    /// <summary>
+    /// S3 bucket name
+    /// </summary>
+    public required string BucketName { get; init; }
+
+    /// <summary>
+    /// AWS region (e.g., "us-east-1")
+    /// </summary>
+    public required string Region { get; init; }
+
+    /// <summary>
+    /// Optional key prefix for all stored files
+    /// </summary>
+    public string? KeyPrefix { get; init; }
+
+    /// <summary>
+    /// AWS access key ID (if not using IAM role)
+    /// </summary>
+    public string? AccessKeyId { get; init; }
+
+    /// <summary>
+    /// AWS secret access key (if not using IAM role)
+    /// </summary>
+    public string? SecretAccessKey { get; init; }
+
+    /// <summary>
+    /// Whether to use server-side encryption
+    /// </summary>
+    public bool EnableServerSideEncryption { get; init; } = true;
+}
+
+/// <summary>
+/// Configuration options for Azure Blob storage
+/// </summary>
+public sealed record AzureBlobOptions
+{
+    /// <summary>
+    /// Azure Storage connection string
+    /// </summary>
+    public required string ConnectionString { get; init; }
+
+    /// <summary>
+    /// Container name for storing files
+    /// </summary>
+    public required string ContainerName { get; init; }
+
+    /// <summary>
+    /// Optional blob prefix for all stored files
+    /// </summary>
+    public string? BlobPrefix { get; init; }
+}
+
+/// <summary>
+/// Configuration options for Google Cloud Storage
+/// </summary>
+public sealed record GoogleCloudStorageOptions
+{
+    /// <summary>
+    /// GCS bucket name
+    /// </summary>
+    public required string BucketName { get; init; }
+
+    /// <summary>
+    /// GCP project ID
+    /// </summary>
+    public required string ProjectId { get; init; }
+
+    /// <summary>
+    /// Optional object prefix for all stored files
+    /// </summary>
+    public string? ObjectPrefix { get; init; }
+
+    /// <summary>
+    /// Path to service account credentials JSON file (if not using default credentials)
+    /// </summary>
+    public string? CredentialsPath { get; init; }
+}

--- a/src/Honua.Core/Features/FileStorage/Domain/CloudStorageOptions.cs
+++ b/src/Honua.Core/Features/FileStorage/Domain/CloudStorageOptions.cs
@@ -62,7 +62,7 @@ public sealed record LocalStorageOptions
     /// <summary>
     /// Base directory path for storing files
     /// </summary>
-    public required string BasePath { get; init; }
+    public string BasePath { get; init; } = string.Empty;
 
     /// <summary>
     /// Whether to create the base directory if it doesn't exist
@@ -78,12 +78,12 @@ public sealed record AwsS3Options
     /// <summary>
     /// S3 bucket name
     /// </summary>
-    public required string BucketName { get; init; }
+    public string BucketName { get; init; } = string.Empty;
 
     /// <summary>
     /// AWS region (e.g., "us-east-1")
     /// </summary>
-    public required string Region { get; init; }
+    public string Region { get; init; } = string.Empty;
 
     /// <summary>
     /// Optional key prefix for all stored files
@@ -114,12 +114,12 @@ public sealed record AzureBlobOptions
     /// <summary>
     /// Azure Storage connection string
     /// </summary>
-    public required string ConnectionString { get; init; }
+    public string ConnectionString { get; init; } = string.Empty;
 
     /// <summary>
     /// Container name for storing files
     /// </summary>
-    public required string ContainerName { get; init; }
+    public string ContainerName { get; init; } = string.Empty;
 
     /// <summary>
     /// Optional blob prefix for all stored files
@@ -135,12 +135,12 @@ public sealed record GoogleCloudStorageOptions
     /// <summary>
     /// GCS bucket name
     /// </summary>
-    public required string BucketName { get; init; }
+    public string BucketName { get; init; } = string.Empty;
 
     /// <summary>
     /// GCP project ID
     /// </summary>
-    public required string ProjectId { get; init; }
+    public string ProjectId { get; init; } = string.Empty;
 
     /// <summary>
     /// Optional object prefix for all stored files

--- a/src/Honua.Core/Features/FileStorage/Domain/CloudStorageProvider.cs
+++ b/src/Honua.Core/Features/FileStorage/Domain/CloudStorageProvider.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.FileStorage.Domain;
+
+/// <summary>
+/// Supported cloud storage providers for file storage operations
+/// </summary>
+public enum CloudStorageProvider
+{
+    /// <summary>
+    /// Local filesystem storage (for development and testing)
+    /// </summary>
+    Local = 0,
+
+    /// <summary>
+    /// Amazon Web Services S3
+    /// </summary>
+    AwsS3 = 1,
+
+    /// <summary>
+    /// Microsoft Azure Blob Storage
+    /// </summary>
+    AzureBlob = 2,
+
+    /// <summary>
+    /// Google Cloud Storage
+    /// </summary>
+    GoogleCloudStorage = 3
+}

--- a/src/Honua.Core/Features/FileStorage/Domain/FileUploadRequest.cs
+++ b/src/Honua.Core/Features/FileStorage/Domain/FileUploadRequest.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+
+namespace Honua.Core.Features.FileStorage.Domain;
+
+/// <summary>
+/// Request to upload a file to cloud storage
+/// </summary>
+public sealed record FileUploadRequest
+{
+    /// <summary>
+    /// Stream containing the file content
+    /// </summary>
+    public required Stream Content { get; init; }
+
+    /// <summary>
+    /// Original filename
+    /// </summary>
+    public required string FileName { get; init; }
+
+    /// <summary>
+    /// MIME content type of the file
+    /// </summary>
+    public required string ContentType { get; init; }
+
+    /// <summary>
+    /// Size of the file in bytes (optional, for validation)
+    /// </summary>
+    public long? SizeBytes { get; init; }
+
+    /// <summary>
+    /// Time-to-live for temporary files (null for permanent storage)
+    /// </summary>
+    public TimeSpan? TimeToLive { get; init; }
+
+    /// <summary>
+    /// Custom metadata to associate with the file
+    /// </summary>
+    public ImmutableDictionary<string, string> Metadata { get; init; } = ImmutableDictionary<string, string>.Empty;
+
+    /// <summary>
+    /// Optional subfolder/prefix for organizing files
+    /// </summary>
+    public string? Folder { get; init; }
+}
+
+/// <summary>
+/// Request to upload a file from a byte array
+/// </summary>
+public sealed record ByteArrayUploadRequest
+{
+    /// <summary>
+    /// File content as byte array
+    /// </summary>
+    public required byte[] Content { get; init; }
+
+    /// <summary>
+    /// Original filename
+    /// </summary>
+    public required string FileName { get; init; }
+
+    /// <summary>
+    /// MIME content type of the file
+    /// </summary>
+    public required string ContentType { get; init; }
+
+    /// <summary>
+    /// Time-to-live for temporary files (null for permanent storage)
+    /// </summary>
+    public TimeSpan? TimeToLive { get; init; }
+
+    /// <summary>
+    /// Custom metadata to associate with the file
+    /// </summary>
+    public ImmutableDictionary<string, string> Metadata { get; init; } = ImmutableDictionary<string, string>.Empty;
+
+    /// <summary>
+    /// Optional subfolder/prefix for organizing files
+    /// </summary>
+    public string? Folder { get; init; }
+}
+
+/// <summary>
+/// Single file in a batch upload request
+/// </summary>
+public sealed record BatchFileItem
+{
+    /// <summary>
+    /// Stream containing the file content
+    /// </summary>
+    public required Stream Content { get; init; }
+
+    /// <summary>
+    /// Original filename
+    /// </summary>
+    public required string FileName { get; init; }
+
+    /// <summary>
+    /// MIME content type of the file
+    /// </summary>
+    public required string ContentType { get; init; }
+
+    /// <summary>
+    /// Size of the file in bytes (optional, for validation)
+    /// </summary>
+    public long? SizeBytes { get; init; }
+
+    /// <summary>
+    /// Custom metadata to associate with the file
+    /// </summary>
+    public ImmutableDictionary<string, string> Metadata { get; init; } = ImmutableDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// Request to upload multiple files as a batch (e.g., Shapefile components)
+/// </summary>
+public sealed record BatchUploadRequest
+{
+    /// <summary>
+    /// Files to upload
+    /// </summary>
+    public required IReadOnlyList<BatchFileItem> Files { get; init; }
+
+    /// <summary>
+    /// Time-to-live for temporary files (null for permanent storage)
+    /// </summary>
+    public TimeSpan? TimeToLive { get; init; }
+
+    /// <summary>
+    /// Optional subfolder/prefix for organizing the batch
+    /// </summary>
+    public string? Folder { get; init; }
+
+    /// <summary>
+    /// Whether to continue uploading remaining files if one fails
+    /// </summary>
+    public bool ContinueOnError { get; init; }
+}

--- a/src/Honua.Core/Features/FileStorage/Domain/UploadResult.cs
+++ b/src/Honua.Core/Features/FileStorage/Domain/UploadResult.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.FileStorage.Domain;
+
+/// <summary>
+/// Result of a file upload operation
+/// </summary>
+public sealed record UploadResult
+{
+    /// <summary>
+    /// Whether the upload was successful
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// The uploaded file information (null if upload failed)
+    /// </summary>
+    public CloudFile? File { get; init; }
+
+    /// <summary>
+    /// Error message if upload failed
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Duration of the upload operation
+    /// </summary>
+    public TimeSpan Duration { get; init; }
+
+    /// <summary>
+    /// Creates a successful upload result
+    /// </summary>
+    /// <param name="file">The uploaded file</param>
+    /// <param name="duration">Duration of the upload</param>
+    /// <returns>Successful upload result</returns>
+    public static UploadResult CreateSuccess(CloudFile file, TimeSpan duration = default)
+        => new()
+        {
+            Success = true,
+            File = file,
+            Duration = duration
+        };
+
+    /// <summary>
+    /// Creates a failed upload result
+    /// </summary>
+    /// <param name="errorMessage">Description of the failure</param>
+    /// <param name="duration">Duration before failure</param>
+    /// <returns>Failed upload result</returns>
+    public static UploadResult CreateFailure(string errorMessage, TimeSpan duration = default)
+        => new()
+        {
+            Success = false,
+            ErrorMessage = errorMessage,
+            Duration = duration
+        };
+}

--- a/src/Honua.Server/Features/FileStorage/FileStorageCleanupService.cs
+++ b/src/Honua.Server/Features/FileStorage/FileStorageCleanupService.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FileStorage.Abstractions;
+using Honua.Core.Features.FileStorage.Domain;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.FileStorage;
+
+/// <summary>
+/// Background service that periodically cleans up expired temporary files
+/// </summary>
+internal sealed class FileStorageCleanupService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly CloudStorageOptions _options;
+    private readonly ILogger<FileStorageCleanupService> _logger;
+
+    /// <summary>
+    /// Creates a new cleanup service instance
+    /// </summary>
+    /// <param name="serviceProvider">Service provider for resolving scoped services</param>
+    /// <param name="options">Cloud storage options</param>
+    /// <param name="logger">Logger instance</param>
+    public FileStorageCleanupService(
+        IServiceProvider serviceProvider,
+        IOptions<CloudStorageOptions> options,
+        ILogger<FileStorageCleanupService> logger)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _options = options.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.EnableAutomaticCleanup)
+        {
+            _logger.LogInformation("Automatic file cleanup is disabled");
+            return;
+        }
+
+        _logger.LogInformation(
+            "File storage cleanup service started with interval of {Interval}",
+            _options.CleanupInterval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_options.CleanupInterval, stoppingToken);
+                await RunCleanupAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // Normal shutdown, don't log as error
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during file storage cleanup");
+            }
+        }
+
+        _logger.LogInformation("File storage cleanup service stopped");
+    }
+
+    private async Task RunCleanupAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var fileStorage = scope.ServiceProvider.GetRequiredService<ICloudFileStorage>();
+
+        var cleanedCount = await fileStorage.CleanupExpiredFilesAsync(cancellationToken);
+
+        if (cleanedCount > 0)
+        {
+            _logger.LogInformation("Cleanup completed: removed {Count} expired files", cleanedCount);
+        }
+    }
+}

--- a/src/Honua.Server/Features/FileStorage/FileStorageCleanupService.cs
+++ b/src/Honua.Server/Features/FileStorage/FileStorageCleanupService.cs
@@ -3,8 +3,6 @@
 
 using Honua.Core.Features.FileStorage.Abstractions;
 using Honua.Core.Features.FileStorage.Domain;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Server.Features.FileStorage;
@@ -39,13 +37,11 @@ internal sealed class FileStorageCleanupService : BackgroundService
     {
         if (!_options.EnableAutomaticCleanup)
         {
-            _logger.LogInformation("Automatic file cleanup is disabled");
+            FileStorageLog.CleanupDisabled(_logger);
             return;
         }
 
-        _logger.LogInformation(
-            "File storage cleanup service started with interval of {Interval}",
-            _options.CleanupInterval);
+        FileStorageLog.CleanupServiceStarted(_logger, _options.CleanupInterval);
 
         while (!stoppingToken.IsCancellationRequested)
         {
@@ -61,11 +57,11 @@ internal sealed class FileStorageCleanupService : BackgroundService
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error during file storage cleanup");
+                FileStorageLog.CleanupError(_logger, ex);
             }
         }
 
-        _logger.LogInformation("File storage cleanup service stopped");
+        FileStorageLog.CleanupServiceStopped(_logger);
     }
 
     private async Task RunCleanupAsync(CancellationToken cancellationToken)
@@ -77,7 +73,7 @@ internal sealed class FileStorageCleanupService : BackgroundService
 
         if (cleanedCount > 0)
         {
-            _logger.LogInformation("Cleanup completed: removed {Count} expired files", cleanedCount);
+            FileStorageLog.CleanupCompleted(_logger, cleanedCount);
         }
     }
 }

--- a/src/Honua.Server/Features/FileStorage/FileStorageLog.cs
+++ b/src/Honua.Server/Features/FileStorage/FileStorageLog.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.FileStorage;
+
+internal static partial class FileStorageLog
+{
+    [LoggerMessage(
+        EventId = 5401,
+        Level = LogLevel.Information,
+        Message = "Automatic file cleanup is disabled")]
+    public static partial void CleanupDisabled(ILogger logger);
+
+    [LoggerMessage(
+        EventId = 5402,
+        Level = LogLevel.Information,
+        Message = "File storage cleanup service started with interval of {Interval}")]
+    public static partial void CleanupServiceStarted(ILogger logger, TimeSpan interval);
+
+    [LoggerMessage(
+        EventId = 5403,
+        Level = LogLevel.Error,
+        Message = "Error during file storage cleanup")]
+    public static partial void CleanupError(ILogger logger, Exception exception);
+
+    [LoggerMessage(
+        EventId = 5404,
+        Level = LogLevel.Information,
+        Message = "File storage cleanup service stopped")]
+    public static partial void CleanupServiceStopped(ILogger logger);
+
+    [LoggerMessage(
+        EventId = 5405,
+        Level = LogLevel.Information,
+        Message = "Cleanup completed: removed {Count} expired files")]
+    public static partial void CleanupCompleted(ILogger logger, int count);
+
+    [LoggerMessage(
+        EventId = 5410,
+        Level = LogLevel.Information,
+        Message = "Uploaded file {FileName} ({SizeBytes} bytes) as {FileId} in {DurationMs}ms")]
+    public static partial void FileUploaded(
+        ILogger logger,
+        string fileName,
+        long sizeBytes,
+        string fileId,
+        long durationMs);
+
+    [LoggerMessage(
+        EventId = 5411,
+        Level = LogLevel.Error,
+        Message = "Failed to upload file {FileName}")]
+    public static partial void FileUploadFailed(ILogger logger, Exception exception, string fileName);
+
+    [LoggerMessage(
+        EventId = 5412,
+        Level = LogLevel.Warning,
+        Message = "File metadata exists but file not found on disk: {FileId}")]
+    public static partial void FileMissingOnDisk(ILogger logger, string fileId);
+
+    [LoggerMessage(
+        EventId = 5413,
+        Level = LogLevel.Information,
+        Message = "Deleted file {FileId}")]
+    public static partial void FileDeleted(ILogger logger, string fileId);
+
+    [LoggerMessage(
+        EventId = 5414,
+        Level = LogLevel.Error,
+        Message = "Failed to delete file {FileId}")]
+    public static partial void FileDeleteFailed(ILogger logger, Exception exception, string fileId);
+
+    [LoggerMessage(
+        EventId = 5415,
+        Level = LogLevel.Information,
+        Message = "Deleted batch {BatchId} with {DeletedCount} files")]
+    public static partial void BatchDeleted(ILogger logger, string batchId, int deletedCount);
+
+    [LoggerMessage(
+        EventId = 5416,
+        Level = LogLevel.Information,
+        Message = "Cleaned up {Count} expired files")]
+    public static partial void ExpiredFilesCleaned(ILogger logger, int count);
+
+    [LoggerMessage(
+        EventId = 5417,
+        Level = LogLevel.Information,
+        Message = "Created storage directory: {BasePath}")]
+    public static partial void StorageDirectoryCreated(ILogger logger, string basePath);
+
+    [LoggerMessage(
+        EventId = 5418,
+        Level = LogLevel.Warning,
+        Message = "Failed to load metadata from {File}")]
+    public static partial void MetadataLoadFailed(ILogger logger, Exception exception, string file);
+
+    [LoggerMessage(
+        EventId = 5419,
+        Level = LogLevel.Information,
+        Message = "Loaded {Count} files from existing metadata")]
+    public static partial void MetadataLoaded(ILogger logger, int count);
+}

--- a/src/Honua.Server/Features/FileStorage/FileStorageServiceExtensions.cs
+++ b/src/Honua.Server/Features/FileStorage/FileStorageServiceExtensions.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FileStorage.Abstractions;
+using Honua.Core.Features.FileStorage.Domain;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Features.FileStorage;
+
+/// <summary>
+/// Extension methods for registering file storage services
+/// </summary>
+public static class FileStorageServiceExtensions
+{
+    /// <summary>
+    /// Adds cloud file storage services to the dependency injection container
+    /// </summary>
+    /// <param name="services">Service collection</param>
+    /// <param name="configuration">Configuration for binding options</param>
+    /// <returns>Service collection for chaining</returns>
+    public static IServiceCollection AddCloudFileStorage(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // Bind configuration
+        var section = configuration.GetSection("FileStorage");
+        services.Configure<CloudStorageOptions>(section);
+
+        // Bind provider-specific options
+        var localSection = section.GetSection("LocalStorage");
+        if (localSection.Exists())
+        {
+            services.Configure<LocalStorageOptions>(localSection);
+        }
+        else
+        {
+            // Default local storage path if not configured
+            services.Configure<LocalStorageOptions>(options =>
+            {
+                options = new LocalStorageOptions
+                {
+                    BasePath = Path.Combine(Path.GetTempPath(), "honua-storage"),
+                    CreateDirectoryIfNotExists = true
+                };
+            });
+            services.AddSingleton(new LocalStorageOptions
+            {
+                BasePath = section.GetValue("LocalStorage:BasePath", null as string)
+                           ?? Path.Combine(Path.GetTempPath(), "honua-storage"),
+                CreateDirectoryIfNotExists = section.GetValue("LocalStorage:CreateDirectoryIfNotExists", true)
+            });
+            services.AddSingleton<Microsoft.Extensions.Options.IOptions<LocalStorageOptions>>(sp =>
+                Microsoft.Extensions.Options.Options.Create(sp.GetRequiredService<LocalStorageOptions>()));
+        }
+
+        // Determine provider from configuration or environment
+        var providerName = section.GetValue<string>("Provider")
+                           ?? Environment.GetEnvironmentVariable("HONUA_STORAGE_PROVIDER")
+                           ?? "Local";
+
+        var provider = Enum.TryParse<CloudStorageProvider>(providerName, ignoreCase: true, out var p)
+            ? p
+            : CloudStorageProvider.Local;
+
+        // Register appropriate provider
+        switch (provider)
+        {
+            case CloudStorageProvider.Local:
+                services.AddSingleton<ICloudFileStorage, LocalFileStorage>();
+                break;
+
+            case CloudStorageProvider.AwsS3:
+                // TODO: Sprint 2 - Add AWS S3 implementation
+                throw new NotSupportedException(
+                    "AWS S3 storage provider is not yet implemented. " +
+                    "Use 'Local' provider for development or wait for Sprint 2 implementation.");
+
+            case CloudStorageProvider.AzureBlob:
+                // TODO: Sprint 3 - Add Azure Blob implementation
+                throw new NotSupportedException(
+                    "Azure Blob storage provider is not yet implemented. " +
+                    "Use 'Local' provider for development or wait for Sprint 3 implementation.");
+
+            case CloudStorageProvider.GoogleCloudStorage:
+                // TODO: Sprint 3 - Add GCS implementation
+                throw new NotSupportedException(
+                    "Google Cloud Storage provider is not yet implemented. " +
+                    "Use 'Local' provider for development or wait for Sprint 3 implementation.");
+
+            default:
+                throw new InvalidOperationException($"Unknown storage provider: {providerName}");
+        }
+
+        // Register cleanup background service
+        var enableCleanup = section.GetValue("EnableAutomaticCleanup", true);
+        if (enableCleanup)
+        {
+            services.AddHostedService<FileStorageCleanupService>();
+        }
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds cloud file storage services with a specific provider
+    /// </summary>
+    /// <param name="services">Service collection</param>
+    /// <param name="configure">Configuration action for options</param>
+    /// <returns>Service collection for chaining</returns>
+    public static IServiceCollection AddCloudFileStorage(
+        this IServiceCollection services,
+        Action<CloudStorageOptions> configure)
+    {
+        var options = new CloudStorageOptions();
+        configure(options);
+
+        services.AddSingleton(Microsoft.Extensions.Options.Options.Create(options));
+
+        // Configure local storage options if using local provider
+        if (options.Provider == CloudStorageProvider.Local && options.LocalStorage is not null)
+        {
+            services.AddSingleton(Microsoft.Extensions.Options.Options.Create(options.LocalStorage));
+        }
+        else if (options.Provider == CloudStorageProvider.Local)
+        {
+            services.AddSingleton(Microsoft.Extensions.Options.Options.Create(new LocalStorageOptions
+            {
+                BasePath = Path.Combine(Path.GetTempPath(), "honua-storage"),
+                CreateDirectoryIfNotExists = true
+            }));
+        }
+
+        switch (options.Provider)
+        {
+            case CloudStorageProvider.Local:
+                services.AddSingleton<ICloudFileStorage, LocalFileStorage>();
+                break;
+
+            case CloudStorageProvider.AwsS3:
+            case CloudStorageProvider.AzureBlob:
+            case CloudStorageProvider.GoogleCloudStorage:
+                throw new NotSupportedException(
+                    $"{options.Provider} storage provider is not yet implemented. " +
+                    "Use 'Local' provider for development.");
+
+            default:
+                throw new InvalidOperationException($"Unknown storage provider: {options.Provider}");
+        }
+
+        if (options.EnableAutomaticCleanup)
+        {
+            services.AddHostedService<FileStorageCleanupService>();
+        }
+
+        return services;
+    }
+}

--- a/src/Honua.Server/Features/FileStorage/FileStorageServiceExtensions.cs
+++ b/src/Honua.Server/Features/FileStorage/FileStorageServiceExtensions.cs
@@ -3,8 +3,6 @@
 
 using Honua.Core.Features.FileStorage.Abstractions;
 using Honua.Core.Features.FileStorage.Domain;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Server.Features.FileStorage;
 

--- a/src/Honua.Server/Features/FileStorage/LocalFileStorage.cs
+++ b/src/Honua.Server/Features/FileStorage/LocalFileStorage.cs
@@ -1,0 +1,489 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Honua.Core.Features.FileStorage.Abstractions;
+using Honua.Core.Features.FileStorage.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.FileStorage;
+
+/// <summary>
+/// Local filesystem implementation of cloud file storage for development and testing
+/// </summary>
+internal sealed class LocalFileStorage : ICloudFileStorage
+{
+    private readonly LocalStorageOptions _options;
+    private readonly ILogger<LocalFileStorage> _logger;
+    private readonly ConcurrentDictionary<string, CloudFile> _fileIndex;
+    private readonly ConcurrentDictionary<string, HashSet<string>> _batchIndex;
+    private readonly string _basePath;
+    private readonly string _metadataPath;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// Creates a new local file storage instance
+    /// </summary>
+    /// <param name="options">Local storage options</param>
+    /// <param name="logger">Logger instance</param>
+    public LocalFileStorage(
+        IOptions<LocalStorageOptions> options,
+        ILogger<LocalFileStorage> logger)
+    {
+        _options = options.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _basePath = _options.BasePath;
+        _metadataPath = Path.Combine(_basePath, ".metadata");
+        _fileIndex = new ConcurrentDictionary<string, CloudFile>();
+        _batchIndex = new ConcurrentDictionary<string, HashSet<string>>();
+
+        InitializeStorage();
+    }
+
+    /// <inheritdoc />
+    public CloudStorageProvider Provider => CloudStorageProvider.Local;
+
+    /// <inheritdoc />
+    public async Task<UploadResult> UploadAsync(FileUploadRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var fileId = GenerateFileId();
+            var storagePath = BuildStoragePath(fileId, request.FileName, request.Folder);
+            var fullPath = Path.Combine(_basePath, storagePath);
+
+            // Ensure directory exists
+            var directory = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            // Write file content
+            string? contentHash;
+            long sizeBytes;
+            await using (var fileStream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, true))
+            {
+                using var hashAlgorithm = MD5.Create();
+                await using var cryptoStream = new CryptoStream(fileStream, hashAlgorithm, CryptoStreamMode.Write, leaveOpen: true);
+
+                await request.Content.CopyToAsync(cryptoStream, cancellationToken);
+                await cryptoStream.FlushFinalBlockAsync(cancellationToken);
+
+                contentHash = Convert.ToHexString(hashAlgorithm.Hash ?? []);
+                sizeBytes = fileStream.Length;
+            }
+
+            var uploadedAt = DateTimeOffset.UtcNow;
+            var expiresAt = request.TimeToLive.HasValue
+                ? uploadedAt.Add(request.TimeToLive.Value)
+                : (DateTimeOffset?)null;
+
+            var cloudFile = new CloudFile
+            {
+                FileId = fileId,
+                FileName = request.FileName,
+                StoragePath = storagePath,
+                ContentType = request.ContentType,
+                SizeBytes = sizeBytes,
+                UploadedAt = uploadedAt,
+                ExpiresAt = expiresAt,
+                ContentHash = contentHash,
+                Metadata = request.Metadata,
+                Provider = CloudStorageProvider.Local
+            };
+
+            _fileIndex[fileId] = cloudFile;
+            await SaveMetadataAsync(cloudFile, cancellationToken);
+
+            stopwatch.Stop();
+            _logger.LogInformation(
+                "Uploaded file {FileName} ({SizeBytes} bytes) as {FileId} in {Duration}ms",
+                request.FileName, sizeBytes, fileId, stopwatch.ElapsedMilliseconds);
+
+            return UploadResult.CreateSuccess(cloudFile, stopwatch.Elapsed);
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _logger.LogError(ex, "Failed to upload file {FileName}", request.FileName);
+            return UploadResult.CreateFailure(ex.Message, stopwatch.Elapsed);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<UploadResult> UploadAsync(ByteArrayUploadRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        using var stream = new MemoryStream(request.Content);
+        return await UploadAsync(new FileUploadRequest
+        {
+            Content = stream,
+            FileName = request.FileName,
+            ContentType = request.ContentType,
+            SizeBytes = request.Content.Length,
+            TimeToLive = request.TimeToLive,
+            Metadata = request.Metadata,
+            Folder = request.Folder
+        }, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<Stream?> DownloadAsync(string fileId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileId);
+
+        var cloudFile = await GetMetadataAsync(fileId, cancellationToken);
+        if (cloudFile is null)
+        {
+            return null;
+        }
+
+        var fullPath = Path.Combine(_basePath, cloudFile.StoragePath);
+        if (!File.Exists(fullPath))
+        {
+            _logger.LogWarning("File metadata exists but file not found on disk: {FileId}", fileId);
+            return null;
+        }
+
+        return new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, true);
+    }
+
+    /// <inheritdoc />
+    public async Task<byte[]?> DownloadBytesAsync(string fileId, CancellationToken cancellationToken = default)
+    {
+        await using var stream = await DownloadAsync(fileId, cancellationToken);
+        if (stream is null)
+        {
+            return null;
+        }
+
+        using var memoryStream = new MemoryStream();
+        await stream.CopyToAsync(memoryStream, cancellationToken);
+        return memoryStream.ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteAsync(string fileId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileId);
+
+        if (!_fileIndex.TryRemove(fileId, out var cloudFile))
+        {
+            return false;
+        }
+
+        var fullPath = Path.Combine(_basePath, cloudFile.StoragePath);
+        var metadataFile = GetMetadataFilePath(fileId);
+
+        try
+        {
+            if (File.Exists(fullPath))
+            {
+                File.Delete(fullPath);
+            }
+
+            if (File.Exists(metadataFile))
+            {
+                File.Delete(metadataFile);
+            }
+
+            // Remove from batch index if present
+            foreach (var batch in _batchIndex)
+            {
+                batch.Value.Remove(fileId);
+            }
+
+            _logger.LogInformation("Deleted file {FileId}", fileId);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete file {FileId}", fileId);
+            // Re-add to index since deletion failed
+            _fileIndex[fileId] = cloudFile;
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<BatchUploadResult> UploadBatchAsync(BatchUploadRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var stopwatch = Stopwatch.StartNew();
+        var batchId = Guid.NewGuid().ToString("N");
+        var uploadedFiles = new List<CloudFile>();
+        var failedFiles = new Dictionary<string, string>();
+
+        _batchIndex[batchId] = new HashSet<string>();
+
+        foreach (var file in request.Files)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var metadata = file.Metadata.Add("BatchId", batchId);
+            var result = await UploadAsync(new FileUploadRequest
+            {
+                Content = file.Content,
+                FileName = file.FileName,
+                ContentType = file.ContentType,
+                SizeBytes = file.SizeBytes,
+                TimeToLive = request.TimeToLive,
+                Metadata = metadata,
+                Folder = request.Folder ?? batchId
+            }, cancellationToken);
+
+            if (result.Success && result.File is not null)
+            {
+                uploadedFiles.Add(result.File);
+                _batchIndex[batchId].Add(result.File.FileId);
+            }
+            else
+            {
+                failedFiles[file.FileName] = result.ErrorMessage ?? "Unknown error";
+
+                if (!request.ContinueOnError)
+                {
+                    // Rollback uploaded files
+                    foreach (var uploaded in uploadedFiles)
+                    {
+                        await DeleteAsync(uploaded.FileId, cancellationToken);
+                    }
+
+                    stopwatch.Stop();
+                    return BatchUploadResult.CreateFailure(batchId, failedFiles, stopwatch.Elapsed);
+                }
+            }
+        }
+
+        stopwatch.Stop();
+
+        if (failedFiles.Count > 0)
+        {
+            return BatchUploadResult.CreatePartialSuccess(batchId, uploadedFiles, failedFiles, stopwatch.Elapsed);
+        }
+
+        return BatchUploadResult.CreateSuccess(batchId, uploadedFiles, stopwatch.Elapsed);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> DeleteBatchAsync(string batchId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(batchId);
+
+        if (!_batchIndex.TryRemove(batchId, out var fileIds))
+        {
+            return 0;
+        }
+
+        var deletedCount = 0;
+        foreach (var fileId in fileIds)
+        {
+            if (await DeleteAsync(fileId, cancellationToken))
+            {
+                deletedCount++;
+            }
+        }
+
+        _logger.LogInformation("Deleted batch {BatchId} with {DeletedCount} files", batchId, deletedCount);
+        return deletedCount;
+    }
+
+    /// <inheritdoc />
+    public Task<CloudFile?> GetMetadataAsync(string fileId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileId);
+
+        _fileIndex.TryGetValue(fileId, out var cloudFile);
+        return Task.FromResult(cloudFile);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> ExistsAsync(string fileId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileId);
+
+        var exists = _fileIndex.ContainsKey(fileId);
+        return Task.FromResult(exists);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<CloudFile>> ListFilesAsync(
+        string? folder = null,
+        int maxResults = 1000,
+        CancellationToken cancellationToken = default)
+    {
+        var files = _fileIndex.Values
+            .Where(f => string.IsNullOrEmpty(folder) || f.StoragePath.StartsWith(folder, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(f => f.UploadedAt)
+            .Take(maxResults)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<CloudFile>>(files);
+    }
+
+    /// <inheritdoc />
+    public Task<string?> GetPresignedUrlAsync(
+        string fileId,
+        TimeSpan? expiresIn = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileId);
+
+        // For local storage, we return the file path as a "URL"
+        // In production, cloud providers would return actual presigned URLs
+        if (!_fileIndex.TryGetValue(fileId, out var cloudFile))
+        {
+            return Task.FromResult<string?>(null);
+        }
+
+        var fullPath = Path.Combine(_basePath, cloudFile.StoragePath);
+        return Task.FromResult<string?>(new Uri(fullPath).AbsoluteUri);
+    }
+
+    /// <inheritdoc />
+    public Task<(string Url, string FileId)?> GetPresignedUploadUrlAsync(
+        string fileName,
+        string contentType,
+        TimeSpan? expiresIn = null,
+        string? folder = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentType);
+
+        // For local storage, we generate a file ID and path
+        // Real cloud implementations would provide presigned upload URLs
+        var fileId = GenerateFileId();
+        var storagePath = BuildStoragePath(fileId, fileName, folder);
+        var fullPath = Path.Combine(_basePath, storagePath);
+
+        // Ensure directory exists
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        return Task.FromResult<(string Url, string FileId)?>(
+            (new Uri(fullPath).AbsoluteUri, fileId));
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CleanupExpiredFilesAsync(CancellationToken cancellationToken = default)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var expiredFiles = _fileIndex.Values
+            .Where(f => f.ExpiresAt.HasValue && f.ExpiresAt.Value <= now)
+            .ToList();
+
+        var cleanedCount = 0;
+        foreach (var file in expiredFiles)
+        {
+            if (await DeleteAsync(file.FileId, cancellationToken))
+            {
+                cleanedCount++;
+            }
+        }
+
+        if (cleanedCount > 0)
+        {
+            _logger.LogInformation("Cleaned up {Count} expired files", cleanedCount);
+        }
+
+        return cleanedCount;
+    }
+
+    private void InitializeStorage()
+    {
+        if (_options.CreateDirectoryIfNotExists && !Directory.Exists(_basePath))
+        {
+            Directory.CreateDirectory(_basePath);
+            _logger.LogInformation("Created storage directory: {BasePath}", _basePath);
+        }
+
+        if (!Directory.Exists(_metadataPath))
+        {
+            Directory.CreateDirectory(_metadataPath);
+        }
+
+        // Load existing metadata
+        LoadExistingMetadata();
+    }
+
+    private void LoadExistingMetadata()
+    {
+        if (!Directory.Exists(_metadataPath))
+        {
+            return;
+        }
+
+        var metadataFiles = Directory.GetFiles(_metadataPath, "*.json");
+        foreach (var file in metadataFiles)
+        {
+            try
+            {
+                var json = File.ReadAllText(file);
+                var cloudFile = JsonSerializer.Deserialize<CloudFile>(json, JsonOptions);
+                if (cloudFile is not null)
+                {
+                    _fileIndex[cloudFile.FileId] = cloudFile;
+
+                    // Rebuild batch index
+                    if (cloudFile.Metadata.TryGetValue("BatchId", out var batchId))
+                    {
+                        if (!_batchIndex.ContainsKey(batchId))
+                        {
+                            _batchIndex[batchId] = new HashSet<string>();
+                        }
+                        _batchIndex[batchId].Add(cloudFile.FileId);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to load metadata from {File}", file);
+            }
+        }
+
+        _logger.LogInformation("Loaded {Count} files from existing metadata", _fileIndex.Count);
+    }
+
+    private async Task SaveMetadataAsync(CloudFile cloudFile, CancellationToken cancellationToken)
+    {
+        var metadataFile = GetMetadataFilePath(cloudFile.FileId);
+        var json = JsonSerializer.Serialize(cloudFile, JsonOptions);
+        await File.WriteAllTextAsync(metadataFile, json, cancellationToken);
+    }
+
+    private string GetMetadataFilePath(string fileId) =>
+        Path.Combine(_metadataPath, $"{fileId}.json");
+
+    private static string GenerateFileId() =>
+        Guid.NewGuid().ToString("N");
+
+    private static string BuildStoragePath(string fileId, string fileName, string? folder)
+    {
+        var extension = Path.GetExtension(fileName);
+        var storageName = $"{fileId}{extension}";
+
+        return string.IsNullOrEmpty(folder)
+            ? storageName
+            : Path.Combine(folder, storageName);
+    }
+}

--- a/src/Honua.Server/Features/FileStorage/LocalFileStorage.cs
+++ b/src/Honua.Server/Features/FileStorage/LocalFileStorage.cs
@@ -2,13 +2,11 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text.Json;
 using Honua.Core.Features.FileStorage.Abstractions;
 using Honua.Core.Features.FileStorage.Domain;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Server.Features.FileStorage;
@@ -24,7 +22,7 @@ internal sealed class LocalFileStorage : ICloudFileStorage
     private readonly ConcurrentDictionary<string, HashSet<string>> _batchIndex;
     private readonly string _basePath;
     private readonly string _metadataPath;
-    private static readonly JsonSerializerOptions JsonOptions = new()
+    private static readonly JsonSerializerOptions _jsonOptions = new()
     {
         WriteIndented = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
@@ -77,7 +75,7 @@ internal sealed class LocalFileStorage : ICloudFileStorage
             long sizeBytes;
             await using (var fileStream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, true))
             {
-                using var hashAlgorithm = MD5.Create();
+                using var hashAlgorithm = SHA256.Create();
                 await using var cryptoStream = new CryptoStream(fileStream, hashAlgorithm, CryptoStreamMode.Write, leaveOpen: true);
 
                 await request.Content.CopyToAsync(cryptoStream, cancellationToken);
@@ -110,16 +108,19 @@ internal sealed class LocalFileStorage : ICloudFileStorage
             await SaveMetadataAsync(cloudFile, cancellationToken);
 
             stopwatch.Stop();
-            _logger.LogInformation(
-                "Uploaded file {FileName} ({SizeBytes} bytes) as {FileId} in {Duration}ms",
-                request.FileName, sizeBytes, fileId, stopwatch.ElapsedMilliseconds);
+            FileStorageLog.FileUploaded(
+                _logger,
+                request.FileName,
+                sizeBytes,
+                fileId,
+                stopwatch.ElapsedMilliseconds);
 
             return UploadResult.CreateSuccess(cloudFile, stopwatch.Elapsed);
         }
         catch (Exception ex)
         {
             stopwatch.Stop();
-            _logger.LogError(ex, "Failed to upload file {FileName}", request.FileName);
+            FileStorageLog.FileUploadFailed(_logger, ex, request.FileName);
             return UploadResult.CreateFailure(ex.Message, stopwatch.Elapsed);
         }
     }
@@ -156,7 +157,7 @@ internal sealed class LocalFileStorage : ICloudFileStorage
         var fullPath = Path.Combine(_basePath, cloudFile.StoragePath);
         if (!File.Exists(fullPath))
         {
-            _logger.LogWarning("File metadata exists but file not found on disk: {FileId}", fileId);
+            FileStorageLog.FileMissingOnDisk(_logger, fileId);
             return null;
         }
 
@@ -208,12 +209,12 @@ internal sealed class LocalFileStorage : ICloudFileStorage
                 batch.Value.Remove(fileId);
             }
 
-            _logger.LogInformation("Deleted file {FileId}", fileId);
+            FileStorageLog.FileDeleted(_logger, fileId);
             return true;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to delete file {FileId}", fileId);
+            FileStorageLog.FileDeleteFailed(_logger, ex, fileId);
             // Re-add to index since deletion failed
             _fileIndex[fileId] = cloudFile;
             return false;
@@ -300,7 +301,7 @@ internal sealed class LocalFileStorage : ICloudFileStorage
             }
         }
 
-        _logger.LogInformation("Deleted batch {BatchId} with {DeletedCount} files", batchId, deletedCount);
+        FileStorageLog.BatchDeleted(_logger, batchId, deletedCount);
         return deletedCount;
     }
 
@@ -403,7 +404,7 @@ internal sealed class LocalFileStorage : ICloudFileStorage
 
         if (cleanedCount > 0)
         {
-            _logger.LogInformation("Cleaned up {Count} expired files", cleanedCount);
+            FileStorageLog.ExpiredFilesCleaned(_logger, cleanedCount);
         }
 
         return cleanedCount;
@@ -414,7 +415,7 @@ internal sealed class LocalFileStorage : ICloudFileStorage
         if (_options.CreateDirectoryIfNotExists && !Directory.Exists(_basePath))
         {
             Directory.CreateDirectory(_basePath);
-            _logger.LogInformation("Created storage directory: {BasePath}", _basePath);
+            FileStorageLog.StorageDirectoryCreated(_logger, _basePath);
         }
 
         if (!Directory.Exists(_metadataPath))
@@ -439,7 +440,7 @@ internal sealed class LocalFileStorage : ICloudFileStorage
             try
             {
                 var json = File.ReadAllText(file);
-                var cloudFile = JsonSerializer.Deserialize<CloudFile>(json, JsonOptions);
+                var cloudFile = JsonSerializer.Deserialize<CloudFile>(json, _jsonOptions);
                 if (cloudFile is not null)
                 {
                     _fileIndex[cloudFile.FileId] = cloudFile;
@@ -447,27 +448,24 @@ internal sealed class LocalFileStorage : ICloudFileStorage
                     // Rebuild batch index
                     if (cloudFile.Metadata.TryGetValue("BatchId", out var batchId))
                     {
-                        if (!_batchIndex.ContainsKey(batchId))
-                        {
-                            _batchIndex[batchId] = new HashSet<string>();
-                        }
-                        _batchIndex[batchId].Add(cloudFile.FileId);
+                        var batchFiles = _batchIndex.GetOrAdd(batchId, _ => new HashSet<string>());
+                        batchFiles.Add(cloudFile.FileId);
                     }
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to load metadata from {File}", file);
+                FileStorageLog.MetadataLoadFailed(_logger, ex, file);
             }
         }
 
-        _logger.LogInformation("Loaded {Count} files from existing metadata", _fileIndex.Count);
+        FileStorageLog.MetadataLoaded(_logger, _fileIndex.Count);
     }
 
     private async Task SaveMetadataAsync(CloudFile cloudFile, CancellationToken cancellationToken)
     {
         var metadataFile = GetMetadataFilePath(cloudFile.FileId);
-        var json = JsonSerializer.Serialize(cloudFile, JsonOptions);
+        var json = JsonSerializer.Serialize(cloudFile, _jsonOptions);
         await File.WriteAllTextAsync(metadataFile, json, cancellationToken);
     }
 

--- a/tests/Honua.Core.Tests/Features/FileStorage/Domain/BatchUploadResultTests.cs
+++ b/tests/Honua.Core.Tests/Features/FileStorage/Domain/BatchUploadResultTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.FileStorage.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.FileStorage.Domain;
+
+/// <summary>
+/// Unit tests for BatchUploadResult domain model
+/// </summary>
+public class BatchUploadResultTests
+{
+    [UnitTest]
+    public void CreateSuccess_ShouldReturnSuccessfulBatchResult()
+    {
+        // Arrange
+        var batchId = "batch-123";
+        var files = new[]
+        {
+            CreateTestCloudFile("file1.shp"),
+            CreateTestCloudFile("file1.dbf"),
+            CreateTestCloudFile("file1.shx")
+        };
+        var duration = TimeSpan.FromSeconds(2);
+
+        // Act
+        var result = BatchUploadResult.CreateSuccess(batchId, files, duration);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.BatchId.Should().Be(batchId);
+        result.UploadedFiles.Should().HaveCount(3);
+        result.FailedFiles.Should().BeEmpty();
+        result.TotalFiles.Should().Be(3);
+        result.SuccessCount.Should().Be(3);
+        result.FailureCount.Should().Be(0);
+        result.Duration.Should().Be(duration);
+    }
+
+    [UnitTest]
+    public void CreatePartialSuccess_ShouldReturnPartialResult()
+    {
+        // Arrange
+        var batchId = "batch-456";
+        var successfulFiles = new[]
+        {
+            CreateTestCloudFile("file1.shp"),
+            CreateTestCloudFile("file1.dbf")
+        };
+        var failedFiles = new Dictionary<string, string>
+        {
+            ["file1.prj"] = "Permission denied"
+        };
+        var duration = TimeSpan.FromSeconds(1);
+
+        // Act
+        var result = BatchUploadResult.CreatePartialSuccess(batchId, successfulFiles, failedFiles, duration);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.BatchId.Should().Be(batchId);
+        result.UploadedFiles.Should().HaveCount(2);
+        result.FailedFiles.Should().HaveCount(1);
+        result.FailedFiles["file1.prj"].Should().Be("Permission denied");
+        result.TotalFiles.Should().Be(3);
+        result.SuccessCount.Should().Be(2);
+        result.FailureCount.Should().Be(1);
+        result.Duration.Should().Be(duration);
+    }
+
+    [UnitTest]
+    public void CreateFailure_ShouldReturnFailedResult()
+    {
+        // Arrange
+        var batchId = "batch-789";
+        var failedFiles = new Dictionary<string, string>
+        {
+            ["file1.shp"] = "Disk full",
+            ["file1.dbf"] = "Disk full"
+        };
+        var duration = TimeSpan.FromMilliseconds(500);
+
+        // Act
+        var result = BatchUploadResult.CreateFailure(batchId, failedFiles, duration);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.BatchId.Should().Be(batchId);
+        result.UploadedFiles.Should().BeEmpty();
+        result.FailedFiles.Should().HaveCount(2);
+        result.TotalFiles.Should().Be(2);
+        result.SuccessCount.Should().Be(0);
+        result.FailureCount.Should().Be(2);
+        result.Duration.Should().Be(duration);
+    }
+
+    private static CloudFile CreateTestCloudFile(string fileName) => new()
+    {
+        FileId = Guid.NewGuid().ToString("N"),
+        FileName = fileName,
+        StoragePath = $"batch/{fileName}",
+        ContentType = "application/octet-stream",
+        SizeBytes = 1024,
+        UploadedAt = DateTimeOffset.UtcNow,
+        Provider = CloudStorageProvider.Local
+    };
+}

--- a/tests/Honua.Core.Tests/Features/FileStorage/Domain/CloudFileTests.cs
+++ b/tests/Honua.Core.Tests/Features/FileStorage/Domain/CloudFileTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using FluentAssertions;
+using Honua.Core.Features.FileStorage.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.FileStorage.Domain;
+
+/// <summary>
+/// Unit tests for CloudFile domain model
+/// </summary>
+public class CloudFileTests
+{
+    [UnitTest]
+    public void CloudFile_Create_WithAllProperties_ShouldSetAllValues()
+    {
+        // Arrange
+        var uploadedAt = DateTimeOffset.UtcNow;
+        var expiresAt = uploadedAt.AddHours(24);
+        var metadata = ImmutableDictionary<string, string>.Empty
+            .Add("source", "test")
+            .Add("format", "geojson");
+
+        // Act
+        var cloudFile = new CloudFile
+        {
+            FileId = "test-file-123",
+            FileName = "test.geojson",
+            StoragePath = "uploads/test-file-123.geojson",
+            ContentType = "application/geo+json",
+            SizeBytes = 1024,
+            UploadedAt = uploadedAt,
+            ExpiresAt = expiresAt,
+            ContentHash = "ABC123",
+            Metadata = metadata,
+            Provider = CloudStorageProvider.Local
+        };
+
+        // Assert
+        cloudFile.FileId.Should().Be("test-file-123");
+        cloudFile.FileName.Should().Be("test.geojson");
+        cloudFile.StoragePath.Should().Be("uploads/test-file-123.geojson");
+        cloudFile.ContentType.Should().Be("application/geo+json");
+        cloudFile.SizeBytes.Should().Be(1024);
+        cloudFile.UploadedAt.Should().Be(uploadedAt);
+        cloudFile.ExpiresAt.Should().Be(expiresAt);
+        cloudFile.ContentHash.Should().Be("ABC123");
+        cloudFile.Metadata.Should().HaveCount(2);
+        cloudFile.Provider.Should().Be(CloudStorageProvider.Local);
+    }
+
+    [UnitTest]
+    public void CloudFile_Create_WithOptionalProperties_ShouldUseDefaults()
+    {
+        // Act
+        var cloudFile = new CloudFile
+        {
+            FileId = "test-file-456",
+            FileName = "test.shp",
+            StoragePath = "shapefiles/test-file-456.shp",
+            ContentType = "application/octet-stream",
+            SizeBytes = 2048,
+            UploadedAt = DateTimeOffset.UtcNow,
+            Provider = CloudStorageProvider.AwsS3
+        };
+
+        // Assert
+        cloudFile.ExpiresAt.Should().BeNull();
+        cloudFile.ContentHash.Should().BeNull();
+        cloudFile.Metadata.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public void CloudFile_Equality_WithSameValues_ShouldBeEqual()
+    {
+        // Arrange
+        var uploadedAt = DateTimeOffset.UtcNow;
+        var metadata = ImmutableDictionary<string, string>.Empty.Add("key", "value");
+
+        var file1 = new CloudFile
+        {
+            FileId = "same-id",
+            FileName = "file.json",
+            StoragePath = "path/file.json",
+            ContentType = "application/json",
+            SizeBytes = 100,
+            UploadedAt = uploadedAt,
+            Metadata = metadata,
+            Provider = CloudStorageProvider.Local
+        };
+
+        var file2 = new CloudFile
+        {
+            FileId = "same-id",
+            FileName = "file.json",
+            StoragePath = "path/file.json",
+            ContentType = "application/json",
+            SizeBytes = 100,
+            UploadedAt = uploadedAt,
+            Metadata = metadata,
+            Provider = CloudStorageProvider.Local
+        };
+
+        // Act & Assert
+        file1.Should().Be(file2);
+        (file1 == file2).Should().BeTrue();
+    }
+}

--- a/tests/Honua.Core.Tests/Features/FileStorage/Domain/UploadResultTests.cs
+++ b/tests/Honua.Core.Tests/Features/FileStorage/Domain/UploadResultTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.FileStorage.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.FileStorage.Domain;
+
+/// <summary>
+/// Unit tests for UploadResult domain model
+/// </summary>
+public class UploadResultTests
+{
+    [UnitTest]
+    public void CreateSuccess_ShouldReturnSuccessResult()
+    {
+        // Arrange
+        var duration = TimeSpan.FromMilliseconds(150);
+        var cloudFile = CreateTestCloudFile();
+
+        // Act
+        var result = UploadResult.CreateSuccess(cloudFile, duration);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.File.Should().Be(cloudFile);
+        result.ErrorMessage.Should().BeNull();
+        result.Duration.Should().Be(duration);
+    }
+
+    [UnitTest]
+    public void CreateFailure_ShouldReturnFailureResult()
+    {
+        // Arrange
+        var duration = TimeSpan.FromMilliseconds(50);
+        const string errorMessage = "File size exceeds maximum allowed";
+
+        // Act
+        var result = UploadResult.CreateFailure(errorMessage, duration);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.File.Should().BeNull();
+        result.ErrorMessage.Should().Be(errorMessage);
+        result.Duration.Should().Be(duration);
+    }
+
+    [UnitTest]
+    public void CreateSuccess_WithDefaultDuration_ShouldHaveZeroDuration()
+    {
+        // Arrange
+        var cloudFile = CreateTestCloudFile();
+
+        // Act
+        var result = UploadResult.CreateSuccess(cloudFile);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Duration.Should().Be(TimeSpan.Zero);
+    }
+
+    private static CloudFile CreateTestCloudFile() => new()
+    {
+        FileId = "test-123",
+        FileName = "test.geojson",
+        StoragePath = "test/test-123.geojson",
+        ContentType = "application/geo+json",
+        SizeBytes = 1024,
+        UploadedAt = DateTimeOffset.UtcNow,
+        Provider = CloudStorageProvider.Local
+    };
+}

--- a/tests/Honua.Server.Tests/Features/FileStorage/LocalFileStorageTests.cs
+++ b/tests/Honua.Server.Tests/Features/FileStorage/LocalFileStorageTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Immutable;
 using System.Text;
 using FluentAssertions;
-using Honua.Core.Features.FileStorage.Abstractions;
 using Honua.Core.Features.FileStorage.Domain;
 using Honua.Server.Features.FileStorage;
 using Honua.TestKit.Attributes;
@@ -20,7 +19,7 @@ namespace Honua.Server.Tests.Features.FileStorage;
 public class LocalFileStorageTests : IAsyncLifetime, IDisposable
 {
     private readonly string _testBasePath;
-    private readonly ICloudFileStorage _storage;
+    private readonly LocalFileStorage _storage;
     private bool _disposed;
 
     public LocalFileStorageTests()
@@ -422,7 +421,10 @@ public class LocalFileStorageTests : IAsyncLifetime, IDisposable
 
     public void Dispose()
     {
-        if (_disposed) return;
+        if (_disposed)
+        {
+            return;
+        }
 
         try
         {

--- a/tests/Honua.Server.Tests/Features/FileStorage/LocalFileStorageTests.cs
+++ b/tests/Honua.Server.Tests/Features/FileStorage/LocalFileStorageTests.cs
@@ -1,0 +1,442 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.FileStorage.Abstractions;
+using Honua.Core.Features.FileStorage.Domain;
+using Honua.Server.Features.FileStorage;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.FileStorage;
+
+/// <summary>
+/// Integration tests for LocalFileStorage implementation
+/// </summary>
+[Collection("Unit")]
+public class LocalFileStorageTests : IAsyncLifetime, IDisposable
+{
+    private readonly string _testBasePath;
+    private readonly ICloudFileStorage _storage;
+    private bool _disposed;
+
+    public LocalFileStorageTests()
+    {
+        _testBasePath = Path.Combine(Path.GetTempPath(), $"honua-test-{Guid.NewGuid():N}");
+        var options = Options.Create(new LocalStorageOptions
+        {
+            BasePath = _testBasePath,
+            CreateDirectoryIfNotExists = true
+        });
+        _storage = new LocalFileStorage(options, NullLogger<LocalFileStorage>.Instance);
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync()
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    [IntegrationTest]
+    public void Provider_ShouldReturnLocal()
+    {
+        // Assert
+        _storage.Provider.Should().Be(CloudStorageProvider.Local);
+    }
+
+    [IntegrationTest]
+    public async Task UploadAsync_WithStreamContent_ShouldCreateFile()
+    {
+        // Arrange
+        var content = "Hello, World! This is a test file."u8.ToArray();
+        using var stream = new MemoryStream(content);
+        var request = new FileUploadRequest
+        {
+            Content = stream,
+            FileName = "test.txt",
+            ContentType = "text/plain",
+            SizeBytes = content.Length
+        };
+
+        // Act
+        var result = await _storage.UploadAsync(request);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.File.Should().NotBeNull();
+        result.File!.FileName.Should().Be("test.txt");
+        result.File.ContentType.Should().Be("text/plain");
+        result.File.SizeBytes.Should().Be(content.Length);
+        result.File.ContentHash.Should().NotBeNullOrEmpty();
+        result.File.Provider.Should().Be(CloudStorageProvider.Local);
+    }
+
+    [IntegrationTest]
+    public async Task UploadAsync_WithByteArray_ShouldCreateFile()
+    {
+        // Arrange
+        var content = Encoding.UTF8.GetBytes("GeoJSON content here");
+        var request = new ByteArrayUploadRequest
+        {
+            Content = content,
+            FileName = "test.geojson",
+            ContentType = "application/geo+json"
+        };
+
+        // Act
+        var result = await _storage.UploadAsync(request);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.File.Should().NotBeNull();
+        result.File!.FileName.Should().Be("test.geojson");
+    }
+
+    [IntegrationTest]
+    public async Task DownloadAsync_ExistingFile_ShouldReturnContent()
+    {
+        // Arrange
+        var originalContent = "Test content for download";
+        var uploadResult = await UploadTestFileAsync(originalContent);
+
+        // Act
+        await using var stream = await _storage.DownloadAsync(uploadResult.File!.FileId);
+
+        // Assert
+        stream.Should().NotBeNull();
+        using var reader = new StreamReader(stream!);
+        var downloadedContent = await reader.ReadToEndAsync();
+        downloadedContent.Should().Be(originalContent);
+    }
+
+    [IntegrationTest]
+    public async Task DownloadAsync_NonExistingFile_ShouldReturnNull()
+    {
+        // Act
+        var stream = await _storage.DownloadAsync("non-existing-file-id");
+
+        // Assert
+        stream.Should().BeNull();
+    }
+
+    [IntegrationTest]
+    public async Task DownloadBytesAsync_ExistingFile_ShouldReturnBytes()
+    {
+        // Arrange
+        var originalContent = "Binary content test";
+        var uploadResult = await UploadTestFileAsync(originalContent);
+
+        // Act
+        var bytes = await _storage.DownloadBytesAsync(uploadResult.File!.FileId);
+
+        // Assert
+        bytes.Should().NotBeNull();
+        Encoding.UTF8.GetString(bytes!).Should().Be(originalContent);
+    }
+
+    [IntegrationTest]
+    public async Task DeleteAsync_ExistingFile_ShouldRemoveFile()
+    {
+        // Arrange
+        var uploadResult = await UploadTestFileAsync("To be deleted");
+
+        // Act
+        var deleted = await _storage.DeleteAsync(uploadResult.File!.FileId);
+
+        // Assert
+        deleted.Should().BeTrue();
+
+        var exists = await _storage.ExistsAsync(uploadResult.File.FileId);
+        exists.Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    public async Task DeleteAsync_NonExistingFile_ShouldReturnFalse()
+    {
+        // Act
+        var deleted = await _storage.DeleteAsync("non-existing-id");
+
+        // Assert
+        deleted.Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    public async Task UploadBatchAsync_MultipleFiles_ShouldUploadAll()
+    {
+        // Arrange
+        var files = new List<BatchFileItem>
+        {
+            CreateBatchFileItem("shapefile.shp", "application/octet-stream", "SHP content"),
+            CreateBatchFileItem("shapefile.dbf", "application/octet-stream", "DBF content"),
+            CreateBatchFileItem("shapefile.shx", "application/octet-stream", "SHX content")
+        };
+
+        var request = new BatchUploadRequest
+        {
+            Files = files,
+            Folder = "shapefiles"
+        };
+
+        // Act
+        var result = await _storage.UploadBatchAsync(request);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.UploadedFiles.Should().HaveCount(3);
+        result.FailedFiles.Should().BeEmpty();
+        result.TotalFiles.Should().Be(3);
+    }
+
+    [IntegrationTest]
+    public async Task DeleteBatchAsync_ExistingBatch_ShouldDeleteAllFiles()
+    {
+        // Arrange
+        var files = new List<BatchFileItem>
+        {
+            CreateBatchFileItem("file1.txt", "text/plain", "Content 1"),
+            CreateBatchFileItem("file2.txt", "text/plain", "Content 2")
+        };
+
+        var request = new BatchUploadRequest { Files = files };
+        var uploadResult = await _storage.UploadBatchAsync(request);
+
+        // Act
+        var deletedCount = await _storage.DeleteBatchAsync(uploadResult.BatchId);
+
+        // Assert
+        deletedCount.Should().Be(2);
+
+        foreach (var file in uploadResult.UploadedFiles)
+        {
+            var exists = await _storage.ExistsAsync(file.FileId);
+            exists.Should().BeFalse();
+        }
+    }
+
+    [IntegrationTest]
+    public async Task GetMetadataAsync_ExistingFile_ShouldReturnMetadata()
+    {
+        // Arrange
+        var content = Encoding.UTF8.GetBytes("Test");
+        var metadata = ImmutableDictionary<string, string>.Empty
+            .Add("source", "test")
+            .Add("format", "geojson");
+
+        using var stream = new MemoryStream(content);
+        var request = new FileUploadRequest
+        {
+            Content = stream,
+            FileName = "metadata-test.json",
+            ContentType = "application/json",
+            Metadata = metadata
+        };
+
+        var uploadResult = await _storage.UploadAsync(request);
+
+        // Act
+        var fileMetadata = await _storage.GetMetadataAsync(uploadResult.File!.FileId);
+
+        // Assert
+        fileMetadata.Should().NotBeNull();
+        fileMetadata!.FileName.Should().Be("metadata-test.json");
+        fileMetadata.Metadata.Should().ContainKey("source");
+        fileMetadata.Metadata["source"].Should().Be("test");
+    }
+
+    [IntegrationTest]
+    public async Task ExistsAsync_ExistingFile_ShouldReturnTrue()
+    {
+        // Arrange
+        var uploadResult = await UploadTestFileAsync("Test content");
+
+        // Act
+        var exists = await _storage.ExistsAsync(uploadResult.File!.FileId);
+
+        // Assert
+        exists.Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    public async Task ExistsAsync_NonExistingFile_ShouldReturnFalse()
+    {
+        // Act
+        var exists = await _storage.ExistsAsync("non-existing-id");
+
+        // Assert
+        exists.Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    public async Task ListFilesAsync_WithFiles_ShouldReturnFilesList()
+    {
+        // Arrange
+        await UploadTestFileAsync("File 1", "folder1");
+        await UploadTestFileAsync("File 2", "folder1");
+        await UploadTestFileAsync("File 3", "folder2");
+
+        // Act
+        var allFiles = await _storage.ListFilesAsync();
+        var folder1Files = await _storage.ListFilesAsync("folder1");
+
+        // Assert
+        allFiles.Should().HaveCountGreaterOrEqualTo(3);
+        folder1Files.Should().HaveCount(2);
+    }
+
+    [IntegrationTest]
+    public async Task GetPresignedUrlAsync_ExistingFile_ShouldReturnUrl()
+    {
+        // Arrange
+        var uploadResult = await UploadTestFileAsync("Test for presigned URL");
+
+        // Act
+        var url = await _storage.GetPresignedUrlAsync(uploadResult.File!.FileId);
+
+        // Assert
+        url.Should().NotBeNullOrEmpty();
+        url.Should().StartWith("file:///");
+    }
+
+    [IntegrationTest]
+    public async Task GetPresignedUploadUrlAsync_ShouldReturnUrlAndFileId()
+    {
+        // Act
+        var result = await _storage.GetPresignedUploadUrlAsync(
+            "future-file.json",
+            "application/json");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Value.Url.Should().NotBeNullOrEmpty();
+        result.Value.FileId.Should().NotBeNullOrEmpty();
+    }
+
+    [IntegrationTest]
+    public async Task UploadAsync_WithTimeToLive_ShouldSetExpiration()
+    {
+        // Arrange
+        var ttl = TimeSpan.FromHours(1);
+        var content = Encoding.UTF8.GetBytes("Temporary file");
+        using var stream = new MemoryStream(content);
+
+        var request = new FileUploadRequest
+        {
+            Content = stream,
+            FileName = "temp.txt",
+            ContentType = "text/plain",
+            TimeToLive = ttl
+        };
+
+        // Act
+        var result = await _storage.UploadAsync(request);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.File!.ExpiresAt.Should().NotBeNull();
+        result.File.ExpiresAt.Should().BeCloseTo(
+            DateTimeOffset.UtcNow.Add(ttl),
+            TimeSpan.FromMinutes(1));
+    }
+
+    [IntegrationTest]
+    public async Task CleanupExpiredFilesAsync_WithExpiredFiles_ShouldRemoveThem()
+    {
+        // Arrange - Create a file with very short TTL
+        var content = Encoding.UTF8.GetBytes("Expiring soon");
+        using var stream = new MemoryStream(content);
+
+        var request = new FileUploadRequest
+        {
+            Content = stream,
+            FileName = "expiring.txt",
+            ContentType = "text/plain",
+            TimeToLive = TimeSpan.FromMilliseconds(1) // Very short TTL
+        };
+
+        var uploadResult = await _storage.UploadAsync(request);
+        await Task.Delay(50); // Wait for file to expire
+
+        // Act
+        var cleanedCount = await _storage.CleanupExpiredFilesAsync();
+
+        // Assert
+        cleanedCount.Should().BeGreaterOrEqualTo(1);
+
+        var exists = await _storage.ExistsAsync(uploadResult.File!.FileId);
+        exists.Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    public async Task UploadAsync_WithFolder_ShouldOrganizeCorrectly()
+    {
+        // Arrange
+        var content = Encoding.UTF8.GetBytes("Organized file");
+        using var stream = new MemoryStream(content);
+
+        var request = new FileUploadRequest
+        {
+            Content = stream,
+            FileName = "organized.txt",
+            ContentType = "text/plain",
+            Folder = "imports/2024"
+        };
+
+        // Act
+        var result = await _storage.UploadAsync(request);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.File!.StoragePath.Should().Contain("imports");
+    }
+
+    private async Task<UploadResult> UploadTestFileAsync(string content, string? folder = null)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        using var stream = new MemoryStream(bytes);
+
+        var request = new FileUploadRequest
+        {
+            Content = stream,
+            FileName = $"test-{Guid.NewGuid():N}.txt",
+            ContentType = "text/plain",
+            Folder = folder
+        };
+
+        return await _storage.UploadAsync(request);
+    }
+
+    private static BatchFileItem CreateBatchFileItem(string fileName, string contentType, string content)
+    {
+        return new BatchFileItem
+        {
+            Content = new MemoryStream(Encoding.UTF8.GetBytes(content)),
+            FileName = fileName,
+            ContentType = contentType
+        };
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        try
+        {
+            if (Directory.Exists(_testBasePath))
+            {
+                Directory.Delete(_testBasePath, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best effort cleanup
+        }
+
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #207

## Summary
Add cloud file storage abstraction with a local provider, metadata persistence, batch upload, and cleanup support.

## Changes Made
- add file storage domain models and interface for uploads, metadata, cleanup, and batches
- implement local provider with SHA-256 hashing, metadata persistence, batch rollback, and cleanup
- add DI registration and background cleanup service
- add tests for domain models and LocalFileStorage

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)

## Coverage Impact
- Line coverage: not measured locally (coverage artifacts generated by pre-PR)
- Branch coverage: not measured locally (coverage artifacts generated by pre-PR)

## Breaking Changes
None

## Additional Context
Cloud provider implementations remain TODO; follow-up tickets can add emulator-backed integration tests (LocalStack/Azurite/GCS).

---

## Pre-PR Checklist (for contributor)
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit message follows format: `type: description (#issue-number)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] Documentation updated if needed

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed