### PR TITLE
feat: postgis connection management ui (#26)

### DIFF
--- a/docs/ADMIN_UI.md
+++ b/docs/ADMIN_UI.md
@@ -70,6 +70,19 @@ dotnet run --project src/Honua.Server
 Then open `http://localhost:8080/admin/` (integrated) or run the Admin UI
 standalone via `dotnet run --project src/Honua.Admin`.
 
+## Connections
+
+Use the Connections page to manage secure PostGIS connections. Provide the host,
+port, database, and username, then choose one credential mode:
+
+- **Managed (encrypted)**: supply a password; it is encrypted and stored server-side.
+- **External secret**: supply a secret reference (for example
+  `aws:secretsmanager:prod-db`) and a secret type.
+
+Use **Save & Test** (or the row-level test action) to validate connectivity.
+External secret references cannot be edited in place; delete and recreate the
+connection to update the reference.
+
 ## Tests
 
 ### bUnit

--- a/src/Honua.Admin/Components/Connections/ConnectionForm.razor
+++ b/src/Honua.Admin/Components/Connections/ConnectionForm.razor
@@ -1,0 +1,205 @@
+<EditForm EditContext="_editContext">
+    <DataAnnotationsValidator />
+    <MudForm @ref="_form">
+        <MudStack Spacing="3">
+            <MudGrid>
+                <MudItem xs="12" md="6">
+                    <MudTextField @bind-Value="Model.Name"
+                                  Label="Connection name"
+                                  Required="true"
+                                  Disabled="@Model.IsEdit"
+                                  For="@(() => Model.Name)" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField @bind-Value="Model.Description"
+                                  Label="Description"
+                                  Lines="2"
+                                  For="@(() => Model.Description)" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField @bind-Value="Model.Host"
+                                  Label="Host"
+                                  Required="true"
+                                  For="@(() => Model.Host)" />
+                </MudItem>
+                <MudItem xs="12" md="3">
+                    <MudNumericField T="int" @bind-Value="Model.Port"
+                                     Label="Port"
+                                     Required="true"
+                                     For="@(() => Model.Port)" />
+                </MudItem>
+                <MudItem xs="12" md="3">
+                    <MudTextField @bind-Value="Model.DatabaseName"
+                                  Label="Database"
+                                  Required="true"
+                                  For="@(() => Model.DatabaseName)" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField @bind-Value="Model.Username"
+                                  Label="Username"
+                                  Required="true"
+                                  For="@(() => Model.Username)" />
+                </MudItem>
+            </MudGrid>
+
+            <MudPaper Class="pa-3" Elevation="0">
+                <MudText Typo="Typo.subtitle2" Class="mb-2">Credentials</MudText>
+                <MudRadioGroup T="bool" @bind-Value="Model.UseSecretReference" Disabled="@Model.CredentialModeLocked">
+                    <MudRadio T="bool" Value="false">Managed (encrypted)</MudRadio>
+                    <MudRadio T="bool" Value="true">External secret</MudRadio>
+                </MudRadioGroup>
+                @if (Model.CredentialModeLocked)
+                {
+                    <MudText Typo="Typo.caption" Class="mt-1">Credential mode cannot be changed for existing connections.</MudText>
+                }
+
+                @if (Model.UseSecretReference)
+                {
+                    <MudGrid Class="mt-2">
+                        <MudItem xs="12" md="8">
+                            <MudTextField @bind-Value="Model.SecretReference"
+                                          Label="Secret reference"
+                                          Required="@(!Model.IsEdit)"
+                                          Disabled="@Model.CredentialModeLocked"
+                                          Placeholder="aws:secretsmanager:prod-db"
+                                          For="@(() => Model.SecretReference)" />
+                        </MudItem>
+                        <MudItem xs="12" md="4">
+                            <MudTextField @bind-Value="Model.SecretType"
+                                          Label="Secret type"
+                                          Required="@(!Model.IsEdit)"
+                                          Disabled="@Model.CredentialModeLocked"
+                                          Placeholder="aws / azure / env"
+                                          For="@(() => Model.SecretType)" />
+                        </MudItem>
+                    </MudGrid>
+                    <MudText Typo="Typo.caption" Class="mt-1">Secret values are resolved at runtime. Update references by deleting and recreating the connection.</MudText>
+                }
+                else
+                {
+                    <MudGrid Class="mt-2">
+                        <MudItem xs="12" md="6">
+                            <MudTextField @bind-Value="Model.Password"
+                                          Label="Password"
+                                          InputType="InputType.Password"
+                                          Required="@(!Model.IsEdit)"
+                                          For="@(() => Model.Password)" />
+                            @if (Model.IsEdit)
+                            {
+                                <MudText Typo="Typo.caption">Leave blank to keep the existing password.</MudText>
+                            }
+                        </MudItem>
+                    </MudGrid>
+                }
+            </MudPaper>
+
+            <MudPaper Class="pa-3" Elevation="0">
+                <MudText Typo="Typo.subtitle2" Class="mb-2">Security</MudText>
+                <MudGrid>
+                    <MudItem xs="12" md="4">
+                        <MudSwitch T="bool" @bind-Value="Model.SslRequired" Color="Color.Primary" Label="Require SSL" />
+                    </MudItem>
+                    <MudItem xs="12" md="4">
+                        <MudSelect T="string" @bind-Value="Model.SslMode" Label="SSL mode" Required="true" For="@(() => Model.SslMode)">
+                            @foreach (var mode in _sslModes)
+                            {
+                                <MudSelectItem Value="@mode" Disabled="@(Model.SslRequired && mode == "Disable")">@mode</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudItem>
+                </MudGrid>
+                <MudText Typo="Typo.caption" Class="mt-1">Passwords are encrypted and stored server-side. API responses never expose credentials.</MudText>
+            </MudPaper>
+
+            <MudPaper Class="pa-3" Elevation="0">
+                <MudText Typo="Typo.subtitle2" Class="mb-2">Connection string preview</MudText>
+                <MudTextField Value="@BuildPreview()" ReadOnly="true" Lines="2" Variant="Variant.Outlined" />
+            </MudPaper>
+
+            <ValidationSummary />
+
+            <MudStack Row="true" Spacing="2" Justify="Justify.FlexEnd">
+                <MudButton Variant="Variant.Text" OnClick="OnCancel" Disabled="@IsBusy">Cancel</MudButton>
+                <MudButton Variant="Variant.Outlined" Color="Color.Primary" OnClick="() => SubmitAsync(true)" Disabled="@IsBusy">Save &amp; Test</MudButton>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="() => SubmitAsync(false)" Disabled="@IsBusy" data-testid="connection-save">Save</MudButton>
+            </MudStack>
+        </MudStack>
+    </MudForm>
+</EditForm>
+
+@code {
+    private static readonly string[] _sslModes =
+    [
+        "Disable",
+        "Allow",
+        "Prefer",
+        "Require",
+        "VerifyCA",
+        "VerifyFull"
+    ];
+
+    private MudForm? _form;
+    private EditContext? _editContext;
+
+    [Parameter, EditorRequired]
+    public ConnectionFormModel Model { get; set; } = new();
+
+    [Parameter]
+    public bool IsBusy { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> OnSubmit { get; set; }
+
+    [Parameter]
+    public EventCallback OnCancel { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        if (_editContext == null || !ReferenceEquals(_editContext.Model, Model))
+        {
+            _editContext = new EditContext(Model);
+        }
+    }
+
+    private async Task SubmitAsync(bool runTest)
+    {
+        if (_form is null)
+        {
+            return;
+        }
+
+        var editContextValid = _editContext?.Validate() ?? false;
+        await _form.Validate();
+
+        if (_form.IsValid && editContextValid)
+        {
+            await OnSubmit.InvokeAsync(runTest);
+        }
+    }
+
+    private string BuildPreview()
+    {
+        if (string.IsNullOrWhiteSpace(Model.Host) ||
+            string.IsNullOrWhiteSpace(Model.DatabaseName) ||
+            string.IsNullOrWhiteSpace(Model.Username))
+        {
+            return "Complete the required fields to preview the connection string.";
+        }
+
+        var credential = Model.UseSecretReference
+            ? "Password=<secret reference>"
+            : string.IsNullOrWhiteSpace(Model.Password)
+                ? "Password=<hidden>"
+                : "Password=********";
+
+        return string.Join("; ", new[]
+        {
+            $"Host={Model.Host}",
+            $"Port={Model.Port}",
+            $"Database={Model.DatabaseName}",
+            $"Username={Model.Username}",
+            credential,
+            $"SslMode={Model.SslMode}"
+        });
+    }
+}

--- a/src/Honua.Admin/Components/Connections/ConnectionFormModel.cs
+++ b/src/Honua.Admin/Components/Connections/ConnectionFormModel.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+using Honua.Admin.Models;
+
+namespace Honua.Admin.Components.Connections;
+
+public sealed class ConnectionFormModel : IValidatableObject
+{
+    [Required]
+    [StringLength(64, MinimumLength = 1)]
+    public string Name { get; set; } = string.Empty;
+
+    [StringLength(1000)]
+    public string? Description { get; set; }
+
+    [Required]
+    [StringLength(255, MinimumLength = 1)]
+    public string Host { get; set; } = string.Empty;
+
+    [Range(1, 65535)]
+    public int Port { get; set; } = 5432;
+
+    [Required]
+    [StringLength(64, MinimumLength = 1)]
+    public string DatabaseName { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(64, MinimumLength = 1)]
+    public string Username { get; set; } = string.Empty;
+
+    [StringLength(255)]
+    public string? Password { get; set; }
+
+    [StringLength(255)]
+    public string? SecretReference { get; set; }
+
+    [StringLength(32)]
+    public string? SecretType { get; set; }
+
+    public bool SslRequired { get; set; } = true;
+
+    [Required]
+    public string SslMode { get; set; } = "Require";
+
+    public bool UseSecretReference { get; set; }
+
+    public bool IsEdit { get; set; }
+
+    public bool CredentialModeLocked { get; set; }
+
+    public Guid? ConnectionId { get; set; }
+
+    public static ConnectionFormModel CreateNew() => new();
+
+    public static ConnectionFormModel FromDetail(SecureConnectionDetail detail)
+    {
+        var usesSecret = string.Equals(detail.StorageType, "external", StringComparison.OrdinalIgnoreCase);
+
+        return new ConnectionFormModel
+        {
+            ConnectionId = detail.ConnectionId,
+            Name = detail.Name,
+            Description = detail.Description,
+            Host = detail.Host,
+            Port = detail.Port,
+            DatabaseName = detail.DatabaseName,
+            Username = detail.Username,
+            SslRequired = detail.SslRequired,
+            SslMode = detail.SslMode,
+            UseSecretReference = usesSecret,
+            CredentialModeLocked = true,
+            SecretReference = detail.CredentialReference,
+            IsEdit = true
+        };
+    }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (SslRequired && string.Equals(SslMode, "Disable", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return new ValidationResult(
+                "SSL mode cannot be Disable when SSL is required.",
+                new[] { nameof(SslMode) });
+        }
+
+        if (!IsEdit)
+        {
+            if (UseSecretReference)
+            {
+                if (string.IsNullOrWhiteSpace(SecretReference))
+                {
+                    yield return new ValidationResult(
+                        "Secret reference is required.",
+                        new[] { nameof(SecretReference) });
+                }
+
+                if (string.IsNullOrWhiteSpace(SecretType))
+                {
+                    yield return new ValidationResult(
+                        "Secret type is required.",
+                        new[] { nameof(SecretType) });
+                }
+            }
+            else if (string.IsNullOrWhiteSpace(Password))
+            {
+                yield return new ValidationResult(
+                    "Password is required.",
+                    new[] { nameof(Password) });
+            }
+        }
+        else if (UseSecretReference && string.IsNullOrWhiteSpace(SecretReference))
+        {
+            yield return new ValidationResult(
+                "Secret reference is required.",
+                new[] { nameof(SecretReference) });
+        }
+    }
+}

--- a/src/Honua.Admin/Models/ApiResponse.cs
+++ b/src/Honua.Admin/Models/ApiResponse.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Admin.Models;
+
+internal sealed class ApiResponse<T>
+{
+    public bool Success { get; init; }
+
+    public T? Data { get; init; }
+
+    public string? Message { get; init; }
+
+    public DateTimeOffset Timestamp { get; init; }
+}

--- a/src/Honua.Admin/Models/SecureConnectionModels.cs
+++ b/src/Honua.Admin/Models/SecureConnectionModels.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Admin.Models;
+
+public sealed record SecureConnectionSummary
+{
+    public Guid ConnectionId { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public string Host { get; init; } = string.Empty;
+    public int Port { get; init; }
+    public string DatabaseName { get; init; } = string.Empty;
+    public string Username { get; init; } = string.Empty;
+    public bool SslRequired { get; init; }
+    public string SslMode { get; init; } = string.Empty;
+    public string StorageType { get; init; } = string.Empty;
+    public bool IsActive { get; init; }
+    public string HealthStatus { get; init; } = string.Empty;
+    public DateTimeOffset? LastHealthCheck { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
+    public string CreatedBy { get; init; } = string.Empty;
+}
+
+public sealed record SecureConnectionDetail
+{
+    public Guid ConnectionId { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public string Host { get; init; } = string.Empty;
+    public int Port { get; init; }
+    public string DatabaseName { get; init; } = string.Empty;
+    public string Username { get; init; } = string.Empty;
+    public bool SslRequired { get; init; }
+    public string SslMode { get; init; } = string.Empty;
+    public string StorageType { get; init; } = string.Empty;
+    public string? CredentialReference { get; init; }
+    public int EncryptionVersion { get; init; }
+    public bool IsActive { get; init; }
+    public string HealthStatus { get; init; } = string.Empty;
+    public DateTimeOffset? LastHealthCheck { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
+    public string CreatedBy { get; init; } = string.Empty;
+}
+
+public sealed record CreateSecureConnectionRequest
+{
+    public string Name { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public string Host { get; init; } = string.Empty;
+    public int Port { get; init; }
+    public string DatabaseName { get; init; } = string.Empty;
+    public string Username { get; init; } = string.Empty;
+    public string? Password { get; init; }
+    public string? SecretReference { get; init; }
+    public string? SecretType { get; init; }
+    public bool SslRequired { get; init; }
+    public string SslMode { get; init; } = string.Empty;
+}
+
+public sealed record UpdateSecureConnectionRequest
+{
+    public string? Description { get; init; }
+    public string? Host { get; init; }
+    public int? Port { get; init; }
+    public string? DatabaseName { get; init; }
+    public string? Username { get; init; }
+    public string? Password { get; init; }
+    public bool? SslRequired { get; init; }
+    public string? SslMode { get; init; }
+    public bool? IsActive { get; init; }
+}
+
+public sealed record ConnectionTestResult
+{
+    public Guid ConnectionId { get; init; }
+    public string ConnectionName { get; init; } = string.Empty;
+    public bool IsHealthy { get; init; }
+    public DateTimeOffset TestedAt { get; init; }
+    public string? Message { get; init; }
+}

--- a/src/Honua.Admin/Pages/Connections.razor
+++ b/src/Honua.Admin/Pages/Connections.razor
@@ -1,15 +1,383 @@
-﻿@page "/connections"
+@page "/connections"
+@using System.Globalization
+
+@inject ISecureConnectionsClient ConnectionsClient
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
 
 <PageTitle>Connections</PageTitle>
 
-<MudText Typo="Typo.h4" Class="mb-2">Connections</MudText>
-<MudText Typo="Typo.body2" Class="mb-4">
-    Manage secure database connections and validate connectivity.
-</MudText>
+<MudStack Spacing="2">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+        <MudText Typo="Typo.h4">Connections</MudText>
+        <MudButton StartIcon="@Icons.Material.Filled.Add"
+                   Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   OnClick="StartCreate"
+                   data-testid="connections-add">
+            Add connection
+        </MudButton>
+    </MudStack>
 
-<MudPaper Class="pa-4" Elevation="1">
-    <MudText Typo="Typo.subtitle2">Coming soon</MudText>
     <MudText Typo="Typo.body2">
-        Connection management UI will land with issue #26.
+        Manage secure database connections and validate connectivity.
     </MudText>
-</MudPaper>
+
+    @if (!string.IsNullOrWhiteSpace(_errorMessage))
+    {
+        <MudAlert Severity="Severity.Error" Dense="true">@_errorMessage</MudAlert>
+    }
+
+    <MudCollapse Expanded="@_showForm">
+        <MudPaper Class="pa-4">
+            <MudText Typo="Typo.h6" Class="mb-2">@(_isEdit ? "Edit connection" : "New connection")</MudText>
+            @if (_formModel is not null)
+            {
+                <ConnectionForm Model="_formModel" IsBusy="_isSaving" OnSubmit="HandleSubmitAsync" OnCancel="CancelForm" />
+            }
+        </MudPaper>
+    </MudCollapse>
+
+    <MudPaper Class="pa-2">
+        @if (_isLoading)
+        {
+            <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+        }
+        <MudTable Items="_connections" Dense="true" Hover="true">
+            <HeaderContent>
+                <MudTh>Name</MudTh>
+                <MudTh>Host</MudTh>
+                <MudTh>Database</MudTh>
+                <MudTh>User</MudTh>
+                <MudTh>Storage</MudTh>
+                <MudTh>SSL</MudTh>
+                <MudTh>Status</MudTh>
+                <MudTh>Last check</MudTh>
+                <MudTh></MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Name">@context.Name</MudTd>
+                <MudTd DataLabel="Host">@($"{context.Host}:{context.Port}")</MudTd>
+                <MudTd DataLabel="Database">@context.DatabaseName</MudTd>
+                <MudTd DataLabel="User">@context.Username</MudTd>
+                <MudTd DataLabel="Storage">
+                    <MudChip T="string" Color="@GetStorageColor(context.StorageType)" Size="Size.Small" Variant="Variant.Outlined">
+                        @context.StorageType
+                    </MudChip>
+                </MudTd>
+                <MudTd DataLabel="SSL">@context.SslMode</MudTd>
+                <MudTd DataLabel="Status">
+                    <MudChip T="string" Color="@GetHealthColor(context.HealthStatus)" Size="Size.Small">@context.HealthStatus</MudChip>
+                </MudTd>
+                <MudTd DataLabel="Last check">@FormatTimestamp(context.LastHealthCheck)</MudTd>
+                <MudTd Style="text-align: right;">
+                    <MudTooltip Text="Test connection">
+                        <MudIconButton Icon="@Icons.Material.Filled.Sync"
+                                       OnClick="@(() => TestConnectionAsync(context))"
+                                       Disabled="@IsTesting(context.ConnectionId)" />
+                    </MudTooltip>
+                    <MudTooltip Text="Edit">
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit"
+                                       OnClick="@(() => EditConnectionAsync(context))"
+                                       Disabled="@_isSaving" />
+                    </MudTooltip>
+                    <MudTooltip Text="Delete">
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                       Color="Color.Error"
+                                       OnClick="@(() => DeleteConnectionAsync(context))"
+                                       Disabled="@_isSaving" />
+                    </MudTooltip>
+                </MudTd>
+            </RowTemplate>
+            <NoRecordsContent>
+                <MudText Typo="Typo.body2" Class="pa-4">No connections configured yet.</MudText>
+            </NoRecordsContent>
+        </MudTable>
+    </MudPaper>
+</MudStack>
+
+@code {
+    private readonly List<SecureConnectionSummary> _connections = new();
+    private readonly HashSet<Guid> _testingConnections = new();
+    private ConnectionFormModel? _formModel;
+    private bool _showForm;
+    private bool _isEdit;
+    private bool _isLoading;
+    private bool _isSaving;
+    private string? _errorMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadConnectionsAsync();
+    }
+
+    private async Task LoadConnectionsAsync()
+    {
+        _isLoading = true;
+        _errorMessage = null;
+        StateHasChanged();
+
+        var result = await ConnectionsClient.GetConnectionsAsync();
+        if (result.Success)
+        {
+            _connections.Clear();
+            _connections.AddRange(result.Data ?? Array.Empty<SecureConnectionSummary>());
+        }
+        else
+        {
+            _errorMessage = result.Message ?? "Failed to load connections.";
+        }
+
+        _isLoading = false;
+    }
+
+    private void StartCreate()
+    {
+        _formModel = ConnectionFormModel.CreateNew();
+        _formModel.IsEdit = false;
+        _formModel.CredentialModeLocked = false;
+        _isEdit = false;
+        _showForm = true;
+    }
+
+    private void CancelForm()
+    {
+        _showForm = false;
+        _formModel = null;
+        _isEdit = false;
+    }
+
+    private async Task EditConnectionAsync(SecureConnectionSummary summary)
+    {
+        _isSaving = true;
+        _errorMessage = null;
+        try
+        {
+            var detailResult = await ConnectionsClient.GetConnectionAsync(summary.ConnectionId);
+            if (!detailResult.Success || detailResult.Data is null)
+            {
+                Snackbar.Add(detailResult.Message ?? "Unable to load connection details.", Severity.Error);
+                return;
+            }
+
+            _formModel = ConnectionFormModel.FromDetail(detailResult.Data);
+            _isEdit = true;
+            _showForm = true;
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private async Task HandleSubmitAsync(bool runTest)
+    {
+        if (_formModel is null)
+        {
+            return;
+        }
+
+        _isSaving = true;
+        try
+        {
+            if (_formModel.IsEdit && _formModel.ConnectionId.HasValue)
+            {
+                var updateRequest = new UpdateSecureConnectionRequest
+                {
+                    Description = _formModel.Description,
+                    Host = _formModel.Host,
+                    Port = _formModel.Port,
+                    DatabaseName = _formModel.DatabaseName,
+                    Username = _formModel.Username,
+                    Password = string.IsNullOrWhiteSpace(_formModel.Password) ? null : _formModel.Password,
+                    SslRequired = _formModel.SslRequired,
+                    SslMode = _formModel.SslMode
+                };
+
+                var updateResult = await ConnectionsClient.UpdateConnectionAsync(_formModel.ConnectionId.Value, updateRequest);
+                if (!updateResult.Success || updateResult.Data is null)
+                {
+                    Snackbar.Add(updateResult.Message ?? "Failed to update connection.", Severity.Error);
+                    return;
+                }
+
+                UpsertConnection(updateResult.Data);
+                Snackbar.Add("Connection updated.", Severity.Success);
+
+                if (runTest)
+                {
+                    await TestConnectionAsync(updateResult.Data);
+                }
+            }
+            else
+            {
+                var createRequest = new CreateSecureConnectionRequest
+                {
+                    Name = _formModel.Name,
+                    Description = _formModel.Description,
+                    Host = _formModel.Host,
+                    Port = _formModel.Port,
+                    DatabaseName = _formModel.DatabaseName,
+                    Username = _formModel.Username,
+                    Password = _formModel.UseSecretReference ? null : _formModel.Password,
+                    SecretReference = _formModel.UseSecretReference ? _formModel.SecretReference : null,
+                    SecretType = _formModel.UseSecretReference ? _formModel.SecretType : null,
+                    SslRequired = _formModel.SslRequired,
+                    SslMode = _formModel.SslMode
+                };
+
+                if (runTest)
+                {
+                    var draftHealthy = await TestDraftConnectionAsync(createRequest);
+                    if (!draftHealthy)
+                    {
+                        return;
+                    }
+                }
+
+                var createResult = await ConnectionsClient.CreateConnectionAsync(createRequest);
+                if (!createResult.Success || createResult.Data is null)
+                {
+                    Snackbar.Add(createResult.Message ?? "Failed to create connection.", Severity.Error);
+                    return;
+                }
+
+                UpsertConnection(createResult.Data);
+                Snackbar.Add("Connection created.", Severity.Success);
+
+                if (runTest)
+                {
+                    await TestConnectionAsync(createResult.Data);
+                }
+            }
+
+            _showForm = false;
+            _formModel = null;
+            _isEdit = false;
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private async Task DeleteConnectionAsync(SecureConnectionSummary summary)
+    {
+        var confirm = await DialogService.ShowMessageBox(
+            "Delete connection",
+            $"Delete connection '{summary.Name}'? This cannot be undone.",
+            yesText: "Delete",
+            cancelText: "Cancel");
+
+        if (confirm != true)
+        {
+            return;
+        }
+
+        _isSaving = true;
+        try
+        {
+            var result = await ConnectionsClient.DeleteConnectionAsync(summary.ConnectionId);
+            if (!result.Success)
+            {
+                Snackbar.Add(result.Message ?? "Failed to delete connection.", Severity.Error);
+                return;
+            }
+
+            _connections.RemoveAll(connection => connection.ConnectionId == summary.ConnectionId);
+            Snackbar.Add("Connection deleted.", Severity.Success);
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private async Task TestConnectionAsync(SecureConnectionSummary summary)
+    {
+        if (!_testingConnections.Add(summary.ConnectionId))
+        {
+            return;
+        }
+
+        try
+        {
+            var result = await ConnectionsClient.TestConnectionAsync(summary.ConnectionId);
+            if (!result.Success || result.Data is null)
+            {
+                Snackbar.Add(result.Message ?? "Connection test failed.", Severity.Error);
+                return;
+            }
+
+            var status = result.Data.IsHealthy ? "Healthy" : "Unhealthy";
+            var updated = summary with
+            {
+                HealthStatus = status,
+                LastHealthCheck = result.Data.TestedAt
+            };
+
+            UpsertConnection(updated);
+            Snackbar.Add(result.Data.Message ?? "Connection test completed.",
+                result.Data.IsHealthy ? Severity.Success : Severity.Error);
+        }
+        finally
+        {
+            _testingConnections.Remove(summary.ConnectionId);
+        }
+    }
+
+    private async Task<bool> TestDraftConnectionAsync(CreateSecureConnectionRequest request)
+    {
+        var result = await ConnectionsClient.TestDraftConnectionAsync(request);
+        if (!result.Success || result.Data is null)
+        {
+            Snackbar.Add(result.Message ?? "Connection test failed.", Severity.Error);
+            return false;
+        }
+
+        Snackbar.Add(result.Data.Message ?? "Connection test completed.",
+            result.Data.IsHealthy ? Severity.Success : Severity.Error);
+
+        return result.Data.IsHealthy;
+    }
+
+    private void UpsertConnection(SecureConnectionSummary summary)
+    {
+        var index = _connections.FindIndex(connection => connection.ConnectionId == summary.ConnectionId);
+        if (index >= 0)
+        {
+            _connections[index] = summary;
+        }
+        else
+        {
+            _connections.Add(summary);
+        }
+
+        _connections.Sort((left, right) => string.Compare(left.Name, right.Name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string FormatTimestamp(DateTimeOffset? timestamp)
+    {
+        if (!timestamp.HasValue)
+        {
+            return "Never";
+        }
+
+        return timestamp.Value.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+    }
+
+    private static Color GetStorageColor(string storageType)
+        => string.Equals(storageType, "external", StringComparison.OrdinalIgnoreCase)
+            ? Color.Secondary
+            : Color.Primary;
+
+    private static Color GetHealthColor(string status)
+        => status switch
+        {
+            "Healthy" => Color.Success,
+            "Unhealthy" => Color.Error,
+            _ => Color.Warning
+        };
+
+    private bool IsTesting(Guid connectionId) => _testingConnections.Contains(connectionId);
+}

--- a/src/Honua.Admin/Program.cs
+++ b/src/Honua.Admin/Program.cs
@@ -39,5 +39,6 @@ builder.Services.AddHttpClient("AdminApi", (sp, client) =>
 
 builder.Services.AddScoped(sp =>
     new HonuaApiClient(sp.GetRequiredService<IHttpClientFactory>().CreateClient("AdminApi")));
+builder.Services.AddScoped<ISecureConnectionsClient, SecureConnectionsClient>();
 
 await builder.Build().RunAsync();

--- a/src/Honua.Admin/Services/SecureConnectionsClient.cs
+++ b/src/Honua.Admin/Services/SecureConnectionsClient.cs
@@ -1,0 +1,171 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using Honua.Admin.Models;
+
+namespace Honua.Admin.Services;
+
+public interface ISecureConnectionsClient
+{
+    Task<ApiResult<IReadOnlyList<SecureConnectionSummary>>> GetConnectionsAsync(CancellationToken cancellationToken = default);
+    Task<ApiResult<SecureConnectionDetail>> GetConnectionAsync(Guid connectionId, CancellationToken cancellationToken = default);
+    Task<ApiResult<SecureConnectionSummary>> CreateConnectionAsync(CreateSecureConnectionRequest request, CancellationToken cancellationToken = default);
+    Task<ApiResult<ConnectionTestResult>> TestDraftConnectionAsync(CreateSecureConnectionRequest request, CancellationToken cancellationToken = default);
+    Task<ApiResult<SecureConnectionSummary>> UpdateConnectionAsync(Guid connectionId, UpdateSecureConnectionRequest request, CancellationToken cancellationToken = default);
+    Task<ApiResult<bool>> DeleteConnectionAsync(Guid connectionId, CancellationToken cancellationToken = default);
+    Task<ApiResult<ConnectionTestResult>> TestConnectionAsync(Guid connectionId, CancellationToken cancellationToken = default);
+}
+
+public sealed record ApiResult<T>(bool Success, T? Data, string? Message);
+
+public static class ApiResult
+{
+    public static ApiResult<T> Ok<T>(T? data, string? message = null) => new(true, data, message);
+
+    public static ApiResult<T> Fail<T>(string? message) => new(false, default, message);
+}
+
+internal sealed class SecureConnectionsClient : ISecureConnectionsClient
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly HttpClient _httpClient;
+
+    public SecureConnectionsClient(IHttpClientFactory httpClientFactory)
+    {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        _httpClient = httpClientFactory.CreateClient("AdminApi");
+    }
+
+    public async Task<ApiResult<IReadOnlyList<SecureConnectionSummary>>> GetConnectionsAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync("connections", cancellationToken);
+        var result = await ReadResponseAsync<List<SecureConnectionSummary>>(response, cancellationToken);
+
+        return result.Success
+            ? ApiResult.Ok<IReadOnlyList<SecureConnectionSummary>>(result.Data ?? new List<SecureConnectionSummary>(), result.Message)
+            : ApiResult.Fail<IReadOnlyList<SecureConnectionSummary>>(result.Message);
+    }
+
+    public async Task<ApiResult<SecureConnectionDetail>> GetConnectionAsync(Guid connectionId, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync($"connections/{connectionId}", cancellationToken);
+        return await ReadResponseAsync<SecureConnectionDetail>(response, cancellationToken);
+    }
+
+    public async Task<ApiResult<SecureConnectionSummary>> CreateConnectionAsync(CreateSecureConnectionRequest request, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.PostAsJsonAsync("connections", request, cancellationToken);
+        return await ReadResponseAsync<SecureConnectionSummary>(response, cancellationToken);
+    }
+
+    public async Task<ApiResult<ConnectionTestResult>> TestDraftConnectionAsync(CreateSecureConnectionRequest request, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.PostAsJsonAsync("connections/test", request, cancellationToken);
+        return await ReadResponseAsync<ConnectionTestResult>(response, cancellationToken);
+    }
+
+    public async Task<ApiResult<SecureConnectionSummary>> UpdateConnectionAsync(Guid connectionId, UpdateSecureConnectionRequest request, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.PutAsJsonAsync($"connections/{connectionId}", request, cancellationToken);
+        return await ReadResponseAsync<SecureConnectionSummary>(response, cancellationToken);
+    }
+
+    public async Task<ApiResult<bool>> DeleteConnectionAsync(Guid connectionId, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.DeleteAsync($"connections/{connectionId}", cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await ReadErrorAsync(response, cancellationToken);
+            return ApiResult.Fail<bool>(error ?? "Failed to delete connection.");
+        }
+
+        return ApiResult.Ok(true, "Connection deleted.");
+    }
+
+    public async Task<ApiResult<ConnectionTestResult>> TestConnectionAsync(Guid connectionId, CancellationToken cancellationToken = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"connections/{connectionId}/test");
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+        return await ReadResponseAsync<ConnectionTestResult>(response, cancellationToken);
+    }
+
+    private static async Task<ApiResult<T>> ReadResponseAsync<T>(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await ReadErrorAsync(response, cancellationToken);
+            return ApiResult.Fail<T>(error ?? response.ReasonPhrase ?? "Request failed.");
+        }
+
+        var payload = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            return ApiResult.Fail<T>("Empty response from server.");
+        }
+
+        ApiResponse<T>? apiResponse;
+        try
+        {
+            apiResponse = JsonSerializer.Deserialize<ApiResponse<T>>(payload, _jsonOptions);
+        }
+        catch (JsonException)
+        {
+            return ApiResult.Fail<T>("Unable to parse response from server.");
+        }
+
+        if (apiResponse is null)
+        {
+            return ApiResult.Fail<T>("Unable to parse response from server.");
+        }
+
+        if (!apiResponse.Success)
+        {
+            return ApiResult.Fail<T>(apiResponse.Message ?? "Request failed.");
+        }
+
+        return ApiResult.Ok(apiResponse.Data, apiResponse.Message);
+    }
+
+    private static async Task<string?> ReadErrorAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (response.Content is null)
+        {
+            return null;
+        }
+
+        var payload = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(payload);
+            var root = document.RootElement;
+
+            if (root.TryGetProperty("message", out var message))
+            {
+                return message.GetString();
+            }
+
+            if (root.TryGetProperty("title", out var title))
+            {
+                return title.GetString();
+            }
+
+            if (root.TryGetProperty("detail", out var detail))
+            {
+                return detail.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            // Ignore parsing errors and fall back to default message.
+        }
+
+        return null;
+    }
+}

--- a/src/Honua.Admin/_Imports.razor
+++ b/src/Honua.Admin/_Imports.razor
@@ -10,7 +10,9 @@
 @using Microsoft.JSInterop
 @using Honua.Admin
 @using Honua.Admin.Components
+@using Honua.Admin.Components.Connections
 @using Honua.Admin.Layout
+@using Honua.Admin.Models
 @using Honua.Admin.Pages
 @using Honua.Admin.Services
 @using MudBlazor

--- a/src/Honua.Core/Features/Security/Abstractions/IConnectionHealthTester.cs
+++ b/src/Honua.Core/Features/Security/Abstractions/IConnectionHealthTester.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Security.Abstractions;
+
+/// <summary>
+/// Tests database connectivity for a supplied connection string.
+/// </summary>
+public interface IConnectionHealthTester
+{
+    /// <summary>
+    /// Attempts to open a connection and run a lightweight query.
+    /// </summary>
+    /// <param name="connectionString">Connection string to test.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True when the connection is healthy.</returns>
+    Task<bool> TestConnectionAsync(string connectionString, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Postgres/Features/Security/PostgresConnectionHealthTester.cs
+++ b/src/Honua.Postgres/Features/Security/PostgresConnectionHealthTester.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Security.Abstractions;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+namespace Honua.Postgres.Features.Security;
+
+internal sealed class PostgresConnectionHealthTester : IConnectionHealthTester
+{
+    private static readonly Action<ILogger, Exception?> _logHealthCheckSuccess =
+        LoggerMessage.Define(LogLevel.Debug, new EventId(2101, nameof(_logHealthCheckSuccess)),
+            "Connection test succeeded");
+
+    private static readonly Action<ILogger, object?, Exception?> _logHealthCheckUnexpectedResult =
+        LoggerMessage.Define<object?>(LogLevel.Warning, new EventId(2102, nameof(_logHealthCheckUnexpectedResult)),
+            "Connection test returned unexpected result: {Result}");
+
+    private static readonly Action<ILogger, string, Exception?> _logHealthCheckFailed =
+        LoggerMessage.Define<string>(LogLevel.Warning, new EventId(2103, nameof(_logHealthCheckFailed)),
+            "Connection test failed: {Error}");
+
+    private readonly ILogger<PostgresConnectionHealthTester> _logger;
+
+    public PostgresConnectionHealthTester(ILogger<PostgresConnectionHealthTester> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<bool> TestConnectionAsync(string connectionString, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new ArgumentException("Connection string is required.", nameof(connectionString));
+        }
+
+        try
+        {
+            using var connection = new NpgsqlConnection(connectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT 1";
+            command.CommandTimeout = 5;
+
+            var result = await command.ExecuteScalarAsync(cancellationToken);
+            var isHealthy = result?.ToString() == "1";
+
+            if (isHealthy)
+            {
+                _logHealthCheckSuccess(_logger, null);
+            }
+            else
+            {
+                _logHealthCheckUnexpectedResult(_logger, result, null);
+            }
+
+            return isHealthy;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logHealthCheckFailed(_logger, ex.Message, ex);
+            return false;
+        }
+    }
+}

--- a/src/Honua.Postgres/Features/Security/SecurityServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/Features/Security/SecurityServiceCollectionExtensions.cs
@@ -47,6 +47,7 @@ internal static class SecurityServiceCollectionExtensions
                 serviceProvider.GetRequiredService<ILogger<ConnectionEncryptionService>>()));
 
         services.TryAddSingleton<IDatabaseConnectionStringBuilder, PostgresConnectionStringBuilder>();
+        services.TryAddSingleton<IConnectionHealthTester, PostgresConnectionHealthTester>();
 
         // Register secret resolvers
         services.AddAwsSecretsManagerSupport(configuration);

--- a/src/Honua.Server/Features/Admin/SecureConnectionEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/SecureConnectionEndpoints.cs
@@ -54,6 +54,10 @@ internal static class SecureConnectionEndpoints
             .WithDisplayName("Create Secure Connection")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
 
+        group.MapPost("/test", HandleTestDraftConnection)
+            .WithDisplayName("Test Secure Connection Draft")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+
         group.MapPut("/{id:guid}", HandleUpdateConnection)
             .WithDisplayName("Update Secure Connection")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Put }));
@@ -75,6 +79,87 @@ internal static class SecureConnectionEndpoints
         group.MapPost("/encryption/rotate-key", HandleRotateEncryptionKey)
             .WithDisplayName("Rotate Encryption Key")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+    }
+
+    /// <summary>
+    /// POST /api/v1/admin/connections/test - Test a draft connection before saving.
+    /// </summary>
+    private static async Task<Results<Ok<ApiResponse<ConnectionTestResult>>, BadRequest<ApiResponse<object>>>>
+        HandleTestDraftConnection(
+            CreateSecureConnectionRequest request,
+            [FromServices] IDatabaseConnectionStringBuilder connectionStringBuilder,
+            [FromServices] IConnectionSecretResolver secretResolver,
+            [FromServices] IConnectionHealthTester connectionTester,
+            HttpContext context,
+            [FromServices] ILogger<SecureConnectionEndpointsLog> logger)
+    {
+        try
+        {
+            var validationResults = new List<ValidationResult>();
+            var validationContext = new ValidationContext(request);
+            if (!Validator.TryValidateObject(request, validationContext, validationResults, true))
+            {
+                var errors = validationResults.Select(r => r.ErrorMessage).ToList();
+                logger.LogWarning("Invalid test connection request: {Errors}", string.Join(", ", errors));
+                return TypedResults.BadRequest(ApiResponse<object>.Failure($"Validation failed: {string.Join(", ", errors)}"));
+            }
+
+            if (!request.IsValid(out var validationError))
+            {
+                logger.LogWarning("Invalid test connection request: {Error}", validationError);
+                return TypedResults.BadRequest(ApiResponse<object>.Failure($"Validation failed: {validationError}"));
+            }
+
+            if (!Enum.TryParse<SslMode>(request.SslMode, true, out _))
+            {
+                return TypedResults.BadRequest(ApiResponse<object>.Failure("Invalid SSL mode"));
+            }
+
+            string connectionString;
+
+            if (!string.IsNullOrWhiteSpace(request.SecretReference))
+            {
+                connectionString = await secretResolver.ResolveConnectionStringAsync(
+                    request.SecretReference,
+                    context.RequestAborted);
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(request.Password))
+                {
+                    return TypedResults.BadRequest(ApiResponse<object>.Failure("Password is required when not using secret reference"));
+                }
+
+                var effectiveSslMode = request.SslRequired
+                    ? SslMode.Require
+                    : SslMode.Prefer;
+
+                connectionString = connectionStringBuilder.BuildConnectionString(
+                    request.Host,
+                    request.Port,
+                    request.DatabaseName,
+                    request.Username,
+                    request.Password,
+                    effectiveSslMode);
+            }
+
+            var isHealthy = await connectionTester.TestConnectionAsync(connectionString, context.RequestAborted);
+            var result = new ConnectionTestResult
+            {
+                ConnectionId = Guid.Empty,
+                ConnectionName = request.Name,
+                IsHealthy = isHealthy,
+                TestedAt = DateTimeOffset.UtcNow,
+                Message = isHealthy ? "Connection is healthy" : "Connection test failed"
+            };
+
+            return TypedResults.Ok(ApiResponse<ConnectionTestResult>.CreateSuccess(result));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to test draft connection");
+            return TypedResults.BadRequest(ApiResponse<object>.Failure("Failed to test connection"));
+        }
     }
 
     /// <summary>

--- a/tests/Honua.Admin.Tests/Pages/ConnectionsTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/ConnectionsTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Admin.Components.Connections;
+using Honua.Admin.Models;
+using Honua.Admin.Pages;
+using Honua.Admin.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+
+namespace Honua.Admin.Tests.Pages;
+
+public sealed class ConnectionsTests
+{
+    [Fact]
+    public void ConnectionsPage_RendersConnectionsFromService()
+    {
+        using var ctx = new TestContext();
+        ctx.Services.AddMudServices();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var connections = new List<SecureConnectionSummary>
+        {
+            new()
+            {
+                ConnectionId = Guid.NewGuid(),
+                Name = "primary-db",
+                Host = "db.internal",
+                Port = 5432,
+                DatabaseName = "honua",
+                Username = "admin",
+                SslMode = "Require",
+                SslRequired = true,
+                StorageType = "managed",
+                IsActive = true,
+                HealthStatus = "Healthy",
+                CreatedAt = DateTimeOffset.UtcNow,
+                CreatedBy = "tester"
+            }
+        };
+
+        ctx.Services.AddSingleton<ISecureConnectionsClient>(new FakeConnectionsClient(connections));
+
+        var cut = ctx.Render(builder =>
+        {
+            builder.OpenComponent<MudPopoverProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<Connections>(1);
+            builder.CloseComponent();
+        });
+
+        cut.WaitForAssertion(() => Assert.Contains("primary-db", cut.Markup));
+        Assert.Contains("db.internal", cut.Markup);
+        Assert.Contains("Healthy", cut.Markup);
+    }
+
+    [Fact]
+    public void ConnectionForm_SubmitRequiresPasswordOnCreate()
+    {
+        using var ctx = new TestContext();
+        ctx.Services.AddMudServices();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var model = new ConnectionFormModel
+        {
+            Name = "primary",
+            Host = "db.internal",
+            Port = 5432,
+            DatabaseName = "honua",
+            Username = "admin",
+            SslMode = "Require",
+            IsEdit = false,
+            UseSecretReference = false
+        };
+
+        var submitted = false;
+
+        var cut = ctx.Render(builder =>
+        {
+            builder.OpenComponent<MudPopoverProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<ConnectionForm>(1);
+            builder.AddAttribute(2, "Model", model);
+            builder.AddAttribute(3, "OnSubmit", EventCallback.Factory.Create<bool>(this, (bool _) => submitted = true));
+            builder.CloseComponent();
+        });
+
+        cut.Find("[data-testid=connection-save]").Click();
+
+        Assert.False(submitted);
+    }
+
+    private sealed class FakeConnectionsClient : ISecureConnectionsClient
+    {
+        private readonly IReadOnlyList<SecureConnectionSummary> _connections;
+
+        public FakeConnectionsClient(IReadOnlyList<SecureConnectionSummary> connections)
+        {
+            _connections = connections;
+        }
+
+        public Task<ApiResult<IReadOnlyList<SecureConnectionSummary>>> GetConnectionsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(ApiResult.Ok<IReadOnlyList<SecureConnectionSummary>>(_connections));
+
+        public Task<ApiResult<SecureConnectionDetail>> GetConnectionAsync(Guid connectionId, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<ApiResult<SecureConnectionSummary>> CreateConnectionAsync(CreateSecureConnectionRequest request, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<ApiResult<ConnectionTestResult>> TestDraftConnectionAsync(CreateSecureConnectionRequest request, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<ApiResult<SecureConnectionSummary>> UpdateConnectionAsync(Guid connectionId, UpdateSecureConnectionRequest request, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<ApiResult<bool>> DeleteConnectionAsync(Guid connectionId, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<ApiResult<ConnectionTestResult>> TestConnectionAsync(Guid connectionId, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
<!-- Required: Link to the GitHub issue this PR addresses -->
Fixes #26

<!-- Alternative formats: Closes #, Resolves #, Related to # -->

## Summary
Add full PostGIS connection management UI plus a pre-save draft connection test endpoint.


## Changes Made
<!-- List key changes -->
- Implemented connections page UI with list, create, edit, delete, and test actions
- Added connection form component + models + API client for admin endpoints
- Added draft connection test endpoint and connection health tester abstraction

## Testing
<!-- Describe how this was tested -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)

## Coverage Impact
<!-- Required if this adds new code -->
- Line coverage: Not measured locally (see CI artifacts)
- Branch coverage: Not measured locally (see CI artifacts)

## Breaking Changes
<!-- List any breaking changes, or write "None" -->
None

## Additional Context
Pre-PR check ran on host; Testcontainers-based suites succeeded; two cache/load-balancer tests skipped as expected.


---

## Pre-PR Checklist (for contributor)
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit message follows format: `type: description (#issue-number)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] Documentation updated if needed

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed
