### PR TITLE
feat: add admin layer style endpoints (#244)

### DIFF
--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -45,6 +45,8 @@ public static class EndpointRegistry
         new("POST", "/api/v1/admin/metadata/resources"),
         new("PUT", "/api/v1/admin/metadata/resources/{kind}/{namespace}/{name}"),
         new("DELETE", "/api/v1/admin/metadata/resources/{kind}/{namespace}/{name}"),
+        new("GET", "/api/v1/admin/metadata/layers/{layerId}/style"),
+        new("PUT", "/api/v1/admin/metadata/layers/{layerId}/style"),
 
         // v1 admin import endpoints (primary)
         new("GET", "/api/v1/admin/import/formats"),

--- a/src/Honua.Server/Features/Admin/AdminLayerStyleEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AdminLayerStyleEndpoints.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Validation.Abstractions;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Caching;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Styling;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Admin endpoints for layer style metadata management.
+/// </summary>
+internal static class AdminLayerStyleEndpoints
+{
+    /// <summary>
+    /// Maps layer style endpoints to the admin metadata API group.
+    /// </summary>
+    public static void MapAdminLayerStyleEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/metadata/layers")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Metadata", "Styles")
+            .RequireAdminAuthorization();
+
+        _ = group.MapGet("/{layerId:int}/style", HandleGetLayerStyle)
+            .WithName("GetAdminLayerStyle")
+            .WithSummary("Get layer style metadata")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        _ = group.MapPut("/{layerId:int}/style", HandleUpdateLayerStyle)
+            .WithName("UpdateAdminLayerStyle")
+            .WithSummary("Update layer style metadata")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Put }));
+    }
+
+    private static async Task<IResult> HandleGetLayerStyle(
+        int layerId,
+        HttpContext context,
+        IResourceValidator resourceValidator,
+        ILayerStyleService styleService,
+        CancellationToken cancellationToken)
+    {
+        var layerResult = await resourceValidator.ValidateLayerAsync(layerId, cancellationToken);
+        if (!layerResult.IsValid || layerResult.Resource == null)
+        {
+            var statusCode = layerResult.ErrorCode == ResourceValidationError.InvalidIdentifier
+                ? StatusCodes.Status400BadRequest
+                : StatusCodes.Status404NotFound;
+            var message = layerResult.ErrorMessage ?? $"Layer {layerId} not found.";
+            return ProblemDetailsHelpers.CreateAdminProblem(context, statusCode, message);
+        }
+
+        var snapshot = await styleService.GetStyleAsync(layerResult.Resource, cancellationToken).ConfigureAwait(false);
+        if (snapshot == null)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status404NotFound,
+                $"Style for layer {layerId} not found.");
+        }
+
+        var response = new LayerStyleResponse
+        {
+            MapLibreStyle = snapshot.MapLibreStyle,
+            DrawingInfo = snapshot.DrawingInfo
+        };
+
+        var payload = ApiResponse<LayerStyleResponse>.CreateSuccess(response);
+        return Results.Json(payload, LayerStyleJsonContext.Default.ApiResponseLayerStyleResponse);
+    }
+
+    private static async Task<IResult> HandleUpdateLayerStyle(
+        int layerId,
+        LayerStyleUpdateRequest request,
+        HttpContext context,
+        IResourceValidator resourceValidator,
+        ILayerStyleService styleService,
+        OutputCacheInvalidationService cacheInvalidator,
+        CancellationToken cancellationToken)
+    {
+        var layerResult = await resourceValidator.ValidateLayerAsync(layerId, cancellationToken);
+        if (!layerResult.IsValid || layerResult.Resource == null)
+        {
+            var statusCode = layerResult.ErrorCode == ResourceValidationError.InvalidIdentifier
+                ? StatusCodes.Status400BadRequest
+                : StatusCodes.Status404NotFound;
+            var message = layerResult.ErrorMessage ?? $"Layer {layerId} not found.";
+            return ProblemDetailsHelpers.CreateAdminProblem(context, statusCode, message);
+        }
+
+        var result = await styleService.UpdateStyleAsync(
+                layerResult.Resource,
+                request.MapLibreStyle,
+                request.DrawingInfo,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (result.Status == LayerStyleUpdateStatus.Invalid)
+        {
+            var message = result.ErrorMessage ?? "Invalid layer style payload.";
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, message);
+        }
+
+        if (result.Status == LayerStyleUpdateStatus.NotFound)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status404NotFound,
+                $"Style for layer {layerId} not found.");
+        }
+
+        if (result.Style == null)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status500InternalServerError,
+                "Failed to update layer style.");
+        }
+
+        await cacheInvalidator.InvalidateLayerAsync(null, layerId, cancellationToken).ConfigureAwait(false);
+
+        var response = new LayerStyleResponse
+        {
+            MapLibreStyle = result.Style.MapLibreStyle,
+            DrawingInfo = result.Style.DrawingInfo
+        };
+
+        var payload = ApiResponse<LayerStyleResponse>.CreateSuccess(response);
+        return Results.Json(payload, LayerStyleJsonContext.Default.ApiResponseLayerStyleResponse);
+    }
+}

--- a/src/Honua.Server/Features/Admin/Models/LayerStyleJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/LayerStyleJsonContext.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Server.Features.Infrastructure.Models;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// JSON source generation context for layer style admin APIs.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(LayerStyleUpdateRequest))]
+[JsonSerializable(typeof(LayerStyleResponse))]
+[JsonSerializable(typeof(ApiResponse<LayerStyleResponse>))]
+[JsonSerializable(typeof(ApiResponse<object>))]
+[JsonSerializable(typeof(JsonElement))]
+public sealed partial class LayerStyleJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Admin/Models/LayerStyleModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/LayerStyleModels.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Request payload for updating a layer style.
+/// </summary>
+public sealed class LayerStyleUpdateRequest
+{
+    /// <summary>
+    /// MapLibre style JSON (canonical format).
+    /// </summary>
+    public JsonElement? MapLibreStyle { get; init; }
+
+    /// <summary>
+    /// GeoServices drawingInfo JSON (import/compat).
+    /// </summary>
+    public JsonElement? DrawingInfo { get; init; }
+}
+
+/// <summary>
+/// Response payload containing layer styles.
+/// </summary>
+public sealed class LayerStyleResponse
+{
+    /// <summary>
+    /// MapLibre style JSON (canonical format).
+    /// </summary>
+    public JsonElement? MapLibreStyle { get; init; }
+
+    /// <summary>
+    /// GeoServices drawingInfo JSON (cached conversion or import).
+    /// </summary>
+    public JsonElement? DrawingInfo { get; init; }
+}

--- a/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheInvalidationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheInvalidationService.cs
@@ -40,6 +40,8 @@ internal sealed class OutputCacheInvalidationService
         {
             tags.Add($"layer:{layerId.Value}");
             tags.Add($"collection:{layerId.Value}");
+            tags.Add("layer-metadata");
+            tags.Add("layer-styles");
             responsePatterns.Add(ResponseCacheUtilities.BuildFeatureServerLayerPattern(layerId.Value));
             responsePatterns.Add(ResponseCacheUtilities.BuildODataLayerPattern(layerId.Value));
             responsePatterns.Add(ResponseCacheUtilities.BuildOgcCollectionPattern(

--- a/src/Honua.Server/Features/Infrastructure/Styling/LayerStyleLog.cs
+++ b/src/Honua.Server/Features/Infrastructure/Styling/LayerStyleLog.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Server.Features.Infrastructure.Styling;
+
+/// <summary>
+/// Source-generated logging for style operations.
+/// </summary>
+internal static partial class LayerStyleLog
+{
+    [LoggerMessage(
+        EventId = 6400,
+        Level = LogLevel.Warning,
+        Message = "Unsupported GeoServices renderer type '{RendererType}' for layer {LayerId}. Falling back to default MapLibre style.")]
+    public static partial void UnsupportedRendererType(ILogger logger, string rendererType, int layerId);
+}

--- a/src/Honua.Server/Features/Infrastructure/Styling/LayerStyleService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Styling/LayerStyleService.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.Styling.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace Honua.Server.Features.Infrastructure.Styling;
 
@@ -13,10 +14,12 @@ namespace Honua.Server.Features.Infrastructure.Styling;
 internal sealed class LayerStyleService : ILayerStyleService
 {
     private readonly ILayerStyleCatalog _styleCatalog;
+    private readonly ILogger<LayerStyleService> _logger;
 
-    public LayerStyleService(ILayerStyleCatalog styleCatalog)
+    public LayerStyleService(ILayerStyleCatalog styleCatalog, ILogger<LayerStyleService> logger)
     {
         _styleCatalog = styleCatalog ?? throw new ArgumentNullException(nameof(styleCatalog));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     /// <inheritdoc />
@@ -93,7 +96,6 @@ internal sealed class LayerStyleService : ILayerStyleService
             }
 
             var generatedDrawingInfoJson = MapLibreToGeoServicesConverter.Convert(normalized, layer);
-            _ = await _styleCatalog.SetDrawingInfoAsync(layer.Id, generatedDrawingInfoJson, cancellationToken).ConfigureAwait(false);
 
             return new LayerStyleUpdateResult(
                 LayerStyleUpdateStatus.Updated,
@@ -104,6 +106,11 @@ internal sealed class LayerStyleService : ILayerStyleService
         }
 
         var drawingInfoJson = drawingInfo!.Value.GetRawText();
+        if (TryGetRendererType(drawingInfo.Value, out var rendererType)
+            && !IsSupportedRendererType(rendererType))
+        {
+            LayerStyleLog.UnsupportedRendererType(_logger, rendererType ?? "unknown", layer.Id);
+        }
         var mapLibreJson = GeoServicesToMapLibreConverter.Convert(drawingInfo.Value, layer);
 
         var saved = await _styleCatalog.SetStyleAsync(layer.Id, mapLibreJson, drawingInfoJson, cancellationToken)
@@ -120,4 +127,27 @@ internal sealed class LayerStyleService : ILayerStyleService
                 StyleJsonUtilities.ParseJsonElement(drawingInfoJson)),
             null);
     }
+
+    private static bool TryGetRendererType(JsonElement drawingInfo, out string? rendererType)
+    {
+        rendererType = null;
+
+        if (!drawingInfo.TryGetProperty("renderer", out var renderer) || renderer.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (!renderer.TryGetProperty("type", out var typeElement) || typeElement.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        rendererType = typeElement.GetString();
+        return !string.IsNullOrWhiteSpace(rendererType);
+    }
+
+    private static bool IsSupportedRendererType(string? rendererType)
+        => string.Equals(rendererType, "simple", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(rendererType, "uniqueValue", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(rendererType, "classBreaks", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Honua.Server/Features/Ogc/Common/OgcCommonModels.cs
+++ b/src/Honua.Server/Features/Ogc/Common/OgcCommonModels.cs
@@ -139,6 +139,11 @@ public static class RelationTypes
     public const string Items = "items";
 
     /// <summary>
+    /// Refers to a style resource for the collection.
+    /// </summary>
+    public const string Style = "style";
+
+    /// <summary>
     /// Indicates the link target provides service documentation.
     /// </summary>
     public const string ServiceDoc = "service-doc";

--- a/src/Honua.Server/Features/OgcFeatures/CollectionsEndpoints.cs
+++ b/src/Honua.Server/Features/OgcFeatures/CollectionsEndpoints.cs
@@ -364,6 +364,14 @@ internal static class CollectionsEndpoints
                 title: "Queryables"
             ),
 
+            // Style link (MapLibre style JSON)
+            Link.Create(
+                href: $"{baseUrl}/api/styles/{layer.Id}.json",
+                rel: RelationTypes.Style,
+                type: MediaTypes.Json,
+                title: "Style"
+            ),
+
             // Tilesets list link (OGC API Tiles)
             Link.Create(
                 href: $"{baseUrl}/ogc/tiles/collections/{collectionId}/tiles",

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -266,6 +266,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Import.EsriImportApiJsonContext.Default,
         Honua.Server.Features.Admin.OperationsProgressJsonContext.Default,
         Honua.Server.Features.Admin.Models.MetadataResourceJsonContext.Default,
+        Honua.Server.Features.Admin.Models.LayerStyleJsonContext.Default,
         Honua.Server.Features.Admin.Models.TableDiscoveryJsonContext.Default,
         Honua.Server.Features.Admin.Models.ConfigurationJsonContext.Default,
         Honua.Server.Features.HealthCheck.HealthJsonContext.Default,
@@ -417,6 +418,9 @@ app.MapLayerPublishingEndpoints();
 
 // Configure admin metadata version/manifest endpoints
 app.MapAdminMetadataEndpoints();
+
+// Configure admin layer style endpoints
+app.MapAdminLayerStyleEndpoints();
 
 // Configure secure connection management endpoints
 app.MapSecureConnectionEndpoints();

--- a/tests/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -356,6 +356,23 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.GetMetadata)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task GetLayerMetadata_IncludesDrawingInfo()
+    {
+        var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}");
+
+        response.Be200Ok();
+
+        var content = await response.Content.ReadAsStringAsync();
+        var layerResponse = JsonSerializer.Deserialize<LayerResponse>(
+            content, FeatureServerJsonContext.Default.LayerResponse);
+
+        layerResponse.Should().NotBeNull();
+        layerResponse!.DrawingInfo.Should().NotBeNull();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
     public async Task GetLayerMetadata_WithNonExistentService_Returns404()
     {
         // Act

--- a/tests/Honua.Server.Tests/Features/Admin/LayerStyleEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/LayerStyleEndpointsTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Infrastructure.Styling;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+/// <summary>
+/// Integration tests for admin layer style endpoints.
+/// </summary>
+[Collection("Database")]
+[Protocol(Protocols.Admin)]
+public sealed class LayerStyleEndpointsTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /api/v1/admin/metadata/layers/{layerId}/style")]
+    public async Task GetLayerStyle_ReturnsMapLibreAndDrawingInfo()
+    {
+        var client = _fixture.CreateAdminClient();
+
+        var response = await client.GetAsync(
+            $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/style");
+
+        response.Be200Ok();
+
+        var payload = await response.Content.ReadAsStringAsync();
+        var apiResponse = JsonSerializer.Deserialize(
+            payload,
+            LayerStyleJsonContext.Default.ApiResponseLayerStyleResponse);
+
+        apiResponse.Should().NotBeNull();
+        apiResponse!.Success.Should().BeTrue();
+        apiResponse.Data.Should().NotBeNull();
+        apiResponse.Data!.MapLibreStyle.HasValue.Should().BeTrue();
+        apiResponse.Data!.DrawingInfo.HasValue.Should().BeTrue();
+
+        apiResponse.Data.MapLibreStyle!.Value.ValueKind.Should().Be(JsonValueKind.Object);
+        apiResponse.Data.DrawingInfo!.Value.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("PUT /api/v1/admin/metadata/layers/{layerId}/style")]
+    [Endpoint("GET /api/v1/admin/metadata/layers/{layerId}/style")]
+    public async Task UpdateLayerStyle_WithMapLibreStyle_UpdatesAndReturnsStyle()
+    {
+        var client = _fixture.CreateAdminClient();
+
+        var layer = LayerDefinition.CreateBasic(
+            WebAppFixture.TestLayerId,
+            "Test Layer",
+            GeometryType.Point);
+
+        var style = StyleDefaults.BuildDefaultMapLibreStyle(layer);
+        var updatedName = $"Updated Style {Guid.NewGuid():N}";
+        style["name"] = updatedName;
+        var mapLibreStyle = JsonSerializer.SerializeToElement(style);
+
+        var request = new LayerStyleUpdateRequest
+        {
+            MapLibreStyle = mapLibreStyle
+        };
+
+        var updateResponse = await client.PutAsync(
+            $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/style",
+            JsonContent.Create(request, LayerStyleJsonContext.Default.LayerStyleUpdateRequest));
+
+        updateResponse.Be200Ok();
+
+        var updatePayload = await updateResponse.Content.ReadAsStringAsync();
+        var updateApiResponse = JsonSerializer.Deserialize(
+            updatePayload,
+            LayerStyleJsonContext.Default.ApiResponseLayerStyleResponse);
+
+        updateApiResponse.Should().NotBeNull();
+        updateApiResponse!.Success.Should().BeTrue();
+        updateApiResponse.Data.Should().NotBeNull();
+
+        var updatedStyle = updateApiResponse.Data!.MapLibreStyle;
+        updatedStyle.HasValue.Should().BeTrue();
+        updatedStyle!.Value.GetProperty("name").GetString().Should().Be(updatedName);
+
+        var getResponse = await client.GetAsync(
+            $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/style");
+
+        getResponse.Be200Ok();
+
+        var getPayload = await getResponse.Content.ReadAsStringAsync();
+        var getApiResponse = JsonSerializer.Deserialize(
+            getPayload,
+            LayerStyleJsonContext.Default.ApiResponseLayerStyleResponse);
+
+        getApiResponse.Should().NotBeNull();
+        getApiResponse!.Data.Should().NotBeNull();
+        getApiResponse.Data!.MapLibreStyle!.Value.GetProperty("name").GetString().Should().Be(updatedName);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #244

## Summary
- add admin layer style GET/PUT endpoints returning MapLibre style + drawingInfo
- invalidate style-related caches and expose MapLibre style links in OGC collections
- log unsupported GeoServices renderer types and add integration coverage for style endpoints + FeatureServer drawingInfo

## Changes Made
- added admin layer style endpoint group under `/api/v1/admin/metadata/layers/{layerId}/style`
- updated layer style service + cache invalidation and OGC collection style links
- added integration tests for admin style endpoints and FeatureServer drawingInfo

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)

## Coverage Impact
- Line coverage: not measured locally (CI reports)
- Branch coverage: not measured locally (CI reports)

## Breaking Changes
None

## Additional Context
- Pre-push validation ran full build/format/test/AOT checks

---

## Pre-PR Checklist (for contributor)
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit message follows format: `type: description (#issue-number)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] Documentation updated if needed

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed
