### PR TITLE
refactor: normalize endpoints and add tests (#229)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,12 @@ New to Honua Server? Start here:
 - **[API Examples](API_EXAMPLES.md)** - Sample requests for all protocols
 - **[Model Optimization Guide](MODEL_OPTIMIZATION_GUIDE.md)** - Data model best practices
 
+### Protocol Specification Coverage
+- **[Coverage Index](specifications/protocol-coverage.md)** - Entry point for protocol coverage docs
+- **[OGC API Features Coverage](specifications/ogc-api-features-coverage.md)** - Operations and query parameter support
+- **[OData v4 Coverage](specifications/odata-v4-coverage.md)** - Operations and OData query option support
+- **[GeoServices FeatureServer Coverage](feature-server-matrix.md)** - FeatureServer operations and parameter support
+
 ## 🎯 By Role
 
 ### For New Developers

--- a/docs/feature-server-matrix.md
+++ b/docs/feature-server-matrix.md
@@ -10,6 +10,11 @@ Legend:
 - Stubbed: endpoint exists but returns "not implemented".
 - Not implemented: no endpoint or handler.
 
+## Esri REST Feature Service coverage
+
+This matrix tracks Honua coverage against the Esri REST Feature Service specification:
+- https://developers.arcgis.com/rest/services-reference/enterprise/feature-service/
+
 ## Feature Service (root resource)
 
 | Esri operation | Esri path | Methods | Honua status | Honua endpoint(s) | Notes |

--- a/docs/specifications/odata-v4-coverage.md
+++ b/docs/specifications/odata-v4-coverage.md
@@ -1,0 +1,116 @@
+# OData v4 Coverage Matrix
+
+This page summarizes OData v4 coverage in Honua Server, focusing on operations and query options. It complements the protocol testing map in docs/ODATA_TEST_PARITY.md.
+
+Legend:
+- Implemented: endpoint exists and behavior is supported.
+- Partial: endpoint exists but only a subset of parameters/behavior is supported.
+- Not implemented: endpoint or behavior is absent.
+
+## Operations and allowed query options
+
+| OData operation | Methods | Honua endpoint(s) | Allowed query options | Notes |
+| --- | --- | --- | --- | --- |
+| Service document | GET | `/odata` | None | Lists entity sets. |
+| Metadata document | GET | `/odata/$metadata` | None | EDMX metadata only. |
+| Layers collection | GET | `/odata/Layers` | `$filter`, `$select`, `$top`, `$skip`, `$count`, `$format` | Collection of layers. |
+| Layers count | GET | `/odata/Layers/$count` | `$filter`, `$format` | Plain text count. |
+| Single layer | GET | `/odata/Layers({layerId})` | `$select`, `$format` | Layer metadata. |
+| Features collection (all layers) | GET | `/odata/Features` | `$filter`, `$select`, `$orderby`, `$top`, `$skip`, `$count`, `$expand`, `$apply`, `$search`, `$format` | Requires a `LayerId` filter when layer is not in the path. |
+| Features count (all layers) | GET | `/odata/Features/$count` | `$filter`, `$format` | Requires a `LayerId` filter when layer is not in the path. |
+| Features for layer | GET | `/odata/Layers({layerId})/Features` | `$filter`, `$select`, `$orderby`, `$top`, `$skip`, `$count`, `$expand`, `$apply`, `$search`, `$format` | Canonical layer-scoped features. |
+| Features count for layer | GET | `/odata/Layers({layerId})/Features/$count` | `$filter`, `$format` | Layer-scoped count. |
+| Legacy features for layer | GET | `/odata/Features({layerId})` | `$filter`, `$select`, `$orderby`, `$top`, `$skip`, `$count`, `$expand`, `$apply`, `$search`, `$format` | Legacy layer-scoped route. |
+| Legacy features count | GET | `/odata/Features({layerId})/$count` | `$filter`, `$format` | Legacy layer-scoped count. |
+| Single feature (canonical) | GET | `/odata/Features(LayerId={layerId},ObjectId={objectId})` | `$select`, `$format` | Entity key is `(LayerId, ObjectId)`. |
+| Single feature (layer route) | GET | `/odata/Layers({layerId})/Features({objectId})` | `$select`, `$format` | Alternative key syntax. |
+| Single feature (legacy) | GET | `/odata/Features({layerId},{objectId})` | `$select`, `$format` | Legacy key syntax. |
+| Create feature | POST | `/odata/Features` | None | Requires `LayerId` in payload when not in path. |
+| Create feature (layer) | POST | `/odata/Layers({layerId})/Features` | None | GeoJSON-style OData payload. |
+| Update feature | PATCH | `/odata/Features(LayerId={layerId},ObjectId={objectId})` | None | Partial update (PATCH only). |
+| Update feature (layer) | PATCH | `/odata/Layers({layerId})/Features({objectId})` | None | Partial update (PATCH only). |
+| Update feature (legacy) | PATCH | `/odata/Features({layerId},{objectId})` | None | Legacy key syntax. |
+| Delete feature | DELETE | `/odata/Features(LayerId={layerId},ObjectId={objectId})` | None | Delete by key. |
+| Delete feature (layer) | DELETE | `/odata/Layers({layerId})/Features({objectId})` | None | Delete by key. |
+| Delete feature (legacy) | DELETE | `/odata/Features({layerId},{objectId})` | None | Legacy key syntax. |
+| Batch operations | POST | `/odata/$batch` | None | JSON batch format; supports atomicity groups. |
+| Aggregation (legacy) | GET | `/odata/Features({layerId})/$apply` | `$apply`, `$filter` | Supports aggregate/groupby/filter/compute (see below). |
+| Search (legacy) | GET | `/odata/Features({layerId})/$search` | `$search`, `$top`, `$skip`, `$count` | Full-text search. |
+
+## Query option support details
+
+| Query option | Status | Notes |
+| --- | --- | --- |
+| `$filter` | Partial | Supported on Layers/Features collections and count endpoints. Function/operator coverage is limited to the implemented OData subset. |
+| `$select` | Implemented | Field selection for Layers and Features; `*` returns all fields. |
+| `$orderby` | Partial | Simple field names with optional `asc`/`desc`; no expressions or functions. |
+| `$top` / `$skip` | Implemented | Validated and normalized by server limits. |
+| `$count` | Implemented | `@odata.count` in payload; `/.../$count` endpoints return text. |
+| `$expand` | Partial | Supports comma-separated relationship names only; no nested expand options. |
+| `$search` | Partial | Full-text search across string fields; supports AND/OR/NOT and quoted phrases. |
+| `$apply` | Partial | `aggregate`, `groupby`, `filter`, and `compute` (simple arithmetic) are supported. |
+| `$format` | Partial | Only `json` and `application/json` are accepted. |
+
+## $filter operator coverage
+
+| Category | Supported operators | Notes |
+| --- | --- | --- |
+| Logical | `and`, `or`, `not` | |
+| Comparison | `eq`, `ne`, `gt`, `ge`, `lt`, `le` | |
+| Arithmetic | `add`, `sub`, `mul`, `div`, `mod` | |
+| Null comparisons | `eq null`, `ne null` | Other null comparisons are rejected. |
+
+## $filter function coverage
+
+| Category | Supported functions | Notes |
+| --- | --- | --- |
+| String | `contains`, `startswith`, `endswith`, `substring`, `tolower`, `toupper`, `length`, `trim`, `indexof`, `replace`, `concat` | |
+| Numeric | `round`, `floor`, `ceiling`, `abs` | |
+| Date/time | `now`, `year`, `month`, `day`, `hour`, `minute`, `second` | |
+| Spatial | `geo.distance`, `geo.intersects` | Requires `geography`/`geometry` WKT literals. |
+
+## Typed literal support
+
+| Literal | Status | Notes |
+| --- | --- | --- |
+| `date'YYYY-MM-DD'` | Implemented | |
+| `datetime'...'/datetimeoffset'...'` | Implemented | RFC 3339 timestamps. |
+| `geography'WKT'` / `geometry'WKT'` | Implemented | Optional `SRID=####;` prefix in the literal. |
+
+## $filter unsupported operators and functions (non-exhaustive)
+
+| Category | Not supported | Notes |
+| --- | --- | --- |
+| Operators | `has`, `in`, `any`, `all` | Not recognized by the filter parser. |
+| Type functions | `cast`, `isof` | Not recognized by the filter parser. |
+| Spatial functions | `geo.length` and other `geo.*` functions not listed above | Only `geo.distance` and `geo.intersects` are implemented. |
+| Any other functions | Any function not listed in the supported list | Unsupported functions return 400. |
+
+## $filter examples
+
+```
+# Comparison + logical
+population ge 1000000 and state eq 'CA'
+
+# String functions
+startswith(name,'San') or contains(name,'Beach')
+
+# Arithmetic
+(area_sq_km mul 2) gt 500
+
+# Date/time
+year(founded_date) ge 1900
+
+# Spatial (WKT literal)
+geo.intersects(Geometry, geography'SRID=4326;POINT(-122.4 37.8)')
+
+# Distance (WKT literal, meters for geography)
+geo.distance(Geometry, geography'SRID=4326;POINT(-122.4 37.8)') lt 5000
+```
+
+## Unsupported or not implemented
+
+- `$compute` query option (separate from `$apply` compute) is not supported.
+- `$skiptoken`, `$deltatoken`, `$value`, and `$ref` endpoints are not supported.
+- `PUT` updates are not supported (PATCH only).
+- Multipart/mixed batch payloads are not supported (JSON batch only).

--- a/docs/specifications/ogc-api-features-coverage.md
+++ b/docs/specifications/ogc-api-features-coverage.md
@@ -1,0 +1,154 @@
+# OGC API Features Coverage Matrix
+
+This page summarizes OGC API Features coverage in Honua Server, focusing on the public operations and query parameters. It complements the specification notes in:
+- docs/specifications/ogc-api-features-part1-core.md
+- docs/specifications/ogc-api-features-part2-crs.md
+- docs/specifications/ogc-api-features-part3-filtering.md
+
+Legend:
+- Implemented: endpoint exists and behavior is supported.
+- Partial: endpoint exists but only a subset of parameters/behavior is supported.
+- Not implemented: endpoint or behavior is absent.
+
+## Operations
+
+| OGC operation | Spec path | Methods | Honua status | Honua endpoint(s) | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Landing page | `/ogc/features` | GET | Implemented | `GET /ogc/features` | Supports `f=json|html` and Accept negotiation. |
+| Conformance | `/ogc/features/conformance` | GET | Implemented | `GET /ogc/features/conformance` | Supports `f=json|html`. |
+| OpenAPI definition | `/api` (spec) | GET | Implemented | `GET /openapi.json` | Service-wide OpenAPI document (includes OGC Features). |
+| Collections list | `/ogc/features/collections` | GET | Implemented | `GET /ogc/features/collections` | Supports `f=json|html`. |
+| Collection metadata | `/ogc/features/collections/{collectionId}` | GET | Implemented | `GET /ogc/features/collections/{collectionId}` | Supports `f=json|html`. |
+| Queryables | `/ogc/features/collections/{collectionId}/queryables` | GET | Implemented | `GET /ogc/features/collections/{collectionId}/queryables` | Supports `f=json|html`. |
+| Items (features) | `/ogc/features/collections/{collectionId}/items` | GET | Implemented | `GET /ogc/features/collections/{collectionId}/items` | Filtering + CRS + paging supported (see parameter matrix). |
+| Single item | `/ogc/features/collections/{collectionId}/items/{featureId}` | GET | Implemented | `GET /ogc/features/collections/{collectionId}/items/{featureId}` | Supports `f` + `crs`. |
+| Create item | `/ogc/features/collections/{collectionId}/items` | POST | Implemented | `POST /ogc/features/collections/{collectionId}/items` | GeoJSON request body only. |
+| Replace item | `/ogc/features/collections/{collectionId}/items/{featureId}` | PUT | Implemented | `PUT /ogc/features/collections/{collectionId}/items/{featureId}` | GeoJSON request body only; upsert behavior. |
+| Delete item | `/ogc/features/collections/{collectionId}/items/{featureId}` | DELETE | Implemented | `DELETE /ogc/features/collections/{collectionId}/items/{featureId}` | No query parameters. |
+| Batch operations (extension) | N/A | POST | Implemented | `POST /ogc/features/collections/{collectionId}/items/batch` | Honua extension (not in OGC standard). |
+
+## Items query parameter coverage
+
+Applies to `GET /ogc/features/collections/{collectionId}/items` unless noted.
+
+| Parameter | Status | Notes |
+| --- | --- | --- |
+| `f` | Implemented | `geojson`, `json`, `gml`, `html` for feature content. |
+| `limit` | Implemented | Validated and normalized by server limits. |
+| `offset` | Implemented | Standard offset paging. |
+| `bbox` | Implemented | 4 or 6 comma-separated values; anti-meridian supported for geographic CRS. |
+| `bbox-crs` | Implemented | CRS for interpreting `bbox`; must be in collection `crs` list. |
+| `crs` | Implemented | Output CRS; must be in collection `crs` list. Response includes `Content-Crs`. |
+| `datetime` | Implemented | RFC 3339 instant or interval; requires temporal fields on the layer. |
+| `filter` | Partial | CQL2-Text and CQL2-JSON supported; function/operator coverage is limited to the implemented CQL subset. |
+| `filter-lang` | Partial | Supports `cql2-text` (default) and `cql2-json` only. |
+| `filter-crs` | Partial | CRS for filter geometries; requires `filter` and a supported CRS. |
+| Queryable properties | Partial | Simple queryables (string, numeric, boolean, date/time, UUID) are supported as equality filters. |
+
+## CQL2 operator coverage
+
+Applies to both `cql2-text` and `cql2-json` filters. Unsupported operators return a 400.
+
+| Category | Supported operators | Notes |
+| --- | --- | --- |
+| Logical | `AND`, `OR`, `NOT` | Standard boolean logic. |
+| Comparison | `=`, `<>`, `<`, `<=`, `>`, `>=` | Type coercion follows layer field types. |
+| Null checks | `IS NULL`, `IS NOT NULL` | |
+| Pattern | `LIKE`, `NOT LIKE` | Works with text fields. |
+| Set | `IN`, `NOT IN` | Value list or array literal. |
+| Range | `BETWEEN`, `NOT BETWEEN` | |
+| Arithmetic | `+`, `-`, `*`, `/`, `%`, `DIV`, `^` | Includes unary `-`. |
+
+## CQL2 spatial predicates
+
+| Predicate | Status | Notes |
+| --- | --- | --- |
+| `S_INTERSECTS` | Implemented | |
+| `S_CONTAINS` | Implemented | |
+| `S_WITHIN` | Implemented | |
+| `S_CROSSES` | Implemented | |
+| `S_TOUCHES` | Implemented | |
+| `S_OVERLAPS` | Implemented | |
+| `S_DISJOINT` | Implemented | |
+| `S_EQUALS` | Implemented | |
+| `S_DWITHIN` | Implemented | Distance predicate. |
+| `S_BEYOND` | Implemented | Distance predicate. |
+
+## CQL2 temporal predicates
+
+| Predicate | Status |
+| --- | --- |
+| `T_AFTER`, `T_BEFORE` | Implemented |
+| `T_CONTAINS`, `T_DISJOINT`, `T_DURING` | Implemented |
+| `T_EQUALS` | Implemented |
+| `T_FINISHEDBY`, `T_FINISHES` | Implemented |
+| `T_INTERSECTS` | Implemented |
+| `T_MEETS`, `T_METBY` | Implemented |
+| `T_OVERLAPPEDBY`, `T_OVERLAPS` | Implemented |
+| `T_STARTEDBY`, `T_STARTS` | Implemented |
+
+## CQL2 array predicates
+
+| Predicate | Status | Notes |
+| --- | --- | --- |
+| `A_EQUALS` | Implemented | Requires JSON array field. |
+| `A_CONTAINS` | Implemented | Requires JSON array field. |
+| `A_CONTAINEDBY` | Implemented | Requires JSON array field. |
+| `A_OVERLAPS` | Implemented | Requires JSON array field. |
+
+## CQL2 function coverage
+
+Functions are case-insensitive. Unsupported functions return a 400.
+
+| Category | Supported functions | Notes |
+| --- | --- | --- |
+| String | `UPPER`, `LOWER`, `LENGTH`, `CHAR_LENGTH`, `CHARACTER_LENGTH`, `TRIM`, `LTRIM`, `RTRIM`, `SUBSTRING`, `SUBSTR`, `REPLACE`, `CONCAT`, `POSITION` | |
+| Numeric | `ABS`, `CEIL`, `CEILING`, `FLOOR`, `ROUND`, `POWER`, `MOD` | |
+| Date/time | `NOW`, `YEAR`, `MONTH`, `DAY`, `HOUR`, `MINUTE`, `SECOND`, `CURRENT_DATE`, `CURRENT_TIMESTAMP`, `CURRENT_TIME` | |
+| Null handling | `COALESCE`, `NULLIF` | |
+| Geometry | `GEODISTANCE` | Uses geography when possible. |
+| Collation helpers | `CASEI`, `ACCENTI` | `ACCENTI` requires PostgreSQL `unaccent` extension. |
+
+## CQL2 unsupported operators and functions (non-exhaustive)
+
+| Category | Not supported | Notes |
+| --- | --- | --- |
+| Spatial predicates | Any `S_*` predicate not listed above | Only the supported list is implemented. |
+| Temporal predicates | Any `T_*` predicate not listed above | Only the supported list is implemented. |
+| Array predicates | Any `A_*` predicate not listed above | Only the supported list is implemented. |
+| Functions | Any function not listed above | Functions are matched case-insensitively. |
+
+## CQL2 examples
+
+```
+# Comparison + logical
+population >= 1000000 AND state = 'CA'
+
+# Pattern + range
+name LIKE 'San%' AND founded BETWEEN 1850 AND 1950
+
+# Set membership
+type IN ('park', 'forest', 'reserve')
+
+# Spatial predicate
+S_INTERSECTS(geometry, POINT(-122.4 37.8))
+
+# Distance predicate
+S_DWITHIN(geometry, POINT(-122.4 37.8), 5000)
+
+# Temporal predicate (interval)
+T_INTERSECTS(date_field, INTERVAL('2020-01-01','2021-01-01'))
+
+# Function
+LOWER(name) = 'honolulu'
+
+# Array predicate (JSON array field)
+A_CONTAINS(tags, ('coastal','urban'))
+```
+
+## Unsupported or not implemented
+
+- `PATCH /ogc/features/collections/{collectionId}/items/{featureId}` (partial update) is not implemented.
+- `sortby`, `properties`, and `ids` query parameters are not supported on items endpoints.
+- Filter languages other than `cql2-text` and `cql2-json` are not supported.
+- Write operations do not accept GML; GeoJSON is required.

--- a/docs/specifications/protocol-coverage.md
+++ b/docs/specifications/protocol-coverage.md
@@ -1,0 +1,22 @@
+# Protocol Coverage Index
+
+This index groups the protocol coverage pages that document which operations and parameters are implemented in Honua Server.
+
+## Coverage pages
+
+- OGC API Features coverage: docs/specifications/ogc-api-features-coverage.md
+- OData v4 coverage: docs/specifications/odata-v4-coverage.md
+- GeoServices FeatureServer coverage (Esri REST): docs/feature-server-matrix.md
+
+## Related specification notes
+
+- OGC API Features Part 1 (Core): docs/specifications/ogc-api-features-part1-core.md
+- OGC API Features Part 2 (CRS): docs/specifications/ogc-api-features-part2-crs.md
+- OGC API Features Part 3 (Filtering): docs/specifications/ogc-api-features-part3-filtering.md
+- OData test parity: docs/ODATA_TEST_PARITY.md
+
+## Esri REST Feature Service coverage
+
+Honua's GeoServices FeatureServer coverage is tracked in the matrix above and is aligned to the Esri REST Feature Service specification:
+- Esri REST Feature Service spec: https://developers.arcgis.com/rest/services-reference/enterprise/feature-service/
+

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
@@ -169,8 +169,17 @@ internal sealed partial class PostgreSqlLayerPublishingService(
                 LayerPublishingErrorKind.Validation,
                 "Primary key is required.");
 
-        var primaryKeyColumn = selectedColumns.First(col =>
+        var primaryKeyColumn = selectedColumns.FirstOrDefault(col =>
             string.Equals(col.Name, primaryKeyName, StringComparison.OrdinalIgnoreCase));
+        if (primaryKeyColumn == null)
+        {
+            var existsInTable = columns.Any(col =>
+                string.Equals(col.Name, primaryKeyName, StringComparison.OrdinalIgnoreCase));
+            var message = existsInTable
+                ? $"Primary key field '{primaryKeyName}' must be included in selected fields."
+                : $"Primary key field '{primaryKeyName}' was not found on the source table.";
+            throw new LayerPublishingException(LayerPublishingErrorKind.Validation, message);
+        }
         var primaryKeyType = MapPostgresType(primaryKeyColumn.DataType);
         if (primaryKeyType is not FieldType.Integer and not FieldType.BigInteger)
         {

--- a/src/Honua.Server/Features/Admin/AdminMetadataEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AdminMetadataEndpoints.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -496,7 +497,7 @@ internal static class AdminMetadataEndpoints
             return 0;
         }
 
-        return long.TryParse(resourceVersion, out var value) ? value : 0;
+        return long.TryParse(resourceVersion, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) ? value : 0;
     }
 
     private static Task WriteError(HttpContext context, int statusCode, string message)

--- a/src/Honua.Server/Features/Admin/MetadataResourceEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/MetadataResourceEndpoints.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain;
 using Honua.Server.Features.Admin.Models;
@@ -383,7 +384,7 @@ internal static class MetadataResourceEndpoints
             return 0;
         }
 
-        return long.TryParse(resourceVersion, out var value) ? value : 0;
+        return long.TryParse(resourceVersion, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) ? value : 0;
     }
 
     private static Task WriteValidationError(HttpContext context, IReadOnlyList<string> errors)

--- a/src/Honua.Server/Features/FeatureServer/AttachmentEndpoints.cs
+++ b/src/Honua.Server/Features/FeatureServer/AttachmentEndpoints.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Attachments.Abstractions;
 using Honua.Core.Features.Catalog.Domain;
@@ -98,7 +99,7 @@ internal static class AttachmentEndpoints
         var layerId = resource.Value.Layer.Id;
 
         if (!context.Request.Query.TryGetValue("objectId", out var objectIdValue) ||
-            !long.TryParse(objectIdValue, out var featureId))
+            !long.TryParse(objectIdValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var featureId))
         {
             await RouteValidationHelpers.WriteValidationErrorAsync(context, "objectId parameter is required");
             return;
@@ -142,7 +143,7 @@ internal static class AttachmentEndpoints
         }
 
         if (string.IsNullOrWhiteSpace(objectIdValue) ||
-            !long.TryParse(objectIdValue, out var featureId))
+            !long.TryParse(objectIdValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var featureId))
         {
             await RouteValidationHelpers.WriteValidationErrorAsync(context, "objectId parameter is required");
             return;
@@ -199,14 +200,14 @@ internal static class AttachmentEndpoints
         var form = await context.Request.ReadFormAsync(context.RequestAborted);
 
         if (!form.TryGetValue("objectId", out var objectIdValue) ||
-            !long.TryParse(objectIdValue, out var featureId))
+            !long.TryParse(objectIdValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var featureId))
         {
             await RouteValidationHelpers.WriteValidationErrorAsync(context, "objectId parameter is required");
             return;
         }
 
         if (!form.TryGetValue("attachmentId", out var attachmentIdValue) ||
-            !long.TryParse(attachmentIdValue, out var attachmentId))
+            !long.TryParse(attachmentIdValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var attachmentId))
         {
             await RouteValidationHelpers.WriteValidationErrorAsync(context, "attachmentId parameter is required");
             return;
@@ -244,7 +245,7 @@ internal static class AttachmentEndpoints
         var form = await context.Request.ReadFormAsync(context.RequestAborted);
 
         if (!form.TryGetValue("objectId", out var objectIdValue) ||
-            !long.TryParse(objectIdValue, out var featureId))
+            !long.TryParse(objectIdValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var featureId))
         {
             await RouteValidationHelpers.WriteValidationErrorAsync(context, "objectId parameter is required");
             return;
@@ -262,7 +263,7 @@ internal static class AttachmentEndpoints
 
         foreach (var idString in attachmentIdStrings)
         {
-            if (long.TryParse(idString.Trim(), out var id))
+            if (long.TryParse(idString.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
             {
                 attachmentIds.Add(id);
             }
@@ -301,14 +302,14 @@ internal static class AttachmentEndpoints
         var layerId = resource.Value.Layer.Id;
 
         if (!context.Request.RouteValues.TryGetValue("featureId", out var featureIdObj) ||
-            !long.TryParse(featureIdObj?.ToString(), out var featureId))
+            !long.TryParse(featureIdObj?.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var featureId))
         {
             await RouteValidationHelpers.WriteValidationErrorAsync(context, "Feature ID must be a valid long integer");
             return;
         }
 
         if (!context.Request.RouteValues.TryGetValue("attachmentId", out var attachmentIdObj) ||
-            !long.TryParse(attachmentIdObj?.ToString(), out var attachmentId))
+            !long.TryParse(attachmentIdObj?.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var attachmentId))
         {
             await RouteValidationHelpers.WriteValidationErrorAsync(context, "Attachment ID must be a valid long integer");
             return;

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
@@ -1010,7 +1010,7 @@ internal sealed class FeatureServerQueryHandler(
             return false;
         }
 
-        if (long.TryParse(timeValue, out var unixMs))
+        if (long.TryParse(timeValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var unixMs))
         {
             try
             {
@@ -1023,7 +1023,11 @@ internal sealed class FeatureServerQueryHandler(
             }
         }
 
-        if (DateTimeOffset.TryParse(timeValue, out var parsedTime))
+        if (DateTimeOffset.TryParse(
+            timeValue,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var parsedTime))
         {
             time = parsedTime;
             return true;

--- a/src/Honua.Server/Features/Import/ImportEndpoints.cs
+++ b/src/Honua.Server/Features/Import/ImportEndpoints.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Globalization;
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
@@ -307,8 +308,12 @@ internal static partial class ImportEndpoints
         try
         {
             // Parse optional parameters
-            int? sourceSrid = int.TryParse(form["SourceSrid"], out int src) ? src : (int?)null;
-            int targetSrid = int.TryParse(form["TargetSrid"], out int tgt) ? tgt : 4326;
+            int? sourceSrid = int.TryParse(form["SourceSrid"], NumberStyles.Integer, CultureInfo.InvariantCulture, out int src)
+                ? src
+                : (int?)null;
+            int targetSrid = int.TryParse(form["TargetSrid"], NumberStyles.Integer, CultureInfo.InvariantCulture, out int tgt)
+                ? tgt
+                : 4326;
             bool overwriteExisting = bool.TryParse(form["OverwriteExisting"], out bool overwrite) && overwrite;
             bool forceBackground = bool.TryParse(form["ForceBackground"], out bool forceBg) && forceBg;
             bool trackProgress = bool.TryParse(form["TrackProgress"], out bool track) && track;

--- a/src/Honua.Server/Features/Infrastructure/Styling/MapLibreStyleNormalizer.cs
+++ b/src/Honua.Server/Features/Infrastructure/Styling/MapLibreStyleNormalizer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Honua.Core.Features.Catalog.Domain;
@@ -128,7 +129,7 @@ internal static class MapLibreStyleNormalizer
         }
 
         if (versionNode is JsonValue stringNode && stringNode.TryGetValue<string>(out var text)
-            && int.TryParse(text, out var parsedText))
+            && int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedText))
         {
             version = parsedText;
             return true;

--- a/src/Honua.Server/Features/Infrastructure/Validation/ValidationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Validation/ValidationExtensions.cs
@@ -72,7 +72,7 @@ public static class ValidationExtensions
         CancellationToken cancellationToken = default)
     {
         // For OGC API Features, collection ID maps to layer ID
-        if (!int.TryParse(collectionId, out var layerId))
+        if (!int.TryParse(collectionId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId))
         {
             return ValidationResult<LayerDefinition>.Failure($"Invalid collection ID '{collectionId}'");
         }

--- a/src/Honua.Server/Features/OData/Models/ODataExtensions.cs
+++ b/src/Honua.Server/Features/OData/Models/ODataExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using Honua.Core.Features.Shared.Models;
 
 namespace Honua.Server.Features.OData.Models;
@@ -79,7 +80,7 @@ public static class ODataExtensions
         {
             long longId => longId,
             int intId => intId,
-            string strId when long.TryParse(strId, out var parsedId) => parsedId,
+            string strId when long.TryParse(strId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedId) => parsedId,
             _ => 0
         };
 

--- a/src/Honua.Server/Features/OData/Services/ODataFeaturePayloadParser.cs
+++ b/src/Honua.Server/Features/OData/Services/ODataFeaturePayloadParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using System.Text.Json;
 using Honua.Server.Features.OData.Models;
 
@@ -141,10 +142,11 @@ internal static class ODataFeaturePayloadParser
         {
             int i => TryAssign(i, out result),
             long l when l is >= int.MinValue and <= int.MaxValue => TryAssign((int)l, out result),
-            string s when int.TryParse(s, out var parsed) => TryAssign(parsed, out result),
+            string s when int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) => TryAssign(parsed, out result),
             JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetInt32(out var parsed) =>
                 TryAssign(parsed, out result),
-            JsonElement element when element.ValueKind == JsonValueKind.String && int.TryParse(element.GetString(), out var parsed) =>
+            JsonElement element when element.ValueKind == JsonValueKind.String &&
+                                     int.TryParse(element.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) =>
                 TryAssign(parsed, out result),
             _ => false
         };
@@ -157,10 +159,11 @@ internal static class ODataFeaturePayloadParser
         {
             long l => TryAssign(l, out result),
             int i => TryAssign(i, out result),
-            string s when long.TryParse(s, out var parsed) => TryAssign(parsed, out result),
+            string s when long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) => TryAssign(parsed, out result),
             JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetInt64(out var parsed) =>
                 TryAssign(parsed, out result),
-            JsonElement element when element.ValueKind == JsonValueKind.String && long.TryParse(element.GetString(), out var parsed) =>
+            JsonElement element when element.ValueKind == JsonValueKind.String &&
+                                     long.TryParse(element.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) =>
                 TryAssign(parsed, out result),
             _ => false
         };
@@ -180,17 +183,36 @@ internal static class ODataFeaturePayloadParser
         {
             null => null,
             ODataSpatialGeometry geometry => geometry,
-            JsonElement element => element.ValueKind switch
-            {
-                JsonValueKind.Null or JsonValueKind.Undefined => null,
-                JsonValueKind.Object => JsonSerializer.Deserialize<ODataSpatialGeometry>(
-                    element.GetRawText(),
-                    ODataJsonContext.Default.ODataSpatialGeometry),
-                _ => SetError<ODataSpatialGeometry?>("Geometry must be an object in OData spatial format.", out errorMessage)
-            },
+            JsonElement element => ParseGeometryElement(element, out errorMessage),
             Dictionary<string, object?> dict => DeserializeGeometry(dict, out errorMessage),
             _ => SetError<ODataSpatialGeometry?>("Geometry must be an object in OData spatial format.", out errorMessage)
         };
+    }
+
+    private static ODataSpatialGeometry? ParseGeometryElement(JsonElement element, out string? errorMessage)
+    {
+        errorMessage = null;
+
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Null:
+            case JsonValueKind.Undefined:
+                return null;
+            case JsonValueKind.Object:
+                try
+                {
+                    return JsonSerializer.Deserialize<ODataSpatialGeometry>(
+                        element.GetRawText(),
+                        ODataJsonContext.Default.ODataSpatialGeometry);
+                }
+                catch (JsonException)
+                {
+                    errorMessage = "Geometry must be a valid OData spatial object.";
+                    return null;
+                }
+            default:
+                return SetError<ODataSpatialGeometry?>("Geometry must be an object in OData spatial format.", out errorMessage);
+        }
     }
 
     private static Dictionary<string, object?> ParseAttributesValue(object? value, out string? errorMessage)

--- a/src/Honua.Server/Features/OData/Services/ODataSearchService.cs
+++ b/src/Honua.Server/Features/OData/Services/ODataSearchService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Honua.Core.Exceptions;
 using Honua.Core.Features.Catalog.Domain;
@@ -423,7 +424,7 @@ internal sealed partial class ODataSearchService
                 {
                     long l => l,
                     int i => i,
-                    string s when long.TryParse(s, out var parsed) => parsed,
+                    string s when long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) => parsed,
                     System.Text.Json.JsonElement je when je.ValueKind == System.Text.Json.JsonValueKind.Number => je.GetInt64(),
                     _ => (long?)null
                 };

--- a/src/Honua.Server/Features/OgcFeatures/CollectionsEndpoints.cs
+++ b/src/Honua.Server/Features/OgcFeatures/CollectionsEndpoints.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Globalization;
 using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
@@ -545,7 +546,7 @@ internal static class CollectionsEndpoints
         }
 
         resolvedCollectionId = collectionResult.Value!;
-        if (!int.TryParse(resolvedCollectionId, out layerId))
+        if (!int.TryParse(resolvedCollectionId, NumberStyles.Integer, CultureInfo.InvariantCulture, out layerId))
         {
             return false;
         }

--- a/src/Honua.Server/Features/OgcFeatures/Models/OgcExtensions.cs
+++ b/src/Honua.Server/Features/OgcFeatures/Models/OgcExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Shared.Models;
@@ -58,7 +59,7 @@ public static class OgcExtensions
         {
             long longId => longId,
             int intId => intId,
-            string strId when long.TryParse(strId, out var parsedId) => parsedId,
+            string strId when long.TryParse(strId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedId) => parsedId,
             _ => null
         };
 

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesQueryHandler.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesQueryHandler.cs
@@ -150,7 +150,6 @@ internal sealed partial class OgcFeaturesQueryHandler(
             };
 
             var useStreaming = effectiveLimit > StreamingThreshold &&
-                               !string.Equals(outputFormat, MediaTypes.Gml, StringComparison.OrdinalIgnoreCase) &&
                                !string.Equals(outputFormat, MediaTypes.Html, StringComparison.OrdinalIgnoreCase);
 
             var cacheableFormat = string.Equals(outputFormat, MediaTypes.Json, StringComparison.OrdinalIgnoreCase) ||
@@ -191,6 +190,15 @@ internal sealed partial class OgcFeaturesQueryHandler(
                 var streamBaseUrl = BaseUrlResolver.GetBaseUrl(context);
                 var streamBasePath = $"{streamBaseUrl}/ogc/features/collections/{collectionId}/items";
                 var streamLinks = BuildItemsLinks(request, streamBasePath, outputFormat, effectiveLimit, effectiveOffset, hasMoreResults);
+
+                if (string.Equals(outputFormat, MediaTypes.Gml, StringComparison.OrdinalIgnoreCase))
+                {
+                    return new StreamingGmlItemsResult(
+                        _streamingFeatureStore,
+                        layer,
+                        query,
+                        filterResult.CrsDefinition.Uri);
+                }
 
                 return new StreamingItemsResult(
                     _streamingFeatureStore,
@@ -643,6 +651,15 @@ internal sealed partial class OgcFeaturesQueryHandler(
         await context.Response.BodyWriter.CompleteAsync();
     }
 
+    private static void EnableChunkedEncodingIfHttp1(HttpContext context)
+    {
+        if (string.IsNullOrEmpty(context.Request.Protocol)
+            || context.Request.Protocol.StartsWith("HTTP/1", StringComparison.OrdinalIgnoreCase))
+        {
+            context.Response.Headers.TransferEncoding = "chunked";
+        }
+    }
+
     private sealed class StreamingItemsResult : IResult
     {
         private readonly IStreamingFeatureStore _streamingFeatureStore;
@@ -684,6 +701,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
         {
             httpContext.Response.ContentType = _outputFormat;
             httpContext.Response.Headers["Content-Crs"] = FormatContentCrs(_crsUri);
+            EnableChunkedEncodingIfHttp1(httpContext);
 
             var stream = _streamingFeatureStore.StreamFeaturesAsync(
                 _layer.Id,
@@ -700,6 +718,45 @@ internal sealed partial class OgcFeaturesQueryHandler(
                 _links,
                 _numberMatched,
                 httpContext.RequestAborted);
+        }
+    }
+
+    private sealed class StreamingGmlItemsResult : IResult
+    {
+        private readonly IStreamingFeatureStore _streamingFeatureStore;
+        private readonly LayerDefinition _layer;
+        private readonly FeatureQuery _query;
+        private readonly string _crsUri;
+
+        public StreamingGmlItemsResult(
+            IStreamingFeatureStore streamingFeatureStore,
+            LayerDefinition layer,
+            FeatureQuery query,
+            string crsUri)
+        {
+            _streamingFeatureStore = streamingFeatureStore;
+            _layer = layer;
+            _query = query;
+            _crsUri = crsUri;
+        }
+
+        public async Task ExecuteAsync(HttpContext httpContext)
+        {
+            httpContext.Response.ContentType = MediaTypes.Gml;
+            httpContext.Response.Headers["Content-Crs"] = FormatContentCrs(_crsUri);
+            EnableChunkedEncodingIfHttp1(httpContext);
+
+            var stream = _streamingFeatureStore.StreamGmlFeaturesAsync(
+                _layer.Id,
+                _query,
+                httpContext.RequestAborted);
+
+            await OgcResponseFormatter.StreamGmlFeatureCollectionAsync(
+                stream,
+                httpContext.Response.BodyWriter,
+                httpContext.RequestAborted);
+
+            await httpContext.Response.BodyWriter.CompleteAsync();
         }
     }
 

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesTransactionHandler.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesTransactionHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Honua.Core.Exceptions;
@@ -160,7 +161,7 @@ internal sealed partial class OgcFeaturesTransactionHandler(
             var layer = layerValidation.Layer!;
             var layerId = layer.Id;
 
-            if (!long.TryParse(featureId, out var objectId))
+            if (!long.TryParse(featureId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
             {
                 return StandardErrorHelpers.CreateNotFound(context, $"Feature '{featureId}' not found.");
             }
@@ -349,7 +350,7 @@ internal sealed partial class OgcFeaturesTransactionHandler(
             };
         }
 
-        if (!long.TryParse(operation.FeatureId, out var objectId))
+        if (!long.TryParse(operation.FeatureId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
         {
             return new BatchOperationResult
             {
@@ -421,7 +422,7 @@ internal sealed partial class OgcFeaturesTransactionHandler(
             };
         }
 
-        if (!long.TryParse(operation.FeatureId, out var objectId))
+        if (!long.TryParse(operation.FeatureId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
         {
             return new BatchOperationResult
             {

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesUtilities.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesUtilities.cs
@@ -151,7 +151,7 @@ internal static class OgcFeaturesUtilities
         if (trimmed.StartsWith("EPSG:", StringComparison.OrdinalIgnoreCase))
         {
             var code = trimmed[5..];
-            if (int.TryParse(code, out var srid))
+            if (int.TryParse(code, NumberStyles.Integer, CultureInfo.InvariantCulture, out var srid))
             {
                 return $"http://www.opengis.net/def/crs/EPSG/0/{srid}";
             }
@@ -161,7 +161,7 @@ internal static class OgcFeaturesUtilities
         if (trimmed.StartsWith(urnPrefix, StringComparison.OrdinalIgnoreCase))
         {
             var code = trimmed[urnPrefix.Length..];
-            if (int.TryParse(code, out var srid))
+            if (int.TryParse(code, NumberStyles.Integer, CultureInfo.InvariantCulture, out var srid))
             {
                 return $"http://www.opengis.net/def/crs/EPSG/0/{srid}";
             }

--- a/src/Honua.Server/Features/OgcFeatures/Services/OgcResponseFormatter.cs
+++ b/src/Honua.Server/Features/OgcFeatures/Services/OgcResponseFormatter.cs
@@ -1,10 +1,13 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Collections.Immutable;
 using System.Net;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using System.IO;
+using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.OgcFeatures.Models;
 
@@ -110,6 +113,38 @@ internal static class OgcResponseFormatter
 
         builder.AppendLine("</wfs:FeatureCollection>");
         return builder.ToString();
+    }
+
+    /// <summary>
+    /// Streams GML representation of a feature collection.
+    /// </summary>
+    public static async Task StreamGmlFeatureCollectionAsync(
+        IAsyncEnumerable<GmlFeature> features,
+        System.IO.Pipelines.PipeWriter bodyWriter,
+        CancellationToken cancellationToken)
+    {
+        await using var writer = new StreamWriter(
+            bodyWriter.AsStream(),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            bufferSize: 8192,
+            leaveOpen: true);
+
+        await writer.WriteLineAsync(
+            $"<wfs:FeatureCollection xmlns:wfs=\"{OgcFeaturesUtilities.WfsNamespace}\" xmlns:gml=\"{OgcFeaturesUtilities.GmlNamespace}\">");
+
+        await foreach (var feature in features.WithCancellation(cancellationToken))
+        {
+            await writer.WriteLineAsync("  <wfs:member>");
+            await writer.WriteLineAsync($"    <gml:Feature gml:id=\"{feature.Id}\">");
+            WriteGmlGeometry(writer, feature.GeometryGml, "      ");
+            WriteGmlProperties(writer, feature.Attributes, "      ");
+            await writer.WriteLineAsync("    </gml:Feature>");
+            await writer.WriteLineAsync("  </wfs:member>");
+            await writer.FlushAsync(cancellationToken);
+        }
+
+        await writer.WriteLineAsync("</wfs:FeatureCollection>");
+        await writer.FlushAsync(cancellationToken);
     }
 
     /// <summary>
@@ -314,6 +349,47 @@ internal static class OgcResponseFormatter
                 .Replace("'", "&apos;", StringComparison.Ordinal);
 
             builder.AppendLine($"{indent}<gml:property name=\"{safeKey}\">{safeValue}</gml:property>");
+        }
+    }
+
+    private static void WriteGmlGeometry(TextWriter writer, string? geometryGml, string indent)
+    {
+        if (string.IsNullOrWhiteSpace(geometryGml))
+        {
+            writer.WriteLine($"{indent}<gml:Point />");
+            return;
+        }
+
+        var lines = geometryGml.Split('\n');
+        foreach (var line in lines)
+        {
+            writer.Write(indent);
+            writer.WriteLine(line.TrimEnd('\r'));
+        }
+    }
+
+    private static void WriteGmlProperties(TextWriter writer, ImmutableDictionary<string, object?> properties, string indent)
+    {
+        if (properties.IsEmpty)
+        {
+            return;
+        }
+
+        foreach (var (key, value) in properties)
+        {
+            if (value == null)
+            {
+                continue;
+            }
+
+            var safeKey = key.Replace(" ", "_", StringComparison.Ordinal);
+            var safeValue = value.ToString()?.Replace("&", "&amp;", StringComparison.Ordinal)
+                .Replace("<", "&lt;", StringComparison.Ordinal)
+                .Replace(">", "&gt;", StringComparison.Ordinal)
+                .Replace("\"", "&quot;", StringComparison.Ordinal)
+                .Replace("'", "&apos;", StringComparison.Ordinal);
+
+            writer.WriteLine($"{indent}<gml:property name=\"{safeKey}\">{safeValue}</gml:property>");
         }
     }
 

--- a/src/Honua.Server/Features/OgcFeatures/Services/OgcResponseFormatter.cs
+++ b/src/Honua.Server/Features/OgcFeatures/Services/OgcResponseFormatter.cs
@@ -2,11 +2,12 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.IO;
 using System.Net;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
-using System.IO;
+
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.OgcFeatures.Models;

--- a/src/Honua.Server/Features/OgcTiles/CollectionsEndpoints.cs
+++ b/src/Honua.Server/Features/OgcTiles/CollectionsEndpoints.cs
@@ -135,7 +135,7 @@ internal static class CollectionsEndpoints
                 return OgcCommonUtilities.CreateFormatError(context, formatError);
             }
 
-            if (!int.TryParse(collectionId, out var layerId))
+            if (!int.TryParse(collectionId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId))
             {
                 return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
             }

--- a/src/Honua.Server/Features/OgcTiles/TilesEndpoints.cs
+++ b/src/Honua.Server/Features/OgcTiles/TilesEndpoints.cs
@@ -255,7 +255,7 @@ internal static class TilesEndpoints
             return CreateFormatError(context, f);
         }
 
-        if (!int.TryParse(collectionId, out var layerId))
+        if (!int.TryParse(collectionId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId))
         {
             return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
         }
@@ -306,7 +306,7 @@ internal static class TilesEndpoints
             return CreateFormatError(context, f);
         }
 
-        if (!int.TryParse(collectionId, out var layerId))
+        if (!int.TryParse(collectionId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId))
         {
             return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
         }

--- a/tests/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
+++ b/tests/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
@@ -140,6 +140,39 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
         toggleApi.Data!.Enabled.Should().BeFalse();
     }
 
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
+    public async Task PublishLayer_PrimaryKeyNotInFields_ReturnsBadRequest()
+    {
+        var publishRequest = new PublishLayerRequest
+        {
+            Schema = _schema,
+            Table = _tableName,
+            LayerName = $"Layer {_tableName}",
+            Description = "Layer publish integration test",
+            GeometryColumn = "geom",
+            GeometryType = "Point",
+            Srid = 4326,
+            PrimaryKey = "id",
+            Fields = new[] { "name", "population" },
+            ServiceName = _serviceName,
+            Enabled = true
+        };
+
+        var response = await _client.PostAsync(
+            $"/api/v1/admin/connections/{_connectionId}/layers",
+            JsonContent.Create(publishRequest, options: _jsonOptions));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var payload = await response.Content.ReadAsStringAsync();
+        var api = JsonSerializer.Deserialize<ApiResponse<object>>(payload, _jsonOptions);
+        api.Should().NotBeNull();
+        api!.Success.Should().BeFalse();
+        api.Message.Should().Contain("Primary key field 'id' must be included in selected fields.");
+    }
+
     private async Task CreatePostGisTableAsync()
     {
         var sql = $"""

--- a/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerTemporalTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerTemporalTests.cs
@@ -81,6 +81,31 @@ public sealed class FeatureServerTemporalTests : IClassFixture<WebAppFixture>
         };
     }
 
+    private static long? TryReadObjectId(JsonElement feature)
+    {
+        if (!feature.TryGetProperty("attributes", out var attributes))
+        {
+            return null;
+        }
+
+        if (attributes.TryGetProperty("objectid", out var objectId) ||
+            attributes.TryGetProperty("OBJECTID", out objectId))
+        {
+            if (objectId.ValueKind == JsonValueKind.Number && objectId.TryGetInt64(out var numericId))
+            {
+                return numericId;
+            }
+
+            if (objectId.ValueKind == JsonValueKind.String &&
+                long.TryParse(objectId.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedId))
+            {
+                return parsedId;
+            }
+        }
+
+        return null;
+    }
+
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
@@ -107,6 +132,49 @@ public sealed class FeatureServerTemporalTests : IClassFixture<WebAppFixture>
 
         // Verify temporal filtering was applied (implementation dependent on test data)
         // In a real test environment, this would verify against known test data
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task GeoServicesQuery_TimeParsing_UsesInvariantCulture()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUiCulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            var overrideCulture = new CultureInfo("en-GB");
+            CultureInfo.CurrentCulture = overrideCulture;
+            CultureInfo.CurrentUICulture = overrideCulture;
+
+            var serviceId = WebAppFixture.TestServiceId;
+            var layerId = WebAppFixture.TestLayerId;
+            var encodedTime = Uri.EscapeDataString("07/06/2024");
+
+            var response = await _client.GetAsync(
+                $"/rest/services/{serviceId}/FeatureServer/{layerId}/query?time={encodedTime}&f=json");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var content = await response.Content.ReadAsStringAsync();
+            using var document = JsonDocument.Parse(content);
+
+            document.RootElement.TryGetProperty("features", out var featuresElement).Should().BeTrue();
+
+            var objectIds = featuresElement.EnumerateArray()
+                .Select(feature => TryReadObjectId(feature))
+                .Where(id => id.HasValue)
+                .Select(id => id!.Value)
+                .ToArray();
+
+            objectIds.Should().Contain(4);
+            objectIds.Should().NotContain(2);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
     }
 
     [IntegrationTest]

--- a/tests/Honua.Server.Tests/Features/OData/ODataErrorHandlingTests.cs
+++ b/tests/Honua.Server.Tests/Features/OData/ODataErrorHandlingTests.cs
@@ -395,6 +395,30 @@ public sealed class ODataErrorHandlingTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /odata/Layers({layerId})/Features with invalid geometry coordinate type")]
+    public async Task Create_InvalidGeometryCoordinateType_ReturnsBadRequest()
+    {
+        var payload = new
+        {
+            Geometry = new
+            {
+                type = "Point",
+                coordinates = 123
+            },
+            Attributes = new { name = "Test" }
+        };
+
+        var json = JsonSerializer.Serialize(payload);
+        var response = await _fixture.Client.PostAsync(
+            $"/odata/Layers({TestLayerId})/Features",
+            new StringContent(json, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await AssertODataErrorAsync(response);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
     [Endpoint("PATCH /odata/Features({layerId},{objectId}) with invalid JSON")]
     public async Task Update_InvalidJson_ReturnsBadRequest()
     {

--- a/tests/Honua.Server.Tests/Features/OgcFeatures/OgcFeaturesStreamingTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcFeatures/OgcFeaturesStreamingTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.OgcFeatures;
+
+[Collection("Database")]
+[Protocol(Protocols.OgcApiFeatures)]
+[Operation(Operations.Query)]
+public sealed class OgcFeaturesStreamingTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+    private const int TestLayerId = 0;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        await _fixture.EnsureLargeTestDatasetAsync();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    public async Task GetItems_LargeLimit_UsesStreamingResponse()
+    {
+        var response = await _fixture.Client.GetAsync($"/ogc/features/collections/{TestLayerId}/items?limit=2000");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.True(response.Headers.TransferEncodingChunked ?? false,
+            "Expected chunked transfer encoding for streaming responses");
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(content);
+
+        document.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        document.RootElement.GetProperty("features").EnumerateArray().Should().NotBeEmpty();
+        document.RootElement.TryGetProperty("numberMatched", out _).Should().BeTrue();
+        document.RootElement.TryGetProperty("numberReturned", out _).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items?f=gml")]
+    public async Task GetItems_LargeLimit_Gml_UsesStreamingResponse()
+    {
+        var response = await _fixture.Client.GetAsync($"/ogc/features/collections/{TestLayerId}/items?limit=2000&f=gml");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.True(response.Headers.TransferEncodingChunked ?? false,
+            "Expected chunked transfer encoding for streaming GML responses");
+
+        response.Content.Headers.ContentType?.MediaType.Should().Contain("application/gml+xml");
+
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("<wfs:FeatureCollection");
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #229

## Summary
Stream OGC GML responses via IStreamingFeatureStore and add streaming coverage for large query responses. Also includes endpoint parsing/validation refactors and related tests.

## Changes Made
- stream OGC items in GML using incremental writer and chunked transfer encoding
- add OGC streaming integration tests for large JSON/GML responses
- refactor endpoint parsing/validation helpers and add coverage for admin, FeatureServer, and OData behaviors

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)

## Coverage Impact
- Line coverage: Not measured locally (reports generated by pre-pr run)
- Branch coverage: Not measured locally (reports generated by pre-pr run)

## Breaking Changes
None

## Additional Context
Pre-push validation ran full format/build/tests.

---

## Pre-PR Checklist (for contributor)
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit message follows format: `type: description (#issue-number)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] Documentation updated if needed

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed
