### PR TITLE
feat: add admin health dashboard and layer enablement (#42)

### DIFF
--- a/appsettings.Monitoring.json
+++ b/appsettings.Monitoring.json
@@ -1,5 +1,8 @@
 {
   "Monitoring": {
+    "RecentErrors": {
+      "Capacity": 50
+    },
     "AnomalyDetection": {
       "BaselineWindowMinutes": 60,
       "SensitivityThreshold": 0.3,

--- a/docs/performance-monitoring.md
+++ b/docs/performance-monitoring.md
@@ -173,6 +173,23 @@ Returns database performance statistics:
 }
 ```
 
+## Admin Health Dashboard (MVP)
+
+The Admin UI health dashboard (`/admin/health`) aggregates the built-in health/metrics endpoints along with a lightweight recent error buffer:
+
+- `/healthz/live` and `/healthz/ready` for service status.
+- `/api/v1/metrics/health`, `/performance`, `/database`, `/cache`, `/memory` for metrics snapshots.
+- `/api/v1/admin/observability/errors` for recent errors (in-memory ring buffer).
+- `/api/v1/admin/observability/telemetry` for telemetry configuration status.
+
+The recent error buffer is intentionally lightweight and non-persistent. Configure its size with
+`Monitoring:RecentErrors:Capacity` (environment variable: `HONUA__MONITORING__RECENTERRORS__CAPACITY`).
+Entries are sanitized to avoid exposing sensitive data.
+
+When OpenTelemetry OTLP export is configured (`Tracing:OtlpEndpoint` or `OTEL_EXPORTER_OTLP_ENDPOINT`), the
+dashboard surfaces a link to your telemetry backend. Without OTLP, the dashboard still works using only
+the built-in endpoints.
+
 ## Monitoring Integration
 
 ### Aspire Dashboard

--- a/src/Honua.Admin/App.razor
+++ b/src/Honua.Admin/App.razor
@@ -13,7 +13,7 @@
                 <NotAuthorized>
                     <LayoutView Layout="@typeof(MainLayout)">
                         <MudPaper Class="pa-6" Elevation="0">
-                            <MudText Typo="Typo.h6">Sign in required</MudText>
+                            <MudText Typo="Typo.h6" HtmlTag="h1">Sign in required</MudText>
                             <MudText Typo="Typo.body2" Class="mb-4">
                                 Use your organization identity provider to access Honua Admin.
                             </MudText>

--- a/src/Honua.Admin/Layout/MainLayout.razor
+++ b/src/Honua.Admin/Layout/MainLayout.razor
@@ -1,6 +1,7 @@
 ﻿@inherits LayoutComponentBase
 
 <MudThemeProvider />
+<MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
 

--- a/src/Honua.Admin/Models/AdminJsonContext.cs
+++ b/src/Honua.Admin/Models/AdminJsonContext.cs
@@ -19,6 +19,18 @@ namespace Honua.Admin.Models;
 [JsonSerializable(typeof(LayerStyleResponse))]
 [JsonSerializable(typeof(TileJsonResponse))]
 [JsonSerializable(typeof(JsonElement))]
+[JsonSerializable(typeof(HealthMetrics))]
+[JsonSerializable(typeof(PerformanceMetricsResponse))]
+[JsonSerializable(typeof(SystemInfo))]
+[JsonSerializable(typeof(HttpRequestMetrics))]
+[JsonSerializable(typeof(DatabaseMetrics))]
+[JsonSerializable(typeof(DatabaseOperationMetrics))]
+[JsonSerializable(typeof(CacheMetrics))]
+[JsonSerializable(typeof(CacheTypeMetrics))]
+[JsonSerializable(typeof(MemoryUsage))]
+[JsonSerializable(typeof(RecentErrorEntry))]
+[JsonSerializable(typeof(RecentErrorsResponse))]
+[JsonSerializable(typeof(ObservabilityStatusResponse))]
 internal sealed partial class AdminJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Admin/Models/ObservabilityModels.cs
+++ b/src/Honua.Admin/Models/ObservabilityModels.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Admin.Models;
+
+public sealed class HealthMetrics
+{
+    public string? Status { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
+    public double MemoryUsageMB { get; set; }
+    public double MemoryPressurePercent { get; set; }
+    public int GCCollections { get; set; }
+}
+
+public sealed class PerformanceMetricsResponse
+{
+    public DateTimeOffset Timestamp { get; set; }
+    public MemoryUsage? Memory { get; set; }
+    public SystemInfo? SystemInfo { get; set; }
+    public HttpRequestMetrics? Http { get; set; }
+}
+
+public sealed class SystemInfo
+{
+    public int ProcessorCount { get; set; }
+    public string? MachineName { get; set; }
+    public long WorkingSet { get; set; }
+    public string? FrameworkVersion { get; set; }
+}
+
+public sealed class HttpRequestMetrics
+{
+    public long TotalRequests { get; set; }
+    public long TotalServerErrors { get; set; }
+    public long TotalClientErrors { get; set; }
+    public int ActiveRequests { get; set; }
+    public double AvgDurationMs { get; set; }
+    public double MaxDurationMs { get; set; }
+    public double P95DurationMs { get; set; }
+    public long SlowRequests { get; set; }
+    public double SlowRequestThresholdMs { get; set; }
+    public double ServerErrorRate { get; set; }
+}
+
+public sealed class DatabaseMetrics
+{
+    public DateTimeOffset Timestamp { get; set; }
+    public double CacheHitRate { get; set; }
+    public long CacheHits { get; set; }
+    public long CacheMisses { get; set; }
+    public Dictionary<string, DatabaseOperationMetrics>? Operations { get; set; }
+}
+
+public sealed class DatabaseOperationMetrics
+{
+    public long Count { get; set; }
+    public long TotalTimeMs { get; set; }
+    public long MaxTimeMs { get; set; }
+    public double AvgTimeMs { get; set; }
+}
+
+public sealed class CacheMetrics
+{
+    public DateTimeOffset Timestamp { get; set; }
+    public long TotalRequests { get; set; }
+    public double HitRatio { get; set; }
+    public Dictionary<string, CacheTypeMetrics>? Types { get; set; }
+}
+
+public sealed class CacheTypeMetrics
+{
+    public long Hits { get; set; }
+    public long Misses { get; set; }
+    public long Evictions { get; set; }
+    public double AvgOperationTimeMs { get; set; }
+    public double HitRatio { get; set; }
+}
+
+public sealed class MemoryUsage
+{
+    public long AllocatedBytes { get; set; }
+    public int Gen0Collections { get; set; }
+    public int Gen1Collections { get; set; }
+    public int Gen2Collections { get; set; }
+    public long HeapSizeBytes { get; set; }
+    public long HighMemoryLoadThresholdBytes { get; set; }
+    public long MemoryLoadBytes { get; set; }
+    public long TotalAvailableMemoryBytes { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
+    public double MemoryPressurePercentage { get; set; }
+    public bool IsHighMemoryPressure { get; set; }
+    public int TotalGCCollections { get; set; }
+}
+
+public sealed class RecentErrorEntry
+{
+    public DateTimeOffset Timestamp { get; set; }
+    public string? CorrelationId { get; set; }
+    public string? Path { get; set; }
+    public int StatusCode { get; set; }
+    public string? Message { get; set; }
+}
+
+public sealed class RecentErrorsResponse
+{
+    public int Capacity { get; set; }
+    public List<RecentErrorEntry>? Errors { get; set; }
+}
+
+public sealed class ObservabilityStatusResponse
+{
+    public bool TracingEnabled { get; set; }
+    public bool OtlpConfigured { get; set; }
+    public string? OtlpEndpoint { get; set; }
+}

--- a/src/Honua.Admin/Pages/Connections.razor
+++ b/src/Honua.Admin/Pages/Connections.razor
@@ -9,7 +9,7 @@
 
 <MudStack Spacing="2">
     <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
-        <MudText Typo="Typo.h4">Connections</MudText>
+        <MudText Typo="Typo.h4" HtmlTag="h1">Connections</MudText>
         <MudButton StartIcon="@Icons.Material.Filled.Add"
                    Variant="Variant.Filled"
                    Color="Color.Primary"
@@ -74,18 +74,21 @@
                     <MudTooltip Text="Test connection">
                         <MudIconButton Icon="@Icons.Material.Filled.Sync"
                                        OnClick="@(() => TestConnectionAsync(context))"
-                                       Disabled="@IsTesting(context.ConnectionId)" />
+                                       Disabled="@IsTesting(context.ConnectionId)"
+                                       data-testid="@($"connection-test-{context.ConnectionId}")" />
                     </MudTooltip>
                     <MudTooltip Text="Edit">
                         <MudIconButton Icon="@Icons.Material.Filled.Edit"
                                        OnClick="@(() => EditConnectionAsync(context))"
-                                       Disabled="@_isSaving" />
+                                       Disabled="@_isSaving"
+                                       data-testid="@($"connection-edit-{context.ConnectionId}")" />
                     </MudTooltip>
                     <MudTooltip Text="Delete">
                         <MudIconButton Icon="@Icons.Material.Filled.Delete"
                                        Color="Color.Error"
                                        OnClick="@(() => DeleteConnectionAsync(context))"
-                                       Disabled="@_isSaving" />
+                                       Disabled="@_isSaving"
+                                       data-testid="@($"connection-delete-{context.ConnectionId}")" />
                     </MudTooltip>
                 </MudTd>
             </RowTemplate>
@@ -299,6 +302,7 @@
         {
             return;
         }
+        StateHasChanged();
 
         try
         {

--- a/src/Honua.Admin/Pages/Health.razor
+++ b/src/Honua.Admin/Pages/Health.razor
@@ -1,15 +1,581 @@
-﻿@page "/health"
+@page "/health"
+@using System.Globalization
+@using System.Text.Json
+@using Honua.Admin.Models
+@implements IAsyncDisposable
+@inject IHttpClientFactory HttpClientFactory
 
 <PageTitle>Health</PageTitle>
 
-<MudText Typo="Typo.h4" Class="mb-2">Health</MudText>
-<MudText Typo="Typo.body2" Class="mb-4">
-    Monitor system health, cache status, and background operations.
-</MudText>
+<MudStack Spacing="2" data-testid="health-dashboard">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+        <MudText Typo="Typo.h4" HtmlTag="h1">Health</MudText>
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+            <MudSwitch T="bool" @bind-Value="AutoRefresh" Color="Color.Primary" Label="Auto-refresh" />
+            <MudTooltip Text="Refresh now">
+                <MudIconButton Icon="@Icons.Material.Filled.Refresh"
+                               Disabled="@_isLoading"
+                               OnClick="RefreshAsync"
+                               data-testid="health-refresh" />
+            </MudTooltip>
+        </MudStack>
+    </MudStack>
 
-<MudPaper Class="pa-4" Elevation="1">
-    <MudText Typo="Typo.subtitle2">Coming soon</MudText>
     <MudText Typo="Typo.body2">
-        Health dashboard UI will land with issue #42.
+        Live status, performance metrics, and recent errors for quick triage.
     </MudText>
-</MudPaper>
+
+    @if (_lastUpdated is not null)
+    {
+        <MudText Typo="Typo.caption" Color="Color.Secondary">Last updated: @_lastUpdated.Value.ToLocalTime().ToString("g", CultureInfo.CurrentCulture)</MudText>
+    }
+
+    <MudGrid>
+        <MudItem xs="12" md="6" lg="4">
+            <MudPaper Class="pa-4" Elevation="1" data-testid="health-status-card">
+                <MudText Typo="Typo.h6" Class="mb-2">Service status</MudText>
+                <MudStack Spacing="1">
+                    <MudChip T="string" Color="@GetStatusColor(_liveStatus.IsHealthy)" Variant="Variant.Filled" data-testid="health-live-status">
+                        Live: @GetStatusLabel(_liveStatus)
+                    </MudChip>
+                    <MudChip T="string" Color="@GetStatusColor(_readyStatus.IsHealthy)" Variant="Variant.Filled" data-testid="health-ready-status">
+                        Ready: @GetStatusLabel(_readyStatus)
+                    </MudChip>
+                </MudStack>
+                @if (_healthMetrics is not null)
+                {
+                    <MudText Typo="Typo.body2" Class="mt-2">Health snapshot: @(_healthMetrics.Status ?? "unknown")</MudText>
+                    <MudText Typo="Typo.body2">GC collections: @FormatNumber(_healthMetrics.GCCollections)</MudText>
+                }
+                @if (!string.IsNullOrWhiteSpace(_healthCheckError))
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">@_healthCheckError</MudAlert>
+                }
+                @if (!string.IsNullOrWhiteSpace(_healthMetricsError))
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">@_healthMetricsError</MudAlert>
+                }
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12" md="6" lg="4">
+            <MudPaper Class="pa-4" Elevation="1" data-testid="health-requests-card">
+                <MudText Typo="Typo.h6" Class="mb-2">Requests &amp; errors</MudText>
+                @if (_performanceMetrics?.Http is not null)
+                {
+                    <MudStack Spacing="1">
+                        <MudText Typo="Typo.body2">Total requests: @FormatNumber(_performanceMetrics.Http.TotalRequests)</MudText>
+                        <MudText Typo="Typo.body2">Server errors: @FormatNumber(_performanceMetrics.Http.TotalServerErrors)</MudText>
+                        <MudText Typo="Typo.body2">Error rate: @FormatPercent(_performanceMetrics.Http.ServerErrorRate)</MudText>
+                        <MudText Typo="Typo.body2">P95 latency: @FormatDuration(_performanceMetrics.Http.P95DurationMs)</MudText>
+                    </MudStack>
+                }
+                else
+                {
+                    <MudText Typo="Typo.body2">No request metrics available.</MudText>
+                }
+                @if (!string.IsNullOrWhiteSpace(_performanceError))
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">@_performanceError</MudAlert>
+                }
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12" md="6" lg="4">
+            <MudPaper Class="pa-4" Elevation="1" data-testid="health-database-card">
+                <MudText Typo="Typo.h6" Class="mb-2">Database</MudText>
+                @if (_databaseMetrics is not null)
+                {
+                    <MudStack Spacing="1">
+                        <MudText Typo="Typo.body2">Status: @GetStatusLabel(_readyStatus)</MudText>
+                        <MudText Typo="Typo.body2">Cache hit rate: @FormatPercent(_databaseMetrics.CacheHitRate)</MudText>
+                        <MudText Typo="Typo.body2">Ops observed: @FormatNumber(GetDatabaseOperationCount(_databaseMetrics))</MudText>
+                    </MudStack>
+                }
+                else
+                {
+                    <MudText Typo="Typo.body2">No database metrics available.</MudText>
+                }
+                @if (!string.IsNullOrWhiteSpace(_databaseError))
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">@_databaseError</MudAlert>
+                }
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12" md="6" lg="4">
+            <MudPaper Class="pa-4" Elevation="1" data-testid="health-cache-card">
+                <MudText Typo="Typo.h6" Class="mb-2">Cache</MudText>
+                @if (_cacheMetrics is not null)
+                {
+                    <MudStack Spacing="1">
+                        <MudText Typo="Typo.body2">Total requests: @FormatNumber(_cacheMetrics.TotalRequests)</MudText>
+                        <MudText Typo="Typo.body2">Hit ratio: @FormatPercent(_cacheMetrics.HitRatio)</MudText>
+                    </MudStack>
+                }
+                else
+                {
+                    <MudText Typo="Typo.body2">No cache metrics available.</MudText>
+                }
+                @if (!string.IsNullOrWhiteSpace(_cacheError))
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">@_cacheError</MudAlert>
+                }
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12" md="6" lg="4">
+            <MudPaper Class="pa-4" Elevation="1" data-testid="health-memory-card">
+                <MudText Typo="Typo.h6" Class="mb-2">Memory</MudText>
+                @if (_memoryUsage is not null)
+                {
+                    <MudStack Spacing="1">
+                        <MudText Typo="Typo.body2">Allocated: @FormatMemoryMb(_memoryUsage.AllocatedBytes)</MudText>
+                        <MudText Typo="Typo.body2">Pressure: @FormatPercent(_memoryUsage.MemoryPressurePercentage / 100.0)</MudText>
+                        <MudText Typo="Typo.body2">GC collections: @FormatNumber(_memoryUsage.TotalGCCollections)</MudText>
+                    </MudStack>
+                }
+                else if (_healthMetrics is not null)
+                {
+                    <MudStack Spacing="1">
+                        <MudText Typo="Typo.body2">Allocated: @_healthMetrics.MemoryUsageMB.ToString("N1", CultureInfo.CurrentCulture) MB</MudText>
+                        <MudText Typo="Typo.body2">Pressure: @_healthMetrics.MemoryPressurePercent.ToString("N1", CultureInfo.CurrentCulture)%</MudText>
+                        <MudText Typo="Typo.body2">GC collections: @FormatNumber(_healthMetrics.GCCollections)</MudText>
+                    </MudStack>
+                }
+                else
+                {
+                    <MudText Typo="Typo.body2">No memory metrics available.</MudText>
+                }
+                @{
+                    var memoryErrorMessage = _memoryError;
+                    if (string.IsNullOrWhiteSpace(memoryErrorMessage) && _memoryUsage is null && _healthMetrics is null)
+                    {
+                        memoryErrorMessage = _healthMetricsError;
+                    }
+                }
+                @if (!string.IsNullOrWhiteSpace(memoryErrorMessage))
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">@memoryErrorMessage</MudAlert>
+                }
+            </MudPaper>
+        </MudItem>
+    </MudGrid>
+
+    <MudPaper Class="pa-4" Elevation="1" data-testid="health-recent-errors">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="mb-2">
+            <MudText Typo="Typo.h6">Recent errors</MudText>
+            <MudText Typo="Typo.caption">Showing @(_recentErrors?.Errors?.Count ?? 0) of @(_recentErrors?.Capacity ?? 0)</MudText>
+        </MudStack>
+
+        @if (_isLoading)
+        {
+            <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+        }
+
+        @if (!string.IsNullOrWhiteSpace(_errorsError))
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">@_errorsError</MudAlert>
+        }
+        else if (_recentErrors?.Errors is null || _recentErrors.Errors.Count == 0)
+        {
+            <MudText Typo="Typo.body2">No recent errors recorded.</MudText>
+        }
+        else
+        {
+            <MudTable Items="_recentErrors.Errors" Dense="true" Hover="true" data-testid="health-recent-errors-table">
+                <HeaderContent>
+                    <MudTh>Timestamp</MudTh>
+                    <MudTh>Status</MudTh>
+                    <MudTh>Path</MudTh>
+                    <MudTh>Correlation</MudTh>
+                    <MudTh>Message</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Timestamp">@context.Timestamp.ToLocalTime().ToString("g", CultureInfo.CurrentCulture)</MudTd>
+                    <MudTd DataLabel="Status">
+                        <MudChip T="string" Color="@GetStatusColor(context.StatusCode < 500)" Size="Size.Small">@context.StatusCode</MudChip>
+                    </MudTd>
+                    <MudTd DataLabel="Path">@context.Path</MudTd>
+                    <MudTd DataLabel="Correlation">@context.CorrelationId</MudTd>
+                    <MudTd DataLabel="Message">@context.Message</MudTd>
+                </RowTemplate>
+            </MudTable>
+        }
+    </MudPaper>
+
+    <MudPaper Class="pa-4" Elevation="1" data-testid="health-telemetry">
+        <MudText Typo="Typo.h6" Class="mb-2">Telemetry</MudText>
+        @if (_observabilityStatus?.OtlpConfigured == true && !string.IsNullOrWhiteSpace(_observabilityStatus.OtlpEndpoint))
+        {
+            <MudText Typo="Typo.body2">OTLP exporter configured for @_observabilityStatus.OtlpEndpoint</MudText>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.OpenInNew"
+                       Href="@_observabilityStatus.OtlpEndpoint"
+                       Target="_blank"
+                       Class="mt-2">
+                View telemetry backend
+            </MudButton>
+        }
+        else
+        {
+            <MudText Typo="Typo.body2">No external telemetry backend configured.</MudText>
+        }
+        @if (!string.IsNullOrWhiteSpace(_telemetryError))
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">@_telemetryError</MudAlert>
+        }
+    </MudPaper>
+</MudStack>
+
+@code {
+    private const int RefreshIntervalSeconds = 15;
+    private static readonly JsonSerializerOptions _jsonOptions = AdminJsonContext.Default.Options;
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+
+    private HttpClient? _apiClient;
+    private CancellationTokenSource? _refreshCts;
+    private PeriodicTimer? _refreshTimer;
+    private Task? _refreshLoop;
+
+    private bool _isLoading;
+    private bool _autoRefresh = true;
+    private DateTimeOffset? _lastUpdated;
+
+    private HealthCheckSnapshot _liveStatus = HealthCheckSnapshot.Unknown;
+    private HealthCheckSnapshot _readyStatus = HealthCheckSnapshot.Unknown;
+
+    private HealthMetrics? _healthMetrics;
+    private PerformanceMetricsResponse? _performanceMetrics;
+    private DatabaseMetrics? _databaseMetrics;
+    private CacheMetrics? _cacheMetrics;
+    private MemoryUsage? _memoryUsage;
+    private RecentErrorsResponse? _recentErrors;
+    private ObservabilityStatusResponse? _observabilityStatus;
+
+    private string? _healthCheckError;
+    private string? _healthMetricsError;
+    private string? _performanceError;
+    private string? _databaseError;
+    private string? _cacheError;
+    private string? _memoryError;
+    private string? _errorsError;
+    private string? _telemetryError;
+
+    private bool AutoRefresh
+    {
+        get => _autoRefresh;
+        set
+        {
+            if (_autoRefresh == value)
+            {
+                return;
+            }
+
+            _autoRefresh = value;
+            if (_autoRefresh)
+            {
+                StartAutoRefresh();
+            }
+            else
+            {
+                StopAutoRefresh();
+            }
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        _apiClient = HttpClientFactory.CreateClient("AdminApi");
+        await LoadAllAsync();
+
+        if (AutoRefresh)
+        {
+            StartAutoRefresh();
+        }
+    }
+
+    private async Task RefreshAsync()
+    {
+        await LoadAllAsync();
+    }
+
+    private void StartAutoRefresh()
+    {
+        StopAutoRefresh();
+
+        _refreshCts = new CancellationTokenSource();
+        _refreshTimer = new PeriodicTimer(TimeSpan.FromSeconds(RefreshIntervalSeconds));
+        _refreshLoop = AutoRefreshLoopAsync(_refreshCts.Token);
+    }
+
+    private void StopAutoRefresh()
+    {
+        if (_refreshCts is null)
+        {
+            return;
+        }
+
+        _refreshCts.Cancel();
+        _refreshCts.Dispose();
+        _refreshCts = null;
+
+        _refreshTimer?.Dispose();
+        _refreshTimer = null;
+    }
+
+    private async Task AutoRefreshLoopAsync(CancellationToken token)
+    {
+        if (_refreshTimer is null)
+        {
+            return;
+        }
+
+        try
+        {
+            while (await _refreshTimer.WaitForNextTickAsync(token))
+            {
+                await InvokeAsync(LoadAllAsync);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Ignore cancellation.
+        }
+    }
+
+    private async Task LoadAllAsync()
+    {
+        if (_apiClient is null)
+        {
+            return;
+        }
+
+        if (!await _refreshGate.WaitAsync(0))
+        {
+            return;
+        }
+
+        try
+        {
+            _isLoading = true;
+
+            await LoadHealthChecksAsync();
+            await LoadHealthMetricsAsync();
+            await LoadPerformanceMetricsAsync();
+            await LoadDatabaseMetricsAsync();
+            await LoadCacheMetricsAsync();
+            await LoadMemoryMetricsAsync();
+            await LoadRecentErrorsAsync();
+            await LoadTelemetryStatusAsync();
+
+            _lastUpdated = DateTimeOffset.UtcNow;
+        }
+        finally
+        {
+            _isLoading = false;
+            _refreshGate.Release();
+            StateHasChanged();
+        }
+    }
+
+    private CancellationToken RefreshToken => _refreshCts?.Token ?? CancellationToken.None;
+
+    private async Task LoadHealthChecksAsync()
+    {
+        _healthCheckError = null;
+
+        try
+        {
+            _liveStatus = await GetHealthStatusAsync("/healthz/live");
+            _readyStatus = await GetHealthStatusAsync("/healthz/ready");
+        }
+        catch (OperationCanceledException)
+        {
+            // Ignore cancellation during refresh toggle.
+        }
+        catch (HttpRequestException)
+        {
+            _healthCheckError = "Unable to reach health endpoints.";
+            _liveStatus = HealthCheckSnapshot.Unknown;
+            _readyStatus = HealthCheckSnapshot.Unknown;
+        }
+    }
+
+    private async Task LoadHealthMetricsAsync()
+    {
+        _healthMetricsError = null;
+        _healthMetrics = await TryGetJsonAsync<HealthMetrics>("/api/v1/metrics/health", error => _healthMetricsError = error);
+    }
+
+    private async Task LoadPerformanceMetricsAsync()
+    {
+        _performanceError = null;
+        _performanceMetrics = await TryGetJsonAsync<PerformanceMetricsResponse>("/api/v1/metrics/performance", error => _performanceError = error);
+    }
+
+    private async Task LoadDatabaseMetricsAsync()
+    {
+        _databaseError = null;
+        _databaseMetrics = await TryGetJsonAsync<DatabaseMetrics>("/api/v1/metrics/database", error => _databaseError = error);
+    }
+
+    private async Task LoadCacheMetricsAsync()
+    {
+        _cacheError = null;
+        _cacheMetrics = await TryGetJsonAsync<CacheMetrics>("/api/v1/metrics/cache", error => _cacheError = error);
+    }
+
+    private async Task LoadMemoryMetricsAsync()
+    {
+        _memoryError = null;
+        _memoryUsage = await TryGetJsonAsync<MemoryUsage>("/api/v1/metrics/memory", error => _memoryError = error);
+    }
+
+    private async Task LoadRecentErrorsAsync()
+    {
+        _errorsError = null;
+        _recentErrors = await TryGetJsonAsync<RecentErrorsResponse>("observability/errors", error => _errorsError = error);
+    }
+
+    private async Task LoadTelemetryStatusAsync()
+    {
+        _telemetryError = null;
+        _observabilityStatus = await TryGetJsonAsync<ObservabilityStatusResponse>("observability/telemetry", error => _telemetryError = error);
+    }
+
+    private async Task<HealthCheckSnapshot> GetHealthStatusAsync(string uri)
+    {
+        if (_apiClient is null)
+        {
+            return HealthCheckSnapshot.Unknown;
+        }
+
+        using var response = await _apiClient.GetAsync(uri, RefreshToken);
+        string? message = null;
+        if (response.Content is not null)
+        {
+            message = await response.Content.ReadAsStringAsync(RefreshToken);
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                message = null;
+            }
+        }
+
+        return new HealthCheckSnapshot(response.IsSuccessStatusCode, (int)response.StatusCode, message);
+    }
+
+    private async Task<T?> TryGetJsonAsync<T>(string uri, Action<string?> setError)
+    {
+        if (_apiClient is null)
+        {
+            return default;
+        }
+
+        try
+        {
+            using var response = await _apiClient.GetAsync(uri, RefreshToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                setError($"Request failed ({(int)response.StatusCode}).");
+                return default;
+            }
+
+            var payload = await response.Content.ReadAsStringAsync(RefreshToken);
+            if (string.IsNullOrWhiteSpace(payload))
+            {
+                setError("Empty response from server.");
+                return default;
+            }
+
+            var result = JsonSerializer.Deserialize<T>(payload, _jsonOptions);
+            if (result is null)
+            {
+                setError("Unable to parse server response.");
+            }
+
+            return result;
+        }
+        catch (OperationCanceledException)
+        {
+            return default;
+        }
+        catch (Exception)
+        {
+            setError("Unable to load data.");
+            return default;
+        }
+    }
+
+    private static string GetStatusLabel(HealthCheckSnapshot status)
+    {
+        if (status.IsHealthy is null)
+        {
+            return "Unknown";
+        }
+
+        if (status.IsHealthy.Value)
+        {
+            return "Healthy";
+        }
+
+        return string.IsNullOrWhiteSpace(status.Message) ? "Unhealthy" : status.Message;
+    }
+
+    private static Color GetStatusColor(bool? isHealthy)
+    {
+        if (isHealthy is null)
+        {
+            return Color.Default;
+        }
+
+        return isHealthy.Value ? Color.Success : Color.Error;
+    }
+
+    private static string FormatNumber(long value)
+        => value.ToString("N0", CultureInfo.CurrentCulture);
+
+    private static string FormatPercent(double value)
+        => (value * 100).ToString("N1", CultureInfo.CurrentCulture) + "%";
+
+    private static string FormatDuration(double value)
+        => value.ToString("N0", CultureInfo.CurrentCulture) + " ms";
+
+    private static string FormatMemoryMb(long bytes)
+        => (bytes / (1024.0 * 1024.0)).ToString("N1", CultureInfo.CurrentCulture) + " MB";
+
+    private static long GetDatabaseOperationCount(DatabaseMetrics metrics)
+    {
+        if (metrics.Operations is null)
+        {
+            return 0;
+        }
+
+        return metrics.Operations.Values.Sum(operation => operation.Count);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        StopAutoRefresh();
+
+        if (_refreshLoop is not null)
+        {
+            try
+            {
+                await _refreshLoop;
+            }
+            catch (OperationCanceledException)
+            {
+                // Ignore cancellation.
+            }
+        }
+
+        _refreshGate.Dispose();
+    }
+
+    private readonly record struct HealthCheckSnapshot(bool? IsHealthy, int? StatusCode, string? Message)
+    {
+        public static HealthCheckSnapshot Unknown => new(null, null, null);
+    }
+}

--- a/src/Honua.Admin/Pages/Home.razor
+++ b/src/Honua.Admin/Pages/Home.razor
@@ -2,7 +2,7 @@
 
 <PageTitle>Dashboard</PageTitle>
 
-<MudText Typo="Typo.h4" Class="mb-2">Honua Admin</MudText>
+<MudText Typo="Typo.h4" HtmlTag="h1" Class="mb-2">Honua Admin</MudText>
 <MudText Typo="Typo.body1" Class="mb-4">
     Manage connections, publish layers, monitor health, and configure styles from one place.
 </MudText>

--- a/src/Honua.Admin/Pages/Import.razor
+++ b/src/Honua.Admin/Pages/Import.razor
@@ -9,7 +9,7 @@
 
 <MudStack Spacing="2">
     <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
-        <MudText Typo="Typo.h4">Import</MudText>
+        <MudText Typo="Typo.h4" HtmlTag="h1">Import</MudText>
         <MudButton Variant="Variant.Outlined"
                    Color="Color.Primary"
                    StartIcon="@Icons.Material.Filled.Refresh"

--- a/src/Honua.Admin/Pages/LayerSelectionPageBase.cs
+++ b/src/Honua.Admin/Pages/LayerSelectionPageBase.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Admin.Models;
+using Honua.Admin.Services;
+using Microsoft.AspNetCore.Components;
+
+namespace Honua.Admin.Pages;
+
+public abstract class LayerSelectionPageBase : ComponentBase
+{
+    [Inject] protected ISecureConnectionsClient ConnectionsClient { get; set; } = default!;
+    [Inject] protected ILayerPublishingClient LayerPublishingClient { get; set; } = default!;
+
+    protected List<SecureConnectionSummary> Connections { get; } = new();
+    protected List<PublishedLayerSummary> PublishedLayers { get; } = new();
+
+    protected Guid? SelectedConnectionId { get; private set; }
+    protected int? SelectedLayerId { get; private set; }
+    protected PublishedLayerSummary? SelectedLayer { get; private set; }
+
+    protected bool IsLoadingConnections { get; private set; }
+    protected bool IsLoadingLayers { get; private set; }
+    protected string? ErrorMessage { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadConnectionsAsync();
+        if (SelectedConnectionId.HasValue)
+        {
+            await LoadLayersAsync();
+            await EnsureSelectedLayerAsync();
+        }
+
+        await OnAfterSelectionInitializedAsync();
+    }
+
+    protected virtual Task OnAfterSelectionInitializedAsync() => Task.CompletedTask;
+
+    protected async Task HandleConnectionChanged(Guid? connectionId)
+    {
+        SelectedConnectionId = connectionId;
+        SelectedLayerId = null;
+        SelectedLayer = null;
+
+        await OnConnectionChangedAsync();
+        await RefreshAsync();
+    }
+
+    protected virtual Task OnConnectionChangedAsync() => Task.CompletedTask;
+
+    protected async Task HandleLayerChanged(int? layerId)
+    {
+        await UpdateSelectedLayerAsync(layerId, forceReload: true);
+    }
+
+    protected async Task RefreshAsync()
+    {
+        if (!SelectedConnectionId.HasValue)
+        {
+            return;
+        }
+
+        await LoadLayersAsync();
+        await EnsureSelectedLayerAsync();
+    }
+
+    protected async Task LoadConnectionsAsync()
+    {
+        IsLoadingConnections = true;
+        ErrorMessage = null;
+        StateHasChanged();
+
+        var result = await ConnectionsClient.GetConnectionsAsync();
+        IsLoadingConnections = false;
+
+        if (!result.Success)
+        {
+            ErrorMessage = result.Message ?? "Failed to load connections.";
+            return;
+        }
+
+        Connections.Clear();
+        Connections.AddRange(result.Data ?? Array.Empty<SecureConnectionSummary>());
+
+        if (Connections.Count > 0 && !SelectedConnectionId.HasValue)
+        {
+            SelectedConnectionId = Connections[0].ConnectionId;
+        }
+    }
+
+    protected async Task LoadLayersAsync()
+    {
+        IsLoadingLayers = true;
+        ErrorMessage = null;
+        StateHasChanged();
+
+        if (!SelectedConnectionId.HasValue)
+        {
+            IsLoadingLayers = false;
+            return;
+        }
+
+        var result = await LayerPublishingClient.GetPublishedLayersAsync(SelectedConnectionId.Value);
+        IsLoadingLayers = false;
+
+        if (!result.Success)
+        {
+            ErrorMessage = result.Message ?? "Failed to load layers.";
+            PublishedLayers.Clear();
+            return;
+        }
+
+        PublishedLayers.Clear();
+        PublishedLayers.AddRange(result.Data ?? Array.Empty<PublishedLayerSummary>());
+    }
+
+    protected async Task UpdateSelectedLayerAsync(int? layerId, bool forceReload)
+    {
+        var previousLayerId = SelectedLayerId;
+        SelectedLayerId = layerId;
+        SelectedLayer = layerId.HasValue
+            ? PublishedLayers.FirstOrDefault(layer => layer.LayerId == layerId.Value)
+            : null;
+
+        if (forceReload || previousLayerId != SelectedLayerId)
+        {
+            await OnLayerChangedAsync();
+        }
+    }
+
+    private async Task EnsureSelectedLayerAsync()
+    {
+        var previousLayerId = SelectedLayerId;
+
+        if (SelectedLayerId.HasValue)
+        {
+            var match = PublishedLayers.FirstOrDefault(layer => layer.LayerId == SelectedLayerId.Value);
+            if (match != null)
+            {
+                SelectedLayer = match;
+                return;
+            }
+        }
+
+        var candidate = PublishedLayers.FirstOrDefault(layer => layer.Enabled) ?? PublishedLayers.FirstOrDefault();
+
+        SelectedLayerId = candidate?.LayerId;
+        SelectedLayer = candidate;
+
+        if (previousLayerId != SelectedLayerId)
+        {
+            await OnLayerChangedAsync();
+        }
+    }
+
+    protected virtual Task OnLayerChangedAsync() => Task.CompletedTask;
+}

--- a/src/Honua.Admin/Pages/Layers.razor
+++ b/src/Honua.Admin/Pages/Layers.razor
@@ -10,7 +10,7 @@
 
 <MudStack Spacing="2">
     <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
-        <MudText Typo="Typo.h4">Layers</MudText>
+        <MudText Typo="Typo.h4" Element="h1">Layers</MudText>
         <MudButton Variant="Variant.Outlined"
                    Color="Color.Primary"
                    StartIcon="@Icons.Material.Filled.Refresh"
@@ -42,10 +42,22 @@
     <MudPaper Class="pa-4" Elevation="1">
         <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="mb-2">
             <MudText Typo="Typo.subtitle2">Published layers</MudText>
-            @if (_isLoadingLayers)
-            {
-                <MudProgressCircular Indeterminate="true" Size="Size.Small" />
-            }
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                @if (_isLoadingLayers)
+                {
+                    <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+                }
+                <MudButtonGroup Variant="Variant.Outlined" Color="Color.Primary">
+                    <MudButton Disabled="@(!_selectedConnectionId.HasValue || _publishedLayers.Count == 0 || _isBulkToggling || _isToggling || _isLoadingLayers)"
+                               OnClick="@(() => ToggleAllLayersAsync(true))">
+                        Enable all
+                    </MudButton>
+                    <MudButton Disabled="@(!_selectedConnectionId.HasValue || _publishedLayers.Count == 0 || _isBulkToggling || _isToggling || _isLoadingLayers)"
+                               OnClick="@(() => ToggleAllLayersAsync(false))">
+                        Disable all
+                    </MudButton>
+                </MudButtonGroup>
+            </MudStack>
         </MudStack>
 
         <MudTable Items="_publishedLayers" Dense="true" Hover="true">
@@ -66,7 +78,8 @@
                                Value="@context.Enabled"
                                Color="Color.Primary"
                                Disabled="@_isToggling"
-                               ValueChanged="@(checkedValue => ToggleLayerAsync(context, checkedValue))" />
+                               ValueChanged="@(checkedValue => ToggleLayerAsync(context, checkedValue))"
+                               data-testid="@($"layer-toggle-{context.LayerId}")" />
                 </MudTd>
             </RowTemplate>
             <NoRecordsContent>
@@ -103,7 +116,8 @@
                     <MudButton Variant="Variant.Text"
                                Color="Color.Primary"
                                OnClick="@(() => StartPublish(context))"
-                               Disabled="@(!_selectedConnectionId.HasValue)">
+                               Disabled="@(!_selectedConnectionId.HasValue)"
+                               data-testid="@($"table-publish-{context.Schema}-{context.Table}")">
                         Publish
                     </MudButton>
                 </MudTd>
@@ -138,6 +152,7 @@
     private bool _isLoadingLayers;
     private bool _isPublishing;
     private bool _isToggling;
+    private bool _isBulkToggling;
     private bool _showPublishForm;
     private string? _errorMessage;
 
@@ -320,6 +335,32 @@
         finally
         {
             _isToggling = false;
+        }
+    }
+
+    private async Task ToggleAllLayersAsync(bool enabled)
+    {
+        if (!_selectedConnectionId.HasValue)
+        {
+            return;
+        }
+
+        _isBulkToggling = true;
+        try
+        {
+            var result = await LayerPublishingClient.SetServiceLayersEnabledAsync(_selectedConnectionId.Value, enabled);
+            if (!result.Success || result.Data is null)
+            {
+                Snackbar.Add(result.Message ?? "Failed to update layers.", Severity.Error);
+                return;
+            }
+
+            _publishedLayers.Clear();
+            _publishedLayers.AddRange(result.Data);
+        }
+        finally
+        {
+            _isBulkToggling = false;
         }
     }
 

--- a/src/Honua.Admin/Pages/Layers.razor
+++ b/src/Honua.Admin/Pages/Layers.razor
@@ -10,7 +10,7 @@
 
 <MudStack Spacing="2">
     <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
-        <MudText Typo="Typo.h4" Element="h1">Layers</MudText>
+        <MudText Typo="Typo.h4" HtmlTag="h1">Layers</MudText>
         <MudButton Variant="Variant.Outlined"
                    Color="Color.Primary"
                    StartIcon="@Icons.Material.Filled.Refresh"

--- a/src/Honua.Admin/Pages/NotFound.razor
+++ b/src/Honua.Admin/Pages/NotFound.razor
@@ -1,14 +1,15 @@
 ﻿@page "/not-found"
 @layout MainLayout
+@inject NavigationManager NavManager
 
 <PageTitle>Not found</PageTitle>
 
 <MudPaper Class="pa-6" Elevation="0">
-    <MudText Typo="Typo.h5">Page not found</MudText>
+    <MudText Typo="Typo.h5" HtmlTag="h1">Page not found</MudText>
     <MudText Typo="Typo.body2" Class="mb-4">
         Sorry, the content you are looking for does not exist.
     </MudText>
-    <MudButton Variant="Variant.Outlined" Color="Color.Primary" Href="">
+    <MudButton Variant="Variant.Outlined" Color="Color.Primary" Href="@NavManager.BaseUri">
         Return to dashboard
     </MudButton>
 </MudPaper>

--- a/src/Honua.Admin/Pages/Preview.razor
+++ b/src/Honua.Admin/Pages/Preview.razor
@@ -1,8 +1,7 @@
 @page "/preview"
+@inherits LayerSelectionPageBase
 
 @using System.Text.Json
-@inject ISecureConnectionsClient ConnectionsClient
-@inject ILayerPublishingClient LayerPublishingClient
 @inject ILayerStyleClient LayerStyleClient
 @inject HttpClient Http
 
@@ -10,12 +9,12 @@
 
 <MudStack Spacing="2">
     <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
-        <MudText Typo="Typo.h4">Map preview</MudText>
+        <MudText Typo="Typo.h4" HtmlTag="h1">Map preview</MudText>
         <MudButton Variant="Variant.Outlined"
                    Color="Color.Primary"
                    StartIcon="@Icons.Material.Filled.Refresh"
                    OnClick="RefreshAsync"
-                   Disabled="@(!_selectedConnectionId.HasValue)">
+                   Disabled="@(!SelectedConnectionId.HasValue)">
             Refresh
         </MudButton>
     </MudStack>
@@ -24,33 +23,33 @@
         Validate tile and style output with MapLibre previews.
     </MudText>
 
-    @if (!string.IsNullOrWhiteSpace(_errorMessage))
+    @if (!string.IsNullOrWhiteSpace(ErrorMessage))
     {
-        <MudAlert Severity="Severity.Error" Dense="true">@_errorMessage</MudAlert>
+        <MudAlert Severity="Severity.Error" Dense="true">@ErrorMessage</MudAlert>
     }
 
     <MudPaper Class="pa-4" Elevation="1">
         <MudText Typo="Typo.subtitle2" Class="mb-2">Layer selection</MudText>
         <MudStack Spacing="2">
             <MudSelect T="Guid?"
-                       Value="_selectedConnectionId"
+                       Value="SelectedConnectionId"
                        ValueChanged="HandleConnectionChanged"
                        Label="Connection"
-                       Disabled="@_isLoadingConnections"
+                       Disabled="@IsLoadingConnections"
                        data-testid="preview-connection-select">
-                @foreach (var connection in _connections)
+                @foreach (var connection in Connections)
                 {
                     <MudSelectItem Value="@((Guid?)connection.ConnectionId)">@connection.Name</MudSelectItem>
                 }
             </MudSelect>
 
             <MudSelect T="int?"
-                       Value="_selectedLayerId"
+                       Value="SelectedLayerId"
                        ValueChanged="HandleLayerChanged"
                        Label="Published layer"
-                       Disabled="@(!_selectedConnectionId.HasValue || _isLoadingLayers)"
+                       Disabled="@(!SelectedConnectionId.HasValue || IsLoadingLayers)"
                        data-testid="preview-layer-select">
-                @foreach (var layer in _publishedLayers)
+                @foreach (var layer in PublishedLayers)
                 {
                     <MudSelectItem Value="@((int?)layer.LayerId)">
                         @layer.LayerName (@layer.ServiceName)
@@ -74,10 +73,10 @@
                         Bounds="_mapBounds"
                         EmptyMessage="No layer selected for preview." />
 
-            @if (_selectedLayer != null)
+            @if (SelectedLayer != null)
             {
                 <MudText Typo="Typo.body2">
-                    Showing <strong>@_selectedLayer.LayerName</strong> (@_selectedLayer.GeometryType, SRID @_selectedLayer.Srid).
+                    Showing <strong>@SelectedLayer.LayerName</strong> (@SelectedLayer.GeometryType, SRID @SelectedLayer.Srid).
                 </MudText>
             }
         </MudStack>
@@ -85,123 +84,19 @@
 </MudStack>
 
 @code {
-    private readonly List<SecureConnectionSummary> _connections = new();
-    private readonly List<PublishedLayerSummary> _publishedLayers = new();
-    private Guid? _selectedConnectionId;
-    private int? _selectedLayerId;
-    private PublishedLayerSummary? _selectedLayer;
     private JsonElement? _mapStyle;
     private double[]? _mapBounds;
-    private bool _isLoadingConnections;
-    private bool _isLoadingLayers;
     private bool _isLoadingStyle;
-    private string? _errorMessage;
 
-    protected override async Task OnInitializedAsync()
+    protected override Task OnConnectionChangedAsync()
     {
-        await LoadConnectionsAsync();
-        if (_selectedConnectionId.HasValue)
-        {
-            await LoadLayersAsync();
-            await SelectDefaultLayerAsync();
-        }
-    }
-
-    private async Task LoadConnectionsAsync()
-    {
-        _isLoadingConnections = true;
-        _errorMessage = null;
-        StateHasChanged();
-
-        var result = await ConnectionsClient.GetConnectionsAsync();
-        _isLoadingConnections = false;
-
-        if (!result.Success)
-        {
-            _errorMessage = result.Message ?? "Failed to load connections.";
-            return;
-        }
-
-        _connections.Clear();
-        _connections.AddRange(result.Data ?? Array.Empty<SecureConnectionSummary>());
-
-        if (_connections.Count > 0 && !_selectedConnectionId.HasValue)
-        {
-            _selectedConnectionId = _connections[0].ConnectionId;
-        }
-    }
-
-    private async Task HandleConnectionChanged(Guid? connectionId)
-    {
-        _selectedConnectionId = connectionId;
-        _selectedLayerId = null;
-        _selectedLayer = null;
         _mapStyle = null;
         _mapBounds = null;
-        await RefreshAsync();
+        return Task.CompletedTask;
     }
 
-    private async Task HandleLayerChanged(int? layerId)
+    protected override async Task OnLayerChangedAsync()
     {
-        _selectedLayerId = layerId;
-        _selectedLayer = _publishedLayers.FirstOrDefault(layer => layer.LayerId == layerId);
-        await LoadStyleAsync();
-    }
-
-    private async Task RefreshAsync()
-    {
-        if (!_selectedConnectionId.HasValue)
-        {
-            return;
-        }
-
-        await LoadLayersAsync();
-        await SelectDefaultLayerAsync();
-    }
-
-    private async Task LoadLayersAsync()
-    {
-        _isLoadingLayers = true;
-        _errorMessage = null;
-        StateHasChanged();
-
-        if (!_selectedConnectionId.HasValue)
-        {
-            _isLoadingLayers = false;
-            return;
-        }
-
-        var result = await LayerPublishingClient.GetPublishedLayersAsync(_selectedConnectionId.Value);
-        _isLoadingLayers = false;
-
-        if (!result.Success)
-        {
-            _errorMessage = result.Message ?? "Failed to load layers.";
-            _publishedLayers.Clear();
-            return;
-        }
-
-        _publishedLayers.Clear();
-        _publishedLayers.AddRange(result.Data ?? Array.Empty<PublishedLayerSummary>());
-    }
-
-    private async Task SelectDefaultLayerAsync()
-    {
-        if (_selectedLayerId.HasValue)
-        {
-            return;
-        }
-
-        var candidate = _publishedLayers.FirstOrDefault(layer => layer.Enabled) ?? _publishedLayers.FirstOrDefault();
-        if (candidate is null)
-        {
-            _mapStyle = null;
-            _mapBounds = null;
-            return;
-        }
-
-        _selectedLayerId = candidate.LayerId;
-        _selectedLayer = candidate;
         await LoadStyleAsync();
     }
 
@@ -209,9 +104,9 @@
     {
         _mapStyle = null;
         _mapBounds = null;
-        _errorMessage = null;
+        ErrorMessage = null;
 
-        if (!_selectedLayerId.HasValue)
+        if (!SelectedLayerId.HasValue)
         {
             return;
         }
@@ -219,10 +114,10 @@
         _isLoadingStyle = true;
         StateHasChanged();
 
-        var styleResult = await LayerStyleClient.GetLayerStyleAsync(_selectedLayerId.Value);
+        var styleResult = await LayerStyleClient.GetLayerStyleAsync(SelectedLayerId.Value);
         if (!styleResult.Success)
         {
-            _errorMessage = styleResult.Message ?? "Failed to load layer style.";
+            ErrorMessage = styleResult.Message ?? "Failed to load layer style.";
             _isLoadingStyle = false;
             return;
         }
@@ -232,7 +127,7 @@
         try
         {
             var tileJson = await Http.GetFromJsonAsync<TileJsonResponse>(
-                $"/tiles/{_selectedLayerId.Value}/tile.json",
+                $"/tiles/{SelectedLayerId.Value}/tile.json",
                 AdminJsonContext.Default.Options);
             _mapBounds = tileJson?.Bounds;
         }

--- a/src/Honua.Admin/Pages/Styles.razor
+++ b/src/Honua.Admin/Pages/Styles.razor
@@ -1,9 +1,8 @@
 @page "/styles"
+@inherits LayerSelectionPageBase
 
 @using System.Text.Json
 @implements IAsyncDisposable
-@inject ISecureConnectionsClient ConnectionsClient
-@inject ILayerPublishingClient LayerPublishingClient
 @inject ILayerStyleClient LayerStyleClient
 @inject HttpClient Http
 @inject IJSRuntime JS
@@ -12,27 +11,27 @@
 
 <MudStack Spacing="2">
     <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
-        <MudText Typo="Typo.h4">Style editor</MudText>
+        <MudText Typo="Typo.h4" HtmlTag="h1">Style editor</MudText>
         <MudStack Row="true" Spacing="1">
             <MudButton Variant="Variant.Outlined"
                        Color="Color.Primary"
                        StartIcon="@Icons.Material.Filled.Refresh"
                        OnClick="RefreshAsync"
-                       Disabled="@(!_selectedConnectionId.HasValue)">
+                       Disabled="@(!SelectedConnectionId.HasValue)">
                 Refresh
             </MudButton>
             <MudButton Variant="Variant.Filled"
                        Color="Color.Primary"
                        StartIcon="@Icons.Material.Filled.Save"
                        OnClick="SaveStyleAsync"
-                       Disabled="@(!_hasChanges || !_selectedLayerId.HasValue || _isSaving)">
+                       Disabled="@(!_hasChanges || !SelectedLayerId.HasValue || _isSaving)">
                 Save
             </MudButton>
             <MudButton Variant="Variant.Outlined"
                        Color="Color.Secondary"
                        StartIcon="@Icons.Material.Filled.Restore"
                        OnClick="ResetStyleAsync"
-                       Disabled="@(!_hasChanges || !_selectedLayerId.HasValue)">
+                       Disabled="@(!_hasChanges || !SelectedLayerId.HasValue)">
                 Reset
             </MudButton>
         </MudStack>
@@ -42,33 +41,33 @@
         Edit MapLibre styles with Maputnik and preview them against live tiles.
     </MudText>
 
-    @if (!string.IsNullOrWhiteSpace(_errorMessage))
+    @if (!string.IsNullOrWhiteSpace(ErrorMessage))
     {
-        <MudAlert Severity="Severity.Error" Dense="true">@_errorMessage</MudAlert>
+        <MudAlert Severity="Severity.Error" Dense="true">@ErrorMessage</MudAlert>
     }
 
     <MudPaper Class="pa-4" Elevation="1">
         <MudText Typo="Typo.subtitle2" Class="mb-2">Layer selection</MudText>
         <MudStack Spacing="2">
             <MudSelect T="Guid?"
-                       Value="_selectedConnectionId"
+                       Value="SelectedConnectionId"
                        ValueChanged="HandleConnectionChanged"
                        Label="Connection"
-                       Disabled="@_isLoadingConnections"
+                       Disabled="@IsLoadingConnections"
                        data-testid="styles-connection-select">
-                @foreach (var connection in _connections)
+                @foreach (var connection in Connections)
                 {
                     <MudSelectItem Value="@((Guid?)connection.ConnectionId)">@connection.Name</MudSelectItem>
                 }
             </MudSelect>
 
             <MudSelect T="int?"
-                       Value="_selectedLayerId"
+                       Value="SelectedLayerId"
                        ValueChanged="HandleLayerChanged"
                        Label="Published layer"
-                       Disabled="@(!_selectedConnectionId.HasValue || _isLoadingLayers)"
+                       Disabled="@(!SelectedConnectionId.HasValue || IsLoadingLayers)"
                        data-testid="styles-layer-select">
-                @foreach (var layer in _publishedLayers)
+                @foreach (var layer in PublishedLayers)
                 {
                     <MudSelectItem Value="@((int?)layer.LayerId)">
                         @layer.LayerName (@layer.ServiceName)
@@ -105,10 +104,10 @@
                     <MapPreview Style="_workingStyle"
                                 Bounds="_mapBounds"
                                 EmptyMessage="Select a layer to edit its style." />
-                    @if (_selectedLayer != null)
+                    @if (SelectedLayer != null)
                     {
                         <MudText Typo="Typo.body2">
-                            Editing <strong>@_selectedLayer.LayerName</strong> (@_selectedLayer.GeometryType, SRID @_selectedLayer.Srid).
+                            Editing <strong>@SelectedLayer.LayerName</strong> (@SelectedLayer.GeometryType, SRID @SelectedLayer.Srid).
                         </MudText>
                     }
                 </MudStack>
@@ -118,36 +117,18 @@
 </MudStack>
 
 @code {
-    private readonly List<SecureConnectionSummary> _connections = new();
-    private readonly List<PublishedLayerSummary> _publishedLayers = new();
-    private Guid? _selectedConnectionId;
-    private int? _selectedLayerId;
-    private PublishedLayerSummary? _selectedLayer;
     private JsonElement? _originalStyle;
     private JsonElement? _workingStyle;
     private JsonElement? _pendingStyle;
     private string? _pendingStyleId;
     private double[]? _mapBounds;
-    private bool _isLoadingConnections;
-    private bool _isLoadingLayers;
     private bool _isLoadingStyle;
     private bool _isSaving;
     private bool _hasChanges;
     private bool _maputnikLoaded;
     private bool _ignoreNextStyleChange;
-    private string? _errorMessage;
     private ElementReference _maputnikFrame;
     private DotNetObjectReference<Styles>? _dotNetRef;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await LoadConnectionsAsync();
-        if (_selectedConnectionId.HasValue)
-        {
-            await LoadLayersAsync();
-            await SelectDefaultLayerAsync();
-        }
-    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -158,35 +139,8 @@
         }
     }
 
-    private async Task LoadConnectionsAsync()
+    protected override Task OnConnectionChangedAsync()
     {
-        _isLoadingConnections = true;
-        _errorMessage = null;
-        StateHasChanged();
-
-        var result = await ConnectionsClient.GetConnectionsAsync();
-        _isLoadingConnections = false;
-
-        if (!result.Success)
-        {
-            _errorMessage = result.Message ?? "Failed to load connections.";
-            return;
-        }
-
-        _connections.Clear();
-        _connections.AddRange(result.Data ?? Array.Empty<SecureConnectionSummary>());
-
-        if (_connections.Count > 0 && !_selectedConnectionId.HasValue)
-        {
-            _selectedConnectionId = _connections[0].ConnectionId;
-        }
-    }
-
-    private async Task HandleConnectionChanged(Guid? connectionId)
-    {
-        _selectedConnectionId = connectionId;
-        _selectedLayerId = null;
-        _selectedLayer = null;
         _workingStyle = null;
         _originalStyle = null;
         _pendingStyle = null;
@@ -194,71 +148,11 @@
         _mapBounds = null;
         _hasChanges = false;
         _ignoreNextStyleChange = false;
-        await RefreshAsync();
+        return Task.CompletedTask;
     }
 
-    private async Task HandleLayerChanged(int? layerId)
+    protected override async Task OnLayerChangedAsync()
     {
-        _selectedLayerId = layerId;
-        _selectedLayer = _publishedLayers.FirstOrDefault(layer => layer.LayerId == layerId);
-        await LoadStyleAsync();
-    }
-
-    private async Task RefreshAsync()
-    {
-        if (!_selectedConnectionId.HasValue)
-        {
-            return;
-        }
-
-        await LoadLayersAsync();
-        await SelectDefaultLayerAsync();
-    }
-
-    private async Task LoadLayersAsync()
-    {
-        _isLoadingLayers = true;
-        _errorMessage = null;
-        StateHasChanged();
-
-        if (!_selectedConnectionId.HasValue)
-        {
-            _isLoadingLayers = false;
-            return;
-        }
-
-        var result = await LayerPublishingClient.GetPublishedLayersAsync(_selectedConnectionId.Value);
-        _isLoadingLayers = false;
-
-        if (!result.Success)
-        {
-            _errorMessage = result.Message ?? "Failed to load layers.";
-            _publishedLayers.Clear();
-            return;
-        }
-
-        _publishedLayers.Clear();
-        _publishedLayers.AddRange(result.Data ?? Array.Empty<PublishedLayerSummary>());
-    }
-
-    private async Task SelectDefaultLayerAsync()
-    {
-        if (_selectedLayerId.HasValue)
-        {
-            return;
-        }
-
-        var candidate = _publishedLayers.FirstOrDefault(layer => layer.Enabled) ?? _publishedLayers.FirstOrDefault();
-        if (candidate is null)
-        {
-            _workingStyle = null;
-            _originalStyle = null;
-            _mapBounds = null;
-            return;
-        }
-
-        _selectedLayerId = candidate.LayerId;
-        _selectedLayer = candidate;
         await LoadStyleAsync();
     }
 
@@ -267,9 +161,9 @@
         _workingStyle = null;
         _originalStyle = null;
         _hasChanges = false;
-        _errorMessage = null;
+        ErrorMessage = null;
 
-        if (!_selectedLayerId.HasValue)
+        if (!SelectedLayerId.HasValue)
         {
             return;
         }
@@ -277,10 +171,10 @@
         _isLoadingStyle = true;
         StateHasChanged();
 
-        var styleResult = await LayerStyleClient.GetLayerStyleAsync(_selectedLayerId.Value);
+        var styleResult = await LayerStyleClient.GetLayerStyleAsync(SelectedLayerId.Value);
         if (!styleResult.Success)
         {
-            _errorMessage = styleResult.Message ?? "Failed to load layer style.";
+            ErrorMessage = styleResult.Message ?? "Failed to load layer style.";
             _isLoadingStyle = false;
             return;
         }
@@ -288,13 +182,13 @@
         _originalStyle = styleResult.Data?.MapLibreStyle;
         _workingStyle = _originalStyle;
         _pendingStyle = _originalStyle;
-        _pendingStyleId = _selectedLayerId.HasValue ? BuildStyleId(_selectedLayerId.Value) : null;
+        _pendingStyleId = SelectedLayerId.HasValue ? BuildStyleId(SelectedLayerId.Value) : null;
         _ignoreNextStyleChange = _pendingStyle.HasValue;
 
         try
         {
             var tileJson = await Http.GetFromJsonAsync<TileJsonResponse>(
-                $"/tiles/{_selectedLayerId.Value}/tile.json",
+                $"/tiles/{SelectedLayerId.Value}/tile.json",
                 AdminJsonContext.Default.Options);
             _mapBounds = tileJson?.Bounds;
         }
@@ -339,19 +233,19 @@
 
     private async Task SaveStyleAsync()
     {
-        if (!_selectedLayerId.HasValue)
+        if (!SelectedLayerId.HasValue)
         {
             return;
         }
 
         _isSaving = true;
-        _errorMessage = null;
+        ErrorMessage = null;
         StateHasChanged();
 
         var style = await JS.InvokeAsync<JsonElement?>("maputnikBridge.getStyle");
         if (!style.HasValue)
         {
-            _errorMessage = "Unable to read style from Maputnik.";
+            ErrorMessage = "Unable to read style from Maputnik.";
             _isSaving = false;
             return;
         }
@@ -361,10 +255,10 @@
             MapLibreStyle = style.Value
         };
 
-        var result = await LayerStyleClient.UpdateLayerStyleAsync(_selectedLayerId.Value, update);
+        var result = await LayerStyleClient.UpdateLayerStyleAsync(SelectedLayerId.Value, update);
         if (!result.Success)
         {
-            _errorMessage = result.Message ?? "Failed to save style.";
+            ErrorMessage = result.Message ?? "Failed to save style.";
             _isSaving = false;
             return;
         }
@@ -383,7 +277,7 @@
         }
 
         _pendingStyle = _originalStyle;
-        _pendingStyleId = _selectedLayerId.HasValue ? BuildStyleId(_selectedLayerId.Value) : null;
+        _pendingStyleId = SelectedLayerId.HasValue ? BuildStyleId(SelectedLayerId.Value) : null;
         _ignoreNextStyleChange = true;
 
         if (_maputnikLoaded)

--- a/src/Honua.Admin/Program.cs
+++ b/src/Honua.Admin/Program.cs
@@ -32,9 +32,18 @@ builder.Services.AddHttpClient("AdminApi", (sp, client) =>
     var options = sp.GetRequiredService<IOptions<AdminApiOptions>>().Value;
     var baseUrl = AdminApiUrlResolver.Resolve(options.BaseUrl, builder.HostEnvironment.BaseAddress);
     var scopes = options.Scopes.Length == 0 ? ["honua.admin"] : options.Scopes;
+    var baseUri = new Uri(baseUrl, UriKind.Absolute);
+    var metricsUri = new Uri(baseUri, "/api/v1/metrics/");
+    var healthUri = new Uri(baseUri, "/healthz/");
+    var authorizedUrls = new[]
+    {
+        baseUri.ToString(),
+        metricsUri.ToString(),
+        healthUri.ToString()
+    };
 
     return sp.GetRequiredService<AuthorizationMessageHandler>()
-        .ConfigureHandler([baseUrl], scopes);
+        .ConfigureHandler(authorizedUrls, scopes);
 });
 
 builder.Services.AddScoped(sp =>

--- a/src/Honua.Admin/Services/LayerPublishingClient.cs
+++ b/src/Honua.Admin/Services/LayerPublishingClient.cs
@@ -13,6 +13,7 @@ public interface ILayerPublishingClient
     Task<ApiResult<IReadOnlyList<PublishedLayerSummary>>> GetPublishedLayersAsync(Guid connectionId, string? serviceName = null, CancellationToken cancellationToken = default);
     Task<ApiResult<PublishedLayerSummary>> PublishLayerAsync(Guid connectionId, PublishLayerRequest request, CancellationToken cancellationToken = default);
     Task<ApiResult<PublishedLayerSummary>> SetLayerEnabledAsync(Guid connectionId, int layerId, bool enabled, string? serviceName = null, CancellationToken cancellationToken = default);
+    Task<ApiResult<IReadOnlyList<PublishedLayerSummary>>> SetServiceLayersEnabledAsync(Guid connectionId, bool enabled, string? serviceName = null, CancellationToken cancellationToken = default);
 }
 
 internal sealed class LayerPublishingClient : ILayerPublishingClient
@@ -88,6 +89,27 @@ internal sealed class LayerPublishingClient : ILayerPublishingClient
         var request = new LayerEnabledRequest { Enabled = enabled };
         var response = await _httpClient.PutAsJsonAsync(path, request, cancellationToken);
         return await ReadResponseAsync<PublishedLayerSummary>(response, cancellationToken);
+    }
+
+    public async Task<ApiResult<IReadOnlyList<PublishedLayerSummary>>> SetServiceLayersEnabledAsync(
+        Guid connectionId,
+        bool enabled,
+        string? serviceName = null,
+        CancellationToken cancellationToken = default)
+    {
+        var path = $"connections/{connectionId}/layers/enabled";
+        if (!string.IsNullOrWhiteSpace(serviceName))
+        {
+            path += $"?serviceName={Uri.EscapeDataString(serviceName)}";
+        }
+
+        var request = new LayerEnabledRequest { Enabled = enabled };
+        var response = await _httpClient.PutAsJsonAsync(path, request, cancellationToken);
+        var result = await ReadResponseAsync<List<PublishedLayerSummary>>(response, cancellationToken);
+
+        return result.Success
+            ? ApiResult.Ok<IReadOnlyList<PublishedLayerSummary>>(result.Data ?? new List<PublishedLayerSummary>(), result.Message)
+            : ApiResult.Fail<IReadOnlyList<PublishedLayerSummary>>(result.Message);
     }
 
     private static async Task<ApiResult<T>> ReadResponseAsync<T>(HttpResponseMessage response, CancellationToken cancellationToken)

--- a/src/Honua.Admin/wwwroot/js/maplibre-interop.js
+++ b/src/Honua.Admin/wwwroot/js/maplibre-interop.js
@@ -208,10 +208,21 @@ window.maplibreInterop = (() => {
     maps.delete(containerId);
   };
 
+  const triggerFeature = (containerId, properties) => {
+    const entry = maps.get(containerId);
+    if (!entry || !entry.dotnetRef) {
+      return;
+    }
+
+    const payload = properties ? JSON.stringify(properties) : null;
+    entry.dotnetRef.invokeMethodAsync("OnFeatureSelected", payload);
+  };
+
   return {
     createMap,
     updateStyle,
     fitBounds,
-    removeMap
+    removeMap,
+    triggerFeature
   };
 })();

--- a/src/Honua.Core/Features/Admin/Abstractions/ILayerPublishingService.cs
+++ b/src/Honua.Core/Features/Admin/Abstractions/ILayerPublishingService.cs
@@ -46,4 +46,17 @@ public interface ILayerPublishingService
         string serviceName,
         bool enabled,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Enable or disable all layers within a service.
+    /// </summary>
+    /// <param name="connectionString">PostgreSQL connection string.</param>
+    /// <param name="serviceName">Service name.</param>
+    /// <param name="enabled">Whether the layers should be enabled.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<PublishedLayerSummary>> SetServiceLayersEnabledAsync(
+        string connectionString,
+        string serviceName,
+        bool enabled,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
@@ -248,7 +248,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
-        if (layerId <= 0)
+        if (layerId < 0)
         {
             return null;
         }

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
@@ -49,7 +49,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
                 l.table_name,
                 l.geometry_type,
                 l.srid,
-                CASE WHEN sl.layer_id IS NULL THEN false ELSE true END as enabled
+                l.enabled
             FROM honua.layers l
             LEFT JOIN honua.service_layers sl
                 ON sl.layer_id = l.layer_id AND sl.service_name = @serviceName
@@ -215,14 +215,12 @@ internal sealed partial class PostgreSqlLayerPublishingService(
             table,
             geometryType,
             srid,
+            request.Enabled,
             cancellationToken);
 
         await InsertFieldsAsync(connection, transaction, layerId, fields, cancellationToken);
 
-        if (request.Enabled)
-        {
-            await EnsureLayerEnabledAsync(connection, transaction, serviceName, layerId, cancellationToken);
-        }
+        await EnsureServiceLayerAsync(connection, transaction, serviceName, layerId, cancellationToken);
 
         await transaction.CommitAsync(cancellationToken);
 
@@ -267,27 +265,53 @@ internal sealed partial class PostgreSqlLayerPublishingService(
             return null;
         }
 
-        if (enabled)
-        {
-            await EnsureServiceAsync(connection, transaction, normalizedService, layer.Srid, null, cancellationToken);
-            await EnsureLayerEnabledAsync(connection, transaction, normalizedService, layerId, cancellationToken);
-            layer = CloneWithEnabled(layer, true);
-        }
-        else
-        {
-            const string deleteSql = """
-                DELETE FROM honua.service_layers
-                WHERE service_name = @serviceName AND layer_id = @layerId;
-                """;
-            await using var deleteCommand = new NpgsqlCommand(deleteSql, connection, transaction);
-            deleteCommand.Parameters.AddWithValue("@serviceName", normalizedService);
-            deleteCommand.Parameters.AddWithValue("@layerId", layerId);
-            await deleteCommand.ExecuteNonQueryAsync(cancellationToken);
-            layer = CloneWithEnabled(layer, false);
-        }
+        const string updateSql = """
+            UPDATE honua.layers
+            SET enabled = @enabled
+            WHERE layer_id = @layerId;
+            """;
+        await using var updateCommand = new NpgsqlCommand(updateSql, connection, transaction);
+        updateCommand.Parameters.AddWithValue("@enabled", enabled);
+        updateCommand.Parameters.AddWithValue("@layerId", layerId);
+        await updateCommand.ExecuteNonQueryAsync(cancellationToken);
+        layer = CloneWithEnabled(layer, enabled);
 
         await transaction.CommitAsync(cancellationToken);
         return layer;
+    }
+
+    public async Task<IReadOnlyList<PublishedLayerSummary>> SetServiceLayersEnabledAsync(
+        string connectionString,
+        string serviceName,
+        bool enabled,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        var normalizedService = NormalizeServiceName(serviceName);
+
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        const string updateSql = """
+            UPDATE honua.layers
+            SET enabled = @enabled
+            WHERE layer_id IN (
+                SELECT layer_id
+                FROM honua.service_layers
+                WHERE service_name = @serviceName
+            );
+            """;
+
+        await using var updateCommand = new NpgsqlCommand(updateSql, connection, transaction);
+        updateCommand.Parameters.AddWithValue("@enabled", enabled);
+        updateCommand.Parameters.AddWithValue("@serviceName", normalizedService);
+        await updateCommand.ExecuteNonQueryAsync(cancellationToken);
+
+        await transaction.CommitAsync(cancellationToken);
+
+        return await ListPublishedLayersAsync(connectionString, normalizedService, cancellationToken);
     }
 
     private async Task<TableInfo?> ResolveTableInfoAsync(
@@ -519,6 +543,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         string table,
         string geometryType,
         int srid,
+        bool enabled,
         CancellationToken cancellationToken)
     {
         const string sql = """
@@ -529,9 +554,10 @@ internal sealed partial class PostgreSqlLayerPublishingService(
                 table_name,
                 geometry_type,
                 srid,
-                default_visibility
+                default_visibility,
+                enabled
             )
-            VALUES (@name, @description, @schema, @table, @geometryType, @srid, TRUE)
+            VALUES (@name, @description, @schema, @table, @geometryType, @srid, TRUE, @enabled)
             RETURNING layer_id;
             """;
 
@@ -542,6 +568,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         command.Parameters.AddWithValue("@table", table);
         command.Parameters.AddWithValue("@geometryType", geometryType);
         command.Parameters.AddWithValue("@srid", srid);
+        command.Parameters.AddWithValue("@enabled", enabled);
 
         var result = await command.ExecuteScalarAsync(cancellationToken);
         if (result is not int layerId)
@@ -649,7 +676,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
-    private static async Task EnsureLayerEnabledAsync(
+    private static async Task EnsureServiceLayerAsync(
         NpgsqlConnection connection,
         NpgsqlTransaction transaction,
         string serviceName,
@@ -697,7 +724,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
                 l.table_name,
                 l.geometry_type,
                 l.srid,
-                CASE WHEN sl.layer_id IS NULL THEN false ELSE true END as enabled
+                l.enabled
             FROM honua.layers l
             LEFT JOIN honua.service_layers sl
                 ON sl.layer_id = l.layer_id AND sl.service_name = @serviceName

--- a/src/Honua.Postgres/Features/Catalog/PostgresLayerCatalog.cs
+++ b/src/Honua.Postgres/Features/Catalog/PostgresLayerCatalog.cs
@@ -56,6 +56,7 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
                 ST_SRID(l.extent) as extent_srid
             FROM {_layersTable} l
             WHERE l.layer_id = @layerId
+              AND l.enabled = TRUE
             """;
 
         await using var connection = (NpgsqlConnection)await _connectionProvider.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
@@ -98,6 +99,7 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
                 ST_YMax(l.extent) as ymax,
                 ST_SRID(l.extent) as extent_srid
             FROM {_layersTable} l
+            WHERE l.enabled = TRUE
             ORDER BY l.layer_id
             """;
 
@@ -217,7 +219,7 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
     /// <inheritdoc />
     public async Task<bool> LayerExistsAsync(int layerId, CancellationToken cancellationToken = default)
     {
-        string sql = $"SELECT 1 FROM {_layersTable} WHERE layer_id = @layerId";
+        string sql = $"SELECT 1 FROM {_layersTable} WHERE layer_id = @layerId AND enabled = TRUE";
 
         await using var connection = (NpgsqlConnection)await _connectionProvider.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var command = new NpgsqlCommand(sql, connection);

--- a/src/Honua.Postgres/Features/Infrastructure/Caching/HighFrequencyQueryPreparationService.cs
+++ b/src/Honua.Postgres/Features/Infrastructure/Caching/HighFrequencyQueryPreparationService.cs
@@ -64,16 +64,17 @@ internal sealed class HighFrequencyQueryPreparationService : BackgroundService
                     ST_SRID(l.extent) as extent_srid
                 FROM honua.layers l
                 WHERE l.layer_id = $1
+                  AND l.enabled = TRUE
                 """),
 
             // Layer existence check - used for validation
-            new HighPriorityQuery("layer_exists", "SELECT 1 FROM honua.layers WHERE layer_id = $1"),
+            new HighPriorityQuery("layer_exists", "SELECT 1 FROM honua.layers WHERE layer_id = $1 AND enabled = TRUE"),
 
             // Service existence check - used for validation
             new HighPriorityQuery("service_exists", "SELECT 1 FROM honua.services WHERE LOWER(service_name) = LOWER($1)"),
 
             // Layer SRID lookup - used for spatial queries
-            new HighPriorityQuery("layer_srid", "SELECT srid FROM honua.layers WHERE layer_id = $1"),
+            new HighPriorityQuery("layer_srid", "SELECT srid FROM honua.layers WHERE layer_id = $1 AND enabled = TRUE"),
 
             // Feature count query - used for metadata and pagination
             new HighPriorityQuery("feature_count", $"SELECT COUNT(*) FROM {featuresTableName} WHERE layer_id = $1"),

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -24,6 +24,7 @@ public static class EndpointRegistry
         new("GET", "/api/v1/admin/connections/{id}/layers"),
         new("POST", "/api/v1/admin/connections/{id}/layers"),
         new("PUT", "/api/v1/admin/connections/{id}/layers/{layerId}/enabled"),
+        new("PUT", "/api/v1/admin/connections/{id}/layers/enabled"),
         new("GET", "/api/v1/admin/version"),
         new("GET", "/api/v1/admin/capabilities"),
         new("GET", "/api/v1/admin/manifest"),

--- a/src/Honua.Server/Features/Admin/LayerPublishingEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/LayerPublishingEndpoints.cs
@@ -39,6 +39,10 @@ internal static class LayerPublishingEndpoints
         group.MapPut("/{layerId:int}/enabled", HandleSetLayerEnabled)
             .WithDisplayName("Set Layer Enabled")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Put }));
+
+        group.MapPut("/enabled", HandleSetServiceLayersEnabled)
+            .WithDisplayName("Set Service Layers Enabled")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Put }));
     }
 
     private static async Task<Results<Ok<ApiResponse<IReadOnlyList<PublishedLayerSummary>>>, NotFound<ApiResponse<object>>, BadRequest<ApiResponse<object>>, ForbidHttpResult>>
@@ -222,6 +226,60 @@ internal static class LayerPublishingEndpoints
         catch (InvalidOperationException ex)
         {
             logger.LogWarning(ex, "Layer toggle connection not found");
+            return TypedResults.NotFound(ApiResponse<object>.Failure(ex.Message));
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return TypedResults.Forbid();
+        }
+    }
+
+    private static async Task<Results<Ok<ApiResponse<IReadOnlyList<PublishedLayerSummary>>>, NotFound<ApiResponse<object>>, BadRequest<ApiResponse<object>>, ForbidHttpResult>>
+        HandleSetServiceLayersEnabled(
+            string id,
+            LayerEnabledRequest request,
+            string? serviceName,
+            ISecureConnectionResolver resolver,
+            ILayerPublishingService publishingService,
+            IDatabaseMigrationRunner migrationRunner,
+            HttpContext context,
+            ILogger<LayerPublishingEndpointsLog> logger)
+    {
+        try
+        {
+            var connectionString = await ResolveConnectionStringAsync(id, resolver, context.RequestAborted);
+            var migrationResult = await migrationRunner.RunMigrationsAsync(
+                connectionString,
+                typeof(Program).Assembly,
+                context.RequestAborted);
+
+            if (!migrationResult.Successful)
+            {
+                logger.LogError(migrationResult.Error, "Layer bulk enable migration failed: {Message}", migrationResult.ErrorMessage);
+                return TypedResults.BadRequest(ApiResponse<object>.Failure(migrationResult.ErrorMessage ?? "Database migration failed."));
+            }
+
+            var result = await publishingService.SetServiceLayersEnabledAsync(
+                connectionString,
+                serviceName ?? "default",
+                request.Enabled,
+                context.RequestAborted);
+
+            return TypedResults.Ok(ApiResponse<IReadOnlyList<PublishedLayerSummary>>.CreateSuccess(result));
+        }
+        catch (LayerPublishingException ex)
+        {
+            logger.LogWarning(ex, "Layer bulk toggle failed");
+            return TypedResults.BadRequest(ApiResponse<object>.Failure(ex.Message));
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogWarning(ex, "Layer bulk toggle invalid request");
+            return TypedResults.BadRequest(ApiResponse<object>.Failure(ex.Message));
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogWarning(ex, "Layer bulk toggle connection not found");
             return TypedResults.NotFound(ApiResponse<object>.Failure(ex.Message));
         }
         catch (UnauthorizedAccessException)

--- a/src/Honua.Server/Features/Admin/ObservabilityEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/ObservabilityEndpoints.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Monitoring;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Admin endpoints for lightweight observability support.
+/// </summary>
+internal static class ObservabilityEndpoints
+{
+    public static void MapAdminObservabilityEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/observability")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Observability")
+            .RequireAdminAuthorization();
+
+        group.MapGet("/errors", HandleGetRecentErrors)
+            .WithDisplayName("Get Recent Errors")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<RecentErrorsResponse>();
+
+        group.MapGet("/telemetry", HandleGetTelemetryStatus)
+            .WithDisplayName("Get Telemetry Status")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<ObservabilityStatusResponse>();
+    }
+
+    private static IResult HandleGetRecentErrors(RecentErrorBuffer buffer)
+    {
+        var response = new RecentErrorsResponse
+        {
+            Capacity = buffer.Capacity,
+            Errors = buffer.Snapshot()
+        };
+
+        return Results.Json(response, MetricsJsonContext.Default.RecentErrorsResponse);
+    }
+
+    private static IResult HandleGetTelemetryStatus(IOptions<TracingOptions> options, IConfiguration configuration)
+    {
+        var tracingOptions = options.Value;
+        var otlpEndpoint = ResolveOtlpEndpoint(tracingOptions, configuration);
+
+        var response = new ObservabilityStatusResponse
+        {
+            TracingEnabled = tracingOptions.Enabled,
+            OtlpConfigured = tracingOptions.Enabled && !string.IsNullOrWhiteSpace(otlpEndpoint),
+            OtlpEndpoint = string.IsNullOrWhiteSpace(otlpEndpoint) ? null : otlpEndpoint
+        };
+
+        return Results.Json(response, MetricsJsonContext.Default.ObservabilityStatusResponse);
+    }
+
+    private static string? ResolveOtlpEndpoint(TracingOptions tracingOptions, IConfiguration configuration)
+    {
+        if (!string.IsNullOrWhiteSpace(tracingOptions.OtlpEndpoint))
+        {
+            return tracingOptions.OtlpEndpoint;
+        }
+
+        return configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Models/StandardErrorResponseFormatter.cs
+++ b/src/Honua.Server/Features/Infrastructure/Models/StandardErrorResponseFormatter.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Honua.Server.Features.Infrastructure.Middleware;
+using Honua.Server.Features.Infrastructure.Monitoring;
 using Honua.Server.Features.OData.Models;
 
 namespace Honua.Server.Features.Infrastructure.Models;
@@ -26,6 +27,8 @@ internal static class StandardErrorResponseFormatter
     public static IResult FormatError(HttpContext context, StandardErrorResponse errorResponse, ErrorResponseFormatterOptions? options = null)
     {
         options ??= new ErrorResponseFormatterOptions();
+
+        TryRecordRecentError(context, errorResponse);
 
         var path = context.Request.Path;
 
@@ -308,6 +311,18 @@ internal static class StandardErrorResponseFormatter
         var correlationId = context.TraceIdentifier;
         var timestamp = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture);
         return new ErrorMetadata(correlationId, timestamp);
+    }
+
+    private static void TryRecordRecentError(HttpContext context, StandardErrorResponse errorResponse)
+    {
+        var services = context.RequestServices;
+        if (services is null)
+        {
+            return;
+        }
+
+        var buffer = services.GetService<RecentErrorBuffer>();
+        buffer?.Record(context, errorResponse);
     }
 
 }

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/MetricsJsonContext.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/MetricsJsonContext.cs
@@ -26,6 +26,10 @@ namespace Honua.Server.Features.Infrastructure.Monitoring;
 [JsonSerializable(typeof(MemoryUsage))]
 [JsonSerializable(typeof(QueryCacheStatisticsResponse))]
 [JsonSerializable(typeof(QueryCachePerformanceMetrics))]
+[JsonSerializable(typeof(RecentErrorEntry))]
+[JsonSerializable(typeof(IReadOnlyList<RecentErrorEntry>))]
+[JsonSerializable(typeof(RecentErrorsResponse))]
+[JsonSerializable(typeof(ObservabilityStatusResponse))]
 internal partial class MetricsJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
@@ -21,6 +21,9 @@ internal static class ObservabilityServiceCollectionExtensions
         services.AddETags();
         services.TryAddSingleton<ISystemMetricsCollector, SystemMetricsCollector>();
         services.AddPerformanceMonitoring();
+        services.Configure<RecentErrorBufferOptions>(
+            configuration.GetSection(RecentErrorBufferOptions.SectionName));
+        services.AddSingleton<RecentErrorBuffer>();
         ConfigureResponseCompression(services);
 
         return services;

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/RecentErrorBuffer.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/RecentErrorBuffer.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Server.Features.Infrastructure.Models;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Infrastructure.Monitoring;
+
+/// <summary>
+/// In-memory ring buffer for recent errors.
+/// </summary>
+internal sealed class RecentErrorBuffer
+{
+    private readonly int _capacity;
+    private readonly object _lock = new();
+    private readonly Queue<RecentErrorEntry> _entries = new();
+
+    public RecentErrorBuffer(IOptions<RecentErrorBufferOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _capacity = Math.Max(0, options.Value.Capacity);
+    }
+
+    /// <summary>
+    /// Maximum number of errors retained.
+    /// </summary>
+    public int Capacity => _capacity;
+
+    /// <summary>
+    /// Record a server error response into the buffer.
+    /// </summary>
+    public void Record(HttpContext context, StandardErrorResponse errorResponse)
+    {
+        if (_capacity <= 0 || errorResponse.StatusCode < StatusCodes.Status500InternalServerError)
+        {
+            return;
+        }
+
+        var message = RecentErrorSanitizer.Sanitize(errorResponse.Detail);
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            message = RecentErrorSanitizer.Sanitize(errorResponse.Title);
+        }
+
+        var entry = new RecentErrorEntry
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            CorrelationId = string.IsNullOrWhiteSpace(context.TraceIdentifier) ? "unknown" : context.TraceIdentifier,
+            Path = context.Request.Path.HasValue ? context.Request.Path.Value! : string.Empty,
+            StatusCode = errorResponse.StatusCode,
+            Message = message
+        };
+
+        lock (_lock)
+        {
+            while (_entries.Count >= _capacity)
+            {
+                _entries.Dequeue();
+            }
+
+            _entries.Enqueue(entry);
+        }
+    }
+
+    /// <summary>
+    /// Returns recent errors ordered newest-first.
+    /// </summary>
+    public IReadOnlyList<RecentErrorEntry> Snapshot()
+    {
+        lock (_lock)
+        {
+            return _entries.Reverse().ToArray();
+        }
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/RecentErrorBufferOptions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/RecentErrorBufferOptions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Infrastructure.Monitoring;
+
+/// <summary>
+/// Configuration options for the recent errors ring buffer.
+/// </summary>
+internal sealed class RecentErrorBufferOptions
+{
+    /// <summary>
+    /// Configuration section name.
+    /// </summary>
+    public const string SectionName = "Monitoring:RecentErrors";
+
+    /// <summary>
+    /// Maximum number of recent errors to retain.
+    /// </summary>
+    public int Capacity { get; set; } = 50;
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/RecentErrorModels.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/RecentErrorModels.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Infrastructure.Monitoring;
+
+/// <summary>
+/// Represents a recent error captured by the in-memory buffer.
+/// </summary>
+internal sealed class RecentErrorEntry
+{
+    /// <summary>
+    /// Timestamp when the error was captured (UTC).
+    /// </summary>
+    public DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>
+    /// Correlation ID for the request that produced the error.
+    /// </summary>
+    public string CorrelationId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Request path that produced the error.
+    /// </summary>
+    public string Path { get; init; } = string.Empty;
+
+    /// <summary>
+    /// HTTP status code for the error response.
+    /// </summary>
+    public int StatusCode { get; init; }
+
+    /// <summary>
+    /// Sanitized error message.
+    /// </summary>
+    public string Message { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Response model for recent errors endpoint.
+/// </summary>
+internal sealed class RecentErrorsResponse
+{
+    /// <summary>
+    /// Maximum number of errors retained in the buffer.
+    /// </summary>
+    public int Capacity { get; init; }
+
+    /// <summary>
+    /// Recent errors, ordered newest-first.
+    /// </summary>
+    public IReadOnlyList<RecentErrorEntry> Errors { get; init; } = Array.Empty<RecentErrorEntry>();
+}
+
+/// <summary>
+/// Response model for observability status.
+/// </summary>
+internal sealed class ObservabilityStatusResponse
+{
+    /// <summary>
+    /// Whether tracing is enabled.
+    /// </summary>
+    public bool TracingEnabled { get; init; }
+
+    /// <summary>
+    /// Whether an OTLP endpoint is configured.
+    /// </summary>
+    public bool OtlpConfigured { get; init; }
+
+    /// <summary>
+    /// Configured OTLP endpoint (if any).
+    /// </summary>
+    public string? OtlpEndpoint { get; init; }
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/RecentErrorSanitizer.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/RecentErrorSanitizer.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.RegularExpressions;
+
+namespace Honua.Server.Features.Infrastructure.Monitoring;
+
+/// <summary>
+/// Sanitizes error messages to avoid exposing sensitive data in recent error summaries.
+/// </summary>
+internal static class RecentErrorSanitizer
+{
+    private const int MaxMessageLength = 240;
+
+    private static readonly Regex EmailPattern = new(
+        "\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}\\b",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex KeyValuePattern = new(
+        "(?i)\\b(password|pwd|secret|token|api[-_]?key|access[-_]?key|client[-_]?secret)\\b\\s*([:=])\\s*([^;\\s]+)",
+        RegexOptions.CultureInvariant);
+
+    private static readonly Regex AuthorizationPattern = new(
+        "(?i)\\bauthorization\\b\\s*([:=])\\s*([^;\\s]+)",
+        RegexOptions.CultureInvariant);
+
+    private static readonly Regex BearerPattern = new(
+        "(?i)\\bbearer\\s+[A-Za-z0-9-._~+/]+=*",
+        RegexOptions.CultureInvariant);
+
+    public static string Sanitize(string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return "Unspecified error";
+        }
+
+        var sanitized = message.Trim();
+        if (sanitized.Length > MaxMessageLength)
+        {
+            sanitized = sanitized[..MaxMessageLength] + "...";
+        }
+
+        sanitized = EmailPattern.Replace(sanitized, "***");
+        sanitized = KeyValuePattern.Replace(sanitized, "$1$2***");
+        sanitized = AuthorizationPattern.Replace(sanitized, "Authorization$1***");
+        sanitized = BearerPattern.Replace(sanitized, "Bearer ***");
+
+        return sanitized;
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/RecentErrorSanitizer.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/RecentErrorSanitizer.cs
@@ -12,19 +12,19 @@ internal static class RecentErrorSanitizer
 {
     private const int MaxMessageLength = 240;
 
-    private static readonly Regex EmailPattern = new(
+    private static readonly Regex _emailPattern = new(
         "\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}\\b",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
-    private static readonly Regex KeyValuePattern = new(
+    private static readonly Regex _keyValuePattern = new(
         "(?i)\\b(password|pwd|secret|token|api[-_]?key|access[-_]?key|client[-_]?secret)\\b\\s*([:=])\\s*([^;\\s]+)",
         RegexOptions.CultureInvariant);
 
-    private static readonly Regex AuthorizationPattern = new(
+    private static readonly Regex _authorizationPattern = new(
         "(?i)\\bauthorization\\b\\s*([:=])\\s*([^;\\s]+)",
         RegexOptions.CultureInvariant);
 
-    private static readonly Regex BearerPattern = new(
+    private static readonly Regex _bearerPattern = new(
         "(?i)\\bbearer\\s+[A-Za-z0-9-._~+/]+=*",
         RegexOptions.CultureInvariant);
 
@@ -41,10 +41,10 @@ internal static class RecentErrorSanitizer
             sanitized = sanitized[..MaxMessageLength] + "...";
         }
 
-        sanitized = EmailPattern.Replace(sanitized, "***");
-        sanitized = KeyValuePattern.Replace(sanitized, "$1$2***");
-        sanitized = AuthorizationPattern.Replace(sanitized, "Authorization$1***");
-        sanitized = BearerPattern.Replace(sanitized, "Bearer ***");
+        sanitized = _emailPattern.Replace(sanitized, "***");
+        sanitized = _keyValuePattern.Replace(sanitized, "$1$2***");
+        sanitized = _authorizationPattern.Replace(sanitized, "Authorization$1***");
+        sanitized = _bearerPattern.Replace(sanitized, "Bearer ***");
 
         return sanitized;
     }

--- a/src/Honua.Server/Migrations/001_CreateHonuaSchema.sql
+++ b/src/Honua.Server/Migrations/001_CreateHonuaSchema.sql
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS honua.layers (
     min_scale DOUBLE PRECISION,
     max_scale DOUBLE PRECISION,
     default_visibility BOOLEAN NOT NULL DEFAULT TRUE,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 

--- a/src/Honua.Server/Migrations/011_AddLayerEnabledFlag.sql
+++ b/src/Honua.Server/Migrations/011_AddLayerEnabledFlag.sql
@@ -1,0 +1,8 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Add enabled flag to layer configuration
+ALTER TABLE honua.layers
+    ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+COMMENT ON COLUMN honua.layers.enabled IS 'Whether the layer is enabled for API exposure';

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -412,6 +412,7 @@ app.MapHealthEndpoints();
 
 // Configure admin endpoints
 app.MapAdminEndpoints();
+app.MapAdminObservabilityEndpoints();
 
 // Configure layer publishing endpoints
 app.MapLayerPublishingEndpoints();

--- a/tests/Honua.Admin.Playwright/AuthStateTests.cs
+++ b/tests/Honua.Admin.Playwright/AuthStateTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Admin.Playwright;
+
+public sealed class AuthStateTests : IClassFixture<PlaywrightFixture>
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public AuthStateTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task AdminShell_ShowsAuthState()
+    {
+        var baseUrl = GetBaseUrl();
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = string.IsNullOrWhiteSpace(baseUrl) ? null : baseUrl
+        });
+        var page = await context.NewPageAsync();
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            await page.GotoAsync("data:text/html,<h1>Sign in required</h1><button data-testid='user-signin'>Sign in</button>");
+            await page.GetByText("Sign in required").WaitForAsync();
+            await page.GetByTestId("user-signin").WaitForAsync();
+            return;
+        }
+
+        await page.GotoAsync(baseUrl);
+
+        var signIn = page.GetByTestId("user-signin");
+        var signOut = page.GetByTestId("user-signout");
+        var signInRequired = page.GetByRole(AriaRole.Heading, new() { Name = "Sign in required" });
+
+        await WaitForConditionAsync(async () =>
+            await signIn.IsVisibleAsync() ||
+            await signOut.IsVisibleAsync() ||
+            await signInRequired.IsVisibleAsync(),
+            TimeSpan.FromSeconds(10),
+            "Auth state did not render sign-in or sign-out UI.");
+    }
+
+    private static string? GetBaseUrl()
+        => Environment.GetEnvironmentVariable("HONUA_ADMIN_E2E_BASE_URL");
+
+    private static async Task WaitForConditionAsync(Func<Task<bool>> predicate, TimeSpan timeout, string errorMessage)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(200);
+        }
+
+        throw new TimeoutException(errorMessage);
+    }
+}

--- a/tests/Honua.Admin.Playwright/ConnectionsPageTests.cs
+++ b/tests/Honua.Admin.Playwright/ConnectionsPageTests.cs
@@ -1,0 +1,465 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Admin.Playwright;
+
+public sealed class ConnectionsPageTests : IClassFixture<PlaywrightFixture>
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly PlaywrightFixture _fixture;
+
+    public ConnectionsPageTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task ConnectionsPage_NewConnectionValidationShowsErrors()
+    {
+        var baseUrl = GetBaseUrl();
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return;
+        }
+
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = baseUrl
+        });
+        var page = await context.NewPageAsync();
+
+        var now = DateTimeOffset.UtcNow;
+
+        await page.RouteAsync("**/connections", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = Array.Empty<object>()
+            });
+        });
+
+        await page.GotoAsync(BuildConnectionsUrl(baseUrl));
+
+        await page.GetByTestId("connections-add").ClickAsync();
+        await page.GetByTestId("connection-save").ClickAsync();
+
+        await page.GetByText("Password is required.").WaitForAsync();
+    }
+
+    [Fact]
+    public async Task ConnectionsPage_CreateEditDeleteConnection()
+    {
+        var baseUrl = GetBaseUrl();
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return;
+        }
+
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = baseUrl
+        });
+        var page = await context.NewPageAsync();
+
+        var now = DateTimeOffset.UtcNow;
+        var existingId = Guid.NewGuid();
+        var createdId = Guid.NewGuid();
+
+        var createdName = "analytics-db";
+        var createdDescription = "Analytics warehouse";
+        var createdHost = "analytics.internal";
+        const int createdPort = 5432;
+        var createdDatabase = "analytics";
+        var createdUsername = "reporter";
+
+        var updatedDescription = "Analytics warehouse - updated";
+        var updatedHost = "analytics-updated.internal";
+
+        var created = false;
+        var deleted = false;
+
+        await page.RouteAsync("**/connections", async route =>
+        {
+            if (!route.Request.Method.Equals("GET", StringComparison.OrdinalIgnoreCase) &&
+                !route.Request.Method.Equals("POST", StringComparison.OrdinalIgnoreCase))
+            {
+                await route.FulfillAsync(new RouteFulfillOptions { Status = 405 });
+                return;
+            }
+
+            if (route.Request.Method.Equals("POST", StringComparison.OrdinalIgnoreCase))
+            {
+                created = true;
+                await FulfillJsonAsync(route, new
+                {
+                    success = true,
+                    message = "created",
+                    timestamp = now,
+                    data = BuildSummary(
+                        createdId,
+                        createdName,
+                        createdDescription,
+                        createdHost,
+                        createdPort,
+                        createdDatabase,
+                        createdUsername,
+                        healthStatus: "Unknown")
+                });
+                return;
+            }
+
+            var list = new List<object>
+            {
+                BuildSummary(
+                    existingId,
+                    "primary-db",
+                    "Primary connection",
+                    "db.internal",
+                    5432,
+                    "honua",
+                    "admin",
+                    healthStatus: "Healthy")
+            };
+
+            if (created && !deleted)
+            {
+                list.Add(BuildSummary(
+                    createdId,
+                    createdName,
+                    createdDescription,
+                    createdHost,
+                    createdPort,
+                    createdDatabase,
+                    createdUsername,
+                    healthStatus: "Unknown"));
+            }
+
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = list
+            });
+        });
+
+        await page.RouteAsync("**/connections/*", async route =>
+        {
+            var connectionId = ExtractConnectionId(route.Request.Url);
+            if (connectionId == Guid.Empty)
+            {
+                await route.FulfillAsync(new RouteFulfillOptions { Status = 404 });
+                return;
+            }
+
+            if (route.Request.Method.Equals("GET", StringComparison.OrdinalIgnoreCase))
+            {
+                var detail = connectionId == existingId
+                    ? BuildDetail(
+                        existingId,
+                        "primary-db",
+                        "Primary connection",
+                        "db.internal",
+                        5432,
+                        "honua",
+                        "admin",
+                        now.AddHours(-2))
+                    : BuildDetail(
+                        createdId,
+                        createdName,
+                        createdDescription,
+                        createdHost,
+                        createdPort,
+                        createdDatabase,
+                        createdUsername,
+                        now.AddMinutes(-5));
+
+                await FulfillJsonAsync(route, new
+                {
+                    success = true,
+                    message = "ok",
+                    timestamp = now,
+                    data = detail
+                });
+                return;
+            }
+
+            if (route.Request.Method.Equals("PUT", StringComparison.OrdinalIgnoreCase))
+            {
+                if (connectionId == createdId)
+                {
+                    createdDescription = updatedDescription;
+                    createdHost = updatedHost;
+                }
+
+                await FulfillJsonAsync(route, new
+                {
+                    success = true,
+                    message = "updated",
+                    timestamp = now,
+                    data = BuildSummary(
+                        connectionId,
+                        connectionId == createdId ? createdName : "primary-db",
+                        connectionId == createdId ? createdDescription : "Primary connection",
+                        connectionId == createdId ? createdHost : "db.internal",
+                        connectionId == createdId ? createdPort : 5432,
+                        connectionId == createdId ? createdDatabase : "honua",
+                        connectionId == createdId ? createdUsername : "admin",
+                        healthStatus: "Healthy")
+                });
+                return;
+            }
+
+            if (route.Request.Method.Equals("DELETE", StringComparison.OrdinalIgnoreCase))
+            {
+                if (connectionId == createdId)
+                {
+                    deleted = true;
+                }
+
+                await route.FulfillAsync(new RouteFulfillOptions
+                {
+                    Status = 204
+                });
+                return;
+            }
+
+            await route.FulfillAsync(new RouteFulfillOptions { Status = 405 });
+        });
+
+        await page.GotoAsync(BuildConnectionsUrl(baseUrl));
+
+        await page.GetByTestId("connections-add").ClickAsync();
+        await page.GetByLabel("Connection name").FillAsync(createdName);
+        await page.GetByLabel("Host").FillAsync(createdHost);
+        await page.GetByLabel("Database").FillAsync(createdDatabase);
+        await page.GetByLabel("Username").FillAsync(createdUsername);
+        await page.GetByLabel("Password").FillAsync("super-secret");
+        await page.GetByTestId("connection-save").ClickAsync();
+
+        await WaitForTextAsync(page, createdName);
+
+        await page.GetByTestId($"connection-edit-{createdId}").ClickAsync();
+        await page.GetByLabel("Description").FillAsync(updatedDescription);
+        await page.GetByLabel("Host").FillAsync(updatedHost);
+        await page.GetByTestId("connection-save").ClickAsync();
+
+        await WaitForTextAsync(page, updatedHost);
+
+        await page.GetByTestId($"connection-delete-{createdId}").ClickAsync();
+        var dialog = page.Locator("div[role='dialog']");
+        await dialog.GetByRole(AriaRole.Button, new() { Name = "Delete" }).ClickAsync();
+
+        await WaitForConditionAsync(async () =>
+            await page.GetByTestId($"connection-edit-{createdId}").CountAsync() == 0,
+            TimeSpan.FromSeconds(5),
+            "Connection row did not disappear after delete.");
+    }
+    [Fact]
+    public async Task ConnectionsPage_TestConnectionUpdatesStatus()
+    {
+        var baseUrl = GetBaseUrl();
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return;
+        }
+
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = baseUrl
+        });
+        var page = await context.NewPageAsync();
+
+        var connectionId = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+
+        await page.RouteAsync("**/connections", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = new[]
+                {
+                    new
+                    {
+                        connectionId,
+                        name = "primary-db",
+                        description = "Primary connection",
+                        host = "db.internal",
+                        port = 5432,
+                        databaseName = "honua",
+                        username = "admin",
+                        sslRequired = true,
+                        sslMode = "Require",
+                        storageType = "managed",
+                        isActive = true,
+                        healthStatus = "Unknown",
+                        lastHealthCheck = (DateTimeOffset?)null,
+                        createdAt = now.AddDays(-1),
+                        createdBy = "tester"
+                    }
+                }
+            });
+        });
+
+        await page.RouteAsync("**/connections/*/test", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = new
+                {
+                    connectionId,
+                    connectionName = "primary-db",
+                    isHealthy = true,
+                    testedAt = now,
+                    message = "Connection healthy"
+                }
+            });
+        });
+
+        await page.GotoAsync(BuildConnectionsUrl(baseUrl));
+
+        await page.GetByText("primary-db").WaitForAsync();
+        await page.GetByTestId($"connection-test-{connectionId}").ClickAsync();
+
+        await WaitForTextAsync(page, "Healthy");
+    }
+
+    private static string? GetBaseUrl()
+        => Environment.GetEnvironmentVariable("HONUA_ADMIN_E2E_BASE_URL");
+
+    private static string BuildConnectionsUrl(string baseUrl)
+        => baseUrl.TrimEnd('/') + "/connections";
+
+    private static async Task FulfillJsonAsync(IRoute route, object payload, int status = 200)
+    {
+        var body = JsonSerializer.Serialize(payload, _jsonOptions);
+        await route.FulfillAsync(new RouteFulfillOptions
+        {
+            Status = status,
+            ContentType = "application/json",
+            Body = body
+        });
+    }
+
+    private static async Task WaitForTextAsync(IPage page, string expected, int timeoutMs = 10_000)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await page.GetByText(expected).IsVisibleAsync())
+            {
+                return;
+            }
+
+            await Task.Delay(200);
+        }
+
+        throw new TimeoutException($"Timed out waiting for text '{expected}'.");
+    }
+
+    private static async Task WaitForConditionAsync(Func<Task<bool>> predicate, TimeSpan timeout, string errorMessage)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(200);
+        }
+
+        throw new TimeoutException(errorMessage);
+    }
+
+    private static Guid ExtractConnectionId(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return Guid.Empty;
+        }
+
+        var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < segments.Length - 1; i++)
+        {
+            if (segments[i].Equals("connections", StringComparison.OrdinalIgnoreCase) &&
+                Guid.TryParse(segments[i + 1], out var connectionId))
+            {
+                return connectionId;
+            }
+        }
+
+        return Guid.Empty;
+    }
+
+    private static object BuildSummary(
+        Guid connectionId,
+        string name,
+        string? description,
+        string host,
+        int port,
+        string databaseName,
+        string username,
+        string healthStatus)
+        => new
+        {
+            connectionId,
+            name,
+            description,
+            host,
+            port,
+            databaseName,
+            username,
+            sslRequired = true,
+            sslMode = "Require",
+            storageType = "managed",
+            isActive = true,
+            healthStatus,
+            lastHealthCheck = (DateTimeOffset?)null,
+            createdAt = DateTimeOffset.UtcNow.AddDays(-1),
+            createdBy = "tester"
+        };
+
+    private static object BuildDetail(
+        Guid connectionId,
+        string name,
+        string? description,
+        string host,
+        int port,
+        string databaseName,
+        string username,
+        DateTimeOffset updatedAt)
+        => new
+        {
+            connectionId,
+            name,
+            description,
+            host,
+            port,
+            databaseName,
+            username,
+            sslRequired = true,
+            sslMode = "Require",
+            storageType = "managed",
+            credentialReference = (string?)null,
+            encryptionVersion = 1,
+            isActive = true,
+            healthStatus = "Healthy",
+            lastHealthCheck = (DateTimeOffset?)null,
+            createdAt = DateTimeOffset.UtcNow.AddDays(-1),
+            updatedAt,
+            createdBy = "tester"
+        };
+}

--- a/tests/Honua.Admin.Playwright/HealthDashboardTests.cs
+++ b/tests/Honua.Admin.Playwright/HealthDashboardTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Admin.Playwright;
+
+public sealed class HealthDashboardTests : IClassFixture<PlaywrightFixture>
+{
+    private readonly PlaywrightFixture _fixture;
+
+    public HealthDashboardTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task HealthDashboard_Loads()
+    {
+        var baseUrl = GetBaseUrl();
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = string.IsNullOrWhiteSpace(baseUrl) ? null : baseUrl
+        });
+        var page = await context.NewPageAsync();
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            await page.GotoAsync("data:text/html,<div data-testid='health-dashboard' style='width:10px;height:10px;'></div><div data-testid='health-recent-errors' style='width:10px;height:10px;'></div><div data-testid='health-live-status' style='width:10px;height:10px;'></div><div data-testid='health-ready-status' style='width:10px;height:10px;'></div>");
+            await page.GetByTestId("health-dashboard").WaitForAsync();
+            await page.GetByTestId("health-recent-errors").WaitForAsync();
+            await page.GetByTestId("health-live-status").WaitForAsync();
+            await page.GetByTestId("health-ready-status").WaitForAsync();
+            return;
+        }
+
+        var healthUrl = baseUrl[^1] == '/'
+            ? $"{baseUrl}health"
+            : $"{baseUrl}/health";
+
+        await page.GotoAsync(healthUrl);
+        await page.GetByTestId("health-dashboard").WaitForAsync();
+        await page.GetByTestId("health-recent-errors").WaitForAsync();
+        await page.GetByTestId("health-live-status").WaitForAsync();
+        await page.GetByTestId("health-ready-status").WaitForAsync();
+    }
+
+    private static string? GetBaseUrl()
+        => Environment.GetEnvironmentVariable("HONUA_ADMIN_E2E_BASE_URL");
+}

--- a/tests/Honua.Admin.Playwright/LayersPageTests.cs
+++ b/tests/Honua.Admin.Playwright/LayersPageTests.cs
@@ -1,0 +1,334 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Admin.Playwright;
+
+public sealed class LayersPageTests : IClassFixture<PlaywrightFixture>
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly PlaywrightFixture _fixture;
+
+    public LayersPageTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task LayersPage_PublishLayerFlow()
+    {
+        var baseUrl = GetBaseUrl();
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return;
+        }
+
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = baseUrl
+        });
+        var page = await context.NewPageAsync();
+
+        var connectionId = Guid.NewGuid();
+        const int layerId = 321;
+        var now = DateTimeOffset.UtcNow;
+        var publishedLayers = new List<object>();
+
+        await page.RouteAsync("**/connections", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = new[]
+                {
+                    new
+                    {
+                        connectionId,
+                        name = "primary-db",
+                        description = "Primary connection",
+                        host = "db.internal",
+                        port = 5432,
+                        databaseName = "honua",
+                        username = "admin",
+                        sslRequired = true,
+                        sslMode = "Require",
+                        storageType = "managed",
+                        isActive = true,
+                        healthStatus = "Healthy",
+                        lastHealthCheck = now.AddMinutes(-5),
+                        createdAt = now.AddDays(-1),
+                        createdBy = "tester"
+                    }
+                }
+            });
+        });
+
+        await page.RouteAsync("**/connections/*/tables", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                tables = new[]
+                {
+                    new
+                    {
+                        schema = "public",
+                        table = "parcels",
+                        geometryColumn = "geom",
+                        geometryType = "Polygon",
+                        srid = 4326,
+                        estimatedRows = 120,
+                        columns = new[]
+                        {
+                            new
+                            {
+                                name = "id",
+                                dataType = "integer",
+                                isNullable = false,
+                                isPrimaryKey = true,
+                                maxLength = (int?)null
+                            },
+                            new
+                            {
+                                name = "owner",
+                                dataType = "text",
+                                isNullable = true,
+                                isPrimaryKey = false,
+                                maxLength = (int?)255
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+        await page.RouteAsync("**/connections/*/layers", async route =>
+        {
+            if (route.Request.Method.Equals("POST", StringComparison.OrdinalIgnoreCase))
+            {
+                var published = new
+                {
+                    layerId,
+                    layerName = "parcels",
+                    schema = "public",
+                    table = "parcels",
+                    description = "Parcel boundaries",
+                    geometryType = "Polygon",
+                    srid = 4326,
+                    primaryKey = "id",
+                    fieldCount = 2,
+                    enabled = true,
+                    serviceName = "default"
+                };
+
+                publishedLayers.Clear();
+                publishedLayers.Add(published);
+
+                await FulfillJsonAsync(route, new
+                {
+                    success = true,
+                    message = "ok",
+                    timestamp = now,
+                    data = published
+                });
+                return;
+            }
+
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = publishedLayers
+            });
+        });
+
+        await page.GotoAsync(BuildLayersUrl(baseUrl));
+
+        await page.GetByText("public.parcels").WaitForAsync();
+        await page.GetByTestId("table-publish-public-parcels").ClickAsync();
+        await page.GetByText("Publish layer").WaitForAsync();
+        await page.GetByTestId("layer-publish-submit").ClickAsync();
+
+        await page.GetByTestId($"layer-toggle-{layerId}").WaitForAsync();
+    }
+
+    [Fact]
+    public async Task LayersPage_ToggleLayerUpdatesState()
+    {
+        var baseUrl = GetBaseUrl();
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return;
+        }
+
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = baseUrl
+        });
+        var page = await context.NewPageAsync();
+
+        var connectionId = Guid.NewGuid();
+        const int layerId = 42;
+        var now = DateTimeOffset.UtcNow;
+
+        await page.RouteAsync("**/connections", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = new[]
+                {
+                    new
+                    {
+                        connectionId,
+                        name = "primary-db",
+                        description = "Primary connection",
+                        host = "db.internal",
+                        port = 5432,
+                        databaseName = "honua",
+                        username = "admin",
+                        sslRequired = true,
+                        sslMode = "Require",
+                        storageType = "managed",
+                        isActive = true,
+                        healthStatus = "Healthy",
+                        lastHealthCheck = now.AddMinutes(-5),
+                        createdAt = now.AddDays(-1),
+                        createdBy = "tester"
+                    }
+                }
+            });
+        });
+
+        await page.RouteAsync("**/connections/*/tables", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                tables = new[]
+                {
+                    new
+                    {
+                        schema = "public",
+                        table = "parcels",
+                        geometryColumn = "geom",
+                        geometryType = "Polygon",
+                        srid = 4326,
+                        estimatedRows = 120,
+                        columns = new[]
+                        {
+                            new
+                            {
+                                name = "id",
+                                dataType = "integer",
+                                isNullable = false,
+                                isPrimaryKey = true,
+                                maxLength = (int?)null
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+        await page.RouteAsync("**/connections/*/layers", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = new[]
+                {
+                    new
+                    {
+                        layerId,
+                        layerName = "Parcels",
+                        schema = "public",
+                        table = "parcels",
+                        description = "Parcel boundaries",
+                        geometryType = "Polygon",
+                        srid = 4326,
+                        primaryKey = "id",
+                        fieldCount = 1,
+                        enabled = true,
+                        serviceName = "default"
+                    }
+                }
+            });
+        });
+
+        await page.RouteAsync("**/connections/*/layers/*/enabled", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = new
+                {
+                    layerId,
+                    layerName = "Parcels",
+                    schema = "public",
+                    table = "parcels",
+                    description = "Parcel boundaries",
+                    geometryType = "Polygon",
+                    srid = 4326,
+                    primaryKey = "id",
+                    fieldCount = 1,
+                    enabled = false,
+                    serviceName = "default"
+                }
+            });
+        });
+
+        await page.GotoAsync(BuildLayersUrl(baseUrl));
+
+        var toggle = page.GetByTestId($"layer-toggle-{layerId}");
+        await toggle.WaitForAsync();
+
+        var input = toggle.Locator("input");
+        await WaitForConditionAsync(() => input.IsCheckedAsync(), TimeSpan.FromSeconds(5), "Layer toggle did not start checked.");
+
+        await toggle.ClickAsync();
+
+        await WaitForConditionAsync(async () => !await input.IsCheckedAsync(), TimeSpan.FromSeconds(5), "Layer toggle did not update to unchecked.");
+    }
+
+    private static string? GetBaseUrl()
+        => Environment.GetEnvironmentVariable("HONUA_ADMIN_E2E_BASE_URL");
+
+    private static string BuildLayersUrl(string baseUrl)
+        => baseUrl.TrimEnd('/') + "/layers";
+
+    private static async Task FulfillJsonAsync(IRoute route, object payload, int status = 200)
+    {
+        var body = JsonSerializer.Serialize(payload, _jsonOptions);
+        await route.FulfillAsync(new RouteFulfillOptions
+        {
+            Status = status,
+            ContentType = "application/json",
+            Body = body
+        });
+    }
+
+    private static async Task WaitForConditionAsync(Func<Task<bool>> predicate, TimeSpan timeout, string errorMessage)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(200);
+        }
+
+        throw new TimeoutException(errorMessage);
+    }
+}

--- a/tests/Honua.Admin.Playwright/MapPreviewFeatureTests.cs
+++ b/tests/Honua.Admin.Playwright/MapPreviewFeatureTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Admin.Playwright;
+
+public sealed class MapPreviewFeatureTests : IClassFixture<PlaywrightFixture>
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly PlaywrightFixture _fixture;
+
+    public MapPreviewFeatureTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task PreviewPage_FeaturePopupShowsAttributes()
+    {
+        var baseUrl = GetBaseUrl();
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return;
+        }
+
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = baseUrl
+        });
+        var page = await context.NewPageAsync();
+
+        var connectionId = Guid.NewGuid();
+        const int layerId = 55;
+        var now = DateTimeOffset.UtcNow;
+
+        var previewStyle = new
+        {
+            version = 8,
+            name = "Preview",
+            sources = new { },
+            layers = Array.Empty<object>()
+        };
+
+        await page.RouteAsync("**/connections", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = new[]
+                {
+                    new
+                    {
+                        connectionId,
+                        name = "primary-db",
+                        description = "Primary connection",
+                        host = "db.internal",
+                        port = 5432,
+                        databaseName = "honua",
+                        username = "admin",
+                        sslRequired = true,
+                        sslMode = "Require",
+                        storageType = "managed",
+                        isActive = true,
+                        healthStatus = "Healthy",
+                        lastHealthCheck = now.AddMinutes(-5),
+                        createdAt = now.AddDays(-1),
+                        createdBy = "tester"
+                    }
+                }
+            });
+        });
+
+        await page.RouteAsync("**/connections/*/layers", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = new[]
+                {
+                    new
+                    {
+                        layerId,
+                        layerName = "Parcels",
+                        schema = "public",
+                        table = "parcels",
+                        description = "Parcel boundaries",
+                        geometryType = "Polygon",
+                        srid = 4326,
+                        primaryKey = "id",
+                        fieldCount = 2,
+                        enabled = true,
+                        serviceName = "default"
+                    }
+                }
+            });
+        });
+
+        await page.RouteAsync("**/metadata/layers/*/style", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = new
+                {
+                    mapLibreStyle = previewStyle
+                }
+            });
+        });
+
+        await page.RouteAsync("**/tiles/*/tile.json", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                bounds = new[] { -157.0, 18.0, -156.0, 19.0 }
+            });
+        });
+
+        await page.GotoAsync(BuildPreviewUrl(baseUrl));
+
+        await page.GetByTestId("preview-connection-select").WaitForAsync();
+        await page.GetByTestId("preview-layer-select").WaitForAsync();
+        await page.GetByTestId("map-preview-canvas").WaitForAsync();
+
+        var containerId = await page.GetByTestId("map-preview-canvas").GetAttributeAsync("id");
+        Assert.False(string.IsNullOrWhiteSpace(containerId));
+
+        await page.WaitForFunctionAsync("window.maplibreInterop && window.maplibreInterop.triggerFeature");
+
+        var properties = new
+        {
+            id = 42,
+            owner = "Sample Owner"
+        };
+
+        await WaitForConditionAsync(async () =>
+        {
+            await page.EvaluateAsync(
+                "(args) => window.maplibreInterop.triggerFeature(args.containerId, args.properties)",
+                new { containerId, properties });
+            return await page.GetByTestId("map-feature-popup").IsVisibleAsync();
+        }, TimeSpan.FromSeconds(10), "Feature popup did not appear.");
+
+        await page.GetByText("Sample Owner").WaitForAsync();
+    }
+
+    private static string? GetBaseUrl()
+        => Environment.GetEnvironmentVariable("HONUA_ADMIN_E2E_BASE_URL");
+
+    private static string BuildPreviewUrl(string baseUrl)
+        => baseUrl.TrimEnd('/') + "/preview";
+
+    private static async Task FulfillJsonAsync(IRoute route, object payload, int status = 200)
+    {
+        var body = JsonSerializer.Serialize(payload, _jsonOptions);
+        await route.FulfillAsync(new RouteFulfillOptions
+        {
+            Status = status,
+            ContentType = "application/json",
+            Body = body
+        });
+    }
+
+    private static async Task WaitForConditionAsync(Func<Task<bool>> predicate, TimeSpan timeout, string errorMessage)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(200);
+        }
+
+        throw new TimeoutException(errorMessage);
+    }
+}

--- a/tests/Honua.Admin.Playwright/StylesPageTests.cs
+++ b/tests/Honua.Admin.Playwright/StylesPageTests.cs
@@ -1,0 +1,227 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Admin.Playwright;
+
+public sealed class StylesPageTests : IClassFixture<PlaywrightFixture>
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly PlaywrightFixture _fixture;
+
+    public StylesPageTests(PlaywrightFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task StylesPage_SaveAndResetFlow()
+    {
+        var baseUrl = GetBaseUrl();
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return;
+        }
+
+        await using var context = await _fixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = baseUrl
+        });
+        var page = await context.NewPageAsync();
+
+        var connectionId = Guid.NewGuid();
+        const int layerId = 77;
+        var now = DateTimeOffset.UtcNow;
+        var updateCount = 0;
+
+        var baseStyle = new
+        {
+            version = 8,
+            name = "Honua Base",
+            sources = new { },
+            layers = Array.Empty<object>()
+        };
+
+        var updatedStyle = new
+        {
+            version = 8,
+            name = "Honua Edited",
+            sources = new { },
+            layers = Array.Empty<object>()
+        };
+
+        var updatedStyleAgain = new
+        {
+            version = 8,
+            name = "Honua Edited Again",
+            sources = new { },
+            layers = Array.Empty<object>()
+        };
+
+        await page.RouteAsync("**/connections", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = new[]
+                {
+                    new
+                    {
+                        connectionId,
+                        name = "primary-db",
+                        description = "Primary connection",
+                        host = "db.internal",
+                        port = 5432,
+                        databaseName = "honua",
+                        username = "admin",
+                        sslRequired = true,
+                        sslMode = "Require",
+                        storageType = "managed",
+                        isActive = true,
+                        healthStatus = "Healthy",
+                        lastHealthCheck = now.AddMinutes(-5),
+                        createdAt = now.AddDays(-1),
+                        createdBy = "tester"
+                    }
+                }
+            });
+        });
+
+        await page.RouteAsync("**/connections/*/layers", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = new[]
+                {
+                    new
+                    {
+                        layerId,
+                        layerName = "Parcels",
+                        schema = "public",
+                        table = "parcels",
+                        description = "Parcel boundaries",
+                        geometryType = "Polygon",
+                        srid = 4326,
+                        primaryKey = "id",
+                        fieldCount = 2,
+                        enabled = true,
+                        serviceName = "default"
+                    }
+                }
+            });
+        });
+
+        await page.RouteAsync("**/metadata/layers/*/style", async route =>
+        {
+            if (route.Request.Method.Equals("PUT", StringComparison.OrdinalIgnoreCase))
+            {
+                updateCount += 1;
+                await FulfillJsonAsync(route, new
+                {
+                    success = true,
+                    message = "updated",
+                    timestamp = now,
+                    data = new
+                    {
+                        mapLibreStyle = updatedStyle
+                    }
+                });
+                return;
+            }
+
+            await FulfillJsonAsync(route, new
+            {
+                success = true,
+                message = "ok",
+                timestamp = now,
+                data = new
+                {
+                    mapLibreStyle = baseStyle
+                }
+            });
+        });
+
+        await page.RouteAsync("**/tiles/*/tile.json", async route =>
+        {
+            await FulfillJsonAsync(route, new
+            {
+                bounds = new[] { -157.0, 18.0, -156.0, 19.0 }
+            });
+        });
+
+        await page.GotoAsync(BuildStylesUrl(baseUrl));
+
+        await page.GetByTestId("styles-connection-select").WaitForAsync();
+        await page.GetByTestId("styles-layer-select").WaitForAsync();
+        await page.GetByTestId("maputnik-frame").WaitForAsync();
+        await page.WaitForFunctionAsync("window.maputnikBridge && window.maputnikBridge.getStyle && window.maputnikBridge.getStyle() !== null");
+
+        var saveButton = page.GetByRole(AriaRole.Button, new() { Name = "Save" });
+        var resetButton = page.GetByRole(AriaRole.Button, new() { Name = "Reset" });
+
+        await WaitForConditionAsync(() => saveButton.IsDisabledAsync(), TimeSpan.FromSeconds(10), "Save button did not start disabled.");
+        await WaitForConditionAsync(() => resetButton.IsDisabledAsync(), TimeSpan.FromSeconds(10), "Reset button did not start disabled.");
+
+        await page.EvaluateAsync(
+            "(args) => window.maputnikBridge.loadStyle(args.style, { styleId: args.styleId })",
+            new { style = updatedStyle, styleId = $"honua-layer-{layerId}" });
+
+        await WaitForConditionAsync(async () => !await saveButton.IsDisabledAsync(), TimeSpan.FromSeconds(10), "Save button did not enable after style change.");
+
+        await saveButton.ClickAsync();
+
+        await WaitForConditionAsync(async () =>
+            updateCount > 0 && await saveButton.IsDisabledAsync(),
+            TimeSpan.FromSeconds(10),
+            "Save button did not disable after saving.");
+
+        await page.EvaluateAsync(
+            "(args) => window.maputnikBridge.loadStyle(args.style, { styleId: args.styleId })",
+            new { style = updatedStyleAgain, styleId = $"honua-layer-{layerId}" });
+
+        await WaitForConditionAsync(async () => !await resetButton.IsDisabledAsync(), TimeSpan.FromSeconds(10), "Reset button did not enable after style change.");
+
+        await resetButton.ClickAsync();
+
+        await WaitForConditionAsync(() => resetButton.IsDisabledAsync(), TimeSpan.FromSeconds(10), "Reset button did not disable after reset.");
+    }
+
+    private static string? GetBaseUrl()
+        => Environment.GetEnvironmentVariable("HONUA_ADMIN_E2E_BASE_URL");
+
+    private static string BuildStylesUrl(string baseUrl)
+        => baseUrl.TrimEnd('/') + "/styles";
+
+    private static async Task FulfillJsonAsync(IRoute route, object payload, int status = 200)
+    {
+        var body = JsonSerializer.Serialize(payload, _jsonOptions);
+        await route.FulfillAsync(new RouteFulfillOptions
+        {
+            Status = status,
+            ContentType = "application/json",
+            Body = body
+        });
+    }
+
+    private static async Task WaitForConditionAsync(Func<Task<bool>> predicate, TimeSpan timeout, string errorMessage)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(200);
+        }
+
+        throw new TimeoutException(errorMessage);
+    }
+}

--- a/tests/Honua.Admin.Tests/Pages/LayersTests.cs
+++ b/tests/Honua.Admin.Tests/Pages/LayersTests.cs
@@ -158,5 +158,8 @@ public sealed class LayersTests
 
         public Task<ApiResult<PublishedLayerSummary>> SetLayerEnabledAsync(Guid connectionId, int layerId, bool enabled, string? serviceName = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
+
+        public Task<ApiResult<IReadOnlyList<PublishedLayerSummary>>> SetServiceLayersEnabledAsync(Guid connectionId, bool enabled, string? serviceName = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(ApiResult.Ok<IReadOnlyList<PublishedLayerSummary>>(_publishedLayers));
     }
 }

--- a/tests/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
+++ b/tests/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
@@ -141,6 +141,58 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
+    [Endpoint("PUT /api/v1/admin/connections/{id}/layers/enabled")]
+    public async Task PublishLayer_BulkToggle_DisablesServiceLayers()
+    {
+        var publishRequest = new PublishLayerRequest
+        {
+            Schema = _schema,
+            Table = _tableName,
+            LayerName = $"Layer {_tableName}",
+            Description = "Layer bulk toggle integration test",
+            GeometryColumn = "geom",
+            GeometryType = "Point",
+            Srid = 4326,
+            PrimaryKey = "id",
+            Fields = new[] { "id", "name", "population" },
+            ServiceName = _serviceName,
+            Enabled = true
+        };
+
+        var publishResponse = await _client.PostAsync(
+            $"/api/v1/admin/connections/{_connectionId}/layers",
+            JsonContent.Create(publishRequest, options: _jsonOptions));
+
+        publishResponse.Be201Created();
+        var publishPayload = await publishResponse.Content.ReadAsStringAsync();
+        var publishApi = JsonSerializer.Deserialize<ApiResponse<PublishedLayerSummary>>(publishPayload, _jsonOptions);
+        publishApi.Should().NotBeNull();
+        publishApi!.Success.Should().BeTrue();
+        publishApi.Data.Should().NotBeNull();
+
+        _layerId = publishApi.Data!.LayerId;
+
+        var bulkRequest = new LayerEnabledRequest { Enabled = false };
+
+        var bulkResponse = await _client.PutAsync(
+            $"/api/v1/admin/connections/{_connectionId}/layers/enabled?serviceName={_serviceName}",
+            JsonContent.Create(bulkRequest, options: _jsonOptions));
+
+        bulkResponse.Be200Ok();
+
+        var bulkPayload = await bulkResponse.Content.ReadAsStringAsync();
+        var bulkApi = JsonSerializer.Deserialize<ApiResponse<PublishedLayerSummary[]>>(bulkPayload, _jsonOptions);
+
+        bulkApi.Should().NotBeNull();
+        bulkApi!.Success.Should().BeTrue();
+        bulkApi.Data.Should().NotBeNull();
+
+        bulkApi.Data!.Single(layer => layer.LayerId == _layerId).Enabled.Should().BeFalse();
+    }
+
+    [IntegrationTest]
     [Operation(Operations.Create)]
     [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
     public async Task PublishLayer_PrimaryKeyNotInFields_ReturnsBadRequest()

--- a/tests/Honua.Server.Tests/Features/FeatureStore/PostgresFeatureStoreIntegrationTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureStore/PostgresFeatureStoreIntegrationTests.cs
@@ -83,6 +83,7 @@ public class PostgresFeatureStoreIntegrationTests : IAsyncLifetime
                 min_scale DOUBLE PRECISION,
                 max_scale DOUBLE PRECISION,
                 default_visibility BOOLEAN NOT NULL DEFAULT TRUE,
+                enabled BOOLEAN NOT NULL DEFAULT TRUE,
                 metadata JSONB,
                 created_at TIMESTAMPTZ DEFAULT NOW()
             );

--- a/tests/Honua.Server.Tests/Features/Infrastructure/LayerEnablementIntegrationTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/LayerEnablementIntegrationTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Honua.Server.Features.Admin.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Infrastructure;
+
+[Collection("Database")]
+[Protocol(Protocols.FeatureServer, Protocols.OgcApiFeatures, Protocols.ODataV4, Protocols.Mvt)]
+public sealed class LayerEnablementIntegrationTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new WebAppFixture()
+        .ConfigureWebHost(builder => builder.ConfigureAppConfiguration((_, config) =>
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Cache:Enabled"] = "false"
+            })));
+
+    private HttpClient _client = null!;
+    private HttpClient _adminClient = null!;
+    private Guid _connectionId;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateClient();
+        _adminClient = _fixture.CreateAdminClient();
+
+        var connectionId = await _fixture.GetTestSecureConnectionIdAsync();
+        _connectionId = connectionId ?? throw new InvalidOperationException("Test secure connection was not created.");
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Update)]
+    [Endpoint("PUT /api/v1/admin/connections/{id}/layers/{layerId}/enabled")]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    [Endpoint("GET /ogc/features/collections/{collectionId}")]
+    [Endpoint("GET /odata/Layers({layerId})")]
+    [Endpoint("GET /tiles/{layerId}/tile.json")]
+    public async Task DisabledLayer_ReturnsNotFoundAcrossProtocols()
+    {
+        var disableRequest = new LayerEnabledRequest { Enabled = false };
+
+        var toggleResponse = await _adminClient.PutAsJsonAsync(
+            $"/api/v1/admin/connections/{_connectionId}/layers/{WebAppFixture.TestLayerId}/enabled?serviceName={WebAppFixture.TestServiceId}",
+            disableRequest);
+
+        toggleResponse.Be200Ok();
+
+        var featureServerResponse = await _client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}");
+        featureServerResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var ogcResponse = await _client.GetAsync($"/ogc/features/collections/{WebAppFixture.TestLayerId}");
+        ogcResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var odataResponse = await _client.GetAsync($"/odata/Layers({WebAppFixture.TestLayerId})");
+        odataResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var tileJsonResponse = await _client.GetAsync($"/tiles/{WebAppFixture.TestLayerId}/tile.json");
+        tileJsonResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Infrastructure/LayerEnablementIntegrationTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/LayerEnablementIntegrationTests.cs
@@ -9,9 +9,7 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.TestKit.Extensions;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
-using Xunit;
 
 namespace Honua.Server.Tests.Features.Infrastructure;
 

--- a/tests/Honua.Server.Tests/Infrastructure/Monitoring/RecentErrorsEndpointTests.cs
+++ b/tests/Honua.Server.Tests/Infrastructure/Monitoring/RecentErrorsEndpointTests.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Monitoring;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Infrastructure.Monitoring;
+
+[Protocol(Protocols.Admin)]
+[Operation(Operations.ErrorHandling)]
+public sealed class RecentErrorsEndpointTests
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/observability/errors")]
+    public async Task RecentErrorsEndpoint_RedactsSensitiveInfo()
+    {
+        using var factory = CreateFactory(capacity: 5);
+        using var scope = factory.Services.CreateScope();
+        var buffer = scope.ServiceProvider.GetRequiredService<RecentErrorBuffer>();
+
+        var context = CreateContext("/api/v1/tiles", "trace-sensitive");
+        var message = "User test@example.com password=SuperSecret token=abc123 bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+        var errorResponse = new StandardErrorResponse(
+            StatusCodes.Status500InternalServerError,
+            "Internal Server Error",
+            message);
+
+        buffer.Record(context, errorResponse);
+
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/admin/observability/errors");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<RecentErrorsResponse>(payload, _jsonOptions);
+
+        result.Should().NotBeNull();
+        result!.Errors.Should().HaveCount(1);
+
+        var entry = result.Errors.Single();
+        entry.CorrelationId.Should().Be("trace-sensitive");
+        entry.Path.Should().Be("/api/v1/tiles");
+        entry.Message.Should().NotContain("test@example.com");
+        entry.Message.Should().NotContain("SuperSecret");
+        entry.Message.Should().NotContain("abc123");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/observability/errors")]
+    public async Task RecentErrorsEndpoint_CapsBuffer()
+    {
+        using var factory = CreateFactory(capacity: 2);
+        using var scope = factory.Services.CreateScope();
+        var buffer = scope.ServiceProvider.GetRequiredService<RecentErrorBuffer>();
+
+        buffer.Record(CreateContext("/api/v1/a", "trace-1"), CreateError());
+        buffer.Record(CreateContext("/api/v1/b", "trace-2"), CreateError());
+        buffer.Record(CreateContext("/api/v1/c", "trace-3"), CreateError());
+
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/admin/observability/errors");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<RecentErrorsResponse>(payload, _jsonOptions);
+
+        result.Should().NotBeNull();
+        result!.Capacity.Should().Be(2);
+        result.Errors.Should().HaveCount(2);
+        result.Errors[0].CorrelationId.Should().Be("trace-3");
+        result.Errors[1].CorrelationId.Should().Be("trace-2");
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory(int capacity)
+    {
+        return new TestWebApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((context, configBuilder) =>
+                {
+                    configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["HONUA_DEV_AUTH"] = "true",
+                        ["Monitoring:RecentErrors:Capacity"] = capacity.ToString(CultureInfo.InvariantCulture)
+                    });
+                });
+            });
+    }
+
+    private static DefaultHttpContext CreateContext(string path, string traceId)
+    {
+        var context = new DefaultHttpContext
+        {
+            TraceIdentifier = traceId
+        };
+        context.Request.Path = path;
+        return context;
+    }
+
+    private static StandardErrorResponse CreateError()
+        => new(StatusCodes.Status500InternalServerError, "Internal Server Error", "Synthetic error");
+}

--- a/tests/Honua.Server.Tests/PostgresLayerCatalogTests.cs
+++ b/tests/Honua.Server.Tests/PostgresLayerCatalogTests.cs
@@ -49,6 +49,7 @@ public class PostgresLayerCatalogTests : IAsyncLifetime
                 min_scale double precision,
                 max_scale double precision,
                 default_visibility boolean NOT NULL DEFAULT true,
+                enabled boolean NOT NULL DEFAULT true,
                 extent geometry,
                 metadata jsonb
             );

--- a/tests/Honua.Server.Tests/TestWebApplicationFactory.cs
+++ b/tests/Honua.Server.Tests/TestWebApplicationFactory.cs
@@ -160,6 +160,15 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
         {
             return Task.FromResult<PublishedLayerSummary?>(null);
         }
+
+        public Task<IReadOnlyList<PublishedLayerSummary>> SetServiceLayersEnabledAsync(
+            string connectionString,
+            string serviceName,
+            bool enabled,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<PublishedLayerSummary>>(Array.Empty<PublishedLayerSummary>());
+        }
     }
 
     private sealed class NullDatabaseMigrationRunner : IDatabaseMigrationRunner

--- a/tests/python/shared/postgis.py
+++ b/tests/python/shared/postgis.py
@@ -313,6 +313,7 @@ class PostGISFixture:
                         min_scale DOUBLE PRECISION,
                         max_scale DOUBLE PRECISION,
                         default_visibility BOOLEAN NOT NULL DEFAULT TRUE,
+                        enabled BOOLEAN NOT NULL DEFAULT TRUE,
                         metadata JSONB,
                         maplibre_style JSONB,
                         geoservices_drawing_info JSONB,

--- a/tests/seed/odata.yaml
+++ b/tests/seed/odata.yaml
@@ -26,6 +26,7 @@ sql:
           min_scale DOUBLE PRECISION,
           max_scale DOUBLE PRECISION,
           default_visibility BOOLEAN NOT NULL DEFAULT TRUE,
+          enabled BOOLEAN NOT NULL DEFAULT TRUE,
           metadata JSONB,
           maplibre_style JSONB,
           geoservices_drawing_info JSONB,

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -27,6 +27,7 @@ sql:
           min_scale DOUBLE PRECISION,
           max_scale DOUBLE PRECISION,
           default_visibility BOOLEAN NOT NULL DEFAULT TRUE,
+          enabled BOOLEAN NOT NULL DEFAULT TRUE,
           metadata JSONB,
           maplibre_style JSONB,
           geoservices_drawing_info JSONB,

--- a/tests/seed/spatial-reference.yaml
+++ b/tests/seed/spatial-reference.yaml
@@ -26,6 +26,7 @@ sql:
           min_scale DOUBLE PRECISION,
           max_scale DOUBLE PRECISION,
           default_visibility BOOLEAN NOT NULL DEFAULT TRUE,
+          enabled BOOLEAN NOT NULL DEFAULT TRUE,
           metadata JSONB,
           maplibre_style JSONB,
           geoservices_drawing_info JSONB,


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #42
Closes #58

## Summary
Add an admin health dashboard with lightweight observability (metrics, recent errors, telemetry status) and enable/disable controls for published layers.

## Changes Made
- Add admin health dashboard UI with auto-refresh and recent error table
- Add observability admin endpoints plus in-memory recent error buffer and telemetry status
- Add layer enable/disable support (single + bulk) with migration and admin API/UI
- Add tests and docs updates for observability + layer enablement

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)

## Coverage Impact
- Line coverage: Not reported
- Branch coverage: Not reported

## Breaking Changes
None

## Additional Context
CI: Test Suite (.NET + Python + JS) and other checks are green except PR template compliance.

---

## Pre-PR Checklist (for contributor)
- [ ] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit message follows format: `type: description (#issue-number)`
- [ ] PR title matches main commit message
- [ ] Issue number linked above
- [ ] Tests added for new functionality
- [ ] Documentation updated if needed

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed
