### PR TITLE
fix: avoid invalid chunked streaming responses

### DIFF
--- a/src/Honua.Server/Features/FeatureServer/Services/FeatureServerQueryExecutor.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/FeatureServerQueryExecutor.cs
@@ -159,10 +159,6 @@ internal sealed class FeatureServerQueryExecutor
 
     private static void EnableChunkedEncodingIfHttp1(HttpContext context)
     {
-        if (string.IsNullOrEmpty(context.Request.Protocol)
-            || context.Request.Protocol.StartsWith("HTTP/1", StringComparison.OrdinalIgnoreCase))
-        {
-            context.Response.Headers.TransferEncoding = "chunked";
-        }
+        // Kestrel will apply chunked transfer encoding automatically when Content-Length is not set.
     }
 }

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesQueryHandler.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesQueryHandler.cs
@@ -653,11 +653,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
 
     private static void EnableChunkedEncodingIfHttp1(HttpContext context)
     {
-        if (string.IsNullOrEmpty(context.Request.Protocol)
-            || context.Request.Protocol.StartsWith("HTTP/1", StringComparison.OrdinalIgnoreCase))
-        {
-            context.Response.Headers.TransferEncoding = "chunked";
-        }
+        // Kestrel will apply chunked transfer encoding automatically when Content-Length is not set.
     }
 
     private sealed class StreamingItemsResult : IResult


### PR DESCRIPTION
## Summary

Fix invalid chunked streaming responses for OGC Features (CITE numberMatched test).

Closes #N/A

## Changes

- Stop forcing `Transfer-Encoding: chunked` so Kestrel can emit valid chunked responses
- Apply fix to both OGC Features streaming and FeatureServer streaming helpers

## Self-Review Checklist

### Code Quality
- [ ] Code follows vertical slice architecture
- [ ] No more than 5 dependencies per endpoint class
- [ ] No legacy code copy-pasted (reference only)
- [ ] No `// TODO` comments without linked issue

### Testing (TDD)
- [ ] Tests written before implementation
- [ ] Integration tests use Testcontainers + PostGIS
- [ ] Edge cases covered
- [ ] Coverage meets phase checkpoint

### Build
- [ ] `dotnet build` passes with warnings-as-errors
- [ ] `dotnet format --verify-no-changes` passes
- [ ] AOT build succeeds (if applicable)

### Documentation
- [ ] CLAUDE.md updated if new patterns established
- [ ] Legacy reference documented in code comments
- [ ] API changes documented

### Artifact Cleanup (REQUIRED)
- [ ] No temporary/scratch files (*.tmp, scratch.*, temp.*)
- [ ] No orphaned markdown files (unused docs, old notes)
- [ ] No commented-out code blocks
- [ ] No `// TODO` without linked issue number
- [ ] No debug logging left enabled
- [ ] No hardcoded test values in production code
- [ ] `docs/pdca/` files archived or deleted if cycle complete
- [ ] `docs/temp/` cleared

### Before Merge
- [ ] All CI checks passing
- [ ] Reviewed own code (diff tab)
- [ ] Commit messages follow conventional format
- [ ] Branch is up to date with trunk
- [ ] **Ran artifact cleanup checklist above**

## Test Plan

- Local docker-compose reproduction (CITE seed) for:
  - `GET /ogc/features/collections/1/items?offset=1&f=geojson&limit=2000`
  - Verified valid JSON; numberMatched=8, numberReturned=7

## Legacy Reference

None
