### PR TITLE
feat: implement quality and observability enhancements for issues 231/227/259/289 (#231)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,12 +8,9 @@
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <!-- Required for IDE0005 (remove unused usings) to work in build -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <!-- CS1591: Missing XML documentation warnings suppressed globally for now -->
-    <!-- Individual projects can enable via <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors> -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <!-- Suppress test-specific warnings and analyzers for clean builds -->
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(MSBuildProjectName)' == 'Honua.TestKit'">
-    <NoWarn>$(NoWarn);CA1041;CA1816;CA1869;CA1310;xUnit2021;xUnit1041;CS4014;CS0618;CS0612;CS1061;IDE0051;IDE0052;IDE0005</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CA1041;CA1816;CA1869;CA1310;xUnit2021;xUnit1041;CS4014;CS0618;CS0612;CS1061;IDE0051;IDE0052;IDE0005</NoWarn>
   </PropertyGroup>
 </Project>

--- a/benchmarks/Honua.Benchmarks/Honua.Benchmarks.csproj
+++ b/benchmarks/Honua.Benchmarks/Honua.Benchmarks.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <PublishAot>false</PublishAot>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docker/prometheus/alerts.yml
+++ b/docker/prometheus/alerts.yml
@@ -9,6 +9,7 @@ groups:
         annotations:
           summary: "Honua instance down"
           description: "Prometheus has not scraped {{ $labels.instance }} for 2 minutes."
+          runbook: "docs/devops/runbooks/server-down.md"
 
       - alert: HonuaHighErrorRate
         expr: sum(rate(honua_http_request_total{status_code=~"5.."}[5m])) / sum(rate(honua_http_request_total[5m])) > 0.05
@@ -18,6 +19,7 @@ groups:
         annotations:
           summary: "High 5xx error rate"
           description: "5xx error rate > 5% for 10 minutes."
+          runbook: "docs/devops/runbooks/high-error-rate.md"
 
       - alert: HonuaHighLatencyP95
         expr: histogram_quantile(0.95, sum(rate(honua_http_request_duration_ms_bucket[5m])) by (le)) > 500
@@ -27,6 +29,7 @@ groups:
         annotations:
           summary: "High request latency (p95)"
           description: "P95 request latency > 500ms for 10 minutes."
+          runbook: "docs/devops/runbooks/high-response-time.md"
 
       - alert: HonuaActiveRequestsHigh
         expr: sum(honua_http_active_requests) > 100
@@ -36,6 +39,7 @@ groups:
         annotations:
           summary: "High active request count"
           description: "Active requests > 100 for 10 minutes."
+          runbook: "docs/devops/runbooks/high-cpu-usage.md"
 
       - alert: HonuaCacheHitRatioLow
         expr: sum(rate(honua_cache_operation_total{operation="hit"}[10m])) / sum(rate(honua_cache_operation_total{operation=~"hit|miss"}[10m])) < 0.7
@@ -45,6 +49,7 @@ groups:
         annotations:
           summary: "Low cache hit ratio"
           description: "Cache hit ratio < 70% for 15 minutes."
+          runbook: "docs/devops/runbooks/high-response-time.md"
 
       - alert: HonuaDatabaseLatencyP95
         expr: histogram_quantile(0.95, sum(rate(honua_database_query_duration_ms_bucket[5m])) by (le)) > 200
@@ -54,3 +59,4 @@ groups:
         annotations:
           summary: "High database query latency (p95)"
           description: "P95 database query latency > 200ms for 10 minutes."
+          runbook: "docs/devops/runbooks/database-issues.md"

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,8 @@
 
 **Performance:**
 - [Performance Monitoring](devops/performance-monitoring.md)
+- [Cloud-Native Alerting](alerting/README.md)
+- [Optional Prometheus + Grafana Stack](devops/optional-observability-stack.md)
 - [Caching Strategy](devops/CACHING_STRATEGY.md)
 - [Query Optimization](devops/query-optimization.md)
 - [Connection Pool Sizing](devops/connection-pool-sizing.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -57,6 +57,8 @@
 
 ### Operations
 * [📊 Performance Testing](devops/performance-testing.md)
+* [🚨 Cloud-Native Alerting](alerting/README.md)
+* [📈 Optional Prometheus + Grafana Stack](devops/optional-observability-stack.md)
 * [🔗 Connection Pool Sizing](devops/connection-pool-sizing.md)
 * [🗄️ Query Optimization](devops/query-optimization.md)
 * [💾 Backup and Restore](devops/backup-restore.md)

--- a/docs/alerting/README.md
+++ b/docs/alerting/README.md
@@ -1,0 +1,60 @@
+# Cloud-Native Alerting (OTLP -> Collector -> Managed Prometheus)
+
+This guide defines Honua alerting using open standards and managed services.
+
+## Goals
+
+- Use OTLP for metrics/traces/logs emitted by Honua.
+- Route telemetry through OpenTelemetry Collector.
+- Keep one PromQL ruleset for all clouds.
+- Avoid running a required self-hosted Prometheus/Grafana stack.
+
+## Reference Architecture
+
+1. Honua emits OTLP telemetry (`OTEL_*` environment variables).
+2. OpenTelemetry Collector receives OTLP and batches data.
+3. Collector exports metrics to managed Prometheus via `remote_write` (or provider equivalent).
+4. Alert policies are created from a shared PromQL rules file in this repository.
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+processors:
+  batch:
+exporters:
+  prometheusremotewrite:
+    endpoint: ${PROM_RW_ENDPOINT}
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheusremotewrite]
+```
+
+## Shared Alert Rules
+
+- Rules file: `docs/alerting/rules/honua-core.yaml`
+- Scope: API availability, 5xx rate, latency, and saturation signals.
+
+Use this exact file across providers to keep alert semantics consistent.
+
+## Provider Overlays
+
+- AWS overlay: `docs/alerting/aws/README.md`
+- GCP overlay: `docs/alerting/gcp/README.md`
+- Azure overlay: `docs/alerting/azure/README.md`
+
+Each overlay contains:
+- collector auth + exporter wiring
+- rule publication examples for the cloud provider
+- minimal provider-specific assumptions
+
+## Operational Notes
+
+- Keep `honua-core.yaml` as the source of truth and regenerate provider policies from it.
+- Route notifications to on-call destinations (SNS, Cloud Monitoring channels, Action Groups).
+- Review thresholds after load tests and major feature releases.

--- a/docs/alerting/aws/README.md
+++ b/docs/alerting/aws/README.md
@@ -1,0 +1,23 @@
+# AWS Overlay (AMP + SigV4)
+
+## Collector exporter overlay
+
+Use this overlay with the base collector config from `docs/alerting/README.md`:
+
+- file: `docs/alerting/aws/collector-overlay.yaml`
+- environment variables:
+  - `AWS_REGION`
+  - `PROM_RW_ENDPOINT` (AMP remote_write URL)
+
+## Publish PromQL rules to AMP
+
+```bash
+aws amp put-rule-groups-namespace \
+  --workspace-id "$AMP_WORKSPACE_ID" \
+  --name honua-core \
+  --data fileb://docs/alerting/rules/honua-core.yaml
+```
+
+## Notifications
+
+Bind AMP alertmanager routes to SNS (or managed Grafana notification policies).

--- a/docs/alerting/aws/collector-overlay.yaml
+++ b/docs/alerting/aws/collector-overlay.yaml
@@ -1,0 +1,13 @@
+extensions:
+  sigv4auth:
+    service: "aps"
+    region: "${AWS_REGION}"
+
+exporters:
+  prometheusremotewrite:
+    endpoint: "${PROM_RW_ENDPOINT}"
+    auth:
+      authenticator: sigv4auth
+
+service:
+  extensions: [sigv4auth]

--- a/docs/alerting/azure/README.md
+++ b/docs/alerting/azure/README.md
@@ -1,0 +1,20 @@
+# Azure Overlay (Azure Monitor Managed Prometheus)
+
+## Collector exporter overlay
+
+Use this overlay with the base collector config from `docs/alerting/README.md`:
+
+- file: `docs/alerting/azure/collector-overlay.yaml`
+- authentication: Managed Identity + Azure Monitor workspace permissions
+
+## Publish PromQL alert rules
+
+Create Azure Monitor Prometheus rule groups from `docs/alerting/rules/honua-core.yaml` expressions.
+
+Example workflow:
+1. Define rule group ARM/Bicep/Terraform resources.
+2. Apply with `az deployment` or Terraform.
+
+## Notifications
+
+Use Action Groups for paging and incident routing.

--- a/docs/alerting/azure/collector-overlay.yaml
+++ b/docs/alerting/azure/collector-overlay.yaml
@@ -1,0 +1,12 @@
+exporters:
+  prometheusremotewrite:
+    endpoint: "${AZURE_PROM_REMOTE_WRITE_ENDPOINT}"
+    headers:
+      x-ms-client-principal-id: "${AZURE_CLIENT_ID}"
+
+processors:
+  resource:
+    attributes:
+      - key: cloud.provider
+        value: azure
+        action: upsert

--- a/docs/alerting/gcp/README.md
+++ b/docs/alerting/gcp/README.md
@@ -1,0 +1,20 @@
+# GCP Overlay (Managed Service for Prometheus)
+
+## Collector exporter overlay
+
+Use this overlay with the base collector config from `docs/alerting/README.md`:
+
+- file: `docs/alerting/gcp/collector-overlay.yaml`
+- authentication: Workload Identity (recommended)
+
+## Publish PromQL alert policies
+
+Use Cloud Monitoring alert policies with PromQL conditions and reuse expressions from `docs/alerting/rules/honua-core.yaml`.
+
+Example workflow:
+1. Create policy JSON/YAML for each rule.
+2. Apply with `gcloud monitoring policies create --policy-from-file=...`.
+
+## Notifications
+
+Attach notification channels (PagerDuty, email, Slack, etc.) through Cloud Monitoring.

--- a/docs/alerting/gcp/collector-overlay.yaml
+++ b/docs/alerting/gcp/collector-overlay.yaml
@@ -1,0 +1,10 @@
+exporters:
+  prometheusremotewrite:
+    endpoint: "https://monitoring.googleapis.com/v1/projects/${GCP_PROJECT_ID}/location/global/prometheus/api/v1/write"
+
+processors:
+  resource:
+    attributes:
+      - key: cloud.provider
+        value: gcp
+        action: upsert

--- a/docs/alerting/rules/honua-core.yaml
+++ b/docs/alerting/rules/honua-core.yaml
@@ -1,0 +1,62 @@
+groups:
+  - name: honua-core
+    rules:
+      - alert: HonuaInstanceDown
+        expr: up{job=~"honua|honua-server|honua-servers"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Honua target is down"
+          description: "Prometheus has not scraped {{ $labels.instance }} for 2 minutes."
+          runbook: "docs/devops/runbooks/server-down.md"
+
+      - alert: HonuaHigh5xxRate
+        expr: |
+          sum(rate(honua_http_request_total{status_code=~"5.."}[5m]))
+          /
+          clamp_min(sum(rate(honua_http_request_total[5m])), 0.001)
+          > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Honua 5xx rate is high"
+          description: "5xx ratio is above 5% for 5 minutes."
+          runbook: "docs/devops/runbooks/high-error-rate.md"
+
+      - alert: HonuaHighLatencyP95
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(honua_http_request_duration_ms_bucket[5m])) by (le)
+          ) > 2000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Honua p95 latency is high"
+          description: "p95 latency is above 2000ms for 5 minutes."
+          runbook: "docs/devops/runbooks/high-response-time.md"
+
+      - alert: HonuaHighActiveRequests
+        expr: sum(honua_http_active_requests) > 200
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Honua active requests are elevated"
+          description: "Active requests exceeded 200 for 10 minutes."
+          runbook: "docs/devops/runbooks/high-cpu-usage.md"
+
+      - alert: HonuaDatabaseLatencyP95
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(honua_database_query_duration_ms_bucket[5m])) by (le)
+          ) > 250
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Honua database latency is high"
+          description: "p95 database query latency is above 250ms for 10 minutes."
+          runbook: "docs/devops/runbooks/database-issues.md"

--- a/docs/contributor/CI_QUALITY_GATES.md
+++ b/docs/contributor/CI_QUALITY_GATES.md
@@ -15,6 +15,7 @@ This document summarizes the CI pipelines and quality gates that contributors mu
 ## Quality Gates
 
 - Warnings are treated as errors during CI builds.
+- XML docs (`CS1591`) are currently enforced for `Honua.Core` as warnings (phase-in plan), with full-repo enforcement planned.
 - Formatting is enforced with `dotnet format` checks.
 - API surface coverage is enforced via architecture tests.
 - Coverage thresholds are enforced via Codecov; see `CODECOV_SETUP.md` for current targets.

--- a/docs/contributor/development/contributing.md
+++ b/docs/contributor/development/contributing.md
@@ -97,6 +97,11 @@ public async Task<LayerDefinition> Get(int id) { }  // Unclear method name
 public ValidationResult ValidateQuery(FeatureQuery query) { }
 ```
 
+XML documentation enforcement is being rolled out in phases:
+- `Honua.Core`: CS1591 is enabled (warning-level) to baseline and improve public API docs.
+- Other assemblies: CS1591 remains suppressed temporarily while legacy public surfaces are documented.
+- New public APIs should include XML documentation regardless of project so phase-in can move to full enforcement.
+
 #### Architecture Patterns
 
 **✅ Follow These Patterns:**

--- a/docs/devops/README.md
+++ b/docs/devops/README.md
@@ -30,6 +30,8 @@ This section is for installing, configuring, operating, and upgrading Honua in p
 
 **Performance Monitoring:**
 - [**Performance Monitoring**](performance-monitoring.md) — observability setup and metrics
+- [**Cloud-Native Alerting**](../alerting/README.md) — OTLP Collector to managed Prometheus alerting
+- [**Optional Prometheus + Grafana Stack**](optional-observability-stack.md) — Terraform add-on for in-cluster dashboards and alerts
 - [**Performance Testing**](performance-testing.md) — load testing strategies
 - [**Load & Soak Testing**](load-soak-testing.md) — comprehensive performance validation
 

--- a/docs/devops/optional-observability-stack.md
+++ b/docs/devops/optional-observability-stack.md
@@ -1,0 +1,63 @@
+# Optional Observability Stack (Prometheus + Grafana)
+
+This guide covers the optional in-cluster observability add-on for Honua.
+
+Use this only when you want self-hosted dashboards and alerts in Kubernetes.
+Core Honua deployment does not require this stack.
+
+## Scope
+
+The Terraform module `infrastructure/terraform/modules/observability-stack` provisions:
+
+- Prometheus (`prometheus-community/prometheus` Helm chart)
+- Grafana (`grafana/grafana` Helm chart)
+- Honua scrape job targeting `/metrics` with `format=prometheus`
+- Alert rules from `docker/prometheus/alerts.yml`
+- Dashboard provisioning from `docker/grafana/dashboards/honua-overview.json`
+- Grafana admin credentials in a Kubernetes secret
+
+## Quick Start
+
+```bash
+terraform -chdir=infrastructure/terraform/examples/observability init
+terraform -chdir=infrastructure/terraform/examples/observability apply \
+  -var "honua_metrics_target=honua-honua.default.svc.cluster.local:80"
+```
+
+## Configuration Knobs
+
+Common module variables:
+
+- `honua_metrics_target`: required scrape target (`host:port`)
+- `namespace`: observability namespace
+- `scrape_interval` and `evaluation_interval`: Prometheus cadence
+- `alert_rules_file`: PromQL alert rules input
+- `honua_dashboard_file`: Grafana dashboard JSON input
+- `prometheus_persistence_enabled` / `prometheus_persistence_size`
+- `grafana_persistence_enabled` / `grafana_persistence_size`
+- `grafana_ingress_enabled` / `grafana_ingress_host`
+
+## Outputs
+
+- `prometheus_url`
+- `grafana_url`
+- `grafana_admin_secret_name`
+- `grafana_admin_secret_keys`
+- `dashboard_configmap_name`
+
+## Security Hardening Defaults
+
+- Grafana credentials are generated and stored as a Kubernetes secret.
+- Prometheus and Grafana are internal by default (no ingress unless enabled).
+- Dashboard and alert rule artifacts are source-controlled and reproducible.
+
+Recommended hardening for production:
+
+1. Restrict Grafana ingress with authenticated SSO and IP policies.
+2. Encrypt Kubernetes secrets at rest and control RBAC access to namespace secrets.
+3. Configure retention and PVC classes appropriate for incident forensics.
+4. Route alert notifications through your incident platform.
+
+## When Not to Use This Module
+
+If you are on AWS/GCP/Azure managed monitoring, prefer the cloud-native path in `docs/alerting/README.md` and avoid running this optional stack.

--- a/infrastructure/helm/honua/README.md
+++ b/infrastructure/helm/honua/README.md
@@ -34,9 +34,23 @@ resources:
 
 autoscaling:
   enabled: true
-  minReplicas: 3
-  maxReplicas: 10
+  minReplicas: 2
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
 
 ingress:
   enabled: true
@@ -134,6 +148,9 @@ secret:
 | `image.tag` | `latest-aot` | Image tag. AOT recommended. Pin to `vX.Y.Z-aot` for production. |
 | `resources` | `{}` | CPU/memory requests and limits. **Set for production.** |
 | `autoscaling.enabled` | false | Enable HPA. |
+| `autoscaling.targetCPUUtilizationPercentage` | `70` | CPU utilization threshold for scale decisions. |
+| `autoscaling.targetMemoryUtilizationPercentage` | `80` | Memory utilization threshold for scale decisions. |
+| `autoscaling.behavior` | scale up/down policies | autoscaling/v2 behavior policies and stabilization windows. |
 | `ingress.enabled` | false | Enable ingress. |
 | `config.env.*` | — | Non-secret environment variables (stored in ConfigMap). |
 | `secret.env.*` | — | Secret environment variables (stored in Secret). |
@@ -150,6 +167,19 @@ The chart configures probes on:
 - **Liveness**: `/healthz/live` (is the process alive?)
 - **Readiness**: `/healthz/ready` (is the database connected?)
 - **Startup**: `/healthz/live` with 30 retries (initial boot tolerance)
+
+## Geospatial HPA tuning guidance
+
+The default HPA thresholds are tuned for mixed geospatial workloads:
+- `targetCPUUtilizationPercentage: 70` for CPU-heavy spatial predicates and tile generation.
+- `targetMemoryUtilizationPercentage: 80` for bursty map rendering and large feature payloads.
+- `scaleUp` stabilization of 60s with 50% growth to react quickly to traffic ramps.
+- `scaleDown` stabilization of 300s with 10% shrink to avoid thrash after short spikes.
+
+For dataset-specific tuning:
+- Increase `maxReplicas` only after validating PostgreSQL connection limits.
+- Raise memory targets (for example 85-90) if large map exports are common and pod OOM is not observed.
+- Reduce `scaleDown` aggressiveness further for workloads with repeated 3-10 minute query bursts.
 
 ## Local validation
 

--- a/infrastructure/helm/honua/templates/hpa.yaml
+++ b/infrastructure/helm/honua/templates/hpa.yaml
@@ -29,4 +29,8 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/infrastructure/helm/honua/values.yaml
+++ b/infrastructure/helm/honua/values.yaml
@@ -79,9 +79,22 @@ startupProbe:
 autoscaling:
   enabled: false
   minReplicas: 2
-  maxReplicas: 10
-  targetCPUUtilizationPercentage: 80
+  maxReplicas: 20
+  targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 80
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
 
 nodeSelector: {}
 

--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -7,12 +7,14 @@ This directory contains infrastructure modules and examples for Honua Server.
 - `modules/azure-aca` – Azure Container Apps + PostgreSQL Flexible Server + Key Vault
 - `modules/aws-serverless` – Lambda + API Gateway + RDS
 - `modules/azure-functions` – Azure Functions + PostgreSQL Flexible Server
+- `modules/observability-stack` – optional Prometheus + Grafana add-on for Kubernetes
 
 ## Examples
 - `examples/aws`
 - `examples/azure`
 - `examples/aws-serverless`
 - `examples/azure-functions`
+- `examples/observability`
 
 ## Bootstrap service accounts (least privilege)
 - `bootstrap/aws-ecs` – IAM user + policy for ECS/Fargate deployments
@@ -38,6 +40,9 @@ terraform -chdir=infrastructure/terraform/examples/aws-serverless validate
 
 terraform -chdir=infrastructure/terraform/examples/azure-functions init
 terraform -chdir=infrastructure/terraform/examples/azure-functions validate
+
+terraform -chdir=infrastructure/terraform/examples/observability init
+terraform -chdir=infrastructure/terraform/examples/observability validate
 
 checkov -d infrastructure/terraform/modules --download-external-modules true --compact
 ```

--- a/infrastructure/terraform/examples/observability/main.tf
+++ b/infrastructure/terraform/examples/observability/main.tf
@@ -1,0 +1,31 @@
+provider "kubernetes" {
+  config_path = var.kubeconfig_path
+}
+
+provider "helm" {
+  kubernetes = {
+    config_path = var.kubeconfig_path
+  }
+}
+
+module "observability" {
+  source = "../../modules/observability-stack"
+
+  namespace            = var.namespace
+  honua_metrics_target = var.honua_metrics_target
+
+  grafana_ingress_enabled = var.grafana_ingress_host != ""
+  grafana_ingress_host    = var.grafana_ingress_host
+}
+
+output "prometheus_url" {
+  value = module.observability.prometheus_url
+}
+
+output "grafana_url" {
+  value = module.observability.grafana_url
+}
+
+output "grafana_admin_secret_name" {
+  value = module.observability.grafana_admin_secret_name
+}

--- a/infrastructure/terraform/examples/observability/variables.tf
+++ b/infrastructure/terraform/examples/observability/variables.tf
@@ -1,0 +1,22 @@
+variable "kubeconfig_path" {
+  description = "Path to kubeconfig file."
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "namespace" {
+  description = "Observability namespace."
+  type        = string
+  default     = "honua-observability"
+}
+
+variable "honua_metrics_target" {
+  description = "Honua metrics endpoint target in host:port form."
+  type        = string
+}
+
+variable "grafana_ingress_host" {
+  description = "Optional Grafana ingress host. Leave empty to disable ingress."
+  type        = string
+  default     = ""
+}

--- a/infrastructure/terraform/examples/observability/versions.tf
+++ b/infrastructure/terraform/examples/observability/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.13"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.29"
+    }
+  }
+}

--- a/infrastructure/terraform/modules/observability-stack/README.md
+++ b/infrastructure/terraform/modules/observability-stack/README.md
@@ -28,6 +28,9 @@ module "observability" {
 }
 ```
 
+Defaults for `alert_rules_file` and `honua_dashboard_file` are resolved relative to
+the module path, so callers do not need to match a specific root-module folder depth.
+
 ## Outputs
 
 - `prometheus_url`

--- a/infrastructure/terraform/modules/observability-stack/README.md
+++ b/infrastructure/terraform/modules/observability-stack/README.md
@@ -1,0 +1,43 @@
+# Observability Stack Module (Optional Add-On)
+
+Deploys an optional Prometheus + Grafana stack on Kubernetes using Helm.
+
+This module is intentionally separate from core Honua deployment modules so the
+base platform can run without self-hosted observability components.
+
+## What it provisions
+
+- Prometheus Helm release (`prometheus-community/prometheus`)
+- Grafana Helm release (`grafana/grafana`)
+- Honua metrics scrape job (`/metrics?format=prometheus` by default)
+- Alert rules loaded from `docker/prometheus/alerts.yml`
+- Honua dashboard provisioning from `docker/grafana/dashboards/honua-overview.json`
+- Grafana admin credentials in a Kubernetes secret
+
+## Usage
+
+```hcl
+module "observability" {
+  source = "../../modules/observability-stack"
+
+  namespace            = "honua-observability"
+  honua_metrics_target = "honua-honua.default.svc.cluster.local:80"
+
+  grafana_ingress_enabled = true
+  grafana_ingress_host    = "grafana.example.com"
+}
+```
+
+## Outputs
+
+- `prometheus_url`
+- `grafana_url`
+- `grafana_admin_secret_name`
+- `grafana_admin_secret_keys`
+- `dashboard_configmap_name`
+
+## Operational notes
+
+- Keep alert rules in `docker/prometheus/alerts.yml` and update runbooks in `docs/devops/runbooks/`.
+- For managed-cloud monitoring, prefer `docs/alerting/` and forward OTLP to managed Prometheus.
+- Treat this module as optional for environments that require in-cluster dashboards.

--- a/infrastructure/terraform/modules/observability-stack/main.tf
+++ b/infrastructure/terraform/modules/observability-stack/main.tf
@@ -1,5 +1,9 @@
 locals {
-  alert_rules = yamldecode(file(var.alert_rules_file))
+  default_alert_rules_file = "${path.module}/../../../../docker/prometheus/alerts.yml"
+  default_dashboard_file   = "${path.module}/../../../../docker/grafana/dashboards/honua-overview.json"
+  alert_rules_file         = var.alert_rules_file != "" ? var.alert_rules_file : local.default_alert_rules_file
+  honua_dashboard_file     = var.honua_dashboard_file != "" ? var.honua_dashboard_file : local.default_dashboard_file
+  alert_rules              = yamldecode(file(local.alert_rules_file))
 
   honua_scrape_config = merge(
     {
@@ -140,7 +144,7 @@ resource "kubernetes_config_map_v1" "honua_dashboard" {
   }
 
   data = {
-    "honua-overview.json" = file(var.honua_dashboard_file)
+    "honua-overview.json" = file(local.honua_dashboard_file)
   }
 
   depends_on = [kubernetes_namespace_v1.this]

--- a/infrastructure/terraform/modules/observability-stack/main.tf
+++ b/infrastructure/terraform/modules/observability-stack/main.tf
@@ -1,0 +1,175 @@
+locals {
+  alert_rules = yamldecode(file(var.alert_rules_file))
+
+  honua_scrape_config = merge(
+    {
+      job_name     = "honua"
+      metrics_path = var.honua_metrics_path
+      static_configs = [
+        {
+          targets = [var.honua_metrics_target]
+        }
+      ]
+    },
+    var.honua_metrics_format != "" ? {
+      params = {
+        format = [var.honua_metrics_format]
+      }
+    } : {}
+  )
+
+  prometheus_values = {
+    alertmanager = {
+      enabled = true
+    }
+    kube-state-metrics = {
+      enabled = false
+    }
+    prometheus-node-exporter = {
+      enabled = false
+    }
+    server = {
+      persistentVolume = {
+        enabled = var.prometheus_persistence_enabled
+        size    = var.prometheus_persistence_size
+      }
+    }
+    serverFiles = {
+      "prometheus.yml" = {
+        global = {
+          scrape_interval     = var.scrape_interval
+          evaluation_interval = var.evaluation_interval
+        }
+        scrape_configs = [
+          local.honua_scrape_config
+        ]
+      }
+      "alerting_rules.yml" = local.alert_rules
+    }
+  }
+
+  prometheus_server_url = "http://${var.prometheus_release_name}-server.${var.namespace}.svc.cluster.local"
+
+  grafana_values = {
+    admin = {
+      existingSecret = kubernetes_secret_v1.grafana_admin.metadata[0].name
+      userKey        = "admin-user"
+      passwordKey    = "admin-password"
+    }
+    persistence = {
+      enabled = var.grafana_persistence_enabled
+      size    = var.grafana_persistence_size
+    }
+    datasources = {
+      "datasources.yaml" = {
+        apiVersion = 1
+        datasources = [
+          {
+            name      = "Prometheus"
+            type      = "prometheus"
+            access    = "proxy"
+            url       = local.prometheus_server_url
+            isDefault = true
+            editable  = true
+          }
+        ]
+      }
+    }
+    dashboardProviders = {
+      "dashboardproviders.yaml" = {
+        apiVersion = 1
+        providers = [
+          {
+            name            = "honua"
+            orgId           = 1
+            folder          = "Honua"
+            type            = "file"
+            disableDeletion = false
+            editable        = true
+            options = {
+              path = "/var/lib/grafana/dashboards/honua"
+            }
+          }
+        ]
+      }
+    }
+    dashboardsConfigMaps = {
+      honua = kubernetes_config_map_v1.honua_dashboard.metadata[0].name
+    }
+    ingress = {
+      enabled          = var.grafana_ingress_enabled
+      ingressClassName = var.grafana_ingress_class_name
+      annotations      = var.grafana_ingress_annotations
+      hosts            = var.grafana_ingress_host != "" ? [var.grafana_ingress_host] : []
+      tls              = []
+    }
+  }
+}
+
+resource "kubernetes_namespace_v1" "this" {
+  count = var.create_namespace ? 1 : 0
+
+  metadata {
+    name = var.namespace
+  }
+}
+
+resource "random_password" "grafana_admin" {
+  length  = 32
+  special = true
+}
+
+resource "kubernetes_secret_v1" "grafana_admin" {
+  metadata {
+    name      = "${var.grafana_release_name}-admin"
+    namespace = var.namespace
+  }
+
+  data = {
+    "admin-user"     = var.grafana_admin_user
+    "admin-password" = random_password.grafana_admin.result
+  }
+
+  depends_on = [kubernetes_namespace_v1.this]
+}
+
+resource "kubernetes_config_map_v1" "honua_dashboard" {
+  metadata {
+    name      = "honua-overview-dashboard"
+    namespace = var.namespace
+  }
+
+  data = {
+    "honua-overview.json" = file(var.honua_dashboard_file)
+  }
+
+  depends_on = [kubernetes_namespace_v1.this]
+}
+
+resource "helm_release" "prometheus" {
+  name             = var.prometheus_release_name
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "prometheus"
+  version          = var.prometheus_chart_version
+  namespace        = var.namespace
+  create_namespace = var.create_namespace
+
+  values = [yamlencode(local.prometheus_values)]
+}
+
+resource "helm_release" "grafana" {
+  name             = var.grafana_release_name
+  repository       = "https://grafana.github.io/helm-charts"
+  chart            = "grafana"
+  version          = var.grafana_chart_version
+  namespace        = var.namespace
+  create_namespace = var.create_namespace
+
+  values = [yamlencode(local.grafana_values)]
+
+  depends_on = [
+    helm_release.prometheus,
+    kubernetes_secret_v1.grafana_admin,
+    kubernetes_config_map_v1.honua_dashboard,
+  ]
+}

--- a/infrastructure/terraform/modules/observability-stack/outputs.tf
+++ b/infrastructure/terraform/modules/observability-stack/outputs.tf
@@ -1,0 +1,37 @@
+output "prometheus_release" {
+  description = "Prometheus Helm release name."
+  value       = helm_release.prometheus.name
+}
+
+output "grafana_release" {
+  description = "Grafana Helm release name."
+  value       = helm_release.grafana.name
+}
+
+output "prometheus_url" {
+  description = "In-cluster Prometheus URL."
+  value       = "http://${var.prometheus_release_name}-server.${var.namespace}.svc.cluster.local"
+}
+
+output "grafana_url" {
+  description = "Grafana URL (ingress host when configured, otherwise cluster-local service URL)."
+  value       = var.grafana_ingress_enabled && var.grafana_ingress_host != "" ? "https://${var.grafana_ingress_host}" : "http://${var.grafana_release_name}.${var.namespace}.svc.cluster.local"
+}
+
+output "grafana_admin_secret_name" {
+  description = "Kubernetes secret containing Grafana admin credentials."
+  value       = kubernetes_secret_v1.grafana_admin.metadata[0].name
+}
+
+output "grafana_admin_secret_keys" {
+  description = "Secret data keys for Grafana admin credentials."
+  value = {
+    username = "admin-user"
+    password = "admin-password"
+  }
+}
+
+output "dashboard_configmap_name" {
+  description = "ConfigMap that provisions the Honua Grafana dashboard."
+  value       = kubernetes_config_map_v1.honua_dashboard.metadata[0].name
+}

--- a/infrastructure/terraform/modules/observability-stack/variables.tf
+++ b/infrastructure/terraform/modules/observability-stack/variables.tf
@@ -1,0 +1,130 @@
+variable "namespace" {
+  description = "Namespace for Prometheus and Grafana."
+  type        = string
+  default     = "honua-observability"
+}
+
+variable "create_namespace" {
+  description = "Create the namespace when it does not exist."
+  type        = bool
+  default     = true
+}
+
+variable "prometheus_release_name" {
+  description = "Helm release name for Prometheus."
+  type        = string
+  default     = "honua-prometheus"
+}
+
+variable "grafana_release_name" {
+  description = "Helm release name for Grafana."
+  type        = string
+  default     = "honua-grafana"
+}
+
+variable "prometheus_chart_version" {
+  description = "Prometheus chart version."
+  type        = string
+  default     = "27.34.0"
+}
+
+variable "grafana_chart_version" {
+  description = "Grafana chart version."
+  type        = string
+  default     = "8.13.1"
+}
+
+variable "honua_metrics_target" {
+  description = "Scrape target for Honua metrics (host:port)."
+  type        = string
+}
+
+variable "honua_metrics_path" {
+  description = "Metrics path exposed by Honua."
+  type        = string
+  default     = "/metrics"
+}
+
+variable "honua_metrics_format" {
+  description = "Optional format query param for Honua metrics endpoint."
+  type        = string
+  default     = "prometheus"
+}
+
+variable "scrape_interval" {
+  description = "Prometheus scrape interval."
+  type        = string
+  default     = "15s"
+}
+
+variable "evaluation_interval" {
+  description = "Prometheus rule evaluation interval."
+  type        = string
+  default     = "30s"
+}
+
+variable "alert_rules_file" {
+  description = "Path to a Prometheus rules YAML file."
+  type        = string
+  default     = "../../../../docker/prometheus/alerts.yml"
+}
+
+variable "honua_dashboard_file" {
+  description = "Path to the Honua Grafana dashboard JSON."
+  type        = string
+  default     = "../../../../docker/grafana/dashboards/honua-overview.json"
+}
+
+variable "prometheus_persistence_enabled" {
+  description = "Enable Prometheus persistence."
+  type        = bool
+  default     = true
+}
+
+variable "prometheus_persistence_size" {
+  description = "Prometheus PVC size."
+  type        = string
+  default     = "20Gi"
+}
+
+variable "grafana_persistence_enabled" {
+  description = "Enable Grafana persistence."
+  type        = bool
+  default     = true
+}
+
+variable "grafana_persistence_size" {
+  description = "Grafana PVC size."
+  type        = string
+  default     = "10Gi"
+}
+
+variable "grafana_ingress_enabled" {
+  description = "Expose Grafana with ingress."
+  type        = bool
+  default     = false
+}
+
+variable "grafana_ingress_host" {
+  description = "Ingress hostname for Grafana when ingress is enabled."
+  type        = string
+  default     = ""
+}
+
+variable "grafana_ingress_class_name" {
+  description = "Optional ingress class for Grafana."
+  type        = string
+  default     = ""
+}
+
+variable "grafana_ingress_annotations" {
+  description = "Ingress annotations for Grafana."
+  type        = map(string)
+  default     = {}
+}
+
+variable "grafana_admin_user" {
+  description = "Grafana admin username."
+  type        = string
+  default     = "admin"
+}

--- a/infrastructure/terraform/modules/observability-stack/variables.tf
+++ b/infrastructure/terraform/modules/observability-stack/variables.tf
@@ -64,15 +64,15 @@ variable "evaluation_interval" {
 }
 
 variable "alert_rules_file" {
-  description = "Path to a Prometheus rules YAML file."
+  description = "Path to a Prometheus rules YAML file. Leave empty to use the module default."
   type        = string
-  default     = "../../../../docker/prometheus/alerts.yml"
+  default     = ""
 }
 
 variable "honua_dashboard_file" {
-  description = "Path to the Honua Grafana dashboard JSON."
+  description = "Path to the Honua Grafana dashboard JSON. Leave empty to use the module default."
   type        = string
-  default     = "../../../../docker/grafana/dashboards/honua-overview.json"
+  default     = ""
 }
 
 variable "prometheus_persistence_enabled" {

--- a/infrastructure/terraform/modules/observability-stack/versions.tf
+++ b/infrastructure/terraform/modules/observability-stack/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.13"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.29"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
+  }
+}

--- a/src/Honua.Admin/Honua.Admin.csproj
+++ b/src/Honua.Admin/Honua.Admin.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Honua.AppHost/Honua.AppHost.csproj
+++ b/src/Honua.AppHost/Honua.AppHost.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Honua.Postgres/Honua.Postgres.csproj
+++ b/src/Honua.Postgres/Honua.Postgres.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Honua.Server/Honua.Server.csproj
+++ b/src/Honua.Server/Honua.Server.csproj
@@ -12,7 +12,7 @@
     <!-- Suppress trim warnings from Serilog and endpoint mapping for AOT compatibility -->
     <!-- Suppress obsolete warnings for deprecated interfaces during transition period -->
     <!-- Suppress analyzer warnings that are not critical for compilation -->
-    <NoWarn>$(NoWarn);IL2104;IL2026;IL3002;IL3050;CS0618;CS0612;CA1041;CA1000;CA1848;CA1862;IDE0051;IDE0052;IDE0005</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;IL2104;IL2026;IL3002;IL3050;CS0618;CS0612;CA1041;CA1000;CA1848;CA1862;IDE0051;IDE0052;IDE0005</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Honua.ServiceDefaults/Honua.ServiceDefaults.csproj
+++ b/src/Honua.ServiceDefaults/Honua.ServiceDefaults.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Honua.Admin.Playwright/Honua.Admin.Playwright.csproj
+++ b/tests/Honua.Admin.Playwright/Honua.Admin.Playwright.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj
+++ b/tests/Honua.Admin.Tests/Honua.Admin.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj
+++ b/tests/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AssemblyName>Honua.Architecture.Tests</AssemblyName>
     <RootNamespace>Honua.Architecture.Tests</RootNamespace>
   </PropertyGroup>

--- a/tests/Honua.Core.Tests/Honua.Core.Tests.csproj
+++ b/tests/Honua.Core.Tests/Honua.Core.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Honua.LoadTests/Honua.LoadTests.csproj
+++ b/tests/Honua.LoadTests/Honua.LoadTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <OutputType>Exe</OutputType>
     <StartupObject>Honua.LoadTests.Program</StartupObject>
   </PropertyGroup>

--- a/tests/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj
+++ b/tests/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Honua.Server.Tests/Honua.Server.Tests.csproj
+++ b/tests/Honua.Server.Tests/Honua.Server.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Honua.TestKit/Honua.TestKit.csproj
+++ b/tests/Honua.TestKit/Honua.TestKit.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Issue Link

Closes #231  
Closes #227  
Closes #259  
Closes #289

## Summary

This PR implements four scoped improvements:
1. phased XML documentation enforcement (`CS1591`) for `Honua.Core`
2. cloud-native alerting documentation and shared PromQL rules
3. optional Terraform-based Prometheus + Grafana observability stack
4. advanced Helm HPA autoscaling/v2 behavior with geospatial tuning defaults

## Changes Made

- Phased CS1591 enforcement (`#231`):
  - removed global `CS1591` suppression in `Directory.Build.props`
  - kept suppression scoped to non-Core projects for this phase
  - updated contributor quality/docs guidance for XML docs phase-in
- Cloud-native alerting design docs (`#227`):
  - added `docs/alerting/README.md`
  - added shared rules file `docs/alerting/rules/honua-core.yaml`
  - added provider overlays for AWS/GCP/Azure under `docs/alerting/*`
- Optional observability IaC (`#259`):
  - added Terraform module `infrastructure/terraform/modules/observability-stack`
  - added usage example `infrastructure/terraform/examples/observability`
  - added ops doc `docs/devops/optional-observability-stack.md`
- Helm HPA advanced behavior (`#289`):
  - added `autoscaling.behavior` configuration to chart values/template
  - tuned defaults to recommended thresholds (CPU 70, memory 80, scale-up/down policies)
  - documented geospatial workload HPA tuning guidance in Helm README

## Testing

- [x] `dotnet build Honua.sln --configuration Release`
- [x] `dotnet format Honua.sln --verify-no-changes`
- [x] `dotnet test tests/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj --configuration Release --no-build`
- [x] `terraform -chdir=infrastructure/terraform/examples/observability init -backend=false`
- [x] `terraform -chdir=infrastructure/terraform/examples/observability validate`
- [x] `helm lint infrastructure/helm/honua`
- [x] `helm template honua infrastructure/helm/honua --set autoscaling.enabled=true` (verified HPA behavior output)
- [ ] Full `scripts/pre-pr-check.sh` passed end-to-end in this environment (Playwright browser binaries missing locally)

## Coverage Impact

No new runtime C# behavior paths were added in server/core/postgres handlers. Changes are primarily infra/docs/chart/build-configuration. Existing architecture tests remain green.

## Breaking Changes

None expected for runtime APIs.

Build/config note:
- `CS1591` global suppression was removed and is now intentionally scoped per project (with active phase-in on `Honua.Core`).

## Additional Context

Pre-push hook executed local validation and failed only on Playwright browser dependency setup (`playwright.ps1 install` not present in this machine state). All relevant build/format/terraform/helm validations in this PR scope are passing.

## Pre-PR Checklist (for contributor)

- [x] I ran `scripts/pre-pr-check.sh` locally (or equivalent commands) and reviewed failures.
- [x] I ran `dotnet format Honua.sln` / `--verify-no-changes`.
- [x] I confirmed warnings-as-errors build for changed areas.
- [x] I validated Terraform and Helm changes locally.
- [x] I did not leave temporary planning/scratch artifacts in the repo.

## Reviewer Checklist

- [ ] Confirm `CS1591` scope matches phase-1 intent (`Honua.Core` active enforcement baseline).
- [ ] Confirm `docs/alerting/rules/honua-core.yaml` is acceptable as the cross-cloud canonical ruleset.
- [ ] Review optional observability module defaults/security posture for your target cluster.
- [ ] Confirm HPA defaults and `autoscaling.behavior` align with production expectations.
