### PR TITLE
feat: return feature data in extractChanges for delta sync

### DIFF
--- a/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Collections.Immutable;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Server.Features.FeatureServer.Models;
+using Honua.Server.Features.FeatureServer.Services;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
@@ -181,19 +183,36 @@ internal static partial class FeatureServerEndpoints
 
         foreach (var layer in replicaLayers)
         {
-            var adds = 0L;
             if (isFirstSync)
             {
-                adds = await featureReader.CountAsync(layer.Id, new FeatureQuery(), cancellationToken);
-            }
+                // First sync: return all features as adds with full geometry/attributes.
+                var result = await featureReader.QueryAsync(layer.Id, new FeatureQuery(), cancellationToken);
+                var addFeatures = result.Items
+                    .Select(f => ConvertFeatureToGeoServices(f))
+                    .ToArray();
 
-            layerChanges.Add(new LayerChanges
+                layerChanges.Add(new LayerChanges
+                {
+                    Id = layer.Id,
+                    Adds = addFeatures.Length,
+                    Updates = 0,
+                    Deletes = 0,
+                    AddFeatures = addFeatures,
+                    UpdateFeatures = null,
+                    DeleteIds = null
+                });
+            }
+            else
             {
-                Id = layer.Id,
-                Adds = (int)Math.Min(adds, int.MaxValue),
-                Updates = 0,
-                Deletes = 0
-            });
+                // Incremental sync: report zero changes until CDC-to-replica mapping is wired.
+                layerChanges.Add(new LayerChanges
+                {
+                    Id = layer.Id,
+                    Adds = 0,
+                    Updates = 0,
+                    Deletes = 0
+                });
+            }
         }
 
         var response = new ExtractChangesResponse
@@ -532,5 +551,18 @@ internal static partial class FeatureServerEndpoints
 
         layers = resolved.ToArray();
         return true;
+    }
+
+    /// <summary>
+    /// Converts a domain Feature to a GeoServicesFeature for replication responses.
+    /// </summary>
+    private static GeoServicesFeature ConvertFeatureToGeoServices(Feature feature)
+    {
+        return new GeoServicesFeature
+        {
+            Attributes = new Dictionary<string, object?>(feature.Attributes),
+            Geometry = GeoServicesGeometryConverter.ConvertWkbToGeoServicesGeometry(
+                feature.Geometry, null, null, false, false)
+        };
     }
 }

--- a/src/Honua.Server/Features/FeatureServer/Models/Replication/ReplicationModels.cs
+++ b/src/Honua.Server/Features/FeatureServer/Models/Replication/ReplicationModels.cs
@@ -183,6 +183,24 @@ public sealed class LayerChanges
     /// </summary>
     [JsonPropertyName("deletes")]
     public int Deletes { get; set; }
+
+    /// <summary>
+    /// Actual feature data for inserts since last sync.
+    /// </summary>
+    [JsonPropertyName("addFeatures")]
+    public GeoServicesFeature[]? AddFeatures { get; set; }
+
+    /// <summary>
+    /// Actual feature data for updates since last sync.
+    /// </summary>
+    [JsonPropertyName("updateFeatures")]
+    public GeoServicesFeature[]? UpdateFeatures { get; set; }
+
+    /// <summary>
+    /// Object IDs of features deleted since last sync.
+    /// </summary>
+    [JsonPropertyName("deleteIds")]
+    public long[]? DeleteIds { get; set; }
 }
 
 /// <summary>

--- a/src/Honua.Server/Features/FeatureServer/Models/Serialization/FeatureServerJsonContext.cs
+++ b/src/Honua.Server/Features/FeatureServer/Models/Serialization/FeatureServerJsonContext.cs
@@ -96,6 +96,7 @@ namespace Honua.Server.Features.FeatureServer.Models;
 [JsonSerializable(typeof(ExtractChangesResponse))]
 [JsonSerializable(typeof(LayerChanges))]
 [JsonSerializable(typeof(LayerChanges[]))]
+[JsonSerializable(typeof(long[]), TypeInfoPropertyName = "Int64Array")]
 [JsonSerializable(typeof(ReplicaState))]
 [JsonSerializable(typeof(SynchronizeReplicaRequest))]
 [JsonSerializable(typeof(SynchronizeReplicaResponse))]


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #419
Fixes honua-io/honua-mobile#8

## Summary
Enhanced `extractChanges` replication endpoint to return actual feature geometries and attributes, enabling mobile clients to populate their GeoPackage offline store on first sync.

## Changes Made
- First sync now returns full feature data as `AddFeatures` arrays via `IFeatureReader.QueryAsync`
- Added `AddFeatures` (GeoServicesFeature[]), `UpdateFeatures` (GeoServicesFeature[]), and `DeleteIds` (long[]) fields to `LayerChanges` model
- Registered `long[]` in `FeatureServerJsonContext` for serialization support
- Preserved backward-compatible count fields (Adds, Updates, Deletes)

## Testing
- [ ] Unit tests added/updated
- [x] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)

## Coverage Impact
- Minimal new code paths; existing replication tests cover the handler flow

## Breaking Changes
None — new fields are additive and nullable; existing clients continue to work.

## Additional Context
This is the server-side counterpart to the mobile delta download engine (honua-io/honua-mobile#8). The first-sync path is the critical piece; incremental CDC-to-replica mapping is deferred to a follow-up.

---

## Pre-PR Checklist (for contributor)
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit message follows format: `type: description (#issue-number)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] Documentation updated if needed
- [ ] If protocol/auth behavior changed, updated MVP compatibility contract and release checklist notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)