### PR TITLE
docs: publish sdk compatibility matrix baseline (#428)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ Full hosted documentation: **[honua.gitbook.io/honuaio](https://honua.gitbook.io
 |---|---|
 | **Consume geospatial data** | [Protocols Overview](user/STANDARDS_APIS.md) / [API Examples](user/API_EXAMPLES.md) |
 | **Manage the server** | [Admin API](user/CONTROL_PLANE_API.md) / [Admin UI](user/admin-ui.md) |
+| **Check server/SDK compatibility** | [Server + SDK Compatibility Matrix](user/SDK_COMPATIBILITY_MATRIX.md) / [Control Plane Migration Guide](user/CONTROL_PLANE_MIGRATION_GUIDE.md) |
+| **Standardize SDK release docs** | [SDK Migration Guide Baseline](user/SDK_MIGRATION_GUIDE_BASELINE.md) |
 | **Integrate AI agents** | [MCP Server](user/MCP_SERVER.md) |
 | **Deploy to production** | [Infrastructure & Deployment](devops/infrastructure.md) |
 | **Monitor and troubleshoot** | [Monitoring](devops/monitoring.md) / [Troubleshooting](devops/troubleshooting.md) |
@@ -22,6 +24,8 @@ Full hosted documentation: **[honua.gitbook.io/honuaio](https://honua.gitbook.io
 - [API Examples](user/API_EXAMPLES.md) — request/response examples
 - [Integration Patterns](user/INTEGRATION_PATTERNS.md) — common integration approaches
 - [Admin API](user/CONTROL_PLANE_API.md) — server management endpoints
+- [Server + SDK Compatibility Matrix](user/SDK_COMPATIBILITY_MATRIX.md) — supported control-plane server/SDK combinations and migration baseline
+- [SDK Migration Guide Baseline](user/SDK_MIGRATION_GUIDE_BASELINE.md) — required migration/changelog structure for SDK repos
 - [Control Plane Migration Guide](user/CONTROL_PLANE_MIGRATION_GUIDE.md) — SDK and upgrade workflow
 - [Control Plane Versioning Policy](user/CONTROL_PLANE_VERSIONING_POLICY.md) — deprecation and compatibility guarantees
 - [MCP Server](user/MCP_SERVER.md) — AI/agent integration via Model Context Protocol

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -4,6 +4,8 @@
 
 * [Documentation Overview](README.md)
 * [User Journeys](user/USER_JOURNEYS.md)
+* [Server + SDK Compatibility Matrix](user/SDK_COMPATIBILITY_MATRIX.md)
+* [SDK Migration Guide Baseline](user/SDK_MIGRATION_GUIDE_BASELINE.md)
 * [MVP Sales Playbook + Launch GTM](user/MVP_LAUNCH_GTM_PLAYBOOK.md)
 * [MVP Compatibility Contract](user/MVP_COMPATIBILITY_CONTRACT.md)
 * [Data Modeling Guide](user/DATA_MODELING_GUIDE.md)
@@ -32,6 +34,7 @@
 * [Admin API Reference](user/CONTROL_PLANE_API.md)
 * [Admin UI](user/admin-ui.md)
 * [MCP Server](user/MCP_SERVER.md)
+* [Server + SDK Compatibility Matrix](user/SDK_COMPATIBILITY_MATRIX.md)
 * [Control Plane Migration Guide](user/CONTROL_PLANE_MIGRATION_GUIDE.md)
 * [Control Plane Versioning Policy](user/CONTROL_PLANE_VERSIONING_POLICY.md)
 

--- a/docs/user/CONTROL_PLANE_MIGRATION_GUIDE.md
+++ b/docs/user/CONTROL_PLANE_MIGRATION_GUIDE.md
@@ -2,6 +2,21 @@
 
 This guide covers migration for the Honua control-plane/admin API only.
 
+For SDK-specific support windows and release-channel expectations, see
+[Server + SDK Compatibility Matrix](SDK_COMPATIBILITY_MATRIX.md). For the
+per-repository release-note and migration-guide template, see
+[SDK Migration Guide Baseline](SDK_MIGRATION_GUIDE_BASELINE.md).
+
+## Migration Baseline
+
+Before regenerating or upgrading SDK artifacts:
+
+1. Confirm the target server release channel and admin API major.
+2. Select the matching SDK line for JavaScript/TypeScript, Python, or .NET.
+3. Review release notes for admin contract changes, deprecations, auth changes,
+   and SDK regeneration requirements.
+4. Continue with the generation and validation steps below.
+
 ## Quickstart: Generate SDKs
 
 Validate contract and generate SDK artifacts from the curated admin OpenAPI spec:
@@ -78,6 +93,7 @@ OPENAPI_BASE_REF=origin/trunk ./scripts/validate-openapi-contracts.sh
 ```
 
 2. If breakage is intentional, update:
+- `docs/user/SDK_COMPATIBILITY_MATRIX.md`
 - `docs/user/CONTROL_PLANE_VERSIONING_POLICY.md`
 - `docs/user/CONTROL_PLANE_API.md`
 - release checklist compatibility notes
@@ -92,3 +108,12 @@ Deprecations must follow `docs/user/CONTROL_PLANE_VERSIONING_POLICY.md`:
 - announce and document replacements
 - preserve deprecated operations during grace period
 - remove only in next major path (except emergency security cases)
+
+## SDK Handoff Baseline
+
+When a server change affects generated control-plane clients or SDK runtime
+checks, update all three places in the same rollout window:
+- this migration guide
+- [Server + SDK Compatibility Matrix](SDK_COMPATIBILITY_MATRIX.md)
+- [SDK Migration Guide Baseline](SDK_MIGRATION_GUIDE_BASELINE.md)
+- the affected SDK changelog and migration notes

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -11,7 +11,9 @@ This section is for people **using Honua in production** — API consumers, GIS 
 - **[Geospatial API Examples](API_EXAMPLES.md)** - Practical request/response examples for data access
 - **[Client Templates + Smoke Runbook](CLIENT_TEMPLATE_RUNBOOK.md)** - ArcGIS Pro, QGIS, Power BI, and Excel demo/client validation
 - **[Server Management API](CONTROL_PLANE_API.md)** - Admin + automation API for workflows and UI
-- **[Control Plane Migration Guide](CONTROL_PLANE_MIGRATION_GUIDE.md)** - SDK generation + upgrade workflow
+- **[Server + SDK Compatibility Matrix](SDK_COMPATIBILITY_MATRIX.md)** - Supported control-plane server/SDK combinations, channels, and migration baseline
+- **[SDK Migration Guide Baseline](SDK_MIGRATION_GUIDE_BASELINE.md)** - Required release-note and migration-guide structure for JS, Python, and .NET SDK repos
+- **[Control Plane Migration Guide](CONTROL_PLANE_MIGRATION_GUIDE.md)** - SDK generation + upgrade workflow after picking a supported server/SDK line
 
 ## Reference & Optimization
 - **[Data Modeling Guide](DATA_MODELING_GUIDE.md)** - Spatial data modeling best practices

--- a/docs/user/SDK_COMPATIBILITY_MATRIX.md
+++ b/docs/user/SDK_COMPATIBILITY_MATRIX.md
@@ -1,0 +1,116 @@
+# Server + SDK Compatibility Matrix
+
+This page is the canonical compatibility contract for Honua Server control-plane
+SDKs. It applies to the generated JavaScript/TypeScript, Python, and .NET
+admin clients backed by `/api/v*/admin/*`.
+
+Use this page first when you need to:
+- choose an SDK artifact for a server release
+- plan a server or SDK upgrade
+- decide whether release notes require SDK regeneration
+
+Use it together with:
+- [Control Plane API](CONTROL_PLANE_API.md)
+- [Control Plane Migration Guide](CONTROL_PLANE_MIGRATION_GUIDE.md)
+- [Control Plane Versioning Policy](CONTROL_PLANE_VERSIONING_POLICY.md)
+- [SDK Migration Guide Baseline](SDK_MIGRATION_GUIDE_BASELINE.md)
+
+## Scope and Invariants
+
+- This matrix applies only to the control-plane/admin API. It does not cover
+  FeatureServer, OGC, OData, WMS, WMTS, or other standards APIs.
+- Current admin API major in this repo: `v1`.
+- JavaScript/TypeScript, Python, and .NET SDK artifacts are generated from the
+  same curated admin OpenAPI contract and should be treated as one versioned
+  release set.
+- Server and SDK must stay on the same admin API major.
+- Production deployments should stay on `stable` or a designated `LTS` line.
+
+## SDK Families
+
+| SDK family | Generated client | Example surface | Compatibility note |
+|---|---|---|---|
+| JavaScript / TypeScript | `typescript-fetch` | generated TypeScript client consumed from app code or automation | Follow the same server major and release channel as the target server. |
+| Python | OpenAPI Python client | `honua_control_plane_sdk` package namespace | Generated from the same contract snapshot as the JS/.NET artifacts. |
+| .NET | OpenAPI C# client | `Honua.ControlPlane.Sdk.*` namespaces | Generated from the same contract snapshot as the JS/Python artifacts. |
+
+## Current Published SDK Lines
+
+These are the current package lines in sibling SDK repositories as of the
+March 2026 compatibility baseline:
+
+| Package | Current line | Status | Intended server line |
+|---|---|---|---|
+| `@honua/sdk-js` | `0.0.1-alpha.x` | alpha | `v1` preview/beta control-plane line |
+| `honua-sdk` | `0.0.1a*` | alpha | `v1` preview/beta control-plane line |
+| `Honua.Sdk.Admin` | `0.1.0-alpha.x` | alpha | `v1` preview/beta control-plane line |
+| `Honua.Sdk.Grpc` | `0.1.0-alpha.x` | alpha | `v1` preview/beta control-plane line |
+
+These package versions are still pre-release. Pin exact package versions and
+validate against the target server before broad rollout.
+
+## Release Channel Mapping
+
+| Channel | Server meaning | SDK meaning | Expected use |
+|---|---|---|---|
+| `stable` | Default production release on the current admin API major | Default production SDK artifacts for JS/TS, Python, and .NET | Match `stable` server with the same `stable` SDK line. |
+| `beta` | Pre-release for the next `v1` minor or additive control-plane work | Matching beta SDK artifacts from the same contract snapshot | Use for staging and pre-production validation only. |
+| `preview` | Early evaluation build; shape may still change between drops | Matching preview SDK artifacts only | Use for evaluation, not production commitments. |
+| `LTS` | Stable server line explicitly called out in release notes for longer-lived support | Matching LTS SDK line with critical or security-only updates | Use when the server release itself is designated as LTS. |
+
+`LTS` only applies when a release line is explicitly labeled as such in release
+notes or release assets.
+
+## Supported Server and SDK Combinations
+
+The support rules below apply equally to the generated JavaScript/TypeScript,
+Python, and .NET SDK artifacts.
+
+| Server line | SDK line | Support | Notes |
+|---|---|---|---|
+| `stable` `v1` | Matching `stable` `v1` | Supported | Default production pairing. |
+| `stable` `v1` | Older `stable` `v1` or matching `LTS` `v1` | Supported for backward-compatible releases | Safe only while release notes keep the admin API changes additive and do not call out a required SDK migration for workflows you use. |
+| Designated `LTS` `v1` | Matching `LTS` `v1` | Supported | Preferred for pinned enterprise environments that want lower change velocity. |
+| `beta` `v1` | Matching `beta` `v1` | Supported for validation only | Use for test environments, partner validation, or planned upgrade rehearsals. |
+| `preview` line | Matching `preview` line | Evaluation only | Breaking changes may land between preview drops. |
+| `stable` or `LTS` | `beta` or `preview` | Not supported | Do not mix pre-release SDKs into a production server line. |
+| `beta` or `preview` | `stable` or `LTS` | Not supported | Pre-release servers should be exercised with the matching pre-release SDK line. |
+| Any `v1` server | Any different admin API major | Not supported | A server and SDK must share the same admin API major. |
+
+## Changelog Expectations
+
+Any release that changes `docs/api-specs/admin-api.json` or the generated
+control-plane SDK artifacts should call out:
+- the server release channel and admin API major affected
+- whether JavaScript/TypeScript, Python, and .NET artifacts all need to move
+  together
+- whether existing `stable` or `LTS` SDKs remain supported against the new
+  server line
+- added, deprecated, or removed fields/endpoints
+- whether consumers need to regenerate or re-download SDK artifacts
+- any required migration step for auth, write-path, import, or long-running
+  operation changes
+
+For `beta` and `preview` releases, changelog entries should also mark unstable
+operations explicitly. If a change is breaking, the release notes must link to
+the versioning policy and migration guide.
+
+## Migration Guide Baseline
+
+The baseline migration guidance for any server/SDK upgrade is:
+
+1. Determine the target server release channel and admin API major.
+2. Choose the matching SDK channel and the same admin API major for
+   JavaScript/TypeScript, Python, or .NET.
+3. Read the release notes for admin contract additions, deprecations, auth
+   changes, and SDK regeneration requirements.
+4. Refresh the SDK artifact if the release notes or contract diff say the admin
+   surface changed.
+5. Re-run the automation flows you depend on: auth, connection management,
+   publish/update/import, and long-running operations.
+6. If the release is breaking or deprecates an operation you use, follow the
+   step-by-step process in [Control Plane Migration Guide](CONTROL_PLANE_MIGRATION_GUIDE.md)
+   before production rollout.
+
+The reusable per-SDK document template lives in
+[SDK Migration Guide Baseline](SDK_MIGRATION_GUIDE_BASELINE.md).

--- a/docs/user/SDK_MIGRATION_GUIDE_BASELINE.md
+++ b/docs/user/SDK_MIGRATION_GUIDE_BASELINE.md
@@ -1,0 +1,87 @@
+# SDK Migration Guide Baseline
+
+This document defines the minimum migration-guide structure that the
+JavaScript/TypeScript, Python, and .NET SDK repositories should follow for
+control-plane releases.
+
+Use this baseline whenever an SDK release changes generated admin surfaces,
+runtime compatibility checks, auth behavior, import workflows, or long-running
+operation handling.
+
+## Required Sections
+
+Every SDK release that changes public behavior should include:
+
+1. A version header such as `Migrating from X.Y to X.Z`.
+2. Server compatibility guidance.
+3. Breaking changes with before/after examples.
+4. New capabilities worth adopting.
+5. Deprecations with replacement guidance and sunset timing.
+6. Validation steps for the workflows most likely to regress.
+
+## Server Compatibility Block
+
+Each SDK migration entry should call out:
+
+- supported control-plane API major
+- minimum supported Honua Server version or release line
+- supported server release channels (`stable`, `beta`, `preview`, `LTS`)
+- whether the release requires regenerating or re-downloading the SDK artifact
+
+When the server exposes `GET /api/v1/admin/capabilities`, SDKs should use that
+contract for runtime validation and feature detection.
+
+## Changelog Expectations
+
+SDK changelogs and release notes should explicitly state:
+
+- the server release line the SDK was validated against
+- whether all generated SDK families moved together
+- added, deprecated, or removed fields/endpoints
+- any auth, import, or long-running-operation behavior changes
+- whether production users should upgrade immediately or only after staging
+  validation
+
+For `beta` and `preview` releases, mark unstable operations explicitly. For
+breaking changes, link back to:
+
+- [Server + SDK Compatibility Matrix](SDK_COMPATIBILITY_MATRIX.md)
+- [Control Plane Migration Guide](CONTROL_PLANE_MIGRATION_GUIDE.md)
+- [Control Plane Versioning Policy](CONTROL_PLANE_VERSIONING_POLICY.md)
+
+## Release Template
+
+Use the following structure in SDK repos:
+
+```markdown
+## Migrating from X.Y to X.Z
+
+### Server Compatibility
+- Control-plane API major: `v1`
+- Minimum server line: `stable v1` / `beta v1` / `preview v1`
+- Runtime handshake: `GET /api/v1/admin/capabilities`
+
+### Breaking Changes
+- Describe breaking changes with before/after examples.
+
+### New Features
+- Describe new capabilities and any opt-in steps.
+
+### Deprecations
+- Describe deprecated APIs, replacements, and sunset timing.
+
+### Validation Checklist
+- auth/login flow
+- connection management flow
+- import/publish flow
+- long-running operations you depend on
+```
+
+## Per-Repo Expectations
+
+- `honua-sdk-js`: keep `MIGRATION.md` and `CHANGELOG.md` current in the repo
+  root.
+- `honua-sdk-python`: keep `MIGRATION.md` and `CHANGELOG.md` current in the
+  repo root.
+- `honua-sdk-dotnet`: keep a shared `MIGRATION.md` and `CHANGELOG.md` for
+  `Honua.Sdk.Admin` and `Honua.Sdk.Grpc`.


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #428

## Summary
Publish the first canonical server and SDK compatibility matrix for Honua control-plane SDKs and define the reusable migration-guide baseline that the SDK repos should follow.

## Changes Made
- add `Server + SDK Compatibility Matrix` with current JS, Python, and .NET package lines plus release-channel mapping and support rules
- add `SDK Migration Guide Baseline` so each SDK repo can follow the same migration and changelog structure
- link the matrix and baseline from central docs and the control-plane migration guide

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local doc validation passed (`git diff --check`)

## Coverage Impact
- No code changes
- Coverage impact: none

## Breaking Changes
None. This PR adds documentation and central linking only.

## Additional Context
Validation completed:
- `git diff --check`

This is a docs-only PR. The repo-wide `scripts/pre-pr-check.sh` gate is currently blocked by unrelated formatting debt outside this PR diff.

---

## Pre-PR Checklist (for contributor)
- [x] `scripts/pre-pr-check.sh` is currently blocked by unrelated repo-wide formatting debt outside this docs-only PR
- [x] Commit message follows format: `type: description (#issue-number)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [x] Documentation updated if needed
- [ ] If protocol/auth behavior changed, updated MVP compatibility contract and release checklist notes

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed