### PR TITLE
docs: publish enterprise procurement readiness packet (#389)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+This repository accepts private reports for suspected security vulnerabilities in Honua Server, its published container images, and the deployment artifacts maintained in this repository.
+
+## Reporting a Vulnerability
+
+- Do not open public GitHub issues for suspected vulnerabilities.
+- Use GitHub's private vulnerability reporting / security advisory flow for this repository when available.
+- If private reporting is unavailable in your environment, contact the maintainers through a private channel first and request a secure handoff before sending exploit details.
+
+Include:
+
+- affected version, image tag, or commit
+- deployment model (`Docker Compose`, `Helm`, `AWS`, `Azure`, and so on)
+- reproduction steps or proof of concept
+- impact assessment and any known mitigations
+- whether the issue has already been disclosed publicly
+
+## Scope
+
+In scope:
+
+- application code in `src/`
+- published Honua container images
+- Helm chart content in `infrastructure/helm/`
+- deployment and security guidance in `docs/devops/`
+
+Out of scope unless Honua code is the root cause:
+
+- customer-specific cloud account misconfiguration
+- third-party managed service outages
+- denial-of-service caused solely by missing edge controls that are already documented as operator responsibilities
+
+## Response Targets
+
+These are response targets, not a guarantee that every issue will be fixed in the same window.
+
+| Severity | Example impact | Acknowledge | Initial triage | Target remediation guidance |
+| --- | --- | --- | --- | --- |
+| Critical | remote code execution, auth bypass, active secret exposure | `1` business day | `3` business days | patch or mitigation target within `7` calendar days |
+| High | privilege escalation, tenant data exposure, significant integrity risk | `2` business days | `5` business days | patch or mitigation target within `30` calendar days |
+| Medium | meaningful but contained security weakness with workaround | `3` business days | `10` business days | fix in the next planned release or mitigation within `90` calendar days |
+| Low | hardening issue or low-likelihood abuse path | `5` business days | next backlog review | fix as capacity allows |
+
+## Disclosure Policy
+
+- Honua follows coordinated disclosure.
+- Public disclosure should wait until a fix or documented mitigation is available.
+- If a vulnerability is being actively exploited, Honua may publish mitigations before a full patch is available.
+- Release notes and security advisories should identify affected versions, mitigation steps, and upgrade guidance.
+
+## Supported Fix Path
+
+- Security fixes are applied to the current supported release line and current development branch.
+- Older releases may require customers to upgrade to receive a fix if no patch branch exists.
+
+## Operational Security Baseline
+
+Honua's current operator-facing security guidance lives in:
+
+- `docs/devops/security.md`
+- `docs/devops/infrastructure.md`
+- `docs/user/ENTERPRISE_PROCUREMENT_READINESS.md`
+
+These documents define the shared-responsibility model for TLS termination, WAF/rate limiting, identity configuration, managed database usage, and production deployment expectations.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Full hosted documentation: **[honua.gitbook.io/honuaio](https://honua.gitbook.io
 | **Standardize SDK release docs** | [SDK Migration Guide Baseline](user/SDK_MIGRATION_GUIDE_BASELINE.md) |
 | **Integrate AI agents** | [MCP Server](user/MCP_SERVER.md) |
 | **Deploy to production** | [Infrastructure & Deployment](devops/infrastructure.md) |
+| **Review enterprise procurement readiness** | [Enterprise Procurement Readiness](user/ENTERPRISE_PROCUREMENT_READINESS.md) |
 | **Monitor and troubleshoot** | [Monitoring](devops/monitoring.md) / [Troubleshooting](devops/troubleshooting.md) |
 | **Evaluate protocol coverage** | [Coverage Matrices](#coverage-matrices) |
 | **Check MVP launch limits** | [MVP Compatibility Contract](user/MVP_COMPATIBILITY_CONTRACT.md) |
@@ -29,6 +30,7 @@ Full hosted documentation: **[honua.gitbook.io/honuaio](https://honua.gitbook.io
 - [Control Plane Migration Guide](user/CONTROL_PLANE_MIGRATION_GUIDE.md) — SDK and upgrade workflow
 - [Control Plane Versioning Policy](user/CONTROL_PLANE_VERSIONING_POLICY.md) — deprecation and compatibility guarantees
 - [MCP Server](user/MCP_SERVER.md) — AI/agent integration via Model Context Protocol
+- [Enterprise Procurement Readiness](user/ENTERPRISE_PROCUREMENT_READINESS.md) — buyer-facing security, support, licensing, and architecture package
 - [MVP Compatibility Contract](user/MVP_COMPATIBILITY_CONTRACT.md) — launch-ready protocol and limitation summary
 - [Admin UI](user/admin-ui.md) — browser interface guide
 - [Data Modeling Guide](user/DATA_MODELING_GUIDE.md) — spatial data modeling

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,6 +6,7 @@
 * [User Journeys](user/USER_JOURNEYS.md)
 * [Server + SDK Compatibility Matrix](user/SDK_COMPATIBILITY_MATRIX.md)
 * [SDK Migration Guide Baseline](user/SDK_MIGRATION_GUIDE_BASELINE.md)
+* [Enterprise Procurement Readiness](user/ENTERPRISE_PROCUREMENT_READINESS.md)
 * [MVP Sales Playbook + Launch GTM](user/MVP_LAUNCH_GTM_PLAYBOOK.md)
 * [MVP Compatibility Contract](user/MVP_COMPATIBILITY_CONTRACT.md)
 * [Data Modeling Guide](user/DATA_MODELING_GUIDE.md)

--- a/docs/devops/README.md
+++ b/docs/devops/README.md
@@ -16,6 +16,7 @@ Control-plane direction:
 ## Security
 
 - [Security](security.md) — authentication, authorization, rate limiting, CSP, credential rotation
+- [Enterprise Procurement Readiness](../user/ENTERPRISE_PROCUREMENT_READINESS.md) — buyer-facing summary of security policy, support levels, and deployment commitments
 
 ## Monitoring & Performance
 

--- a/docs/user/ENTERPRISE_PROCUREMENT_READINESS.md
+++ b/docs/user/ENTERPRISE_PROCUREMENT_READINESS.md
@@ -1,0 +1,151 @@
+# Enterprise Procurement Readiness
+
+This document is the canonical procurement-facing package for Honua Server. It consolidates commercial posture, support commitments, deployment reference patterns, and the security/compliance artifacts currently published in this repository.
+
+## Commercial and Licensing Posture
+
+- **Open-core model**: Honua follows the edition boundary in [ADR 0024](../contributor/adr/0024-open-core-edition-model.md).
+- **Community edition**: free to use, deploy, and modify under [ELv2](../../LICENSE).
+- **Pro and Enterprise editions**: commercial subscriptions with runtime license-key enforcement for paid capabilities; deployment surfaces themselves are not paywalled.
+- **Deployment pricing boundary**: customer cloud spend, managed database spend, and optional professional services are separate from the software subscription unless explicitly bundled in an order form.
+- **Transparent pricing posture**: Honua should separate quotes into `software subscription`, `support tier`, and `professional services`. Community pricing is public (`free`). Commercial package structure is public even when final enterprise pricing remains quote-based.
+
+## Shared Responsibility Summary
+
+Honua Server is primarily a customer-managed deployment model today.
+
+- Honua provides the application, container images, Helm chart, deployment guidance, and support commitments defined here.
+- The customer owns the cloud account, network controls, TLS certificates, identity-provider configuration, backup operations, and infrastructure availability unless a separate services agreement says otherwise.
+- Edge controls such as WAF, IP allowlists, and rate limiting are operator responsibilities and are documented in [Security Configuration](../devops/security.md).
+
+## Availability, Performance, and Durability Objectives
+
+These objectives assume the recommended reference architecture, indexed spatial
+data, managed PostGIS, and normal operating conditions. They are planning
+targets for procurement and support discussions, not an unconditional guarantee
+for undersized or misconfigured customer infrastructure.
+
+| Objective area | Community | Pro | Enterprise |
+| --- | --- | --- | --- |
+| Availability objective | best effort, no uptime SLA | `99.9%` monthly for the Honua application layer on the recommended single-region HA footprint | `99.95%` monthly for the Honua application layer on the recommended HA or multi-region footprint |
+| Query latency objective | no SLA | indexed query `P50 <= 250 ms`, `P95 <= 1.5 s`, `P99 <= 4 s` | indexed query `P50 <= 200 ms`, `P95 <= 1.0 s`, `P99 <= 3 s` on dedicated enterprise sizing |
+| Map export objective | no SLA | `P95 <= 10 s` for standard map exports on the recommended footprint | `P95 <= 8 s` on dedicated enterprise sizing |
+| Tile generation objective | no SLA | `P95 <= 1.5 s` for warm tile generation and `<= 3 s` for cold generation | `P95 <= 1.0 s` warm and `<= 2.5 s` cold on dedicated enterprise sizing |
+| Durability baseline | operator-managed only | managed PostGIS backups at least daily, target `RPO <= 24h` | PITR-enabled managed PostGIS, target `RPO <= 1h`, documented restore exercise expectation |
+| Restore expectation | no SLA | best-effort guidance during support engagement | target `RTO <= 4h` for the recommended HA footprint, subject to customer cloud controls and runbooks |
+
+Performance notes:
+
+- Query latency targets assume selective or indexed spatial/attribute filters and reasonable result windows.
+- Export and tile targets assume default production guidance from [Infrastructure](../devops/infrastructure.md) and [Operations](../devops/operations.md).
+- Community deployments can outperform these numbers, but Honua does not offer a contractual SLA on the free tier.
+
+## Reference Architecture Summaries
+
+| Reference pattern | Recommended use | Core components | Availability target | Primary pointers |
+| --- | --- | --- | --- | --- |
+| `Kubernetes HA` | default production deployment | ingress/WAF, `2+` Honua replicas, managed PostGIS, optional Redis for multi-node caching | `99.9%` monthly application availability target for the Honua service layer | [Infrastructure](../devops/infrastructure.md), [Helm chart](../../infrastructure/helm/honua/README.md) |
+| `AWS/Azure managed cloud` | production when customer standardizes on Terraform-managed infrastructure | managed edge, managed PostGIS, Honua containers or serverless targets, post-apply validation hooks | `99.5%` monthly application availability target for the Honua service layer | [Infrastructure](../devops/infrastructure.md), dedicated `honua-terraform` repository |
+| `Single-node / Docker Compose` | evaluation, demos, and non-critical internal use | single Honua instance, local PostGIS, optional Redis/MinIO | no production SLO or SLA | [Infrastructure](../devops/infrastructure.md), [Docker Compose sample](../devops/docker-compose.md) |
+
+Notes:
+
+- The availability targets above are reference objectives for customer-managed deployments built from Honua's recommended architecture. They are not a managed-SaaS uptime guarantee.
+- Redis is recommended for multi-node coherence and scale; PostGIS is required in every deployment model.
+- TLS termination, WAF, and network restrictions are expected at the ingress or cloud edge, not inside the Honua process.
+
+## Reference Architecture Sizing Profiles
+
+These profiles are starting points for procurement and capacity planning. They
+should be validated with the customer dataset, query patterns, and export/tile
+mix before production sign-off.
+
+| Profile | Expected usage | App sizing baseline | PostGIS baseline | Redis baseline | Deployment notes |
+| --- | --- | --- | --- | --- | --- |
+| `Small` | `1-10` users, `<1M` features, pilot or departmental workload | `1 x 2 vCPU / 4 GiB` Honua node | `2 vCPU / 8 GiB` managed PostGIS or hardened single-node PostGIS | optional | Docker Compose or single-node Kubernetes only; no production HA commitment |
+| `Medium` | `10-100` users, `1M-100M` features, production single-region | `2-3 x 2-4 vCPU / 8 GiB` Honua replicas behind ingress | `4-8 vCPU / 16-32 GiB` managed PostGIS with automated backups | `1-2 GiB` managed Redis or equivalent | Preferred Pro footprint; use Helm or managed container orchestration |
+| `Large` | `100+` users, `100M+` features, enterprise or multi-team workload | `4+ x 4-8 vCPU / 16 GiB` Honua replicas, optionally split across regions | `8-16 vCPU / 32-64 GiB` HA managed PostGIS with replica/failover strategy | managed Redis with HA or clustered cache | Preferred Enterprise footprint; requires observability, failover runbooks, and restore drills |
+
+Cloud-specific deployment guidance:
+
+- `AWS ECS/EKS`: pair ALB/WAF with RDS for PostgreSQL + PostGIS and ElastiCache for Redis. Use the dedicated `honua-terraform` repository for Terraform examples and this repo's [Helm chart](../../infrastructure/helm/honua/README.md) for Kubernetes packaging.
+- `Azure ACA/AKS`: pair Front Door or Application Gateway with Azure Database for PostgreSQL Flexible Server and Azure Cache for Redis. Use the dedicated `honua-terraform` repository for Terraform examples and this repo's [Helm chart](../../infrastructure/helm/honua/README.md) for Kubernetes packaging.
+- Serverless targets can be part of a delivery architecture, but the default procurement posture for uptime-sensitive deployments remains containerized Honua plus managed PostGIS.
+
+## Support, SLA, and SLO Matrix
+
+Severity definitions:
+
+- `Sev 1`: production outage, active security event, or no-workaround blocker
+- `Sev 2`: major degradation with workaround
+- `Sev 3`: non-blocking defect or implementation question
+
+| Area | Community | Pro | Enterprise |
+| --- | --- | --- | --- |
+| Support channel | docs and GitHub issue flow | email support | email support plus shared Slack/Teams incident channel by agreement |
+| Coverage window | best effort | business hours | business hours with coordinated incident response for `Sev 1` |
+| Initial response target | no SLA | within `2` business days | `Sev 1`: within `4` business hours; `Sev 2`: next business day; `Sev 3`: within `2` business days |
+| Status update cadence | no SLA | reasonable-effort during active case | at least each business day for active `Sev 1` and `Sev 2` cases |
+| Architecture review | self-service docs | available as scoped services | included by agreement |
+| Security advisory notice | public release notes | public release notes and direct notice for contracted contacts | public release notes and direct notice for contracted contacts |
+
+Additional service-level notes:
+
+- Pro support aligns to the current paid-tier commitment in ADR 0024: initial response within `48` business hours.
+- Enterprise support aligns to the current paid-tier commitment in ADR 0024: critical-incident response within `4` business hours.
+- Availability objectives depend on the chosen architecture, not only on edition. Use the reference architecture table above when documenting customer commitments.
+
+## Security and Vulnerability Response
+
+- Vulnerability disclosure and response policy: [root SECURITY.md](../../SECURITY.md)
+- Operator security configuration: [Security Configuration](../devops/security.md)
+- Deployment hardening and validation flow: [Infrastructure](../devops/infrastructure.md)
+
+Current published security posture:
+
+- admin access supports API-key authentication and optional OIDC
+- TLS, WAF, forwarded-header trust, and rate limiting are enforced at the edge
+- production guidance recommends managed PostGIS and Redis for multi-node deployments
+- health checks, metrics, and tracing are available for runtime monitoring
+
+## Data Flow and Authentication Architecture Summary
+
+Current procurement-facing architecture summary:
+
+- request flow: `client -> ingress/WAF/TLS termination -> Honua Server -> PostGIS (+ optional Redis / object storage)`
+- admin authentication: `X-API-Key` by default, optional OIDC bearer-token flow for browser-based admin access
+- runtime authorization: admin surfaces require admin credentials; geospatial data access remains governed by service and layer access controls
+- encryption in transit: expected at the ingress or cloud edge and between managed services where the customer enables it
+- encryption at rest: provided by the chosen PostGIS, Redis, and object-storage platform configuration
+
+These controls are described in more detail in [Security Configuration](../devops/security.md) and [Infrastructure](../devops/infrastructure.md).
+
+## Published Security and Compliance Artifact Summary
+
+This table describes what is published in-repo today. It is intentionally explicit so procurement reviews do not over-assume maturity that is not yet documented.
+
+| Artifact | Status today | Source |
+| --- | --- | --- |
+| Edition and licensing boundary | published | [ADR 0024](../contributor/adr/0024-open-core-edition-model.md), [LICENSE](../../LICENSE) |
+| Deployment and reference architecture guidance | published | [Infrastructure](../devops/infrastructure.md), [Helm chart](../../infrastructure/helm/honua/README.md) |
+| Security configuration baseline | published | [Security Configuration](../devops/security.md) |
+| Vulnerability disclosure and security response policy | published | [root SECURITY.md](../../SECURITY.md) |
+| Versioning and upgrade expectations | published | [Control Plane Versioning Policy](CONTROL_PLANE_VERSIONING_POLICY.md) |
+| MVP scope and known limitations | published | [MVP Compatibility Contract](MVP_COMPATIBILITY_CONTRACT.md) |
+| CI-visible security signals | published | [README](../../README.md) badges for `CodeQL` and `Container Security` |
+| SOC 2 report | not published in this repository | n/a |
+| FedRAMP package | not published in this repository | n/a |
+| Penetration-test summary | not published in this repository | n/a |
+| Formal DPA/MSA templates | commercial process artifact, not published in this repository | n/a |
+
+## Recommended Procurement Packet Contents
+
+For the minimum current-state procurement packet, send:
+
+1. this document
+2. [root SECURITY.md](../../SECURITY.md)
+3. [Security Configuration](../devops/security.md)
+4. [Infrastructure](../devops/infrastructure.md)
+5. [ADR 0024](../contributor/adr/0024-open-core-edition-model.md)
+
+That set covers support commitments, deployment model, licensing posture, security reporting, and currently published technical controls without implying unpublished certifications.

--- a/docs/user/MVP_LAUNCH_GTM_PLAYBOOK.md
+++ b/docs/user/MVP_LAUNCH_GTM_PLAYBOOK.md
@@ -3,6 +3,8 @@
 ## Purpose
 This playbook defines a low-touch, product-led launch motion with simple pricing, self-service trials, and cloud marketplace distribution.
 
+For the customer-facing procurement packet, support commitments, licensing posture, and security response policy, use [Enterprise Procurement Readiness](ENTERPRISE_PROCUREMENT_READINESS.md) as the canonical source.
+
 ## Launch Goals (First 90 Days)
 - `100-200` Community edition deployments
 - `20-40` Community-to-Pro conversions

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -5,6 +5,7 @@ This section is for people **using Honua in production** — API consumers, GIS 
 ## Getting Started
 - **[User Journeys](USER_JOURNEYS.md)** - Role-based guides for GIS professionals, developers, data analysts
 - **[Geospatial Data APIs](STANDARDS_APIS.md)** - FeatureServer + MapServer, OGC API Features/Tiles, OData v4, MVT overview
+- **[Enterprise Procurement Readiness](ENTERPRISE_PROCUREMENT_READINESS.md)** - canonical buyer packet for security, support, licensing, and deployment posture
 
 ## Integration & Development
 - **[Integration Patterns](INTEGRATION_PATTERNS.md)** - Common integration approaches with code examples


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #389

## Summary
Publish the canonical enterprise procurement packet for Honua Server, including security policy, support posture, sizing guidance, and procurement-facing architecture notes.

## Changes Made
- add root `SECURITY.md` and `Enterprise Procurement Readiness` as the canonical buyer-facing packet
- add explicit availability, latency, durability, support, and sizing guidance by edition and deployment profile
- link the procurement packet from central docs, devops docs, and launch/GTM docs

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local doc validation passed (`git diff --check`)

## Coverage Impact
- No code changes
- Coverage impact: none

## Breaking Changes
None. This PR adds documentation and central linking only.

## Additional Context
Validation completed:
- `git diff --check`

This is a docs-only PR. The repo-wide `scripts/pre-pr-check.sh` gate is currently blocked by unrelated formatting debt outside this PR diff.

---

## Pre-PR Checklist (for contributor)
- [x] `scripts/pre-pr-check.sh` is currently blocked by unrelated repo-wide formatting debt outside this docs-only PR
- [x] Commit message follows format: `type: description (#issue-number)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [x] Documentation updated if needed
- [ ] If protocol/auth behavior changed, updated MVP compatibility contract and release checklist notes

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed