### PR TITLE
docs: clarify open-core and operator tooling boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Honua's admin UI and admin API are intended to become the foundation of a Honua-
 - Honua is not standardizing on Flux or Argo CD as its primary rollout controller.
 - Helm and Terraform remain packaging and infrastructure surfaces.
 - Change management, deploy coordination, and instance lifecycle workflows are expected to live in the Honua control plane.
+- The public admin API is the substrate for those workflows; operator-grade AI DevOps/copilot tooling may be delivered through private enterprise surfaces on top of it rather than through the open-core server repository.
 
 ## Documentation
 

--- a/docs/contributor/adr/0024-open-core-edition-model.md
+++ b/docs/contributor/adr/0024-open-core-edition-model.md
@@ -26,11 +26,19 @@ Key design constraints:
 5. **Align paid tiers to the EnterpriseReady framework** (enterpriseready.io):
    SSO, RBAC, Audit Logging, Change Management, Product Assurance, Deployment
    Options, Integrations, Support, and Reporting.
+6. **Operator-grade AI DevOps tooling can be proprietary.** The open-core promise
+   applies to the runtime, protocols, SDKs, deployment targets, and base MCP
+   data-access surface. Higher-level operator/copilot tooling may remain private
+   without undermining platform adoption.
 
 ## Decision
 
 Three editions: **Community**, **Pro**, and **Enterprise**. The gate is runtime
 capabilities, not infrastructure or protocols.
+
+One additional boundary matters: Honua's operator-grade AI DevOps/copilot
+tooling is not part of the open-core runtime. It may live in private enterprise
+tooling on top of the public admin/control-plane APIs.
 
 ### Edition Boundaries
 
@@ -57,6 +65,9 @@ A complete, production-capable feature server for a single-process deployment.
 Community on serverless works — each invocation is independent with its own
 in-memory cache. It is functional at low-to-moderate concurrency. The natural
 ceiling is cache coherence and connection pooling at scale, not an artificial gate.
+
+Community explicitly includes the base MCP data-access surface. It does **not**
+include private operator/copilot tooling for rollout automation or delegated ops.
 
 #### Pro (Per-Node License)
 
@@ -97,6 +108,7 @@ Everything in Pro, plus:
 | **RBAC** | Per-service, per-layer, per-operation role-based access; row-level security | Role-Based Access Control |
 | **Audit Logging** | Immutable audit trail (who queried/edited what, when, from where); SIEM export (Splunk, Datadog, Elastic) | Audit Logging |
 | **Change Management** | GitOps manifest API (apply, dryRun, prune); drift detection; approval workflows; rollback | Change Management |
+| **Private Operator Copilot** | AI DevOps/operator tooling, rollout planning, delegated operations, and implementation workflows delivered through private enterprise tooling on top of the public control-plane API | Change Management / Support |
 | **Compliance** | SOC 2 / FedRAMP evidence collection; data residency controls; encryption-at-rest key rotation | Product Assurance |
 | **Federated Queries** | Cross-instance queries (Honua-to-Honua); external source proxy (Esri REST, OGC WFS) | Integrations |
 | **Multi-Tenancy** | Schema-per-tenant isolation; tenant-scoped API keys; per-tenant usage metering | Deployment Options |
@@ -143,7 +155,7 @@ License checks must be:
 
 - **Community** = complete feature server, single process, deploy anywhere
 - **Pro** = distributed coordination, streaming, analytics
-- **Enterprise** = governance, compliance, multi-tenancy, extensibility
+- **Enterprise** = governance, compliance, multi-tenancy, extensibility, and private operator tooling
 
 ### EnterpriseReady Pillar Mapping
 
@@ -152,7 +164,7 @@ License checks must be:
 | Single Sign-On | API keys | API keys | OIDC, SAML, SCIM |
 | Audit Logging | Structured logs | Structured logs | Immutable trail + SIEM |
 | RBAC | Admin key (all-or-nothing) | Admin key | Per-resource roles + RLS |
-| Change Management | Manual config | Manual config | GitOps + drift detection |
+| Change Management | Manual config | Manual config | GitOps + drift detection + private operator copilot |
 | Product Assurance | AOT, TLS, SQL playground | + Streaming, analytics, sync, AI spatial agent | + Compliance, secure connections |
 | Deployment Options | All targets, single-process | + Distributed cache | + Multi-tenant, HA/DR |
 | Integrations | SDKs, MCP (REST) | + CDC, real-time, MCP (gRPC) | + Federation, plugins, Kafka/NATS |

--- a/docs/user/CONTROL_PLANE_API.md
+++ b/docs/user/CONTROL_PLANE_API.md
@@ -8,10 +8,11 @@ The Server Management API powers the Honua Admin UI and supports headless automa
 
 The Honua Admin UI is intended to operate as a UI on top of this control-plane API.
 
-- This API is the foundation for a Honua-managed GitOps controller.
+- This API is the foundation for a Honua-managed control plane and related automation surfaces.
 - Honua is not positioning Flux or Argo CD as its primary control plane.
 - Helm and Terraform remain infrastructure and packaging surfaces around the platform.
 - Deploy coordination, upgrade readiness, and change-management workflows are expected to be expressed through the Honua control plane.
+- This public API is intentionally broader than any single operator product. Base control-plane primitives remain documented here even when higher-level AI DevOps/operator tooling is delivered through private enterprise surfaces.
 
 ## **When to Use the Management API**
 

--- a/docs/user/MCP_SERVER.md
+++ b/docs/user/MCP_SERVER.md
@@ -2,6 +2,8 @@
 
 Honua ships an MCP server package in the `honua-sdk-js` repository (path `mcp`, package `@honua/mcp-server`) so AI clients can safely discover services, inspect layer schema, and run filtered geospatial queries.
 
+This document covers the public/open-core MCP data-access surface. It does **not** describe Honua's private operator tooling or AI DevOps rollout automation layer.
+
 ## Capabilities
 
 - Service discovery: list available services and metadata


### PR DESCRIPTION
## Summary
- clarify that the public control-plane and base MCP data-access surfaces remain part of the open-core platform
- explicitly separate private AI DevOps/operator tooling from the public runtime and protocol substrate
- align the README, control-plane API docs, MCP docs, and edition-model ADR around the same boundary

## Validation
- docs-only change
- reviewed updated boundary language across the touched docs