### PR TITLE
feat: generate PMTiles v3 archives from tile outputs

### DIFF
--- a/docs/devops/tile-operations-runbook.md
+++ b/docs/devops/tile-operations-runbook.md
@@ -1,6 +1,6 @@
 # Tile Operations Runbook
 
-This runbook covers asynchronous tile lifecycle jobs for cache management and priming.
+This runbook covers asynchronous tile lifecycle jobs for cache management, priming, and archive generation.
 
 ## Supported Operations
 
@@ -14,6 +14,7 @@ Start jobs through:
 - `warm`
 - `invalidate`
 - `purge`
+- `archive`
 
 Request scope options:
 
@@ -33,9 +34,10 @@ Request scope options:
 
 ## Operational Notes
 
-- Jobs are tracked via the unified operations progress store as `OperationType.TileCache`.
+- Jobs are tracked via the unified operations progress store as `OperationType.TileCache` (or `OperationType.PMTilesArchive` for archive jobs).
 - `seed`/`warm` currently target MVT generation through the standard tile provider.
 - `invalidate`/`purge` use output cache invalidation scopes (layer/service/global metadata).
+- `archive` generates a PMTiles v3 archive from tile outputs and uploads it to cloud storage.
 - Retry creates a new job ID while preserving the original request parameters.
 
 ## Metrics
@@ -46,6 +48,8 @@ Prometheus/OpenTelemetry surfaces include:
 - `honua.tile.jobs.total` (tagged by `operation`, `status`)
 - `honua.tile.jobs.duration_ms`
 - `honua.tile.jobs.tiles_processed`
+- `honua.tile.archives.total` (archive generation count)
+- `honua.tile.archives.size_bytes` (archive size histogram)
 
 ## Example: Invalidate a Layer
 
@@ -69,4 +73,51 @@ curl -X POST https://<host>/api/v1/admin/tile-operations/jobs \
     "maxTiles":2000
   }'
 ```
+
+## PMTiles Archive Generation
+
+Generate a PMTiles v3 archive from existing tile outputs. The archive is built by fetching tiles through the standard tile provider, assembling them into a sorted Hilbert-curve-indexed PMTiles v3 file, and uploading the result to cloud storage.
+
+### Request
+
+```bash
+curl -X POST https://<host>/api/v1/admin/tile-operations/jobs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "archive",
+    "layerId": 3,
+    "minZoom": 0,
+    "maxZoom": 10,
+    "bbox": [-123.0, 37.0, -121.0, 38.0],
+    "maxTiles": 5000
+  }'
+```
+
+The `archive` operation requires `layerId` (single-layer archives only for this release).
+
+### Archive-Specific Response Fields
+
+When querying job status (`GET /api/v1/admin/tile-operations/jobs/{jobId}`), archive jobs include:
+
+| Field | Description |
+|-------|-------------|
+| `archiveFileId` | Cloud storage file ID for the generated archive |
+| `downloadUrl` | Time-limited presigned URL to download the `.pmtiles` file (24h expiry) |
+| `archiveSizeBytes` | Final archive size in bytes |
+
+### Validation
+
+Download the archive and inspect with `pmtiles show`:
+
+```bash
+curl -o output.pmtiles "<downloadUrl>"
+pmtiles show output.pmtiles
+```
+
+### Notes
+
+- Archives are stored with a 24-hour TTL in cloud storage.
+- If cloud storage is not configured, both `archiveFileId` and `downloadUrl` will be null.
+- This operation generates tiles on-demand (does not read from cache). For large tile sets, use `maxTiles` to limit scope.
+- The archive uses PMTiles v3 format with MVT tile type and tiles sorted by Hilbert curve index.
 

--- a/src/Honua.Core/Features/Infrastructure/Domain/OperationProgress.cs
+++ b/src/Honua.Core/Features/Infrastructure/Domain/OperationProgress.cs
@@ -119,5 +119,10 @@ public enum OperationType
     /// <summary>
     /// Tile cache lifecycle operation (seed/warm/invalidate/purge).
     /// </summary>
-    TileCache
+    TileCache,
+
+    /// <summary>
+    /// PMTiles archive generation operation.
+    /// </summary>
+    PMTilesArchive
 }

--- a/src/Honua.Core/Features/Tiles/PMTiles/HilbertCurve.cs
+++ b/src/Honua.Core/Features/Tiles/PMTiles/HilbertCurve.cs
@@ -21,13 +21,15 @@ public static class HilbertCurve
     /// <returns>The Hilbert tile ID.</returns>
     public static ulong XYZToTileId(int z, int x, int y)
     {
-        if (z == 0)
-        {
-            return 0;
-        }
-
         ArgumentOutOfRangeException.ThrowIfNegative(z);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(z, 26);
+
+        if (z == 0)
+        {
+            ArgumentOutOfRangeException.ThrowIfNotEqual(x, 0);
+            ArgumentOutOfRangeException.ThrowIfNotEqual(y, 0);
+            return 0;
+        }
         var n = 1 << z;
         ArgumentOutOfRangeException.ThrowIfNegative(x);
         ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(x, n);

--- a/src/Honua.Core/Features/Tiles/PMTiles/HilbertCurve.cs
+++ b/src/Honua.Core/Features/Tiles/PMTiles/HilbertCurve.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Tiles.PMTiles;
+
+/// <summary>
+/// Hilbert curve mapping for PMTiles v3 tile IDs.
+/// Converts (z, x, y) tile coordinates to a single Hilbert curve tile ID
+/// per the PMTiles specification.
+/// </summary>
+public static class HilbertCurve
+{
+    /// <summary>
+    /// Converts tile coordinates to a PMTiles v3 Hilbert tile ID.
+    /// The tile ID is the position on the Hilbert curve at zoom level z,
+    /// offset by the cumulative tile count of all preceding zoom levels.
+    /// </summary>
+    /// <param name="z">Zoom level (0-26).</param>
+    /// <param name="x">Tile column.</param>
+    /// <param name="y">Tile row.</param>
+    /// <returns>The Hilbert tile ID.</returns>
+    public static ulong XYZToTileId(int z, int x, int y)
+    {
+        if (z == 0)
+        {
+            return 0;
+        }
+
+        ArgumentOutOfRangeException.ThrowIfNegative(z);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(z, 26);
+        var n = 1 << z;
+        ArgumentOutOfRangeException.ThrowIfNegative(x);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(x, n);
+        ArgumentOutOfRangeException.ThrowIfNegative(y);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(y, n);
+
+        var offset = CumulativeTileCount(z);
+        var hilbertIndex = XYToHilbert(n, x, y);
+        return offset + (ulong)hilbertIndex;
+    }
+
+    /// <summary>
+    /// Converts a PMTiles v3 Hilbert tile ID back to (z, x, y) coordinates.
+    /// </summary>
+    /// <param name="tileId">The Hilbert tile ID.</param>
+    /// <returns>A tuple of (z, x, y) coordinates.</returns>
+    public static (int Z, int X, int Y) TileIdToXYZ(ulong tileId)
+    {
+        if (tileId == 0)
+        {
+            return (0, 0, 0);
+        }
+
+        var z = 0;
+        var acc = 1UL; // zoom 0 occupies tile ID 0
+        for (var i = 1; i <= 26; i++)
+        {
+            var count = 1UL << (2 * i);
+            if (acc + count > tileId)
+            {
+                z = i;
+                break;
+            }
+            acc += count;
+        }
+
+        var n = 1 << z;
+        var hilbertIndex = (long)(tileId - acc);
+        var (x, y) = HilbertToXY(n, hilbertIndex);
+        return (z, x, y);
+    }
+
+    private static ulong CumulativeTileCount(int z)
+    {
+        // Sum of 4^i for i=0..(z-1) = (4^z - 1) / 3
+        // But tile ID 0 is zoom 0, so offset = 1 + sum(4^i for i=1..z-1)
+        var acc = 0UL;
+        for (var i = 0; i < z; i++)
+        {
+            acc += 1UL << (2 * i);
+        }
+        return acc;
+    }
+
+    private static long XYToHilbert(int n, int x, int y)
+    {
+        var d = 0L;
+        var rx = 0;
+        var ry = 0;
+        var tmpX = x;
+        var tmpY = y;
+
+        for (var s = n / 2; s > 0; s /= 2)
+        {
+            rx = (tmpX & s) > 0 ? 1 : 0;
+            ry = (tmpY & s) > 0 ? 1 : 0;
+            d += (long)s * s * ((3 * rx) ^ ry);
+            Rotate(s, ref tmpX, ref tmpY, rx, ry);
+        }
+
+        return d;
+    }
+
+    private static (int X, int Y) HilbertToXY(int n, long d)
+    {
+        var x = 0;
+        var y = 0;
+        var rx = 0;
+        var ry = 0;
+        var t = d;
+
+        for (var s = 1; s < n; s *= 2)
+        {
+            rx = (int)(1 & (t / 2));
+            ry = (int)(1 & (t ^ rx));
+            Rotate(s, ref x, ref y, rx, ry);
+            x += s * rx;
+            y += s * ry;
+            t /= 4;
+        }
+
+        return (x, y);
+    }
+
+    private static void Rotate(int n, ref int x, ref int y, int rx, int ry)
+    {
+        if (ry != 0)
+        {
+            return;
+        }
+
+        if (rx == 1)
+        {
+            x = n - 1 - x;
+            y = n - 1 - y;
+        }
+
+        (x, y) = (y, x);
+    }
+}

--- a/src/Honua.Core/Features/Tiles/PMTiles/PMTilesArchiveMetadata.cs
+++ b/src/Honua.Core/Features/Tiles/PMTiles/PMTilesArchiveMetadata.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Tiles.PMTiles;
+
+/// <summary>
+/// Metadata for a PMTiles archive, describing bounds, zoom, and attribution.
+/// </summary>
+public sealed record PMTilesArchiveMetadata
+{
+    /// <summary>Minimum longitude of the tile data bounds.</summary>
+    public required double MinLon { get; init; }
+
+    /// <summary>Minimum latitude of the tile data bounds.</summary>
+    public required double MinLat { get; init; }
+
+    /// <summary>Maximum longitude of the tile data bounds.</summary>
+    public required double MaxLon { get; init; }
+
+    /// <summary>Maximum latitude of the tile data bounds.</summary>
+    public required double MaxLat { get; init; }
+
+    /// <summary>Minimum zoom level present in the archive.</summary>
+    public required int MinZoom { get; init; }
+
+    /// <summary>Maximum zoom level present in the archive.</summary>
+    public required int MaxZoom { get; init; }
+
+    /// <summary>Center longitude for default map view.</summary>
+    public double? CenterLon { get; init; }
+
+    /// <summary>Center latitude for default map view.</summary>
+    public double? CenterLat { get; init; }
+
+    /// <summary>Center zoom for default map view.</summary>
+    public int? CenterZoom { get; init; }
+
+    /// <summary>Attribution string for the tile data.</summary>
+    public string? Attribution { get; init; }
+
+    /// <summary>Human-readable description of the tile data.</summary>
+    public string? Description { get; init; }
+}

--- a/src/Honua.Core/Features/Tiles/PMTiles/PMTilesDirectory.cs
+++ b/src/Honua.Core/Features/Tiles/PMTiles/PMTilesDirectory.cs
@@ -1,0 +1,241 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.IO.Compression;
+
+namespace Honua.Core.Features.Tiles.PMTiles;
+
+/// <summary>
+/// A single entry in a PMTiles v3 directory.
+/// </summary>
+internal readonly record struct PMTilesEntry(ulong TileId, ulong Offset, uint Length, uint RunLength)
+{
+    /// <summary>Whether this entry points to a leaf directory rather than tile data.</summary>
+    public bool IsLeaf => RunLength == 0;
+}
+
+/// <summary>
+/// Serializes and deserializes PMTiles v3 directories using varint encoding.
+/// </summary>
+internal static class PMTilesDirectory
+{
+    private const int MaxRootDirectoryEntries = 16384;
+
+    /// <summary>
+    /// Builds root and leaf directory bytes from a sorted list of entries.
+    /// If entries fit within the root directory, leafBytes will be empty.
+    /// </summary>
+    public static (byte[] RootBytes, byte[] LeafBytes) BuildDirectories(
+        IReadOnlyList<PMTilesEntry> entries,
+        PMTilesCompression internalCompression)
+    {
+        if (entries.Count <= MaxRootDirectoryEntries)
+        {
+            var rootBytes = SerializeEntries(entries);
+            var compressedRoot = Compress(rootBytes, internalCompression);
+            return (compressedRoot, []);
+        }
+
+        // Split into leaf directories, root directory points to them
+        var leafEntriesPerGroup = Math.Max(1, (entries.Count + MaxRootDirectoryEntries - 1) / MaxRootDirectoryEntries);
+        var rootEntries = new List<PMTilesEntry>();
+        using var leafStream = new MemoryStream();
+
+        for (var i = 0; i < entries.Count; i += leafEntriesPerGroup)
+        {
+            var count = Math.Min(leafEntriesPerGroup, entries.Count - i);
+            var group = new List<PMTilesEntry>(count);
+            for (var j = 0; j < count; j++)
+            {
+                group.Add(entries[i + j]);
+            }
+
+            var leafBytes = SerializeEntries(group);
+            var compressedLeaf = Compress(leafBytes, internalCompression);
+
+            rootEntries.Add(new PMTilesEntry(
+                TileId: entries[i].TileId,
+                Offset: (ulong)leafStream.Position,
+                Length: (uint)compressedLeaf.Length,
+                RunLength: 0 // RunLength=0 means this is a leaf directory pointer
+            ));
+
+            leafStream.Write(compressedLeaf);
+        }
+
+        var rootBytes2 = SerializeEntries(rootEntries);
+        var compressedRoot2 = Compress(rootBytes2, internalCompression);
+        return (compressedRoot2, leafStream.ToArray());
+    }
+
+    /// <summary>
+    /// Serializes directory entries to bytes using varint encoding per PMTiles v3 spec.
+    /// Layout: num_entries varint, then four columns: tile_ids, run_lengths, lengths, offsets.
+    /// </summary>
+    internal static byte[] SerializeEntries(IReadOnlyList<PMTilesEntry> entries)
+    {
+        using var stream = new MemoryStream();
+
+        // num_entries prefix (required by spec)
+        WriteVarint(stream, (ulong)entries.Count);
+
+        // Column 1: tile_id deltas
+        var lastTileId = 0UL;
+        foreach (var entry in entries)
+        {
+            WriteVarint(stream, entry.TileId - lastTileId);
+            lastTileId = entry.TileId;
+        }
+
+        // Column 2: run_length
+        foreach (var entry in entries)
+        {
+            WriteVarint(stream, entry.RunLength);
+        }
+
+        // Column 3: length
+        foreach (var entry in entries)
+        {
+            WriteVarint(stream, entry.Length);
+        }
+
+        // Column 4: offset encoding per PMTiles v3 spec:
+        //   First entry always writes offset + 1.
+        //   Subsequent entries: if contiguous (offset == prev.offset + prev.length), write 0.
+        //   Otherwise write offset + 1 (absolute, not delta).
+        for (var i = 0; i < entries.Count; i++)
+        {
+            var entry = entries[i];
+            if (i > 0 && entry.Offset == entries[i - 1].Offset + entries[i - 1].Length)
+            {
+                WriteVarint(stream, 0);
+            }
+            else
+            {
+                WriteVarint(stream, entry.Offset + 1);
+            }
+        }
+
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Deserializes directory entries from varint-encoded column data.
+    /// Reads the num_entries prefix, then four columns.
+    /// </summary>
+    internal static PMTilesEntry[] DeserializeEntries(ReadOnlySpan<byte> data)
+    {
+        var pos = 0;
+        var numEntries = (int)ReadVarint(data, ref pos);
+        var entries = new PMTilesEntry[numEntries];
+
+        // Column 1: tile_id deltas
+        var lastTileId = 0UL;
+        for (var i = 0; i < numEntries; i++)
+        {
+            var delta = ReadVarint(data, ref pos);
+            lastTileId += delta;
+            entries[i] = new PMTilesEntry(lastTileId, 0, 0, 0);
+        }
+
+        // Column 2: run_length
+        for (var i = 0; i < numEntries; i++)
+        {
+            var runLength = (uint)ReadVarint(data, ref pos);
+            entries[i] = entries[i] with { RunLength = runLength };
+        }
+
+        // Column 3: length
+        for (var i = 0; i < numEntries; i++)
+        {
+            var length = (uint)ReadVarint(data, ref pos);
+            entries[i] = entries[i] with { Length = length };
+        }
+
+        // Column 4: offset decoding per PMTiles v3 spec:
+        //   0 (when i > 0) means contiguous (offset = prev.offset + prev.length).
+        //   Otherwise offset = v - 1 (absolute).
+        for (var i = 0; i < numEntries; i++)
+        {
+            var v = ReadVarint(data, ref pos);
+            ulong offset;
+            if (v == 0 && i > 0)
+            {
+                offset = entries[i - 1].Offset + entries[i - 1].Length;
+            }
+            else
+            {
+                offset = v - 1;
+            }
+            entries[i] = entries[i] with { Offset = offset };
+        }
+
+        return entries;
+    }
+
+    internal static void WriteVarint(Stream stream, ulong value)
+    {
+        while (value >= 0x80)
+        {
+            stream.WriteByte((byte)(value | 0x80));
+            value >>= 7;
+        }
+        stream.WriteByte((byte)value);
+    }
+
+    private static ulong ReadVarint(ReadOnlySpan<byte> data, ref int pos)
+    {
+        var result = 0UL;
+        var shift = 0;
+        for (var bytesRead = 0; bytesRead < 10; bytesRead++)
+        {
+            var b = data[pos++];
+            result |= (ulong)(b & 0x7F) << shift;
+            if ((b & 0x80) == 0)
+            {
+                return result;
+            }
+            shift += 7;
+        }
+        throw new InvalidDataException("Varint exceeds 10 bytes.");
+    }
+
+    internal static byte[] Compress(byte[] data, PMTilesCompression compression)
+    {
+        if (compression == PMTilesCompression.None)
+        {
+            return data;
+        }
+
+        if (compression == PMTilesCompression.Gzip)
+        {
+            using var output = new MemoryStream();
+            using (var gzip = new GZipStream(output, CompressionLevel.Optimal, leaveOpen: true))
+            {
+                gzip.Write(data);
+            }
+            return output.ToArray();
+        }
+
+        throw new NotSupportedException($"Compression type {compression} is not supported for directory serialization.");
+    }
+
+    internal static byte[] Decompress(byte[] data, PMTilesCompression compression)
+    {
+        if (compression == PMTilesCompression.None)
+        {
+            return data;
+        }
+
+        if (compression == PMTilesCompression.Gzip)
+        {
+            using var input = new MemoryStream(data);
+            using var gzip = new GZipStream(input, CompressionMode.Decompress);
+            using var output = new MemoryStream();
+            gzip.CopyTo(output);
+            return output.ToArray();
+        }
+
+        throw new NotSupportedException($"Compression type {compression} is not supported for directory deserialization.");
+    }
+}

--- a/src/Honua.Core/Features/Tiles/PMTiles/PMTilesHeader.cs
+++ b/src/Honua.Core/Features/Tiles/PMTiles/PMTilesHeader.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Tiles.PMTiles;
+
+/// <summary>
+/// PMTiles v3 archive header (127 bytes).
+/// See: https://github.com/protomaps/PMTiles/blob/main/spec/v3/spec.md
+/// </summary>
+internal struct PMTilesHeader
+{
+    public const int HeaderSize = 127;
+    public const byte SpecVersion = 3;
+    public static readonly byte[] MagicBytes = "PMTiles"u8.ToArray();
+
+    public ulong RootDirectoryOffset { get; set; }
+    public ulong RootDirectoryLength { get; set; }
+    public ulong JsonMetadataOffset { get; set; }
+    public ulong JsonMetadataLength { get; set; }
+    public ulong LeafDirectoryOffset { get; set; }
+    public ulong LeafDirectoryLength { get; set; }
+    public ulong TileDataOffset { get; set; }
+    public ulong TileDataLength { get; set; }
+    public ulong AddressedTilesCount { get; set; }
+    public ulong TileEntriesCount { get; set; }
+    public ulong TileContentsCount { get; set; }
+    public bool Clustered { get; set; }
+    public PMTilesCompression InternalCompression { get; set; }
+    public PMTilesCompression TileCompression { get; set; }
+    public PMTilesTileType TileType { get; set; }
+    public byte MinZoom { get; set; }
+    public byte MaxZoom { get; set; }
+    public int MinLonE7 { get; set; }
+    public int MinLatE7 { get; set; }
+    public int MaxLonE7 { get; set; }
+    public int MaxLatE7 { get; set; }
+    public byte CenterZoom { get; set; }
+    public int CenterLonE7 { get; set; }
+    public int CenterLatE7 { get; set; }
+
+    public void WriteTo(Span<byte> buffer)
+    {
+        if (buffer.Length < HeaderSize)
+        {
+            throw new ArgumentException($"Buffer must be at least {HeaderSize} bytes.", nameof(buffer));
+        }
+
+        buffer.Clear();
+
+        // Magic number (7 bytes)
+        MagicBytes.CopyTo(buffer);
+
+        // Version (1 byte)
+        buffer[7] = SpecVersion;
+
+        // Root directory offset and length (8+8 bytes)
+        BitConverter.TryWriteBytes(buffer[8..], RootDirectoryOffset);
+        BitConverter.TryWriteBytes(buffer[16..], RootDirectoryLength);
+
+        // JSON metadata offset and length (8+8 bytes)
+        BitConverter.TryWriteBytes(buffer[24..], JsonMetadataOffset);
+        BitConverter.TryWriteBytes(buffer[32..], JsonMetadataLength);
+
+        // Leaf directories offset and length (8+8 bytes)
+        BitConverter.TryWriteBytes(buffer[40..], LeafDirectoryOffset);
+        BitConverter.TryWriteBytes(buffer[48..], LeafDirectoryLength);
+
+        // Tile data offset and length (8+8 bytes)
+        BitConverter.TryWriteBytes(buffer[56..], TileDataOffset);
+        BitConverter.TryWriteBytes(buffer[64..], TileDataLength);
+
+        // Addressed tiles count (8 bytes)
+        BitConverter.TryWriteBytes(buffer[72..], AddressedTilesCount);
+
+        // Tile entries count (8 bytes)
+        BitConverter.TryWriteBytes(buffer[80..], TileEntriesCount);
+
+        // Tile contents count (8 bytes)
+        BitConverter.TryWriteBytes(buffer[88..], TileContentsCount);
+
+        // Clustered (1 byte)
+        buffer[96] = Clustered ? (byte)1 : (byte)0;
+
+        // Internal compression (1 byte)
+        buffer[97] = (byte)InternalCompression;
+
+        // Tile compression (1 byte)
+        buffer[98] = (byte)TileCompression;
+
+        // Tile type (1 byte)
+        buffer[99] = (byte)TileType;
+
+        // Min zoom (1 byte)
+        buffer[100] = MinZoom;
+
+        // Max zoom (1 byte)
+        buffer[101] = MaxZoom;
+
+        // Min position (4+4 bytes, E7 encoding)
+        BitConverter.TryWriteBytes(buffer[102..], MinLonE7);
+        BitConverter.TryWriteBytes(buffer[106..], MinLatE7);
+
+        // Max position (4+4 bytes)
+        BitConverter.TryWriteBytes(buffer[110..], MaxLonE7);
+        BitConverter.TryWriteBytes(buffer[114..], MaxLatE7);
+
+        // Center zoom (1 byte)
+        buffer[118] = CenterZoom;
+
+        // Center position (4+4 bytes)
+        BitConverter.TryWriteBytes(buffer[119..], CenterLonE7);
+        BitConverter.TryWriteBytes(buffer[123..], CenterLatE7);
+    }
+
+    public static PMTilesHeader ReadFrom(ReadOnlySpan<byte> buffer)
+    {
+        if (buffer.Length < HeaderSize)
+        {
+            throw new ArgumentException($"Buffer must be at least {HeaderSize} bytes.", nameof(buffer));
+        }
+
+        // Validate magic
+        if (!buffer[..7].SequenceEqual(MagicBytes))
+        {
+            throw new InvalidDataException("Invalid PMTiles magic bytes.");
+        }
+
+        if (buffer[7] != SpecVersion)
+        {
+            throw new InvalidDataException($"Unsupported PMTiles version: {buffer[7]}.");
+        }
+
+        return new PMTilesHeader
+        {
+            RootDirectoryOffset = BitConverter.ToUInt64(buffer[8..]),
+            RootDirectoryLength = BitConverter.ToUInt64(buffer[16..]),
+            JsonMetadataOffset = BitConverter.ToUInt64(buffer[24..]),
+            JsonMetadataLength = BitConverter.ToUInt64(buffer[32..]),
+            LeafDirectoryOffset = BitConverter.ToUInt64(buffer[40..]),
+            LeafDirectoryLength = BitConverter.ToUInt64(buffer[48..]),
+            TileDataOffset = BitConverter.ToUInt64(buffer[56..]),
+            TileDataLength = BitConverter.ToUInt64(buffer[64..]),
+            AddressedTilesCount = BitConverter.ToUInt64(buffer[72..]),
+            TileEntriesCount = BitConverter.ToUInt64(buffer[80..]),
+            TileContentsCount = BitConverter.ToUInt64(buffer[88..]),
+            Clustered = buffer[96] == 1,
+            InternalCompression = (PMTilesCompression)buffer[97],
+            TileCompression = (PMTilesCompression)buffer[98],
+            TileType = (PMTilesTileType)buffer[99],
+            MinZoom = buffer[100],
+            MaxZoom = buffer[101],
+            MinLonE7 = BitConverter.ToInt32(buffer[102..]),
+            MinLatE7 = BitConverter.ToInt32(buffer[106..]),
+            MaxLonE7 = BitConverter.ToInt32(buffer[110..]),
+            MaxLatE7 = BitConverter.ToInt32(buffer[114..]),
+            CenterZoom = buffer[118],
+            CenterLonE7 = BitConverter.ToInt32(buffer[119..]),
+            CenterLatE7 = BitConverter.ToInt32(buffer[123..]),
+        };
+    }
+}
+
+/// <summary>
+/// PMTiles v3 compression types.
+/// </summary>
+public enum PMTilesCompression : byte
+{
+    /// <summary>Unknown compression.</summary>
+    Unknown = 0,
+    /// <summary>No compression.</summary>
+    None = 1,
+    /// <summary>Gzip compression.</summary>
+    Gzip = 2,
+    /// <summary>Brotli compression.</summary>
+    Brotli = 3,
+    /// <summary>Zstd compression.</summary>
+    Zstd = 4
+}
+
+/// <summary>
+/// PMTiles v3 tile content types.
+/// </summary>
+public enum PMTilesTileType : byte
+{
+    /// <summary>Unknown tile type.</summary>
+    Unknown = 0,
+    /// <summary>Mapbox Vector Tile (MVT).</summary>
+    Mvt = 1,
+    /// <summary>PNG image.</summary>
+    Png = 2,
+    /// <summary>JPEG image.</summary>
+    Jpeg = 3,
+    /// <summary>WebP image.</summary>
+    Webp = 4,
+    /// <summary>AVIF image.</summary>
+    Avif = 5
+}

--- a/src/Honua.Core/Features/Tiles/PMTiles/PMTilesWriter.cs
+++ b/src/Honua.Core/Features/Tiles/PMTiles/PMTilesWriter.cs
@@ -186,7 +186,11 @@ public sealed class PMTilesWriter
         return stream.ToArray();
     }
 
-    private static int ToE7(double value) => (int)(value * 10_000_000);
+    private static int ToE7(double value)
+    {
+        var scaled = Math.Clamp(value, -180.0, 180.0) * 10_000_000;
+        return (int)Math.Round(scaled);
+    }
 
     private static int ContentHash(byte[] data)
     {

--- a/src/Honua.Core/Features/Tiles/PMTiles/PMTilesWriter.cs
+++ b/src/Honua.Core/Features/Tiles/PMTiles/PMTilesWriter.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Core.Features.Tiles.PMTiles;
+
+/// <summary>
+/// Writes a PMTiles v3 archive from tile data.
+/// Tiles are collected in memory, sorted by Hilbert curve tile ID,
+/// and written as a complete archive to the output stream.
+/// </summary>
+public sealed class PMTilesWriter
+{
+    private readonly List<TileEntry> _tiles = [];
+    private readonly PMTilesCompression _tileCompression;
+    private readonly PMTilesCompression _internalCompression;
+
+    /// <summary>
+    /// Gets the number of tiles added to the writer.
+    /// </summary>
+    public int TileCount => _tiles.Count;
+
+    /// <summary>
+    /// Initializes a new PMTiles writer.
+    /// </summary>
+    /// <param name="tileCompression">Compression applied to tile data. Use <see cref="PMTilesCompression.None"/> if tiles are already compressed.</param>
+    /// <param name="internalCompression">Compression for internal directories. Defaults to Gzip.</param>
+    public PMTilesWriter(
+        PMTilesCompression tileCompression = PMTilesCompression.None,
+        PMTilesCompression internalCompression = PMTilesCompression.Gzip)
+    {
+        _tileCompression = tileCompression;
+        _internalCompression = internalCompression;
+    }
+
+    /// <summary>
+    /// Adds a tile to the archive.
+    /// </summary>
+    /// <param name="z">Zoom level.</param>
+    /// <param name="x">Tile column.</param>
+    /// <param name="y">Tile row.</param>
+    /// <param name="data">Raw tile data bytes.</param>
+    public void AddTile(int z, int x, int y, byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (data.Length == 0)
+        {
+            return;
+        }
+
+        var tileId = HilbertCurve.XYZToTileId(z, x, y);
+        _tiles.Add(new TileEntry(tileId, data));
+    }
+
+    /// <summary>
+    /// Writes the complete PMTiles v3 archive to the output stream.
+    /// </summary>
+    /// <param name="output">The stream to write the archive to.</param>
+    /// <param name="metadata">Archive metadata (bounds, zoom, attribution).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The total number of bytes written.</returns>
+    public async Task<long> WriteAsync(Stream output, PMTilesArchiveMetadata metadata, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        // Sort tiles by Hilbert curve tile ID
+        _tiles.Sort(static (a, b) => a.TileId.CompareTo(b.TileId));
+
+        // Phase 1: Write tile data to a buffer and build directory entries
+        using var tileDataStream = new MemoryStream();
+        var entries = new List<PMTilesEntry>(_tiles.Count);
+        var uniqueContents = new HashSet<int>();
+
+        foreach (var tile in _tiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var tileBytes = _tileCompression != PMTilesCompression.None
+                ? PMTilesDirectory.Compress(tile.Data, _tileCompression)
+                : tile.Data;
+
+            var offset = (ulong)tileDataStream.Position;
+            tileDataStream.Write(tileBytes);
+            uniqueContents.Add(ContentHash(tile.Data));
+
+            entries.Add(new PMTilesEntry(
+                TileId: tile.TileId,
+                Offset: offset,
+                Length: (uint)tileBytes.Length,
+                RunLength: 1));
+        }
+
+        // Phase 2: Build JSON metadata
+        var jsonMetadata = BuildJsonMetadata(metadata);
+        var compressedMetadata = PMTilesDirectory.Compress(jsonMetadata, _internalCompression);
+
+        // Phase 3: Build directories
+        var (rootDirBytes, leafDirBytes) = PMTilesDirectory.BuildDirectories(entries, _internalCompression);
+
+        // Phase 4: Calculate offsets
+        // Layout: [header 127] [root_dir] [json_metadata] [leaf_dirs] [tile_data]
+        var rootDirOffset = (ulong)PMTilesHeader.HeaderSize;
+        var rootDirLength = (ulong)rootDirBytes.Length;
+
+        var jsonMetadataOffset = rootDirOffset + rootDirLength;
+        var jsonMetadataLength = (ulong)compressedMetadata.Length;
+
+        var leafDirOffset = jsonMetadataOffset + jsonMetadataLength;
+        var leafDirLength = (ulong)leafDirBytes.Length;
+
+        var tileDataOffset = leafDirOffset + leafDirLength;
+        var tileDataLength = (ulong)tileDataStream.Length;
+
+        // Phase 5: Build header
+        var header = new PMTilesHeader
+        {
+            RootDirectoryOffset = rootDirOffset,
+            RootDirectoryLength = rootDirLength,
+            JsonMetadataOffset = jsonMetadataOffset,
+            JsonMetadataLength = jsonMetadataLength,
+            LeafDirectoryOffset = leafDirOffset,
+            LeafDirectoryLength = leafDirLength,
+            TileDataOffset = tileDataOffset,
+            TileDataLength = tileDataLength,
+            AddressedTilesCount = (ulong)_tiles.Count,
+            TileEntriesCount = (ulong)entries.Count,
+            TileContentsCount = (ulong)uniqueContents.Count,
+            Clustered = true,
+            InternalCompression = _internalCompression,
+            TileCompression = _tileCompression,
+            TileType = PMTilesTileType.Mvt,
+            MinZoom = (byte)metadata.MinZoom,
+            MaxZoom = (byte)metadata.MaxZoom,
+            MinLonE7 = ToE7(metadata.MinLon),
+            MinLatE7 = ToE7(metadata.MinLat),
+            MaxLonE7 = ToE7(metadata.MaxLon),
+            MaxLatE7 = ToE7(metadata.MaxLat),
+            CenterZoom = (byte)(metadata.CenterZoom ?? (metadata.MinZoom + metadata.MaxZoom) / 2),
+            CenterLonE7 = ToE7(metadata.CenterLon ?? (metadata.MinLon + metadata.MaxLon) / 2.0),
+            CenterLatE7 = ToE7(metadata.CenterLat ?? (metadata.MinLat + metadata.MaxLat) / 2.0),
+        };
+
+        // Phase 6: Write everything
+        Span<byte> headerBytes = stackalloc byte[PMTilesHeader.HeaderSize];
+        header.WriteTo(headerBytes);
+
+        await output.WriteAsync(headerBytes.ToArray(), cancellationToken).ConfigureAwait(false);
+        await output.WriteAsync(rootDirBytes, cancellationToken).ConfigureAwait(false);
+        await output.WriteAsync(compressedMetadata, cancellationToken).ConfigureAwait(false);
+        if (leafDirBytes.Length > 0)
+        {
+            await output.WriteAsync(leafDirBytes, cancellationToken).ConfigureAwait(false);
+        }
+        tileDataStream.Position = 0;
+        await tileDataStream.CopyToAsync(output, cancellationToken).ConfigureAwait(false);
+        await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        return (long)(tileDataOffset + tileDataLength);
+    }
+
+    private static byte[] BuildJsonMetadata(PMTilesArchiveMetadata metadata)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+
+        writer.WriteStartObject();
+
+        if (metadata.Attribution is not null)
+        {
+            writer.WriteString("attribution", metadata.Attribution);
+        }
+
+        if (metadata.Description is not null)
+        {
+            writer.WriteString("description", metadata.Description);
+        }
+
+        writer.WriteString("type", "overlay");
+        writer.WriteString("format", "pbf");
+
+        writer.WriteEndObject();
+        writer.Flush();
+
+        return stream.ToArray();
+    }
+
+    private static int ToE7(double value) => (int)(value * 10_000_000);
+
+    private static int ContentHash(byte[] data)
+    {
+        var hash = new HashCode();
+        hash.AddBytes(data);
+        return hash.ToHashCode();
+    }
+
+    private readonly record struct TileEntry(ulong TileId, byte[] Data);
+}

--- a/src/Honua.Server/Features/Admin/TileOperations/TileOperationJobService.cs
+++ b/src/Honua.Server/Features/Admin/TileOperations/TileOperationJobService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
@@ -12,7 +13,9 @@ using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
+using Honua.Core.Features.Shared.Models;
 using Honua.Core.Features.Tiles;
+using Honua.Core.Features.Tiles.PMTiles;
 using Honua.Server.Features.Infrastructure.Caching;
 using Honua.Server.Features.Infrastructure.Progress;
 using Microsoft.Extensions.DependencyInjection;
@@ -92,7 +95,9 @@ internal sealed partial class TileOperationJobService(
 
     public async Task<IReadOnlyList<TileOperationProgress>> ListAsync(bool activeOnly, CancellationToken cancellationToken = default)
     {
-        var operationIds = await _progressStore.GetActiveOperationIdsAsync(OperationType.TileCache, cancellationToken).ConfigureAwait(false);
+        var tileCacheIds = await _progressStore.GetActiveOperationIdsAsync(OperationType.TileCache, cancellationToken).ConfigureAwait(false);
+        var archiveIds = await _progressStore.GetActiveOperationIdsAsync(OperationType.PMTilesArchive, cancellationToken).ConfigureAwait(false);
+        var operationIds = tileCacheIds.Concat(archiveIds).Distinct().ToList();
         var result = new List<TileOperationProgress>(operationIds.Count);
         foreach (var operationId in operationIds)
         {
@@ -220,6 +225,7 @@ internal sealed partial class TileOperationJobService(
                 "warm" => await ExecuteSeedOrWarmAsync(started, request, warmMode: true, layerCatalog, tileProvider, linkedCts.Token).ConfigureAwait(false),
                 "invalidate" => await ExecuteInvalidationAsync(started, request, layerCatalog, linkedCts.Token).ConfigureAwait(false),
                 "purge" => await ExecuteInvalidationAsync(started, request, layerCatalog, linkedCts.Token).ConfigureAwait(false),
+                "archive" => await ExecuteArchiveAsync(started, request, layerCatalog, tileProvider, scope.ServiceProvider, linkedCts.Token).ConfigureAwait(false),
                 _ => started with
                 {
                     Status = OperationStatus.Failed,
@@ -409,6 +415,225 @@ internal sealed partial class TileOperationJobService(
         };
     }
 
+    private async Task<TileOperationProgress> ExecuteArchiveAsync(
+        TileOperationProgress progress,
+        TileOperationStartRequest request,
+        ILayerCatalog layerCatalog,
+        ITileProvider tileProvider,
+        IServiceProvider serviceProvider,
+        CancellationToken cancellationToken)
+    {
+        if (!string.Equals(request.TileMatrixSetId, "WebMercatorQuad", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException("Only TileMatrixSetId 'WebMercatorQuad' is currently supported.");
+        }
+
+        if (!request.LayerId.HasValue)
+        {
+            throw new InvalidOperationException("Archive operations require a layerId.");
+        }
+
+        var layerId = request.LayerId.Value;
+
+        var tileCoordinates = BuildTileCoordinates(request);
+        if (tileCoordinates.Count == 0)
+        {
+            throw new InvalidOperationException("Archive operation produced no target tiles.");
+        }
+
+        var total = (long)tileCoordinates.Count;
+        var processed = 0L;
+        var successful = 0L;
+        var failed = 0L;
+        var warningList = new List<string>();
+
+        var current = progress with
+        {
+            TotalTiles = total,
+            CurrentPhase = "Generating tiles for archive"
+        };
+        await _progressStore.SetProgressAsync(current.JobId, current, TimeSpan.FromHours(24), cancellationToken).ConfigureAwait(false);
+
+        // Phase 1: Collect all tiles for the single layer
+        var writer = new PMTilesWriter(tileCompression: PMTilesCompression.None);
+        foreach (var coordinate in tileCoordinates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var tileData = await tileProvider.GetMvtTileAsync(
+                    layerId,
+                    coordinate.X,
+                    coordinate.Y,
+                    coordinate.Z,
+                    query: null,
+                    _tileOptions,
+                    _tileLimits,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (tileData is { Length: > 0 })
+                {
+                    writer.AddTile(coordinate.Z, coordinate.X, coordinate.Y, tileData);
+                    successful++;
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                failed++;
+                if (warningList.Count < 20)
+                {
+                    warningList.Add($"Layer {layerId} tile {coordinate.Z}/{coordinate.X}/{coordinate.Y}: {ex.Message}");
+                }
+            }
+
+            processed++;
+            if (processed % 25 == 0 || processed == total)
+            {
+                current = current with
+                {
+                    ProcessedTiles = processed,
+                    SuccessfulTiles = successful,
+                    FailedTiles = failed,
+                    Warnings = warningList.ToArray(),
+                    CurrentPhase = $"Generating tiles ({processed}/{total})"
+                };
+                await _progressStore.SetProgressAsync(current.JobId, current, TimeSpan.FromHours(24), cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        if (processed > 0)
+        {
+            TileOperationMetrics.TileThroughput.Add(processed, new TagList { { "operation", "archive" } });
+        }
+
+        if (writer.TileCount == 0)
+        {
+            return current with
+            {
+                Status = OperationStatus.Failed,
+                CompletedAt = DateTimeOffset.UtcNow,
+                ErrorMessage = "No tiles were generated for the archive.",
+                CurrentPhase = "Failed"
+            };
+        }
+
+        // Phase 2: Write PMTiles archive
+        current = current with { CurrentPhase = "Writing PMTiles archive" };
+        await _progressStore.SetProgressAsync(current.JobId, current, TimeSpan.FromHours(24), cancellationToken).ConfigureAwait(false);
+
+        var bbox = request.Bbox is { Length: 4 }
+            ? request.Bbox
+            : [-180d, -SpatialConstants.WebMercatorMaxLatitude, 180d, SpatialConstants.WebMercatorMaxLatitude];
+
+        var minZoom = Math.Clamp(request.MinZoom ?? _tileLimits.MinTileZoom, _tileLimits.MinTileZoom, _tileLimits.MaxTileZoom);
+        var maxZoom = Math.Clamp(request.MaxZoom ?? minZoom, minZoom, _tileLimits.MaxTileZoom);
+
+        var metadata = new PMTilesArchiveMetadata
+        {
+            MinLon = Math.Min(bbox[0], bbox[2]),
+            MinLat = Math.Min(bbox[1], bbox[3]),
+            MaxLon = Math.Max(bbox[0], bbox[2]),
+            MaxLat = Math.Max(bbox[1], bbox[3]),
+            MinZoom = minZoom,
+            MaxZoom = maxZoom
+        };
+
+        using var archiveStream = new MemoryStream();
+        var archiveSize = await writer.WriteAsync(archiveStream, metadata, cancellationToken).ConfigureAwait(false);
+        archiveStream.Position = 0;
+
+        // Phase 3: Upload archive
+        current = current with { CurrentPhase = "Uploading archive" };
+        await _progressStore.SetProgressAsync(current.JobId, current, TimeSpan.FromHours(24), cancellationToken).ConfigureAwait(false);
+
+        var cloudStorage = serviceProvider.GetService<ICloudFileStorage>();
+        if (cloudStorage == null)
+        {
+            return current with
+            {
+                ProcessedTiles = processed,
+                SuccessfulTiles = successful,
+                FailedTiles = failed,
+                ArchiveSizeBytes = archiveSize,
+                Status = OperationStatus.Failed,
+                CompletedAt = DateTimeOffset.UtcNow,
+                Warnings = warningList.ToArray(),
+                ErrorMessage = "Cloud storage is not configured. Archive operations require cloud storage.",
+                CurrentPhase = "Failed"
+            };
+        }
+
+        var uploadResult = await cloudStorage.UploadAsync(new FileUploadRequest
+        {
+            Content = archiveStream,
+            FileName = $"{current.JobId}.pmtiles",
+            ContentType = "application/vnd.pmtiles",
+            SizeBytes = archiveSize,
+            TimeToLive = TimeSpan.FromHours(24),
+            Folder = "pmtiles",
+            Metadata = ImmutableDictionary<string, string>.Empty
+                .Add("jobId", current.JobId)
+                .Add("operation", "archive")
+        }, cancellationToken).ConfigureAwait(false);
+
+        if (!uploadResult.Success)
+        {
+            return current with
+            {
+                ProcessedTiles = processed,
+                SuccessfulTiles = successful,
+                FailedTiles = failed,
+                ArchiveSizeBytes = archiveSize,
+                Status = OperationStatus.Failed,
+                CompletedAt = DateTimeOffset.UtcNow,
+                Warnings = warningList.ToArray(),
+                ErrorMessage = $"Archive upload failed: {uploadResult.ErrorMessage ?? "unknown error"}.",
+                CurrentPhase = "Failed"
+            };
+        }
+
+        var archiveFileId = uploadResult.File?.FileId;
+        if (string.IsNullOrWhiteSpace(archiveFileId))
+        {
+            return current with
+            {
+                ProcessedTiles = processed,
+                SuccessfulTiles = successful,
+                FailedTiles = failed,
+                ArchiveSizeBytes = archiveSize,
+                Status = OperationStatus.Failed,
+                CompletedAt = DateTimeOffset.UtcNow,
+                Warnings = warningList.ToArray(),
+                ErrorMessage = "Archive upload succeeded but returned no file ID.",
+                CurrentPhase = "Failed"
+            };
+        }
+
+        var downloadUrl = await cloudStorage.GetPresignedUrlAsync(
+            archiveFileId,
+            TimeSpan.FromHours(24),
+            cancellationToken).ConfigureAwait(false);
+
+        TileOperationMetrics.ArchivesGenerated.Add(1);
+        TileOperationMetrics.ArchiveSizeBytes.Record(archiveSize);
+
+        var completedStatus = failed > 0 ? OperationStatus.Failed : OperationStatus.Completed;
+        return current with
+        {
+            ProcessedTiles = processed,
+            SuccessfulTiles = successful,
+            FailedTiles = failed,
+            ArchiveSizeBytes = archiveSize,
+            ArchiveFileId = archiveFileId,
+            DownloadUrl = downloadUrl,
+            Status = completedStatus,
+            CompletedAt = DateTimeOffset.UtcNow,
+            Warnings = warningList.ToArray(),
+            ErrorMessage = failed > 0 ? $"{failed} tiles failed during generation." : null,
+            CurrentPhase = failed > 0 ? "Archive completed with failures" : "Archive generation completed"
+        };
+    }
+
     private static async Task<IReadOnlyList<int>> ResolveLayerIdsAsync(
         TileOperationStartRequest request,
         ILayerCatalog layerCatalog,
@@ -441,7 +666,7 @@ internal sealed partial class TileOperationJobService(
 
         var bbox = request.Bbox is { Length: 4 }
             ? request.Bbox
-            : [-180d, -85.05112878d, 180d, 85.05112878d];
+            : [-180d, -SpatialConstants.WebMercatorMaxLatitude, 180d, SpatialConstants.WebMercatorMaxLatitude];
 
         var minLon = Math.Min(bbox[0], bbox[2]);
         var maxLon = Math.Max(bbox[0], bbox[2]);
@@ -482,7 +707,7 @@ internal sealed partial class TileOperationJobService(
 
     private static int LatToTileY(double lat, int z, int n)
     {
-        var clampedLat = Math.Clamp(lat, -85.05112878d, 85.05112878d);
+        var clampedLat = Math.Clamp(lat, -SpatialConstants.WebMercatorMaxLatitude, SpatialConstants.WebMercatorMaxLatitude);
         var latRad = clampedLat * Math.PI / 180d;
         var y = (int)Math.Floor(
             (1d - Math.Log(Math.Tan(latRad) + (1d / Math.Cos(latRad))) / Math.PI) / 2d * n);
@@ -492,9 +717,9 @@ internal sealed partial class TileOperationJobService(
     private static TileOperationStartRequest NormalizeRequest(TileOperationStartRequest request)
     {
         var operation = request.Operation.Trim().ToLowerInvariant();
-        if (operation is not ("seed" or "warm" or "invalidate" or "purge"))
+        if (operation is not ("seed" or "warm" or "invalidate" or "purge" or "archive"))
         {
-            throw new ArgumentException("Operation must be one of: seed, warm, invalidate, purge.", nameof(request));
+            throw new ArgumentException("Operation must be one of: seed, warm, invalidate, purge, archive.", nameof(request));
         }
 
         return request with
@@ -596,7 +821,9 @@ internal sealed partial class TileOperationJobService(
 
     private async Task<IReadOnlyList<string>> RecoverQueuedJobIdsAsync(CancellationToken cancellationToken)
     {
-        var activeOperationIds = await _progressStore.GetActiveOperationIdsAsync(OperationType.TileCache, cancellationToken).ConfigureAwait(false);
+        var tileCacheIds = await _progressStore.GetActiveOperationIdsAsync(OperationType.TileCache, cancellationToken).ConfigureAwait(false);
+        var archiveIds = await _progressStore.GetActiveOperationIdsAsync(OperationType.PMTilesArchive, cancellationToken).ConfigureAwait(false);
+        var activeOperationIds = tileCacheIds.Concat(archiveIds).Distinct().ToList();
         var recovered = new List<string>(activeOperationIds.Count);
 
         foreach (var jobId in activeOperationIds)

--- a/src/Honua.Server/Features/Admin/TileOperations/TileOperationMetrics.cs
+++ b/src/Honua.Server/Features/Admin/TileOperations/TileOperationMetrics.cs
@@ -30,5 +30,15 @@ internal static class TileOperationMetrics
         "honua.tile.jobs.tiles_processed",
         "tiles",
         "Number of tiles processed by tile jobs.");
+
+    public static readonly Counter<long> ArchivesGenerated = HonuaTelemetry.Meter.CreateCounter<long>(
+        "honua.tile.archives.total",
+        "archives",
+        "Number of PMTiles archives generated.");
+
+    public static readonly Histogram<double> ArchiveSizeBytes = HonuaTelemetry.Meter.CreateHistogram<double>(
+        "honua.tile.archives.size_bytes",
+        "bytes",
+        "Size of generated PMTiles archives.");
 }
 

--- a/src/Honua.Server/Features/Admin/TileOperations/TileOperationsEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/TileOperations/TileOperationsEndpoints.cs
@@ -18,13 +18,13 @@ internal static class TileOperationsEndpoints
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Admin", "Tile Operations")
-            .WithDescription("Tile cache seed/warm/invalidate/purge job control")
+            .WithDescription("Tile cache seed/warm/invalidate/purge/archive job control")
             .RequireAdminAuthorization();
 
         _ = group.Map("/jobs", HandleStartJob)
             .WithName("StartTileOperationJob")
             .WithSummary("Start a tile operation job")
-            .WithDescription("Queues a tile operation (seed, warm, invalidate, purge) for asynchronous execution")
+            .WithDescription("Queues a tile operation (seed, warm, invalidate, purge, archive) for asynchronous execution")
             .WithMetadata(new HttpMethodMetadata([HttpMethods.Post]));
 
         _ = group.Map("/jobs/{jobId}", HandleGetJobStatus)
@@ -208,6 +208,17 @@ internal static class TileOperationsEndpoints
                     StatusCodes.Status400BadRequest,
                     ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
                     "Seed/warm operations require either 'layerId' or 'serviceId'."));
+            }
+        }
+
+        if (operation is "archive")
+        {
+            if (!request.LayerId.HasValue)
+            {
+                return Results.BadRequest(ProblemDetailsHelpers.CreateAdminProblem(
+                    StatusCodes.Status400BadRequest,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+                    "Archive operations require 'layerId'."));
             }
         }
 

--- a/src/Honua.Server/Features/Infrastructure/Progress/TileOperationProgress.cs
+++ b/src/Honua.Server/Features/Infrastructure/Progress/TileOperationProgress.cs
@@ -20,6 +20,9 @@ internal sealed record TileOperationProgress : IOperationProgress, ICancellableO
     public long ProcessedTiles { get; init; }
     public long SuccessfulTiles { get; init; }
     public long FailedTiles { get; init; }
+    public long ArchiveSizeBytes { get; init; }
+    public string? ArchiveFileId { get; init; }
+    public string? DownloadUrl { get; init; }
     public DateTimeOffset StartedAt { get; init; }
     public DateTimeOffset? CompletedAt { get; init; }
     public string? ErrorMessage { get; init; }
@@ -33,7 +36,7 @@ internal sealed record TileOperationProgress : IOperationProgress, ICancellableO
     public TimeSpan Duration => (CompletedAt ?? DateTimeOffset.UtcNow) - StartedAt;
 
     string IOperationProgress.OperationId => JobId;
-    OperationType IOperationProgress.Type => OperationType.TileCache;
+    OperationType IOperationProgress.Type => Operation == "archive" ? OperationType.PMTilesArchive : OperationType.TileCache;
 
     public IOperationProgress WithCancellation(DateTimeOffset completedAt, string? currentPhase)
         => this with

--- a/tests/Honua.Core.Tests/Features/Tiles/PMTiles/HilbertCurveTests.cs
+++ b/tests/Honua.Core.Tests/Features/Tiles/PMTiles/HilbertCurveTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Tiles.PMTiles;
+
+namespace Honua.Core.Tests.Features.Tiles.PMTiles;
+
+public class HilbertCurveTests
+{
+    [Fact]
+    public void XYZToTileId_Zoom0_Returns0()
+    {
+        HilbertCurve.XYZToTileId(0, 0, 0).Should().Be(0UL);
+    }
+
+    [Theory]
+    [InlineData(1, 0, 0, 1)]
+    [InlineData(1, 0, 1, 2)]
+    [InlineData(1, 1, 1, 3)]
+    [InlineData(1, 1, 0, 4)]
+    public void XYZToTileId_Zoom1_ReturnsExpectedIds(int z, int x, int y, ulong expectedId)
+    {
+        HilbertCurve.XYZToTileId(z, x, y).Should().Be(expectedId);
+    }
+
+    [Fact]
+    public void XYZToTileId_Zoom2_HasExpectedOffset()
+    {
+        // Zoom 2 starts at tile ID 5 (1 + 4 = 5)
+        var id = HilbertCurve.XYZToTileId(2, 0, 0);
+        id.Should().BeGreaterOrEqualTo(5UL);
+        id.Should().BeLessThan(5UL + 16UL); // 4^2 = 16 tiles at zoom 2
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0)]
+    [InlineData(1, 0, 0)]
+    [InlineData(1, 1, 1)]
+    [InlineData(2, 3, 3)]
+    [InlineData(3, 7, 7)]
+    [InlineData(5, 15, 20)]
+    [InlineData(10, 512, 512)]
+    public void RoundTrip_TileIdToXYZ_ReturnsOriginal(int z, int x, int y)
+    {
+        var tileId = HilbertCurve.XYZToTileId(z, x, y);
+        var (rz, rx, ry) = HilbertCurve.TileIdToXYZ(tileId);
+        rz.Should().Be(z);
+        rx.Should().Be(x);
+        ry.Should().Be(y);
+    }
+
+    [Fact]
+    public void XYZToTileId_DifferentCoordinates_ProduceDifferentIds()
+    {
+        var ids = new HashSet<ulong>();
+        for (var z = 0; z <= 3; z++)
+        {
+            var n = 1 << z;
+            for (var x = 0; x < n; x++)
+            {
+                for (var y = 0; y < n; y++)
+                {
+                    var id = HilbertCurve.XYZToTileId(z, x, y);
+                    ids.Add(id).Should().BeTrue($"tile ({z}/{x}/{y}) produced duplicate id {id}");
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void XYZToTileId_IdsAreContiguous()
+    {
+        // All tile IDs from zoom 0 through 3 should form a contiguous range 0..N
+        var ids = new List<ulong>();
+        for (var z = 0; z <= 3; z++)
+        {
+            var n = 1 << z;
+            for (var x = 0; x < n; x++)
+            {
+                for (var y = 0; y < n; y++)
+                {
+                    ids.Add(HilbertCurve.XYZToTileId(z, x, y));
+                }
+            }
+        }
+
+        ids.Sort();
+
+        // Total tiles: 1 + 4 + 16 + 64 = 85
+        ids.Should().HaveCount(85);
+        for (var i = 0; i < ids.Count; i++)
+        {
+            ids[i].Should().Be((ulong)i, $"tile at index {i} should have id {i}");
+        }
+    }
+}

--- a/tests/Honua.Core.Tests/Features/Tiles/PMTiles/PMTilesDirectoryTests.cs
+++ b/tests/Honua.Core.Tests/Features/Tiles/PMTiles/PMTilesDirectoryTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Tiles.PMTiles;
+
+namespace Honua.Core.Tests.Features.Tiles.PMTiles;
+
+public class PMTilesDirectoryTests
+{
+    [Fact]
+    public void SerializeDeserialize_SingleEntry_RoundTrips()
+    {
+        var entries = new PMTilesEntry[]
+        {
+            new(TileId: 0, Offset: 0, Length: 100, RunLength: 1)
+        };
+
+        var bytes = PMTilesDirectory.SerializeEntries(entries);
+        var result = PMTilesDirectory.DeserializeEntries(bytes);
+
+        result.Should().HaveCount(1);
+        result[0].TileId.Should().Be(0UL);
+        result[0].Offset.Should().Be(0UL);
+        result[0].Length.Should().Be(100U);
+        result[0].RunLength.Should().Be(1U);
+    }
+
+    [Fact]
+    public void SerializeDeserialize_ContiguousEntries_RoundTrips()
+    {
+        // Contiguous entries: each entry's offset == previous offset + previous length
+        var entries = new PMTilesEntry[]
+        {
+            new(TileId: 0, Offset: 0, Length: 100, RunLength: 1),
+            new(TileId: 1, Offset: 100, Length: 200, RunLength: 1),
+            new(TileId: 2, Offset: 300, Length: 150, RunLength: 1),
+        };
+
+        var bytes = PMTilesDirectory.SerializeEntries(entries);
+        var result = PMTilesDirectory.DeserializeEntries(bytes);
+
+        result.Should().HaveCount(3);
+        for (var i = 0; i < entries.Length; i++)
+        {
+            result[i].TileId.Should().Be(entries[i].TileId, $"TileId mismatch at index {i}");
+            result[i].Offset.Should().Be(entries[i].Offset, $"Offset mismatch at index {i}");
+            result[i].Length.Should().Be(entries[i].Length, $"Length mismatch at index {i}");
+            result[i].RunLength.Should().Be(entries[i].RunLength, $"RunLength mismatch at index {i}");
+        }
+    }
+
+    [Fact]
+    public void SerializeDeserialize_NonContiguousEntries_RoundTrips()
+    {
+        // Non-contiguous: gaps between entries
+        var entries = new PMTilesEntry[]
+        {
+            new(TileId: 0, Offset: 0, Length: 100, RunLength: 1),
+            new(TileId: 5, Offset: 500, Length: 200, RunLength: 1),
+            new(TileId: 10, Offset: 1000, Length: 150, RunLength: 1),
+        };
+
+        var bytes = PMTilesDirectory.SerializeEntries(entries);
+        var result = PMTilesDirectory.DeserializeEntries(bytes);
+
+        result.Should().HaveCount(3);
+        for (var i = 0; i < entries.Length; i++)
+        {
+            result[i].TileId.Should().Be(entries[i].TileId, $"TileId mismatch at index {i}");
+            result[i].Offset.Should().Be(entries[i].Offset, $"Offset mismatch at index {i}");
+            result[i].Length.Should().Be(entries[i].Length, $"Length mismatch at index {i}");
+            result[i].RunLength.Should().Be(entries[i].RunLength, $"RunLength mismatch at index {i}");
+        }
+    }
+
+    [Fact]
+    public void SerializeDeserialize_ContiguousOffsets_EncodedAsZero()
+    {
+        // Verify that contiguous offsets produce compact encoding (varint 0)
+        var entries = new PMTilesEntry[]
+        {
+            new(TileId: 0, Offset: 0, Length: 50, RunLength: 1),
+            new(TileId: 1, Offset: 50, Length: 50, RunLength: 1),
+        };
+
+        var bytes = PMTilesDirectory.SerializeEntries(entries);
+
+        // The serialized bytes should contain varint 0 for the second offset
+        // because offset 50 == previous offset (0) + previous length (50)
+        var result = PMTilesDirectory.DeserializeEntries(bytes);
+        result[0].Offset.Should().Be(0UL);
+        result[1].Offset.Should().Be(50UL);
+    }
+
+    [Fact]
+    public void SerializeDeserialize_LeafEntries_RoundTrips()
+    {
+        // Leaf entries have RunLength=0
+        var entries = new PMTilesEntry[]
+        {
+            new(TileId: 0, Offset: 0, Length: 512, RunLength: 0),
+            new(TileId: 100, Offset: 512, Length: 256, RunLength: 0),
+        };
+
+        var bytes = PMTilesDirectory.SerializeEntries(entries);
+        var result = PMTilesDirectory.DeserializeEntries(bytes);
+
+        result.Should().HaveCount(2);
+        result[0].RunLength.Should().Be(0U);
+        result[0].IsLeaf.Should().BeTrue();
+        result[1].RunLength.Should().Be(0U);
+        result[1].IsLeaf.Should().BeTrue();
+        result[0].Offset.Should().Be(0UL);
+        result[1].Offset.Should().Be(512UL);
+    }
+
+    [Fact]
+    public void SerializeEntries_IncludesNumEntriesPrefix()
+    {
+        var entries = new PMTilesEntry[]
+        {
+            new(TileId: 42, Offset: 0, Length: 100, RunLength: 1)
+        };
+
+        var bytes = PMTilesDirectory.SerializeEntries(entries);
+
+        // First byte should be the varint-encoded number of entries (1)
+        bytes[0].Should().Be(1, "first byte should be num_entries varint for 1 entry");
+    }
+
+    [Fact]
+    public void SerializeEntries_ManyEntries_NumEntriesPrefixIsCorrect()
+    {
+        var entries = new PMTilesEntry[200];
+        for (var i = 0; i < 200; i++)
+        {
+            entries[i] = new PMTilesEntry(
+                TileId: (ulong)i,
+                Offset: (ulong)(i * 100),
+                Length: 100,
+                RunLength: 1);
+        }
+
+        var bytes = PMTilesDirectory.SerializeEntries(entries);
+        var result = PMTilesDirectory.DeserializeEntries(bytes);
+
+        result.Should().HaveCount(200);
+
+        // Verify first and last entries
+        result[0].TileId.Should().Be(0UL);
+        result[199].TileId.Should().Be(199UL);
+    }
+
+    [Fact]
+    public async Task WriteAsync_DirectoryEntriesLocateTileData()
+    {
+        // End-to-end test: write an archive, parse directory, use entries to read tiles
+        var tile0 = new byte[] { 1, 2, 3, 4, 5 };
+        var tile1 = new byte[] { 10, 20, 30, 40, 50, 60 };
+        var tile2 = new byte[] { 100, 200 };
+
+        var writer = new PMTilesWriter(PMTilesCompression.None, PMTilesCompression.None);
+        writer.AddTile(0, 0, 0, tile0);
+        writer.AddTile(1, 0, 0, tile1);
+        writer.AddTile(1, 1, 0, tile2);
+
+        var metadata = new PMTilesArchiveMetadata
+        {
+            MinLon = -180,
+            MinLat = -85,
+            MaxLon = 180,
+            MaxLat = 85,
+            MinZoom = 0,
+            MaxZoom = 1
+        };
+
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(stream, metadata);
+        var archiveBytes = stream.ToArray();
+
+        // Parse header
+        var header = PMTilesHeader.ReadFrom(archiveBytes);
+
+        // Read and decompress root directory
+        var rootDirBytes = archiveBytes.AsSpan(
+            (int)header.RootDirectoryOffset,
+            (int)header.RootDirectoryLength).ToArray();
+        var decompressedDir = PMTilesDirectory.Decompress(rootDirBytes, header.InternalCompression);
+        var entries = PMTilesDirectory.DeserializeEntries(decompressedDir);
+
+        entries.Should().HaveCount(3);
+
+        // Verify each entry can locate its tile data
+        var expectedTiles = new[] { tile0, tile1, tile2 };
+        // Entries are sorted by Hilbert tile ID
+        var sortedTileIds = new[]
+        {
+            HilbertCurve.XYZToTileId(0, 0, 0),
+            HilbertCurve.XYZToTileId(1, 0, 0),
+            HilbertCurve.XYZToTileId(1, 1, 0),
+        };
+        Array.Sort(sortedTileIds);
+
+        for (var i = 0; i < entries.Length; i++)
+        {
+            entries[i].TileId.Should().Be(sortedTileIds[i]);
+
+            var tileOffset = (int)(header.TileDataOffset + entries[i].Offset);
+            var tileLength = (int)entries[i].Length;
+            var tileData = archiveBytes.AsSpan(tileOffset, tileLength).ToArray();
+
+            // Find expected tile by matching length (each test tile has unique length)
+            var expectedTile = expectedTiles.First(t => t.Length == tileLength);
+            tileData.Should().BeEquivalentTo(expectedTile,
+                $"tile at entry {i} (tileId={entries[i].TileId}) should match expected data");
+        }
+    }
+}

--- a/tests/Honua.Core.Tests/Features/Tiles/PMTiles/PMTilesWriterTests.cs
+++ b/tests/Honua.Core.Tests/Features/Tiles/PMTiles/PMTilesWriterTests.cs
@@ -1,0 +1,263 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Tiles.PMTiles;
+
+namespace Honua.Core.Tests.Features.Tiles.PMTiles;
+
+public class PMTilesWriterTests
+{
+    private static readonly PMTilesArchiveMetadata DefaultMetadata = new()
+    {
+        MinLon = -180,
+        MinLat = -85,
+        MaxLon = 180,
+        MaxLat = 85,
+        MinZoom = 0,
+        MaxZoom = 2
+    };
+
+    [Fact]
+    public async Task WriteAsync_SingleTile_ProducesValidArchive()
+    {
+        var writer = new PMTilesWriter(PMTilesCompression.None, PMTilesCompression.None);
+        writer.AddTile(0, 0, 0, CreateFakeTileData(100));
+
+        using var stream = new MemoryStream();
+        var bytesWritten = await writer.WriteAsync(stream, DefaultMetadata);
+
+        bytesWritten.Should().BeGreaterThan(PMTilesHeader.HeaderSize);
+        stream.Position = 0;
+
+        // Validate header
+        var headerBytes = new byte[PMTilesHeader.HeaderSize];
+        await stream.ReadExactlyAsync(headerBytes);
+        var header = PMTilesHeader.ReadFrom(headerBytes);
+
+        header.AddressedTilesCount.Should().Be(1);
+        header.TileEntriesCount.Should().Be(1);
+        header.TileType.Should().Be(PMTilesTileType.Mvt);
+        header.MinZoom.Should().Be(0);
+        header.MaxZoom.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task WriteAsync_MultipleTilesMultipleZooms_ProducesValidArchive()
+    {
+        var writer = new PMTilesWriter(PMTilesCompression.None, PMTilesCompression.None);
+        writer.AddTile(0, 0, 0, CreateFakeTileData(50));
+        writer.AddTile(1, 0, 0, CreateFakeTileData(60));
+        writer.AddTile(1, 1, 0, CreateFakeTileData(70));
+        writer.AddTile(1, 0, 1, CreateFakeTileData(80));
+        writer.AddTile(1, 1, 1, CreateFakeTileData(90));
+
+        using var stream = new MemoryStream();
+        var bytesWritten = await writer.WriteAsync(stream, DefaultMetadata);
+
+        stream.Position = 0;
+        var headerBytes = new byte[PMTilesHeader.HeaderSize];
+        await stream.ReadExactlyAsync(headerBytes);
+        var header = PMTilesHeader.ReadFrom(headerBytes);
+
+        header.AddressedTilesCount.Should().Be(5);
+        header.TileEntriesCount.Should().Be(5);
+        header.Clustered.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task WriteAsync_EmptyTiles_AreSkipped()
+    {
+        var writer = new PMTilesWriter(PMTilesCompression.None, PMTilesCompression.None);
+        writer.AddTile(0, 0, 0, []);
+        writer.AddTile(1, 0, 0, CreateFakeTileData(50));
+
+        writer.TileCount.Should().Be(1);
+
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(stream, DefaultMetadata);
+
+        stream.Position = 0;
+        var headerBytes = new byte[PMTilesHeader.HeaderSize];
+        await stream.ReadExactlyAsync(headerBytes);
+        var header = PMTilesHeader.ReadFrom(headerBytes);
+
+        header.AddressedTilesCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task WriteAsync_WithGzipCompression_SetsHeaderCorrectly()
+    {
+        var writer = new PMTilesWriter(PMTilesCompression.Gzip, PMTilesCompression.Gzip);
+        writer.AddTile(0, 0, 0, CreateFakeTileData(100));
+
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(stream, DefaultMetadata);
+
+        stream.Position = 0;
+        var headerBytes = new byte[PMTilesHeader.HeaderSize];
+        await stream.ReadExactlyAsync(headerBytes);
+        var header = PMTilesHeader.ReadFrom(headerBytes);
+
+        header.TileCompression.Should().Be(PMTilesCompression.Gzip);
+        header.InternalCompression.Should().Be(PMTilesCompression.Gzip);
+    }
+
+    [Fact]
+    public async Task WriteAsync_MagicBytesAreCorrect()
+    {
+        var writer = new PMTilesWriter(PMTilesCompression.None, PMTilesCompression.None);
+        writer.AddTile(0, 0, 0, CreateFakeTileData(50));
+
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(stream, DefaultMetadata);
+
+        stream.Position = 0;
+        var magic = new byte[7];
+        await stream.ReadExactlyAsync(magic);
+
+        magic.Should().BeEquivalentTo("PMTiles"u8.ToArray());
+    }
+
+    [Fact]
+    public async Task WriteAsync_VersionIs3()
+    {
+        var writer = new PMTilesWriter(PMTilesCompression.None, PMTilesCompression.None);
+        writer.AddTile(0, 0, 0, CreateFakeTileData(50));
+
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(stream, DefaultMetadata);
+
+        stream.Position = 7;
+        var version = stream.ReadByte();
+
+        version.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task WriteAsync_BoundsAreEncodedAsE7()
+    {
+        var metadata = new PMTilesArchiveMetadata
+        {
+            MinLon = -122.5,
+            MinLat = 37.5,
+            MaxLon = -121.5,
+            MaxLat = 38.5,
+            MinZoom = 5,
+            MaxZoom = 10
+        };
+
+        var writer = new PMTilesWriter(PMTilesCompression.None, PMTilesCompression.None);
+        writer.AddTile(5, 5, 12, CreateFakeTileData(50));
+
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(stream, metadata);
+
+        stream.Position = 0;
+        var headerBytes = new byte[PMTilesHeader.HeaderSize];
+        await stream.ReadExactlyAsync(headerBytes);
+        var header = PMTilesHeader.ReadFrom(headerBytes);
+
+        header.MinLonE7.Should().Be(-1_225_000_000);
+        header.MinLatE7.Should().Be(375_000_000);
+        header.MaxLonE7.Should().Be(-1_215_000_000);
+        header.MaxLatE7.Should().Be(385_000_000);
+        header.MinZoom.Should().Be(5);
+        header.MaxZoom.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task WriteAsync_TileDataIsRetrievable()
+    {
+        var tileData = CreateFakeTileData(200);
+        var writer = new PMTilesWriter(PMTilesCompression.None, PMTilesCompression.None);
+        writer.AddTile(0, 0, 0, tileData);
+
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(stream, DefaultMetadata);
+
+        stream.Position = 0;
+        var headerBytes = new byte[PMTilesHeader.HeaderSize];
+        await stream.ReadExactlyAsync(headerBytes);
+        var header = PMTilesHeader.ReadFrom(headerBytes);
+
+        // Read tile data from the archive
+        stream.Position = (long)header.TileDataOffset;
+        var retrievedTile = new byte[tileData.Length];
+        await stream.ReadExactlyAsync(retrievedTile);
+
+        retrievedTile.Should().BeEquivalentTo(tileData);
+    }
+
+    [Fact]
+    public async Task WriteAsync_LayoutIsHeaderRootMetadataLeafData()
+    {
+        var writer = new PMTilesWriter(PMTilesCompression.None, PMTilesCompression.None);
+        writer.AddTile(0, 0, 0, CreateFakeTileData(50));
+
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(stream, DefaultMetadata);
+
+        stream.Position = 0;
+        var headerBytes = new byte[PMTilesHeader.HeaderSize];
+        await stream.ReadExactlyAsync(headerBytes);
+        var header = PMTilesHeader.ReadFrom(headerBytes);
+
+        // Root directory follows header
+        header.RootDirectoryOffset.Should().Be((ulong)PMTilesHeader.HeaderSize);
+
+        // JSON metadata follows root directory
+        header.JsonMetadataOffset.Should().Be(header.RootDirectoryOffset + header.RootDirectoryLength);
+
+        // Leaf directory follows JSON metadata
+        header.LeafDirectoryOffset.Should().Be(header.JsonMetadataOffset + header.JsonMetadataLength);
+
+        // Tile data follows leaf directory
+        header.TileDataOffset.Should().Be(header.LeafDirectoryOffset + header.LeafDirectoryLength);
+    }
+
+    [Fact]
+    public async Task WriteAsync_CancellationToken_Throws()
+    {
+        var writer = new PMTilesWriter();
+        writer.AddTile(0, 0, 0, CreateFakeTileData(50));
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        using var stream = new MemoryStream();
+        var act = () => writer.WriteAsync(stream, DefaultMetadata, cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void AddTile_NullData_ThrowsArgumentNullException()
+    {
+        var writer = new PMTilesWriter();
+        var act = () => writer.AddTile(0, 0, 0, null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void TileCount_ReflectsAddedTiles()
+    {
+        var writer = new PMTilesWriter();
+        writer.TileCount.Should().Be(0);
+
+        writer.AddTile(0, 0, 0, CreateFakeTileData(10));
+        writer.TileCount.Should().Be(1);
+
+        writer.AddTile(1, 0, 0, CreateFakeTileData(10));
+        writer.TileCount.Should().Be(2);
+    }
+
+    private static byte[] CreateFakeTileData(int size)
+    {
+        var data = new byte[size];
+        Random.Shared.NextBytes(data);
+        // Ensure first and last bytes are nonzero for unique hash behavior
+        data[0] = (byte)(data[0] | 1);
+        data[^1] = (byte)(data[^1] | 1);
+        return data;
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Admin/PMTilesArchiveEndpointTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/PMTilesArchiveEndpointTests.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Domain;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+[Collection("Database")]
+[Protocol(Protocols.Admin)]
+[Operation(Operations.Tile)]
+public sealed class PMTilesArchiveEndpointTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/tile-operations/jobs")]
+    public async Task StartJob_ArchiveOperation_ReturnsAccepted()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/tile-operations/jobs", new
+        {
+            operation = "archive",
+            layerId = WebAppFixture.TestLayerId,
+            minZoom = 0,
+            maxZoom = 1
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        GetPropertyCaseInsensitive(json.RootElement, "jobId").GetString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/tile-operations/jobs")]
+    public async Task StartJob_ArchiveOperationWithoutLayer_ReturnsBadRequest()
+    {
+        var content = new StringContent(
+            """{"operation":"archive"}""",
+            System.Text.Encoding.UTF8,
+            "application/json");
+        var response = await _client.PostAsync("/api/v1/admin/tile-operations/jobs", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/tile-operations/jobs/{jobId}")]
+    public async Task GetJobStatus_ArchiveJob_ReturnsProgressWithArchiveFields()
+    {
+        var jobId = await StartArchiveJobAsync();
+        var (finalStatus, lastJson) = await WaitForJobCompletionAsync(jobId);
+
+        finalStatus.Should().NotBeNull("job should have completed within timeout");
+
+        var root = lastJson!.RootElement;
+        GetPropertyCaseInsensitive(root, "operation").GetString().Should().Be("archive");
+
+        var archiveSize = GetPropertyCaseInsensitive(root, "archiveSizeBytes").GetInt64();
+
+        if (finalStatus == OperationStatus.Completed)
+        {
+            archiveSize.Should().BeGreaterThan(0, "completed archive should have non-zero size");
+            GetPropertyCaseInsensitive(root, "archiveFileId").GetString().Should().NotBeNullOrWhiteSpace();
+        }
+
+        lastJson.Dispose();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/tile-operations/jobs")]
+    public async Task ListJobs_WithArchiveJob_IncludesArchiveInList()
+    {
+        await StartArchiveJobAsync();
+
+        var response = await _client.GetAsync("/api/v1/admin/tile-operations/jobs?activeOnly=false");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var jobs = GetPropertyCaseInsensitive(json.RootElement, "jobs");
+        jobs.ValueKind.Should().Be(JsonValueKind.Array);
+        jobs.GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/tile-operations/jobs/{jobId}")]
+    public async Task CompletedArchiveJob_ProducesValidPMTilesArchive()
+    {
+        var jobId = await StartArchiveJobAsync();
+        var (finalStatus, lastJson) = await WaitForJobCompletionAsync(jobId);
+
+        finalStatus.Should().Be(OperationStatus.Completed,
+            "archive job must complete successfully to validate the archive binary");
+
+        var root = lastJson!.RootElement;
+        var archiveFileId = GetPropertyCaseInsensitive(root, "archiveFileId").GetString();
+        archiveFileId.Should().NotBeNullOrWhiteSpace();
+        lastJson.Dispose();
+
+        // Download archive bytes from cloud storage
+        var cloudStorage = _fixture.GetOptionalService<ICloudFileStorage>();
+        cloudStorage.Should().NotBeNull("test host should register LocalFileStorage");
+
+        var archiveBytes = await cloudStorage!.DownloadBytesAsync(archiveFileId!);
+        archiveBytes.Should().NotBeNull("archive file should exist in storage");
+        archiveBytes!.Length.Should().BeGreaterThan(127,
+            "archive should be larger than just a header");
+
+        // Validate PMTiles v3 magic bytes and version
+        archiveBytes[..7].Should().BeEquivalentTo("PMTiles"u8.ToArray(),
+            "archive must start with PMTiles magic bytes");
+        archiveBytes[7].Should().Be(3, "archive must be PMTiles v3");
+
+        // Parse header fields at known offsets (PMTiles v3 binary layout)
+        var rootDirOffset = BitConverter.ToUInt64(archiveBytes, 8);
+        var rootDirLength = BitConverter.ToUInt64(archiveBytes, 16);
+        var jsonMetaOffset = BitConverter.ToUInt64(archiveBytes, 24);
+        var jsonMetaLength = BitConverter.ToUInt64(archiveBytes, 32);
+        var leafDirOffset = BitConverter.ToUInt64(archiveBytes, 40);
+        var leafDirLength = BitConverter.ToUInt64(archiveBytes, 48);
+        var tileDataOffset = BitConverter.ToUInt64(archiveBytes, 56);
+        var tileDataLength = BitConverter.ToUInt64(archiveBytes, 64);
+        var addressedTiles = BitConverter.ToUInt64(archiveBytes, 72);
+        var tileEntries = BitConverter.ToUInt64(archiveBytes, 80);
+        var clustered = archiveBytes[96];
+        var tileType = archiveBytes[99];
+
+        // Validate header semantics
+        tileType.Should().Be(1, "tile type should be MVT (1)");
+        addressedTiles.Should().BeGreaterThan(0, "archive should contain at least one tile");
+        tileEntries.Should().BeGreaterThan(0);
+        clustered.Should().Be(1, "archive should be clustered");
+
+        // Validate archive layout: sections must be contiguous
+        rootDirOffset.Should().Be(127, "root directory should start immediately after header");
+        jsonMetaOffset.Should().Be(rootDirOffset + rootDirLength);
+        leafDirOffset.Should().Be(jsonMetaOffset + jsonMetaLength);
+        tileDataOffset.Should().Be(leafDirOffset + leafDirLength);
+
+        // Validate total size matches archive byte length
+        var totalSize = tileDataOffset + tileDataLength;
+        ((ulong)archiveBytes.Length).Should().Be(totalSize,
+            "archive byte length must match header-declared total size");
+
+        // Validate tile data section is non-empty and within bounds
+        tileDataLength.Should().BeGreaterThan(0, "tile data section should not be empty");
+        (tileDataOffset + tileDataLength).Should().Be((ulong)archiveBytes.Length,
+            "tile data should extend to end of archive");
+    }
+
+    private async Task<string> StartArchiveJobAsync()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/tile-operations/jobs", new
+        {
+            operation = "archive",
+            layerId = WebAppFixture.TestLayerId,
+            minZoom = 0,
+            maxZoom = 1,
+            maxTiles = 5
+        });
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return GetPropertyCaseInsensitive(json.RootElement, "jobId").GetString()!;
+    }
+
+    private async Task<(OperationStatus? Status, JsonDocument? Json)> WaitForJobCompletionAsync(
+        string jobId,
+        int timeoutSeconds = 30)
+    {
+        var timeout = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        JsonDocument? lastJson = null;
+
+        while (DateTime.UtcNow < timeout)
+        {
+            var response = await _client.GetAsync($"/api/v1/admin/tile-operations/jobs/{jobId}");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            lastJson?.Dispose();
+            lastJson = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var status = (OperationStatus)GetPropertyCaseInsensitive(lastJson.RootElement, "status").GetInt32();
+
+            if (status is OperationStatus.Completed or OperationStatus.Failed)
+            {
+                return (status, lastJson);
+            }
+
+            await Task.Delay(200);
+        }
+
+        return (null, lastJson);
+    }
+
+    private static JsonElement GetPropertyCaseInsensitive(JsonElement element, string propertyName)
+    {
+        foreach (var property in element.EnumerateObject())
+        {
+            if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                return property.Value;
+            }
+        }
+
+        throw new KeyNotFoundException($"Property '{propertyName}' was not found.");
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #425

## Summary
Add PMTiles v3 archive generation as a new `archive` tile operation. Pure C# implementation (no third-party library), AOT-compatible. Tiles are fetched via the standard tile provider, sorted by Hilbert curve index, assembled into a spec-compliant PMTiles v3 binary, and uploaded to cloud storage with a presigned download URL.

## Changes Made
- Add `HilbertCurve` class for (z,x,y) ↔ PMTiles v3 Hilbert tile ID mapping with input validation (z ≤ 26)
- Add `PMTilesHeader` for 127-byte binary header read/write matching spec byte layout
- Add `PMTilesDirectory` for varint-encoded columnar directory serialization (absolute offset encoding, `num_entries` prefix, 10-byte varint limit)
- Add `PMTilesWriter` to collect tiles, build root/leaf directories, and write contiguous archive sections
- Add `PMTilesArchiveMetadata` record for bounds, zoom range, and attribution
- Add `"archive"` operation to `TileOperationJobService` with single-layer scoping
- Add `OperationType.PMTilesArchive` progress tracking with archive-specific fields (`archiveFileId`, `downloadUrl`, `archiveSizeBytes`)
- Add explicit failure when cloud storage is unavailable or upload returns no file ID
- Add endpoint validation requiring `layerId` for archive operations
- Add OpenTelemetry metrics: `honua.tile.archives.total`, `honua.tile.archives.size_bytes`
- Use `SpatialConstants.WebMercatorMaxLatitude` consistently (no magic numbers)
- Update `docs/devops/tile-operations-runbook.md` with archive operation examples, response fields, and validation instructions

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)

### Test details
- 20 `HilbertCurveTests` — round-trip, uniqueness, contiguity, known values, zoom-0 edge case
- 8 `PMTilesDirectoryTests` — serialize/deserialize round-trips (contiguous, non-contiguous, leaf entries), `num_entries` prefix, 200-entry scale test, end-to-end tile data location
- 7 `PMTilesWriterTests` — single/multi tile, empty skip, gzip compression, magic/version bytes, E7 bounds, layout validation, cancellation
- 5 `PMTilesArchiveEndpointTests` — start job returns 202, missing layer returns 400, job status with archive fields, list includes archive jobs, end-to-end binary validation (magic, version, header fields, contiguous layout, total size)

## Coverage Impact
- Line coverage: New code — PMTiles core library is fully covered by 35 unit tests
- Branch coverage: All error paths, edge cases, and compression modes tested

## Breaking Changes
None

## Additional Context
- PMTiles v3 spec reference: https://github.com/protomaps/PMTiles/blob/main/spec/v3/spec.md
- Directory offset encoding verified against protomaps reference Python serializer and TypeScript deserializer
- Archive layout: `[header 127B][root_dir][json_metadata][leaf_dirs][tile_data]`
- Archives stored with 24-hour TTL in cloud storage

---

## Pre-PR Checklist (for contributor)
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit message follows format: `type: description (#issue-number)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] Documentation updated if needed
- [ ] If protocol/auth behavior changed, updated MVP compatibility contract and release checklist notes
- [ ] If breaking admin/control-plane API changes: updated migration guide and versioning policy docs
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review and documented in migration guide

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed