### PR TITLE
fix: recover tile operation admin regressions (#425)

### DIFF
--- a/src/Honua.Server/Features/Admin/TileOperations/TileOperationJobService.cs
+++ b/src/Honua.Server/Features/Admin/TileOperations/TileOperationJobService.cs
@@ -17,6 +17,7 @@ using Honua.Core.Features.Shared.Models;
 using Honua.Core.Features.Tiles;
 using Honua.Core.Features.Tiles.PMTiles;
 using Honua.Server.Features.Infrastructure.Caching;
+using Honua.Server.Features.Infrastructure.Middleware;
 using Honua.Server.Features.Infrastructure.Progress;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Caching.Distributed;
@@ -26,7 +27,7 @@ namespace Honua.Server.Features.Admin.TileOperations;
 
 internal interface ITileOperationJobService
 {
-    Task<string> StartAsync(TileOperationStartRequest request, CancellationToken cancellationToken = default);
+    Task<string> StartAsync(TileOperationStartRequest request, string? schemaName = null, CancellationToken cancellationToken = default);
     Task<TileOperationProgress?> GetAsync(string jobId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<TileOperationProgress>> ListAsync(bool activeOnly, CancellationToken cancellationToken = default);
     Task<bool> CancelAsync(string jobId, CancellationToken cancellationToken = default);
@@ -65,15 +66,15 @@ internal sealed partial class TileOperationJobService(
             SingleWriter = false
         });
 
-    public async Task<string> StartAsync(TileOperationStartRequest request, CancellationToken cancellationToken = default)
+    public async Task<string> StartAsync(TileOperationStartRequest request, string? schemaName = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         PruneExpiredJobRequests();
 
         var normalized = NormalizeRequest(request);
         var jobId = Guid.NewGuid().ToString("N");
-        _jobRequests[jobId] = CreateCachedRequest(normalized);
-        await PersistJobRequestAsync(jobId, normalized, cancellationToken).ConfigureAwait(false);
+        _jobRequests[jobId] = CreateCachedRequest(normalized, schemaName);
+        await PersistJobRequestAsync(jobId, normalized, schemaName, cancellationToken).ConfigureAwait(false);
 
         var progress = TileOperationProgress.CreateInitial(
             jobId,
@@ -161,7 +162,7 @@ internal sealed partial class TileOperationJobService(
         }
 
         _jobRequests.TryRemove(jobId, out _);
-        return await StartAsync(originalRequest, cancellationToken).ConfigureAwait(false);
+        return await StartAsync(originalRequest.Value.Request, originalRequest.Value.SchemaName, cancellationToken).ConfigureAwait(false);
     }
 
     public async IAsyncEnumerable<string> ReadQueuedJobIdsAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -180,11 +181,13 @@ internal sealed partial class TileOperationJobService(
 
     public async Task ProcessQueuedJobAsync(string jobId, CancellationToken cancellationToken = default)
     {
-        var request = await TryGetActiveJobRequestAsync(jobId, cancellationToken).ConfigureAwait(false);
-        if (request == null)
+        var cachedRequest = await TryGetActiveJobRequestAsync(jobId, cancellationToken).ConfigureAwait(false);
+        if (cachedRequest == null)
         {
             return;
         }
+
+        var request = cachedRequest.Value.Request;
 
         TileOperationMetrics.QueueDepth.Add(-1, new TagList { { "operation", request.Operation } });
 
@@ -216,6 +219,12 @@ internal sealed partial class TileOperationJobService(
         try
         {
             using var scope = _serviceScopeFactory.CreateScope();
+            var schemaContext = scope.ServiceProvider.GetService<SchemaContext>();
+            if (!string.IsNullOrWhiteSpace(cachedRequest.Value.SchemaName) && schemaContext != null)
+            {
+                schemaContext.CurrentSchema = cachedRequest.Value.SchemaName;
+            }
+
             var layerCatalog = scope.ServiceProvider.GetRequiredService<ILayerCatalog>();
             var tileProvider = scope.ServiceProvider.GetRequiredService<ITileProvider>();
 
@@ -276,7 +285,7 @@ internal sealed partial class TileOperationJobService(
         else
         {
             RefreshJobRequestRetention(jobId);
-            await PersistJobRequestAsync(jobId, request, cancellationToken).ConfigureAwait(false);
+            await PersistJobRequestAsync(jobId, request, cachedRequest.Value.SchemaName, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -731,18 +740,18 @@ internal sealed partial class TileOperationJobService(
         };
     }
 
-    private static CachedTileOperationRequest CreateCachedRequest(TileOperationStartRequest request)
+    private static CachedTileOperationRequest CreateCachedRequest(TileOperationStartRequest request, string? schemaName)
     {
-        return new CachedTileOperationRequest(request, DateTimeOffset.UtcNow.Add(_jobRequestRetention));
+        return new CachedTileOperationRequest(request, schemaName, DateTimeOffset.UtcNow.Add(_jobRequestRetention));
     }
 
-    private async Task<TileOperationStartRequest?> TryGetActiveJobRequestAsync(string jobId, CancellationToken cancellationToken)
+    private async Task<CachedTileOperationRequest?> TryGetActiveJobRequestAsync(string jobId, CancellationToken cancellationToken)
     {
         if (_jobRequests.TryGetValue(jobId, out var cachedRequest))
         {
             if (cachedRequest.ExpiresAtUtc > DateTimeOffset.UtcNow)
             {
-                return cachedRequest.Request;
+                return cachedRequest;
             }
 
             _jobRequests.TryRemove(jobId, out _);
@@ -759,15 +768,16 @@ internal sealed partial class TileOperationJobService(
             return null;
         }
 
-        var request = JsonSerializer.Deserialize<TileOperationStartRequest>(json);
+        var request = JsonSerializer.Deserialize<PersistedTileOperationRequest>(json);
         if (request == null)
         {
             await RemovePersistedJobRequestAsync(jobId, cancellationToken).ConfigureAwait(false);
             return null;
         }
 
-        _jobRequests[jobId] = CreateCachedRequest(request);
-        return request;
+        var restoredRequest = CreateCachedRequest(request.Request, request.SchemaName);
+        _jobRequests[jobId] = restoredRequest;
+        return restoredRequest;
     }
 
     private void RefreshJobRequestRetention(string jobId)
@@ -778,7 +788,7 @@ internal sealed partial class TileOperationJobService(
             return;
         }
 
-        _jobRequests[jobId] = CreateCachedRequest(cachedRequest.Request);
+        _jobRequests[jobId] = CreateCachedRequest(cachedRequest.Request, cachedRequest.SchemaName);
     }
 
     private void PruneExpiredJobRequests()
@@ -793,14 +803,22 @@ internal sealed partial class TileOperationJobService(
         }
     }
 
-    private async Task PersistJobRequestAsync(string jobId, TileOperationStartRequest request, CancellationToken cancellationToken)
+    private async Task PersistJobRequestAsync(
+        string jobId,
+        TileOperationStartRequest request,
+        string? schemaName,
+        CancellationToken cancellationToken)
     {
         if (_requestCache == null)
         {
             return;
         }
 
-        var json = JsonSerializer.Serialize(request);
+        var json = JsonSerializer.Serialize(new PersistedTileOperationRequest
+        {
+            Request = request,
+            SchemaName = schemaName
+        });
         await _requestCache.SetStringAsync(
                 GetRequestCacheKey(jobId),
                 json,
@@ -862,7 +880,12 @@ internal sealed partial class TileOperationJobService(
     private static string GetRequestCacheKey(string jobId) => $"{RequestCacheKeyPrefix}{jobId}";
 
     private readonly record struct TileCoordinate(int Z, int X, int Y);
-    private readonly record struct CachedTileOperationRequest(TileOperationStartRequest Request, DateTimeOffset ExpiresAtUtc);
+    private readonly record struct CachedTileOperationRequest(TileOperationStartRequest Request, string? SchemaName, DateTimeOffset ExpiresAtUtc);
+    private sealed record PersistedTileOperationRequest
+    {
+        public required TileOperationStartRequest Request { get; init; }
+        public string? SchemaName { get; init; }
+    }
 
     [LoggerMessage(EventId = 9200, Level = LogLevel.Warning, Message = "Tile job {JobId} failed during {Operation}.")]
     private static partial void LogJobFailed(ILogger logger, string jobId, string operation, Exception exception);

--- a/src/Honua.Server/Features/Admin/TileOperations/TileOperationJobService.cs
+++ b/src/Honua.Server/Features/Admin/TileOperations/TileOperationJobService.cs
@@ -768,7 +768,7 @@ internal sealed partial class TileOperationJobService(
             return null;
         }
 
-        var request = JsonSerializer.Deserialize<PersistedTileOperationRequest>(json);
+        var request = TryDeserializePersistedJobRequest(json);
         if (request == null)
         {
             await RemovePersistedJobRequestAsync(jobId, cancellationToken).ConfigureAwait(false);
@@ -778,6 +778,39 @@ internal sealed partial class TileOperationJobService(
         var restoredRequest = CreateCachedRequest(request.Request, request.SchemaName);
         _jobRequests[jobId] = restoredRequest;
         return restoredRequest;
+    }
+
+    private static PersistedTileOperationRequest? TryDeserializePersistedJobRequest(string json)
+    {
+        try
+        {
+            var persistedRequest = JsonSerializer.Deserialize<PersistedTileOperationRequest>(json);
+            if (persistedRequest is { Request: not null })
+            {
+                return persistedRequest;
+            }
+        }
+        catch (JsonException)
+        {
+            // Older deployments stored TileOperationStartRequest directly in cache.
+        }
+
+        try
+        {
+            var legacyRequest = JsonSerializer.Deserialize<TileOperationStartRequest>(json);
+            if (legacyRequest != null)
+            {
+                return new PersistedTileOperationRequest
+                {
+                    Request = legacyRequest
+                };
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return null;
     }
 
     private void RefreshJobRequestRetention(string jobId)

--- a/src/Honua.Server/Features/Admin/TileOperations/TileOperationsEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/TileOperations/TileOperationsEndpoints.cs
@@ -4,6 +4,8 @@
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Models;
 using Honua.Server.Features.Infrastructure.Progress;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Honua.Server.Features.Admin.TileOperations;
 
@@ -21,52 +23,54 @@ internal static class TileOperationsEndpoints
             .WithDescription("Tile cache seed/warm/invalidate/purge/archive job control")
             .RequireAdminAuthorization();
 
-        _ = group.Map("/jobs", HandleStartJob)
+        _ = group.MapPost("/jobs", HandleStartJob)
             .WithName("StartTileOperationJob")
             .WithSummary("Start a tile operation job")
-            .WithDescription("Queues a tile operation (seed, warm, invalidate, purge, archive) for asynchronous execution")
-            .WithMetadata(new HttpMethodMetadata([HttpMethods.Post]));
+            .WithDescription("Queues a tile operation (seed, warm, invalidate, purge, archive) for asynchronous execution");
 
-        _ = group.Map("/jobs/{jobId}", HandleGetJobStatus)
+        _ = group.MapGet("/jobs/{jobId}", HandleGetJobStatus)
             .WithName("GetTileOperationJobStatus")
             .WithSummary("Get tile operation job status")
-            .WithDescription("Returns progress and status details for a tile operation job")
-            .WithMetadata(new HttpMethodMetadata([HttpMethods.Get]));
+            .WithDescription("Returns progress and status details for a tile operation job");
 
-        _ = group.Map("/jobs", HandleListJobs)
+        _ = group.MapGet("/jobs", HandleListJobs)
             .WithName("ListTileOperationJobs")
             .WithSummary("List tile operation jobs")
-            .WithDescription("Lists tile operation jobs, optionally including completed jobs")
-            .WithMetadata(new HttpMethodMetadata([HttpMethods.Get]));
+            .WithDescription("Lists tile operation jobs, optionally including completed jobs");
 
-        _ = group.Map("/jobs/{jobId}/cancel", HandleCancelJob)
+        _ = group.MapPost("/jobs/{jobId}/cancel", HandleCancelJob)
             .WithName("CancelTileOperationJob")
             .WithSummary("Cancel tile operation job")
-            .WithDescription("Attempts to cancel a queued or running tile operation job")
-            .WithMetadata(new HttpMethodMetadata([HttpMethods.Post]));
+            .WithDescription("Attempts to cancel a queued or running tile operation job");
 
-        _ = group.Map("/jobs/{jobId}/retry", HandleRetryJob)
+        _ = group.MapPost("/jobs/{jobId}/retry", HandleRetryJob)
             .WithName("RetryTileOperationJob")
             .WithSummary("Retry tile operation job")
-            .WithDescription("Queues a retry of a failed or cancelled tile operation job")
-            .WithMetadata(new HttpMethodMetadata([HttpMethods.Post]));
+            .WithDescription("Queues a retry of a failed or cancelled tile operation job");
     }
 
-    private static async Task<IResult> HandleStartJob(
+    private static async Task<Results<JsonHttpResult<TileOperationStartResponse>, JsonHttpResult<ProblemDetailsResponse>>> HandleStartJob(
         TileOperationStartRequest request,
         HttpContext context,
         ITileOperationJobService jobService,
         CancellationToken cancellationToken)
     {
-        var validationError = ValidateStartRequest(request);
+        var validationError = ValidateStartRequest(context, request);
         if (validationError != null)
         {
-            return validationError;
+            return TypedResults.Json(
+                validationError,
+                ProblemJsonContext.Default.ProblemDetailsResponse,
+                statusCode: StatusCodes.Status400BadRequest,
+                contentType: ProblemDetailsHelpers.ContentType);
         }
 
         try
         {
-            var jobId = await jobService.StartAsync(request, cancellationToken).ConfigureAwait(false);
+            var jobId = await jobService.StartAsync(
+                request,
+                context.RequestServices.GetService<ISchemaContext>()?.CurrentSchema,
+                cancellationToken).ConfigureAwait(false);
             var response = new TileOperationStartResponse
             {
                 JobId = jobId,
@@ -75,14 +79,18 @@ internal static class TileOperationsEndpoints
                 CancelUrl = $"/api/v1/admin/tile-operations/jobs/{jobId}/cancel"
             };
 
-            return Results.Json(
+            return TypedResults.Json(
                 response,
                 TileOperationsJsonContext.Default.TileOperationStartResponse,
                 statusCode: StatusCodes.Status202Accepted);
         }
         catch (ArgumentException ex)
         {
-            return StandardErrorHelpers.CreateBadRequest(context, ex.Message);
+            return TypedResults.Json(
+                ProblemDetailsHelpers.CreateAdminProblemDetails(context, StatusCodes.Status400BadRequest, ex.Message),
+                ProblemJsonContext.Default.ProblemDetailsResponse,
+                statusCode: StatusCodes.Status400BadRequest,
+                contentType: ProblemDetailsHelpers.ContentType);
         }
     }
 
@@ -173,30 +181,33 @@ internal static class TileOperationsEndpoints
             statusCode: StatusCodes.Status202Accepted);
     }
 
-    private static IResult? ValidateStartRequest(TileOperationStartRequest request)
+    private static ProblemDetailsResponse? ValidateStartRequest(HttpContext context, TileOperationStartRequest request)
     {
         if (string.IsNullOrWhiteSpace(request.Operation))
         {
-            return Results.BadRequest(ProblemDetailsHelpers.CreateAdminProblem(
+            return ProblemDetailsHelpers.CreateAdminProblemDetails(
+                context,
                 StatusCodes.Status400BadRequest,
                 ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
-                "Property 'operation' is required."));
+                "Property 'operation' is required.");
         }
 
         if (request.Bbox != null && request.Bbox.Length != 4)
         {
-            return Results.BadRequest(ProblemDetailsHelpers.CreateAdminProblem(
+            return ProblemDetailsHelpers.CreateAdminProblemDetails(
+                context,
                 StatusCodes.Status400BadRequest,
                 ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
-                "Property 'bbox' must contain exactly four values: [minLon, minLat, maxLon, maxLat]."));
+                "Property 'bbox' must contain exactly four values: [minLon, minLat, maxLon, maxLat].");
         }
 
         if (request.MinZoom.HasValue && request.MaxZoom.HasValue && request.MinZoom > request.MaxZoom)
         {
-            return Results.BadRequest(ProblemDetailsHelpers.CreateAdminProblem(
+            return ProblemDetailsHelpers.CreateAdminProblemDetails(
+                context,
                 StatusCodes.Status400BadRequest,
                 ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
-                "Property 'minZoom' must be less than or equal to 'maxZoom'."));
+                "Property 'minZoom' must be less than or equal to 'maxZoom'.");
         }
 
         var operation = request.Operation.Trim().ToLowerInvariant();
@@ -204,10 +215,11 @@ internal static class TileOperationsEndpoints
         {
             if (!request.LayerId.HasValue && string.IsNullOrWhiteSpace(request.ServiceId))
             {
-                return Results.BadRequest(ProblemDetailsHelpers.CreateAdminProblem(
+                return ProblemDetailsHelpers.CreateAdminProblemDetails(
+                    context,
                     StatusCodes.Status400BadRequest,
                     ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
-                    "Seed/warm operations require either 'layerId' or 'serviceId'."));
+                    "Seed/warm operations require either 'layerId' or 'serviceId'.");
             }
         }
 
@@ -215,10 +227,11 @@ internal static class TileOperationsEndpoints
         {
             if (!request.LayerId.HasValue)
             {
-                return Results.BadRequest(ProblemDetailsHelpers.CreateAdminProblem(
+                return ProblemDetailsHelpers.CreateAdminProblemDetails(
+                    context,
                     StatusCodes.Status400BadRequest,
                     ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
-                    "Archive operations require 'layerId'."));
+                    "Archive operations require 'layerId'.");
             }
         }
 

--- a/src/Honua.Server/Features/Infrastructure/Models/ProblemDetailsHelpers.cs
+++ b/src/Honua.Server/Features/Infrastructure/Models/ProblemDetailsHelpers.cs
@@ -26,6 +26,12 @@ internal static class ProblemDetailsHelpers
     public static IResult CreateAdminProblem(HttpContext context, int statusCode, string title, string detail)
         => CreateProblem(context, AdminType, statusCode, title, detail);
 
+    public static ProblemDetailsResponse CreateAdminProblemDetails(HttpContext context, int statusCode, string detail)
+        => CreateProblemDetails(AdminType, statusCode, GetTitle(statusCode), detail, BuildInstance(context), context);
+
+    public static ProblemDetailsResponse CreateAdminProblemDetails(HttpContext context, int statusCode, string title, string detail)
+        => CreateProblemDetails(AdminType, statusCode, title, detail, BuildInstance(context), context);
+
     public static IResult CreateAdminProblem(int statusCode, string title, string detail, string? instance = null)
         => CreateProblem(AdminType, statusCode, title, detail, instance);
 

--- a/tests/Honua.Server.Tests/Features/Admin/TileOperationJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/TileOperationJobServiceTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Text.Json;
 using FluentAssertions;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Catalog.Abstractions;
@@ -12,6 +13,7 @@ using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Core.Features.Tiles;
 using Honua.Server.Features.Admin.TileOperations;
 using Honua.Server.Features.Infrastructure.Caching;
+using Honua.Server.Features.Infrastructure.Progress;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
@@ -68,9 +70,72 @@ public sealed class TileOperationJobServiceTests
         retryJobId.Should().NotBe(failedJobId);
     }
 
+    [Fact]
+    public async Task RetryAsync_WithLegacyCachedRequestPayload_ReturnsNewJobId()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var progressStore = new InMemoryUniversalProgressStore();
+        var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        var sut = CreateSut(progressStore, serviceProvider.GetRequiredService<IServiceScopeFactory>(), cache);
+        const string jobId = "legacy-failed-job";
+
+        await cache.SetStringAsync(
+            $"tile:request:{jobId}",
+            JsonSerializer.Serialize(new TileOperationStartRequest
+            {
+                Operation = "seed",
+                LayerId = 1,
+                TileMatrixSetId = "UnsupportedSet"
+            }));
+
+        await progressStore.SetProgressAsync(
+            jobId,
+            TileOperationProgress.CreateInitial(jobId, "seed", null, 1, "UnsupportedSet") with
+            {
+                Status = OperationStatus.Failed,
+                CompletedAt = DateTimeOffset.UtcNow,
+                ErrorMessage = "Simulated failure"
+            });
+
+        var retryJobId = await sut.RetryAsync(jobId);
+
+        retryJobId.Should().NotBeNullOrWhiteSpace();
+        retryJobId.Should().NotBe(jobId);
+    }
+
+    [Fact]
+    public async Task ReadQueuedJobIdsAsync_WithLegacyCachedRequestPayload_RecoversQueuedJob()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var progressStore = new InMemoryUniversalProgressStore();
+        var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        var sut = CreateSut(progressStore, serviceProvider.GetRequiredService<IServiceScopeFactory>(), cache);
+        const string jobId = "legacy-queued-job";
+
+        await cache.SetStringAsync(
+            $"tile:request:{jobId}",
+            JsonSerializer.Serialize(new TileOperationStartRequest
+            {
+                Operation = "archive",
+                LayerId = 1,
+                TileMatrixSetId = "WebMercatorQuad"
+            }));
+
+        await progressStore.SetProgressAsync(
+            jobId,
+            TileOperationProgress.CreateInitial(jobId, "archive", null, 1, "WebMercatorQuad"));
+
+        await using var enumerator = sut.ReadQueuedJobIdsAsync().GetAsyncEnumerator();
+        var hasRecoveredJob = await enumerator.MoveNextAsync();
+
+        hasRecoveredJob.Should().BeTrue();
+        enumerator.Current.Should().Be(jobId);
+    }
+
     private static TileOperationJobService CreateSut(
         IUniversalProgressStore progressStore,
-        IServiceScopeFactory serviceScopeFactory)
+        IServiceScopeFactory serviceScopeFactory,
+        IDistributedCache? requestCache = null)
     {
         var cacheInvalidationService = new OutputCacheInvalidationService(
             cacheStore: null,
@@ -80,7 +145,7 @@ public sealed class TileOperationJobServiceTests
 
         return new TileOperationJobService(
             progressStore,
-            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            requestCache ?? new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
             cacheInvalidationService,
             serviceScopeFactory,
             Options.Create(new TileOptions()),


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #425

## Summary
Recover the tile-operation admin fixes that were missing after the PMTiles archive work landed.

## Changes Made
- restore explicit `MapPost` and `MapGet` registrations for tile-operation admin endpoints so the archive/start/status/list/cancel/retry routes bind to the intended verbs
- preserve and restore schema context for queued tile jobs by carrying `schemaName` through cached and persisted job requests
- return typed admin `ProblemDetailsResponse` payloads from tile-operation validation and bad-request paths

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)

## Coverage Impact
- Line coverage: Not measured locally for this regression fix
- Branch coverage: Not measured locally for this regression fix

## Breaking Changes
None

## Additional Context
Clean `origin/trunk` still fails the PMTiles admin regression slice:
- `StartJob_ArchiveOperationWithoutLayer_ReturnsBadRequest` returns `405` instead of `400`
- `CompletedArchiveJob_ProducesValidPMTilesArchive` ends in `Failed`

This branch turns that slice green again.

---

## Pre-PR Checklist (for contributor)
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit message follows format: `type: description (#issue-number)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] Documentation updated if needed
- [ ] If protocol/auth behavior changed, updated MVP compatibility contract and release checklist notes
- [ ] If breaking admin/control-plane API changes: updated migration guide and versioning policy docs
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review and documented in migration guide

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed
