### PR TITLE
feat: add GeoParquet feature query export (#424)

### DIFF
--- a/docs/contributor/RELEASE_CHECKLIST.md
+++ b/docs/contributor/RELEASE_CHECKLIST.md
@@ -16,6 +16,7 @@ Use this checklist for every MVP release.
 - [ ] Update [MVP Compatibility Contract](../user/MVP_COMPATIBILITY_CONTRACT.md)
 - [ ] Execute [Client Templates + Manual Smoke Runbook](../user/CLIENT_TEMPLATE_RUNBOOK.md)
 - [ ] Confirm supported/partial/unsupported protocol notes are current
+- [ ] Confirm newly added or removed public query/output formats are reflected in API examples and coverage matrices
 - [ ] Confirm replication limitations section reflects runtime behavior
 
 ### Tested Client Versions (Required)

--- a/docs/user/API_EXAMPLES.md
+++ b/docs/user/API_EXAMPLES.md
@@ -53,6 +53,11 @@ curl "http://localhost:8080/rest/services/1/FeatureServer/0/query?where=populati
 curl "http://localhost:8080/rest/services/1/FeatureServer/0/query?where=population%20%3E%2010000&outFields=*&f=fgb" --output features.fgb
 ```
 
+**GeoParquet output:**
+```bash
+curl "http://localhost:8080/rest/services/1/FeatureServer/0/query?where=population%20%3E%2010000&outFields=*&f=parquet" --output features.parquet
+```
+
 **Example response (trimmed):**
 ```json
 {

--- a/docs/user/MVP_COMPATIBILITY_CONTRACT.md
+++ b/docs/user/MVP_COMPATIBILITY_CONTRACT.md
@@ -7,7 +7,7 @@ Use this page first, then drill into the linked protocol matrices/spec docs.
 
 | Protocol | MVP status | Supported now | Partial / unsupported highlights | Deep reference |
 |---|---|---|---|---|
-| GeoServices REST FeatureServer | Supported with partial parity | Query, edits, attachments, related records, domains, replica endpoints, calculate, validateSQL, append | Advanced Esri operations remain partial/unsupported (query bins/top features, advanced SQL options, full offline parity) | [FeatureServer Coverage Matrix](feature-server-matrix.md) |
+| GeoServices REST FeatureServer | Supported with partial parity | Query, edits, attachments, related records, domains, replica endpoints, calculate, validateSQL, append, GeoParquet query export | Advanced Esri operations remain partial/unsupported (query bins/top features, advanced SQL options, full offline parity) | [FeatureServer Coverage Matrix](feature-server-matrix.md) |
 | GeoServices REST MapServer | Supported with partial parity | Export/identify/legend/find/query/tiles, WMS 1.3, WMTS 1.0 (KVP + RESTful) | WMTS scope limited to WebMercatorQuad; some Esri operations unsupported (generateKml) | [MapServer Coverage Matrix](map-server-matrix.md) |
 | GeoServices REST ImageServer | Supported | Service metadata, exportImage, identify, tile | Raster serving for ArcGIS image workflows | — |
 | GeoServices REST Geometry Service | Supported | Buffer, simplify, project, intersect, union, clip, difference, area, length | 9 geometry operations via PostGIS | [Geometry Service Coverage](specifications/geometry-service-coverage.md) |

--- a/docs/user/STANDARDS_APIS.md
+++ b/docs/user/STANDARDS_APIS.md
@@ -32,10 +32,15 @@ Honua exposes multiple industry-standard geospatial APIs. This page helps you ch
 |-- /applyEdits
 ```
 
+**Output formats:**
+- Metadata: `json`
+- Features: `json` (GeoServices), `geojson`, `pbf` (Protocol Buffers), `fgb` (FlatGeobuf), `geobuf` (when store supports native output), `parquet` (GeoParquet with WKB geometry)
+
 **Typical use cases:**
 - ArcGIS Pro connectivity
 - ArcGIS SDK clients
 - Legacy FeatureServer integrations
+- Analytics workflows (GeoParquet export)
 
 ---
 

--- a/docs/user/feature-server-matrix.md
+++ b/docs/user/feature-server-matrix.md
@@ -106,7 +106,7 @@ MapServer coverage is tracked separately:
 | Statistics | `outStatistics`, `groupByFieldsForStatistics` | Implemented | Aggregate queries with COUNT, SUM, MIN, MAX, AVG, STDDEV, VAR. Supports GROUP BY on any layer field. |
 | KNN output | `nearestCount`, `returnDistance` | Partial | `returnDistance` only affects KNN queries. |
 | Temporal | `time`, `timeRelation` | Implemented | Uses layer timeInfo or first temporal field. |
-| Output format | `f=json`, `f=geojson`, `f=pbf`, `f=fgb`, `f=geobuf` | Implemented | `f=fgb` and `f=geobuf` return binary payloads; `f=geobuf` requires a store with native GeoBuf support. |
+| Output format | `f=json`, `f=geojson`, `f=pbf`, `f=fgb`, `f=geobuf`, `f=parquet` | Implemented | `f=fgb`, `f=geobuf`, and `f=parquet` return binary payloads; `f=geobuf` requires a store with native GeoBuf support; `f=parquet` returns GeoParquet format with WKB-encoded geometry. |
 | Geometry precision | `geometryPrecision` | Implemented | Rounds coordinates to specified decimal places. |
 
 ### Not implemented (explicitly rejected)
@@ -194,7 +194,7 @@ MapServer coverage is tracked separately:
 | `spatialReference` | Implemented | From service definition. |
 | `initialExtent` / `fullExtent` | Implemented | From service effective extent. |
 | `maxRecordCount` | Implemented | From query limits. |
-| `supportedQueryFormats` | Implemented | Normalized to uppercase and augmented with runtime-supported binary formats (`PBF`, `FGB`, and `GEOBUF` when the backing store exposes native GeoBuf output). |
+| `supportedQueryFormats` | Implemented | Normalized to uppercase and augmented with runtime-supported binary formats (`PBF`, `FGB`, `PARQUET`, and `GEOBUF` when the backing store exposes native GeoBuf output). |
 | `supportsAdvancedQueries` | Implemented | From service definition. |
 | `supportsStatistics` | Implemented | Always true. |
 | `objectIdField` | Implemented | Resolved from layer primary keys or defaults to `objectid`. |
@@ -226,4 +226,4 @@ MapServer coverage is tracked separately:
 | `templates` | Implemented | Empty array (no feature templates configured). |
 | `timeInfo` | Implemented | Start/end time fields, time extent, track ID. |
 | `maxRecordCount` | Implemented | From query limits. |
-| `supportedQueryFormats` | Implemented | Normalized format list plus runtime-supported binary formats (`PBF`, `FGB`, and conditional `GEOBUF`). |
+| `supportedQueryFormats` | Implemented | Normalized format list plus runtime-supported binary formats (`PBF`, `FGB`, `PARQUET`, and conditional `GEOBUF`). |

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
@@ -493,7 +493,8 @@ internal sealed class FeatureServerQueryHandler(
             var isPbf = string.Equals(format, "pbf", StringComparison.OrdinalIgnoreCase);
             var isFgb = string.Equals(format, "fgb", StringComparison.OrdinalIgnoreCase);
             var isGeobuf = string.Equals(format, "geobuf", StringComparison.OrdinalIgnoreCase);
-            var useStreaming = effectiveLimit > StreamingThreshold && !isPbf && !isFgb && !isGeobuf;
+            var isParquet = string.Equals(format, "parquet", StringComparison.OrdinalIgnoreCase);
+            var useStreaming = effectiveLimit > StreamingThreshold && !isPbf && !isFgb && !isGeobuf && !isParquet;
 
             if (!useStreaming)
             {
@@ -572,7 +573,7 @@ internal sealed class FeatureServerQueryHandler(
                     result = ApplyPaginationWindow(result, query.Offset, query.Limit);
                 }
 
-                (object? formattedResponse, string? contentType) = _queryServices.FormatQueryResult(
+                (object? formattedResponse, string? contentType) = await _queryServices.FormatQueryResultAsync(
                     result,
                     layer,
                     format,
@@ -592,6 +593,13 @@ internal sealed class FeatureServerQueryHandler(
                     return await CreateCachedBytesResultAsync(
                         (byte[])formattedResponse!,
                         contentType ?? "application/x-protobuf");
+                }
+
+                if (isParquet)
+                {
+                    return await CreateCachedBytesResultAsync(
+                        (byte[])formattedResponse!,
+                        contentType ?? "application/vnd.apache.parquet");
                 }
 
                 return format.ToLowerInvariant() switch

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerUtilities.cs
@@ -203,7 +203,7 @@ internal static partial class FeatureServerEndpoints
     private static class SupportedFormats
     {
         public static readonly FrozenSet<string> Query =
-            new[] { "json", "pjson", "geojson", "pbf", "fgb", "geobuf" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+            new[] { "json", "pjson", "geojson", "pbf", "fgb", "geobuf", "parquet" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
         public static readonly FrozenSet<string> JsonOnly =
             new[] { "json", "pjson" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
@@ -641,6 +641,12 @@ internal static partial class FeatureServerEndpoints
                     mediaType.Equals("application/vnd.google.protobuf", StringComparison.OrdinalIgnoreCase))
                 {
                     format = "pbf";
+                    return true;
+                }
+
+                if (mediaType.Equals("application/vnd.apache.parquet", StringComparison.OrdinalIgnoreCase))
+                {
+                    format = "parquet";
                     return true;
                 }
 

--- a/src/Honua.Server/Features/FeatureServer/Services/FeatureServerQueryServices.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/FeatureServerQueryServices.cs
@@ -36,7 +36,7 @@ internal sealed class FeatureServerQueryServices(
         CancellationToken cancellationToken = default)
         => _spatialReferenceResolver.ResolveSridAsync(srValue, geometrySpatialReference, cancellationToken);
 
-    public (object? Response, string? ContentType) FormatQueryResult(
+    public ValueTask<(object Response, string ContentType)> FormatQueryResultAsync(
         QueryResult<Feature> result,
         LayerDefinition layer,
         string format,
@@ -47,7 +47,7 @@ internal sealed class FeatureServerQueryServices(
         int? geometryPrecision,
         double? maxAllowableOffset,
         string[]? outFields)
-        => _queryFormatter.FormatQueryResult(
+        => _queryFormatter.FormatQueryResultAsync(
             result,
             layer,
             format,

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -1,0 +1,660 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Shared.Models;
+using Honua.Server.Features.Infrastructure.Services;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using Parquet;
+using Parquet.Schema;
+using ParquetDataColumn = Parquet.Data.DataColumn;
+
+namespace Honua.Server.Features.FeatureServer.Services;
+
+/// <summary>
+/// Service for formatting query results as GeoParquet.
+/// </summary>
+internal sealed class GeoParquetQueryFormatter
+{
+    private const string GeometryColumnName = "geometry";
+    private const string GeoMetadataKey = "geo";
+
+    [ThreadStatic]
+    private static WKBReader? _wkbReader;
+
+    /// <summary>
+    /// Formats query result as GeoParquet.
+    /// </summary>
+    public static async Task<(byte[] response, string contentType)> FormatAsGeoParquetAsync(
+        QueryResult<Feature> result,
+        LayerDefinition layer,
+        bool returnGeometry,
+        int? outputSrid,
+        bool returnZ,
+        bool returnM,
+        GeometryLimits geometryLimits,
+        string[]? outFields = null,
+        CancellationToken cancellationToken = default)
+    {
+        var selectedFields = ResolveSelectedFields(layer, outFields);
+        var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
+        var schema = new ParquetSchema(BuildSchemaFields(selectedFields, returnGeometry && layer.HasGeometry));
+        var features = result.Items.ToList();
+
+        using var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream, cancellationToken: cancellationToken))
+        {
+            writer.CustomMetadata = BuildGeoParquetMetadata(layer, returnGeometry, outputSrid, returnZ);
+
+            using (var rowGroupWriter = writer.CreateRowGroup())
+            {
+                foreach (var column in BuildColumns(
+                    features,
+                    selectedFields,
+                    schema,
+                    objectIdFieldName,
+                    returnGeometry && layer.HasGeometry,
+                    outputSrid ?? layer.SpatialReference.Wkid,
+                    geometryLimits,
+                    returnZ,
+                    returnM))
+                {
+                    await rowGroupWriter.WriteColumnAsync(column, cancellationToken);
+                }
+            }
+        }
+
+        return (stream.ToArray(), "application/vnd.apache.parquet");
+    }
+
+    private static List<FieldDefinition> ResolveSelectedFields(LayerDefinition layer, string[]? outFields)
+    {
+        var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
+        var includeAllFields = outFields == null || outFields.Length == 0 ||
+            (outFields.Length == 1 && outFields[0].Equals("*", StringComparison.Ordinal));
+
+        HashSet<string>? requestedFields = null;
+        if (!includeAllFields)
+        {
+            requestedFields = new HashSet<string>(outFields!, StringComparer.OrdinalIgnoreCase)
+            {
+                objectIdFieldName
+            };
+        }
+
+        var selectedFields = layer.Fields
+            .Where(field => !field.IsGeometry)
+            .Where(field => includeAllFields || requestedFields!.Contains(field.Name))
+            .ToList();
+
+        if (!selectedFields.Any(field => field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase)))
+        {
+            selectedFields.Insert(0, new FieldDefinition(objectIdFieldName, FieldType.BigInteger, Nullable: false));
+        }
+
+        return selectedFields;
+    }
+
+    private static Field[] BuildSchemaFields(List<FieldDefinition> selectedFields, bool includeGeometry)
+    {
+        var fields = new List<Field>(selectedFields.Count + (includeGeometry ? 1 : 0));
+
+        foreach (var field in selectedFields)
+        {
+            fields.Add(CreateSchemaField(field));
+        }
+
+        if (includeGeometry)
+        {
+            fields.Add(new DataField<byte[]>(GeometryColumnName, true));
+        }
+
+        return fields.ToArray();
+    }
+
+    private static IEnumerable<ParquetDataColumn> BuildColumns(
+        IReadOnlyList<Feature> features,
+        List<FieldDefinition> selectedFields,
+        ParquetSchema schema,
+        string objectIdFieldName,
+        bool includeGeometry,
+        int outputSrid,
+        GeometryLimits geometryLimits,
+        bool returnZ,
+        bool returnM)
+    {
+        foreach (var field in selectedFields)
+        {
+            yield return BuildAttributeColumn(
+                features,
+                schema.FindDataField(field.Name)!,
+                field,
+                field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (includeGeometry)
+        {
+            var geometryField = schema.FindDataField(GeometryColumnName)!;
+            var geometryValues = features
+                .Select(feature => ProcessGeometry(feature.Geometry, outputSrid, geometryLimits, returnZ, returnM))
+                .ToArray();
+
+            yield return new ParquetDataColumn(geometryField, geometryValues);
+        }
+    }
+
+    private static ParquetDataColumn BuildAttributeColumn(
+        IReadOnlyList<Feature> features,
+        DataField dataField,
+        FieldDefinition field,
+        bool isObjectIdField)
+    {
+        return field.Type switch
+        {
+            FieldType.BigInteger => new ParquetDataColumn(
+                dataField,
+                BuildInt64Values(features, field, isObjectIdField)),
+            FieldType.Integer => new ParquetDataColumn(
+                dataField,
+                BuildInt32Values(features, field, isObjectIdField)),
+            FieldType.Float => new ParquetDataColumn(
+                dataField,
+                BuildFloatValues(features, field)),
+            FieldType.Double => new ParquetDataColumn(
+                dataField,
+                BuildDoubleValues(features, field)),
+            FieldType.Boolean => new ParquetDataColumn(
+                dataField,
+                BuildBooleanValues(features, field)),
+            FieldType.DateTime => new ParquetDataColumn(
+                dataField,
+                BuildDateTimeValues(features, field, dateOnly: false)),
+            FieldType.Date => new ParquetDataColumn(
+                dataField,
+                BuildDateTimeValues(features, field, dateOnly: true)),
+            FieldType.Time => new ParquetDataColumn(
+                dataField,
+                BuildTimeOnlyValues(features, field)),
+            FieldType.Binary => new ParquetDataColumn(
+                dataField,
+                BuildBinaryValues(features, field)),
+            _ => new ParquetDataColumn(
+                dataField,
+                BuildStringValues(features, field)),
+        };
+    }
+
+    private static DataField CreateSchemaField(FieldDefinition field)
+    {
+        return field.Type switch
+        {
+            FieldType.BigInteger => new DataField(field.Name, field.Nullable ? typeof(long?) : typeof(long), field.Nullable),
+            FieldType.Integer => new DataField(field.Name, field.Nullable ? typeof(int?) : typeof(int), field.Nullable),
+            FieldType.Float => new DataField(field.Name, field.Nullable ? typeof(float?) : typeof(float), field.Nullable),
+            FieldType.Double => new DataField(field.Name, field.Nullable ? typeof(double?) : typeof(double), field.Nullable),
+            FieldType.Boolean => new DataField(field.Name, field.Nullable ? typeof(bool?) : typeof(bool), field.Nullable),
+            FieldType.DateTime => new DateTimeDataField(
+                field.Name,
+                DateTimeFormat.DateAndTime,
+                isAdjustedToUTC: true,
+                DateTimeTimeUnit.Millis,
+                field.Nullable),
+            FieldType.Date => new DateTimeDataField(
+                field.Name,
+                DateTimeFormat.Date,
+                isAdjustedToUTC: true,
+                unit: null,
+                field.Nullable),
+            FieldType.Time => new TimeOnlyDataField(field.Name, TimeSpanFormat.MilliSeconds, field.Nullable),
+            FieldType.Binary => new DataField<byte[]>(field.Name, field.Nullable),
+            _ => new DataField<string>(field.Name, field.Nullable),
+        };
+    }
+
+    private static Array BuildInt64Values(IReadOnlyList<Feature> features, FieldDefinition field, bool isObjectIdField)
+    {
+        if (isObjectIdField)
+        {
+            var values = new long[features.Count];
+            for (var i = 0; i < features.Count; i++)
+            {
+                values[i] = GetInt64Value(features[i], field, isObjectIdField);
+            }
+
+            return values;
+        }
+
+        var nullableValues = new long?[features.Count];
+        for (var i = 0; i < features.Count; i++)
+        {
+            nullableValues[i] = TryConvertInt64(GetAttributeValue(features[i], field.Name));
+        }
+
+        return nullableValues;
+    }
+
+    private static Array BuildInt32Values(IReadOnlyList<Feature> features, FieldDefinition field, bool isObjectIdField)
+    {
+        if (isObjectIdField)
+        {
+            var objectIdValues = new int[features.Count];
+            for (var i = 0; i < features.Count; i++)
+            {
+                objectIdValues[i] = Convert.ToInt32(GetInt64Value(features[i], field, isObjectIdField), CultureInfo.InvariantCulture);
+            }
+
+            return objectIdValues;
+        }
+
+        var values = new int?[features.Count];
+        for (var i = 0; i < features.Count; i++)
+        {
+            values[i] = TryConvertInt32(GetAttributeValue(features[i], field.Name));
+        }
+
+        return values;
+    }
+
+    private static float?[] BuildFloatValues(IReadOnlyList<Feature> features, FieldDefinition field)
+    {
+        var values = new float?[features.Count];
+        for (var i = 0; i < features.Count; i++)
+        {
+            values[i] = TryConvertFloat(GetAttributeValue(features[i], field.Name));
+        }
+
+        return values;
+    }
+
+    private static double?[] BuildDoubleValues(IReadOnlyList<Feature> features, FieldDefinition field)
+    {
+        var values = new double?[features.Count];
+        for (var i = 0; i < features.Count; i++)
+        {
+            values[i] = TryConvertDouble(GetAttributeValue(features[i], field.Name));
+        }
+
+        return values;
+    }
+
+    private static bool?[] BuildBooleanValues(IReadOnlyList<Feature> features, FieldDefinition field)
+    {
+        var values = new bool?[features.Count];
+        for (var i = 0; i < features.Count; i++)
+        {
+            values[i] = TryConvertBoolean(GetAttributeValue(features[i], field.Name));
+        }
+
+        return values;
+    }
+
+    private static DateTime?[] BuildDateTimeValues(IReadOnlyList<Feature> features, FieldDefinition field, bool dateOnly)
+    {
+        var values = new DateTime?[features.Count];
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = TryConvertDateTime(GetAttributeValue(features[i], field.Name));
+            values[i] = dateOnly && value.HasValue
+                ? DateTime.SpecifyKind(value.Value.Date, DateTimeKind.Utc)
+                : value;
+        }
+
+        return values;
+    }
+
+    private static TimeOnly?[] BuildTimeOnlyValues(IReadOnlyList<Feature> features, FieldDefinition field)
+    {
+        var values = new TimeOnly?[features.Count];
+        for (var i = 0; i < features.Count; i++)
+        {
+            values[i] = TryConvertTimeOnly(GetAttributeValue(features[i], field.Name));
+        }
+
+        return values;
+    }
+
+    private static byte[]?[] BuildBinaryValues(IReadOnlyList<Feature> features, FieldDefinition field)
+    {
+        var values = new byte[]?[features.Count];
+        for (var i = 0; i < features.Count; i++)
+        {
+            values[i] = TryConvertBytes(GetAttributeValue(features[i], field.Name));
+        }
+
+        return values;
+    }
+
+    private static string?[] BuildStringValues(IReadOnlyList<Feature> features, FieldDefinition field)
+    {
+        var values = new string?[features.Count];
+        for (var i = 0; i < features.Count; i++)
+        {
+            values[i] = ConvertToStringValue(GetAttributeValue(features[i], field.Name));
+        }
+
+        return values;
+    }
+
+    private static long GetInt64Value(Feature feature, FieldDefinition field, bool isObjectIdField)
+    {
+        var value = GetAttributeValue(feature, field.Name);
+        return TryConvertInt64(value) ?? (isObjectIdField ? feature.Id : 0L);
+    }
+
+    private static object? GetAttributeValue(Feature feature, string fieldName)
+    {
+        return feature.Attributes.TryGetValue(fieldName, out var value) ? value : null;
+    }
+
+    private static byte[]? ProcessGeometry(
+        byte[]? geometryBytes,
+        int outputSrid,
+        GeometryLimits geometryLimits,
+        bool returnZ,
+        bool returnM)
+    {
+        if (geometryBytes == null || geometryBytes.Length == 0)
+        {
+            return null;
+        }
+
+        var geometry = GetWkbReader().Read(geometryBytes);
+        if (geometry == null)
+        {
+            return null;
+        }
+
+        geometry.SRID = outputSrid;
+        geometry = GeometryOutputProcessor.ApplyLimits(geometry, geometryLimits);
+        if (geometry == null)
+        {
+            return null;
+        }
+
+        if (!returnZ || !returnM)
+        {
+            geometry = GeometryOutputProcessor.ApplyDimensionFilter(geometry, returnZ, returnM);
+        }
+
+        var hasZ = GeometryHasZ(geometry);
+        var hasM = GeometryHasM(geometry);
+        var writer = new WKBWriter(ByteOrder.LittleEndian, handleSRID: false, emitZ: hasZ, emitM: hasM);
+        return writer.Write(geometry);
+    }
+
+    private static Dictionary<string, string> BuildGeoParquetMetadata(
+        LayerDefinition layer,
+        bool returnGeometry,
+        int? outputSrid,
+        bool returnZ)
+    {
+        if (!returnGeometry || !layer.HasGeometry)
+        {
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+
+        var srid = outputSrid ?? layer.SpatialReference.Wkid;
+        var geometryType = MapGeometryTypeToGeoParquet(layer.GeometryType, returnZ);
+
+        var geoMetadata = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["version"] = "1.1.0",
+            ["primary_column"] = GeometryColumnName,
+            ["columns"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                [GeometryColumnName] = BuildGeometryColumnMetadata(layer, srid, geometryType)
+            }
+        };
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [GeoMetadataKey] = JsonSerializer.Serialize(geoMetadata)
+        };
+    }
+
+    private static Dictionary<string, object?> BuildGeometryColumnMetadata(
+        LayerDefinition layer,
+        int srid,
+        string geometryType)
+    {
+        var metadata = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["encoding"] = "WKB",
+            ["geometry_types"] = new[] { geometryType },
+            ["crs"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["type"] = "name",
+                ["properties"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["name"] = $"EPSG:{srid}"
+                }
+            }
+        };
+
+        if (layer.Extent.HasValue && srid == layer.SpatialReference.Wkid)
+        {
+            metadata["bbox"] = new[]
+            {
+                layer.Extent.Value.MinX,
+                layer.Extent.Value.MinY,
+                layer.Extent.Value.MaxX,
+                layer.Extent.Value.MaxY
+            };
+        }
+
+        return metadata;
+    }
+
+    private static string MapGeometryTypeToGeoParquet(Honua.Core.Features.Catalog.Domain.GeometryType geometryType, bool returnZ)
+    {
+        var baseType = geometryType switch
+        {
+            Honua.Core.Features.Catalog.Domain.GeometryType.Point => "Point",
+            Honua.Core.Features.Catalog.Domain.GeometryType.LineString => "LineString",
+            Honua.Core.Features.Catalog.Domain.GeometryType.Polygon => "Polygon",
+            Honua.Core.Features.Catalog.Domain.GeometryType.MultiPoint => "MultiPoint",
+            Honua.Core.Features.Catalog.Domain.GeometryType.MultiLineString => "MultiLineString",
+            Honua.Core.Features.Catalog.Domain.GeometryType.MultiPolygon => "MultiPolygon",
+            Honua.Core.Features.Catalog.Domain.GeometryType.GeometryCollection => "GeometryCollection",
+            _ => "Geometry"
+        };
+
+        return returnZ ? $"{baseType} Z" : baseType;
+    }
+
+    private static long? TryConvertInt64(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            long longValue => longValue,
+            int intValue => intValue,
+            short shortValue => shortValue,
+            byte byteValue => byteValue,
+            double doubleValue => Convert.ToInt64(doubleValue, CultureInfo.InvariantCulture),
+            decimal decimalValue => Convert.ToInt64(decimalValue, CultureInfo.InvariantCulture),
+            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetInt64(out var jsonLong) => jsonLong,
+            string stringValue when long.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    private static int? TryConvertInt32(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            int intValue => intValue,
+            long longValue => Convert.ToInt32(longValue, CultureInfo.InvariantCulture),
+            short shortValue => shortValue,
+            byte byteValue => byteValue,
+            double doubleValue => Convert.ToInt32(doubleValue, CultureInfo.InvariantCulture),
+            decimal decimalValue => Convert.ToInt32(decimalValue, CultureInfo.InvariantCulture),
+            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetInt32(out var jsonInt) => jsonInt,
+            string stringValue when int.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    private static float? TryConvertFloat(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            float floatValue => floatValue,
+            double doubleValue => Convert.ToSingle(doubleValue, CultureInfo.InvariantCulture),
+            decimal decimalValue => Convert.ToSingle(decimalValue, CultureInfo.InvariantCulture),
+            int intValue => intValue,
+            long longValue => longValue,
+            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetSingle(out var jsonFloat) => jsonFloat,
+            string stringValue when float.TryParse(stringValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    private static double? TryConvertDouble(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            double doubleValue => doubleValue,
+            float floatValue => floatValue,
+            decimal decimalValue => Convert.ToDouble(decimalValue, CultureInfo.InvariantCulture),
+            int intValue => intValue,
+            long longValue => longValue,
+            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetDouble(out var jsonDouble) => jsonDouble,
+            string stringValue when double.TryParse(stringValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    private static bool? TryConvertBoolean(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            bool boolValue => boolValue,
+            JsonElement element when element.ValueKind == JsonValueKind.True => true,
+            JsonElement element when element.ValueKind == JsonValueKind.False => false,
+            string stringValue when bool.TryParse(stringValue, out var parsedBool) => parsedBool,
+            string stringValue when int.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedInt) => parsedInt != 0,
+            int intValue => intValue != 0,
+            long longValue => longValue != 0,
+            _ => null
+        };
+    }
+
+    private static DateTime? TryConvertDateTime(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            DateTimeOffset dateTimeOffset => dateTimeOffset.UtcDateTime,
+            DateTime dateTime => dateTime.Kind switch
+            {
+                DateTimeKind.Utc => dateTime,
+                DateTimeKind.Local => dateTime.ToUniversalTime(),
+                _ => DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
+            },
+            DateOnly dateOnly => DateTime.SpecifyKind(dateOnly.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc),
+            JsonElement element when element.ValueKind == JsonValueKind.String => TryConvertDateTime(element.GetString()),
+            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetInt64(out var milliseconds) =>
+                DateTimeOffset.FromUnixTimeMilliseconds(milliseconds).UtcDateTime,
+            string stringValue when DateTimeOffset.TryParse(
+                stringValue,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind | DateTimeStyles.AllowWhiteSpaces,
+                out var parsedOffset) => parsedOffset.UtcDateTime,
+            string stringValue when DateTime.TryParse(
+                stringValue,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces,
+                out var parsedDateTime) => parsedDateTime,
+            long milliseconds => DateTimeOffset.FromUnixTimeMilliseconds(milliseconds).UtcDateTime,
+            double milliseconds => DateTimeOffset.FromUnixTimeMilliseconds(Convert.ToInt64(milliseconds, CultureInfo.InvariantCulture)).UtcDateTime,
+            _ => null
+        };
+    }
+
+    private static TimeOnly? TryConvertTimeOnly(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            TimeOnly timeOnly => timeOnly,
+            TimeSpan timeSpan => TimeOnly.FromTimeSpan(timeSpan),
+            DateTime dateTime => TimeOnly.FromDateTime(dateTime),
+            DateTimeOffset dateTimeOffset => TimeOnly.FromDateTime(dateTimeOffset.UtcDateTime),
+            JsonElement element when element.ValueKind == JsonValueKind.String => TryConvertTimeOnly(element.GetString()),
+            string stringValue when TimeOnly.TryParse(stringValue, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var parsedTime) => parsedTime,
+            string stringValue when TimeSpan.TryParse(stringValue, CultureInfo.InvariantCulture, out var parsedSpan) => TimeOnly.FromTimeSpan(parsedSpan),
+            _ => null
+        };
+    }
+
+    private static byte[]? TryConvertBytes(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            byte[] bytes => bytes,
+            JsonElement element when element.ValueKind == JsonValueKind.String => TryConvertBytes(element.GetString()),
+            string stringValue when TryDecodeBase64(stringValue, out var decoded) => decoded,
+            string stringValue => System.Text.Encoding.UTF8.GetBytes(stringValue),
+            _ => null
+        };
+    }
+
+    private static string? ConvertToStringValue(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string stringValue => stringValue,
+            DateTimeOffset dateTimeOffset => dateTimeOffset.ToString("O", CultureInfo.InvariantCulture),
+            DateTime dateTime => dateTime.ToString("O", CultureInfo.InvariantCulture),
+            DateOnly dateOnly => dateOnly.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            TimeOnly timeOnly => timeOnly.ToString("HH:mm:ss.fffffff", CultureInfo.InvariantCulture),
+            JsonElement element when element.ValueKind is JsonValueKind.Object or JsonValueKind.Array => element.GetRawText(),
+            JsonElement element => element.ToString(),
+            _ => value.ToString()
+        };
+    }
+
+    private static bool TryDecodeBase64(string? value, out byte[] decoded)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            decoded = [];
+            return false;
+        }
+
+        try
+        {
+            decoded = Convert.FromBase64String(value);
+            return true;
+        }
+        catch (FormatException)
+        {
+            decoded = [];
+            return false;
+        }
+    }
+
+    private static bool GeometryHasZ(Geometry geometry)
+        => geometry.Coordinates.Any(coordinate => !double.IsNaN(coordinate.Z));
+
+    private static bool GeometryHasM(Geometry geometry)
+        => geometry.Coordinates.Any(coordinate => !double.IsNaN(coordinate.M));
+
+    private static WKBReader GetWkbReader()
+    {
+        _wkbReader ??= new WKBReader();
+        return _wkbReader;
+    }
+}

--- a/src/Honua.Server/Features/FeatureServer/Services/IFeatureServerQueryServices.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/IFeatureServerQueryServices.cs
@@ -21,7 +21,7 @@ internal interface IFeatureServerQueryServices
         GeoServicesSpatialReference? geometrySpatialReference,
         CancellationToken cancellationToken = default);
 
-    (object? Response, string? ContentType) FormatQueryResult(
+    ValueTask<(object Response, string ContentType)> FormatQueryResultAsync(
         QueryResult<Feature> result,
         LayerDefinition layer,
         string format,

--- a/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
@@ -36,7 +36,7 @@ internal interface IQueryFormatter
     /// <param name="maxAllowableOffset">Generalization tolerance override</param>
     /// <param name="outFields">Fields to include in output</param>
     /// <returns>Formatted result and content type</returns>
-    (object response, string contentType) FormatQueryResult(
+    ValueTask<(object response, string contentType)> FormatQueryResultAsync(
         QueryResult<Feature> result,
         LayerDefinition layer,
         string format,
@@ -68,7 +68,7 @@ internal sealed class QueryFormatter : IQueryFormatter
     /// <summary>
     /// Formats query result into the specified format
     /// </summary>
-    public (object response, string contentType) FormatQueryResult(
+    public ValueTask<(object response, string contentType)> FormatQueryResultAsync(
         QueryResult<Feature> result,
         LayerDefinition layer,
         string format,
@@ -88,10 +88,46 @@ internal sealed class QueryFormatter : IQueryFormatter
 
         return format.ToLowerInvariant() switch
         {
-            "pbf" => _pbfFormatter.FormatAsPbf(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields),
-            "geojson" => FormatAsGeoJson(result, layer, returnGeometry, returnZ, returnM, effectiveLimits, outFields),
-            "json" or _ => FormatAsGeoServicesJson(result, layer, returnGeometry, outputSrid, returnZ, returnM, effectiveLimits, outFields)
+            "pbf" => ValueTask.FromResult<(object response, string contentType)>(
+                _pbfFormatter.FormatAsPbf(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields)),
+            "parquet" => new ValueTask<(object response, string contentType)>(
+                FormatParquetAsync(
+                    result,
+                    layer,
+                    returnGeometry,
+                    outputSrid,
+                    returnZ,
+                    returnM,
+                    effectiveLimits,
+                    outFields)),
+            "geojson" => ValueTask.FromResult<(object response, string contentType)>(
+                FormatAsGeoJson(result, layer, returnGeometry, returnZ, returnM, effectiveLimits, outFields)),
+            "json" or _ => ValueTask.FromResult<(object response, string contentType)>(
+                FormatAsGeoServicesJson(result, layer, returnGeometry, outputSrid, returnZ, returnM, effectiveLimits, outFields))
         };
+    }
+
+    private static async Task<(object response, string contentType)> FormatParquetAsync(
+        QueryResult<Feature> result,
+        LayerDefinition layer,
+        bool returnGeometry,
+        int? outputSrid,
+        bool returnZ,
+        bool returnM,
+        GeometryLimits effectiveLimits,
+        string[]? outFields)
+    {
+        var (response, contentType) = await GeoParquetQueryFormatter.FormatAsGeoParquetAsync(
+            result,
+            layer,
+            returnGeometry,
+            outputSrid,
+            returnZ,
+            returnM,
+            effectiveLimits,
+            outFields);
+
+        return (response, contentType);
     }
 
     /// <summary>

--- a/src/Honua.Server/Honua.Server.csproj
+++ b/src/Honua.Server/Honua.Server.csproj
@@ -59,6 +59,7 @@
     <PackageReference Include="NetTopologySuite" Version="2.6.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.2" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
+    <PackageReference Include="Parquet.Net" Version="5.5.0" />
     <EmbeddedResource Include="Migrations\*.sql" />
   </ItemGroup>
 

--- a/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerQueryParameterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerQueryParameterTests.cs
@@ -2,12 +2,14 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Net;
+using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using Honua.Server.Features.FeatureServer.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Parquet;
 
 namespace Honua.Server.Tests.Features.FeatureServer;
 
@@ -88,6 +90,20 @@ public sealed class FeatureServerQueryParameterTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithGeoParquetFormat_ReturnsOk()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?f=parquet");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.apache.parquet");
+        var payload = await response.Content.ReadAsByteArrayAsync();
+        await AssertGeoParquetPayloadAsync(payload, expectGeometry: true);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
     public async Task Query_WithFlatGeobufFormatAndDistinct_ReturnsBadRequest()
     {
         var response = await _fixture.Client.GetAsync(
@@ -96,6 +112,20 @@ public sealed class FeatureServerQueryParameterTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("returnDistinctValues is not supported when f=fgb.");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithGeoParquetFormatNoGeometry_ReturnsOk()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?f=parquet&returnGeometry=false");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.apache.parquet");
+        var payload = await response.Content.ReadAsByteArrayAsync();
+        await AssertGeoParquetPayloadAsync(payload, expectGeometry: false);
     }
 
     [IntegrationTest]
@@ -145,6 +175,24 @@ public sealed class FeatureServerQueryParameterTests : IAsyncLifetime
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/geobuf");
         var payload = await response.Content.ReadAsByteArrayAsync();
         payload.Should().NotBeEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithGeoParquetAcceptHeader_ReturnsOk()
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query");
+        request.Headers.Accept.ParseAdd("application/vnd.apache.parquet");
+
+        var response = await _fixture.Client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.apache.parquet");
+        var payload = await response.Content.ReadAsByteArrayAsync();
+        await AssertGeoParquetPayloadAsync(payload, expectGeometry: true);
     }
 
     [IntegrationTest]
@@ -315,5 +363,33 @@ public sealed class FeatureServerQueryParameterTests : IAsyncLifetime
         }
 
         return value.ToString();
+    }
+
+    private static async Task AssertGeoParquetPayloadAsync(byte[] payload, bool expectGeometry)
+    {
+        payload.Should().NotBeEmpty();
+        payload.Length.Should().BeGreaterThanOrEqualTo(4);
+        Encoding.ASCII.GetString(payload, 0, 4).Should().Be("PAR1");
+
+        using var stream = new MemoryStream(payload);
+        using var reader = await ParquetReader.CreateAsync(stream);
+
+        var fields = reader.Schema.GetDataFields().ToArray();
+        fields.Select(field => field.Name).Should().OnlyHaveUniqueItems();
+        fields.Select(field => field.Name).Should().Contain("objectid");
+
+        if (expectGeometry)
+        {
+            fields.Select(field => field.Name).Should().Contain("geometry");
+            reader.CustomMetadata.Should().ContainKey("geo");
+
+            using var metadataDocument = JsonDocument.Parse(reader.CustomMetadata["geo"]);
+            metadataDocument.RootElement.GetProperty("primary_column").GetString().Should().Be("geometry");
+        }
+        else
+        {
+            fields.Select(field => field.Name).Should().NotContain("geometry");
+            reader.CustomMetadata.Should().NotContainKey("geo");
+        }
     }
 }

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Shared.Models;
+using Honua.Server.Features.FeatureServer.Services;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using Parquet;
+using Parquet.Schema;
+using GeometryType = Honua.Core.Features.Catalog.Domain.GeometryType;
+
+namespace Honua.Server.Tests.Features.FeatureServer.Services;
+
+public sealed class GeoParquetQueryFormatterTests
+{
+    [Fact]
+    public async Task FormatAsGeoParquetAsync_WithFeatures_WritesReadableParquetWithGeoMetadata()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("name", FieldType.String, 255),
+            new FieldDefinition("created", FieldType.DateTime));
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(-157.8583, 21.3069),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["name"] = "Honolulu Harbor",
+                ["created"] = new DateTimeOffset(2024, 01, 02, 03, 04, 05, TimeSpan.Zero)
+            }.ToImmutableDictionary());
+
+        var (payload, contentType) = await GeoParquetQueryFormatter.FormatAsGeoParquetAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryLimits: new GeometryLimits());
+
+        contentType.Should().Be("application/vnd.apache.parquet");
+        using var stream = new MemoryStream(payload);
+        using var reader = await ParquetReader.CreateAsync(stream);
+
+        reader.Schema.GetDataFields().Select(field => field.Name)
+            .Should().Equal("objectid", "name", "created", "geometry");
+        reader.CustomMetadata.Should().ContainKey("geo");
+
+        using var metadataDocument = JsonDocument.Parse(reader.CustomMetadata["geo"]);
+        metadataDocument.RootElement.GetProperty("primary_column").GetString().Should().Be("geometry");
+
+        var createdField = reader.Schema.FindDataField("created");
+        createdField.Should().BeOfType<DateTimeDataField>();
+
+        using var rowGroupReader = reader.OpenRowGroupReader(0);
+        var createdColumn = await rowGroupReader.ReadColumnAsync(createdField!);
+        createdColumn.Data.Should().BeAssignableTo<DateTime?[]>();
+        ((DateTime?[])createdColumn.Data)[0].Should().Be(new DateTime(2024, 01, 02, 03, 04, 05, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task FormatAsGeoParquetAsync_EmptyResult_PreservesRequestedSchema()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("name", FieldType.String, 255),
+            new FieldDefinition("created", FieldType.DateTime));
+
+        var (payload, _) = await GeoParquetQueryFormatter.FormatAsGeoParquetAsync(
+            QueryResult<Feature>.Empty(),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryLimits: new GeometryLimits(),
+            outFields: ["name", "created"]);
+
+        using var stream = new MemoryStream(payload);
+        using var reader = await ParquetReader.CreateAsync(stream);
+
+        reader.RowGroupCount.Should().Be(1);
+        reader.Schema.GetDataFields().Select(field => field.Name)
+            .Should().Equal("objectid", "name", "created", "geometry");
+
+        using var rowGroupReader = reader.OpenRowGroupReader(0);
+        var objectIdColumn = await rowGroupReader.ReadColumnAsync(reader.Schema.FindDataField("objectid")!);
+        objectIdColumn.Data.Should().BeAssignableTo<long[]>();
+        ((long[])objectIdColumn.Data).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FormatAsGeoParquetAsync_AppliesGeometryPrecisionAndDimensionFiltering()
+    {
+        var layer = CreateLayer(new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false));
+        var feature = Feature.Create(
+            1,
+            CreatePointWkbWithZm(1.2349, 2.3451, 3.4567, 4.5678),
+            new Dictionary<string, object?> { ["objectid"] = 1L }.ToImmutableDictionary());
+
+        var (payload, _) = await GeoParquetQueryFormatter.FormatAsGeoParquetAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryLimits: new GeometryLimits { MaxCoordinatePrecision = 2 });
+
+        using var stream = new MemoryStream(payload);
+        using var reader = await ParquetReader.CreateAsync(stream);
+        using var rowGroupReader = reader.OpenRowGroupReader(0);
+        var geometryColumn = await rowGroupReader.ReadColumnAsync(reader.Schema.FindDataField("geometry")!);
+        var geometryBytes = ((byte[]?[])geometryColumn.Data)[0];
+
+        geometryBytes.Should().NotBeNull();
+        var geometry = new WKBReader().Read(geometryBytes!);
+        var point = geometry.Should().BeOfType<Point>().Subject;
+
+        point.X.Should().Be(1.23);
+        point.Y.Should().Be(2.35);
+        double.IsNaN(point.Coordinate.Z).Should().BeTrue();
+        double.IsNaN(point.Coordinate.M).Should().BeTrue();
+    }
+
+    private static LayerDefinition CreateLayer(params FieldDefinition[] fields)
+        => new(
+            Id: 1,
+            Name: "harbors",
+            Description: "Harbors",
+            GeometryType: GeometryType.Point,
+            SpatialReference: SpatialReference.WGS84,
+            Fields:
+            [
+                .. fields,
+                new FieldDefinition("shape", FieldType.Geometry, Nullable: true)
+            ]);
+
+    private static byte[] CreatePointWkb(double x, double y)
+        => new WKBWriter().Write(new Point(x, y) { SRID = 4326 });
+
+    private static byte[] CreatePointWkbWithZm(double x, double y, double z, double m)
+        => new WKBWriter(ByteOrder.LittleEndian, handleSRID: false, emitZ: true, emitM: true)
+            .Write(new Point(new CoordinateZM(x, y, z, m)) { SRID = 4326 });
+}

--- a/tests/Honua.Server.Tests/Honua.Server.Tests.csproj
+++ b/tests/Honua.Server.Tests/Honua.Server.Tests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.OData.Client" Version="8.4.3" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Parquet.Net" Version="5.5.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #424

## Summary
Add GeoParquet FeatureServer query export with real Parquet/GeoParquet output and schema-correct readback coverage.

## Changes Made
- add a `Parquet.Net`-backed GeoParquet formatter for FeatureServer query responses
- preserve requested field schema for empty and non-empty exports, with typed date/time handling and geometry shaping before WKB serialization
- extend docs and readback tests to cover `f=parquet` behavior end to end

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)

## Coverage Impact
- Line coverage: Not measured locally in the pre-PR gate; added formatter and integration coverage for the new export path
- Branch coverage: Not measured locally in the pre-PR gate; added empty-result, typed-field, and geometry-shaping cases

## Breaking Changes
None

## Additional Context
- `scripts/pre-pr-check.sh` passed locally, including full solution tests and AOT publish.

---

## Pre-PR Checklist (for contributor)
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit message follows format: `type: description (#issue-number)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] Documentation updated if needed
- [x] If protocol/auth behavior changed, updated MVP compatibility contract and release checklist notes
- [ ] If breaking admin/control-plane API changes: updated migration guide and versioning policy docs
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review and documented in migration guide

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed
