### PR TITLE
feat: Cloud-native formats: add GeoParquet query export surface (#424)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Please use these forms instead of blank issues so reports include enough detail 
 
 ## Capabilities
 
-**Query and edit** — FeatureServer query, applyEdits, attachments, and related records. OGC transactions (POST/PUT/DELETE). OData CRUD with spatial functions. Query output in JSON, GeoJSON, PBF, FlatGeobuf, GeoParquet, and GeoBuf formats with Accept-header content negotiation.
+**Query and edit** — FeatureServer query, applyEdits, attachments, and related records. OGC transactions (POST/PUT/DELETE). OData CRUD with spatial functions. Query output in JSON, GeoJSON, PBF, FlatGeobuf, and GeoParquet formats, plus GeoBuf when the configured feature store supports native GeoBuf output, with Accept-header content negotiation.
 
 **Map rendering** — MapServer (export/identify/legend/find/query) plus OGC API Maps endpoints for rendered map images.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Please use these forms instead of blank issues so reports include enough detail 
 
 ## Capabilities
 
-**Query and edit** — FeatureServer query, applyEdits, attachments, and related records. OGC transactions (POST/PUT/DELETE). OData CRUD with spatial functions.
+**Query and edit** — FeatureServer query, applyEdits, attachments, and related records. OGC transactions (POST/PUT/DELETE). OData CRUD with spatial functions. Query output in JSON, GeoJSON, PBF, FlatGeobuf, GeoParquet, and GeoBuf formats with Accept-header content negotiation.
 
 **Map rendering** — MapServer (export/identify/legend/find/query) plus OGC API Maps endpoints for rendered map images.
 

--- a/docs/user/API_EXAMPLES.md
+++ b/docs/user/API_EXAMPLES.md
@@ -38,6 +38,18 @@ All examples assume `http://localhost:8080` as the base URL. If your deployment 
 curl "http://localhost:8080/rest/services/1/FeatureServer/0/query?where=population%20%3E%2010000&outFields=*&f=json"
 ```
 
+**Example JSON response (trimmed):**
+```json
+{
+  "features": [
+    {
+      "attributes": { "OBJECTID": 1, "name": "Downtown", "population": 24500 },
+      "geometry": { "x": -122.41, "y": 37.78 }
+    }
+  ]
+}
+```
+
 **GeoJSON output:**
 ```bash
 curl "http://localhost:8080/rest/services/1/FeatureServer/0/query?where=population%20%3E%2010000&outFields=*&f=geojson"
@@ -58,16 +70,10 @@ curl "http://localhost:8080/rest/services/1/FeatureServer/0/query?where=populati
 curl "http://localhost:8080/rest/services/1/FeatureServer/0/query?where=population%20%3E%2010000&outFields=*&f=parquet" --output features.parquet
 ```
 
-**Example response (trimmed):**
-```json
-{
-  "features": [
-    {
-      "attributes": { "OBJECTID": 1, "name": "Downtown", "population": 24500 },
-      "geometry": { "x": -122.41, "y": 37.78 }
-    }
-  ]
-}
+**GeoParquet via Accept header:**
+```bash
+curl -H "Accept: application/vnd.apache.parquet" \
+  "http://localhost:8080/rest/services/1/FeatureServer/0/query?where=population%20%3E%2010000&outFields=*" --output features.parquet
 ```
 
 ### **Add Features**

--- a/docs/user/INTEGRATION_PATTERNS.md
+++ b/docs/user/INTEGRATION_PATTERNS.md
@@ -132,6 +132,32 @@ resp = requests.post(
 resp.raise_for_status()
 ```
 
+### **Analytics Export (GeoParquet)**
+
+```python
+import requests
+
+HONUA = "http://localhost:8080"
+
+# Export features as GeoParquet for columnar analytics
+resp = requests.get(
+    f"{HONUA}/rest/services/1/FeatureServer/0/query",
+    params={"where": "1=1", "outFields": "*", "f": "parquet"}
+)
+resp.raise_for_status()
+
+with open("features.parquet", "wb") as f:
+    f.write(resp.content)
+
+# Load directly into DuckDB, pandas, or geopandas
+import geopandas as gpd
+gdf = gpd.read_parquet("features.parquet")
+```
+
+Use `f=parquet` (or `Accept: application/vnd.apache.parquet`) to get GeoParquet 1.1.0 output with WKB-encoded geometry and CRS metadata. Ideal for analytics pipelines, data science notebooks, and bulk data exchange. Non-4326 `outSR` is rejected when the GeoParquet response includes a geometry column; it is allowed when `returnGeometry=false` or the layer has no geometry. When `outSR` is omitted, coordinates are automatically reprojected to EPSG:4326.
+
+> **Truncation note:** The query endpoint applies `maxRecordCount` by default (typically 2 000 features). Binary formats like GeoParquet do not include an `exceededTransferLimit` flag. To verify completeness, compare the row count in the returned file against the service's `maxRecordCount`. For larger exports, page with `resultOffset`/`resultRecordCount` or first call `returnCountOnly=true` to check the total.
+
 **Orchestrators**: Use Airflow, Dagster, Prefect, or your existing ETL platform. The goal is consistent extraction, idempotent loads, and observability.
 
 ---

--- a/docs/user/USER_JOURNEYS.md
+++ b/docs/user/USER_JOURNEYS.md
@@ -58,8 +58,15 @@ curl http://localhost:8080/healthz/ready
 http://<host>/odata/Features?$select=id,name,population&$filter=population%20gt%2010000&$top=50
 ```
 
+**GeoParquet export for analytics pipelines:**
+```bash
+curl "http://<host>/rest/services/1/FeatureServer/0/query?where=1%3D1&outFields=*&f=parquet" --output features.parquet
+```
+Use `f=parquet` to export query results as GeoParquet 1.1.0 for direct use with DuckDB, pandas/geopandas, or other columnar analytics tools. Results are subject to `maxRecordCount`; compare the returned row count against the service limit to detect truncation.
+
 **Next Steps:**
 - [OData API Examples](API_EXAMPLES.md#odata-v4-api)
+- [GeoParquet Export Examples](API_EXAMPLES.md#geoservices-rest-api)
 - [Client Templates + Smoke Runbook](CLIENT_TEMPLATE_RUNBOOK.md)
 - [Data Modeling Guide](DATA_MODELING_GUIDE.md)
 

--- a/docs/user/feature-server-matrix.md
+++ b/docs/user/feature-server-matrix.md
@@ -97,17 +97,18 @@ MapServer coverage is tracked separately:
 | --- | --- | --- | --- |
 | Filtering | `where`, `objectIds` | Implemented | ArcGIS SQL parser; objectIds bypass where. |
 | Spatial filters | `geometry`, `geometryType`, `spatialRel`, `distance`, `units` | Implemented | Distance + KNN supported; geometry supports GeoServices JSON or point/envelope CSV. |
-| Spatial reference | `inSR`, `outSR` | Implemented | GeoJSON output requires EPSG:4326. |
+| Spatial reference | `inSR`, `outSR` | Implemented | GeoJSON and GeoParquet output require EPSG:4326 when the response contains geometry; non-4326 `outSR` is rejected unless the geometry column is absent (`returnGeometry=false`, non-geometry layer, or a special query mode that returns JSON). Coordinates are reprojected to 4326 when `outSR` is omitted. |
 | Pagination | `resultOffset`, `resultRecordCount` | Implemented | Validated against limits. |
 | Fields | `outFields` | Implemented | `*` returns all fields. |
 | Sorting | `orderByFields` | Implemented | Validates against layer fields; supports any field with ASC/DESC. |
-| Output flags | `returnGeometry`, `returnIdsOnly`, `returnCountOnly`, `returnExtentOnly`, `returnZ`, `returnM` | Implemented | Standard query outputs supported. |
+| Output flags | `returnGeometry`, `returnIdsOnly`, `returnCountOnly`, `returnExtentOnly`, `returnZ`, `returnM` | Implemented | Standard query outputs supported. `returnZ` and `returnM` are applied by `json`, `geojson`, and `pbf` formatters; binary formats `fgb`, `geobuf`, and `parquet` write raw geometry and do not filter dimensions. |
 | Distinct | `returnDistinctValues` | Implemented | In-memory distinct over returned features; works best with explicit `outFields`. |
 | Statistics | `outStatistics`, `groupByFieldsForStatistics` | Implemented | Aggregate queries with COUNT, SUM, MIN, MAX, AVG, STDDEV, VAR. Supports GROUP BY on any layer field. |
-| KNN output | `nearestCount`, `returnDistance` | Partial | `returnDistance` only affects KNN queries. |
+| KNN output | `nearestCount`, `returnDistance` | Partial | `returnDistance` only affects KNN queries. The computed `distance` attribute is included in `json`, `geojson`, and `parquet` output; `pbf`, `fgb`, and `geobuf` build their schema from layer fields only and omit runtime-computed attributes. |
 | Temporal | `time`, `timeRelation` | Implemented | Uses layer timeInfo or first temporal field. |
-| Output format | `f=json`, `f=geojson`, `f=pbf`, `f=fgb`, `f=geobuf`, `f=parquet` | Implemented | `f=fgb`, `f=geobuf`, and `f=parquet` return binary payloads; `f=geobuf` requires a store with native GeoBuf support; `f=parquet` returns GeoParquet format with WKB-encoded geometry. |
+| Output format | `f=json`, `f=geojson`, `f=pbf`, `f=fgb`, `f=geobuf`, `f=parquet` | Implemented | Six output formats supported. Binary formats (`fgb`, `geobuf`, `parquet`) also accept `Accept` header negotiation; `f=` takes precedence. See [Output format details](#output-format-details) below. |
 | Geometry precision | `geometryPrecision` | Implemented | Rounds coordinates to specified decimal places. |
+| Geometry simplification | `maxAllowableOffset` | Implemented | Simplifies geometry to the given tolerance. Applies to `json`, `geojson`, and `pbf` output only; `fgb`, `geobuf`, and `parquet` do not apply it. |
 
 ### Not implemented (explicitly rejected)
 
@@ -122,6 +123,25 @@ MapServer coverage is tracked separately:
 | GDB version | `gdbVersion` | Rejected. |
 | Quantization | `quantizationParameters` | Rejected. |
 | Datum transform | `datumTransformation` | Rejected. |
+
+### Output format details
+
+All non-JSON formats also accept `Accept` header negotiation (e.g. `Accept: application/vnd.apache.parquet`). When both `f=` and `Accept` are present, `f=` takes precedence.
+
+**Special query modes**: `returnCountOnly`, `returnIdsOnly`, `returnExtentOnly`, and `outStatistics` queries always return JSON regardless of the requested format.
+
+| Format | Content type | Notes |
+| --- | --- | --- |
+| `json` / `pjson` | `application/json` | Default GeoServices JSON. |
+| `geojson` | `application/geo+json` | RFC 7946. Requires EPSG:4326. |
+| `pbf` | `application/x-protobuf` | Esri-compatible Protocol Buffers. |
+| `fgb` | `application/vnd.flatgeobuf` | FlatGeobuf binary. |
+| `geobuf` | `application/geobuf` | Requires a store with native GeoBuf support. |
+| `parquet` | `application/vnd.apache.parquet` | GeoParquet 1.1.0 with WKB-encoded geometry. Non-4326 `outSR` is rejected when the response includes a geometry column (CRS metadata cannot be written correctly; tracked as follow-up); allowed when `returnGeometry=false` or the layer has no geometry. When `outSR` is omitted, coordinates are reprojected to EPSG:4326 (matching GeoJSON behavior). CRS metadata omits the `crs` key for EPSG:4326 (spec-compliant OGC:CRS84 default). `bbox` is omitted because the spec defines it as the bounding box of geometries in the file, not the layer extent. |
+
+**Binary format limitations** (`fgb`, `geobuf`, `parquet`):
+- `geometryPrecision`, `maxAllowableOffset`, `returnZ`, and `returnM` are not applied — geometry is written as raw WKB.
+- `exceededTransferLimit` is not conveyed. Clients should compare the returned feature count against `maxRecordCount` to detect truncation.
 
 ## ApplyEdits parameter coverage (layer `/applyEdits`)
 
@@ -226,4 +246,4 @@ MapServer coverage is tracked separately:
 | `templates` | Implemented | Empty array (no feature templates configured). |
 | `timeInfo` | Implemented | Start/end time fields, time extent, track ID. |
 | `maxRecordCount` | Implemented | From query limits. |
-| `supportedQueryFormats` | Implemented | Normalized format list plus runtime-supported binary formats (`PBF`, `FGB`, `PARQUET`, and conditional `GEOBUF`). |
+| `supportedQueryFormats` | Implemented | Normalized format list plus runtime-supported binary formats (`PBF`, `FGB`, `PARQUET`, and conditional `GEOBUF` when the backing store exposes native GeoBuf output). |

--- a/docs/user/feature-server-matrix.md
+++ b/docs/user/feature-server-matrix.md
@@ -101,14 +101,14 @@ MapServer coverage is tracked separately:
 | Pagination | `resultOffset`, `resultRecordCount` | Implemented | Validated against limits. |
 | Fields | `outFields` | Implemented | `*` returns all fields. |
 | Sorting | `orderByFields` | Implemented | Validates against layer fields; supports any field with ASC/DESC. |
-| Output flags | `returnGeometry`, `returnIdsOnly`, `returnCountOnly`, `returnExtentOnly`, `returnZ`, `returnM` | Implemented | Standard query outputs supported. `returnZ` and `returnM` are applied by `json`, `geojson`, and `pbf` formatters; binary formats `fgb`, `geobuf`, and `parquet` write raw geometry and do not filter dimensions. |
+| Output flags | `returnGeometry`, `returnIdsOnly`, `returnCountOnly`, `returnExtentOnly`, `returnZ`, `returnM` | Implemented | Standard query outputs supported. `returnZ` and `returnM` are applied by `json`, `geojson`, `pbf`, and `parquet`. `fgb` and `geobuf` write raw geometry and do not filter dimensions. |
 | Distinct | `returnDistinctValues` | Implemented | In-memory distinct over returned features; works best with explicit `outFields`. |
 | Statistics | `outStatistics`, `groupByFieldsForStatistics` | Implemented | Aggregate queries with COUNT, SUM, MIN, MAX, AVG, STDDEV, VAR. Supports GROUP BY on any layer field. |
 | KNN output | `nearestCount`, `returnDistance` | Partial | `returnDistance` only affects KNN queries. The computed `distance` attribute is included in `json`, `geojson`, and `parquet` output; `pbf`, `fgb`, and `geobuf` build their schema from layer fields only and omit runtime-computed attributes. |
 | Temporal | `time`, `timeRelation` | Implemented | Uses layer timeInfo or first temporal field. |
 | Output format | `f=json`, `f=geojson`, `f=pbf`, `f=fgb`, `f=geobuf`, `f=parquet` | Implemented | Six output formats supported. Binary formats (`fgb`, `geobuf`, `parquet`) also accept `Accept` header negotiation; `f=` takes precedence. See [Output format details](#output-format-details) below. |
 | Geometry precision | `geometryPrecision` | Implemented | Rounds coordinates to specified decimal places. |
-| Geometry simplification | `maxAllowableOffset` | Implemented | Simplifies geometry to the given tolerance. Applies to `json`, `geojson`, and `pbf` output only; `fgb`, `geobuf`, and `parquet` do not apply it. |
+| Geometry simplification | `maxAllowableOffset` | Implemented | Simplifies geometry to the given tolerance. Applies to `json`, `geojson`, `pbf`, and `parquet`; `fgb` and `geobuf` do not apply it. |
 
 ### Not implemented (explicitly rejected)
 
@@ -140,7 +140,7 @@ All non-JSON formats also accept `Accept` header negotiation (e.g. `Accept: appl
 | `parquet` | `application/vnd.apache.parquet` | GeoParquet 1.1.0 with WKB-encoded geometry. Non-4326 `outSR` is rejected when the response includes a geometry column (CRS metadata cannot be written correctly; tracked as follow-up); allowed when `returnGeometry=false` or the layer has no geometry. When `outSR` is omitted, coordinates are reprojected to EPSG:4326 (matching GeoJSON behavior). CRS metadata omits the `crs` key for EPSG:4326 (spec-compliant OGC:CRS84 default). `bbox` is omitted because the spec defines it as the bounding box of geometries in the file, not the layer extent. |
 
 **Binary format limitations** (`fgb`, `geobuf`, `parquet`):
-- `geometryPrecision`, `maxAllowableOffset`, `returnZ`, and `returnM` are not applied — geometry is written as raw WKB.
+- `parquet` applies `geometryPrecision`, `maxAllowableOffset`, `returnZ`, and `returnM` before writing WKB. `fgb` and `geobuf` still write raw geometry and ignore those parameters.
 - `exceededTransferLimit` is not conveyed. Clients should compare the returned feature count against `maxRecordCount` to detect truncation.
 
 ## ApplyEdits parameter coverage (layer `/applyEdits`)

--- a/docs/user/feature-server-matrix.md
+++ b/docs/user/feature-server-matrix.md
@@ -101,7 +101,7 @@ MapServer coverage is tracked separately:
 | Pagination | `resultOffset`, `resultRecordCount` | Implemented | Validated against limits. |
 | Fields | `outFields` | Implemented | `*` returns all fields. |
 | Sorting | `orderByFields` | Implemented | Validates against layer fields; supports any field with ASC/DESC. |
-| Output flags | `returnGeometry`, `returnIdsOnly`, `returnCountOnly`, `returnExtentOnly`, `returnZ`, `returnM` | Implemented | Standard query outputs supported. `returnZ` and `returnM` are applied by `json`, `geojson`, `pbf`, and `parquet`. `fgb` and `geobuf` write raw geometry and do not filter dimensions. |
+| Output flags | `returnGeometry`, `returnIdsOnly`, `returnCountOnly`, `returnExtentOnly`, `returnZ`, `returnM` | Implemented | Standard query outputs supported. `returnZ` and `returnM` are applied by `json`, `geojson`, and `pbf`. `parquet` applies `returnZ` but always strips M values (GeoParquet 1.1.0 only supports XY/XYZ). `fgb` and `geobuf` write raw geometry and do not filter dimensions. |
 | Distinct | `returnDistinctValues` | Implemented | In-memory distinct over returned features; works best with explicit `outFields`. |
 | Statistics | `outStatistics`, `groupByFieldsForStatistics` | Implemented | Aggregate queries with COUNT, SUM, MIN, MAX, AVG, STDDEV, VAR. Supports GROUP BY on any layer field. |
 | KNN output | `nearestCount`, `returnDistance` | Partial | `returnDistance` only affects KNN queries. The computed `distance` attribute is included in `json`, `geojson`, and `parquet` output; `pbf`, `fgb`, and `geobuf` build their schema from layer fields only and omit runtime-computed attributes. |
@@ -137,10 +137,10 @@ All non-JSON formats also accept `Accept` header negotiation (e.g. `Accept: appl
 | `pbf` | `application/x-protobuf` | Esri-compatible Protocol Buffers. |
 | `fgb` | `application/vnd.flatgeobuf` | FlatGeobuf binary. |
 | `geobuf` | `application/geobuf` | Requires a store with native GeoBuf support. |
-| `parquet` | `application/vnd.apache.parquet` | GeoParquet 1.1.0 with WKB-encoded geometry. Non-4326 `outSR` is rejected when the response includes a geometry column (CRS metadata cannot be written correctly; tracked as follow-up); allowed when `returnGeometry=false` or the layer has no geometry. When `outSR` is omitted, coordinates are reprojected to EPSG:4326 (matching GeoJSON behavior). CRS metadata omits the `crs` key for EPSG:4326 (spec-compliant OGC:CRS84 default). `bbox` is omitted because the spec defines it as the bounding box of geometries in the file, not the layer extent. |
+| `parquet` | `application/vnd.apache.parquet` | GeoParquet 1.1.0 with WKB-encoded geometry. M values are always stripped (the spec only supports XY/XYZ); `returnZ` is honored. Non-4326 `outSR` is rejected when the response includes a geometry column (CRS metadata cannot be written correctly; tracked as follow-up); allowed when `returnGeometry=false` or the layer has no geometry. When `outSR` is omitted, coordinates are reprojected to EPSG:4326 (matching GeoJSON behavior). CRS metadata omits the `crs` key for EPSG:4326 (spec-compliant OGC:CRS84 default). `bbox` is omitted because the spec defines it as the bounding box of geometries in the file, not the layer extent. |
 
 **Binary format limitations** (`fgb`, `geobuf`, `parquet`):
-- `parquet` applies `geometryPrecision`, `maxAllowableOffset`, `returnZ`, and `returnM` before writing WKB. `fgb` and `geobuf` still write raw geometry and ignore those parameters.
+- `parquet` applies `geometryPrecision`, `maxAllowableOffset`, and `returnZ` before writing WKB. M values are always stripped (GeoParquet 1.1.0 only supports XY/XYZ). `fgb` and `geobuf` still write raw geometry and ignore those parameters.
 - `exceededTransferLimit` is not conveyed. Clients should compare the returned feature count against `maxRecordCount` to detect truncation.
 
 ## ApplyEdits parameter coverage (layer `/applyEdits`)

--- a/docs/user/feature-server-matrix.md
+++ b/docs/user/feature-server-matrix.md
@@ -126,7 +126,7 @@ MapServer coverage is tracked separately:
 
 ### Output format details
 
-All non-JSON formats also accept `Accept` header negotiation (e.g. `Accept: application/vnd.apache.parquet`). When both `f=` and `Accept` are present, `f=` takes precedence.
+All non-JSON formats also accept `Accept` header negotiation (e.g. `Accept: application/vnd.apache.parquet`). When both `f=` and `Accept` are present, `f=` takes precedence. Accept negotiation uses first-recognized-type selection; quality values (`q=`) and media-range specificity are not evaluated. For deterministic results, prefer `f=` or send a single media type in the `Accept` header.
 
 **Special query modes**: `returnCountOnly`, `returnIdsOnly`, `returnExtentOnly`, and `outStatistics` queries always return JSON regardless of the requested format.
 

--- a/docs/user/feature-server-matrix.md
+++ b/docs/user/feature-server-matrix.md
@@ -97,7 +97,7 @@ MapServer coverage is tracked separately:
 | --- | --- | --- | --- |
 | Filtering | `where`, `objectIds` | Implemented | ArcGIS SQL parser; objectIds bypass where. |
 | Spatial filters | `geometry`, `geometryType`, `spatialRel`, `distance`, `units` | Implemented | Distance + KNN supported; geometry supports GeoServices JSON or point/envelope CSV. |
-| Spatial reference | `inSR`, `outSR` | Implemented | GeoJSON and GeoParquet output require EPSG:4326 when the response contains geometry; non-4326 `outSR` is rejected unless the geometry column is absent (`returnGeometry=false`, non-geometry layer, or a special query mode that returns JSON). Coordinates are reprojected to 4326 when `outSR` is omitted. |
+| Spatial reference | `inSR`, `outSR` | Implemented | GeoJSON output requires EPSG:4326; non-4326 `outSR` is rejected for non-special query modes. GeoParquet output requires EPSG:4326 when the response includes a geometry column; non-4326 `outSR` is rejected unless geometry is absent (`returnGeometry=false`, non-geometry layer, or a special query mode). Both formats reproject coordinates to EPSG:4326 when `outSR` is omitted. |
 | Pagination | `resultOffset`, `resultRecordCount` | Implemented | Validated against limits. |
 | Fields | `outFields` | Implemented | `*` returns all fields. |
 | Sorting | `orderByFields` | Implemented | Validates against layer fields; supports any field with ASC/DESC. |

--- a/docs/user/map-server-matrix.md
+++ b/docs/user/map-server-matrix.md
@@ -53,7 +53,7 @@ Legend: **Implemented** | **Partial** | **Not implemented**
 | `maxImageWidth` | Optional | Implemented | Configurable, default 4096. |
 | `maxImageHeight` | Optional | Implemented | Configurable, default 4096. |
 | `maxRecordCount` | Optional | Implemented | From `LimitsOptions.Query.MaxRecordCount`. |
-| `supportedQueryFormats` | Optional | Implemented | Comma-separated string from service `SupportedFormats`. |
+| `supportedQueryFormats` | Optional | Implemented | Normalized to uppercase from service `SupportedFormats`. Unlike FeatureServer, MapServer does not augment with runtime binary formats; however, layer queries delegate to the FeatureServer handler and support its full format set (including `f=parquet`). |
 | `minScale` | Optional | Implemented | Derived from max of layer `minScale` values. |
 | `maxScale` | Optional | Implemented | Derived from min of layer `maxScale` values. |
 | `documentInfo` | Optional | Implemented | Title, Author, Comments, Subject, Category, Keywords. |
@@ -81,7 +81,7 @@ Legend: **Implemented** | **Partial** | **Not implemented**
 | `minScale` / `maxScale` | Required | Implemented | |
 | `defaultVisibility` | Required | Implemented | |
 | `maxRecordCount` | Required | Implemented | |
-| `supportedQueryFormats` | Optional | Implemented | Comma-separated string from service `SupportedFormats`. |
+| `supportedQueryFormats` | Optional | Implemented | Normalized to uppercase from service `SupportedFormats`. Layer queries delegate to FeatureServer and support its full format set. |
 | `supportsStatistics` | Optional | Implemented | `false` (not yet supported). |
 | `supportsOrderBy` | Optional | Implemented | `true`. |
 | `supportsDistinct` | Optional | Implemented | `true`. |

--- a/src/Honua.Core/Features/Catalog/Domain/LayerDefinition.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/LayerDefinition.cs
@@ -80,6 +80,12 @@ public record LayerDefinition(
     public bool HasGeometry => GeometryType != GeometryType.None;
 
     /// <summary>
+    /// Effective object identifier field name: the primary key field name if available,
+    /// otherwise the canonical <see cref="FieldNames.ObjectId"/> fallback.
+    /// </summary>
+    public string ObjectIdFieldName => PrimaryKeyField?.Name ?? FieldNames.ObjectId;
+
+    /// <summary>
     /// Primary key field (typically the first integer field named 'id' or 'objectid')
     /// </summary>
     public FieldDefinition? PrimaryKeyField => Fields.FirstOrDefault(f =>

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerLog.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerLog.cs
@@ -205,6 +205,19 @@ internal static partial class FeatureServerLog
         Message = "GeoParquet conversion failed for field '{FieldName}' (value type: {ValueType}), value treated as null")]
     public static partial void GeoParquetConversionFailed(ILogger logger, string fieldName, string valueType, Exception exception);
 
+    /// <summary>
+    /// Logs when a geometry WKB value cannot be parsed during GeoParquet export and is treated as null.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="featureId">The object ID of the feature with corrupt geometry.</param>
+    /// <param name="wkbLength">The byte length of the unparseable WKB payload.</param>
+    /// <param name="exception">The parse exception.</param>
+    [LoggerMessage(
+        EventId = 2208,
+        Level = LogLevel.Debug,
+        Message = "GeoParquet export: corrupt WKB for feature {FeatureId} ({WkbLength} bytes), geometry treated as null")]
+    public static partial void GeoParquetCorruptGeometry(ILogger logger, long featureId, int wkbLength, Exception exception);
+
     // ApplyEdits events (2300-2399)
 
     /// <summary>

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerLog.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerLog.cs
@@ -192,6 +192,19 @@ internal static partial class FeatureServerLog
         Message = "Query {Operation} executed: {ServiceId}/FeatureServer/{LayerId} in {ElapsedMilliseconds} ms")]
     public static partial void QueryExecuted(ILogger logger, string operation, string serviceId, int layerId, double elapsedMilliseconds);
 
+    /// <summary>
+    /// Logs when a GeoParquet attribute conversion fails and the value is treated as null.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="fieldName">The field whose value could not be converted.</param>
+    /// <param name="valueType">The CLR type name of the unconvertible value.</param>
+    /// <param name="exception">The conversion exception.</param>
+    [LoggerMessage(
+        EventId = 2207,
+        Level = LogLevel.Debug,
+        Message = "GeoParquet conversion failed for field '{FieldName}' (value type: {ValueType}), value treated as null")]
+    public static partial void GeoParquetConversionFailed(ILogger logger, string fieldName, string valueType, Exception exception);
+
     // ApplyEdits events (2300-2399)
 
     /// <summary>

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
@@ -283,6 +283,35 @@ internal sealed class FeatureServerQueryHandler(
                 outputSrid ??= wgs84Srid;
             }
 
+            // GeoParquet CRS metadata: the formatter can only emit spec-compliant CRS for
+            // EPSG:4326 (omitted key = OGC:CRS84). Non-4326 outSR would produce a file
+            // with reprojected coordinates but "crs": null, misleading analytics clients.
+            // Only enforce when the response will actually contain geometry metadata —
+            // statistics, count, extent, and IDs queries always return JSON regardless of f=,
+            // and returnGeometry=false omits the geometry column entirely.
+            var requiresParquetOutput = string.Equals(format, "parquet", StringComparison.OrdinalIgnoreCase)
+                && !validatedParams.ReturnCountOnly
+                && !validatedParams.ReturnExtentOnly
+                && !validatedParams.ReturnIdsOnly
+                && validatedParams.ReturnGeometry
+                && layer.HasGeometry
+                && string.IsNullOrWhiteSpace(validatedParams.OutStatistics);
+
+            if (requiresParquetOutput)
+            {
+                var wgs84Srid = SpatialReference.WGS84.Wkid;
+                if (outputSrid.HasValue && outputSrid.Value != wgs84Srid)
+                {
+                    return StandardErrorHelpers.CreateBadRequest(context,
+                        "GeoParquet output does not yet support non-4326 outSR. CRS metadata cannot be written correctly for the requested spatial reference.");
+                }
+
+                // Force 4326 reprojection for parquet output, matching GeoJSON behavior.
+                // Without this, a layer natively in e.g. EPSG:3857 would produce a file
+                // with 3857 coordinates but "crs": null metadata, misleading analytics clients.
+                outputSrid ??= wgs84Srid;
+            }
+
             FilterExpression? filterExpression = null;
             if (!string.IsNullOrWhiteSpace(validatedParams.Where))
             {
@@ -565,7 +594,8 @@ internal sealed class FeatureServerQueryHandler(
                     : query;
                 QueryResult<Feature> result = await _queryExecutor.QueryWithValidationAsync(layerId, queryForExecution, cancellationToken);
                 queryStopwatch.Stop();
-                FeatureServerLog.QueryExecuted(_logger, "query", serviceId, layerId, queryStopwatch.Elapsed.TotalMilliseconds);
+                var queryOperation = isParquet ? "query_parquet" : "query";
+                FeatureServerLog.QueryExecuted(_logger, queryOperation, serviceId, layerId, queryStopwatch.Elapsed.TotalMilliseconds);
 
                 if (shouldApplyDistinct)
                 {

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
@@ -432,7 +432,7 @@ internal sealed class FeatureServerQueryHandler(
                 return await CreateCachedResultAsync(statisticsResponse, FeatureServerJsonContext.Default.QueryResponse, "application/json");
             }
 
-            var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
+            var objectIdFieldName = layer.ObjectIdFieldName;
 
             if (validatedParams.ReturnCountOnly)
             {

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
@@ -266,6 +266,8 @@ internal sealed class FeatureServerQueryHandler(
                     [$"Unsupported outSR value: {validatedParams.OutSr}"]);
             }
 
+            var wgs84Srid = SpatialReference.WGS84.Wkid;
+
             var requiresGeoJsonOutput = string.Equals(format, "geojson", StringComparison.OrdinalIgnoreCase)
                 && !validatedParams.ReturnCountOnly
                 && !validatedParams.ReturnExtentOnly
@@ -273,7 +275,6 @@ internal sealed class FeatureServerQueryHandler(
 
             if (requiresGeoJsonOutput)
             {
-                var wgs84Srid = SpatialReference.WGS84.Wkid;
                 if (outputSrid.HasValue && outputSrid.Value != wgs84Srid)
                 {
                     return StandardErrorHelpers.CreateBadRequest(context,
@@ -299,7 +300,6 @@ internal sealed class FeatureServerQueryHandler(
 
             if (requiresParquetOutput)
             {
-                var wgs84Srid = SpatialReference.WGS84.Wkid;
                 if (outputSrid.HasValue && outputSrid.Value != wgs84Srid)
                 {
                     return StandardErrorHelpers.CreateBadRequest(context,

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerRelatedRecordsHandler.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerRelatedRecordsHandler.cs
@@ -172,7 +172,7 @@ internal sealed class FeatureServerRelatedRecordsHandler(
             QueryResult<Feature> result = await _relatedRecordsService.ExecuteRelatedQueryAsync(layerId, relatedQuery, cancellationToken);
 
             // Group results by origin object ID
-            var objectIdFieldName = relatedLayer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
+            var objectIdFieldName = relatedLayer.ObjectIdFieldName;
             RelatedRecordGroup[] relatedRecordGroups = _relatedRecordsService.GroupRelatedRecords(
                 result,
                 objectIds,

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerUtilities.cs
@@ -492,6 +492,7 @@ internal static partial class FeatureServerEndpoints
         AddSupportedFormat(normalizedFormats, "GEOJSON");
         AddSupportedFormat(normalizedFormats, "PBF");
         AddSupportedFormat(normalizedFormats, "FGB");
+        AddSupportedFormat(normalizedFormats, "PARQUET");
 
         if (supportsGeobufOutput)
         {

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerUtilities.cs
@@ -319,7 +319,7 @@ internal static partial class FeatureServerEndpoints
         JsonElement? drawingInfo,
         bool supportsGeobufOutput)
     {
-        var objectIdField = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
+        var objectIdField = layer.ObjectIdFieldName;
         var displayField = ResolveDisplayFieldFromLayer(layer, objectIdField);
         var supportsStatistics = true;
         var supportsAdvancedQueries = service.SupportsAdvancedQueries;

--- a/src/Honua.Server/Features/FeatureServer/Models/Query/QueryParameters.cs
+++ b/src/Honua.Server/Features/FeatureServer/Models/Query/QueryParameters.cs
@@ -48,7 +48,7 @@ public sealed class QueryParameters
     public bool ReturnExtentOnly { get; init; }
 
     /// <summary>
-    /// Output format (json, pjson, geojson, pbf, fgb, geobuf)
+    /// Output format (json, pjson, geojson, pbf, fgb, geobuf, parquet)
     /// </summary>
     public string F { get; init; } = "json";
 

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -1,660 +1,580 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
-using System.Globalization;
-using System.Text.Json;
-using Honua.Core.Configuration;
+using System.Collections.Immutable;
+using Apache.Arrow;
+using Apache.Arrow.Types;
+using ParquetSharp.Arrow;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Shared.Models;
-using Honua.Server.Features.Infrastructure.Services;
-using NetTopologySuite.Geometries;
-using NetTopologySuite.IO;
-using Parquet;
-using Parquet.Schema;
-using ParquetDataColumn = Parquet.Data.DataColumn;
+using Honua.Server.Features.FeatureServer.Models;
+using Microsoft.Extensions.Logging;
 
 namespace Honua.Server.Features.FeatureServer.Services;
 
 /// <summary>
-/// Service for formatting query results as GeoParquet.
+/// Service for formatting query results as GeoParquet
 /// </summary>
 internal sealed class GeoParquetQueryFormatter
 {
+    // Constants for GeoParquet format
     private const string GeometryColumnName = "geometry";
+    private const string GeoParquetVersion = "1.1.0";
+    private const string GeometryEncoding = "WKB";
     private const string GeoMetadataKey = "geo";
+    private const string ContentType = "application/vnd.apache.parquet";
 
-    [ThreadStatic]
-    private static WKBReader? _wkbReader;
 
     /// <summary>
-    /// Formats query result as GeoParquet.
+    /// Formats query result as GeoParquet
     /// </summary>
-    public static async Task<(byte[] response, string contentType)> FormatAsGeoParquetAsync(
+    /// <param name="result">Query result with features</param>
+    /// <param name="layer">Layer definition for metadata</param>
+    /// <param name="returnGeometry">Whether to include geometry</param>
+    /// <param name="outputSrid">Output SRID for geometry</param>
+    /// <param name="returnZ">Whether to include Z values</param>
+    /// <param name="returnM">Whether to include M values</param>
+    /// <param name="geometryPrecision">Accepted for interface symmetry with other formatters; not applied to binary formats.</param>
+    /// <param name="maxAllowableOffset">Accepted for interface symmetry with other formatters; not applied to binary formats.</param>
+    /// <param name="outFields">Fields to include in output</param>
+    /// <param name="logger">Optional logger for conversion diagnostics</param>
+    /// <returns>Formatted result as byte array and content type</returns>
+    public static (byte[] response, string contentType) FormatAsGeoParquet(
         QueryResult<Feature> result,
         LayerDefinition layer,
         bool returnGeometry,
         int? outputSrid,
         bool returnZ,
         bool returnM,
-        GeometryLimits geometryLimits,
+        int? geometryPrecision,
+        double? maxAllowableOffset,
         string[]? outFields = null,
-        CancellationToken cancellationToken = default)
+        ILogger? logger = null)
     {
-        var selectedFields = ResolveSelectedFields(layer, outFields);
-        var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
-        var schema = new ParquetSchema(BuildSchemaFields(selectedFields, returnGeometry && layer.HasGeometry));
-        var features = result.Items.ToList();
+        var features = result.Items;
 
-        using var stream = new MemoryStream();
-        using (var writer = await ParquetWriter.CreateAsync(schema, stream, cancellationToken: cancellationToken))
+        if (features.Length == 0)
         {
-            writer.CustomMetadata = BuildGeoParquetMetadata(layer, returnGeometry, outputSrid, returnZ);
-
-            using (var rowGroupWriter = writer.CreateRowGroup())
-            {
-                foreach (var column in BuildColumns(
-                    features,
-                    selectedFields,
-                    schema,
-                    objectIdFieldName,
-                    returnGeometry && layer.HasGeometry,
-                    outputSrid ?? layer.SpatialReference.Wkid,
-                    geometryLimits,
-                    returnZ,
-                    returnM))
-                {
-                    await rowGroupWriter.WriteColumnAsync(column, cancellationToken);
-                }
-            }
+            // Return empty GeoParquet file with schema only
+            return CreateEmptyGeoParquet(layer, returnGeometry, outFields, outputSrid);
         }
 
-        return (stream.ToArray(), "application/vnd.apache.parquet");
+        // Detect runtime-computed attributes (e.g. "distance" from KNN queries) that
+        // exist in the result set but are not declared in the layer schema.
+        var runtimeFields = DetectRuntimeFields(features, layer);
+
+        var (schema, fieldsToInclude, objectIdFieldName) = BuildSchema(layer, returnGeometry, outFields, outputSrid, runtimeFields);
+
+        // Build record batch
+        var arrays = BuildArrays(features, schema, layer, returnGeometry, objectIdFieldName, fieldsToInclude, logger);
+
+        using var recordBatch = new RecordBatch(schema, arrays, features.Length);
+
+        // Write to Parquet format
+        using var stream = new MemoryStream();
+        var arrowWriterProperties = new ArrowWriterPropertiesBuilder().StoreSchema().Build();
+        using (var writer = new FileWriter(stream, schema, null, arrowWriterProperties, true))
+        {
+            writer.WriteRecordBatch(recordBatch);
+            writer.Close();
+        }
+
+        return (stream.ToArray(), ContentType);
     }
 
-    private static List<FieldDefinition> ResolveSelectedFields(LayerDefinition layer, string[]? outFields)
+    /// <summary>
+    /// Creates empty GeoParquet file with schema only
+    /// </summary>
+    private static (byte[] response, string contentType) CreateEmptyGeoParquet(
+        LayerDefinition layer,
+        bool returnGeometry,
+        string[]? outFields,
+        int? outputSrid)
+    {
+        var (schema, _, _) = BuildSchema(layer, returnGeometry, outFields, outputSrid);
+
+        using var stream = new MemoryStream();
+        var arrowWriterProperties = new ArrowWriterPropertiesBuilder().StoreSchema().Build();
+        using (var writer = new FileWriter(stream, schema, null, arrowWriterProperties, true))
+        {
+            writer.Close();
+        }
+
+        return (stream.ToArray(), ContentType);
+    }
+
+    /// <summary>
+    /// Builds the Arrow schema and resolves which attribute fields to include.
+    /// Shared by both populated and empty GeoParquet paths.
+    /// </summary>
+    /// <param name="layer">Layer definition for schema metadata.</param>
+    /// <param name="returnGeometry">Whether to include the geometry column.</param>
+    /// <param name="outFields">Requested output fields, or null / ["*"] for all.</param>
+    /// <param name="outputSrid">Output SRID for CRS metadata.</param>
+    /// <param name="runtimeFields">
+    /// Runtime-computed attributes detected from the result set (e.g. "distance" from KNN queries).
+    /// These exist in <c>feature.Attributes</c> but are not part of the layer schema.
+    /// Pass an empty list for the empty-result path.
+    /// </param>
+    private static (Schema schema, List<FieldDefinition> fieldsToInclude, string objectIdFieldName) BuildSchema(
+        LayerDefinition layer,
+        bool returnGeometry,
+        string[]? outFields,
+        int? outputSrid,
+        IReadOnlyList<(string name, IArrowType type)>? runtimeFields = null)
     {
         var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
         var includeAllFields = outFields == null || outFields.Length == 0 ||
-            (outFields.Length == 1 && outFields[0].Equals("*", StringComparison.Ordinal));
+                              (outFields.Length == 1 && outFields[0].Equals("*", StringComparison.Ordinal));
 
-        HashSet<string>? requestedFields = null;
-        if (!includeAllFields)
+        var schemaFields = new List<Field>
         {
-            requestedFields = new HashSet<string>(outFields!, StringComparer.OrdinalIgnoreCase)
-            {
-                objectIdFieldName
-            };
+            new Field(objectIdFieldName, new Int64Type(), false)
+        };
+
+        if (returnGeometry && layer.HasGeometry)
+        {
+            schemaFields.Add(new Field(GeometryColumnName, new BinaryType(), true));
         }
 
-        var selectedFields = layer.Fields
-            .Where(field => !field.IsGeometry)
-            .Where(field => includeAllFields || requestedFields!.Contains(field.Name))
+        var fieldsToInclude = (includeAllFields
+            ? layer.Fields.Where(f => !f.IsGeometry && !f.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase))
+            : layer.Fields.Where(f => !f.IsGeometry && !f.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase) && outFields!.Contains(f.Name, StringComparer.OrdinalIgnoreCase)))
             .ToList();
 
-        if (!selectedFields.Any(field => field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase)))
+        foreach (var field in fieldsToInclude)
         {
-            selectedFields.Insert(0, new FieldDefinition(objectIdFieldName, FieldType.BigInteger, Nullable: false));
+            schemaFields.Add(new Field(field.Name, MapToArrowType(field), field.Nullable));
         }
 
-        return selectedFields;
-    }
-
-    private static Field[] BuildSchemaFields(List<FieldDefinition> selectedFields, bool includeGeometry)
-    {
-        var fields = new List<Field>(selectedFields.Count + (includeGeometry ? 1 : 0));
-
-        foreach (var field in selectedFields)
+        // Append runtime-computed attributes (e.g. "distance" from KNN queries) that are
+        // not declared in the layer schema but appear in feature.Attributes.
+        // Only include when outFields is omitted / "*", or the field was explicitly requested,
+        // to match the filtering behavior of JSON/GeoJSON/PBF formatters.
+        if (runtimeFields != null)
         {
-            fields.Add(CreateSchemaField(field));
-        }
-
-        if (includeGeometry)
-        {
-            fields.Add(new DataField<byte[]>(GeometryColumnName, true));
-        }
-
-        return fields.ToArray();
-    }
-
-    private static IEnumerable<ParquetDataColumn> BuildColumns(
-        IReadOnlyList<Feature> features,
-        List<FieldDefinition> selectedFields,
-        ParquetSchema schema,
-        string objectIdFieldName,
-        bool includeGeometry,
-        int outputSrid,
-        GeometryLimits geometryLimits,
-        bool returnZ,
-        bool returnM)
-    {
-        foreach (var field in selectedFields)
-        {
-            yield return BuildAttributeColumn(
-                features,
-                schema.FindDataField(field.Name)!,
-                field,
-                field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase));
-        }
-
-        if (includeGeometry)
-        {
-            var geometryField = schema.FindDataField(GeometryColumnName)!;
-            var geometryValues = features
-                .Select(feature => ProcessGeometry(feature.Geometry, outputSrid, geometryLimits, returnZ, returnM))
-                .ToArray();
-
-            yield return new ParquetDataColumn(geometryField, geometryValues);
-        }
-    }
-
-    private static ParquetDataColumn BuildAttributeColumn(
-        IReadOnlyList<Feature> features,
-        DataField dataField,
-        FieldDefinition field,
-        bool isObjectIdField)
-    {
-        return field.Type switch
-        {
-            FieldType.BigInteger => new ParquetDataColumn(
-                dataField,
-                BuildInt64Values(features, field, isObjectIdField)),
-            FieldType.Integer => new ParquetDataColumn(
-                dataField,
-                BuildInt32Values(features, field, isObjectIdField)),
-            FieldType.Float => new ParquetDataColumn(
-                dataField,
-                BuildFloatValues(features, field)),
-            FieldType.Double => new ParquetDataColumn(
-                dataField,
-                BuildDoubleValues(features, field)),
-            FieldType.Boolean => new ParquetDataColumn(
-                dataField,
-                BuildBooleanValues(features, field)),
-            FieldType.DateTime => new ParquetDataColumn(
-                dataField,
-                BuildDateTimeValues(features, field, dateOnly: false)),
-            FieldType.Date => new ParquetDataColumn(
-                dataField,
-                BuildDateTimeValues(features, field, dateOnly: true)),
-            FieldType.Time => new ParquetDataColumn(
-                dataField,
-                BuildTimeOnlyValues(features, field)),
-            FieldType.Binary => new ParquetDataColumn(
-                dataField,
-                BuildBinaryValues(features, field)),
-            _ => new ParquetDataColumn(
-                dataField,
-                BuildStringValues(features, field)),
-        };
-    }
-
-    private static DataField CreateSchemaField(FieldDefinition field)
-    {
-        return field.Type switch
-        {
-            FieldType.BigInteger => new DataField(field.Name, field.Nullable ? typeof(long?) : typeof(long), field.Nullable),
-            FieldType.Integer => new DataField(field.Name, field.Nullable ? typeof(int?) : typeof(int), field.Nullable),
-            FieldType.Float => new DataField(field.Name, field.Nullable ? typeof(float?) : typeof(float), field.Nullable),
-            FieldType.Double => new DataField(field.Name, field.Nullable ? typeof(double?) : typeof(double), field.Nullable),
-            FieldType.Boolean => new DataField(field.Name, field.Nullable ? typeof(bool?) : typeof(bool), field.Nullable),
-            FieldType.DateTime => new DateTimeDataField(
-                field.Name,
-                DateTimeFormat.DateAndTime,
-                isAdjustedToUTC: true,
-                DateTimeTimeUnit.Millis,
-                field.Nullable),
-            FieldType.Date => new DateTimeDataField(
-                field.Name,
-                DateTimeFormat.Date,
-                isAdjustedToUTC: true,
-                unit: null,
-                field.Nullable),
-            FieldType.Time => new TimeOnlyDataField(field.Name, TimeSpanFormat.MilliSeconds, field.Nullable),
-            FieldType.Binary => new DataField<byte[]>(field.Name, field.Nullable),
-            _ => new DataField<string>(field.Name, field.Nullable),
-        };
-    }
-
-    private static Array BuildInt64Values(IReadOnlyList<Feature> features, FieldDefinition field, bool isObjectIdField)
-    {
-        if (isObjectIdField)
-        {
-            var values = new long[features.Count];
-            for (var i = 0; i < features.Count; i++)
+            foreach (var (name, type) in runtimeFields)
             {
-                values[i] = GetInt64Value(features[i], field, isObjectIdField);
+                if (includeAllFields || outFields!.Contains(name, StringComparer.OrdinalIgnoreCase))
+                {
+                    schemaFields.Add(new Field(name, type, nullable: true));
+                }
             }
-
-            return values;
         }
 
-        var nullableValues = new long?[features.Count];
-        for (var i = 0; i < features.Count; i++)
-        {
-            nullableValues[i] = TryConvertInt64(GetAttributeValue(features[i], field.Name));
-        }
-
-        return nullableValues;
+        var schema = new Schema(schemaFields, BuildGeoParquetMetadata(layer, returnGeometry, outputSrid));
+        return (schema, fieldsToInclude, objectIdFieldName);
     }
 
-    private static Array BuildInt32Values(IReadOnlyList<Feature> features, FieldDefinition field, bool isObjectIdField)
-    {
-        if (isObjectIdField)
-        {
-            var objectIdValues = new int[features.Count];
-            for (var i = 0; i < features.Count; i++)
-            {
-                objectIdValues[i] = Convert.ToInt32(GetInt64Value(features[i], field, isObjectIdField), CultureInfo.InvariantCulture);
-            }
-
-            return objectIdValues;
-        }
-
-        var values = new int?[features.Count];
-        for (var i = 0; i < features.Count; i++)
-        {
-            values[i] = TryConvertInt32(GetAttributeValue(features[i], field.Name));
-        }
-
-        return values;
-    }
-
-    private static float?[] BuildFloatValues(IReadOnlyList<Feature> features, FieldDefinition field)
-    {
-        var values = new float?[features.Count];
-        for (var i = 0; i < features.Count; i++)
-        {
-            values[i] = TryConvertFloat(GetAttributeValue(features[i], field.Name));
-        }
-
-        return values;
-    }
-
-    private static double?[] BuildDoubleValues(IReadOnlyList<Feature> features, FieldDefinition field)
-    {
-        var values = new double?[features.Count];
-        for (var i = 0; i < features.Count; i++)
-        {
-            values[i] = TryConvertDouble(GetAttributeValue(features[i], field.Name));
-        }
-
-        return values;
-    }
-
-    private static bool?[] BuildBooleanValues(IReadOnlyList<Feature> features, FieldDefinition field)
-    {
-        var values = new bool?[features.Count];
-        for (var i = 0; i < features.Count; i++)
-        {
-            values[i] = TryConvertBoolean(GetAttributeValue(features[i], field.Name));
-        }
-
-        return values;
-    }
-
-    private static DateTime?[] BuildDateTimeValues(IReadOnlyList<Feature> features, FieldDefinition field, bool dateOnly)
-    {
-        var values = new DateTime?[features.Count];
-        for (var i = 0; i < features.Count; i++)
-        {
-            var value = TryConvertDateTime(GetAttributeValue(features[i], field.Name));
-            values[i] = dateOnly && value.HasValue
-                ? DateTime.SpecifyKind(value.Value.Date, DateTimeKind.Utc)
-                : value;
-        }
-
-        return values;
-    }
-
-    private static TimeOnly?[] BuildTimeOnlyValues(IReadOnlyList<Feature> features, FieldDefinition field)
-    {
-        var values = new TimeOnly?[features.Count];
-        for (var i = 0; i < features.Count; i++)
-        {
-            values[i] = TryConvertTimeOnly(GetAttributeValue(features[i], field.Name));
-        }
-
-        return values;
-    }
-
-    private static byte[]?[] BuildBinaryValues(IReadOnlyList<Feature> features, FieldDefinition field)
-    {
-        var values = new byte[]?[features.Count];
-        for (var i = 0; i < features.Count; i++)
-        {
-            values[i] = TryConvertBytes(GetAttributeValue(features[i], field.Name));
-        }
-
-        return values;
-    }
-
-    private static string?[] BuildStringValues(IReadOnlyList<Feature> features, FieldDefinition field)
-    {
-        var values = new string?[features.Count];
-        for (var i = 0; i < features.Count; i++)
-        {
-            values[i] = ConvertToStringValue(GetAttributeValue(features[i], field.Name));
-        }
-
-        return values;
-    }
-
-    private static long GetInt64Value(Feature feature, FieldDefinition field, bool isObjectIdField)
-    {
-        var value = GetAttributeValue(feature, field.Name);
-        return TryConvertInt64(value) ?? (isObjectIdField ? feature.Id : 0L);
-    }
-
-    private static object? GetAttributeValue(Feature feature, string fieldName)
-    {
-        return feature.Attributes.TryGetValue(fieldName, out var value) ? value : null;
-    }
-
-    private static byte[]? ProcessGeometry(
-        byte[]? geometryBytes,
-        int outputSrid,
-        GeometryLimits geometryLimits,
-        bool returnZ,
-        bool returnM)
-    {
-        if (geometryBytes == null || geometryBytes.Length == 0)
-        {
-            return null;
-        }
-
-        var geometry = GetWkbReader().Read(geometryBytes);
-        if (geometry == null)
-        {
-            return null;
-        }
-
-        geometry.SRID = outputSrid;
-        geometry = GeometryOutputProcessor.ApplyLimits(geometry, geometryLimits);
-        if (geometry == null)
-        {
-            return null;
-        }
-
-        if (!returnZ || !returnM)
-        {
-            geometry = GeometryOutputProcessor.ApplyDimensionFilter(geometry, returnZ, returnM);
-        }
-
-        var hasZ = GeometryHasZ(geometry);
-        var hasM = GeometryHasM(geometry);
-        var writer = new WKBWriter(ByteOrder.LittleEndian, handleSRID: false, emitZ: hasZ, emitM: hasM);
-        return writer.Write(geometry);
-    }
-
+    /// <summary>
+    /// Builds GeoParquet metadata following the specification
+    /// </summary>
     private static Dictionary<string, string> BuildGeoParquetMetadata(
         LayerDefinition layer,
         bool returnGeometry,
-        int? outputSrid,
-        bool returnZ)
+        int? outputSrid)
     {
+        var metadata = new Dictionary<string, string>();
+
         if (!returnGeometry || !layer.HasGeometry)
         {
-            return new Dictionary<string, string>(StringComparer.Ordinal);
+            return metadata;
         }
 
         var srid = outputSrid ?? layer.SpatialReference.Wkid;
-        var geometryType = MapGeometryTypeToGeoParquet(layer.GeometryType, returnZ);
 
-        var geoMetadata = new Dictionary<string, object?>(StringComparer.Ordinal)
-        {
-            ["version"] = "1.1.0",
-            ["primary_column"] = GeometryColumnName,
-            ["columns"] = new Dictionary<string, object?>(StringComparer.Ordinal)
-            {
-                [GeometryColumnName] = BuildGeometryColumnMetadata(layer, srid, geometryType)
-            }
-        };
+        // Build JSON manually to avoid AOT issues.
+        // GeoParquet 1.1.0 spec CRS rules:
+        //   - Omitting the `crs` key implies OGC:CRS84 (WGS84 lon/lat).
+        //   - `"crs": null` means the CRS is undefined/unknown.
+        //   - Any present `crs` value must be a full PROJJSON CRS object.
+        // For EPSG:4326 we omit the key (spec-compliant OGC:CRS84 default).
+        // For other SRIDs we write null because generating valid PROJJSON requires
+        // a CRS lookup table or projection library; tracked as follow-up.
+        var crsPart = srid == 4326
+            ? ""
+            : ",\"crs\":null";
 
-        return new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [GeoMetadataKey] = JsonSerializer.Serialize(geoMetadata)
-        };
-    }
+        // bbox is omitted: GeoParquet 1.1.0 defines bbox as the bounding box of the
+        // geometries *in the file*, but we only have the full layer extent which would
+        // be incorrect for filtered or empty exports. Computing the actual result bbox
+        // would require parsing every WKB geometry; deferred to a follow-up.
 
-    private static Dictionary<string, object?> BuildGeometryColumnMetadata(
-        LayerDefinition layer,
-        int srid,
-        string geometryType)
-    {
-        var metadata = new Dictionary<string, object?>(StringComparer.Ordinal)
-        {
-            ["encoding"] = "WKB",
-            ["geometry_types"] = new[] { geometryType },
-            ["crs"] = new Dictionary<string, object?>(StringComparer.Ordinal)
-            {
-                ["type"] = "name",
-                ["properties"] = new Dictionary<string, object?>(StringComparer.Ordinal)
-                {
-                    ["name"] = $"EPSG:{srid}"
-                }
-            }
-        };
+        var geomType = MapGeometryTypeToGeoParquet(layer.GeometryType);
+        var geoJson = $@"{{""version"":""{GeoParquetVersion}"",""primary_column"":""{GeometryColumnName}"",""columns"":{{""{GeometryColumnName}"":{{""encoding"":""{GeometryEncoding}"",""geometry_types"":[""{geomType}""]{crsPart}}}}}}}";
 
-        if (layer.Extent.HasValue && srid == layer.SpatialReference.Wkid)
-        {
-            metadata["bbox"] = new[]
-            {
-                layer.Extent.Value.MinX,
-                layer.Extent.Value.MinY,
-                layer.Extent.Value.MaxX,
-                layer.Extent.Value.MaxY
-            };
-        }
+        metadata[GeoMetadataKey] = geoJson;
 
         return metadata;
     }
 
-    private static string MapGeometryTypeToGeoParquet(Honua.Core.Features.Catalog.Domain.GeometryType geometryType, bool returnZ)
+
+    /// <summary>
+    /// Detects runtime-computed attributes present in the result set but not declared in the
+    /// layer schema (e.g. the "distance" field injected by KNN queries when returnDistance=true).
+    /// Internal fields prefixed with "__" are excluded.
+    /// </summary>
+    private static List<(string name, IArrowType type)> DetectRuntimeFields(
+        ImmutableArray<Feature> features,
+        LayerDefinition layer)
     {
-        var baseType = geometryType switch
+        var result = new List<(string name, IArrowType type)>();
+        if (features.Length == 0) return result;
+
+        var layerFieldNames = new HashSet<string>(
+            layer.Fields.Select(f => f.Name), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (key, value) in features[0].Attributes)
         {
-            Honua.Core.Features.Catalog.Domain.GeometryType.Point => "Point",
-            Honua.Core.Features.Catalog.Domain.GeometryType.LineString => "LineString",
-            Honua.Core.Features.Catalog.Domain.GeometryType.Polygon => "Polygon",
-            Honua.Core.Features.Catalog.Domain.GeometryType.MultiPoint => "MultiPoint",
-            Honua.Core.Features.Catalog.Domain.GeometryType.MultiLineString => "MultiLineString",
-            Honua.Core.Features.Catalog.Domain.GeometryType.MultiPolygon => "MultiPolygon",
-            Honua.Core.Features.Catalog.Domain.GeometryType.GeometryCollection => "GeometryCollection",
+            if (layerFieldNames.Contains(key)) continue;
+            // Skip internal fields (e.g. __honua_total_count)
+            if (key.StartsWith("__", StringComparison.Ordinal)) continue;
+
+            var arrowType = InferArrowTypeFromValue(value);
+            if (arrowType != null)
+                result.Add((key, arrowType));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Infers an Arrow type from a CLR runtime value. Returns null for unrecognised types.
+    /// </summary>
+    private static IArrowType? InferArrowTypeFromValue(object? value)
+    {
+        return value switch
+        {
+            double => new DoubleType(),
+            float => new FloatType(),
+            int => new Int32Type(),
+            long => new Int64Type(),
+            bool => new BooleanType(),
+            string => new StringType(),
+            DateTime => new TimestampType(TimeUnit.Millisecond, TimeZoneInfo.Utc),
+            DateTimeOffset => new TimestampType(TimeUnit.Millisecond, TimeZoneInfo.Utc),
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Maps layer geometry type to GeoParquet geometry type string
+    /// </summary>
+    private static string MapGeometryTypeToGeoParquet(Core.Features.Catalog.Domain.GeometryType geometryType)
+    {
+        return geometryType switch
+        {
+            Core.Features.Catalog.Domain.GeometryType.Point => "Point",
+            Core.Features.Catalog.Domain.GeometryType.LineString => "LineString",
+            Core.Features.Catalog.Domain.GeometryType.Polygon => "Polygon",
+            Core.Features.Catalog.Domain.GeometryType.MultiPoint => "MultiPoint",
+            Core.Features.Catalog.Domain.GeometryType.MultiLineString => "MultiLineString",
+            Core.Features.Catalog.Domain.GeometryType.MultiPolygon => "MultiPolygon",
+            Core.Features.Catalog.Domain.GeometryType.GeometryCollection => "GeometryCollection",
             _ => "Geometry"
         };
-
-        return returnZ ? $"{baseType} Z" : baseType;
     }
 
-    private static long? TryConvertInt64(object? value)
+    /// <summary>
+    /// Maps field definition to Arrow data type.
+    /// IMPORTANT: keep in sync with <see cref="BuildAttributeArray"/> which selects the
+    /// matching typed builder for the same SQL type strings.
+    /// </summary>
+    private static IArrowType MapToArrowType(FieldDefinition field)
     {
-        return value switch
+        return field.SqlType.ToLowerInvariant() switch
         {
-            null => null,
-            long longValue => longValue,
-            int intValue => intValue,
-            short shortValue => shortValue,
-            byte byteValue => byteValue,
-            double doubleValue => Convert.ToInt64(doubleValue, CultureInfo.InvariantCulture),
-            decimal decimalValue => Convert.ToInt64(decimalValue, CultureInfo.InvariantCulture),
-            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetInt64(out var jsonLong) => jsonLong,
-            string stringValue when long.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) => parsed,
-            _ => null
+            "bigint" or "int8" => new Int64Type(),
+            "integer" or "int4" => new Int32Type(),
+            "smallint" or "int2" => new Int16Type(),
+            "real" or "float4" => new FloatType(),
+            "double precision" or "float8" => new DoubleType(),
+            "boolean" or "bool" => new BooleanType(),
+            "date" => new Date32Type(),
+            "timestamp" or "timestamptz" or "timestamp with time zone" or "timestamp without time zone" => new TimestampType(TimeUnit.Millisecond, TimeZoneInfo.Utc),
+            "bytea" => new BinaryType(),
+            "uuid" => new StringType(),
+            "json" or "jsonb" => new StringType(),
+            _ when field.SqlType.StartsWith("varchar", StringComparison.OrdinalIgnoreCase) => new StringType(),
+            _ when field.SqlType.StartsWith("char", StringComparison.OrdinalIgnoreCase) => new StringType(),
+            _ when field.SqlType.StartsWith("text", StringComparison.OrdinalIgnoreCase) => new StringType(),
+            _ when field.SqlType.StartsWith("numeric", StringComparison.OrdinalIgnoreCase) => new DoubleType(),
+            _ when field.SqlType.StartsWith("decimal", StringComparison.OrdinalIgnoreCase) => new DoubleType(),
+            _ => new StringType() // Default to string for unknown types
         };
     }
 
-    private static int? TryConvertInt32(object? value)
+    /// <summary>
+    /// Builds Arrow arrays for each column
+    /// </summary>
+    private static IArrowArray[] BuildArrays(
+        ImmutableArray<Feature> features,
+        Schema schema,
+        LayerDefinition layer,
+        bool returnGeometry,
+        string objectIdFieldName,
+        List<FieldDefinition> fieldsToInclude,
+        ILogger? logger = null)
     {
-        return value switch
-        {
-            null => null,
-            int intValue => intValue,
-            long longValue => Convert.ToInt32(longValue, CultureInfo.InvariantCulture),
-            short shortValue => shortValue,
-            byte byteValue => byteValue,
-            double doubleValue => Convert.ToInt32(doubleValue, CultureInfo.InvariantCulture),
-            decimal decimalValue => Convert.ToInt32(decimalValue, CultureInfo.InvariantCulture),
-            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetInt32(out var jsonInt) => jsonInt,
-            string stringValue when int.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) => parsed,
-            _ => null
-        };
-    }
+        var arrays = new List<IArrowArray>();
 
-    private static float? TryConvertFloat(object? value)
-    {
-        return value switch
+        foreach (var field in schema.FieldsList)
         {
-            null => null,
-            float floatValue => floatValue,
-            double doubleValue => Convert.ToSingle(doubleValue, CultureInfo.InvariantCulture),
-            decimal decimalValue => Convert.ToSingle(decimalValue, CultureInfo.InvariantCulture),
-            int intValue => intValue,
-            long longValue => longValue,
-            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetSingle(out var jsonFloat) => jsonFloat,
-            string stringValue when float.TryParse(stringValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsed) => parsed,
-            _ => null
-        };
-    }
-
-    private static double? TryConvertDouble(object? value)
-    {
-        return value switch
-        {
-            null => null,
-            double doubleValue => doubleValue,
-            float floatValue => floatValue,
-            decimal decimalValue => Convert.ToDouble(decimalValue, CultureInfo.InvariantCulture),
-            int intValue => intValue,
-            long longValue => longValue,
-            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetDouble(out var jsonDouble) => jsonDouble,
-            string stringValue when double.TryParse(stringValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsed) => parsed,
-            _ => null
-        };
-    }
-
-    private static bool? TryConvertBoolean(object? value)
-    {
-        return value switch
-        {
-            null => null,
-            bool boolValue => boolValue,
-            JsonElement element when element.ValueKind == JsonValueKind.True => true,
-            JsonElement element when element.ValueKind == JsonValueKind.False => false,
-            string stringValue when bool.TryParse(stringValue, out var parsedBool) => parsedBool,
-            string stringValue when int.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedInt) => parsedInt != 0,
-            int intValue => intValue != 0,
-            long longValue => longValue != 0,
-            _ => null
-        };
-    }
-
-    private static DateTime? TryConvertDateTime(object? value)
-    {
-        return value switch
-        {
-            null => null,
-            DateTimeOffset dateTimeOffset => dateTimeOffset.UtcDateTime,
-            DateTime dateTime => dateTime.Kind switch
+            if (field.Name == objectIdFieldName)
             {
-                DateTimeKind.Utc => dateTime,
-                DateTimeKind.Local => dateTime.ToUniversalTime(),
-                _ => DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
+                arrays.Add(BuildObjectIdArray(features));
+            }
+            else if (field.Name == GeometryColumnName && returnGeometry)
+            {
+                arrays.Add(BuildGeometryArray(features));
+            }
+            else
+            {
+                var fieldDef = fieldsToInclude.FirstOrDefault(f => f.Name.Equals(field.Name, StringComparison.OrdinalIgnoreCase));
+                if (fieldDef != null)
+                {
+                    arrays.Add(BuildAttributeArray(features, field.Name, fieldDef, logger));
+                }
+                else
+                {
+                    // Runtime-computed attribute (e.g. "distance" from KNN queries):
+                    // no FieldDefinition exists, so dispatch by the Arrow type declared in the schema.
+                    arrays.Add(BuildRuntimeAttributeArray(features, field, logger));
+                }
+            }
+        }
+
+        return arrays.ToArray();
+    }
+
+    /// <summary>
+    /// Builds Int64 array for object IDs directly from features without intermediate allocation
+    /// </summary>
+    private static Int64Array BuildObjectIdArray(ImmutableArray<Feature> features)
+    {
+        var builder = new Int64Array.Builder();
+        foreach (var feature in features)
+        {
+            builder.Append(feature.Id);
+        }
+        return builder.Build();
+    }
+
+    /// <summary>
+    /// Builds binary array for WKB geometry data
+    /// </summary>
+    private static BinaryArray BuildGeometryArray(ImmutableArray<Feature> features)
+    {
+        var builder = new BinaryArray.Builder();
+
+        foreach (var feature in features)
+        {
+            if (feature.Geometry != null && feature.Geometry.Length > 0)
+            {
+                builder.Append(feature.Geometry);
+            }
+            else
+            {
+                builder.AppendNull();
+            }
+        }
+
+        return builder.Build();
+    }
+
+    /// <summary>
+    /// Builds attribute array for a specific field.
+    /// IMPORTANT: keep in sync with <see cref="MapToArrowType"/> which declares the
+    /// Arrow schema type for the same SQL type strings.
+    /// </summary>
+    private static IArrowArray BuildAttributeArray(
+        ImmutableArray<Feature> features,
+        string fieldName,
+        FieldDefinition fieldDef,
+        ILogger? logger = null)
+    {
+        var sqlType = fieldDef.SqlType.ToLowerInvariant();
+        return sqlType switch
+        {
+            "bigint" or "int8" => BuildInt64AttributeArray(features, fieldName, logger),
+            "integer" or "int4" => BuildInt32AttributeArray(features, fieldName, logger),
+            "smallint" or "int2" => BuildInt16AttributeArray(features, fieldName, logger),
+            "real" or "float4" => BuildFloatAttributeArray(features, fieldName, logger),
+            "double precision" or "float8" => BuildDoubleAttributeArray(features, fieldName, logger),
+            "boolean" or "bool" => BuildBooleanAttributeArray(features, fieldName, logger),
+            "bytea" => BuildBinaryAttributeArray(features, fieldName, logger),
+            "date" => BuildDate32AttributeArray(features, fieldName, logger),
+            "timestamp" or "timestamptz" or "timestamp with time zone" or "timestamp without time zone" => BuildTimestampAttributeArray(features, fieldName, logger),
+            _ when sqlType.StartsWith("numeric", StringComparison.OrdinalIgnoreCase) => BuildDoubleAttributeArray(features, fieldName, logger),
+            _ when sqlType.StartsWith("decimal", StringComparison.OrdinalIgnoreCase) => BuildDoubleAttributeArray(features, fieldName, logger),
+            _ => BuildStringAttributeArray(features, fieldName, logger)
+        };
+    }
+
+
+    /// <summary>
+    /// Iterates features extracting attribute values, handling nulls and conversion errors.
+    /// </summary>
+    private static void ForEachAttribute(
+        ImmutableArray<Feature> features,
+        string fieldName,
+        Action<object> onValue,
+        Action onNull,
+        ILogger? logger = null)
+    {
+        foreach (var feature in features)
+        {
+            if (feature.Attributes.TryGetValue(fieldName, out var value) && value != null)
+            {
+                try
+                {
+                    onValue(value);
+                }
+                catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException)
+                {
+                    if (logger != null)
+                    {
+                        FeatureServerLog.GeoParquetConversionFailed(logger, fieldName, value.GetType().Name, ex);
+                    }
+
+                    onNull();
+                }
+            }
+            else
+            {
+                onNull();
+            }
+        }
+    }
+
+    private static Int64Array BuildInt64AttributeArray(ImmutableArray<Feature> features, string fieldName, ILogger? logger = null)
+    {
+        var builder = new Int64Array.Builder();
+        ForEachAttribute(features, fieldName, v => builder.Append(Convert.ToInt64(v)), () => builder.AppendNull(), logger);
+        return builder.Build();
+    }
+
+    private static Int32Array BuildInt32AttributeArray(ImmutableArray<Feature> features, string fieldName, ILogger? logger = null)
+    {
+        var builder = new Int32Array.Builder();
+        ForEachAttribute(features, fieldName, v => builder.Append(Convert.ToInt32(v)), () => builder.AppendNull(), logger);
+        return builder.Build();
+    }
+
+    private static Int16Array BuildInt16AttributeArray(ImmutableArray<Feature> features, string fieldName, ILogger? logger = null)
+    {
+        var builder = new Int16Array.Builder();
+        ForEachAttribute(features, fieldName, v => builder.Append(Convert.ToInt16(v)), () => builder.AppendNull(), logger);
+        return builder.Build();
+    }
+
+    private static FloatArray BuildFloatAttributeArray(ImmutableArray<Feature> features, string fieldName, ILogger? logger = null)
+    {
+        var builder = new FloatArray.Builder();
+        ForEachAttribute(features, fieldName, v => builder.Append(Convert.ToSingle(v)), () => builder.AppendNull(), logger);
+        return builder.Build();
+    }
+
+    private static DoubleArray BuildDoubleAttributeArray(ImmutableArray<Feature> features, string fieldName, ILogger? logger = null)
+    {
+        var builder = new DoubleArray.Builder();
+        ForEachAttribute(features, fieldName, v => builder.Append(Convert.ToDouble(v)), () => builder.AppendNull(), logger);
+        return builder.Build();
+    }
+
+    private static BooleanArray BuildBooleanAttributeArray(ImmutableArray<Feature> features, string fieldName, ILogger? logger = null)
+    {
+        var builder = new BooleanArray.Builder();
+        ForEachAttribute(features, fieldName, v => builder.Append(Convert.ToBoolean(v)), () => builder.AppendNull(), logger);
+        return builder.Build();
+    }
+
+    private static Date32Array BuildDate32AttributeArray(ImmutableArray<Feature> features, string fieldName, ILogger? logger = null)
+    {
+        var builder = new Date32Array.Builder();
+        ForEachAttribute(features, fieldName, v => builder.Append(Convert.ToDateTime(v)), () => builder.AppendNull(), logger);
+        return builder.Build();
+    }
+
+    private static TimestampArray BuildTimestampAttributeArray(ImmutableArray<Feature> features, string fieldName, ILogger? logger = null)
+    {
+        var builder = new TimestampArray.Builder(TimeUnit.Millisecond, TimeZoneInfo.Utc);
+        ForEachAttribute(features, fieldName,
+            v =>
+            {
+                var dt = Convert.ToDateTime(v);
+                if (dt.Kind == DateTimeKind.Unspecified)
+                    dt = DateTime.SpecifyKind(dt, DateTimeKind.Utc);
+                builder.Append(new DateTimeOffset(dt.ToUniversalTime()));
             },
-            DateOnly dateOnly => DateTime.SpecifyKind(dateOnly.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc),
-            JsonElement element when element.ValueKind == JsonValueKind.String => TryConvertDateTime(element.GetString()),
-            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetInt64(out var milliseconds) =>
-                DateTimeOffset.FromUnixTimeMilliseconds(milliseconds).UtcDateTime,
-            string stringValue when DateTimeOffset.TryParse(
-                stringValue,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.RoundtripKind | DateTimeStyles.AllowWhiteSpaces,
-                out var parsedOffset) => parsedOffset.UtcDateTime,
-            string stringValue when DateTime.TryParse(
-                stringValue,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces,
-                out var parsedDateTime) => parsedDateTime,
-            long milliseconds => DateTimeOffset.FromUnixTimeMilliseconds(milliseconds).UtcDateTime,
-            double milliseconds => DateTimeOffset.FromUnixTimeMilliseconds(Convert.ToInt64(milliseconds, CultureInfo.InvariantCulture)).UtcDateTime,
-            _ => null
+            () => builder.AppendNull(), logger);
+        return builder.Build();
+    }
+
+    private static BinaryArray BuildBinaryAttributeArray(ImmutableArray<Feature> features, string fieldName, ILogger? logger = null)
+    {
+        var builder = new BinaryArray.Builder();
+        ForEachAttribute(features, fieldName,
+            v =>
+            {
+                if (v is byte[] bytes)
+                {
+                    builder.Append(bytes);
+                }
+                else if (v is string s)
+                {
+                    // BYTEA attributes stored in the JSONB column are serialised as base64
+                    // strings during JSON round-tripping. Decode them back to bytes.
+                    try
+                    {
+                        builder.Append(Convert.FromBase64String(s));
+                    }
+                    catch (FormatException ex)
+                    {
+                        // Not valid base64 — treat as null and log.
+                        if (logger != null)
+                        {
+                            FeatureServerLog.GeoParquetConversionFailed(logger, fieldName, "String(non-base64)", ex);
+                        }
+                        builder.AppendNull();
+                    }
+                }
+                else
+                {
+                    builder.AppendNull();
+                }
+            },
+            () => builder.AppendNull(), logger);
+        return builder.Build();
+    }
+
+    /// <summary>
+    /// Builds an array for a runtime-computed attribute (no <see cref="FieldDefinition"/>).
+    /// Dispatches by the Arrow type declared in the schema field.
+    /// </summary>
+    private static IArrowArray BuildRuntimeAttributeArray(
+        ImmutableArray<Feature> features,
+        Field field,
+        ILogger? logger = null)
+    {
+        return field.DataType switch
+        {
+            DoubleType => BuildDoubleAttributeArray(features, field.Name, logger),
+            FloatType => BuildFloatAttributeArray(features, field.Name, logger),
+            Int32Type => BuildInt32AttributeArray(features, field.Name, logger),
+            Int64Type => BuildInt64AttributeArray(features, field.Name, logger),
+            BooleanType => BuildBooleanAttributeArray(features, field.Name, logger),
+            TimestampType => BuildTimestampAttributeArray(features, field.Name, logger),
+            _ => BuildStringAttributeArray(features, field.Name, logger)
         };
     }
 
-    private static TimeOnly? TryConvertTimeOnly(object? value)
+    private static StringArray BuildStringAttributeArray(ImmutableArray<Feature> features, string fieldName, ILogger? logger = null)
     {
-        return value switch
-        {
-            null => null,
-            TimeOnly timeOnly => timeOnly,
-            TimeSpan timeSpan => TimeOnly.FromTimeSpan(timeSpan),
-            DateTime dateTime => TimeOnly.FromDateTime(dateTime),
-            DateTimeOffset dateTimeOffset => TimeOnly.FromDateTime(dateTimeOffset.UtcDateTime),
-            JsonElement element when element.ValueKind == JsonValueKind.String => TryConvertTimeOnly(element.GetString()),
-            string stringValue when TimeOnly.TryParse(stringValue, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var parsedTime) => parsedTime,
-            string stringValue when TimeSpan.TryParse(stringValue, CultureInfo.InvariantCulture, out var parsedSpan) => TimeOnly.FromTimeSpan(parsedSpan),
-            _ => null
-        };
+        var builder = new StringArray.Builder();
+        ForEachAttribute(features, fieldName, v => builder.Append(v.ToString() ?? string.Empty), () => builder.AppendNull(), logger);
+        return builder.Build();
     }
 
-    private static byte[]? TryConvertBytes(object? value)
-    {
-        return value switch
-        {
-            null => null,
-            byte[] bytes => bytes,
-            JsonElement element when element.ValueKind == JsonValueKind.String => TryConvertBytes(element.GetString()),
-            string stringValue when TryDecodeBase64(stringValue, out var decoded) => decoded,
-            string stringValue => System.Text.Encoding.UTF8.GetBytes(stringValue),
-            _ => null
-        };
-    }
-
-    private static string? ConvertToStringValue(object? value)
-    {
-        return value switch
-        {
-            null => null,
-            string stringValue => stringValue,
-            DateTimeOffset dateTimeOffset => dateTimeOffset.ToString("O", CultureInfo.InvariantCulture),
-            DateTime dateTime => dateTime.ToString("O", CultureInfo.InvariantCulture),
-            DateOnly dateOnly => dateOnly.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-            TimeOnly timeOnly => timeOnly.ToString("HH:mm:ss.fffffff", CultureInfo.InvariantCulture),
-            JsonElement element when element.ValueKind is JsonValueKind.Object or JsonValueKind.Array => element.GetRawText(),
-            JsonElement element => element.ToString(),
-            _ => value.ToString()
-        };
-    }
-
-    private static bool TryDecodeBase64(string? value, out byte[] decoded)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            decoded = [];
-            return false;
-        }
-
-        try
-        {
-            decoded = Convert.FromBase64String(value);
-            return true;
-        }
-        catch (FormatException)
-        {
-            decoded = [];
-            return false;
-        }
-    }
-
-    private static bool GeometryHasZ(Geometry geometry)
-        => geometry.Coordinates.Any(coordinate => !double.IsNaN(coordinate.Z));
-
-    private static bool GeometryHasM(Geometry geometry)
-        => geometry.Coordinates.Any(coordinate => !double.IsNaN(coordinate.M));
-
-    private static WKBReader GetWkbReader()
-    {
-        _wkbReader ??= new WKBReader();
-        return _wkbReader;
-    }
 }

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -129,7 +129,7 @@ internal sealed class GeoParquetQueryFormatter
         int? outputSrid,
         bool returnZ)
     {
-        var (schema, _, _) = BuildSchema(layer, returnGeometry, outFields, outputSrid, returnZ);
+        var (schema, _, _) = BuildSchema(layer, returnGeometry, outFields, outputSrid, returnZ, isEmpty: true);
 
         using var stream = new MemoryStream();
         var arrowWriterProperties = new ArrowWriterPropertiesBuilder().StoreSchema().Build();
@@ -156,13 +156,16 @@ internal sealed class GeoParquetQueryFormatter
     /// These exist in <c>feature.Attributes</c> but are not part of the layer schema.
     /// Pass an empty list for the empty-result path.
     /// </param>
+    /// <param name="isEmpty">True when the result set has zero features, so that
+    /// <c>geometry_types</c> is emitted as <c>[]</c> per GeoParquet 1.1.0 §4.1.</param>
     private static (Schema schema, List<FieldDefinition> fieldsToInclude, string objectIdFieldName) BuildSchema(
         LayerDefinition layer,
         bool returnGeometry,
         string[]? outFields,
         int? outputSrid,
         bool advertiseZ,
-        IReadOnlyList<(string name, IArrowType type)>? runtimeFields = null)
+        IReadOnlyList<(string name, IArrowType type)>? runtimeFields = null,
+        bool isEmpty = false)
     {
         var objectIdFieldName = layer.ObjectIdFieldName;
         var includeAllFields = outFields == null || outFields.Length == 0 ||
@@ -203,18 +206,26 @@ internal sealed class GeoParquetQueryFormatter
             }
         }
 
-        var schema = new Schema(schemaFields, BuildGeoParquetMetadata(layer, returnGeometry, outputSrid, advertiseZ));
+        var schema = new Schema(schemaFields, BuildGeoParquetMetadata(layer, returnGeometry, outputSrid, advertiseZ, isEmpty));
         return (schema, fieldsToInclude, objectIdFieldName);
     }
 
     /// <summary>
-    /// Builds GeoParquet metadata following the specification
+    /// Builds GeoParquet metadata following the specification.
     /// </summary>
+    /// <param name="layer">Layer definition for CRS and geometry type metadata.</param>
+    /// <param name="returnGeometry">Whether the geometry column is included.</param>
+    /// <param name="outputSrid">Output SRID for CRS metadata.</param>
+    /// <param name="advertiseZ">Whether to advertise Z in geometry_types.</param>
+    /// <param name="isEmpty">True when the result set has zero features.
+    /// GeoParquet 1.1.0 §4.1 requires <c>geometry_types</c> to list actual geometry
+    /// types present in the file — an empty file must use <c>[]</c>.</param>
     private static Dictionary<string, string> BuildGeoParquetMetadata(
         LayerDefinition layer,
         bool returnGeometry,
         int? outputSrid,
-        bool advertiseZ)
+        bool advertiseZ,
+        bool isEmpty = false)
     {
         var metadata = new Dictionary<string, string>();
 
@@ -242,8 +253,12 @@ internal sealed class GeoParquetQueryFormatter
         // be incorrect for filtered or empty exports. Computing the actual result bbox
         // would require parsing every WKB geometry; deferred to a follow-up.
 
-        var geomType = MapGeometryTypeToGeoParquet(layer.GeometryType, advertiseZ);
-        var geoJson = $@"{{""version"":""{GeoParquetVersion}"",""primary_column"":""{GeometryColumnName}"",""columns"":{{""{GeometryColumnName}"":{{""encoding"":""{GeometryEncoding}"",""geometry_types"":[""{geomType}""]{crsPart}}}}}}}";
+        // GeoParquet 1.1.0 §4.1: geometry_types lists actual types in the file.
+        // An empty file has no geometries, so geometry_types must be [].
+        var geometryTypesPart = isEmpty
+            ? "[]"
+            : $"[\"{MapGeometryTypeToGeoParquet(layer.GeometryType, advertiseZ)}\"]";
+        var geoJson = $@"{{""version"":""{GeoParquetVersion}"",""primary_column"":""{GeometryColumnName}"",""columns"":{{""{GeometryColumnName}"":{{""encoding"":""{GeometryEncoding}"",""geometry_types"":{geometryTypesPart}{crsPart}}}}}}}";
 
         metadata[GeoMetadataKey] = geoJson;
 

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -9,7 +9,6 @@ using Apache.Arrow.Types;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
-using Honua.Core.Features.Shared.Models;
 using Honua.Server.Features.FeatureServer.Models;
 using Honua.Server.Features.Infrastructure.Services;
 using Microsoft.Extensions.Logging;
@@ -32,8 +31,10 @@ internal sealed class GeoParquetQueryFormatter
     private const string ContentType = "application/vnd.apache.parquet";
 
     [ThreadStatic]
-    private static WKBReader? _wkbReader;
+    private static WKBWriter? _wkbWriter2D;
 
+    [ThreadStatic]
+    private static WKBWriter? _wkbWriter3D;
 
     /// <summary>
     /// Formats query result as GeoParquet
@@ -163,7 +164,7 @@ internal sealed class GeoParquetQueryFormatter
         bool advertiseZ,
         IReadOnlyList<(string name, IArrowType type)>? runtimeFields = null)
     {
-        var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
+        var objectIdFieldName = layer.ObjectIdFieldName;
         var includeAllFields = outFields == null || outFields.Length == 0 ||
                               (outFields.Length == 1 && outFields[0].Equals("*", StringComparison.Ordinal));
 
@@ -463,7 +464,7 @@ internal sealed class GeoParquetQueryFormatter
         Geometry? geometry;
         try
         {
-            geometry = GetWkbReader().Read(geometryBytes);
+            geometry = WkbReaderCache.Get().Read(geometryBytes);
         }
         catch (Exception ex) when (ex is ParseException or FormatException)
         {
@@ -491,11 +492,7 @@ internal sealed class GeoParquetQueryFormatter
         geometry = GeometryOutputProcessor.ApplyDimensionFilter(geometry, returnZ, includeM: false);
 
         var hasZ = GeometryHasZ(geometry);
-        var writer = new WKBWriter(
-            ByteOrder.LittleEndian,
-            handleSRID: false,
-            emitZ: hasZ,
-            emitM: false);
+        var writer = GetWkbWriter(hasZ);
         return (writer.Write(geometry), hasZ);
     }
 
@@ -874,10 +871,16 @@ internal sealed class GeoParquetQueryFormatter
         return false;
     }
 
-    private static WKBReader GetWkbReader()
+    private static WKBWriter GetWkbWriter(bool emitZ)
     {
-        _wkbReader ??= new WKBReader();
-        return _wkbReader;
+        if (emitZ)
+        {
+            _wkbWriter3D ??= new WKBWriter(ByteOrder.LittleEndian, handleSRID: false, emitZ: true, emitM: false);
+            return _wkbWriter3D;
+        }
+
+        _wkbWriter2D ??= new WKBWriter(ByteOrder.LittleEndian, handleSRID: false, emitZ: false, emitM: false);
+        return _wkbWriter2D;
     }
 
 }

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -224,16 +224,22 @@ internal sealed class GeoParquetQueryFormatter
 
         var layerFieldNames = new HashSet<string>(
             layer.Fields.Select(f => f.Name), StringComparer.OrdinalIgnoreCase);
+        var seenRuntimeFields = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var (key, value) in features[0].Attributes)
+        foreach (var feature in features)
         {
-            if (layerFieldNames.Contains(key)) continue;
-            // Skip internal fields (e.g. __honua_total_count)
-            if (key.StartsWith("__", StringComparison.Ordinal)) continue;
+            foreach (var (key, value) in feature.Attributes)
+            {
+                if (seenRuntimeFields.Contains(key) || layerFieldNames.Contains(key)) continue;
+                // Skip internal fields (e.g. __honua_total_count)
+                if (key.StartsWith("__", StringComparison.Ordinal)) continue;
 
-            var arrowType = InferArrowTypeFromValue(value);
-            if (arrowType != null)
+                var arrowType = InferArrowTypeFromValue(value);
+                if (arrowType == null) continue;
+
                 result.Add((key, arrowType));
+                seenRuntimeFields.Add(key);
+            }
         }
 
         return result;

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -44,8 +44,8 @@ internal sealed class GeoParquetQueryFormatter
     /// <param name="outputSrid">Output SRID for geometry</param>
     /// <param name="returnZ">Whether to include Z values</param>
     /// <param name="returnM">Whether to include M values</param>
-    /// <param name="geometryPrecision">Accepted for interface symmetry with other formatters; not applied to binary formats.</param>
-    /// <param name="maxAllowableOffset">Accepted for interface symmetry with other formatters.</param>
+    /// <param name="geometryPrecision">Rounds coordinates to the specified decimal places before writing WKB.</param>
+    /// <param name="maxAllowableOffset">Simplifies geometry to the given tolerance before writing WKB.</param>
     /// <param name="outFields">Fields to include in output</param>
     /// <param name="logger">Optional logger for conversion diagnostics</param>
     /// <param name="baseGeometryLimits">Baseline geometry limits used to apply query-level precision and simplification overrides.</param>

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -2,6 +2,8 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json;
 using Apache.Arrow;
 using Apache.Arrow.Types;
 using ParquetSharp.Arrow;
@@ -258,6 +260,9 @@ internal sealed class GeoParquetQueryFormatter
             long => new Int64Type(),
             bool => new BooleanType(),
             string => new StringType(),
+            DateOnly => new Date32Type(),
+            TimeOnly => new Time32Type(TimeUnit.Millisecond),
+            TimeSpan => new Time32Type(TimeUnit.Millisecond),
             DateTime => new TimestampType(TimeUnit.Millisecond, TimeZoneInfo.Utc),
             DateTimeOffset => new TimestampType(TimeUnit.Millisecond, TimeZoneInfo.Utc),
             _ => null
@@ -298,6 +303,7 @@ internal sealed class GeoParquetQueryFormatter
             "double precision" or "float8" => new DoubleType(),
             "boolean" or "bool" => new BooleanType(),
             "date" => new Date32Type(),
+            "time" => new Time32Type(TimeUnit.Millisecond),
             "timestamp" or "timestamptz" or "timestamp with time zone" or "timestamp without time zone" => new TimestampType(TimeUnit.Millisecond, TimeZoneInfo.Utc),
             "bytea" => new BinaryType(),
             "uuid" => new StringType(),
@@ -411,6 +417,7 @@ internal sealed class GeoParquetQueryFormatter
             "boolean" or "bool" => BuildBooleanAttributeArray(features, fieldName, logger),
             "bytea" => BuildBinaryAttributeArray(features, fieldName, logger),
             "date" => BuildDate32AttributeArray(features, fieldName, logger),
+            "time" => BuildTime32AttributeArray(features, fieldName, logger),
             "timestamp" or "timestamptz" or "timestamp with time zone" or "timestamp without time zone" => BuildTimestampAttributeArray(features, fieldName, logger),
             _ when sqlType.StartsWith("numeric", StringComparison.OrdinalIgnoreCase) => BuildDoubleAttributeArray(features, fieldName, logger),
             _ when sqlType.StartsWith("decimal", StringComparison.OrdinalIgnoreCase) => BuildDoubleAttributeArray(features, fieldName, logger),
@@ -499,22 +506,69 @@ internal sealed class GeoParquetQueryFormatter
     private static Date32Array BuildDate32AttributeArray(ImmutableArray<Feature> features, string fieldName, ILogger? logger = null)
     {
         var builder = new Date32Array.Builder();
-        ForEachAttribute(features, fieldName, v => builder.Append(Convert.ToDateTime(v)), () => builder.AppendNull(), logger);
+        ForEachAttribute(
+            features,
+            fieldName,
+            v =>
+            {
+                var dateTime = TryConvertDateTimeValue(v);
+                if (dateTime.HasValue)
+                {
+                    builder.Append(dateTime.Value);
+                }
+                else
+                {
+                    builder.AppendNull();
+                }
+            },
+            () => builder.AppendNull(),
+            logger);
+        return builder.Build();
+    }
+
+    private static Time32Array BuildTime32AttributeArray(ImmutableArray<Feature> features, string fieldName, ILogger? logger = null)
+    {
+        var builder = new Time32Array.Builder(TimeUnit.Millisecond);
+        ForEachAttribute(
+            features,
+            fieldName,
+            v =>
+            {
+                var milliseconds = TryConvertTimeMilliseconds(v);
+                if (milliseconds.HasValue)
+                {
+                    builder.Append(milliseconds.Value);
+                }
+                else
+                {
+                    builder.AppendNull();
+                }
+            },
+            () => builder.AppendNull(),
+            logger);
         return builder.Build();
     }
 
     private static TimestampArray BuildTimestampAttributeArray(ImmutableArray<Feature> features, string fieldName, ILogger? logger = null)
     {
         var builder = new TimestampArray.Builder(TimeUnit.Millisecond, TimeZoneInfo.Utc);
-        ForEachAttribute(features, fieldName,
+        ForEachAttribute(
+            features,
+            fieldName,
             v =>
             {
-                var dt = Convert.ToDateTime(v);
-                if (dt.Kind == DateTimeKind.Unspecified)
-                    dt = DateTime.SpecifyKind(dt, DateTimeKind.Utc);
-                builder.Append(new DateTimeOffset(dt.ToUniversalTime()));
+                var dateTime = TryConvertDateTimeValue(v);
+                if (dateTime.HasValue)
+                {
+                    builder.Append(new DateTimeOffset(dateTime.Value));
+                }
+                else
+                {
+                    builder.AppendNull();
+                }
             },
-            () => builder.AppendNull(), logger);
+            () => builder.AppendNull(),
+            logger);
         return builder.Build();
     }
 
@@ -571,6 +625,8 @@ internal sealed class GeoParquetQueryFormatter
             Int32Type => BuildInt32AttributeArray(features, field.Name, logger),
             Int64Type => BuildInt64AttributeArray(features, field.Name, logger),
             BooleanType => BuildBooleanAttributeArray(features, field.Name, logger),
+            Date32Type => BuildDate32AttributeArray(features, field.Name, logger),
+            Time32Type => BuildTime32AttributeArray(features, field.Name, logger),
             TimestampType => BuildTimestampAttributeArray(features, field.Name, logger),
             _ => BuildStringAttributeArray(features, field.Name, logger)
         };
@@ -581,6 +637,86 @@ internal sealed class GeoParquetQueryFormatter
         var builder = new StringArray.Builder();
         ForEachAttribute(features, fieldName, v => builder.Append(v.ToString() ?? string.Empty), () => builder.AppendNull(), logger);
         return builder.Build();
+    }
+
+    private static DateTime? TryConvertDateTimeValue(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            DateTime dateTime => NormalizeDateTime(dateTime),
+            DateTimeOffset dateTimeOffset => dateTimeOffset.UtcDateTime,
+            DateOnly dateOnly => DateTime.SpecifyKind(dateOnly.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc),
+            JsonElement element => TryConvertDateTimeElement(element),
+            string stringValue when DateTimeOffset.TryParse(
+                stringValue,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var parsedDateTimeOffset) => parsedDateTimeOffset.UtcDateTime,
+            string stringValue when DateOnly.TryParse(
+                stringValue,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AllowWhiteSpaces,
+                out var parsedDateOnly) => DateTime.SpecifyKind(parsedDateOnly.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc),
+            byte byteValue => DateTimeOffset.FromUnixTimeMilliseconds(byteValue).UtcDateTime,
+            short shortValue => DateTimeOffset.FromUnixTimeMilliseconds(shortValue).UtcDateTime,
+            int intValue => DateTimeOffset.FromUnixTimeMilliseconds(intValue).UtcDateTime,
+            long longValue => DateTimeOffset.FromUnixTimeMilliseconds(longValue).UtcDateTime,
+            float floatValue => DateTimeOffset.FromUnixTimeMilliseconds(Convert.ToInt64(floatValue, CultureInfo.InvariantCulture)).UtcDateTime,
+            double doubleValue => DateTimeOffset.FromUnixTimeMilliseconds(Convert.ToInt64(doubleValue, CultureInfo.InvariantCulture)).UtcDateTime,
+            decimal decimalValue => DateTimeOffset.FromUnixTimeMilliseconds(Convert.ToInt64(decimalValue, CultureInfo.InvariantCulture)).UtcDateTime,
+            _ => null
+        };
+    }
+
+    private static int? TryConvertTimeMilliseconds(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            TimeOnly timeOnly => checked((int)(timeOnly.Ticks / TimeSpan.TicksPerMillisecond)),
+            TimeSpan timeSpan => checked((int)(timeSpan.Ticks / TimeSpan.TicksPerMillisecond)),
+            DateTime dateTime => checked((int)(TimeOnly.FromDateTime(dateTime).Ticks / TimeSpan.TicksPerMillisecond)),
+            DateTimeOffset dateTimeOffset => checked((int)(TimeOnly.FromDateTime(dateTimeOffset.UtcDateTime).Ticks / TimeSpan.TicksPerMillisecond)),
+            JsonElement element => TryConvertTimeMillisecondsElement(element),
+            string stringValue when TimeOnly.TryParse(
+                stringValue,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AllowWhiteSpaces,
+                out var parsedTimeOnly) => checked((int)(parsedTimeOnly.Ticks / TimeSpan.TicksPerMillisecond)),
+            string stringValue when TimeSpan.TryParse(
+                stringValue,
+                CultureInfo.InvariantCulture,
+                out var parsedTimeSpan) => checked((int)(parsedTimeSpan.Ticks / TimeSpan.TicksPerMillisecond)),
+            _ => null
+        };
+    }
+
+    private static DateTime NormalizeDateTime(DateTime value)
+    {
+        return value.Kind == DateTimeKind.Unspecified
+            ? DateTime.SpecifyKind(value, DateTimeKind.Utc)
+            : value.ToUniversalTime();
+    }
+
+    private static DateTime? TryConvertDateTimeElement(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => TryConvertDateTimeValue(element.GetString()),
+            JsonValueKind.Number when element.TryGetInt64(out var milliseconds) => DateTimeOffset.FromUnixTimeMilliseconds(milliseconds).UtcDateTime,
+            JsonValueKind.Number when element.TryGetDouble(out var milliseconds) => DateTimeOffset.FromUnixTimeMilliseconds(Convert.ToInt64(milliseconds, CultureInfo.InvariantCulture)).UtcDateTime,
+            _ => null
+        };
+    }
+
+    private static int? TryConvertTimeMillisecondsElement(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => TryConvertTimeMilliseconds(element.GetString()),
+            _ => null
+        };
     }
 
 }

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -45,11 +45,9 @@ internal sealed class GeoParquetQueryFormatter
     /// <param name="returnZ">Whether to include Z values</param>
     /// <param name="returnM">Accepted for API symmetry but M values are always stripped.
     /// GeoParquet 1.1.0 only supports XY and XYZ geometries.</param>
-    /// <param name="geometryPrecision">Rounds coordinates to the specified decimal places before writing WKB.</param>
-    /// <param name="maxAllowableOffset">Simplifies geometry to the given tolerance before writing WKB.</param>
+    /// <param name="geometryLimits">Pre-computed effective geometry limits (precision, simplification).</param>
     /// <param name="outFields">Fields to include in output</param>
     /// <param name="logger">Optional logger for conversion diagnostics</param>
-    /// <param name="baseGeometryLimits">Baseline geometry limits used to apply query-level precision and simplification overrides.</param>
     /// <returns>Formatted result as byte array and content type</returns>
     public static (byte[] response, string contentType) FormatAsGeoParquet(
         QueryResult<Feature> result,
@@ -58,18 +56,11 @@ internal sealed class GeoParquetQueryFormatter
         int? outputSrid,
         bool returnZ,
         bool returnM,
-        int? geometryPrecision,
-        double? maxAllowableOffset,
+        GeometryLimits geometryLimits,
         string[]? outFields = null,
-        ILogger? logger = null,
-        GeometryLimits? baseGeometryLimits = null)
+        ILogger? logger = null)
     {
         var features = result.Items;
-        var effectiveGeometryLimits = GeometryOutputProcessor.CreateEffectiveLimits(
-            baseGeometryLimits ?? new GeometryLimits(),
-            geometryPrecision,
-            maxAllowableOffset,
-            forceSimplify: maxAllowableOffset is > 0);
 
         if (features.Length == 0)
         {
@@ -81,7 +72,25 @@ internal sealed class GeoParquetQueryFormatter
         // exist in the result set but are not declared in the layer schema.
         var runtimeFields = DetectRuntimeFields(features, layer);
 
-        var (schema, fieldsToInclude, objectIdFieldName) = BuildSchema(layer, returnGeometry, outFields, outputSrid, returnZ, runtimeFields);
+        // Build geometry column first so we know whether any geometry actually has Z.
+        // This drives the GeoParquet metadata `geometry_types` truthfully rather than
+        // relying on the `returnZ` flag which may not match the actual data.
+        BinaryArray? geometryArray = null;
+        bool anyGeometryHasZ = false;
+        if (returnGeometry && layer.HasGeometry)
+        {
+            (geometryArray, anyGeometryHasZ) = BuildGeometryArray(
+                features,
+                outputSrid ?? layer.SpatialReference.Wkid,
+                returnZ,
+                returnM,
+                geometryLimits);
+        }
+
+        var (schema, fieldsToInclude, objectIdFieldName) = BuildSchema(
+            layer, returnGeometry, outFields, outputSrid,
+            advertiseZ: anyGeometryHasZ,
+            runtimeFields);
 
         // Build record batch
         var arrays = BuildArrays(
@@ -89,10 +98,7 @@ internal sealed class GeoParquetQueryFormatter
             schema,
             layer,
             returnGeometry,
-            outputSrid,
-            returnZ,
-            returnM,
-            effectiveGeometryLimits,
+            geometryArray,
             objectIdFieldName,
             fieldsToInclude,
             logger);
@@ -141,7 +147,8 @@ internal sealed class GeoParquetQueryFormatter
     /// <param name="returnGeometry">Whether to include the geometry column.</param>
     /// <param name="outFields">Requested output fields, or null / ["*"] for all.</param>
     /// <param name="outputSrid">Output SRID for CRS metadata.</param>
-    /// <param name="returnZ">Whether Z dimensions should be advertised in GeoParquet metadata.</param>
+    /// <param name="advertiseZ">Whether Z dimensions should be advertised in GeoParquet metadata.
+    /// For populated results this reflects actual geometry content; for empty results it mirrors returnZ.</param>
     /// <param name="runtimeFields">
     /// Runtime-computed attributes detected from the result set (e.g. "distance" from KNN queries).
     /// These exist in <c>feature.Attributes</c> but are not part of the layer schema.
@@ -152,7 +159,7 @@ internal sealed class GeoParquetQueryFormatter
         bool returnGeometry,
         string[]? outFields,
         int? outputSrid,
-        bool returnZ,
+        bool advertiseZ,
         IReadOnlyList<(string name, IArrowType type)>? runtimeFields = null)
     {
         var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
@@ -194,7 +201,7 @@ internal sealed class GeoParquetQueryFormatter
             }
         }
 
-        var schema = new Schema(schemaFields, BuildGeoParquetMetadata(layer, returnGeometry, outputSrid, returnZ));
+        var schema = new Schema(schemaFields, BuildGeoParquetMetadata(layer, returnGeometry, outputSrid, advertiseZ));
         return (schema, fieldsToInclude, objectIdFieldName);
     }
 
@@ -205,7 +212,7 @@ internal sealed class GeoParquetQueryFormatter
         LayerDefinition layer,
         bool returnGeometry,
         int? outputSrid,
-        bool returnZ)
+        bool advertiseZ)
     {
         var metadata = new Dictionary<string, string>();
 
@@ -233,7 +240,7 @@ internal sealed class GeoParquetQueryFormatter
         // be incorrect for filtered or empty exports. Computing the actual result bbox
         // would require parsing every WKB geometry; deferred to a follow-up.
 
-        var geomType = MapGeometryTypeToGeoParquet(layer.GeometryType, returnZ);
+        var geomType = MapGeometryTypeToGeoParquet(layer.GeometryType, advertiseZ);
         var geoJson = $@"{{""version"":""{GeoParquetVersion}"",""primary_column"":""{GeometryColumnName}"",""columns"":{{""{GeometryColumnName}"":{{""encoding"":""{GeometryEncoding}"",""geometry_types"":[""{geomType}""]{crsPart}}}}}}}";
 
         metadata[GeoMetadataKey] = geoJson;
@@ -350,17 +357,15 @@ internal sealed class GeoParquetQueryFormatter
     }
 
     /// <summary>
-    /// Builds Arrow arrays for each column
+    /// Builds Arrow arrays for each column.
+    /// The geometry column is pre-built and passed in (null when geometry is excluded).
     /// </summary>
     private static IArrowArray[] BuildArrays(
         ImmutableArray<Feature> features,
         Schema schema,
         LayerDefinition layer,
         bool returnGeometry,
-        int? outputSrid,
-        bool returnZ,
-        bool returnM,
-        GeometryLimits geometryLimits,
+        BinaryArray? geometryArray,
         string objectIdFieldName,
         List<FieldDefinition> fieldsToInclude,
         ILogger? logger = null)
@@ -373,14 +378,9 @@ internal sealed class GeoParquetQueryFormatter
             {
                 arrays.Add(BuildObjectIdArray(features));
             }
-            else if (field.Name == GeometryColumnName && returnGeometry)
+            else if (field.Name == GeometryColumnName && returnGeometry && geometryArray != null)
             {
-                arrays.Add(BuildGeometryArray(
-                    features,
-                    outputSrid ?? layer.SpatialReference.Wkid,
-                    returnZ,
-                    returnM,
-                    geometryLimits));
+                arrays.Add(geometryArray);
             }
             else
             {
@@ -415,9 +415,9 @@ internal sealed class GeoParquetQueryFormatter
     }
 
     /// <summary>
-    /// Builds binary array for WKB geometry data
+    /// Builds binary array for WKB geometry data and tracks whether any geometry retains Z coordinates.
     /// </summary>
-    private static BinaryArray BuildGeometryArray(
+    private static (BinaryArray array, bool anyHasZ) BuildGeometryArray(
         ImmutableArray<Feature> features,
         int outputSrid,
         bool returnZ,
@@ -425,13 +425,15 @@ internal sealed class GeoParquetQueryFormatter
         GeometryLimits geometryLimits)
     {
         var builder = new BinaryArray.Builder();
+        var anyHasZ = false;
 
         foreach (var feature in features)
         {
-            var geometry = ProcessGeometry(feature.Geometry, outputSrid, geometryLimits, returnZ, returnM);
-            if (geometry != null && geometry.Length > 0)
+            var (wkb, hasZ) = ProcessGeometry(feature.Geometry, outputSrid, geometryLimits, returnZ, returnM);
+            anyHasZ |= hasZ;
+            if (wkb != null && wkb.Length > 0)
             {
-                builder.Append(geometry);
+                builder.Append(wkb);
             }
             else
             {
@@ -439,10 +441,10 @@ internal sealed class GeoParquetQueryFormatter
             }
         }
 
-        return builder.Build();
+        return (builder.Build(), anyHasZ);
     }
 
-    private static byte[]? ProcessGeometry(
+    private static (byte[]? wkb, bool hasZ) ProcessGeometry(
         byte[]? geometryBytes,
         int outputSrid,
         GeometryLimits geometryLimits,
@@ -451,31 +453,32 @@ internal sealed class GeoParquetQueryFormatter
     {
         if (geometryBytes == null || geometryBytes.Length == 0)
         {
-            return null;
+            return (null, false);
         }
 
         var geometry = GetWkbReader().Read(geometryBytes);
         if (geometry == null)
         {
-            return null;
+            return (null, false);
         }
 
         geometry.SRID = outputSrid;
         geometry = GeometryOutputProcessor.ApplyLimits(geometry, geometryLimits);
         if (geometry == null)
         {
-            return null;
+            return (null, false);
         }
 
         // GeoParquet 1.1.0 only supports XY and XYZ — always strip M values.
         geometry = GeometryOutputProcessor.ApplyDimensionFilter(geometry, returnZ, includeM: false);
 
+        var hasZ = GeometryHasZ(geometry);
         var writer = new WKBWriter(
             ByteOrder.LittleEndian,
             handleSRID: false,
-            emitZ: GeometryHasZ(geometry),
+            emitZ: hasZ,
             emitM: false);
-        return writer.Write(geometry);
+        return (writer.Write(geometry), hasZ);
     }
 
     /// <summary>
@@ -802,8 +805,56 @@ internal sealed class GeoParquetQueryFormatter
         };
     }
 
+    /// <summary>
+    /// Checks whether the geometry contains any non-NaN Z value by walking
+    /// coordinate sequences directly, avoiding the intermediate Coordinate[]
+    /// allocation that <see cref="Geometry.Coordinates"/> would produce.
+    /// </summary>
     private static bool GeometryHasZ(Geometry geometry)
-        => geometry.Coordinates.Any(coordinate => !double.IsNaN(coordinate.Z));
+    {
+        for (var g = 0; g < geometry.NumGeometries; g++)
+        {
+            var part = geometry.GetGeometryN(g);
+            if (part is Point point)
+            {
+                if (point.CoordinateSequence.Dimension > 2 &&
+                    !double.IsNaN(point.CoordinateSequence.GetOrdinate(0, Ordinate.Z)))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (part is LineString lineString)
+            {
+                if (SequenceHasZ(lineString.CoordinateSequence)) return true;
+                continue;
+            }
+
+            if (part is Polygon polygon)
+            {
+                if (SequenceHasZ(polygon.ExteriorRing.CoordinateSequence)) return true;
+                for (var h = 0; h < polygon.NumInteriorRings; h++)
+                {
+                    if (SequenceHasZ(polygon.GetInteriorRingN(h).CoordinateSequence)) return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool SequenceHasZ(CoordinateSequence sequence)
+    {
+        if (sequence.Dimension <= 2) return false;
+        for (var i = 0; i < sequence.Count; i++)
+        {
+            if (!double.IsNaN(sequence.GetOrdinate(i, Ordinate.Z))) return true;
+        }
+
+        return false;
+    }
 
     private static WKBReader GetWkbReader()
     {

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -6,12 +6,16 @@ using System.Globalization;
 using System.Text.Json;
 using Apache.Arrow;
 using Apache.Arrow.Types;
-using ParquetSharp.Arrow;
+using Honua.Core.Configuration;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Shared.Models;
 using Honua.Server.Features.FeatureServer.Models;
+using Honua.Server.Features.Infrastructure.Services;
 using Microsoft.Extensions.Logging;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using ParquetSharp.Arrow;
 
 namespace Honua.Server.Features.FeatureServer.Services;
 
@@ -27,6 +31,9 @@ internal sealed class GeoParquetQueryFormatter
     private const string GeoMetadataKey = "geo";
     private const string ContentType = "application/vnd.apache.parquet";
 
+    [ThreadStatic]
+    private static WKBReader? _wkbReader;
+
 
     /// <summary>
     /// Formats query result as GeoParquet
@@ -38,9 +45,10 @@ internal sealed class GeoParquetQueryFormatter
     /// <param name="returnZ">Whether to include Z values</param>
     /// <param name="returnM">Whether to include M values</param>
     /// <param name="geometryPrecision">Accepted for interface symmetry with other formatters; not applied to binary formats.</param>
-    /// <param name="maxAllowableOffset">Accepted for interface symmetry with other formatters; not applied to binary formats.</param>
+    /// <param name="maxAllowableOffset">Accepted for interface symmetry with other formatters.</param>
     /// <param name="outFields">Fields to include in output</param>
     /// <param name="logger">Optional logger for conversion diagnostics</param>
+    /// <param name="baseGeometryLimits">Baseline geometry limits used to apply query-level precision and simplification overrides.</param>
     /// <returns>Formatted result as byte array and content type</returns>
     public static (byte[] response, string contentType) FormatAsGeoParquet(
         QueryResult<Feature> result,
@@ -52,24 +60,41 @@ internal sealed class GeoParquetQueryFormatter
         int? geometryPrecision,
         double? maxAllowableOffset,
         string[]? outFields = null,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        GeometryLimits? baseGeometryLimits = null)
     {
         var features = result.Items;
+        var effectiveGeometryLimits = GeometryOutputProcessor.CreateEffectiveLimits(
+            baseGeometryLimits ?? new GeometryLimits(),
+            geometryPrecision,
+            maxAllowableOffset,
+            forceSimplify: maxAllowableOffset is > 0);
 
         if (features.Length == 0)
         {
             // Return empty GeoParquet file with schema only
-            return CreateEmptyGeoParquet(layer, returnGeometry, outFields, outputSrid);
+            return CreateEmptyGeoParquet(layer, returnGeometry, outFields, outputSrid, returnZ);
         }
 
         // Detect runtime-computed attributes (e.g. "distance" from KNN queries) that
         // exist in the result set but are not declared in the layer schema.
         var runtimeFields = DetectRuntimeFields(features, layer);
 
-        var (schema, fieldsToInclude, objectIdFieldName) = BuildSchema(layer, returnGeometry, outFields, outputSrid, runtimeFields);
+        var (schema, fieldsToInclude, objectIdFieldName) = BuildSchema(layer, returnGeometry, outFields, outputSrid, returnZ, runtimeFields);
 
         // Build record batch
-        var arrays = BuildArrays(features, schema, layer, returnGeometry, objectIdFieldName, fieldsToInclude, logger);
+        var arrays = BuildArrays(
+            features,
+            schema,
+            layer,
+            returnGeometry,
+            outputSrid,
+            returnZ,
+            returnM,
+            effectiveGeometryLimits,
+            objectIdFieldName,
+            fieldsToInclude,
+            logger);
 
         using var recordBatch = new RecordBatch(schema, arrays, features.Length);
 
@@ -92,9 +117,10 @@ internal sealed class GeoParquetQueryFormatter
         LayerDefinition layer,
         bool returnGeometry,
         string[]? outFields,
-        int? outputSrid)
+        int? outputSrid,
+        bool returnZ)
     {
-        var (schema, _, _) = BuildSchema(layer, returnGeometry, outFields, outputSrid);
+        var (schema, _, _) = BuildSchema(layer, returnGeometry, outFields, outputSrid, returnZ);
 
         using var stream = new MemoryStream();
         var arrowWriterProperties = new ArrowWriterPropertiesBuilder().StoreSchema().Build();
@@ -114,6 +140,7 @@ internal sealed class GeoParquetQueryFormatter
     /// <param name="returnGeometry">Whether to include the geometry column.</param>
     /// <param name="outFields">Requested output fields, or null / ["*"] for all.</param>
     /// <param name="outputSrid">Output SRID for CRS metadata.</param>
+    /// <param name="returnZ">Whether Z dimensions should be advertised in GeoParquet metadata.</param>
     /// <param name="runtimeFields">
     /// Runtime-computed attributes detected from the result set (e.g. "distance" from KNN queries).
     /// These exist in <c>feature.Attributes</c> but are not part of the layer schema.
@@ -124,6 +151,7 @@ internal sealed class GeoParquetQueryFormatter
         bool returnGeometry,
         string[]? outFields,
         int? outputSrid,
+        bool returnZ,
         IReadOnlyList<(string name, IArrowType type)>? runtimeFields = null)
     {
         var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
@@ -165,7 +193,7 @@ internal sealed class GeoParquetQueryFormatter
             }
         }
 
-        var schema = new Schema(schemaFields, BuildGeoParquetMetadata(layer, returnGeometry, outputSrid));
+        var schema = new Schema(schemaFields, BuildGeoParquetMetadata(layer, returnGeometry, outputSrid, returnZ));
         return (schema, fieldsToInclude, objectIdFieldName);
     }
 
@@ -175,7 +203,8 @@ internal sealed class GeoParquetQueryFormatter
     private static Dictionary<string, string> BuildGeoParquetMetadata(
         LayerDefinition layer,
         bool returnGeometry,
-        int? outputSrid)
+        int? outputSrid,
+        bool returnZ)
     {
         var metadata = new Dictionary<string, string>();
 
@@ -203,7 +232,7 @@ internal sealed class GeoParquetQueryFormatter
         // be incorrect for filtered or empty exports. Computing the actual result bbox
         // would require parsing every WKB geometry; deferred to a follow-up.
 
-        var geomType = MapGeometryTypeToGeoParquet(layer.GeometryType);
+        var geomType = MapGeometryTypeToGeoParquet(layer.GeometryType, returnZ);
         var geoJson = $@"{{""version"":""{GeoParquetVersion}"",""primary_column"":""{GeometryColumnName}"",""columns"":{{""{GeometryColumnName}"":{{""encoding"":""{GeometryEncoding}"",""geometry_types"":[""{geomType}""]{crsPart}}}}}}}";
 
         metadata[GeoMetadataKey] = geoJson;
@@ -272,9 +301,9 @@ internal sealed class GeoParquetQueryFormatter
     /// <summary>
     /// Maps layer geometry type to GeoParquet geometry type string
     /// </summary>
-    private static string MapGeometryTypeToGeoParquet(Core.Features.Catalog.Domain.GeometryType geometryType)
+    private static string MapGeometryTypeToGeoParquet(Core.Features.Catalog.Domain.GeometryType geometryType, bool returnZ)
     {
-        return geometryType switch
+        var baseType = geometryType switch
         {
             Core.Features.Catalog.Domain.GeometryType.Point => "Point",
             Core.Features.Catalog.Domain.GeometryType.LineString => "LineString",
@@ -285,6 +314,8 @@ internal sealed class GeoParquetQueryFormatter
             Core.Features.Catalog.Domain.GeometryType.GeometryCollection => "GeometryCollection",
             _ => "Geometry"
         };
+
+        return returnZ ? $"{baseType} Z" : baseType;
     }
 
     /// <summary>
@@ -325,6 +356,10 @@ internal sealed class GeoParquetQueryFormatter
         Schema schema,
         LayerDefinition layer,
         bool returnGeometry,
+        int? outputSrid,
+        bool returnZ,
+        bool returnM,
+        GeometryLimits geometryLimits,
         string objectIdFieldName,
         List<FieldDefinition> fieldsToInclude,
         ILogger? logger = null)
@@ -339,7 +374,12 @@ internal sealed class GeoParquetQueryFormatter
             }
             else if (field.Name == GeometryColumnName && returnGeometry)
             {
-                arrays.Add(BuildGeometryArray(features));
+                arrays.Add(BuildGeometryArray(
+                    features,
+                    outputSrid ?? layer.SpatialReference.Wkid,
+                    returnZ,
+                    returnM,
+                    geometryLimits));
             }
             else
             {
@@ -376,15 +416,21 @@ internal sealed class GeoParquetQueryFormatter
     /// <summary>
     /// Builds binary array for WKB geometry data
     /// </summary>
-    private static BinaryArray BuildGeometryArray(ImmutableArray<Feature> features)
+    private static BinaryArray BuildGeometryArray(
+        ImmutableArray<Feature> features,
+        int outputSrid,
+        bool returnZ,
+        bool returnM,
+        GeometryLimits geometryLimits)
     {
         var builder = new BinaryArray.Builder();
 
         foreach (var feature in features)
         {
-            if (feature.Geometry != null && feature.Geometry.Length > 0)
+            var geometry = ProcessGeometry(feature.Geometry, outputSrid, geometryLimits, returnZ, returnM);
+            if (geometry != null && geometry.Length > 0)
             {
-                builder.Append(feature.Geometry);
+                builder.Append(geometry);
             }
             else
             {
@@ -393,6 +439,44 @@ internal sealed class GeoParquetQueryFormatter
         }
 
         return builder.Build();
+    }
+
+    private static byte[]? ProcessGeometry(
+        byte[]? geometryBytes,
+        int outputSrid,
+        GeometryLimits geometryLimits,
+        bool returnZ,
+        bool returnM)
+    {
+        if (geometryBytes == null || geometryBytes.Length == 0)
+        {
+            return null;
+        }
+
+        var geometry = GetWkbReader().Read(geometryBytes);
+        if (geometry == null)
+        {
+            return null;
+        }
+
+        geometry.SRID = outputSrid;
+        geometry = GeometryOutputProcessor.ApplyLimits(geometry, geometryLimits);
+        if (geometry == null)
+        {
+            return null;
+        }
+
+        if (!returnZ || !returnM)
+        {
+            geometry = GeometryOutputProcessor.ApplyDimensionFilter(geometry, returnZ, returnM);
+        }
+
+        var writer = new WKBWriter(
+            ByteOrder.LittleEndian,
+            handleSRID: false,
+            emitZ: GeometryHasZ(geometry),
+            emitM: GeometryHasM(geometry));
+        return writer.Write(geometry);
     }
 
     /// <summary>
@@ -717,6 +801,18 @@ internal sealed class GeoParquetQueryFormatter
             JsonValueKind.String => TryConvertTimeMilliseconds(element.GetString()),
             _ => null
         };
+    }
+
+    private static bool GeometryHasZ(Geometry geometry)
+        => geometry.Coordinates.Any(coordinate => !double.IsNaN(coordinate.Z));
+
+    private static bool GeometryHasM(Geometry geometry)
+        => geometry.Coordinates.Any(coordinate => !double.IsNaN(coordinate.M));
+
+    private static WKBReader GetWkbReader()
+    {
+        _wkbReader ??= new WKBReader();
+        return _wkbReader;
     }
 
 }

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -456,7 +456,16 @@ internal sealed class GeoParquetQueryFormatter
             return (null, false);
         }
 
-        var geometry = GetWkbReader().Read(geometryBytes);
+        Geometry? geometry;
+        try
+        {
+            geometry = GetWkbReader().Read(geometryBytes);
+        }
+        catch (Exception ex) when (ex is ParseException or FormatException)
+        {
+            return (null, false);
+        }
+
         if (geometry == null)
         {
             return (null, false);

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -84,7 +84,8 @@ internal sealed class GeoParquetQueryFormatter
                 outputSrid ?? layer.SpatialReference.Wkid,
                 returnZ,
                 returnM,
-                geometryLimits);
+                geometryLimits,
+                logger);
         }
 
         var (schema, fieldsToInclude, objectIdFieldName) = BuildSchema(
@@ -422,14 +423,15 @@ internal sealed class GeoParquetQueryFormatter
         int outputSrid,
         bool returnZ,
         bool returnM,
-        GeometryLimits geometryLimits)
+        GeometryLimits geometryLimits,
+        ILogger? logger = null)
     {
         var builder = new BinaryArray.Builder();
         var anyHasZ = false;
 
         foreach (var feature in features)
         {
-            var (wkb, hasZ) = ProcessGeometry(feature.Geometry, outputSrid, geometryLimits, returnZ, returnM);
+            var (wkb, hasZ) = ProcessGeometry(feature.Geometry, outputSrid, geometryLimits, returnZ, returnM, feature.Id, logger);
             anyHasZ |= hasZ;
             if (wkb != null && wkb.Length > 0)
             {
@@ -449,7 +451,9 @@ internal sealed class GeoParquetQueryFormatter
         int outputSrid,
         GeometryLimits geometryLimits,
         bool returnZ,
-        bool returnM)
+        bool returnM,
+        long featureId = 0,
+        ILogger? logger = null)
     {
         if (geometryBytes == null || geometryBytes.Length == 0)
         {
@@ -463,6 +467,11 @@ internal sealed class GeoParquetQueryFormatter
         }
         catch (Exception ex) when (ex is ParseException or FormatException)
         {
+            if (logger != null)
+            {
+                FeatureServerLog.GeoParquetCorruptGeometry(logger, featureId, geometryBytes.Length, ex);
+            }
+
             return (null, false);
         }
 

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -43,7 +43,8 @@ internal sealed class GeoParquetQueryFormatter
     /// <param name="returnGeometry">Whether to include geometry</param>
     /// <param name="outputSrid">Output SRID for geometry</param>
     /// <param name="returnZ">Whether to include Z values</param>
-    /// <param name="returnM">Whether to include M values</param>
+    /// <param name="returnM">Accepted for API symmetry but M values are always stripped.
+    /// GeoParquet 1.1.0 only supports XY and XYZ geometries.</param>
     /// <param name="geometryPrecision">Rounds coordinates to the specified decimal places before writing WKB.</param>
     /// <param name="maxAllowableOffset">Simplifies geometry to the given tolerance before writing WKB.</param>
     /// <param name="outFields">Fields to include in output</param>
@@ -466,16 +467,14 @@ internal sealed class GeoParquetQueryFormatter
             return null;
         }
 
-        if (!returnZ || !returnM)
-        {
-            geometry = GeometryOutputProcessor.ApplyDimensionFilter(geometry, returnZ, returnM);
-        }
+        // GeoParquet 1.1.0 only supports XY and XYZ — always strip M values.
+        geometry = GeometryOutputProcessor.ApplyDimensionFilter(geometry, returnZ, includeM: false);
 
         var writer = new WKBWriter(
             ByteOrder.LittleEndian,
             handleSRID: false,
             emitZ: GeometryHasZ(geometry),
-            emitM: GeometryHasM(geometry));
+            emitM: false);
         return writer.Write(geometry);
     }
 
@@ -805,9 +804,6 @@ internal sealed class GeoParquetQueryFormatter
 
     private static bool GeometryHasZ(Geometry geometry)
         => geometry.Coordinates.Any(coordinate => !double.IsNaN(coordinate.Z));
-
-    private static bool GeometryHasM(Geometry geometry)
-        => geometry.Coordinates.Any(coordinate => !double.IsNaN(coordinate.M));
 
     private static WKBReader GetWkbReader()
     {

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoServicesGeometryConverter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoServicesGeometryConverter.cs
@@ -15,8 +15,6 @@ namespace Honua.Server.Features.FeatureServer.Services;
 /// </summary>
 internal static class GeoServicesGeometryConverter
 {
-    [ThreadStatic]
-    private static WKBReader? _wkbReader;
 
     /// <summary>
     /// Converts WKB geometry to GeoServices format.
@@ -31,7 +29,7 @@ internal static class GeoServicesGeometryConverter
         if (wkbGeometry == null || wkbGeometry.Length == 0)
             return null;
 
-        var reader = GetWkbReader();
+        var reader = WkbReaderCache.Get();
         Geometry geometry;
 
         try
@@ -68,12 +66,6 @@ internal static class GeoServicesGeometryConverter
             : null;
 
         return ConvertGeometryToGeoServicesGeometry(geometry, spatialReference);
-    }
-
-    private static WKBReader GetWkbReader()
-    {
-        _wkbReader ??= new WKBReader();
-        return _wkbReader;
     }
 
     /// <summary>

--- a/src/Honua.Server/Features/FeatureServer/Services/PbfQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/PbfQueryFormatter.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
-using Honua.Core.Features.Shared.Models;
 using Honua.Server.Features.FeatureServer.Models;
 using Honua.Server.Features.Infrastructure.Services;
 using Microsoft.Extensions.Options;
@@ -34,9 +33,6 @@ internal sealed class PbfQueryFormatter
     private const double DefaultQuantizationScale = 1e6;
 
     private readonly GeometryLimits _geometryLimits;
-
-    [ThreadStatic]
-    private static WKBReader? _wkbReader;
 
     /// <summary>
     /// Initializes the PBF formatter with geometry processing limits.
@@ -67,7 +63,7 @@ internal sealed class PbfQueryFormatter
             maxAllowableOffset,
             forceSimplify: maxAllowableOffset is > 0);
 
-        var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
+        var objectIdFieldName = layer.ObjectIdFieldName;
         var srid = outputSrid ?? layer.SpatialReference.Wkid;
 
         // Build the FeatureResult sub-message
@@ -347,11 +343,10 @@ internal sealed class PbfQueryFormatter
         GeometryLimits geometryLimits,
         double scale)
     {
-        _wkbReader ??= new WKBReader();
         Geometry? geometry;
         try
         {
-            geometry = _wkbReader.Read(wkb);
+            geometry = WkbReaderCache.Get().Read(wkb);
         }
         catch
         {

--- a/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
@@ -36,7 +36,7 @@ internal interface IQueryFormatter
     /// <param name="maxAllowableOffset">Generalization tolerance override</param>
     /// <param name="outFields">Fields to include in output</param>
     /// <returns>Formatted result and content type</returns>
-    ValueTask<(object response, string contentType)> FormatQueryResultAsync(
+    (object response, string contentType) FormatQueryResult(
         QueryResult<Feature> result,
         LayerDefinition layer,
         string format,
@@ -56,19 +56,21 @@ internal sealed class QueryFormatter : IQueryFormatter
 {
     private readonly GeometryLimits _geometryLimits;
     private readonly PbfQueryFormatter _pbfFormatter;
+    private readonly ILogger<QueryFormatter> _logger;
     [ThreadStatic]
     private static WKBReader? _wkbReader;
 
-    public QueryFormatter(IOptions<LimitsOptions> limitsOptions, PbfQueryFormatter pbfFormatter)
+    public QueryFormatter(IOptions<LimitsOptions> limitsOptions, PbfQueryFormatter pbfFormatter, ILogger<QueryFormatter> logger)
     {
         _geometryLimits = limitsOptions?.Value?.Geometry ?? new GeometryLimits();
         _pbfFormatter = pbfFormatter;
+        _logger = logger;
     }
 
     /// <summary>
     /// Formats query result into the specified format
     /// </summary>
-    public ValueTask<(object response, string contentType)> FormatQueryResultAsync(
+    public (object response, string contentType) FormatQueryResult(
         QueryResult<Feature> result,
         LayerDefinition layer,
         string format,
@@ -88,46 +90,11 @@ internal sealed class QueryFormatter : IQueryFormatter
 
         return format.ToLowerInvariant() switch
         {
-            "pbf" => ValueTask.FromResult<(object response, string contentType)>(
-                _pbfFormatter.FormatAsPbf(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields)),
-            "parquet" => new ValueTask<(object response, string contentType)>(
-                FormatParquetAsync(
-                    result,
-                    layer,
-                    returnGeometry,
-                    outputSrid,
-                    returnZ,
-                    returnM,
-                    effectiveLimits,
-                    outFields)),
-            "geojson" => ValueTask.FromResult<(object response, string contentType)>(
-                FormatAsGeoJson(result, layer, returnGeometry, returnZ, returnM, effectiveLimits, outFields)),
-            "json" or _ => ValueTask.FromResult<(object response, string contentType)>(
-                FormatAsGeoServicesJson(result, layer, returnGeometry, outputSrid, returnZ, returnM, effectiveLimits, outFields))
+            "pbf" => _pbfFormatter.FormatAsPbf(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields),
+            "parquet" => GeoParquetQueryFormatter.FormatAsGeoParquet(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields, _logger),
+            "geojson" => FormatAsGeoJson(result, layer, returnGeometry, returnZ, returnM, effectiveLimits, outFields),
+            "json" or _ => FormatAsGeoServicesJson(result, layer, returnGeometry, outputSrid, returnZ, returnM, effectiveLimits, outFields)
         };
-    }
-
-    private static async Task<(object response, string contentType)> FormatParquetAsync(
-        QueryResult<Feature> result,
-        LayerDefinition layer,
-        bool returnGeometry,
-        int? outputSrid,
-        bool returnZ,
-        bool returnM,
-        GeometryLimits effectiveLimits,
-        string[]? outFields)
-    {
-        var (response, contentType) = await GeoParquetQueryFormatter.FormatAsGeoParquetAsync(
-            result,
-            layer,
-            returnGeometry,
-            outputSrid,
-            returnZ,
-            returnM,
-            effectiveLimits,
-            outFields);
-
-        return (response, contentType);
     }
 
     /// <summary>

--- a/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
@@ -36,7 +36,7 @@ internal interface IQueryFormatter
     /// <param name="maxAllowableOffset">Generalization tolerance override</param>
     /// <param name="outFields">Fields to include in output</param>
     /// <returns>Formatted result and content type</returns>
-    (object response, string contentType) FormatQueryResult(
+    ValueTask<(object response, string contentType)> FormatQueryResultAsync(
         QueryResult<Feature> result,
         LayerDefinition layer,
         string format,
@@ -70,7 +70,7 @@ internal sealed class QueryFormatter : IQueryFormatter
     /// <summary>
     /// Formats query result into the specified format
     /// </summary>
-    public (object response, string contentType) FormatQueryResult(
+    public ValueTask<(object response, string contentType)> FormatQueryResultAsync(
         QueryResult<Feature> result,
         LayerDefinition layer,
         string format,
@@ -88,13 +88,13 @@ internal sealed class QueryFormatter : IQueryFormatter
             maxAllowableOffset,
             forceSimplify: maxAllowableOffset is > 0);
 
-        return format.ToLowerInvariant() switch
+        return ValueTask.FromResult(format.ToLowerInvariant() switch
         {
             "pbf" => _pbfFormatter.FormatAsPbf(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields),
             "parquet" => GeoParquetQueryFormatter.FormatAsGeoParquet(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields, _logger),
             "geojson" => FormatAsGeoJson(result, layer, returnGeometry, returnZ, returnM, effectiveLimits, outFields),
             "json" or _ => FormatAsGeoServicesJson(result, layer, returnGeometry, outputSrid, returnZ, returnM, effectiveLimits, outFields)
-        };
+        });
     }
 
     /// <summary>

--- a/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
@@ -91,7 +91,7 @@ internal sealed class QueryFormatter : IQueryFormatter
         return ValueTask.FromResult(format.ToLowerInvariant() switch
         {
             "pbf" => _pbfFormatter.FormatAsPbf(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields),
-            "parquet" => GeoParquetQueryFormatter.FormatAsGeoParquet(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields, _logger),
+            "parquet" => GeoParquetQueryFormatter.FormatAsGeoParquet(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields, _logger, _geometryLimits),
             "geojson" => FormatAsGeoJson(result, layer, returnGeometry, returnZ, returnM, effectiveLimits, outFields),
             "json" or _ => FormatAsGeoServicesJson(result, layer, returnGeometry, outputSrid, returnZ, returnM, effectiveLimits, outFields)
         });

--- a/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
@@ -57,8 +57,6 @@ internal sealed class QueryFormatter : IQueryFormatter
     private readonly GeometryLimits _geometryLimits;
     private readonly PbfQueryFormatter _pbfFormatter;
     private readonly ILogger<QueryFormatter> _logger;
-    [ThreadStatic]
-    private static WKBReader? _wkbReader;
 
     public QueryFormatter(IOptions<LimitsOptions> limitsOptions, PbfQueryFormatter pbfFormatter, ILogger<QueryFormatter> logger)
     {
@@ -110,7 +108,7 @@ internal sealed class QueryFormatter : IQueryFormatter
         GeometryLimits geometryLimits,
         string[]? outFields)
     {
-        var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
+        var objectIdFieldName = layer.ObjectIdFieldName;
         GeoServicesFeature[] features = result.Items
             .Select(f => ConvertToGeoServicesFeature(f, returnGeometry, outFields, objectIdFieldName, returnZ, returnM, geometryLimits))
             .ToArray();
@@ -157,7 +155,7 @@ internal sealed class QueryFormatter : IQueryFormatter
         GeometryLimits geometryLimits,
         string[]? outFields)
     {
-        var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
+        var objectIdFieldName = layer.ObjectIdFieldName;
         GeoJsonFeature[] features = result.Items
             .Select(f => ConvertToGeoJsonFeature(f, returnGeometry, outFields, objectIdFieldName, returnZ, returnM, geometryLimits))
             .ToArray();
@@ -400,7 +398,7 @@ internal sealed class QueryFormatter : IQueryFormatter
         if (wkbGeometry == null || wkbGeometry.Length == 0)
             return null;
 
-        var reader = GetWkbReader();
+        var reader = WkbReaderCache.Get();
         Geometry geometry;
 
         try
@@ -423,12 +421,6 @@ internal sealed class QueryFormatter : IQueryFormatter
             geometry = GeometryOutputProcessor.ApplyDimensionFilter(geometry, returnZ, returnM);
         }
         return ConvertGeometryToGeoJsonGeometry(geometry);
-    }
-
-    private static WKBReader GetWkbReader()
-    {
-        _wkbReader ??= new WKBReader();
-        return _wkbReader;
     }
 
     private static GeoJsonGeometry ConvertGeometryToGeoJsonGeometry(Geometry geometry)
@@ -632,7 +624,7 @@ internal sealed class StreamingQueryFormatter
             SkipValidation = false
         });
 
-        var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
+        var objectIdFieldName = layer.ObjectIdFieldName;
         var outFieldLookup = CreateFieldLookup(outFields);
         var srid = outputSrid ?? layer.SpatialReference.Wkid;
         var queryFields = QueryFormatter.BuildQueryFields(layer, outFields, objectIdFieldName);
@@ -730,7 +722,7 @@ internal sealed class StreamingQueryFormatter
             SkipValidation = false
         });
 
-        var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
+        var objectIdFieldName = layer.ObjectIdFieldName;
         var outFieldLookup = CreateFieldLookup(outFields);
 
         // Start GeoJSON FeatureCollection

--- a/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
@@ -91,7 +91,7 @@ internal sealed class QueryFormatter : IQueryFormatter
         return ValueTask.FromResult(format.ToLowerInvariant() switch
         {
             "pbf" => _pbfFormatter.FormatAsPbf(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields),
-            "parquet" => GeoParquetQueryFormatter.FormatAsGeoParquet(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields, _logger, _geometryLimits),
+            "parquet" => GeoParquetQueryFormatter.FormatAsGeoParquet(result, layer, returnGeometry, outputSrid, returnZ, returnM, effectiveLimits, outFields, _logger),
             "geojson" => FormatAsGeoJson(result, layer, returnGeometry, returnZ, returnM, effectiveLimits, outFields),
             "json" or _ => FormatAsGeoServicesJson(result, layer, returnGeometry, outputSrid, returnZ, returnM, effectiveLimits, outFields)
         });

--- a/src/Honua.Server/Features/Infrastructure/Services/WkbReaderCache.cs
+++ b/src/Honua.Server/Features/Infrastructure/Services/WkbReaderCache.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using NetTopologySuite.IO;
+
+namespace Honua.Server.Features.Infrastructure.Services;
+
+/// <summary>
+/// Thread-static cache for <see cref="WKBReader"/> instances.
+/// Centralises the pattern previously duplicated across formatters.
+/// </summary>
+internal static class WkbReaderCache
+{
+    [ThreadStatic]
+    private static WKBReader? _instance;
+
+    /// <summary>
+    /// Returns a cached <see cref="WKBReader"/> for the current thread.
+    /// </summary>
+    public static WKBReader Get()
+    {
+        _instance ??= new WKBReader();
+        return _instance;
+    }
+}

--- a/src/Honua.Server/Honua.Server.csproj
+++ b/src/Honua.Server/Honua.Server.csproj
@@ -59,7 +59,7 @@
     <PackageReference Include="NetTopologySuite" Version="2.6.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.2" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
-    <PackageReference Include="Parquet.Net" Version="5.5.0" />
+    <PackageReference Include="Apache.Arrow" Version="18.1.0" />
     <EmbeddedResource Include="Migrations\*.sql" />
   </ItemGroup>
 
@@ -73,6 +73,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.3" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.24" />
+    <PackageReference Include="ParquetSharp" Version="21.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     <Content Update="openapi.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerQueryParameterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerQueryParameterTests.cs
@@ -9,8 +9,6 @@ using Honua.Server.Features.FeatureServer.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
-using Parquet;
-
 namespace Honua.Server.Tests.Features.FeatureServer;
 
 [Collection("Database")]
@@ -418,24 +416,27 @@ public sealed class FeatureServerQueryParameterTests : IAsyncLifetime
         Encoding.ASCII.GetString(payload, 0, 4).Should().Be("PAR1");
 
         using var stream = new MemoryStream(payload);
-        using var reader = await ParquetReader.CreateAsync(stream);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        await batchReader.ReadNextRecordBatchAsync(); // materialize schema
 
-        var fields = reader.Schema.GetDataFields().ToArray();
-        fields.Select(field => field.Name).Should().OnlyHaveUniqueItems();
-        fields.Select(field => field.Name).Should().Contain("objectid");
+        var fieldNames = reader.Schema.FieldsList.Select(f => f.Name).ToArray();
+        fieldNames.Should().OnlyHaveUniqueItems();
+        fieldNames.Should().Contain("objectid");
 
         if (expectGeometry)
         {
-            fields.Select(field => field.Name).Should().Contain("geometry");
-            reader.CustomMetadata.Should().ContainKey("geo");
+            fieldNames.Should().Contain("geometry");
+            reader.Schema.Metadata.Should().ContainKey("geo");
 
-            using var metadataDocument = JsonDocument.Parse(reader.CustomMetadata["geo"]);
+            using var metadataDocument = JsonDocument.Parse(reader.Schema.Metadata["geo"]);
             metadataDocument.RootElement.GetProperty("primary_column").GetString().Should().Be("geometry");
         }
         else
         {
-            fields.Select(field => field.Name).Should().NotContain("geometry");
-            reader.CustomMetadata.Should().NotContainKey("geo");
+            fieldNames.Should().NotContain("geometry");
+            var hasGeoKey = reader.Schema.Metadata?.ContainsKey("geo") ?? false;
+            hasGeoKey.Should().BeFalse();
         }
     }
 }

--- a/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerQueryParameterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerQueryParameterTests.cs
@@ -98,6 +98,20 @@ public sealed class FeatureServerQueryParameterTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.apache.parquet");
         var payload = await response.Content.ReadAsByteArrayAsync();
+        payload.Should().NotBeEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithGeoParquetFormat_ReturnsOk()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?f=parquet");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.apache.parquet");
+        var payload = await response.Content.ReadAsByteArrayAsync();
         await AssertGeoParquetPayloadAsync(payload, expectGeometry: true);
     }
 
@@ -112,6 +126,66 @@ public sealed class FeatureServerQueryParameterTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("returnDistinctValues is not supported when f=fgb.");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithGeoParquetFormatAndNon4326OutSR_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?f=parquet&outSR=3857");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("GeoParquet output does not yet support non-4326 outSR");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithGeoParquetFormatNoGeometry_ReturnsOk()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?f=parquet&returnGeometry=false");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.apache.parquet");
+        var payload = await response.Content.ReadAsByteArrayAsync();
+        payload.Should().NotBeEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithGeoParquetFormatNoGeometryAndNon4326OutSR_ReturnsOk()
+    {
+        // When returnGeometry=false the parquet file has no geometry column or CRS metadata,
+        // so the 4326 restriction should not apply.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?f=parquet&returnGeometry=false&outSR=3857");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.apache.parquet");
+        var payload = await response.Content.ReadAsByteArrayAsync();
+        payload.Should().NotBeEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithGeoParquetFormatAndOutStatisticsAndNon4326OutSR_ReturnsJson()
+    {
+        // outStatistics queries always return JSON regardless of f=, so the parquet
+        // CRS restriction must not reject the request.
+        var outStats = Uri.EscapeDataString(
+            """[{"statisticType":"count","onStatisticField":"objectid","outStatisticFieldName":"cnt"}]""");
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?f=parquet&outSR=3857&outStatistics={outStats}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
     }
 
     [IntegrationTest]
@@ -155,6 +229,24 @@ public sealed class FeatureServerQueryParameterTests : IAsyncLifetime
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.flatgeobuf");
+        var payload = await response.Content.ReadAsByteArrayAsync();
+        payload.Should().NotBeEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithGeoParquetAcceptHeader_ReturnsOk()
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query");
+        request.Headers.Accept.ParseAdd("application/vnd.apache.parquet");
+
+        var response = await _fixture.Client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.apache.parquet");
         var payload = await response.Content.ReadAsByteArrayAsync();
         payload.Should().NotBeEmpty();
     }

--- a/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerQueryParameterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerQueryParameterTests.cs
@@ -98,20 +98,6 @@ public sealed class FeatureServerQueryParameterTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.apache.parquet");
         var payload = await response.Content.ReadAsByteArrayAsync();
-        payload.Should().NotBeEmpty();
-    }
-
-    [IntegrationTest]
-    [Operation(Operations.Query)]
-    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
-    public async Task Query_WithGeoParquetFormat_ReturnsOk()
-    {
-        var response = await _fixture.Client.GetAsync(
-            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?f=parquet");
-
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.apache.parquet");
-        var payload = await response.Content.ReadAsByteArrayAsync();
         await AssertGeoParquetPayloadAsync(payload, expectGeometry: true);
     }
 
@@ -139,20 +125,6 @@ public sealed class FeatureServerQueryParameterTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("GeoParquet output does not yet support non-4326 outSR");
-    }
-
-    [IntegrationTest]
-    [Operation(Operations.Query)]
-    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
-    public async Task Query_WithGeoParquetFormatNoGeometry_ReturnsOk()
-    {
-        var response = await _fixture.Client.GetAsync(
-            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?f=parquet&returnGeometry=false");
-
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.apache.parquet");
-        var payload = await response.Content.ReadAsByteArrayAsync();
-        payload.Should().NotBeEmpty();
     }
 
     [IntegrationTest]
@@ -229,24 +201,6 @@ public sealed class FeatureServerQueryParameterTests : IAsyncLifetime
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.flatgeobuf");
-        var payload = await response.Content.ReadAsByteArrayAsync();
-        payload.Should().NotBeEmpty();
-    }
-
-    [IntegrationTest]
-    [Operation(Operations.Query)]
-    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
-    public async Task Query_WithGeoParquetAcceptHeader_ReturnsOk()
-    {
-        using var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query");
-        request.Headers.Accept.ParseAdd("application/vnd.apache.parquet");
-
-        var response = await _fixture.Client.SendAsync(request);
-
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.apache.parquet");
         var payload = await response.Content.ReadAsByteArrayAsync();
         payload.Should().NotBeEmpty();
     }

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
@@ -70,7 +70,7 @@ public sealed class GeoParquetQueryFormatterTests
     }
 
     [Fact]
-    public void FormatAsGeoParquet_EmptyResult_ReturnsValidParquetWithCorrectContentType()
+    public void FormatAsGeoParquet_EmptyResult_ReturnsValidParquetWithEmptyGeometryTypes()
     {
         var layer = CreateLayer(
             new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
@@ -93,6 +93,15 @@ public sealed class GeoParquetQueryFormatterTests
         payload[1].Should().Be((byte)'A');
         payload[2].Should().Be((byte)'R');
         payload[3].Should().Be((byte)'1');
+
+        // GeoParquet 1.1.0 §4.1: geometry_types must be [] for an empty file
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        reader.Schema.Metadata.Should().ContainKey("geo");
+        using var geoDoc = JsonDocument.Parse(reader.Schema.Metadata["geo"]);
+        var geomCol = geoDoc.RootElement.GetProperty("columns").GetProperty("geometry");
+        geomCol.GetProperty("geometry_types").EnumerateArray().Should().BeEmpty(
+            "empty GeoParquet file must have geometry_types:[] per spec §4.1");
     }
 
     [Fact]
@@ -431,6 +440,8 @@ public sealed class GeoParquetQueryFormatterTests
         geomCol.GetProperty("crs").ValueKind.Should().Be(JsonValueKind.Null);
         // bbox is omitted — layer extent is not the same as the exported result extent
         geomCol.TryGetProperty("bbox", out _).Should().BeFalse();
+        // Empty file must also have geometry_types:[]
+        geomCol.GetProperty("geometry_types").EnumerateArray().Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
@@ -729,6 +729,51 @@ public sealed class GeoParquetQueryFormatterTests
     }
 
     [Fact]
+    public async Task FormatAsGeoParquet_WithCorruptWkb_TreatsGeometryAsNull()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("name", FieldType.String, 255));
+        var corruptWkb = new byte[] { 0xFF, 0xFE, 0x00, 0x01, 0x02, 0x03 };
+        var validFeature = Feature.Create(
+            1,
+            CreatePointWkb(1.0, 2.0),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["name"] = "Valid"
+            }.ToImmutableDictionary());
+        var corruptFeature = Feature.Create(
+            2,
+            corruptWkb,
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 2L,
+                ["name"] = "Corrupt"
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(2, [validFeature, corruptFeature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            new GeometryLimits());
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+        batch!.Length.Should().Be(2);
+        var geometryColumn = (BinaryArray)batch.Column("geometry");
+        geometryColumn.IsNull(0).Should().BeFalse("valid geometry should be preserved");
+        geometryColumn.IsNull(1).Should().BeTrue("corrupt WKB should produce null geometry");
+    }
+
+    [Fact]
     public void FormatAsGeoParquet_With2DGeometryAndReturnZTrue_DoesNotAdvertiseZ()
     {
         // A 2D-only layer/feature with returnZ=true must not claim "Point Z" in metadata

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
@@ -288,6 +288,51 @@ public sealed class GeoParquetQueryFormatterTests
     }
 
     [Fact]
+    public async Task FormatAsGeoParquet_WithEpochMillisecondTemporalValues_PreservesDateAndTimestampColumns()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("updated_at", FieldType.DateTime),
+            new FieldDefinition("event_date", FieldType.Date));
+        const long updatedAtEpochMs = 1718454600000;
+        const long eventDateEpochMs = 1718409600000;
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(0, 0),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["updated_at"] = updatedAtEpochMs,
+                ["event_date"] = eventDateEpochMs
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+
+        var timestampArray = (TimestampArray)batch!.Column("updated_at");
+        timestampArray.GetTimestamp(0)!.Value.ToUnixTimeMilliseconds().Should().Be(updatedAtEpochMs);
+
+        var dateArray = (Date32Array)batch.Column("event_date");
+        var epoch = DateOnly.FromDateTime(DateTime.UnixEpoch);
+        var expectedDate = DateOnly.FromDateTime(DateTimeOffset.FromUnixTimeMilliseconds(eventDateEpochMs).UtcDateTime);
+        dateArray.GetValue(0).Should().Be(expectedDate.DayNumber - epoch.DayNumber);
+    }
+
+    [Fact]
     public void FormatAsGeoParquet_EmptyResultWithNon4326Srid_WritesCrsNull()
     {
         var layer = CreateLayer(
@@ -546,7 +591,7 @@ public sealed class GeoParquetQueryFormatterTests
                 new FieldDefinition("bool_field", FieldType.Boolean),          // BOOLEAN
                 new FieldDefinition("datetime_field", FieldType.DateTime),     // TIMESTAMP WITH TIME ZONE
                 new FieldDefinition("date_field", FieldType.Date),             // DATE
-                new FieldDefinition("time_field", FieldType.Time),             // TIME (default → string)
+                new FieldDefinition("time_field", FieldType.Time),             // TIME
                 new FieldDefinition("json_field", FieldType.Json),             // JSONB
                 new FieldDefinition("binary_field", FieldType.Binary),         // BYTEA
                 new FieldDefinition("uuid_field", FieldType.Uuid),             // UUID
@@ -604,10 +649,13 @@ public sealed class GeoParquetQueryFormatterTests
         batch.Column("bool_field").Should().BeOfType<BooleanArray>();
         batch.Column("datetime_field").Should().BeOfType<TimestampArray>();
         batch.Column("date_field").Should().BeOfType<Date32Array>();
-        batch.Column("time_field").Should().BeOfType<StringArray>();
+        batch.Column("time_field").Should().BeOfType<Time32Array>();
         batch.Column("json_field").Should().BeOfType<StringArray>();
         batch.Column("binary_field").Should().BeOfType<BinaryArray>();
         batch.Column("uuid_field").Should().BeOfType<StringArray>();
+
+        var timeArray = (Time32Array)batch.Column("time_field");
+        timeArray.GetValue(0).Should().Be(14 * 60 * 60 * 1000 + 30 * 60 * 1000);
     }
 
     private static LayerDefinition CreateLayer(params FieldDefinition[] fields)

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
@@ -139,6 +139,49 @@ public sealed class GeoParquetQueryFormatterTests
     }
 
     [Fact]
+    public async Task FormatAsGeoParquet_WithZmGeometryAndReturnMTrue_StripsMPerGeoParquetSpec()
+    {
+        // GeoParquet 1.1.0 only supports XY and XYZ — M values must be stripped
+        // even when the caller requests returnM=true.
+        var layer = CreateLayer(new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false));
+        var feature = Feature.Create(
+            1,
+            CreatePointWkbWithZm(1.0, 2.0, 3.0, 4.0),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: true,
+            returnM: true,
+            geometryPrecision: null,
+            maxAllowableOffset: null,
+            baseGeometryLimits: new GeometryLimits());
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+        var geometryColumn = (BinaryArray)batch!.Column("geometry");
+        geometryColumn.IsNull(0).Should().BeFalse();
+
+        var geometry = new WKBReader().Read(geometryColumn.GetBytes(0).ToArray());
+        var point = geometry.Should().BeOfType<Point>().Subject;
+
+        point.X.Should().Be(1.0);
+        point.Y.Should().Be(2.0);
+        point.Coordinate.Z.Should().Be(3.0);
+        double.IsNaN(point.Coordinate.M).Should().BeTrue("GeoParquet 1.1.0 does not support M values");
+    }
+
+    [Fact]
     public async Task FormatAsGeoParquet_WithoutGeometry_OmitsGeometryColumn()
     {
         var layer = CreateLayer(
@@ -611,6 +654,10 @@ public sealed class GeoParquetQueryFormatterTests
     /// use independent switch statements over SQL type strings. If they diverge for any type,
     /// the Parquet write or read will fail because the schema declares one Arrow type but
     /// the column data uses another.
+    /// Note: The formatter also handles "smallint"/"int2" → Int16 and "decimal" → Double,
+    /// but these SQL types are not reachable via FieldDefinition.SqlType today (the Postgres
+    /// layer maps smallint → FieldType.Integer → "INTEGER"). Those branches are defensive
+    /// for future FieldType additions or raw SQL type overrides.
     /// </summary>
     [Fact]
     public async Task FormatAsGeoParquet_AllSqlTypes_SchemaAndBuilderTypesAreConsistent()

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
@@ -3,16 +3,14 @@
 
 using System.Collections.Immutable;
 using System.Text.Json;
+using Apache.Arrow;
 using FluentAssertions;
-using Honua.Core.Configuration;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Shared.Models;
 using Honua.Server.Features.FeatureServer.Services;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
-using Parquet;
-using Parquet.Schema;
 using GeometryType = Honua.Core.Features.Catalog.Domain.GeometryType;
 
 namespace Honua.Server.Tests.Features.FeatureServer.Services;
@@ -20,12 +18,12 @@ namespace Honua.Server.Tests.Features.FeatureServer.Services;
 public sealed class GeoParquetQueryFormatterTests
 {
     [Fact]
-    public async Task FormatAsGeoParquetAsync_WithFeatures_WritesReadableParquetWithGeoMetadata()
+    public async Task FormatAsGeoParquet_WithFeatures_WritesReadableParquetWithGeoMetadata()
     {
         var layer = CreateLayer(
             new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
             new FieldDefinition("name", FieldType.String, 255),
-            new FieldDefinition("created", FieldType.DateTime));
+            new FieldDefinition("population", FieldType.Integer));
         var feature = Feature.Create(
             1,
             CreatePointWkb(-157.8583, 21.3069),
@@ -33,108 +31,543 @@ public sealed class GeoParquetQueryFormatterTests
             {
                 ["objectid"] = 1L,
                 ["name"] = "Honolulu Harbor",
-                ["created"] = new DateTimeOffset(2024, 01, 02, 03, 04, 05, TimeSpan.Zero)
+                ["population"] = 350000
             }.ToImmutableDictionary());
 
-        var (payload, contentType) = await GeoParquetQueryFormatter.FormatAsGeoParquetAsync(
+        var (payload, contentType) = GeoParquetQueryFormatter.FormatAsGeoParquet(
             QueryResult<Feature>.Create(1, [feature]),
             layer,
             returnGeometry: true,
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryLimits: new GeometryLimits());
+            geometryPrecision: null,
+            maxAllowableOffset: null);
 
         contentType.Should().Be("application/vnd.apache.parquet");
+        payload.Should().NotBeEmpty();
+
+        // Verify magic bytes: Parquet files start with "PAR1"
+        payload[0].Should().Be((byte)'P');
+        payload[1].Should().Be((byte)'A');
+        payload[2].Should().Be((byte)'R');
+        payload[3].Should().Be((byte)'1');
+
         using var stream = new MemoryStream(payload);
-        using var reader = await ParquetReader.CreateAsync(stream);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
 
-        reader.Schema.GetDataFields().Select(field => field.Name)
-            .Should().Equal("objectid", "name", "created", "geometry");
-        reader.CustomMetadata.Should().ContainKey("geo");
+        batch.Should().NotBeNull();
+        batch!.Length.Should().Be(1);
+        batch.Schema.FieldsList.Select(f => f.Name)
+            .Should().Equal("objectid", "geometry", "name", "population");
 
-        using var metadataDocument = JsonDocument.Parse(reader.CustomMetadata["geo"]);
-        metadataDocument.RootElement.GetProperty("primary_column").GetString().Should().Be("geometry");
-
-        var createdField = reader.Schema.FindDataField("created");
-        createdField.Should().BeOfType<DateTimeDataField>();
-
-        using var rowGroupReader = reader.OpenRowGroupReader(0);
-        var createdColumn = await rowGroupReader.ReadColumnAsync(createdField!);
-        createdColumn.Data.Should().BeAssignableTo<DateTime?[]>();
-        ((DateTime?[])createdColumn.Data)[0].Should().Be(new DateTime(2024, 01, 02, 03, 04, 05, DateTimeKind.Utc));
+        reader.Schema.Metadata.Should().ContainKey("geo");
+        using var geoDoc = JsonDocument.Parse(reader.Schema.Metadata["geo"]);
+        geoDoc.RootElement.GetProperty("version").GetString().Should().Be("1.1.0");
+        geoDoc.RootElement.GetProperty("primary_column").GetString().Should().Be("geometry");
     }
 
     [Fact]
-    public async Task FormatAsGeoParquetAsync_EmptyResult_PreservesRequestedSchema()
+    public void FormatAsGeoParquet_EmptyResult_ReturnsValidParquetWithCorrectContentType()
     {
         var layer = CreateLayer(
             new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
-            new FieldDefinition("name", FieldType.String, 255),
-            new FieldDefinition("created", FieldType.DateTime));
+            new FieldDefinition("name", FieldType.String, 255));
 
-        var (payload, _) = await GeoParquetQueryFormatter.FormatAsGeoParquetAsync(
+        var (payload, contentType) = GeoParquetQueryFormatter.FormatAsGeoParquet(
             QueryResult<Feature>.Empty(),
             layer,
             returnGeometry: true,
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryLimits: new GeometryLimits(),
-            outFields: ["name", "created"]);
+            geometryPrecision: null,
+            maxAllowableOffset: null);
 
-        using var stream = new MemoryStream(payload);
-        using var reader = await ParquetReader.CreateAsync(stream);
+        contentType.Should().Be("application/vnd.apache.parquet");
+        payload.Should().NotBeEmpty();
 
-        reader.RowGroupCount.Should().Be(1);
-        reader.Schema.GetDataFields().Select(field => field.Name)
-            .Should().Equal("objectid", "name", "created", "geometry");
-
-        using var rowGroupReader = reader.OpenRowGroupReader(0);
-        var objectIdColumn = await rowGroupReader.ReadColumnAsync(reader.Schema.FindDataField("objectid")!);
-        objectIdColumn.Data.Should().BeAssignableTo<long[]>();
-        ((long[])objectIdColumn.Data).Should().BeEmpty();
+        // Verify magic bytes: Parquet files start with "PAR1"
+        payload[0].Should().Be((byte)'P');
+        payload[1].Should().Be((byte)'A');
+        payload[2].Should().Be((byte)'R');
+        payload[3].Should().Be((byte)'1');
     }
 
     [Fact]
-    public async Task FormatAsGeoParquetAsync_AppliesGeometryPrecisionAndDimensionFiltering()
+    public async Task FormatAsGeoParquet_WithoutGeometry_OmitsGeometryColumn()
     {
-        var layer = CreateLayer(new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false));
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("name", FieldType.String, 255));
         var feature = Feature.Create(
             1,
-            CreatePointWkbWithZm(1.2349, 2.3451, 3.4567, 4.5678),
-            new Dictionary<string, object?> { ["objectid"] = 1L }.ToImmutableDictionary());
+            CreatePointWkb(-157.8583, 21.3069),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["name"] = "Test Feature"
+            }.ToImmutableDictionary());
 
-        var (payload, _) = await GeoParquetQueryFormatter.FormatAsGeoParquetAsync(
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: false,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+        batch!.Schema.FieldsList.Select(f => f.Name)
+            .Should().NotContain("geometry");
+        // No geometry means no geo metadata (metadata may be null or empty)
+        var hasGeoKey = reader.Schema.Metadata?.ContainsKey("geo") ?? false;
+        hasGeoKey.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task FormatAsGeoParquet_WithOutFields_IncludesOnlyRequestedFields()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("name", FieldType.String, 255),
+            new FieldDefinition("population", FieldType.Integer),
+            new FieldDefinition("area", FieldType.Double));
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(0, 0),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["name"] = "Test",
+                ["population"] = 100,
+                ["area"] = 1.5
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
             QueryResult<Feature>.Create(1, [feature]),
             layer,
             returnGeometry: true,
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryLimits: new GeometryLimits { MaxCoordinatePrecision = 2 });
+            geometryPrecision: null,
+            maxAllowableOffset: null,
+            outFields: ["name"]);
 
         using var stream = new MemoryStream(payload);
-        using var reader = await ParquetReader.CreateAsync(stream);
-        using var rowGroupReader = reader.OpenRowGroupReader(0);
-        var geometryColumn = await rowGroupReader.ReadColumnAsync(reader.Schema.FindDataField("geometry")!);
-        var geometryBytes = ((byte[]?[])geometryColumn.Data)[0];
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
 
-        geometryBytes.Should().NotBeNull();
-        var geometry = new WKBReader().Read(geometryBytes!);
-        var point = geometry.Should().BeOfType<Point>().Subject;
+        batch.Should().NotBeNull();
+        batch!.Schema.FieldsList.Select(f => f.Name)
+            .Should().Equal("objectid", "geometry", "name");
+    }
 
-        point.X.Should().Be(1.23);
-        point.Y.Should().Be(2.35);
-        double.IsNaN(point.Coordinate.Z).Should().BeTrue();
-        double.IsNaN(point.Coordinate.M).Should().BeTrue();
+    [Fact]
+    public void FormatAsGeoParquet_GeoMetadata_IncludesCrsAndGeometryType()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false));
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(0, 0),
+            new Dictionary<string, object?> { ["objectid"] = 1L }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        // Read a batch to populate schema fully
+        using var batchReader = reader.GetRecordBatchReader();
+
+        reader.Schema.Metadata.Should().ContainKey("geo");
+        using var geoDoc = JsonDocument.Parse(reader.Schema.Metadata["geo"]);
+        var columns = geoDoc.RootElement.GetProperty("columns");
+        var geomCol = columns.GetProperty("geometry");
+
+        geomCol.GetProperty("encoding").GetString().Should().Be("WKB");
+        geomCol.GetProperty("geometry_types").EnumerateArray().First().GetString().Should().Be("Point");
+
+        // GeoParquet 1.1.0: omitting `crs` key implies OGC:CRS84 (WGS84 lon/lat)
+        geomCol.TryGetProperty("crs", out _).Should().BeFalse("EPSG:4326 should omit crs key (implies OGC:CRS84)");
+    }
+
+    [Fact]
+    public async Task FormatAsGeoParquet_WithDateTimeField_MapsToTimestampType()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("updated_at", FieldType.DateTime));
+        var timestamp = new DateTime(2024, 6, 15, 12, 30, 0, DateTimeKind.Utc);
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(0, 0),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["updated_at"] = timestamp
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+        var updatedAtField = batch!.Schema.GetFieldByName("updated_at");
+        updatedAtField.DataType.Should().BeOfType<Apache.Arrow.Types.TimestampType>();
+    }
+
+    [Fact]
+    public async Task FormatAsGeoParquet_WithUnspecifiedDateTimeKind_TreatsAsUtc()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("created_at", FieldType.DateTime));
+        // DateTimeKind.Unspecified — common for PostgreSQL "timestamp without time zone"
+        var unspecifiedTimestamp = new DateTime(2024, 6, 15, 12, 30, 0, DateTimeKind.Unspecified);
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(0, 0),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["created_at"] = unspecifiedTimestamp
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+        var tsArray = (TimestampArray)batch!.Column("created_at");
+        var storedValue = tsArray.GetTimestamp(0);
+        // Must match the original value interpreted as UTC, not shifted by local timezone
+        storedValue.Should().NotBeNull();
+        storedValue!.Value.DateTime.Should().Be(unspecifiedTimestamp);
+    }
+
+    [Fact]
+    public void FormatAsGeoParquet_EmptyResultWithNon4326Srid_WritesCrsNull()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false));
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Empty(),
+            layer,
+            returnGeometry: true,
+            outputSrid: 3857,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+
+        reader.Schema.Metadata.Should().ContainKey("geo");
+        using var geoDoc = JsonDocument.Parse(reader.Schema.Metadata["geo"]);
+        var geomCol = geoDoc.RootElement.GetProperty("columns")
+            .GetProperty("geometry");
+        // Non-4326 SRIDs write crs:null (full PROJJSON requires a projection library)
+        geomCol.GetProperty("crs").ValueKind.Should().Be(JsonValueKind.Null);
+        // bbox is omitted — layer extent is not the same as the exported result extent
+        geomCol.TryGetProperty("bbox", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task FormatAsGeoParquet_WithRuntimeDistanceAttribute_IncludesDistanceColumn()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("name", FieldType.String, 255));
+        // Simulate a KNN query result where the Postgres reader injects a "distance" runtime attribute.
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(-157.8583, 21.3069),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["name"] = "Nearest Point",
+                ["distance"] = 42.5 // runtime-computed by ST_Distance
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+        batch!.Schema.FieldsList.Select(f => f.Name)
+            .Should().Contain("distance");
+        var distanceArray = (DoubleArray)batch.Column("distance");
+        distanceArray.GetValue(0).Should().BeApproximately(42.5, 1e-9);
+    }
+
+    [Fact]
+    public async Task FormatAsGeoParquet_WithOutFieldsAndRuntimeDistance_ExcludesUnrequestedRuntimeFields()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("name", FieldType.String, 255));
+        // Simulate a KNN result with a runtime "distance" attribute, but outFields only requests "name".
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(-157.8583, 21.3069),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["name"] = "Nearest Point",
+                ["distance"] = 42.5
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null,
+            outFields: ["name"]);
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+        batch!.Schema.FieldsList.Select(f => f.Name)
+            .Should().Equal("objectid", "geometry", "name")
+            .And.NotContain("distance",
+                "runtime fields not in outFields should be excluded, matching JSON/GeoJSON behavior");
+    }
+
+    [Fact]
+    public async Task FormatAsGeoParquet_WithBase64ByteaAttribute_DecodesBytes()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("data", FieldType.Binary));
+        var rawBytes = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF };
+        // Simulate the JSON round-trip: BYTEA values from the JSONB attributes column
+        // arrive as base64 strings after deserialization.
+        var base64Value = Convert.ToBase64String(rawBytes);
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(0, 0),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["data"] = base64Value // string, not byte[]
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+        var dataArray = (BinaryArray)batch!.Column("data");
+        dataArray.IsNull(0).Should().BeFalse("base64 string should be decoded to bytes");
+        dataArray.GetBytes(0).ToArray().Should().Equal(rawBytes);
+    }
+
+    [Fact]
+    public async Task FormatAsGeoParquet_WithNativeByteArrayAttribute_PreservesBytes()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("data", FieldType.Binary));
+        var rawBytes = new byte[] { 0x01, 0x02, 0x03 };
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(0, 0),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["data"] = rawBytes // already byte[] (e.g. from direct column read)
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+        var dataArray = (BinaryArray)batch!.Column("data");
+        dataArray.IsNull(0).Should().BeFalse();
+        dataArray.GetBytes(0).ToArray().Should().Equal(rawBytes);
+    }
+
+    /// <summary>
+    /// Guards against the dual-switch sync risk: MapToArrowType and BuildAttributeArray
+    /// use independent switch statements over SQL type strings. If they diverge for any type,
+    /// the Parquet write or read will fail because the schema declares one Arrow type but
+    /// the column data uses another.
+    /// </summary>
+    [Fact]
+    public async Task FormatAsGeoParquet_AllSqlTypes_SchemaAndBuilderTypesAreConsistent()
+    {
+        // One field per FieldType (except Geometry, which is the geometry column itself).
+        var layer = new LayerDefinition(
+            Id: 1,
+            Name: "type_sync_test",
+            Description: "All SQL type mappings",
+            GeometryType: GeometryType.Point,
+            SpatialReference: SpatialReference.WGS84,
+            Fields:
+            [
+                new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+                new FieldDefinition("text_field", FieldType.String),           // TEXT
+                new FieldDefinition("varchar_field", FieldType.String, 100),   // VARCHAR(100)
+                new FieldDefinition("int_field", FieldType.Integer),           // INTEGER
+                new FieldDefinition("double_field", FieldType.Double),         // DOUBLE PRECISION
+                new FieldDefinition("float_field", FieldType.Float),           // REAL
+                new FieldDefinition("bool_field", FieldType.Boolean),          // BOOLEAN
+                new FieldDefinition("datetime_field", FieldType.DateTime),     // TIMESTAMP WITH TIME ZONE
+                new FieldDefinition("date_field", FieldType.Date),             // DATE
+                new FieldDefinition("time_field", FieldType.Time),             // TIME (default → string)
+                new FieldDefinition("json_field", FieldType.Json),             // JSONB
+                new FieldDefinition("binary_field", FieldType.Binary),         // BYTEA
+                new FieldDefinition("uuid_field", FieldType.Uuid),             // UUID
+                new FieldDefinition("shape", FieldType.Geometry, Nullable: true)
+            ]);
+
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(0, 0),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["text_field"] = "hello",
+                ["varchar_field"] = "world",
+                ["int_field"] = 42,
+                ["double_field"] = 3.14,
+                ["float_field"] = 1.5f,
+                ["bool_field"] = true,
+                ["datetime_field"] = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc),
+                ["date_field"] = new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc),
+                ["time_field"] = "14:30:00",
+                ["json_field"] = "{\"key\":\"value\"}",
+                ["binary_field"] = new byte[] { 0x01, 0x02 },
+                ["uuid_field"] = "550e8400-e29b-41d4-a716-446655440000"
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        // Read back. A MapToArrowType / BuildAttributeArray mismatch causes
+        // InvalidCastException or corrupt column data here.
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+        batch!.Length.Should().Be(1);
+
+        // Verify each column's Arrow type matches its expected schema mapping.
+        batch.Column("objectid").Should().BeOfType<Int64Array>();
+        batch.Column("geometry").Should().BeOfType<BinaryArray>();
+        batch.Column("text_field").Should().BeOfType<StringArray>();
+        batch.Column("varchar_field").Should().BeOfType<StringArray>();
+        batch.Column("int_field").Should().BeOfType<Int32Array>();
+        batch.Column("double_field").Should().BeOfType<DoubleArray>();
+        batch.Column("float_field").Should().BeOfType<FloatArray>();
+        batch.Column("bool_field").Should().BeOfType<BooleanArray>();
+        batch.Column("datetime_field").Should().BeOfType<TimestampArray>();
+        batch.Column("date_field").Should().BeOfType<Date32Array>();
+        batch.Column("time_field").Should().BeOfType<StringArray>();
+        batch.Column("json_field").Should().BeOfType<StringArray>();
+        batch.Column("binary_field").Should().BeOfType<BinaryArray>();
+        batch.Column("uuid_field").Should().BeOfType<StringArray>();
     }
 
     private static LayerDefinition CreateLayer(params FieldDefinition[] fields)
         => new(
             Id: 1,
-            Name: "harbors",
-            Description: "Harbors",
+            Name: "test_layer",
+            Description: "Test Layer",
             GeometryType: GeometryType.Point,
             SpatialReference: SpatialReference.WGS84,
             Fields:
@@ -145,8 +578,4 @@ public sealed class GeoParquetQueryFormatterTests
 
     private static byte[] CreatePointWkb(double x, double y)
         => new WKBWriter().Write(new Point(x, y) { SRID = 4326 });
-
-    private static byte[] CreatePointWkbWithZm(double x, double y, double z, double m)
-        => new WKBWriter(ByteOrder.LittleEndian, handleSRID: false, emitZ: true, emitM: true)
-            .Write(new Point(new CoordinateZM(x, y, z, m)) { SRID = 4326 });
 }

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
@@ -356,6 +356,53 @@ public sealed class GeoParquetQueryFormatterTests
     }
 
     [Fact]
+    public async Task FormatAsGeoParquet_WithRuntimeDistanceOnlyOnLaterRow_IncludesDistanceColumn()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("name", FieldType.String, 255));
+        var firstFeature = Feature.Create(
+            1,
+            CreatePointWkb(-157.8583, 21.3069),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["name"] = "First Row"
+            }.ToImmutableDictionary());
+        var secondFeature = Feature.Create(
+            2,
+            CreatePointWkb(-157.8580, 21.3071),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 2L,
+                ["name"] = "Second Row",
+                ["distance"] = 42.5
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(2, [firstFeature, secondFeature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+        batch!.Schema.FieldsList.Select(f => f.Name)
+            .Should().Contain("distance");
+        var distanceArray = (DoubleArray)batch.Column("distance");
+        distanceArray.GetValue(0).Should().BeNull();
+        distanceArray.GetValue(1).Should().BeApproximately(42.5, 1e-9);
+    }
+
+    [Fact]
     public async Task FormatAsGeoParquet_WithOutFieldsAndRuntimeDistance_ExcludesUnrequestedRuntimeFields()
     {
         var layer = CreateLayer(

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
@@ -42,8 +42,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null);
+            new GeometryLimits());
 
         contentType.Should().Be("application/vnd.apache.parquet");
         payload.Should().NotBeEmpty();
@@ -84,8 +83,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null);
+            new GeometryLimits());
 
         contentType.Should().Be("application/vnd.apache.parquet");
         payload.Should().NotBeEmpty();
@@ -116,9 +114,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: 2,
-            maxAllowableOffset: null,
-            baseGeometryLimits: new GeometryLimits());
+            new GeometryLimits { MaxCoordinatePrecision = 2 });
 
         using var stream = new MemoryStream(payload);
         using var reader = new ParquetSharp.Arrow.FileReader(stream);
@@ -159,9 +155,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: true,
             returnM: true,
-            geometryPrecision: null,
-            maxAllowableOffset: null,
-            baseGeometryLimits: new GeometryLimits());
+            new GeometryLimits());
 
         using var stream = new MemoryStream(payload);
         using var reader = new ParquetSharp.Arrow.FileReader(stream);
@@ -203,8 +197,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null);
+            new GeometryLimits());
 
         using var stream = new MemoryStream(payload);
         using var reader = new ParquetSharp.Arrow.FileReader(stream);
@@ -245,8 +238,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null,
+            new GeometryLimits(),
             outFields: ["name"]);
 
         using var stream = new MemoryStream(payload);
@@ -276,8 +268,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null);
+            new GeometryLimits());
 
         using var stream = new MemoryStream(payload);
         using var reader = new ParquetSharp.Arrow.FileReader(stream);
@@ -319,8 +310,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null);
+            new GeometryLimits());
 
         using var stream = new MemoryStream(payload);
         using var reader = new ParquetSharp.Arrow.FileReader(stream);
@@ -356,8 +346,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null);
+            new GeometryLimits());
 
         using var stream = new MemoryStream(payload);
         using var reader = new ParquetSharp.Arrow.FileReader(stream);
@@ -398,8 +387,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null);
+            new GeometryLimits());
 
         using var stream = new MemoryStream(payload);
         using var reader = new ParquetSharp.Arrow.FileReader(stream);
@@ -430,8 +418,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 3857,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null);
+            new GeometryLimits());
 
         using var stream = new MemoryStream(payload);
         using var reader = new ParquetSharp.Arrow.FileReader(stream);
@@ -470,8 +457,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null);
+            new GeometryLimits());
 
         using var stream = new MemoryStream(payload);
         using var reader = new ParquetSharp.Arrow.FileReader(stream);
@@ -516,8 +502,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null);
+            new GeometryLimits());
 
         using var stream = new MemoryStream(payload);
         using var reader = new ParquetSharp.Arrow.FileReader(stream);
@@ -556,8 +541,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null,
+            new GeometryLimits(),
             outFields: ["name"]);
 
         using var stream = new MemoryStream(payload);
@@ -598,8 +582,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null);
+            new GeometryLimits());
 
         using var stream = new MemoryStream(payload);
         using var reader = new ParquetSharp.Arrow.FileReader(stream);
@@ -635,8 +618,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null);
+            new GeometryLimits());
 
         using var stream = new MemoryStream(payload);
         using var reader = new ParquetSharp.Arrow.FileReader(stream);
@@ -714,8 +696,7 @@ public sealed class GeoParquetQueryFormatterTests
             outputSrid: 4326,
             returnZ: false,
             returnM: false,
-            geometryPrecision: null,
-            maxAllowableOffset: null);
+            new GeometryLimits());
 
         // Read back. A MapToArrowType / BuildAttributeArray mismatch causes
         // InvalidCastException or corrupt column data here.
@@ -745,6 +726,39 @@ public sealed class GeoParquetQueryFormatterTests
 
         var timeArray = (Time32Array)batch.Column("time_field");
         timeArray.GetValue(0).Should().Be(14 * 60 * 60 * 1000 + 30 * 60 * 1000);
+    }
+
+    [Fact]
+    public void FormatAsGeoParquet_With2DGeometryAndReturnZTrue_DoesNotAdvertiseZ()
+    {
+        // A 2D-only layer/feature with returnZ=true must not claim "Point Z" in metadata
+        // because the actual WKB payload is 2D.
+        var layer = CreateLayer(new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false));
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(1.0, 2.0),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: true,
+            returnM: false,
+            new GeometryLimits());
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+
+        reader.Schema.Metadata.Should().ContainKey("geo");
+        using var geoDoc = JsonDocument.Parse(reader.Schema.Metadata["geo"]);
+        var geomCol = geoDoc.RootElement.GetProperty("columns").GetProperty("geometry");
+        geomCol.GetProperty("geometry_types").EnumerateArray().First().GetString()
+            .Should().Be("Point", "2D geometry should not advertise Z even when returnZ=true");
     }
 
     private static LayerDefinition CreateLayer(params FieldDefinition[] fields)

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoParquetQueryFormatterTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Text.Json;
 using Apache.Arrow;
 using FluentAssertions;
+using Honua.Core.Configuration;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Shared.Models;
@@ -94,6 +95,47 @@ public sealed class GeoParquetQueryFormatterTests
         payload[1].Should().Be((byte)'A');
         payload[2].Should().Be((byte)'R');
         payload[3].Should().Be((byte)'1');
+    }
+
+    [Fact]
+    public async Task FormatAsGeoParquet_AppliesGeometryPrecisionAndDimensionFiltering()
+    {
+        var layer = CreateLayer(new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false));
+        var feature = Feature.Create(
+            1,
+            CreatePointWkbWithZm(1.2349, 2.3451, 3.4567, 4.5678),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L
+            }.ToImmutableDictionary());
+
+        var (payload, _) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: 2,
+            maxAllowableOffset: null,
+            baseGeometryLimits: new GeometryLimits());
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ParquetSharp.Arrow.FileReader(stream);
+        using var batchReader = reader.GetRecordBatchReader();
+        var batch = await batchReader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+        var geometryColumn = (BinaryArray)batch!.Column("geometry");
+        geometryColumn.IsNull(0).Should().BeFalse();
+
+        var geometry = new WKBReader().Read(geometryColumn.GetBytes(0).ToArray());
+        var point = geometry.Should().BeOfType<Point>().Subject;
+
+        point.X.Should().Be(1.23);
+        point.Y.Should().Be(2.35);
+        double.IsNaN(point.Coordinate.Z).Should().BeTrue();
+        double.IsNaN(point.Coordinate.M).Should().BeTrue();
     }
 
     [Fact]
@@ -673,4 +715,8 @@ public sealed class GeoParquetQueryFormatterTests
 
     private static byte[] CreatePointWkb(double x, double y)
         => new WKBWriter().Write(new Point(x, y) { SRID = 4326 });
+
+    private static byte[] CreatePointWkbWithZm(double x, double y, double z, double m)
+        => new WKBWriter(ByteOrder.LittleEndian, handleSRID: false, emitZ: true, emitM: true)
+            .Write(new Point(new CoordinateZM(x, y, z, m)) { SRID = 4326 });
 }

--- a/tests/Honua.Server.Tests/Honua.Server.Tests.csproj
+++ b/tests/Honua.Server.Tests/Honua.Server.Tests.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.OData.Client" Version="8.4.3" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Parquet.Net" Version="5.5.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageReference Include="ParquetSharp" Version="21.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/Honua.Server.Tests/Honua.Server.Tests.csproj
+++ b/tests/Honua.Server.Tests/Honua.Server.Tests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Parquet.Net" Version="5.5.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
+    <PackageReference Include="ParquetSharp" Version="21.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #424
## Summary

The low-severity DRY finding (`wgs84Srid` repeated in sibling scopes) was intentionally skipped — the current form is self-contained and the values are in separate `if` blocks with no shared scope benefit.
## Changes Made

- Added the GeoParquet query export surface and related support code.
- Intentionally left the low-severity `wgs84Srid` repetition as-is because extracting it would not improve the current sibling-scope structure.
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Breaking Changes

None
## Additional Context

Decisions:
- **Skip DRY finding**: The `wgs84Srid` repetition across sibling `if` blocks is intentional; extracting would add no meaningful benefit and the blocks are self-contained.
- **No integration test run**: The new integration tests require a database (Testcontainers + PostGIS). The unit tests cover the formatter logic; integration tests will run in CI.

Follow-ons:
- Low-severity DRY cleanup of `wgs84Srid` is available but not required.

Code kaizen:
Deferred 1 low-priority finding(s) to cleanup backlog. Targeted GeoParquet build/tests passed; the only remaining issue I found is README contract drift on conditional GeoBuf support.
## Pre-PR Checklist (for contributor)
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit message follows format: `type: description (#issue-number)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [x] Documentation updated if needed
- [ ] If protocol/auth behavior changed, updated MVP compatibility contract and release checklist notes
- [ ] If breaking admin/control-plane API changes: updated migration guide and versioning policy docs
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review and documented in migration guide

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed
