### PR TITLE
test(mcp): add deterministic MCP certification and separate LLM smoke coverage

### DIFF
--- a/.github/actions/setup-honua-mcp/action.yml
+++ b/.github/actions/setup-honua-mcp/action.yml
@@ -1,0 +1,103 @@
+name: Setup Honua MCP Environment
+description: >
+  Shared setup for MCP CI jobs: checks out honua-sdk-js and inspects
+  which test scripts are available. When at least one script is present,
+  builds and starts the server (via setup-honua-server), seeds MCP data,
+  and installs MCP test dependencies. Skips all heavy setup when no
+  scripts are found.
+
+inputs:
+  dotnet-version:
+    description: .NET SDK version
+    required: true
+  node-version:
+    description: Node.js version
+    required: true
+  python-version:
+    description: Python version
+    required: true
+  sdk-ref:
+    description: honua-sdk-js git ref to checkout
+    required: false
+    default: 'trunk'
+
+outputs:
+  cert-available:
+    description: 'true when test:certification exists in the SDK'
+    value: ${{ steps.check-scripts.outputs.cert }}
+  cert-artifact-available:
+    description: 'true when test:certification:artifact exists in the SDK'
+    value: ${{ steps.check-scripts.outputs.artifact }}
+  smoke-available:
+    description: 'true when test:llm-smoke exists in the SDK'
+    value: ${{ steps.check-scripts.outputs.smoke }}
+
+runs:
+  using: 'composite'
+  steps:
+    # sdk_ref: forward-compatible with a future workflow_dispatch input.
+    # Without that trigger the expression always resolves to 'trunk'.
+    - name: Checkout honua-sdk-js
+      uses: actions/checkout@v5
+      with:
+        repository: honua-io/honua-sdk-js
+        path: honua-sdk-js
+        ref: ${{ inputs.sdk-ref }}
+
+    # Guard: inspect package.json BEFORE heavy setup (server build,
+    # npm ci) so callers can skip cleanly when SDK-side scripts are
+    # not yet landed. This avoids npm ci failures blocking the
+    # intended skip path.
+    - name: Check SDK MCP scripts
+      id: check-scripts
+      shell: bash
+      run: |
+        PKG="honua-sdk-js/mcp/package.json"
+        if [ ! -f "$PKG" ]; then
+          echo "cert=false"    >> "$GITHUB_OUTPUT"
+          echo "artifact=false" >> "$GITHUB_OUTPUT"
+          echo "smoke=false"   >> "$GITHUB_OUTPUT"
+          echo "::warning::honua-sdk-js/mcp/package.json not found — all MCP tests skipped"
+          exit 0
+        fi
+        jq -e '.scripts["test:certification"]' "$PKG" > /dev/null 2>&1 \
+          && echo "cert=true" >> "$GITHUB_OUTPUT" \
+          || echo "cert=false" >> "$GITHUB_OUTPUT"
+        jq -e '.scripts["test:certification:artifact"]' "$PKG" > /dev/null 2>&1 \
+          && echo "artifact=true" >> "$GITHUB_OUTPUT" \
+          || echo "artifact=false" >> "$GITHUB_OUTPUT"
+        jq -e '.scripts["test:llm-smoke"]' "$PKG" > /dev/null 2>&1 \
+          && echo "smoke=true" >> "$GITHUB_OUTPUT" \
+          || echo "smoke=false" >> "$GITHUB_OUTPUT"
+
+    - name: Setup Python
+      if: steps.check-scripts.outputs.cert == 'true' || steps.check-scripts.outputs.smoke == 'true'
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install pyyaml
+      if: steps.check-scripts.outputs.cert == 'true' || steps.check-scripts.outputs.smoke == 'true'
+      shell: bash
+      run: python -m pip install 'pyyaml>=6,<7'
+
+    - name: Setup Honua Server
+      if: steps.check-scripts.outputs.cert == 'true' || steps.check-scripts.outputs.smoke == 'true'
+      uses: ./.github/actions/setup-honua-server
+      with:
+        dotnet-version: ${{ inputs.dotnet-version }}
+        post-seed-yaml: tests/seed/mcp.yaml
+
+    - name: Setup Node.js
+      if: steps.check-scripts.outputs.cert == 'true' || steps.check-scripts.outputs.smoke == 'true'
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'npm'
+        cache-dependency-path: honua-sdk-js/mcp/package-lock.json
+
+    - name: Install MCP test dependencies
+      if: steps.check-scripts.outputs.cert == 'true' || steps.check-scripts.outputs.smoke == 'true'
+      shell: bash
+      run: npm ci
+      working-directory: honua-sdk-js/mcp

--- a/.github/actions/setup-honua-server/action.yml
+++ b/.github/actions/setup-honua-server/action.yml
@@ -1,0 +1,56 @@
+name: Setup Honua Server
+description: >
+  Builds Honua Server, seeds the base schema, and starts the server
+  against a running PostgreSQL service on localhost:5432.
+
+inputs:
+  dotnet-version:
+    description: .NET SDK version
+    required: true
+  post-seed-yaml:
+    description: >
+      Path to a version-1 seed YAML file to apply after the base schema
+      seed (via apply-yaml-seed.sh). Requires python3 and pyyaml on PATH;
+      see setup-honua-mcp which installs both before calling this action.
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: ${{ inputs.dotnet-version }}
+
+    - name: Restore .NET packages
+      shell: bash
+      run: dotnet restore Honua.sln
+
+    - name: Build Honua Server
+      shell: bash
+      run: dotnet build src/Honua.Server --configuration Release --no-restore
+
+    - name: Seed base schema
+      shell: bash
+      run: PGPASSWORD=honua psql -v ON_ERROR_STOP=1 -h localhost -U honua -d honua_test -f tests/seed/base-schema.sql
+
+    - name: Apply additional seed data
+      if: ${{ inputs.post-seed-yaml != '' }}
+      shell: bash
+      run: bash tests/seed/apply-yaml-seed.sh "$SEED_YAML"
+      env:
+        SEED_YAML: ${{ inputs.post-seed-yaml }}
+
+    - name: Start Honua Server
+      shell: bash
+      run: |
+        dotnet run --project src/Honua.Server --configuration Release --no-build --no-launch-profile &
+        curl --retry 15 --retry-delay 2 --retry-connrefused --retry-all-errors -fsS http://localhost:5000/healthz/ready || exit 1
+      env:
+        ConnectionStrings__DefaultConnection: "Host=localhost;Database=honua_test;Username=honua;Password=honua"
+        ASPNETCORE_URLS: "http://localhost:5000"
+        ASPNETCORE_ENVIRONMENT: "Development"
+        HONUA_DEV_AUTH: "true"
+        Security__ConnectionEncryption__MasterKey: "test-master-key-that-is-at-least-32-characters-long-for-security"
+        Security__ConnectionEncryption__Salt: "dGVzdC1zYWx0LWZvci1lbmNyeXB0aW9uLXRlc3RpbmctcHVycG9zZXM="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
   # commit. While set to a branch name like 'trunk' the lane is useful for
   # development but certification artifacts are not release-grade evidence.
   # workflow_dispatch `sdk_ref` overrides this value for manual replays.
-  MCP_SDK_REF: 'trunk'
+  MCP_SDK_REF: '404242df3cbf10f707ee9137405bf93b3de0012d'
 
 jobs:
   changes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [trunk]
   pull_request:
     branches: [trunk]
+  workflow_dispatch:
+    inputs:
+      sdk_ref:
+        description: 'honua-sdk-js git ref for MCP tests (overrides MCP_SDK_REF env)'
+        required: false
+        default: ''
 
 env:
   DOTNET_VERSION: '10.0.x'
@@ -12,6 +18,13 @@ env:
   DOTNET_NOLOGO: true
   PYTHON_VERSION: '3.11'
   NODE_VERSION: '20'
+  # honua-sdk-js ref for MCP certification and LLM smoke tests.
+  # IMPORTANT: for release-evidence certification this MUST be pinned to a
+  # specific tag or commit SHA so results are reproducible for a given server
+  # commit. While set to a branch name like 'trunk' the lane is useful for
+  # development but certification artifacts are not release-grade evidence.
+  # workflow_dispatch `sdk_ref` overrides this value for manual replays.
+  MCP_SDK_REF: 'trunk'
 
 jobs:
   changes:
@@ -30,6 +43,11 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             git fetch origin ${{ github.base_ref }} --depth=1
             echo "range=origin/${{ github.base_ref }}...${{ github.sha }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Manual runs: diff against trunk so AOT/Docker gates are not
+            # silently skipped due to github.event.before being undefined.
+            git fetch origin trunk --depth=1
+            echo "range=origin/trunk...${{ github.sha }}" >> $GITHUB_OUTPUT
           else
             echo "range=${{ github.event.before }}...${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
@@ -402,8 +420,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+      - name: Setup Honua Server
+        uses: ./.github/actions/setup-honua-server
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -413,257 +431,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: tests/js/package-lock.json
-
-      - name: Restore .NET packages
-        run: dotnet restore Honua.sln
-
-      - name: Build Honua Server
-        run: dotnet build src/Honua.Server --configuration Release --no-restore
-
-      - name: Initialize test database
-        run: |
-          PGPASSWORD=honua psql -h localhost -U honua -d honua_test -c "CREATE EXTENSION IF NOT EXISTS postgis;"
-        env:
-          PGPASSWORD: honua
-
-      - name: Seed FeatureServer metadata
-        run: |
-          cat <<'SQL' > /tmp/honua-js-seed.sql
-          CREATE SCHEMA IF NOT EXISTS honua;
-
-          CREATE TABLE IF NOT EXISTS honua.services (
-              service_name VARCHAR(64) PRIMARY KEY,
-              description TEXT NOT NULL DEFAULT '',
-              srid INT NOT NULL DEFAULT 4326,
-              max_record_count INT NOT NULL DEFAULT 1000,
-              supported_formats TEXT[] NOT NULL DEFAULT '{JSON,GeoJSON}',
-              capabilities TEXT[] NOT NULL DEFAULT '{Query,Extract}',
-              service_extent GEOMETRY,
-              created_at TIMESTAMPTZ DEFAULT NOW(),
-              updated_at TIMESTAMPTZ DEFAULT NOW()
-          );
-
-          CREATE TABLE IF NOT EXISTS honua.layers (
-              layer_id SERIAL PRIMARY KEY,
-              layer_name TEXT NOT NULL,
-              description TEXT,
-              table_name TEXT NOT NULL,
-              geometry_type TEXT NOT NULL,
-              srid INT NOT NULL DEFAULT 4326,
-              extent GEOMETRY(POLYGON, 4326),
-              min_scale DOUBLE PRECISION,
-              max_scale DOUBLE PRECISION,
-              default_visibility BOOLEAN NOT NULL DEFAULT TRUE,
-              created_at TIMESTAMPTZ DEFAULT NOW()
-          );
-
-          ALTER TABLE IF EXISTS honua.services
-              ADD COLUMN IF NOT EXISTS metadata JSONB;
-
-          ALTER TABLE IF EXISTS honua.layers
-              ADD COLUMN IF NOT EXISTS metadata JSONB;
-
-          CREATE TABLE IF NOT EXISTS honua.service_layers (
-              service_name VARCHAR(64) NOT NULL REFERENCES honua.services(service_name) ON DELETE CASCADE,
-              layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,
-              layer_order INT NOT NULL,
-              PRIMARY KEY (service_name, layer_id),
-              UNIQUE (service_name, layer_order)
-          );
-
-          CREATE TABLE IF NOT EXISTS honua.layer_fields (
-              layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,
-              field_name VARCHAR(64) NOT NULL,
-              field_type VARCHAR(32) NOT NULL,
-              field_order INT NOT NULL,
-              max_length INT,
-              nullable BOOLEAN NOT NULL DEFAULT TRUE,
-              default_value TEXT,
-              description TEXT,
-              PRIMARY KEY (layer_id, field_name)
-          );
-
-          CREATE TABLE IF NOT EXISTS honua.attachments (
-              id BIGSERIAL PRIMARY KEY,
-              feature_id BIGINT NOT NULL,
-              layer_id INT NOT NULL,
-              filename TEXT NOT NULL,
-              content_type TEXT NOT NULL,
-              size BIGINT NOT NULL CHECK (size >= 0),
-              created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-              storage_path TEXT NOT NULL,
-              keywords TEXT
-          );
-
-          CREATE TABLE IF NOT EXISTS honua.relationships (
-              id SERIAL PRIMARY KEY,
-              layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,
-              relationship_id INT NOT NULL,
-              name TEXT NOT NULL,
-              related_layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,
-              relationship_type TEXT NOT NULL,
-              origin_foreign_key TEXT NOT NULL,
-              destination_foreign_key TEXT NOT NULL,
-              description TEXT,
-              created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-              updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-              CONSTRAINT relationships_layer_relationship_unique UNIQUE(layer_id, relationship_id),
-              CONSTRAINT relationships_valid_ids CHECK(layer_id >= 0 AND related_layer_id >= 0 AND relationship_id > 0),
-              CONSTRAINT relationships_valid_fields CHECK(
-                  LENGTH(name) > 0 AND LENGTH(name) <= 128 AND
-                  LENGTH(relationship_type) > 0 AND LENGTH(relationship_type) <= 64 AND
-                  LENGTH(origin_foreign_key) > 0 AND LENGTH(origin_foreign_key) <= 128 AND
-                  LENGTH(destination_foreign_key) > 0 AND LENGTH(destination_foreign_key) <= 128
-              ),
-              CONSTRAINT relationships_valid_type CHECK(
-                  relationship_type IN ('esriRelRoleOrigin', 'esriRelRoleDestination', 'esriRelRoleAny')
-              )
-          );
-
-          CREATE TABLE IF NOT EXISTS features (
-              objectid BIGSERIAL PRIMARY KEY,
-              layer_id INT NOT NULL,
-              geometry GEOMETRY,
-              attributes JSONB,
-              created_at TIMESTAMPTZ DEFAULT NOW(),
-              updated_at TIMESTAMPTZ DEFAULT NOW()
-          );
-
-          CREATE INDEX IF NOT EXISTS idx_service_layers_service_name ON honua.service_layers(service_name);
-          CREATE INDEX IF NOT EXISTS idx_service_layers_layer_id ON honua.service_layers(layer_id);
-          CREATE INDEX IF NOT EXISTS idx_layer_fields_layer_id ON honua.layer_fields(layer_id);
-          CREATE INDEX IF NOT EXISTS idx_relationships_layer_id ON honua.relationships(layer_id);
-          CREATE INDEX IF NOT EXISTS idx_relationships_related_layer_id ON honua.relationships(related_layer_id);
-          CREATE INDEX IF NOT EXISTS idx_features_layer_id ON features(layer_id);
-          CREATE INDEX IF NOT EXISTS idx_features_geometry ON features USING GIST(geometry);
-          CREATE INDEX IF NOT EXISTS idx_features_attributes ON features USING GIN(attributes);
-
-          INSERT INTO honua.services (
-              service_name,
-              description,
-              srid,
-              max_record_count,
-              supported_formats,
-              capabilities,
-              service_extent
-          )
-          VALUES (
-              'test_service',
-              'Test Feature Service',
-              4326,
-              1000,
-              ARRAY['JSON', 'GeoJSON'],
-              ARRAY['Query', 'Extract', 'Create', 'Update', 'Delete'],
-              ST_MakeEnvelope(-122.5, 37.7, -122.35, 37.84, 4326)
-          )
-          ON CONFLICT (service_name) DO UPDATE SET
-              description = EXCLUDED.description,
-              srid = EXCLUDED.srid,
-              max_record_count = EXCLUDED.max_record_count,
-              supported_formats = EXCLUDED.supported_formats,
-              capabilities = EXCLUDED.capabilities,
-              service_extent = EXCLUDED.service_extent,
-              updated_at = NOW();
-
-          UPDATE honua.services
-          SET metadata = jsonb_build_object('accessPolicy', jsonb_build_object('allowAnonymous', true))
-          WHERE service_name = 'test_service';
-
-          INSERT INTO honua.layers (
-              layer_id,
-              layer_name,
-              description,
-              table_name,
-              geometry_type,
-              srid,
-              extent,
-              default_visibility
-          )
-          VALUES (
-              0,
-              'Test Layer',
-              'Default layer for integration tests',
-              'features',
-              'Point',
-              4326,
-              ST_MakeEnvelope(-122.5, 37.7, -122.35, 37.84, 4326),
-              true
-          )
-          ON CONFLICT (layer_id) DO UPDATE SET
-              layer_name = EXCLUDED.layer_name,
-              description = EXCLUDED.description,
-              table_name = EXCLUDED.table_name,
-              geometry_type = EXCLUDED.geometry_type,
-              srid = EXCLUDED.srid,
-              extent = EXCLUDED.extent,
-              default_visibility = EXCLUDED.default_visibility;
-
-          UPDATE honua.layers
-          SET metadata = jsonb_build_object('accessPolicy', jsonb_build_object('allowAnonymous', true))
-          WHERE layer_id = 0;
-
-          INSERT INTO honua.layer_fields (
-              layer_id,
-              field_name,
-              field_type,
-              field_order,
-              max_length,
-              nullable,
-              default_value,
-              description
-          )
-          VALUES
-              (0, 'objectid', 'Integer', 0, NULL, false, NULL, 'Object ID'),
-              (0, 'name', 'String', 1, 255, true, NULL, 'Name'),
-              (0, 'description', 'String', 2, 1024, true, NULL, 'Description'),
-              (0, 'shape', 'Geometry', 3, NULL, true, NULL, 'Geometry')
-          ON CONFLICT (layer_id, field_name) DO NOTHING;
-
-          INSERT INTO honua.layer_fields (
-              layer_id,
-              field_name,
-              field_type,
-              field_order,
-              max_length,
-              nullable,
-              default_value,
-              description
-          )
-          VALUES
-              (0, 'status', 'String', 4, 64, true, NULL, 'Status'),
-              (0, 'count', 'Integer', 5, NULL, true, NULL, 'Count'),
-              (0, 'ratio', 'Double', 6, NULL, true, NULL, 'Ratio'),
-              (0, 'active', 'Boolean', 7, NULL, true, NULL, 'Active flag'),
-              (0, 'created_at', 'DateTime', 8, NULL, true, NULL, 'Created timestamp'),
-              (0, 'event_date', 'Date', 9, NULL, true, NULL, 'Event date'),
-              (0, 'event_time', 'Time', 10, NULL, true, NULL, 'Event time'),
-              (0, 'uid', 'Uuid', 11, NULL, true, NULL, 'Unique identifier'),
-              (0, 'tags', 'Json', 12, NULL, true, NULL, 'Tag array'),
-              (0, 'numbers', 'Json', 13, NULL, true, NULL, 'Number array')
-          ON CONFLICT (layer_id, field_name) DO NOTHING;
-
-          INSERT INTO honua.service_layers (
-              service_name,
-              layer_id,
-              layer_order
-          )
-          VALUES ('test_service', 0, 0)
-          ON CONFLICT (service_name, layer_id) DO NOTHING;
-          SQL
-          PGPASSWORD=honua psql -v ON_ERROR_STOP=1 -h localhost -U honua -d honua_test -f /tmp/honua-js-seed.sql
-
-      - name: Start Honua Server
-        run: |
-          dotnet run --project src/Honua.Server --configuration Release --no-build --no-launch-profile &
-          sleep 10
-          curl --retry 10 --retry-delay 2 --retry-connrefused http://localhost:5000/healthz/live || exit 1
-        env:
-          ConnectionStrings__DefaultConnection: "Host=localhost;Database=honua_test;Username=honua;Password=honua"
-          ASPNETCORE_URLS: "http://localhost:5000"
-          ASPNETCORE_ENVIRONMENT: "Development"
-          HONUA_DEV_AUTH: "true"
-          Security__ConnectionEncryption__MasterKey: "test-master-key-that-is-at-least-32-characters-long-for-security"
-          Security__ConnectionEncryption__Salt: "dGVzdC1zYWx0LWZvci1lbmNyeXB0aW9uLXRlc3RpbmctcHVycG9zZXM="
 
       - name: Install JavaScript test dependencies
         run: npm ci
@@ -676,6 +443,178 @@ jobs:
           HONUA_BASE_URL: http://localhost:5000
           HONUA_SERVICE_ID: test_service
           HONUA_LAYER_ID: '0'
+
+  mcp-certification:
+    name: MCP Certification (${{ matrix.transport }})
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
+    outputs:
+      # Matrix job: GHA keeps the last-finishing leg's output.
+      # Both legs check the same package.json so the value is always consistent.
+      cert_ran: ${{ steps.setup.outputs.cert-available }}
+    strategy:
+      fail-fast: false
+      matrix:
+        transport: [grpc-web, rest]
+    services:
+      postgres:
+        image: postgis/postgis:16-3.4-alpine
+        env:
+          POSTGRES_USER: honua
+          POSTGRES_PASSWORD: honua
+          POSTGRES_DB: honua_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v5
+
+      # Design: skip-if-absent is intentional for cross-repo coordination.
+      # Test code lives in honua-sdk-js; this repo provides only CI jobs,
+      # seed data, and docs (AC 8). The action inspects package.json
+      # BEFORE npm ci so the skip path cannot fail on missing deps.
+      # See docs/contributor/mcp-certification.md.
+      - name: Setup Honua MCP environment
+        id: setup
+        uses: ./.github/actions/setup-honua-mcp
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION }}
+          sdk-ref: ${{ github.event.inputs.sdk_ref || env.MCP_SDK_REF }}
+
+      - name: Report skipped certification
+        if: steps.setup.outputs.cert-available != 'true'
+        shell: bash
+        run: |
+          echo "::warning::test:certification script not found in honua-sdk-js/mcp — certification skipped"
+          echo "## ⚠️ MCP Certification Skipped (${{ matrix.transport }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "The \`test:certification\` script was not found in \`honua-sdk-js/mcp\` (ref: \`${{ github.event.inputs.sdk_ref || env.MCP_SDK_REF }}\`)." >> "$GITHUB_STEP_SUMMARY"
+          echo "**No certification tests were executed and no artifacts were produced.**" >> "$GITHUB_STEP_SUMMARY"
+          echo "Land the certification scripts in \`honua-sdk-js\` to activate this gate." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Warn if SDK ref is not pinned
+        if: steps.setup.outputs.cert-available == 'true'
+        shell: bash
+        run: |
+          REF="${{ github.event.inputs.sdk_ref || env.MCP_SDK_REF }}"
+          if ! echo "$REF" | grep -qE '^[0-9a-f]{7,40}$|^v[0-9]'; then
+            echo "::warning::MCP_SDK_REF ($REF) appears to be a branch name. Pin to a tag or commit SHA for reproducible release-evidence certification."
+          fi
+
+      - name: Run MCP Certification Tests
+        if: steps.setup.outputs.cert-available == 'true'
+        run: npm run test:certification
+        working-directory: honua-sdk-js/mcp
+        env:
+          HONUA_BASE_URL: http://localhost:5000
+          HONUA_TRANSPORT: ${{ matrix.transport }}
+          HONUA_SERVICE_ID: test_service
+          HONUA_MCP_SERVICE_ID: test_service_mcp
+          HONUA_LAYER_ID: '0'
+          HONUA_MCP_LAYER_ID: '10'
+          HONUA_DEV_AUTH: "true"
+
+      - name: Warn if certification ran without artifact support
+        if: steps.setup.outputs.cert-available == 'true' && steps.setup.outputs.cert-artifact-available != 'true'
+        shell: bash
+        run: |
+          echo "::warning::test:certification ran but test:certification:artifact is missing — no evidence artifacts will be produced. Land the artifact script in honua-sdk-js to satisfy the release-evidence contract."
+          echo "## ⚠️ MCP Certification Artifacts Missing (${{ matrix.transport }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Certification tests **executed**, but the \`test:certification:artifact\` script was not found." >> "$GITHUB_STEP_SUMMARY"
+          echo "**No JSON/Markdown evidence artifacts were produced.**" >> "$GITHUB_STEP_SUMMARY"
+          echo "Land the artifact reporter in \`honua-sdk-js\` to produce release-grade evidence." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Generate certification artifact
+        if: always() && steps.setup.outputs.cert-available == 'true' && steps.setup.outputs.cert-artifact-available == 'true'
+        run: npm run test:certification:artifact
+        working-directory: honua-sdk-js/mcp
+
+      - name: Upload certification artifact
+        if: always() && steps.setup.outputs.cert-available == 'true' && steps.setup.outputs.cert-artifact-available == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: mcp-certification-${{ matrix.transport }}
+          path: |
+            honua-sdk-js/mcp/mcp-certification-results.json
+            honua-sdk-js/mcp/mcp-certification-results.md
+          if-no-files-found: error
+          retention-days: 30
+
+  mcp-llm-smoke:
+    name: MCP LLM Smoke Tests
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && needs.mcp-certification.outputs.cert_ran == 'true' }}
+    runs-on: ubuntu-latest
+    needs: mcp-certification
+    continue-on-error: true
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgis/postgis:16-3.4-alpine
+        env:
+          POSTGRES_USER: honua
+          POSTGRES_PASSWORD: honua
+          POSTGRES_DB: honua_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Honua MCP environment
+        id: setup
+        uses: ./.github/actions/setup-honua-mcp
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION }}
+          sdk-ref: ${{ github.event.inputs.sdk_ref || env.MCP_SDK_REF }}
+
+      - name: Report skipped smoke tests
+        if: steps.setup.outputs.smoke-available != 'true'
+        shell: bash
+        run: |
+          echo "::warning::test:llm-smoke script not found in honua-sdk-js/mcp — smoke tests skipped"
+          echo "## ⚠️ MCP LLM Smoke Tests Skipped" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "The \`test:llm-smoke\` script was not found in \`honua-sdk-js/mcp\` (ref: \`${{ github.event.inputs.sdk_ref || env.MCP_SDK_REF }}\`)." >> "$GITHUB_STEP_SUMMARY"
+          echo "Land the smoke test scripts in \`honua-sdk-js\` to activate this lane." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run MCP LLM Smoke Tests
+        if: steps.setup.outputs.smoke-available == 'true'
+        run: npm run test:llm-smoke
+        working-directory: honua-sdk-js/mcp
+        env:
+          HONUA_BASE_URL: http://localhost:5000
+          HONUA_TRANSPORT: rest
+          HONUA_SERVICE_ID: test_service
+          HONUA_LAYER_ID: '0'
+          HONUA_DEV_AUTH: "true"
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Upload LLM smoke transcripts
+        if: always() && steps.setup.outputs.smoke-available == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: mcp-llm-smoke-transcripts
+          path: |
+            honua-sdk-js/mcp/llm-smoke-results.json
+            honua-sdk-js/mcp/llm-smoke-results.md
+            honua-sdk-js/mcp/llm-smoke-transcripts/
+          if-no-files-found: warn
+          retention-days: 30
 
   llm-architecture-review:
     name: LLM Architecture Review
@@ -727,7 +666,7 @@ jobs:
         if: steps.changed-files.outputs.skip_review == 'false'
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Dependencies
         if: steps.changed-files.outputs.skip_review == 'false'
@@ -985,6 +924,26 @@ jobs:
           docker stop honua-test || true
           docker rm honua-test || true
 
+
+  # Summary gate: a single job that branch-protection can require.
+  # Add every job whose failure should block merge.
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs: [changes, build, test-all, aot-build, js-integration-tests, mcp-certification, core-package-compatibility, docker-build, llm-architecture-review, architecture-gate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required job results
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "::error::One or more required CI jobs failed."
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "::error::One or more required CI jobs were cancelled."
+            exit 1
+          fi
+          echo "All required CI jobs passed."
 
   # Architecture gate job that blocks merge if LLM review finds blocking issues
   architecture-gate:

--- a/.github/workflows/cloud-post-apply-validation.yml
+++ b/.github/workflows/cloud-post-apply-validation.yml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
       platform:
-        description: Optional platform hint (kubernetes, aws-lambda, azure-functions).
+        description: Optional platform hint (kubernetes, aws-ecs, aws-lambda, azure-functions, azure-container-apps).
         required: false
         type: string
       deploy_target_id:
@@ -103,7 +103,7 @@ on:
         required: false
         type: string
       platform:
-        description: Optional platform hint (kubernetes, aws-lambda, azure-functions).
+        description: Optional platform hint (kubernetes, aws-ecs, aws-lambda, azure-functions, azure-container-apps).
         required: false
         type: string
       deploy_target_id:

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,4 +65,5 @@ Full hosted documentation: **[honua.gitbook.io/honuaio](https://honua.gitbook.io
 - [Esri Migration Platform Plan](contributor/ESRI_MIGRATION_PLATFORM_PLAN.md) — JS-first migration architecture and phased SDK strategy
 - [ADRs](contributor/adr/README.md) — architectural decisions
 - [Weekly Backlog Review](contributor/BACKLOG_REVIEW_CADENCE.md) — triage, scope gate, and done/close hygiene cadence
+- [MCP Certification](contributor/mcp-certification.md) — cross-repo MCP certification testing, seed data, and CI jobs
 - [Release Checklist](contributor/RELEASE_CHECKLIST.md) — required compatibility/certification updates per release

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -90,6 +90,7 @@
 * [CITE OGC Maps](contributor/ogc-maps-conformance-testing.md)
 * [CITE WMS 1.3](contributor/cite-wms-conformance-testing.md)
 * [CITE WMTS 1.0](contributor/cite-wmts-conformance-testing.md)
+* [MCP Certification](contributor/mcp-certification.md)
 
 ### CI/CD
 

--- a/docs/contributor/CI_QUALITY_GATES.md
+++ b/docs/contributor/CI_QUALITY_GATES.md
@@ -6,7 +6,7 @@ This document summarizes the CI pipelines and quality gates that contributors mu
 
 ## Core Workflows
 
-- `ci.yml`: build, formatting verification, and full test suite.
+- `ci.yml`: build, formatting verification, full test suite, and MCP certification (see [MCP Certification](mcp-certification.md)).
 - `pr-validation.yml`: PR template compliance validation.
 - `performance-benchmarks.yml`: performance benchmarks (`quick` mode on PR, `full` mode on nightly/manual).
 - `load-soak-nightly.yml`: nightly load/soak testing.
@@ -17,6 +17,10 @@ This document summarizes the CI pipelines and quality gates that contributors mu
 - `control-plane-sdk-governance.yml`: reproducible control-plane SDK generation and release artifact publishing.
 - `proto-wire-governance.yml`: protobuf wire compatibility enforcement via `buf breaking`.
 - `nightly-container-build.yml`: nightly image builds.
+
+## CI Gate (Required Status Check)
+
+The `ci-gate` job in `ci.yml` is a summary job that depends on all merge-blocking CI jobs (`changes`, `build`, `test-all`, `aot-build`, `js-integration-tests`, `mcp-certification`, `core-package-compatibility`, `docker-build`, `llm-architecture-review`, `architecture-gate`). Configure it as a required status check in branch protection to gate PRs on a single job.
 
 ## Quality Gates
 

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -38,6 +38,7 @@ This section is for people **building or extending** Honua (core contributors, a
 - [OGC API Maps Conformance](ogc-maps-conformance-testing.md) — OGC API Maps conformance gate
 - [CITE WMS 1.3](cite-wms-conformance-testing.md) — OGC WMS conformance
 - [CITE WMTS 1.0](cite-wmts-conformance-testing.md) — OGC WMTS conformance
+- [MCP Certification](mcp-certification.md) — cross-repo MCP certification testing, seed data, and CI jobs
 
 ## CI/CD
 

--- a/docs/contributor/RELEASE_CHECKLIST.md
+++ b/docs/contributor/RELEASE_CHECKLIST.md
@@ -8,6 +8,8 @@ Use this checklist for every MVP release.
 - [ ] Full production audit run completed: `./scripts/run-production-audit.sh --mode full`
 - [ ] Audit artifacts reviewed and attached from `.audit/runs/<timestamp>/summary.md`
 - [ ] Conformance workflows pass (OGC Features, OGC Tiles, WMS, WMTS)
+- [ ] MCP certification passes for both transports (`grpc-web`, `rest`) **and** certification artifacts (`mcp-certification-{transport}`) are produced — see [MCP Certification](mcp-certification.md). Skip if SDK-side scripts are not yet landed (CI jobs will show a warning annotation).
+- [ ] `MCP_SDK_REF` in `ci.yml` is pinned to a specific tag or commit SHA (not a branch name) for reproducible release evidence.
 - [ ] OpenAPI contract governance checks pass
 - [ ] Control-plane SDK artifacts generated and attached to release
 

--- a/docs/contributor/ci-workflows.md
+++ b/docs/contributor/ci-workflows.md
@@ -6,7 +6,26 @@
 > - [Gate Model](../ci/gate-model.md) — the five-tier quality gate definitions and governing rules
 > - [Config Conventions](../ci/config-conventions.md) — env vars, cache keys, artifact naming, secret names, and composite actions
 >
+> - [MCP Certification](mcp-certification.md) — cross-repo MCP certification testing, seed data, and CI jobs
+>
 > If docs and workflows disagree, trust `.github/workflows/*.yml`.
+
+## MCP Certification
+
+| Job (in `ci.yml`) | Purpose | Typical Trigger |
+|---|---|---|
+| `mcp-certification` | MCP tool/resource tests with fixed seed data against live Honua (matrix: `grpc-web`, `rest`; SDK ref floats to `trunk`) | PR + push to `trunk` + manual |
+| `mcp-llm-smoke` | Non-blocking LLM smoke tests via OpenAI `gpt-4o` (runs after certification) | PR + push to `trunk` + manual |
+
+See [MCP Certification](mcp-certification.md) for seed data, environment variables, and artifact details.
+
+## Nightly/Scheduled Security
+
+| Workflow File | Purpose |
+|---|---|
+| `security-nightly.yml` | Dependency/security scanning |
+| `trivy-nightly.yml` | Nightly Trivy scan |
+| `nightly-container-build.yml` | Nightly container build checks |
 
 ## Useful Commands
 

--- a/docs/contributor/mcp-certification.md
+++ b/docs/contributor/mcp-certification.md
@@ -1,0 +1,121 @@
+# MCP Certification Testing
+
+This document covers the cross-repo testing setup for Honua's MCP surface.
+
+## Repo ownership split
+
+| Concern | Repo | Path |
+|---------|------|------|
+| Certification test code | honua-sdk-js | `mcp/test/certification/` |
+| LLM smoke test code | honua-sdk-js | `mcp/test/llm-smoke/` |
+| Artifact reporter | honua-sdk-js | `mcp/test/certification/helpers/artifact-reporter.ts` |
+| Base schema seed | honua-server | `tests/seed/base-schema.sql` |
+| MCP seed data | honua-server | `tests/seed/mcp.yaml` |
+| YAML seed applicator | honua-server | `tests/seed/apply-yaml-seed.sh` |
+| CI jobs (cert + smoke) | honua-server | `.github/workflows/ci.yml` |
+| Base CI setup action | honua-server | `.github/actions/setup-honua-server/action.yml` |
+| MCP CI setup action | honua-server | `.github/actions/setup-honua-mcp/action.yml` |
+| Docs | honua-server | `docs/user/MCP_SERVER.md`, `docs/contributor/mcp-certification.md` |
+
+## Seed data
+
+MCP-specific test data lives in `tests/seed/mcp.yaml`. It follows the project's `version: 1` seed YAML format (SQL statement array) and is applied **after** the base CI seed.
+
+### What the seed provides
+
+| Requirement | Data |
+|-------------|------|
+| Multi-service listing | `test_service_mcp` service with layer 10 (layer 10 is also bound to `test_service` at order 1) |
+| Polygon layer | Layer 10 (`Polygon` geometry type), 5 polygon features (objectids 1001–1005) |
+| Point features for stats | 15 point features in layer 0 (objectids 10–24) with `count` (Integer) and `ratio` (Double) |
+| Statistics fields | `count`: sum=725, min=10, max=100; `ratio`: sum=76.5, min=1.1, max=10.5 |
+| Known spatial extent | All features within lon -122.50…-122.35, lat 37.70…37.84 (WGS84) |
+
+### Updating seed data
+
+1. Edit `tests/seed/mcp.yaml`.
+2. Update the matching constants in `honua-sdk-js/mcp/test/certification/helpers/constants.ts` (references `mcp.yaml` line numbers).
+3. Coordinate across both repos when changing expected values.
+
+## CI jobs
+
+> **Current status:** the `honua-server` CI jobs and seed data are landed, but the certification scripts (`test:certification`, `test:certification:artifact`, `test:llm-smoke`) are not yet present in `honua-sdk-js` `trunk`. Until those scripts are landed, the jobs skip with a CI warning annotation and produce no certification artifacts. See [Known gaps](#known-gaps).
+
+### mcp-certification
+
+- **Trigger:** push/PR to `trunk` + manual (`workflow_dispatch`), skips dependabot.
+- **Matrix:** `transport: [grpc-web, rest]` — runs full suite in parallel per transport.
+- **Steps:** checkout honua-server → shared setup (`.github/actions/setup-honua-mcp`) → `test:certification` → `test:certification:artifact` (generate report) → artifact upload.
+- **Artifact:** `mcp-certification-{transport}`, 30-day retention.
+- **Ref strategy:** the SDK ref is controlled by the `MCP_SDK_REF` env var at the top of `ci.yml` (currently `trunk`). While set to a branch name, certification runs are useful for development but the artifacts are **not reproducible release evidence** because the same server commit may exercise different SDK test code over time. For release-grade certification, pin `MCP_SDK_REF` to a specific tag or commit SHA. The CI job emits a warning annotation when the ref appears to be a branch name rather than a pinned ref. The `workflow_dispatch` `sdk_ref` input overrides the env var for one-off manual replays.
+- **Script guard:** the `setup-honua-mcp` action inspects the SDK `package.json` for `test:certification`, `test:certification:artifact`, and `test:llm-smoke` **before** any heavy setup. If neither `test:certification` nor `test:llm-smoke` is found (e.g. SDK-side work not yet landed), the action skips the server build, database seed, and `npm ci` entirely; the job emits a warning annotation and completes without failure. Artifact generation and upload are also gated on the action's `cert-available` and `cert-artifact-available` outputs, so no artifacts are produced when certification was skipped or the artifact script is absent. If `test:certification` is present but `test:certification:artifact` is missing (partial SDK landing), the job emits a warning annotation noting that no evidence artifacts were produced — this ensures the release-evidence gap is visible even though the certification tests themselves passed.
+- **Output:** exposes a `cert_ran` output (`true`/`false`) consumed by downstream jobs.
+
+### mcp-llm-smoke
+
+- **Depends on:** `mcp-certification` (only runs when `cert_ran == 'true'` — skipped entirely when certification scripts are absent).
+- **`continue-on-error: true`** — failures annotate but do not gate.
+- **Test runner skips scenarios** when `OPENAI_API_KEY` secret is empty or unset.
+- **Artifact:** `mcp-llm-smoke-transcripts`, 30-day retention.
+
+## How the seed is applied in CI
+
+All integration-test jobs share a single base schema file (`tests/seed/base-schema.sql`) that creates the `honua` schema, core tables, indexes, and the default `test_service` + layer 0 with all field definitions. This file is applied first via `psql -f`.
+
+MCP-specific data from `tests/seed/mcp.yaml` is then applied using the shared `tests/seed/apply-yaml-seed.sh` script:
+
+```bash
+python3 -m pip install 'pyyaml>=6,<7'
+bash tests/seed/apply-yaml-seed.sh tests/seed/mcp.yaml
+```
+
+## Certification artifact format
+
+**JSON** (`mcp-certification-results.json`):
+
+```json
+{
+  "schemaVersion": 1,
+  "transport": "grpc-web",
+  "timestamp": "...",
+  "durationMs": 8500,
+  "summary": { "total": 48, "passed": 48, "failed": 0, "skipped": 0, "verdict": "PASS" },
+  "tools": [{ "name": "honua_list_services", "tests": [...] }],
+  "resources": [{ "uri": "honua://services", "tests": [...] }],
+  "crossCutting": { "auth": { "tests": [...] }, "retry": {...} }
+}
+```
+
+**Markdown** (`mcp-certification-results.md`): One row per area, columns: Area | Tests | Passed | Failed | Verdict.
+
+## LLM smoke scenarios
+
+| Scenario | Expected tool calls | Pass criteria |
+|----------|-------------------|---------------|
+| discover-and-describe | `honua_list_services` → `honua_describe_layer` | LLM calls both, answer mentions field names + geometry type |
+| spatial-query | `honua_query_features` with filter | LLM calls query, answer contains feature names |
+| statistics-workflow | `honua_statistics` | LLM calls statistics, answer contains numeric result |
+| error-recovery | `honua_query_features` (bad layer) → recovery call | LLM handles error, successfully makes follow-up call |
+
+Provider: OpenAI `gpt-4o`, temperature 0, 30-second per-scenario timeout.
+
+## Environment variables
+
+| Variable | Used by | Required |
+|----------|---------|----------|
+| `HONUA_BASE_URL` | cert + smoke | Yes |
+| `HONUA_TRANSPORT` | cert (matrix) + smoke (`rest`) | Yes |
+| `HONUA_SERVICE_ID` | cert + smoke | Yes (default: `test_service`) |
+| `HONUA_MCP_SERVICE_ID` | cert | Yes (default: `test_service_mcp`) |
+| `HONUA_LAYER_ID` | cert + smoke | Yes (default: `0`) |
+| `HONUA_MCP_LAYER_ID` | cert | Yes (default: `10`) |
+| `HONUA_DEV_AUTH` | cert + smoke | No (default: `true` in CI) |
+| `OPENAI_API_KEY` | smoke only | No (skip if unset) |
+
+## Known gaps
+
+- **Auth certification:** skipped when `HONUA_DEV_AUTH=true`. Full auth testing requires a separate CI lane with auth enforcement.
+- **SDK scripts prerequisite:** CI jobs skip cleanly when `test:certification`, `test:certification:artifact`, or `test:llm-smoke` scripts are not present in the checked-out SDK ref. Land those scripts in `honua-sdk-js` before expecting certification results.
+- **Cache-invalidation testing:** deferred until anonymous writes are available.
+- **C# SDK interop lane:** deferred to follow-up issue.
+- **Schema source consolidation:** `tests/seed/base-schema.sql` and `tests/python/shared/postgis.py` define CI and local-bootstrap catalog schemas independently. They already diverge on some columns. A future pass should have one consume the other to prevent further drift.

--- a/docs/contributor/test-seed-data.md
+++ b/docs/contributor/test-seed-data.md
@@ -71,6 +71,16 @@ runner = SeedRunner("tests/seed/seed.yaml")
 runner.apply(postgis.get_connection(schema), schema=schema, profile="core")
 ```
 
+## Additional Seed Files
+
+| File | Purpose | Applied by |
+|------|---------|------------|
+| `tests/seed/base-schema.sql` | Shared base schema, tables, indexes, and `test_service` + layer 0 seed data | All CI integration-test jobs (`js-integration-tests`, `mcp-certification`, `mcp-llm-smoke`) |
+| `tests/seed/mcp.yaml` | MCP certification data (second service, polygon layer, deterministic features) | CI `mcp-certification` and `mcp-llm-smoke` jobs |
+| `tests/seed/apply-yaml-seed.sh` | Extracts SQL from a YAML seed file with a top-level `sql:` key and applies via `psql` | CI `mcp-certification` and `mcp-llm-smoke` jobs |
+
+`mcp.yaml` uses `version: 1` with a top-level `sql:` key containing raw SQL statements. In CI, it is applied after `base-schema.sql` via `apply-yaml-seed.sh`. This is distinct from the collections format (used by `seed.yaml`) which also uses `version: 1` but with `collections`/`profiles`/`features` keys and is consumed by `SeedRunner`. Other SQL-array seeds like `server.yaml` and `odata.yaml` follow the same format but are loaded by the C# test harness via `SeedRunner`/`WebAppFixture.UseSeed()`, not by `apply-yaml-seed.sh`. See [MCP Certification](mcp-certification.md) for details.
+
 ## Profiles in CI
 
 Use a profile to keep seed data minimal for fast tests:

--- a/docs/devops/infrastructure.md
+++ b/docs/devops/infrastructure.md
@@ -139,6 +139,8 @@ Core deployed-environment checks:
 - `HONUA_CLOUD_TEST_EXPECTED_DEPLOYMENT_MODE` optional
 - `HONUA_CLOUD_TEST_EXPECT_READY_FOR_COORDINATED_DEPLOY` optional
 - `HONUA_CLOUD_TEST_PLATFORM` optional (`kubernetes`, `aws-ecs`, `aws-lambda`, `azure-functions`, `azure-container-apps`)
+- `HONUA_CLOUD_TEST_EXPECT_DEPLOY_PLAN_SUPPORT` optional (code default is `true`). When `false`, the deploy-plan test asserts a `405 Method Not Allowed` contract instead of expecting a plan payload. The validation script auto-defaults to `false` for `aws-lambda`, `azure-functions`, `azure-container-apps`, and `kubernetes`; `aws-ecs` defaults to `true` (full support). Set explicitly to override.
+- `HONUA_CLOUD_TEST_EXPECT_MUTATION_SUPPORT` optional (code default is `true`). When `false`, the import mutation test is skipped entirely (the multi-endpoint import flow does not expose a single unsupported-operation contract like deploy-plan does). The validation script auto-defaults to `false` for `aws-lambda`, `azure-functions`, and `azure-container-apps`; `aws-ecs` and `kubernetes` default to `true`. Set explicitly to override.
 - `HONUA_CLOUD_TEST_DEPLOY_TARGET_ID` optional; when set, enables a live `POST /api/v1/admin/deploy/plan` check against a real configured target
 - `HONUA_CLOUD_TEST_DEPLOY_DESIRED_REVISION` optional
 - `HONUA_CLOUD_TEST_DEPLOY_CURRENT_REVISION` optional

--- a/docs/user/MCP_SERVER.md
+++ b/docs/user/MCP_SERVER.md
@@ -52,6 +52,33 @@ HONUA_BASE_URL="https://honua.example.com" HONUA_TRANSPORT="grpc-web" node dist/
 - `honua://services`
 - `honua://services/{encodedServiceId}/layers/{layerId}`
 
+## Certification
+
+> **Not yet active.** The server-side CI jobs and seed data are landed, but the SDK-side certification scripts (`test:certification`, `test:certification:artifact`, `test:llm-smoke`) are not yet present in `honua-sdk-js` `trunk`. Until those scripts land, the CI jobs skip with a warning annotation and **no certification artifacts are produced**. See [Known gaps](#known-gaps).
+
+Once the SDK-side scripts are available, Honua's CI will run an MCP certification lane on every push and pull request to `trunk` (and on manual dispatch). The suite exercises all 6 tools and 2 resources across both `grpc-web` and `rest` transports. When the `test:certification:artifact` script is also present, the lane produces machine-readable (JSON) and human-readable (Markdown) evidence artifacts; if only `test:certification` is landed, tests run but a CI warning notes the missing artifacts.
+
+| Area | What is tested |
+|------|----------------|
+| Tools | `honua_list_services`, `honua_describe_layer`, `honua_query_features`, `honua_count_features`, `honua_get_extent`, `honua_statistics` |
+| Resources | `honua://services`, `honua://services/{encodedServiceId}/layers/{layerId}` |
+| Transports | `grpc-web`, `rest` (CI matrix, one run each) |
+| Cross-cutting | Auth (skipped under dev-auth — see [Known gaps](#known-gaps)), timeout (`HonuaTimeoutError`), retry (429/5xx backoff), failure cases (bad serviceId, bad layerId, invalid WHERE) |
+
+Certification artifacts are uploaded per-transport as `mcp-certification-{transport}` with 30-day retention. These are separate from the [Client Template Version Matrix](CLIENT_TEMPLATE_VERSION_MATRIX.md).
+
+A non-blocking LLM smoke lane runs after certification passes, connecting OpenAI `gpt-4o` to the MCP server to prove the interface is usable by an actual agent. Smoke transcripts are stored in a separate `mcp-llm-smoke-transcripts` artifact.
+
+See [MCP Certification](../contributor/mcp-certification.md) for contributor guidance on seed data, CI jobs, and test structure.
+
+### Known gaps
+
+- Auth certification is skipped when `HONUA_DEV_AUTH=true` (CI default). Full auth certification requires a non-dev-auth server lane.
+- Cache-invalidation testing deferred until anonymous writes are available in dev auth mode.
+- C# SDK interop lane deferred to follow-up work.
+- Certification test code lives in `honua-sdk-js`. The SDK ref is controlled by the `MCP_SDK_REF` env var in `ci.yml` (currently `trunk`). While set to a branch name, certification is useful for development but artifacts are not reproducible release evidence. Pin `MCP_SDK_REF` to a specific tag or commit SHA for release-grade certification; `workflow_dispatch` `sdk_ref` overrides for one-off replays.
+- MCP certification and LLM smoke jobs skip cleanly (with a CI warning annotation) when the required `test:certification` / `test:llm-smoke` scripts are not yet present in the checked-out SDK ref.
+
 ## Notes
 
 - Prefer `grpc-web` for performance when available.

--- a/scripts/run-cloud-post-apply-validation.sh
+++ b/scripts/run-cloud-post-apply-validation.sh
@@ -15,7 +15,7 @@ Environment variables:
   HONUA_CLOUD_TEST_EXPECTED_DEPLOYMENT_MODE    Optional expected deployment mode (SingleInstance or MultiNode).
   HONUA_CLOUD_TEST_EXPECT_READY_FOR_COORDINATED_DEPLOY
                                                Optional expected deploy readiness flag.
-  HONUA_CLOUD_TEST_PLATFORM                    Optional platform hint (kubernetes, aws-lambda, azure-functions).
+  HONUA_CLOUD_TEST_PLATFORM                    Optional platform hint (kubernetes, aws-ecs, aws-lambda, azure-functions, azure-container-apps).
   HONUA_CLOUD_TEST_EXPECT_DEPLOY_PLAN_SUPPORT  Optional true/false override for deploy-plan cloud tests.
   HONUA_CLOUD_TEST_EXPECT_MUTATION_SUPPORT     Optional true/false override for staged-import mutation cloud tests.
   HONUA_CLOUD_TEST_DEPLOY_TARGET_ID            Optional deploy target id for a live deploy-plan check.
@@ -103,6 +103,49 @@ normalize_base_url() {
     printf 'https://%s\n' "$base_url"
 }
 
+platform_capability_default() {
+    local platform="${1:-}"
+    local capability="${2:-}"
+
+    case "${platform}:${capability}" in
+        aws-lambda:deploy-plan|aws-lambda:mutation)
+            printf 'false\n'
+            ;;
+        azure-functions:deploy-plan|azure-functions:mutation)
+            printf 'false\n'
+            ;;
+        azure-container-apps:deploy-plan|azure-container-apps:mutation)
+            printf 'false\n'
+            ;;
+        kubernetes:deploy-plan)
+            printf 'false\n'
+            ;;
+    esac
+}
+
+apply_platform_capability_defaults() {
+    local platform="${HONUA_CLOUD_TEST_PLATFORM:-}"
+    local deploy_plan_support=""
+    local mutation_support=""
+
+    if [[ -z "$platform" ]]; then
+        return 0
+    fi
+
+    if [[ -z "${HONUA_CLOUD_TEST_EXPECT_DEPLOY_PLAN_SUPPORT:-}" ]]; then
+        deploy_plan_support="$(platform_capability_default "$platform" "deploy-plan")"
+        if [[ -n "$deploy_plan_support" ]]; then
+            export HONUA_CLOUD_TEST_EXPECT_DEPLOY_PLAN_SUPPORT="$deploy_plan_support"
+        fi
+    fi
+
+    if [[ -z "${HONUA_CLOUD_TEST_EXPECT_MUTATION_SUPPORT:-}" ]]; then
+        mutation_support="$(platform_capability_default "$platform" "mutation")"
+        if [[ -n "$mutation_support" ]]; then
+            export HONUA_CLOUD_TEST_EXPECT_MUTATION_SUPPORT="$mutation_support"
+        fi
+    fi
+}
 resolve_tf_output() {
     local key=$1
     jq -r --arg key "$key" '

--- a/tests/Honua.Server.Tests/Cloud/CloudDeploymentValidationTests.cs
+++ b/tests/Honua.Server.Tests/Cloud/CloudDeploymentValidationTests.cs
@@ -257,6 +257,10 @@ public sealed class CloudDeploymentValidationTests
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
     public async Task CloudStagedImport_CompletesAndPublishedLayerBecomesPublicMetadata_WhenMutationChecksAreEnabled()
     {
+        // Unlike deploy-plan (single endpoint with a defined 405 contract), the import
+        // flow spans multiple endpoints and does not expose a uniform unsupported-operation
+        // response. Skip entirely when mutations are disabled rather than asserting a
+        // partial contract. See DeployPlanEndpoint for the contract-asserting pattern.
         if (!GetOptionalBool(ExpectMutationSupportEnv, defaultValue: true))
         {
             return;

--- a/tests/seed/apply-yaml-seed.sh
+++ b/tests/seed/apply-yaml-seed.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Extracts SQL statements from a version-1 seed YAML file and applies them
+# via psql. Requires: python3 (or python), pyyaml, psql.
+#
+# Usage: apply-yaml-seed.sh <yaml-file>
+#
+# Environment variables (psql connection):
+#   PGPASSWORD, PGHOST (default localhost), PGPORT (default 5432),
+#   PGUSER (default honua), PGDATABASE (default honua_test)
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <yaml-file>" >&2
+  exit 1
+fi
+
+YAML_FILE="$1"
+
+# Resolve python3 or python, preferring python3 for portability.
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+  PYTHON=python
+else
+  echo "Error: python3 or python is required." >&2
+  exit 1
+fi
+
+if ! "$PYTHON" -c "import yaml" 2>/dev/null; then
+  echo "Error: pyyaml is required. Install with: $PYTHON -m pip install pyyaml" >&2
+  exit 1
+fi
+
+SQL_TMP="$(mktemp /tmp/yaml-seed-XXXXXX.sql)"
+trap 'rm -f "$SQL_TMP"' EXIT
+
+"$PYTHON" - "$YAML_FILE" > "$SQL_TMP" <<'PYTHON'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f)
+if data.get('version') != 1 or 'sql' not in data:
+    sys.exit(f"Invalid seed YAML: expected version: 1 with a top-level sql key in {sys.argv[1]}")
+for stmt in data['sql']:
+    s = stmt.strip()
+    if not s.endswith(';'):
+        s += ';'
+    print(s)
+    print()
+PYTHON
+
+PGPASSWORD="${PGPASSWORD:-honua}" psql \
+  -v ON_ERROR_STOP=1 \
+  -h "${PGHOST:-localhost}" \
+  -p "${PGPORT:-5432}" \
+  -U "${PGUSER:-honua}" \
+  -d "${PGDATABASE:-honua_test}" \
+  -f "$SQL_TMP"

--- a/tests/seed/base-schema.sql
+++ b/tests/seed/base-schema.sql
@@ -1,0 +1,224 @@
+-- Shared base schema and seed data for CI integration tests.
+-- Used by: js-integration-tests, mcp-certification, mcp-llm-smoke.
+-- Idempotent: safe to re-run (IF NOT EXISTS / ON CONFLICT).
+--
+-- This is a CI-focused schema that covers the tables and columns needed by
+-- integration tests. It is NOT a mirror of the canonical migration set in
+-- src/Honua.Server/Migrations/; the server runs its own migrations at startup.
+-- The schema here is a pragmatic superset/subset: it includes columns from
+-- several migrations (001, 002, 003, 005, 007, 009, 011) and adds seed data
+-- that migrations do not provide. It intentionally excludes migrations that
+-- are not exercised by CI integration tests:
+--   004 (import functions), 006 (secure connections), 008 (service connections),
+--   010 (metadata resources), 012 (replication), 013/014 (alerts).
+-- When adding columns from new migrations, update this file and check that
+-- existing CI seed data remains compatible.
+
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+CREATE SCHEMA IF NOT EXISTS honua;
+
+CREATE TABLE IF NOT EXISTS honua.services (
+    service_name VARCHAR(64) PRIMARY KEY,
+    description TEXT NOT NULL DEFAULT '',
+    srid INT NOT NULL DEFAULT 4326,
+    max_record_count INT NOT NULL DEFAULT 1000,
+    supported_formats TEXT[] NOT NULL DEFAULT '{JSON,GeoJSON}',
+    capabilities TEXT[] NOT NULL DEFAULT '{Query,Extract}',
+    service_extent GEOMETRY,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS honua.layers (
+    layer_id SERIAL PRIMARY KEY,
+    layer_name TEXT NOT NULL,
+    description TEXT,
+    table_name TEXT NOT NULL,
+    geometry_type TEXT NOT NULL,
+    srid INT NOT NULL DEFAULT 4326,
+    extent GEOMETRY(POLYGON, 4326),
+    min_scale DOUBLE PRECISION,
+    max_scale DOUBLE PRECISION,
+    default_visibility BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE IF EXISTS honua.services
+    ADD COLUMN IF NOT EXISTS metadata JSONB;
+
+-- Columns from migrations 005, 007, 009, 011 — keep in sync.
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS table_schema TEXT NOT NULL DEFAULT current_schema();
+
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS metadata JSONB;
+
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS maplibre_style JSONB;
+
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS geoservices_drawing_info JSONB;
+
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS style_version INT DEFAULT 1;
+
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+CREATE TABLE IF NOT EXISTS honua.service_layers (
+    service_name VARCHAR(64) NOT NULL REFERENCES honua.services(service_name) ON DELETE CASCADE,
+    layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,
+    layer_order INT NOT NULL,
+    PRIMARY KEY (service_name, layer_id),
+    UNIQUE (service_name, layer_order)
+);
+
+CREATE TABLE IF NOT EXISTS honua.layer_fields (
+    layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,
+    field_name VARCHAR(64) NOT NULL,
+    field_type VARCHAR(32) NOT NULL,
+    field_order INT NOT NULL,
+    max_length INT,
+    nullable BOOLEAN NOT NULL DEFAULT TRUE,
+    default_value TEXT,
+    description TEXT,
+    PRIMARY KEY (layer_id, field_name)
+);
+
+CREATE TABLE IF NOT EXISTS honua.attachments (
+    id BIGSERIAL PRIMARY KEY,
+    feature_id BIGINT NOT NULL,
+    layer_id INT NOT NULL,
+    filename TEXT NOT NULL,
+    content_type TEXT NOT NULL,
+    size BIGINT NOT NULL CHECK (size >= 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    storage_path TEXT NOT NULL,
+    keywords TEXT
+);
+
+CREATE TABLE IF NOT EXISTS honua.relationships (
+    id SERIAL PRIMARY KEY,
+    layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,
+    relationship_id INT NOT NULL,
+    name TEXT NOT NULL,
+    related_layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,
+    relationship_type TEXT NOT NULL,
+    origin_foreign_key TEXT NOT NULL,
+    destination_foreign_key TEXT NOT NULL,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT relationships_layer_relationship_unique UNIQUE(layer_id, relationship_id),
+    CONSTRAINT relationships_valid_ids CHECK(layer_id >= 0 AND related_layer_id >= 0 AND relationship_id > 0),
+    CONSTRAINT relationships_valid_fields CHECK(
+        LENGTH(name) > 0 AND LENGTH(name) <= 128 AND
+        LENGTH(relationship_type) > 0 AND LENGTH(relationship_type) <= 64 AND
+        LENGTH(origin_foreign_key) > 0 AND LENGTH(origin_foreign_key) <= 128 AND
+        LENGTH(destination_foreign_key) > 0 AND LENGTH(destination_foreign_key) <= 128
+    ),
+    CONSTRAINT relationships_valid_type CHECK(
+        relationship_type IN ('esriRelRoleOrigin', 'esriRelRoleDestination', 'esriRelRoleAny')
+    )
+);
+
+CREATE TABLE IF NOT EXISTS features (
+    objectid BIGSERIAL PRIMARY KEY,
+    layer_id INT NOT NULL,
+    geometry GEOMETRY,
+    attributes JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_service_layers_service_name ON honua.service_layers(service_name);
+CREATE INDEX IF NOT EXISTS idx_service_layers_layer_id ON honua.service_layers(layer_id);
+CREATE INDEX IF NOT EXISTS idx_layer_fields_layer_id ON honua.layer_fields(layer_id);
+CREATE INDEX IF NOT EXISTS idx_relationships_layer_id ON honua.relationships(layer_id);
+CREATE INDEX IF NOT EXISTS idx_relationships_related_layer_id ON honua.relationships(related_layer_id);
+CREATE INDEX IF NOT EXISTS idx_features_layer_id ON features(layer_id);
+CREATE INDEX IF NOT EXISTS idx_features_geometry ON features USING GIST(geometry);
+CREATE INDEX IF NOT EXISTS idx_features_attributes ON features USING GIN(attributes);
+
+-- Base test service
+INSERT INTO honua.services (
+    service_name, description, srid, max_record_count,
+    supported_formats, capabilities, service_extent
+)
+VALUES (
+    'test_service', 'Test Feature Service', 4326, 1000,
+    ARRAY['JSON', 'GeoJSON'],
+    ARRAY['Query', 'Extract', 'Create', 'Update', 'Delete'],
+    ST_MakeEnvelope(-122.5, 37.7, -122.35, 37.84, 4326)
+)
+ON CONFLICT (service_name) DO UPDATE SET
+    description = EXCLUDED.description,
+    srid = EXCLUDED.srid,
+    max_record_count = EXCLUDED.max_record_count,
+    supported_formats = EXCLUDED.supported_formats,
+    capabilities = EXCLUDED.capabilities,
+    service_extent = EXCLUDED.service_extent,
+    updated_at = NOW();
+
+UPDATE honua.services
+SET metadata = jsonb_build_object('accessPolicy', jsonb_build_object('allowAnonymous', true))
+WHERE service_name = 'test_service';
+
+-- Base test layer (layer 0, Point)
+INSERT INTO honua.layers (
+    layer_id, layer_name, description, table_name,
+    geometry_type, srid, extent, default_visibility
+)
+VALUES (
+    0, 'Test Layer', 'Default layer for integration tests',
+    'features', 'Point', 4326,
+    ST_MakeEnvelope(-122.5, 37.7, -122.35, 37.84, 4326), true
+)
+ON CONFLICT (layer_id) DO UPDATE SET
+    layer_name = EXCLUDED.layer_name,
+    description = EXCLUDED.description,
+    table_name = EXCLUDED.table_name,
+    geometry_type = EXCLUDED.geometry_type,
+    srid = EXCLUDED.srid,
+    extent = EXCLUDED.extent,
+    default_visibility = EXCLUDED.default_visibility;
+
+UPDATE honua.layers
+SET metadata = jsonb_build_object('accessPolicy', jsonb_build_object('allowAnonymous', true))
+WHERE layer_id = 0;
+
+-- Layer 0 fields — core set
+INSERT INTO honua.layer_fields (
+    layer_id, field_name, field_type, field_order,
+    max_length, nullable, default_value, description
+)
+VALUES
+    (0, 'objectid', 'Integer', 0, NULL, false, NULL, 'Object ID'),
+    (0, 'name', 'String', 1, 255, true, NULL, 'Name'),
+    (0, 'description', 'String', 2, 1024, true, NULL, 'Description'),
+    (0, 'shape', 'Geometry', 3, NULL, true, NULL, 'Geometry')
+ON CONFLICT (layer_id, field_name) DO NOTHING;
+
+-- Layer 0 fields — extended set
+INSERT INTO honua.layer_fields (
+    layer_id, field_name, field_type, field_order,
+    max_length, nullable, default_value, description
+)
+VALUES
+    (0, 'status', 'String', 4, 64, true, NULL, 'Status'),
+    (0, 'count', 'Integer', 5, NULL, true, NULL, 'Count'),
+    (0, 'ratio', 'Double', 6, NULL, true, NULL, 'Ratio'),
+    (0, 'active', 'Boolean', 7, NULL, true, NULL, 'Active flag'),
+    (0, 'created_at', 'DateTime', 8, NULL, true, NULL, 'Created timestamp'),
+    (0, 'event_date', 'Date', 9, NULL, true, NULL, 'Event date'),
+    (0, 'event_time', 'Time', 10, NULL, true, NULL, 'Event time'),
+    (0, 'uid', 'Uuid', 11, NULL, true, NULL, 'Unique identifier'),
+    (0, 'tags', 'Json', 12, NULL, true, NULL, 'Tag array'),
+    (0, 'numbers', 'Json', 13, NULL, true, NULL, 'Number array')
+ON CONFLICT (layer_id, field_name) DO NOTHING;
+
+-- Bind layer 0 to test_service
+INSERT INTO honua.service_layers (service_name, layer_id, layer_order)
+VALUES ('test_service', 0, 0)
+ON CONFLICT (service_name, layer_id) DO NOTHING;

--- a/tests/seed/mcp.yaml
+++ b/tests/seed/mcp.yaml
@@ -1,0 +1,180 @@
+version: 1
+# MCP certification seed data
+# Depends on: base CI seed (schema + test_service + layer 0 with fields)
+# Applied AFTER the base seed to add MCP-specific test data
+#
+# This file provides deterministic data for the MCP certification suite
+# in honua-sdk-js/mcp/test/certification/. Constants in that suite
+# reference line numbers in this file for traceability.
+#
+# Spatial extent: all features within WGS84 bounding box
+#   lon: -122.50 to -122.35
+#   lat:   37.70 to   37.84
+# SRID: 4326
+
+sql:
+  # ── Second service for multi-service listing ───────────────────────
+  # Line ~20: test_service_mcp
+  - |
+    INSERT INTO honua.services (
+        service_name, description, srid,
+        supported_formats, capabilities, service_extent, metadata
+    )
+    VALUES (
+        'test_service_mcp',
+        'MCP certification service',
+        4326,
+        ARRAY['JSON', 'GeoJSON'],
+        ARRAY['Query'],
+        ST_MakeEnvelope(-122.50, 37.70, -122.35, 37.84, 4326),
+        '{"accessPolicy":{"allowAnonymous":true}}'::jsonb
+    )
+    ON CONFLICT (service_name) DO NOTHING;
+
+  # ── Polygon layer (layer 10) for geometry-type diversity ───────────
+  # Line ~37: layer 10
+  - |
+    INSERT INTO honua.layers (
+        layer_id, layer_name, description, table_name,
+        geometry_type, srid, extent, default_visibility
+    )
+    VALUES (
+        10,
+        'MCP Polygon Layer',
+        'Polygon layer for MCP certification testing',
+        'features',
+        'Polygon',
+        4326,
+        ST_MakeEnvelope(-122.50, 37.70, -122.35, 37.84, 4326),
+        true
+    )
+    ON CONFLICT (layer_id) DO UPDATE SET
+        layer_name = EXCLUDED.layer_name,
+        description = EXCLUDED.description,
+        table_name = EXCLUDED.table_name,
+        geometry_type = EXCLUDED.geometry_type,
+        srid = EXCLUDED.srid,
+        extent = EXCLUDED.extent,
+        default_visibility = EXCLUDED.default_visibility;
+
+  - |
+    UPDATE honua.layers
+    SET metadata = '{"accessPolicy":{"allowAnonymous":true}}'::jsonb
+    WHERE layer_id = 10;
+
+  # ── Layer fields for layer 10 ──────────────────────────────────────
+  # Line ~68: layer 10 fields
+  - |
+    INSERT INTO honua.layer_fields (
+        layer_id, field_name, field_type, field_order, nullable, description
+    )
+    VALUES
+        (10, 'objectid', 'Integer', 0, false, 'Object ID'),
+        (10, 'name',     'String',  1, true,  'Feature name'),
+        (10, 'area',     'Double',  2, true,  'Area in square meters'),
+        (10, 'category', 'String',  3, true,  'Category'),
+        (10, 'shape',    'Geometry', 4, true, 'Geometry')
+    ON CONFLICT (layer_id, field_name) DO NOTHING;
+
+  # ── Service-layer bindings ─────────────────────────────────────────
+  # Line ~82: bind test_service_mcp → layer 10
+  - |
+    INSERT INTO honua.service_layers (service_name, layer_id, layer_order)
+    VALUES ('test_service_mcp', 10, 0)
+    ON CONFLICT (service_name, layer_id) DO NOTHING;
+
+  # Line ~88: bind test_service → layer 10 (layer_order 1, after existing layer 0)
+  - |
+    INSERT INTO honua.service_layers (service_name, layer_id, layer_order)
+    VALUES ('test_service', 10, 1)
+    ON CONFLICT (service_name, layer_id) DO NOTHING;
+
+  # ── 15 point features in layer 0 (objectids 10–24) ────────────────
+  # Fields: objectid, name (String), count (Integer), ratio (Double), status (String)
+  # Deterministic values for statistics certification:
+  #   count: sum=725, min=10, max=100, avg≈48.33
+  #   ratio: sum=76.5, min=1.1, max=10.5, avg≈5.10
+  # Line ~99: MCP point features
+  - |
+    INSERT INTO features (objectid, layer_id, geometry, attributes)
+    VALUES
+        (10, 0, ST_SetSRID(ST_MakePoint(-122.45, 37.75), 4326),
+         '{"objectid":10,"name":"MCP Feature 01","count":10,"ratio":1.5,"status":"active"}'::jsonb),
+        (11, 0, ST_SetSRID(ST_MakePoint(-122.44, 37.76), 4326),
+         '{"objectid":11,"name":"MCP Feature 02","count":20,"ratio":2.5,"status":"active"}'::jsonb),
+        (12, 0, ST_SetSRID(ST_MakePoint(-122.43, 37.77), 4326),
+         '{"objectid":12,"name":"MCP Feature 03","count":30,"ratio":3.5,"status":"active"}'::jsonb),
+        (13, 0, ST_SetSRID(ST_MakePoint(-122.42, 37.78), 4326),
+         '{"objectid":13,"name":"MCP Feature 04","count":40,"ratio":4.5,"status":"inactive"}'::jsonb),
+        (14, 0, ST_SetSRID(ST_MakePoint(-122.41, 37.79), 4326),
+         '{"objectid":14,"name":"MCP Feature 05","count":50,"ratio":5.5,"status":"active"}'::jsonb),
+        (15, 0, ST_SetSRID(ST_MakePoint(-122.40, 37.80), 4326),
+         '{"objectid":15,"name":"MCP Feature 06","count":60,"ratio":6.5,"status":"inactive"}'::jsonb),
+        (16, 0, ST_SetSRID(ST_MakePoint(-122.39, 37.81), 4326),
+         '{"objectid":16,"name":"MCP Feature 07","count":70,"ratio":7.5,"status":"active"}'::jsonb),
+        (17, 0, ST_SetSRID(ST_MakePoint(-122.38, 37.82), 4326),
+         '{"objectid":17,"name":"MCP Feature 08","count":80,"ratio":8.5,"status":"active"}'::jsonb),
+        (18, 0, ST_SetSRID(ST_MakePoint(-122.37, 37.83), 4326),
+         '{"objectid":18,"name":"MCP Feature 09","count":90,"ratio":9.5,"status":"inactive"}'::jsonb),
+        (19, 0, ST_SetSRID(ST_MakePoint(-122.48, 37.71), 4326),
+         '{"objectid":19,"name":"MCP Feature 10","count":100,"ratio":10.5,"status":"active"}'::jsonb),
+        (20, 0, ST_SetSRID(ST_MakePoint(-122.47, 37.73), 4326),
+         '{"objectid":20,"name":"MCP Feature 11","count":15,"ratio":1.1,"status":"active"}'::jsonb),
+        (21, 0, ST_SetSRID(ST_MakePoint(-122.46, 37.74), 4326),
+         '{"objectid":21,"name":"MCP Feature 12","count":25,"ratio":2.2,"status":"inactive"}'::jsonb),
+        (22, 0, ST_SetSRID(ST_MakePoint(-122.36, 37.72), 4326),
+         '{"objectid":22,"name":"MCP Feature 13","count":35,"ratio":3.3,"status":"active"}'::jsonb),
+        (23, 0, ST_SetSRID(ST_MakePoint(-122.49, 37.84), 4326),
+         '{"objectid":23,"name":"MCP Feature 14","count":45,"ratio":4.4,"status":"active"}'::jsonb),
+        (24, 0, ST_SetSRID(ST_MakePoint(-122.35, 37.70), 4326),
+         '{"objectid":24,"name":"MCP Feature 15","count":55,"ratio":5.5,"status":"inactive"}'::jsonb)
+    ON CONFLICT (objectid) DO UPDATE SET
+        layer_id   = EXCLUDED.layer_id,
+        geometry   = EXCLUDED.geometry,
+        attributes = EXCLUDED.attributes,
+        updated_at = NOW();
+
+  # ── 5 polygon features in layer 10 (objectids 1001–1005) ──────────
+  # Fields: objectid, name (String), area (Double), category (String)
+  # Small rectangles within the SF-area bounding box
+  # Line ~142: MCP polygon features
+  - |
+    INSERT INTO features (objectid, layer_id, geometry, attributes)
+    VALUES
+        (1001, 10,
+         ST_SetSRID(ST_GeomFromText(
+           'POLYGON((-122.48 37.72, -122.46 37.72, -122.46 37.74, -122.48 37.74, -122.48 37.72))'
+         ), 4326),
+         '{"objectid":1001,"name":"MCP Polygon 01","area":1250.5,"category":"residential"}'::jsonb),
+        (1002, 10,
+         ST_SetSRID(ST_GeomFromText(
+           'POLYGON((-122.44 37.76, -122.42 37.76, -122.42 37.78, -122.44 37.78, -122.44 37.76))'
+         ), 4326),
+         '{"objectid":1002,"name":"MCP Polygon 02","area":1350.0,"category":"commercial"}'::jsonb),
+        (1003, 10,
+         ST_SetSRID(ST_GeomFromText(
+           'POLYGON((-122.40 37.80, -122.38 37.80, -122.38 37.82, -122.40 37.82, -122.40 37.80))'
+         ), 4326),
+         '{"objectid":1003,"name":"MCP Polygon 03","area":1150.0,"category":"industrial"}'::jsonb),
+        (1004, 10,
+         ST_SetSRID(ST_GeomFromText(
+           'POLYGON((-122.50 37.70, -122.48 37.70, -122.48 37.72, -122.50 37.72, -122.50 37.70))'
+         ), 4326),
+         '{"objectid":1004,"name":"MCP Polygon 04","area":1400.0,"category":"residential"}'::jsonb),
+        (1005, 10,
+         ST_SetSRID(ST_GeomFromText(
+           'POLYGON((-122.36 37.82, -122.35 37.82, -122.35 37.84, -122.36 37.84, -122.36 37.82))'
+         ), 4326),
+         '{"objectid":1005,"name":"MCP Polygon 05","area":980.0,"category":"park"}'::jsonb)
+    ON CONFLICT (objectid) DO UPDATE SET
+        layer_id   = EXCLUDED.layer_id,
+        geometry   = EXCLUDED.geometry,
+        attributes = EXCLUDED.attributes,
+        updated_at = NOW();
+
+  # ── Reset objectid sequence ────────────────────────────────────────
+  - |
+    SELECT setval(
+        pg_get_serial_sequence('features', 'objectid'),
+        (SELECT COALESCE(MAX(objectid), 0) FROM features)
+    );


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #484

## Summary
Add the `honua-server` side of MCP certification support: seeded fixtures, CI plumbing, and contributor/user documentation that distinguish deterministic MCP certification from separate non-blocking LLM smoke coverage.

## Changes Made
- add MCP-specific seed/schema data, YAML seed application support, and validation plumbing used by certification lanes
- wire CI and reusable setup actions for MCP certification and LLM smoke execution
- document cross-repo ownership, contributor workflows, release-evidence expectations, and MCP test data

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)

Local validation already run in the ticket flow covered the targeted MCP/server checks before PR creation.

## Coverage Impact
This PR mostly adds test infrastructure, CI plumbing, docs, and seed fixtures. No separate line/branch coverage delta was measured for this server-side slice.

## Breaking Changes
None

## Additional Context
This PR is intentionally the `honua-server` slice of issue `#484`, not the full cross-repo closure.

The remaining blocking gap lives in `honua-sdk-js/mcp`: the deterministic certification scripts still need to land there, and the default `MCP_SDK_REF` should then be pinned to a specific tag or commit SHA so release evidence is reproducible. Until that repo work lands, this PR provides the server-side fixtures and workflow plumbing needed to support the final certification lane.

---

## Pre-PR Checklist (for contributor)
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit message follows format: `type: description (#issue-number)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] Documentation updated if needed
- [ ] If protocol/auth behavior changed, updated MVP compatibility contract and release checklist notes
- [ ] If breaking admin/control-plane API changes: updated migration guide and versioning policy docs
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review and documented in migration guide

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed
