### PR TITLE
feat: Cloud-native formats: add GeoParquet import + preview runtime support (#423)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 - **Multi-protocol** — one server speaks GeoServices REST (catalog, FeatureServer, MapServer, ImageServer, Geometry Service), OGC API Features/Maps/Tiles, OData v4, and MVT. Connect ArcGIS Pro, QGIS, MapLibre, Power BI, and Excel to the same data.
 - **Cloud-native** — container-first, auto-scaling, OpenTelemetry observability, and IaC templates for Kubernetes, ECS, Lambda, Azure Container Apps, and Azure Functions.
-- **No GDAL dependency** — import GeoJSON, Shapefile (zip), GeoPackage, GPX, KML, WKT, and File Geodatabase (`.gdb.zip`) directly. Import from live Esri REST services or public object URLs for migration.
+- **No GDAL dependency** — import GeoJSON, Shapefile (zip), GeoPackage, GPX, KML, WKT, File Geodatabase (`.gdb.zip`), and GeoParquet (`.parquet`, `.geoparquet`) directly. Import from live Esri REST services or public object URLs for migration.
 - **Enterprise data access** — OData v4 with spatial functions (`geo.distance`, `geo.intersects`), `$search`, `$apply`, and `$batch` puts your spatial data in Excel, Power BI, Tableau, and any OData client.
 
 ## Quick Start
@@ -93,7 +93,7 @@ Please use these forms instead of blank issues so reports include enough detail 
 
 **Vector tiles** — PostGIS-native `ST_AsMVT` generation with TileJSON metadata and auto-generated MapLibre styles.
 
-**File import** — GeoJSON, Shapefile (zip), GeoPackage, GPX, KML, WKT, and File Geodatabase (`.gdb.zip`). CRS auto-detection and PostGIS-based reprojection.
+**File import** — GeoJSON, Shapefile (zip), GeoPackage, GPX, KML, WKT, File Geodatabase (`.gdb.zip`), and GeoParquet (`.parquet`, `.geoparquet`). CRS auto-detection and PostGIS-based reprojection.
 
 **Service import** — Migrate existing Esri feature and map services, preserving structure and metadata.
 

--- a/docs/contributor/adr/0024-open-core-edition-model.md
+++ b/docs/contributor/adr/0024-open-core-edition-model.md
@@ -49,7 +49,7 @@ A complete, production-capable feature server for a single-process deployment.
 | Area | Included |
 |------|----------|
 | **Protocols** | All — GeoServices REST (FeatureServer, MapServer, ImageServer, GeometryService), OGC API (Features, Tiles, Maps), WMS 1.3, WMTS 1.0, OData v4, MVT, gRPC (unary) |
-| **Data** | PostGIS backend; GeoJSON, Shapefile, GeoPackage, GPX, KML, WKT import; Esri REST service import |
+| **Data** | PostGIS backend; GeoJSON, Shapefile, GeoPackage, GPX, KML, WKT, GeoParquet import; Esri REST service import |
 | **Query** | Full Filter AST (CQL2, OData `$filter`, WHERE), spatial queries, statistics, pagination |
 | **Edits** | Full CRUD across GeoServices, OGC, and OData; attachments; related records |
 | **SDKs** | JS SDK, Python SDK, .NET SDK — full query + edit capabilities |

--- a/docs/user/CONTROL_PLANE_API.md
+++ b/docs/user/CONTROL_PLANE_API.md
@@ -204,6 +204,8 @@ file=@parcels.geojson
 
 For Esri File Geodatabases, use a `.gdb.zip` archive that contains the `.gdb` directory and preserves the directory structure inside the archive. See [FileGDB Import Workflow](FILEGDB_IMPORT_WORKFLOW.md).
 
+For GeoParquet files, upload a `.parquet` or `.geoparquet` file directly. The server reads GeoParquet `geo` metadata for CRS detection and requires WKB geometry encoding. Non-WKB encodings are rejected. Nested column types (Struct, List, Map) are skipped with warnings. Rows with null geometry are skipped during both preview and import, and reported as warnings in the import response. Files with more than 100,000 rows in a single Parquet row group are rejected to maintain bounded memory usage; re-export such files with smaller row groups.
+
 ### **Import Endpoints**
 
 | Endpoint | Method | Purpose |

--- a/docs/user/admin-ui.md
+++ b/docs/user/admin-ui.md
@@ -31,7 +31,7 @@ For automation, use the [Server Management API](CONTROL_PLANE_API.md) instead.
 ## Data Import
 
 1. Open **Import**.
-2. Upload your file (GeoJSON, Shapefile, GeoPackage).
+2. Upload your file (GeoJSON, Shapefile, GeoPackage, GeoParquet, and others).
 3. Preview the data.
 4. Confirm target layer and run the import.
 

--- a/src/Honua.Core/Features/Import/Domain/SupportedFileFormat.cs
+++ b/src/Honua.Core/Features/Import/Domain/SupportedFileFormat.cs
@@ -59,5 +59,10 @@ public enum SupportedFileFormat
     /// <summary>
     /// Esri File Geodatabase format (.gdb)
     /// </summary>
-    FileGdb
+    FileGdb,
+
+    /// <summary>
+    /// GeoParquet format (.parquet, .geoparquet)
+    /// </summary>
+    GeoParquet
 }

--- a/src/Honua.Postgres/Features/Import/GeoParquetReader.cs
+++ b/src/Honua.Postgres/Features/Import/GeoParquetReader.cs
@@ -1,0 +1,462 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+using Parquet;
+using Parquet.Schema;
+
+namespace Honua.Postgres.Features.Import;
+
+/// <summary>
+/// Streaming GeoParquet format reader. Reads GeoParquet files using Parquet.Net,
+/// extracting WKB geometry and attribute columns into NTS features.
+/// </summary>
+internal static class GeoParquetReader
+{
+    private const int YieldInterval = 256;
+
+    /// <summary>
+    /// Maximum rows allowed in a single Parquet row group before the import/preview
+    /// paths reject the file. Parquet.Net materializes an entire row group's column
+    /// data in memory, so unbounded row groups defeat the streaming memory contract.
+    /// </summary>
+    internal const long MaxRowsPerRowGroup = 100_000;
+
+    /// <summary>
+    /// Error message used when a GeoParquet file uses a non-WKB geometry encoding.
+    /// Shared between the import and preview rejection paths.
+    /// </summary>
+    internal const string UnsupportedEncodingMessage =
+        "GeoParquet file uses an unsupported geometry encoding. Only WKB encoding is supported in this version.";
+
+    /// <summary>
+    /// Builds a rejection message for files containing a row group that exceeds the
+    /// bounded-memory threshold. Shared between the import and preview paths.
+    /// </summary>
+    internal static string BuildLargeRowGroupMessage(long maxRowGroupRows, int rowGroupCount) =>
+        $"GeoParquet file has a row group containing {maxRowGroupRows:N0} rows across {rowGroupCount} row group(s), " +
+        $"exceeding the {MaxRowsPerRowGroup:N0}-row per-row-group limit. Re-export the file with smaller row groups " +
+        "to enable bounded-memory import.";
+
+    /// <summary>
+    /// Streams features from a GeoParquet file. The stream must be seekable.
+    /// </summary>
+    internal static async IAsyncEnumerable<IFeature> ReadStreamingAsync(
+        Stream stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        if (!stream.CanSeek)
+        {
+            throw new InvalidOperationException("GeoParquet reader requires a seekable stream.");
+        }
+
+        stream.Position = 0;
+        using var reader = await CreateReaderAsync(stream, cancellationToken);
+        var geoMeta = ParseGeoMetadata(reader.CustomMetadata);
+        var primaryColumn = geoMeta.PrimaryColumn;
+        var wkbReader = new WKBReader();
+        var schema = reader.Schema;
+
+        // Find geometry column index; exclude all geometry columns from attributes
+        var geometryFieldIndex = -1;
+        var geometryColumnNames = geoMeta.GeometryColumnNames;
+        var attributeFields = new List<(int Index, DataField Field)>();
+
+        for (var i = 0; i < schema.Fields.Count; i++)
+        {
+            if (schema.Fields[i] is DataField df)
+            {
+                if (string.Equals(df.Name, primaryColumn, StringComparison.OrdinalIgnoreCase))
+                {
+                    geometryFieldIndex = i;
+                }
+                else if (!geometryColumnNames.Contains(df.Name))
+                {
+                    attributeFields.Add((i, df));
+                }
+            }
+            // Nested types (StructField, ListField, MapField) are not DataFields — warned via DetectWarnings
+        }
+
+        if (geometryFieldIndex < 0)
+        {
+            throw new InvalidDataException($"GeoParquet geometry column '{primaryColumn}' not found in schema.");
+        }
+
+        // Parquet is a columnar format — Parquet.Net reads all rows of a column within a
+        // row group in a single ReadColumnAsync call. This means each row group's data is
+        // materialized in memory before features are yielded. Well-partitioned files use
+        // many small row groups and work within the import service's bounded-memory contract.
+        // Files with a single large row group (e.g. Honua's own exporter) will spike memory
+        // proportional to the row group size. See follow-on to bound the exporter's row groups.
+        var recordCount = 0;
+        for (var rg = 0; rg < reader.RowGroupCount; rg++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var rowGroupReader = reader.OpenRowGroupReader(rg);
+
+            // Read geometry column
+            var geometryColumn = await rowGroupReader.ReadColumnAsync(
+                (DataField)schema.Fields[geometryFieldIndex], cancellationToken);
+            var geometryData = geometryColumn.Data as byte[]?[];
+            if (geometryData is null)
+            {
+                throw new InvalidDataException(
+                    $"Geometry column '{primaryColumn}' does not contain binary (WKB) data.");
+            }
+
+            // Read attribute columns
+            var attributeData = new List<(string Name, Array Data)>();
+            foreach (var (index, field) in attributeFields)
+            {
+                var column = await rowGroupReader.ReadColumnAsync(field, cancellationToken);
+                attributeData.Add((field.Name, column.Data));
+            }
+
+            var rowCount = geometryData.Length;
+            for (var row = 0; row < rowCount; row++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var attributes = new AttributesTable();
+                foreach (var (name, data) in attributeData)
+                {
+                    var value = data.GetValue(row);
+                    if (value is DateTimeOffset dto)
+                    {
+                        attributes.Add(name, dto);
+                    }
+                    else if (value is DateTime dt)
+                    {
+                        attributes.Add(name, new DateTimeOffset(dt, TimeSpan.Zero));
+                    }
+                    else
+                    {
+                        attributes.Add(name, value);
+                    }
+                }
+
+                NetTopologySuite.Geometries.Geometry? geometry = null;
+                var wkbBytes = geometryData[row];
+                if (wkbBytes != null)
+                {
+                    try
+                    {
+                        geometry = wkbReader.Read(wkbBytes);
+                    }
+                    catch (Exception ex) when (ex is ParseException or FormatException)
+                    {
+                        throw new InvalidDataException(
+                            $"Row {row} in row group {rg} contains invalid WKB geometry data.", ex);
+                    }
+                }
+
+                yield return new Feature(geometry, attributes);
+
+                recordCount++;
+                if (recordCount % YieldInterval == 0)
+                {
+                    await Task.Yield();
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extracts all import-relevant metadata from a GeoParquet stream in a single pass:
+    /// SRID, encoding support, and warnings. Resets stream position to 0 after reading.
+    /// </summary>
+    internal static async Task<GeoParquetFileMetadata> ExtractMetadataAsync(
+        Stream stream, CancellationToken cancellationToken)
+    {
+        if (!stream.CanSeek)
+        {
+            throw new InvalidOperationException("GeoParquet metadata extraction requires a seekable stream.");
+        }
+
+        stream.Position = 0;
+        using var reader = await CreateReaderAsync(stream, cancellationToken);
+        var geoMeta = ParseGeoMetadata(reader.CustomMetadata);
+        var isWkbEncoding = string.Equals(geoMeta.Encoding, "WKB", StringComparison.OrdinalIgnoreCase);
+
+        var warnings = new List<string>();
+
+        // Check encoding
+        if (!isWkbEncoding)
+        {
+            warnings.Add($"GeoParquet file uses '{geoMeta.Encoding}' geometry encoding. Only WKB encoding is supported.");
+        }
+
+        // Check for multiple geometry columns
+        if (geoMeta.GeometryColumnCount > 1)
+        {
+            warnings.Add($"GeoParquet file contains multiple geometry columns. Only the primary column '{geoMeta.PrimaryColumn}' will be imported.");
+        }
+
+        // Check for nested types in schema
+        var schema = reader.Schema;
+        foreach (var field in schema.Fields)
+        {
+            if (field is StructField sf)
+            {
+                warnings.Add($"Column '{sf.Name}' uses a nested type (Struct) that cannot be imported. This column will be skipped.");
+            }
+            else if (field is ListField lf)
+            {
+                warnings.Add($"Column '{lf.Name}' uses a nested type (List) that cannot be imported. This column will be skipped.");
+            }
+            else if (field is MapField mf)
+            {
+                warnings.Add($"Column '{mf.Name}' uses a nested type (Map) that cannot be imported. This column will be skipped.");
+            }
+        }
+
+        // Verify primary geometry column exists in the Parquet schema as a DataField.
+        // Fail fast here instead of deferring to ReadStreamingAsync, which would read
+        // attribute columns before discovering the mismatch.
+        var hasPrimaryColumn = false;
+        foreach (var field in schema.Fields)
+        {
+            if (field is DataField df &&
+                string.Equals(df.Name, geoMeta.PrimaryColumn, StringComparison.OrdinalIgnoreCase))
+            {
+                hasPrimaryColumn = true;
+                break;
+            }
+        }
+
+        if (!hasPrimaryColumn)
+        {
+            throw new InvalidDataException(
+                $"GeoParquet geometry column '{geoMeta.PrimaryColumn}' not found in Parquet schema.");
+        }
+
+        var totalRowCount = reader.Metadata?.NumRows ?? 0;
+        var rowGroupCount = reader.RowGroupCount;
+
+        // Determine the largest row group — Parquet.Net materializes an entire
+        // row group's columns in memory, so any oversized group defeats the
+        // streaming memory contract. OpenRowGroupReader only reads metadata
+        // from the already-loaded footer; no column data is touched here.
+        long maxRowGroupRows = 0;
+        for (var rg = 0; rg < rowGroupCount; rg++)
+        {
+            using var rgReader = reader.OpenRowGroupReader(rg);
+            if (rgReader.RowCount > maxRowGroupRows)
+            {
+                maxRowGroupRows = rgReader.RowCount;
+            }
+        }
+
+        stream.Position = 0;
+        return new GeoParquetFileMetadata(geoMeta.Srid, isWkbEncoding, warnings.ToArray(), totalRowCount, rowGroupCount, maxRowGroupRows);
+    }
+
+    /// <summary>
+    /// Import-relevant metadata extracted from a GeoParquet file in a single reader pass.
+    /// </summary>
+    internal sealed record GeoParquetFileMetadata(
+        int? Srid,
+        bool IsWkbEncoding,
+        string[] Warnings,
+        long TotalRowCount,
+        int RowGroupCount,
+        long MaxRowGroupRowCount);
+
+    /// <summary>
+    /// Opens a Parquet reader, normalizing library-level I/O and format errors
+    /// (e.g. invalid magic bytes) to <see cref="InvalidDataException"/> so callers
+    /// can treat them as client input errors rather than server faults.
+    /// </summary>
+    private static async Task<ParquetReader> CreateReaderAsync(
+        Stream stream, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await ParquetReader.CreateAsync(stream, leaveStreamOpen: true, cancellationToken: cancellationToken);
+        }
+        catch (Exception ex) when (ex is IOException or FormatException)
+        {
+            throw new InvalidDataException("File is not a valid Parquet file.", ex);
+        }
+    }
+
+    private static GeoParquetMetadata ParseGeoMetadata(IReadOnlyDictionary<string, string>? customMetadata)
+    {
+        if (customMetadata == null || !customMetadata.TryGetValue("geo", out var geoJson))
+        {
+            throw new InvalidDataException("GeoParquet file is missing required 'geo' metadata key.");
+        }
+
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(geoJson);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidDataException("GeoParquet file contains malformed 'geo' metadata JSON.", ex);
+        }
+
+        using (doc)
+        {
+            try
+            {
+                return ParseGeoDocument(doc);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new InvalidDataException(
+                    "GeoParquet 'geo' metadata has unexpected structure (wrong JSON value types).", ex);
+            }
+        }
+    }
+
+    private static GeoParquetMetadata ParseGeoDocument(JsonDocument doc)
+    {
+        var root = doc.RootElement;
+
+        // primary_column is required per GeoParquet 1.0.0+ spec
+        if (!root.TryGetProperty("primary_column", out var pc) ||
+            pc.ValueKind != JsonValueKind.String)
+        {
+            throw new InvalidDataException(
+                "GeoParquet 'geo' metadata has unexpected structure: required 'primary_column' field is missing or not a string.");
+        }
+
+        var primaryColumn = pc.GetString()!;
+
+        // columns is required per GeoParquet 1.0.0+ spec
+        if (!root.TryGetProperty("columns", out var columns) ||
+            columns.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidDataException(
+                "GeoParquet 'geo' metadata has unexpected structure: required 'columns' field is missing or not an object.");
+        }
+
+        string? encoding = null;
+        int? srid = null;
+        var geometryColumnCount = 0;
+        var geometryColumnNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var foundPrimaryInColumns = false;
+
+        foreach (var col in columns.EnumerateObject())
+        {
+            geometryColumnCount++;
+            geometryColumnNames.Add(col.Name);
+
+            if (!string.Equals(col.Name, primaryColumn, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            foundPrimaryInColumns = true;
+            var colObj = col.Value;
+
+            // Encoding
+            if (colObj.TryGetProperty("encoding", out var enc))
+            {
+                encoding = enc.GetString();
+            }
+
+            // CRS detection — priority order per design brief
+            srid = ExtractSrid(colObj);
+        }
+
+        // The GeoParquet spec requires that primary_column references a key in "columns".
+        // Accepting a missing entry would silently default to WKB with no SRID, masking
+        // a malformed file instead of surfacing a clear error.
+        if (!foundPrimaryInColumns)
+        {
+            throw new InvalidDataException(
+                $"GeoParquet 'geo' metadata declares primary_column '{primaryColumn}' but 'columns' does not contain a matching entry.");
+        }
+
+        return new GeoParquetMetadata(primaryColumn, encoding ?? "WKB", srid, geometryColumnCount, geometryColumnNames);
+    }
+
+    private static int? ExtractSrid(JsonElement columnElement)
+    {
+        // GeoParquet 1.1.0 spec: absent "crs" key defaults to OGC:CRS84 (lon-lat).
+        // OGC:CRS84 is mapped to SRID 4326 per industry convention (PostGIS, GDAL, etc.)
+        // even though EPSG:4326 officially defines lat-lon axis order.
+        if (!columnElement.TryGetProperty("crs", out var crs))
+        {
+            return 4326;
+        }
+
+        // Explicit JSON null means "no CRS associated with this data".
+        if (crs.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        // Format 1: PROJJSON with id.authority + id.code (GeoParquet 1.1.0 spec)
+        if (crs.TryGetProperty("id", out var id) &&
+            id.TryGetProperty("authority", out var authority) &&
+            id.TryGetProperty("code", out var code))
+        {
+            var authorityStr = authority.GetString();
+
+            // EPSG authority — PROJJSON permits both numeric and string codes.
+            // Use TryGetInt32/TryParse to gracefully handle non-integral (4326.5) or
+            // out-of-range values instead of throwing FormatException/OverflowException.
+            if (string.Equals(authorityStr, "EPSG", StringComparison.OrdinalIgnoreCase))
+            {
+                if (code.ValueKind == JsonValueKind.Number && code.TryGetInt32(out var epsgCode))
+                {
+                    return epsgCode;
+                }
+
+                if (code.ValueKind == JsonValueKind.String &&
+                    int.TryParse(code.GetString(), out var epsgCodeFromString))
+                {
+                    return epsgCodeFromString;
+                }
+            }
+
+            // OGC:CRS84 → SRID 4326 per industry convention (lon-lat, same as PostGIS/GDAL)
+            if (string.Equals(authorityStr, "OGC", StringComparison.OrdinalIgnoreCase) &&
+                code.ValueKind == JsonValueKind.String &&
+                string.Equals(code.GetString(), "CRS84", StringComparison.OrdinalIgnoreCase))
+            {
+                return 4326;
+            }
+        }
+
+        // Format 2: GeoJSON-style crs.properties.name (Honua export format)
+        if (crs.TryGetProperty("properties", out var props) &&
+            props.TryGetProperty("name", out var name))
+        {
+            var nameStr = name.GetString();
+            if (nameStr != null)
+            {
+                // EPSG:<code> (e.g. "EPSG:4326")
+                if (nameStr.StartsWith("EPSG:", StringComparison.OrdinalIgnoreCase) &&
+                    int.TryParse(nameStr.AsSpan(5), out var epsgCode))
+                {
+                    return epsgCode;
+                }
+
+                // OGC:CRS84 → SRID 4326
+                if (string.Equals(nameStr, "OGC:CRS84", StringComparison.OrdinalIgnoreCase))
+                {
+                    return 4326;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private sealed record GeoParquetMetadata(
+        string PrimaryColumn,
+        string Encoding,
+        int? Srid,
+        int GeometryColumnCount,
+        HashSet<string> GeometryColumnNames);
+}

--- a/src/Honua.Postgres/Features/Import/InMemoryImportJobService.cs
+++ b/src/Honua.Postgres/Features/Import/InMemoryImportJobService.cs
@@ -680,10 +680,10 @@ internal sealed partial class UniversalImportJobService : IImportJobService, IDi
             {
                 status = result.Success ? "completed" : "failed";
                 featureCount = result.FeatureCount;
-                failedFeatures = 0; // ImportProgress doesn't track this directly
                 errorMessage = result.ErrorMessage;
 
                 var currentProgress = await _progressStore.GetProgressAsync<ImportProgress>(jobId, cancellationToken);
+                failedFeatures = currentProgress?.FailedFeatures ?? 0;
                 if (currentProgress != null)
                 {
                     var finalProgress = currentProgress with
@@ -691,7 +691,8 @@ internal sealed partial class UniversalImportJobService : IImportJobService, IDi
                         Status = result.Success ? ImportStatus.Completed : ImportStatus.Failed,
                         FeaturesProcessed = result.FeatureCount,
                         CompletedAt = DateTimeOffset.UtcNow,
-                        ErrorMessage = result.ErrorMessage
+                        ErrorMessage = result.ErrorMessage,
+                        Warnings = result.Warnings
                     };
                     await _progressStore.SetProgressAsync(jobId, finalProgress, TimeSpan.FromDays(1), cancellationToken);
                 }
@@ -714,6 +715,7 @@ internal sealed partial class UniversalImportJobService : IImportJobService, IDi
             {
                 status = "cancelled";
                 var currentProgress = await _progressStore.GetProgressAsync<ImportProgress>(jobId, CancellationToken.None);
+                failedFeatures = currentProgress?.FailedFeatures;
                 if (currentProgress != null)
                 {
                     var cancelledProgress = currentProgress with
@@ -735,6 +737,7 @@ internal sealed partial class UniversalImportJobService : IImportJobService, IDi
                 status = "failed";
                 errorMessage = "Import failed.";
                 var currentProgress = await _progressStore.GetProgressAsync<ImportProgress>(jobId, CancellationToken.None);
+                failedFeatures = currentProgress?.FailedFeatures;
                 if (currentProgress != null)
                 {
                     var failedProgress = currentProgress with

--- a/src/Honua.Postgres/Features/Import/JsonContexts.cs
+++ b/src/Honua.Postgres/Features/Import/JsonContexts.cs
@@ -10,9 +10,23 @@ namespace Honua.Postgres.Features.Import;
 /// </summary>
 [JsonSerializable(typeof(Dictionary<string, object?>))]
 [JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(sbyte))]
+[JsonSerializable(typeof(short))]
 [JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(byte))]
+[JsonSerializable(typeof(ushort))]
+[JsonSerializable(typeof(uint))]
+[JsonSerializable(typeof(ulong))]
+[JsonSerializable(typeof(float))]
 [JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(decimal))]
 [JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(DateTimeOffset))]
+[JsonSerializable(typeof(byte[]))]
+[JsonSerializable(typeof(TimeOnly))]
+[JsonSerializable(typeof(DateOnly))]
+[JsonSerializable(typeof(TimeSpan))]
 [JsonSerializable(typeof(object))]
 internal sealed partial class ImportJsonContext : JsonSerializerContext
 {

--- a/src/Honua.Postgres/Features/Import/StreamingFileImportService.cs
+++ b/src/Honua.Postgres/Features/Import/StreamingFileImportService.cs
@@ -63,9 +63,11 @@ internal sealed partial class StreamingFileImportService : IFileImportService
             [".gpkg"] = SupportedFileFormat.GeoPackage,
             [".gpx"] = SupportedFileFormat.Gpx,
             [".csv"] = SupportedFileFormat.Csv,
-            [".gdb"] = SupportedFileFormat.FileGdb
+            [".gdb"] = SupportedFileFormat.FileGdb,
+            [".parquet"] = SupportedFileFormat.GeoParquet,
+            [".geoparquet"] = SupportedFileFormat.GeoParquet
         }
-        .ToFrozenDictionary();
+        .ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
     private static readonly FrozenSet<string> _shapefileComponentExtensions = new[]
         {
             ".shp", ".dbf", ".shx", ".prj", ".cpg"
@@ -75,6 +77,9 @@ internal sealed partial class StreamingFileImportService : IFileImportService
     private static readonly string _geoPackageScratchRoot = Path.Combine(Path.GetTempPath(), "honua-geopackage");
     private static readonly string _kmzScratchRoot = Path.Combine(Path.GetTempPath(), "honua-kmz");
     private static readonly string _fileGdbScratchRoot = Path.Combine(Path.GetTempPath(), "honua-filegdb");
+    private static readonly string _geoParquetScratchRoot = Path.Combine(Path.GetTempPath(), "honua-geoparquet");
+    private static readonly CompositeFormat _nullGeometryWarningFormat =
+        CompositeFormat.Parse("{0} row(s) were skipped because geometry was null.");
     private static readonly Regex _wktSridRegex = new(
         @"SRID\s*=\s*(\d+)\s*;",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -203,6 +208,7 @@ internal sealed partial class StreamingFileImportService : IFileImportService
         GeoPackageScratch? geoPackageScratch = null;
         KmzScratch? kmzScratch = null;
         FileGdbScratch? fileGdbScratch = null;
+        GeoParquetScratch? geoParquetScratch = null;
 
         ImportLog.ImportStarted(_logger, jobId, request.TableName, formatName, mode, totalBytes);
 
@@ -302,6 +308,79 @@ internal sealed partial class StreamingFileImportService : IFileImportService
                 detectedSrid = FileGdb.FileGdbReader.DetectSrid(fileGdbScratch.GdbPath);
                 warnings = FileGdb.FileGdbAdvancedConstructs.DetectWarnings(fileGdbScratch.GdbPath);
             }
+            else if (format.Value == SupportedFileFormat.GeoParquet)
+            {
+                try
+                {
+                    geoParquetScratch = await PrepareGeoParquetScratchAsync(fileStream, cancellationToken);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    errorMessage = "Failed to buffer GeoParquet file for reading.";
+                    ImportLog.ImportFailedWithException(_logger, ex, jobId, request.TableName);
+                    result = ImportResult.CreateFailure(
+                        request.TableName, format.Value, errorMessage, stopwatch.Elapsed, warnings);
+                    return result;
+                }
+
+                var scratchStream = geoParquetScratch.Stream;
+
+                GeoParquetReader.GeoParquetFileMetadata parquetMeta;
+                try
+                {
+                    parquetMeta = await GeoParquetReader.ExtractMetadataAsync(scratchStream, cancellationToken);
+                }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex) when (ex is InvalidDataException or NotSupportedException or ArgumentException)
+                {
+                    // Preserve the specific validation message (malformed geo metadata,
+                    // missing primary column, etc.) instead of collapsing to "Import failed."
+                    errorMessage = ex.Message;
+                    ImportLog.ImportFailedWithException(_logger, ex, jobId, request.TableName);
+                    result = ImportResult.CreateFailure(
+                        request.TableName, format.Value, errorMessage, stopwatch.Elapsed, warnings);
+                    return result;
+                }
+
+                warnings = parquetMeta.Warnings;
+
+                // Hard-reject files with any oversized row group — Parquet.Net materializes
+                // an entire row group's columns in memory, so unbounded groups defeat the
+                // streaming memory contract. Log and fail fast instead of silently spiking memory.
+                if (parquetMeta.MaxRowGroupRowCount > GeoParquetReader.MaxRowsPerRowGroup)
+                {
+                    GeoParquetLog.LargeRowGroupDetected(_logger, parquetMeta.RowGroupCount, parquetMeta.MaxRowGroupRowCount);
+                    errorMessage = GeoParquetReader.BuildLargeRowGroupMessage(
+                        parquetMeta.MaxRowGroupRowCount, parquetMeta.RowGroupCount);
+                    result = ImportResult.CreateFailure(
+                        request.TableName, format.Value,
+                        errorMessage,
+                        stopwatch.Elapsed, warnings);
+                    return result;
+                }
+
+                // Hard-reject non-WKB encoding before any further processing
+                if (!parquetMeta.IsWkbEncoding)
+                {
+                    errorMessage = GeoParquetReader.UnsupportedEncodingMessage;
+                    result = ImportResult.CreateFailure(
+                        request.TableName, format.Value,
+                        errorMessage,
+                        stopwatch.Elapsed, warnings);
+                    return result;
+                }
+
+                detectedSrid = parquetMeta.Srid;
+
+                // If scratch created a new stream (non-seekable input), dispose the original
+                if (geoParquetScratch.ScratchDir != null && shouldDisposeStream)
+                {
+                    await fileStream.DisposeAsync();
+                    shouldDisposeStream = false;
+                }
+
+                fileStream = scratchStream;
+            }
             else
             {
                 if (request.SourceSrid.HasValue)
@@ -351,7 +430,7 @@ internal sealed partial class StreamingFileImportService : IFileImportService
                 warnings));
 
             // Stream features and insert in batches
-            (importedCount, failedCount) = await ImportStreamingAsync(
+            (importedCount, failedCount, warnings) = await ImportStreamingAsync(
                 request,
                 fileStream,
                 format.Value,
@@ -397,6 +476,20 @@ internal sealed partial class StreamingFileImportService : IFileImportService
                 warnings);
             return result;
         }
+        catch (InvalidDataException ex)
+        {
+            // Preserve the specific message (e.g. "Row X in row group Y contains
+            // invalid WKB geometry data") instead of collapsing to "Import failed."
+            ImportLog.ImportFailedWithException(_logger, ex, jobId, request.TableName);
+            errorMessage = ex.Message;
+            result = ImportResult.CreateFailure(
+                request.TableName,
+                format ?? SupportedFileFormat.GeoJson,
+                errorMessage,
+                stopwatch.Elapsed,
+                warnings);
+            return result;
+        }
         catch (Exception ex)
         {
             ImportLog.ImportFailedWithException(_logger, ex, jobId, request.TableName);
@@ -427,6 +520,7 @@ internal sealed partial class StreamingFileImportService : IFileImportService
             CleanupGeoPackageScratch(geoPackageScratch);
             CleanupKmzScratch(kmzScratch);
             CleanupFileGdbScratch(fileGdbScratch);
+            CleanupGeoParquetScratch(geoParquetScratch);
             RecordImportMetrics(formatName, mode, status, stopwatch.Elapsed, bytesRead, importedCount, failedCount);
 
             if (status == "success")
@@ -450,7 +544,7 @@ internal sealed partial class StreamingFileImportService : IFileImportService
     /// <summary>
     /// Stream features from source and insert into database in batches.
     /// </summary>
-    private async Task<(int imported, int failed)> ImportStreamingAsync(
+    private async Task<(int imported, int failed, string[] warnings)> ImportStreamingAsync(
         ImportRequest request,
         Stream fileStream,
         SupportedFileFormat format,
@@ -476,6 +570,7 @@ internal sealed partial class StreamingFileImportService : IFileImportService
         var batch = new List<IFeature>(_limits.BatchSize);
         var totalImported = 0;
         var totalFailed = 0;
+        var nullGeometrySkipped = 0;
         var batchesCommitted = 0;
         var startTime = DateTimeOffset.UtcNow;
 
@@ -495,11 +590,21 @@ internal sealed partial class StreamingFileImportService : IFileImportService
             SupportedFileFormat.Shapefile => ReadShapefileStreamingAsync(shapefileScratch!.ShpPath, cancellationToken),
             SupportedFileFormat.GeoPackage => ReadGeoPackageStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.FileGdb => FileGdb.FileGdbReader.ReadStreamingAsync(fileGdbScratch!.GdbPath, cancellationToken),
+            SupportedFileFormat.GeoParquet => GeoParquetReader.ReadStreamingAsync(fileStream, cancellationToken),
             _ => throw new NotSupportedException($"Streaming not supported for format: {format}")
         };
 
         await foreach (var feature in featureStream.WithCancellation(cancellationToken))
         {
+            // GeoParquet: skip rows with null geometry and count them as failures
+            // per design decision "Null geometry rows | Skip, count" (ticket #423).
+            if (format == SupportedFileFormat.GeoParquet && feature.Geometry == null)
+            {
+                totalFailed++;
+                nullGeometrySkipped++;
+                continue;
+            }
+
             batch.Add(feature);
 
             // Process batch when full
@@ -559,6 +664,12 @@ internal sealed partial class StreamingFileImportService : IFileImportService
 
         await AnalyzeTableAsync(connection, allowedTableName, cancellationToken);
 
+        // Surface skipped null-geometry rows in the completion progress report
+        // so background/queued imports expose the same warning as synchronous results.
+        string[] completionWarnings = format == SupportedFileFormat.GeoParquet && nullGeometrySkipped > 0
+            ? [.. warnings, string.Format(null, _nullGeometryWarningFormat, nullGeometrySkipped)]
+            : warnings as string[] ?? [.. warnings];
+
         // Report completion
         progress?.Report(new ImportProgress
         {
@@ -573,10 +684,10 @@ internal sealed partial class StreamingFileImportService : IFileImportService
             CompletedAt = DateTimeOffset.UtcNow,
             BytesRead = fileStream.CanSeek ? fileStream.Position : 0,
             TotalBytes = fileStream.CanSeek ? fileStream.Length : null,
-            Warnings = warnings
+            Warnings = completionWarnings
         });
 
-        return (totalImported, totalFailed);
+        return (totalImported, totalFailed, completionWarnings);
     }
 
     private void RecordImportMetrics(
@@ -958,6 +1069,22 @@ internal sealed partial class StreamingFileImportService : IFileImportService
         public static partial void CleanupScratchFailed(ILogger logger, Exception exception, string scratchDir);
     }
 
+    private static partial class GeoParquetLog
+    {
+        [LoggerMessage(
+            EventId = 7440,
+            Level = LogLevel.Warning,
+            Message = "Failed to clean up GeoParquet scratch directory {ScratchDir}")]
+        public static partial void CleanupScratchFailed(ILogger logger, Exception exception, string scratchDir);
+
+        [LoggerMessage(
+            EventId = 7441,
+            Level = LogLevel.Warning,
+            Message = "GeoParquet file has {RowGroupCount} row group(s) with largest group containing {MaxGroupRows} rows. " +
+                      "Row groups exceeding the per-group limit will materialize too much data in memory during import")]
+        public static partial void LargeRowGroupDetected(ILogger logger, int rowGroupCount, long maxGroupRows);
+    }
+
     /// <inheritdoc/>
     public async Task<FilePreview> PreviewFileAsync(
         Stream fileStream,
@@ -975,6 +1102,8 @@ internal sealed partial class StreamingFileImportService : IFileImportService
         GeoPackageScratch? geoPackageScratch = null;
         KmzScratch? kmzScratch = null;
         FileGdbScratch? fileGdbScratch = null;
+        GeoParquetScratch? geoParquetScratch = null;
+        long? geoParquetTotalRows = null;
         string[] warnings = [];
         Stream? kmzStream = null;
         try
@@ -1024,6 +1153,34 @@ internal sealed partial class StreamingFileImportService : IFileImportService
                 detectedSrid = FileGdb.FileGdbReader.DetectSrid(fileGdbScratch.GdbPath);
                 warnings = FileGdb.FileGdbAdvancedConstructs.DetectWarnings(fileGdbScratch.GdbPath);
             }
+            else if (format.Value == SupportedFileFormat.GeoParquet)
+            {
+                geoParquetScratch = await PrepareGeoParquetScratchAsync(fileStream, cancellationToken);
+                var scratchStream = geoParquetScratch.Stream;
+                var parquetMeta = await GeoParquetReader.ExtractMetadataAsync(scratchStream, cancellationToken);
+                detectedSrid = parquetMeta.Srid;
+                warnings = parquetMeta.Warnings;
+                geoParquetTotalRows = parquetMeta.TotalRowCount;
+
+                // Reject files with any oversized row group — consistent with import path
+                if (parquetMeta.MaxRowGroupRowCount > GeoParquetReader.MaxRowsPerRowGroup)
+                {
+                    throw new InvalidDataException(
+                        GeoParquetReader.BuildLargeRowGroupMessage(
+                            parquetMeta.MaxRowGroupRowCount, parquetMeta.RowGroupCount));
+                }
+
+                // Hard-reject non-WKB encoding — consistent with the import path
+                // (ImportFileAsync returns CreateFailure) and the documented contract
+                // ("Non-WKB encodings are rejected" in CONTROL_PLANE_API.md).
+                if (!parquetMeta.IsWkbEncoding)
+                {
+                    throw new NotSupportedException(
+                        GeoParquetReader.UnsupportedEncodingMessage);
+                }
+
+                fileStream = scratchStream;
+            }
             else
             {
                 if (!fileStream.CanSeek)
@@ -1056,13 +1213,20 @@ internal sealed partial class StreamingFileImportService : IFileImportService
                 SupportedFileFormat.Shapefile => ReadShapefileStreamingAsync(shapefileScratch!.ShpPath, cancellationToken),
                 SupportedFileFormat.GeoPackage => ReadGeoPackageStreamingAsync(geoPackageScratch!.FilePath, cancellationToken),
                 SupportedFileFormat.FileGdb => FileGdb.FileGdbReader.ReadStreamingAsync(fileGdbScratch!.GdbPath, cancellationToken),
+                SupportedFileFormat.GeoParquet => GeoParquetReader.ReadStreamingAsync(fileStream, cancellationToken),
                 _ => throw new NotSupportedException($"Preview not supported for format: {format}")
             };
 
             await foreach (var feature in featureStream.WithCancellation(cancellationToken))
             {
-                features.Add(feature);
-                if (features.Count >= _limits.MaxPreviewFeatures)
+                // GeoParquet: skip null-geometry rows from preview samples, matching
+                // the import path's skip behavior (ImportStreamingAsync).
+                if (format.Value == SupportedFileFormat.GeoParquet && feature.Geometry == null)
+                    continue;
+
+                if (features.Count < _limits.MaxPreviewFeatures)
+                    features.Add(feature);
+                else
                     break;
             }
 
@@ -1082,7 +1246,9 @@ internal sealed partial class StreamingFileImportService : IFileImportService
             return new FilePreview
             {
                 Format = format.Value,
-                TotalFeatureCount = features.Count,
+                TotalFeatureCount = geoParquetTotalRows.HasValue
+                    ? (int)Math.Min(geoParquetTotalRows.Value, int.MaxValue)
+                    : features.Count,
                 DetectedSrid = detectedSrid,
                 SampleProperties = sampleProperties,
                 AvailableLayers = availableLayers,
@@ -1100,6 +1266,7 @@ internal sealed partial class StreamingFileImportService : IFileImportService
             CleanupGeoPackageScratch(geoPackageScratch);
             CleanupKmzScratch(kmzScratch);
             CleanupFileGdbScratch(fileGdbScratch);
+            CleanupGeoParquetScratch(geoParquetScratch);
         }
     }
 
@@ -1219,6 +1386,20 @@ internal sealed partial class StreamingFileImportService : IFileImportService
     private sealed record KmzScratch(string DirectoryPath, string KmlPath);
 
     private sealed record FileGdbScratch(string DirectoryPath, string GdbPath);
+
+    private sealed record GeoParquetScratch(Stream Stream, string? ScratchDir) : IDisposable
+    {
+        public void Dispose()
+        {
+            // Only dispose the stream when the scratch owns it (non-seekable buffered copy).
+            // When ScratchDir is null, the scratch wraps the caller's original seekable stream
+            // and the caller is responsible for its lifetime.
+            if (ScratchDir != null)
+            {
+                Stream.Dispose();
+            }
+        }
+    }
 
     private sealed record GeoPackageLayerInfo(string TableName, string GeometryColumn, int? Srid);
 
@@ -1583,6 +1764,58 @@ internal sealed partial class StreamingFileImportService : IFileImportService
                     KmzLog.DeleteZipFailed(_logger, ex, zipPath);
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Buffer a GeoParquet stream to a seekable stream if needed.
+    /// </summary>
+    private async Task<GeoParquetScratch> PrepareGeoParquetScratchAsync(
+        Stream stream,
+        CancellationToken cancellationToken)
+    {
+        if (stream.CanSeek)
+        {
+            if (stream.Position != 0)
+            {
+                stream.Position = 0;
+            }
+
+            return new GeoParquetScratch(stream, null);
+        }
+
+        var scratchDir = Path.Combine(_geoParquetScratchRoot, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(scratchDir);
+
+        var filePath = Path.Combine(scratchDir, "upload.parquet");
+
+        try
+        {
+            await using var outputStream = new FileStream(filePath, new FileStreamOptions
+            {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.Write,
+                Share = FileShare.None,
+                BufferSize = _limits.StreamBufferSize,
+                Options = FileOptions.Asynchronous | FileOptions.SequentialScan
+            });
+            await stream.CopyToAsync(outputStream, cancellationToken);
+
+            var readStream = new FileStream(filePath, new FileStreamOptions
+            {
+                Mode = FileMode.Open,
+                Access = FileAccess.Read,
+                Share = FileShare.Read,
+                BufferSize = _limits.StreamBufferSize,
+                Options = FileOptions.Asynchronous | FileOptions.RandomAccess
+            });
+
+            return new GeoParquetScratch(readStream, scratchDir);
+        }
+        catch
+        {
+            CleanupGeoParquetScratchDirectory(scratchDir);
+            throw;
         }
     }
 
@@ -1992,6 +2225,43 @@ internal sealed partial class StreamingFileImportService : IFileImportService
         catch (Exception ex)
         {
             FileGdbLog.CleanupScratchFailed(_logger, ex, scratchDir);
+        }
+    }
+
+    private void CleanupGeoParquetScratch(GeoParquetScratch? scratch)
+    {
+        if (scratch == null)
+        {
+            return;
+        }
+
+        // Only dispose stream and directory if we created a scratch copy.
+        // When ScratchDir is null, the scratch wraps the caller's original seekable
+        // stream which is disposed by the caller.
+        if (scratch.ScratchDir != null)
+        {
+            scratch.Dispose();
+            CleanupGeoParquetScratchDirectory(scratch.ScratchDir);
+        }
+    }
+
+    private void CleanupGeoParquetScratchDirectory(string scratchDir)
+    {
+        if (string.IsNullOrWhiteSpace(scratchDir))
+        {
+            return;
+        }
+
+        try
+        {
+            if (Directory.Exists(scratchDir))
+            {
+                Directory.Delete(scratchDir, recursive: true);
+            }
+        }
+        catch (Exception ex)
+        {
+            GeoParquetLog.CleanupScratchFailed(_logger, ex, scratchDir);
         }
     }
 

--- a/src/Honua.Postgres/Honua.Postgres.csproj
+++ b/src/Honua.Postgres/Honua.Postgres.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="dbup-postgresql" Version="6.1.5" />
     <PackageReference Include="NetTopologySuite.IO.Esri.Shapefile" Version="1.2.0" />
     <PackageReference Include="NetTopologySuite.IO.GeoPackage" Version="2.0.0" />
+    <PackageReference Include="Parquet.Net" Version="5.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honua.Server/Features/Import/ImportEndpoints.cs
+++ b/src/Honua.Server/Features/Import/ImportEndpoints.cs
@@ -156,7 +156,9 @@ internal static partial class ImportEndpoints
             [".csv"] = "CSV - Comma-separated values with lon/lat or WKT geometry columns",
             [".twkb"] = "TinyWKB - Compact binary format",
             [".gdb"] = "Esri File Geodatabase - native Esri vector format",
-            [".gdb.zip"] = "Zipped File Geodatabase - compressed .gdb archive"
+            [".gdb.zip"] = "Zipped File Geodatabase - compressed .gdb archive",
+            [".parquet"] = "GeoParquet - Apache Parquet with geospatial metadata",
+            [".geoparquet"] = "GeoParquet - Apache Parquet with geospatial metadata"
         };
 
         var response = new FileFormatsResponse
@@ -364,6 +366,22 @@ internal static partial class ImportEndpoints
                 cancellationToken);
             IResult result = Results.Json(preview, ImportJsonContext.Default.FilePreview);
             await result.ExecuteAsync(context);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidDataException or NotSupportedException)
+        {
+            var logger = context.RequestServices.GetRequiredService<ILogger<ImportEndpointsLog>>();
+            Log.PreviewFailed(logger, staged.File?.FileName ?? "unknown", ex);
+            await AdminResponseWriter.WriteErrorAsync(context, "Failed to preview file", StatusCodes.Status400BadRequest);
+        }
+        catch (Exception ex)
+        {
+            var logger = context.RequestServices.GetRequiredService<ILogger<ImportEndpointsLog>>();
+            Log.PreviewFailed(logger, staged.File?.FileName ?? "unknown", ex);
+            await AdminResponseWriter.WriteErrorAsync(context, "Failed to preview file", StatusCodes.Status500InternalServerError);
         }
         finally
         {

--- a/src/Honua.Server/Features/Import/ImportJsonContext.cs
+++ b/src/Honua.Server/Features/Import/ImportJsonContext.cs
@@ -40,8 +40,14 @@ namespace Honua.Server.Features.Import;
 [JsonSerializable(typeof(IReadOnlyList<string>))]
 [JsonSerializable(typeof(object))]
 [JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(sbyte))]
+[JsonSerializable(typeof(short))]
 [JsonSerializable(typeof(int))]
 [JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(byte))]
+[JsonSerializable(typeof(ushort))]
+[JsonSerializable(typeof(uint))]
+[JsonSerializable(typeof(ulong))]
 [JsonSerializable(typeof(double))]
 [JsonSerializable(typeof(float))]
 [JsonSerializable(typeof(decimal))]
@@ -50,7 +56,9 @@ namespace Honua.Server.Features.Import;
 [JsonSerializable(typeof(DateTime))]
 [JsonSerializable(typeof(string[]))]
 [JsonSerializable(typeof(TimeSpan))]
-[JsonSerializable(typeof(DateTimeOffset))]
+[JsonSerializable(typeof(byte[]))]
+[JsonSerializable(typeof(TimeOnly))]
+[JsonSerializable(typeof(DateOnly))]
 internal sealed partial class ImportJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Server/Features/Infrastructure/Security/FileUploadSecurity.cs
+++ b/src/Honua.Server/Features/Infrastructure/Security/FileUploadSecurity.cs
@@ -63,6 +63,9 @@ internal static class FileUploadSecurity
             // KML/KMZ
             "application/vnd.google-earth.kml+xml",
             "application/vnd.google-earth.kmz",
+            // GeoParquet
+            "application/vnd.apache.parquet",
+            "application/x-parquet",
         }
         .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
@@ -83,6 +86,7 @@ internal static class FileUploadSecurity
             ".gml", ".xml",
             ".tab", ".mif", ".mid", // MapInfo formats
             ".gdb", // File geodatabase (folder)
+            ".parquet", ".geoparquet", // GeoParquet
         }
         .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 

--- a/tests/Honua.Postgres.Tests/Features/Import/GeoParquetPreviewTests.cs
+++ b/tests/Honua.Postgres.Tests/Features/Import/GeoParquetPreviewTests.cs
@@ -3,30 +3,21 @@
 
 using System.Data;
 using System.Data.Common;
-using System.Text.Json;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Monitoring;
 using Honua.Postgres.Features.Import;
+using Honua.TestKit;
 using Microsoft.Extensions.Logging.Abstractions;
-using NetTopologySuite.Geometries;
-using NetTopologySuite.IO;
-using Parquet;
-using Parquet.Schema;
-using ParquetDataColumn = Parquet.Data.DataColumn;
 
 namespace Honua.Postgres.Tests.Features.Import;
 
 public sealed class GeoParquetPreviewTests
 {
-    private static readonly string[] PointGeometryTypes = ["Point"];
-    private static readonly long?[] ObjectIdValues = [1L];
-    private static readonly string?[] NameValues = ["Test Feature"];
-
     [Fact]
     public async Task PreviewFileAsync_GeoParquet_ReturnsPreviewMetadata()
     {
-        await using var stream = await CreateGeoParquetStreamAsync();
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync();
         var service = CreateService();
 
         var preview = await service.PreviewFileAsync(stream, "sample.parquet");
@@ -36,6 +27,304 @@ public sealed class GeoParquetPreviewTests
         preview.TotalFeatureCount.Should().Be(1);
         preview.SampleProperties.Should().ContainKey("name");
         preview.SampleProperties["name"].Should().Be("Test Feature");
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_NoCrsKey_DefaultsToSrid4326()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync(crs: GeoParquetTestFactory.CrsStyle.Omitted);
+        var service = CreateService();
+
+        var preview = await service.PreviewFileAsync(stream, "no_crs.parquet");
+
+        preview.Format.Should().Be(SupportedFileFormat.GeoParquet);
+        preview.DetectedSrid.Should().Be(4326);
+        preview.TotalFeatureCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_ExplicitNullCrs_ReturnsNullSrid()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync(crs: GeoParquetTestFactory.CrsStyle.ExplicitNull);
+        var service = CreateService();
+
+        var preview = await service.PreviewFileAsync(stream, "null_crs.parquet");
+
+        preview.Format.Should().Be(SupportedFileFormat.GeoParquet);
+        preview.DetectedSrid.Should().BeNull();
+        preview.TotalFeatureCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_OgcCrs84ProjJson_DefaultsToSrid4326()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync(crs: GeoParquetTestFactory.CrsStyle.OgcCrs84ProjJson);
+        var service = CreateService();
+
+        var preview = await service.PreviewFileAsync(stream, "ogc_crs84_projjson.parquet");
+
+        preview.Format.Should().Be(SupportedFileFormat.GeoParquet);
+        preview.DetectedSrid.Should().Be(4326);
+        preview.TotalFeatureCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_OgcCrs84PropertiesName_DefaultsToSrid4326()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync(crs: GeoParquetTestFactory.CrsStyle.OgcCrs84PropertiesName);
+        var service = CreateService();
+
+        var preview = await service.PreviewFileAsync(stream, "ogc_crs84_propname.parquet");
+
+        preview.Format.Should().Be(SupportedFileFormat.GeoParquet);
+        preview.DetectedSrid.Should().Be(4326);
+        preview.TotalFeatureCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_DecimalEpsgCode_FallsBackToNullSrid()
+    {
+        // CRS with decimal EPSG code (4326.5) — not a valid integer, should fall through gracefully
+        var crs = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["id"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["authority"] = "EPSG",
+                ["code"] = 4326.5
+            }
+        };
+        await using var stream = await GeoParquetTestFactory.CreateWithCustomCrsAsync(crs);
+        var service = CreateService();
+
+        var preview = await service.PreviewFileAsync(stream, "decimal_crs.parquet");
+
+        preview.Format.Should().Be(SupportedFileFormat.GeoParquet);
+        preview.DetectedSrid.Should().BeNull();
+        preview.TotalFeatureCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_OutOfRangeEpsgCode_FallsBackToNullSrid()
+    {
+        // CRS with huge EPSG code exceeding Int32 range — should fall through gracefully
+        var crs = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["id"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["authority"] = "EPSG",
+                ["code"] = 99999999999L
+            }
+        };
+        await using var stream = await GeoParquetTestFactory.CreateWithCustomCrsAsync(crs);
+        var service = CreateService();
+
+        var preview = await service.PreviewFileAsync(stream, "huge_crs.parquet");
+
+        preview.Format.Should().Be(SupportedFileFormat.GeoParquet);
+        preview.DetectedSrid.Should().BeNull();
+        preview.TotalFeatureCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_NonWkbEncoding_ThrowsNotSupportedException()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync(encoding: "point");
+        var service = CreateService();
+
+        var act = () => service.PreviewFileAsync(stream, "non_wkb.parquet");
+
+        await act.Should().ThrowAsync<NotSupportedException>()
+            .WithMessage("*Only WKB encoding is supported*");
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_SecondaryGeometryColumn_ExcludedFromProperties()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateWithSecondaryGeometryAsync();
+        var service = CreateService();
+
+        var preview = await service.PreviewFileAsync(stream, "multi_geom.parquet");
+
+        preview.Format.Should().Be(SupportedFileFormat.GeoParquet);
+        preview.TotalFeatureCount.Should().Be(1);
+        preview.SampleProperties.Should().ContainKey("name");
+        preview.SampleProperties.Should().NotContainKey("geometry");
+        preview.SampleProperties.Should().NotContainKey("geometry2");
+        preview.Warnings.Should().Contain(w => w.Contains("multiple geometry columns"));
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_MalformedGeoJson_ThrowsInvalidDataException()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateWithMalformedMetadataAsync();
+        var service = CreateService();
+
+        var act = () => service.PreviewFileAsync(stream, "bad_meta.parquet");
+
+        await act.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*malformed*");
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_NoGeoMetadataKey_ThrowsInvalidDataException()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateWithoutGeoMetadataAsync();
+        var service = CreateService();
+
+        var act = () => service.PreviewFileAsync(stream, "plain.parquet");
+
+        await act.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*missing required*geo*");
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_WrongShapedMetadata_ThrowsInvalidDataException()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateWithWrongShapedMetadataAsync();
+        var service = CreateService();
+
+        var act = () => service.PreviewFileAsync(stream, "wrong_shape.parquet");
+
+        await act.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*unexpected structure*");
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_TotalFeatureCount_ReflectsFullRowCount()
+    {
+        // Create a file with 5 rows but cap preview samples at 2.
+        // TotalFeatureCount comes from Parquet footer metadata (5),
+        // not the sample size (2).
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync(rowCount: 5);
+        var service = CreateService(maxPreviewFeatures: 2);
+
+        var preview = await service.PreviewFileAsync(stream, "multi_row.parquet");
+
+        preview.Format.Should().Be(SupportedFileFormat.GeoParquet);
+        preview.TotalFeatureCount.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_NullGeometryRow_ExcludedFromSamples()
+    {
+        // Row 1 has geometry, Row 2 has null geometry
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync(includeNullGeometryRow: true);
+        var service = CreateService();
+
+        var preview = await service.PreviewFileAsync(stream, "null_geom.parquet");
+
+        preview.Format.Should().Be(SupportedFileFormat.GeoParquet);
+        // TotalFeatureCount comes from Parquet footer metadata (all rows)
+        preview.TotalFeatureCount.Should().Be(2);
+        // Preview samples exclude null-geometry rows
+        preview.SampleProperties.Should().ContainKey("name");
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_TimeAndBinaryColumns_IncludedInSampleProperties()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateWithTimeAndBinaryColumnsAsync();
+        var service = CreateService();
+
+        var preview = await service.PreviewFileAsync(stream, "time_binary.parquet");
+
+        preview.Format.Should().Be(SupportedFileFormat.GeoParquet);
+        preview.TotalFeatureCount.Should().Be(1);
+        preview.SampleProperties.Should().ContainKey("event_time");
+        // byte[] is converted to base64 in preview path
+        preview.SampleProperties.Should().ContainKey("thumbnail");
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_Int16Column_IncludedInSampleProperties()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateWithInt16ColumnAsync();
+        var service = CreateService();
+
+        var preview = await service.PreviewFileAsync(stream, "int16.parquet");
+
+        preview.Format.Should().Be(SupportedFileFormat.GeoParquet);
+        preview.TotalFeatureCount.Should().Be(1);
+        preview.SampleProperties.Should().ContainKey("priority");
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_ProjJsonStringEpsgCode_DetectsSrid4326()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync(crs: GeoParquetTestFactory.CrsStyle.ProjJsonStringCode);
+        var service = CreateService();
+
+        var preview = await service.PreviewFileAsync(stream, "string_code.parquet");
+
+        preview.Format.Should().Be(SupportedFileFormat.GeoParquet);
+        preview.DetectedSrid.Should().Be(4326);
+        preview.TotalFeatureCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_MissingPrimaryColumn_ThrowsInvalidDataException()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateWithMissingPrimaryColumnAsync();
+        var service = CreateService();
+
+        var act = () => service.PreviewFileAsync(stream, "no_primary_col.parquet");
+
+        await act.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*primary_column*");
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_MissingColumnsField_ThrowsInvalidDataException()
+    {
+        await using var stream = await GeoParquetTestFactory.CreateWithMissingColumnsFieldAsync();
+        var service = CreateService();
+
+        var act = () => service.PreviewFileAsync(stream, "no_columns.parquet");
+
+        await act.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*columns*");
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_LargeSingleRowGroup_ThrowsInvalidDataException()
+    {
+        // Create a file with more rows than MaxRowsPerRowGroup (100,000) in a single
+        // row group. Parquet.Net materializes the whole group in memory, so the service
+        // must reject these files to honour the bounded-memory contract.
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync(
+            rowCount: 100_001);
+        var service = CreateService();
+
+        var act = () => service.PreviewFileAsync(stream, "large_rg.parquet");
+
+        await act.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*row group*");
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_MismatchedPrimaryColumn_ThrowsInvalidDataException()
+    {
+        // Geo metadata references "geometry" but the Parquet schema has no such column
+        await using var stream = await GeoParquetTestFactory.CreateWithMismatchedPrimaryColumnAsync();
+        var service = CreateService();
+
+        var act = () => service.PreviewFileAsync(stream, "mismatched.parquet");
+
+        await act.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*geometry*not found*schema*");
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_PrimaryColumnMissingFromGeoColumns_ThrowsInvalidDataException()
+    {
+        // Parquet schema has "geometry", but geo.columns only describes "other_geom"
+        await using var stream = await GeoParquetTestFactory.CreateWithPrimaryColumnMissingFromGeoColumnsAsync();
+        var service = CreateService();
+
+        var act = () => service.PreviewFileAsync(stream, "missing_in_columns.parquet");
+
+        await act.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*primary_column*columns*");
     }
 
     [Fact]
@@ -49,63 +338,52 @@ public sealed class GeoParquetPreviewTests
         service.GetSupportedExtensions().Should().Contain(".geoparquet");
     }
 
-    private static async Task<MemoryStream> CreateGeoParquetStreamAsync()
+    [Fact]
+    public void DetectFormat_UppercaseExtension_StillDetectsGeoParquet()
     {
-        var objectIdField = new DataField<long?>("objectid");
-        var nameField = new DataField<string>("name", true);
-        var geometryField = new DataField<byte[]>("geometry", true);
-        var schema = new ParquetSchema(objectIdField, nameField, geometryField);
+        var service = CreateService();
 
-        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            ["geo"] = JsonSerializer.Serialize(new Dictionary<string, object?>(StringComparer.Ordinal)
-            {
-                ["version"] = "1.1.0",
-                ["primary_column"] = "geometry",
-                ["columns"] = new Dictionary<string, object?>(StringComparer.Ordinal)
-                {
-                    ["geometry"] = new Dictionary<string, object?>(StringComparer.Ordinal)
-                    {
-                        ["encoding"] = "WKB",
-                        ["geometry_types"] = PointGeometryTypes,
-                        ["crs"] = new Dictionary<string, object?>(StringComparer.Ordinal)
-                        {
-                            ["id"] = new Dictionary<string, object?>(StringComparer.Ordinal)
-                            {
-                                ["authority"] = "EPSG",
-                                ["code"] = 4326
-                            }
-                        }
-                    }
-                }
-            })
-        };
-
-        var point = new Point(-122.4194, 37.7749) { SRID = 4326 };
-        var geometryBytes = new WKBWriter().Write(point);
-
-        var stream = new MemoryStream();
-        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
-        {
-            writer.CustomMetadata = metadata;
-            using var rowGroupWriter = writer.CreateRowGroup();
-            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, ObjectIdValues));
-            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(nameField, NameValues));
-            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(geometryField, new byte[]?[] { geometryBytes }));
-        }
-
-        stream.Position = 0;
-        return stream;
+        service.DetectFormat("SAMPLE.PARQUET").Should().Be(SupportedFileFormat.GeoParquet);
+        service.DetectFormat("data.GeoParquet").Should().Be(SupportedFileFormat.GeoParquet);
+        service.DetectFormat("mixed.Parquet").Should().Be(SupportedFileFormat.GeoParquet);
     }
 
-    private static StreamingFileImportService CreateService()
+    [Fact]
+    public void DetectFormat_UppercaseExtension_WorksForPreExistingFormats()
+    {
+        var service = CreateService();
+
+        service.DetectFormat("data.GEOJSON").Should().Be(SupportedFileFormat.GeoJson);
+        service.DetectFormat("ARCHIVE.GPKG").Should().Be(SupportedFileFormat.GeoPackage);
+        service.DetectFormat("tracks.GPX").Should().Be(SupportedFileFormat.Gpx);
+    }
+
+    [Fact]
+    public async Task PreviewFileAsync_GeoParquet_CorruptedFile_ThrowsInvalidDataException()
+    {
+        // A stream whose contents are not a valid Parquet file. Parquet.Net throws
+        // IOException for invalid magic bytes; GeoParquetReader must normalize this
+        // to InvalidDataException so the endpoint returns 400, not 500.
+        await using var stream = new MemoryStream("not a parquet file"u8.ToArray());
+        var service = CreateService();
+
+        var act = () => service.PreviewFileAsync(stream, "corrupted.parquet");
+
+        await act.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*not a valid Parquet*");
+    }
+
+    private static StreamingFileImportService CreateService(int? maxPreviewFeatures = null)
     {
         var connectionProvider = new ThrowingConnectionProvider();
         var crsDetectionService = new NoopCrsDetectionService();
         var performanceMonitor = new NoopPerformanceMonitor();
         var logger = NullLogger<StreamingFileImportService>.Instance;
+        var limits = maxPreviewFeatures.HasValue
+            ? new ImportLimits { MaxPreviewFeatures = maxPreviewFeatures.Value }
+            : null;
 
-        return new StreamingFileImportService(connectionProvider, crsDetectionService, performanceMonitor, logger);
+        return new StreamingFileImportService(connectionProvider, crsDetectionService, performanceMonitor, logger, limits);
     }
 
     private sealed class ThrowingConnectionProvider : IDatabaseConnectionProvider

--- a/tests/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj
+++ b/tests/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <Compile Remove="Features\Import\FlatGeobufPreviewTests.cs" />
-    <Compile Remove="Features\Import\GeoParquetPreviewTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Honua.Server.Tests/Import/GeoParquetImportTests.cs
+++ b/tests/Honua.Server.Tests/Import/GeoParquetImportTests.cs
@@ -1,0 +1,248 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Headers;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+
+namespace Honua.Server.Tests.Import;
+
+/// <summary>
+/// Integration tests for GeoParquet import (upload) endpoint.
+/// </summary>
+[Collection("Database")]
+[Protocol(Protocols.Admin)]
+[Operation(Operations.Import)]
+public sealed class GeoParquetImportTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Upload_WithGeoParquet_ImportsFeaturesToTable()
+    {
+        // Arrange
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync(
+            encoding: "WKB",
+            crs: GeoParquetTestFactory.CrsStyle.PropertiesName);
+        var fileBytes = stream.ToArray();
+
+        var content = CreateUploadContent(fileBytes, "sample.parquet", "geoparquet_import_test");
+
+        // Act
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        // Assert
+        response.BeSuccessful();
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        responseContent.Should().Contain("geoparquet_import_test");
+        responseContent.Should().Contain("GeoParquet");
+        responseContent.Should().Contain("\"success\":true");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Upload_WithNestedColumn_ImportsSuccessfullyWithWarning()
+    {
+        // Arrange - create file with a StructField column
+        await using var stream = await GeoParquetTestFactory.CreateWithNestedColumnAsync(
+            crs: GeoParquetTestFactory.CrsStyle.PropertiesName);
+        var fileBytes = stream.ToArray();
+
+        var content = CreateUploadContent(fileBytes, "nested.parquet", "geoparquet_nested_test");
+
+        // Act
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        // Assert
+        response.BeSuccessful();
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        responseContent.Should().Contain("geoparquet_nested_test");
+        responseContent.Should().Contain("GeoParquet");
+        responseContent.Should().Contain("\"success\":true");
+        responseContent.Should().Contain("nested type");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Upload_WithNonWkbEncoding_RejectsWithError()
+    {
+        // Arrange - create file with "point" encoding
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync(
+            encoding: "point",
+            crs: GeoParquetTestFactory.CrsStyle.PropertiesName);
+        var fileBytes = stream.ToArray();
+
+        var content = CreateUploadContent(fileBytes, "point_encoded.parquet", "geoparquet_reject_test");
+
+        // Act
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        responseContent.Should().Contain("geoparquet_reject_test");
+        responseContent.Should().Contain("\"success\":false");
+        responseContent.Should().Contain("Only WKB encoding is supported");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Upload_WithNullGeometryRow_SkipsAndCountsAsFailure()
+    {
+        // Arrange - 2 rows: one with geometry, one with null geometry
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync(
+            crs: GeoParquetTestFactory.CrsStyle.PropertiesName,
+            includeNullGeometryRow: true);
+        var fileBytes = stream.ToArray();
+
+        var content = CreateUploadContent(fileBytes, "null_geom.parquet", "geoparquet_null_geom_test");
+
+        // Act
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        // Assert
+        response.BeSuccessful();
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        responseContent.Should().Contain("geoparquet_null_geom_test");
+        responseContent.Should().Contain("GeoParquet");
+        responseContent.Should().Contain("\"success\":true");
+        // Only the row with geometry should be imported
+        responseContent.Should().Contain("\"featureCount\":1");
+        // Null-geometry skip should be surfaced as a warning
+        responseContent.Should().Contain("skipped because geometry was null");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Upload_WithTimeAndBinaryColumns_ImportsSuccessfully()
+    {
+        // Arrange - create file with TimeOnly and byte[] attribute columns
+        await using var stream = await GeoParquetTestFactory.CreateWithTimeAndBinaryColumnsAsync(
+            crs: GeoParquetTestFactory.CrsStyle.PropertiesName);
+        var fileBytes = stream.ToArray();
+
+        var content = CreateUploadContent(fileBytes, "time_binary.parquet", "geoparquet_time_binary_test");
+
+        // Act
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        // Assert
+        response.BeSuccessful();
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        responseContent.Should().Contain("geoparquet_time_binary_test");
+        responseContent.Should().Contain("GeoParquet");
+        responseContent.Should().Contain("\"success\":true");
+        responseContent.Should().Contain("\"featureCount\":1");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Upload_WithInt16Column_ImportsSuccessfully()
+    {
+        // Arrange - create file with an INT16 (short) attribute column
+        await using var stream = await GeoParquetTestFactory.CreateWithInt16ColumnAsync(
+            crs: GeoParquetTestFactory.CrsStyle.PropertiesName);
+        var fileBytes = stream.ToArray();
+
+        var content = CreateUploadContent(fileBytes, "int16.parquet", "geoparquet_int16_test");
+
+        // Act
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        // Assert
+        response.BeSuccessful();
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        responseContent.Should().Contain("geoparquet_int16_test");
+        responseContent.Should().Contain("GeoParquet");
+        responseContent.Should().Contain("\"success\":true");
+        responseContent.Should().Contain("\"featureCount\":1");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Upload_WithLargeSingleRowGroup_RejectsWithError()
+    {
+        // Arrange — file exceeds GeoParquetReader.MaxRowsPerRowGroup (100,000)
+        // in a single row group. Service must reject before streaming features.
+        await using var stream = await GeoParquetTestFactory.CreateStreamAsync(
+            rowCount: 100_001,
+            crs: GeoParquetTestFactory.CrsStyle.PropertiesName);
+        var fileBytes = stream.ToArray();
+
+        var content = CreateUploadContent(fileBytes, "large_rg.parquet", "geoparquet_large_rg_test");
+
+        // Act
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        responseContent.Should().Contain("geoparquet_large_rg_test");
+        responseContent.Should().Contain("\"success\":false");
+        responseContent.Should().Contain("row group");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Upload_WithMissingGeoMetadata_RejectsWithSpecificError()
+    {
+        // Arrange - a plain Parquet file with no "geo" metadata key.
+        // The import path should surface the specific validation message
+        // instead of collapsing to the generic "Import failed."
+        await using var stream = await GeoParquetTestFactory.CreateWithoutGeoMetadataAsync();
+        var fileBytes = stream.ToArray();
+
+        var content = CreateUploadContent(fileBytes, "plain.parquet", "geoparquet_no_geo_test");
+
+        // Act
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        responseContent.Should().Contain("geoparquet_no_geo_test");
+        responseContent.Should().Contain("\"success\":false");
+        // Must surface the specific validation reason, not "Import failed."
+        responseContent.Should().Contain("geo");
+    }
+
+    private static MultipartFormDataContent CreateUploadContent(byte[] fileBytes, string fileName, string tableName)
+    {
+        var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(fileBytes);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+        {
+            Name = "File",
+            FileName = fileName
+        };
+        content.Add(fileContent);
+        content.Add(new StringContent(tableName), "TableName");
+        content.Add(new StringContent("4326"), "TargetSrid");
+        content.Add(new StringContent("true"), "OverwriteExisting");
+        return content;
+    }
+}

--- a/tests/Honua.Server.Tests/Import/GeoParquetUrlPreviewTests.cs
+++ b/tests/Honua.Server.Tests/Import/GeoParquetUrlPreviewTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Import;
+
+/// <summary>
+/// Integration tests for GeoParquet preview-url error handling.
+/// Verifies that invalid GeoParquet metadata returns 400 instead of 500.
+/// </summary>
+[Collection("Database")]
+[Protocol(Protocols.Admin)]
+[Operation(Operations.Import)]
+public sealed class GeoParquetUrlPreviewTests : IAsyncLifetime
+{
+    private const string StubUrl = "https://s3.amazonaws.com/sample-bucket/test.parquet";
+
+    private WebAppFixture _fixture = null!;
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        // Create a valid Parquet file that is missing the required "geo" metadata key.
+        // This triggers InvalidDataException in GeoParquetReader.ParseGeoMetadata.
+        await using var stream = await GeoParquetTestFactory.CreateWithoutGeoMetadataAsync();
+        var parquetBytes = stream.ToArray();
+
+        _fixture = new WebAppFixture()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IHttpClientFactory>(
+                    new BinaryStubHttpClientFactory(
+                        StubUrl,
+                        "application/vnd.apache.parquet",
+                        parquetBytes));
+            });
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/preview-url")]
+    public async Task PreviewUrl_WithMissingGeoMetadata_Returns400()
+    {
+        using var response = await _client.PostAsync(
+            "/api/v1/admin/import/preview-url",
+            JsonContent($$"""
+            {
+              "sourceUrl": "{{StubUrl}}"
+            }
+            """));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("Failed to preview file");
+    }
+
+    private static StringContent JsonContent(string json)
+        => new(json, Encoding.UTF8, "application/json");
+
+    private sealed class BinaryStubHttpClientFactory(string expectedUrl, string contentType, byte[] body) : IHttpClientFactory, IDisposable
+    {
+        private readonly HttpClient _client = new(new BinaryStubHttpMessageHandler(expectedUrl, contentType, body));
+
+        public HttpClient CreateClient(string name) => _client;
+
+        public void Dispose()
+        {
+            _client.Dispose();
+        }
+    }
+
+    private sealed class BinaryStubHttpMessageHandler(string expectedUrl, string contentType, byte[] body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.RequestUri.Should().NotBeNull();
+            request.RequestUri!.ToString().Should().Be(expectedUrl);
+
+            var content = new ByteArrayContent(body);
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = content
+            });
+        }
+    }
+}

--- a/tests/Honua.TestKit/GeoParquetTestFactory.cs
+++ b/tests/Honua.TestKit/GeoParquetTestFactory.cs
@@ -1,0 +1,642 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using Parquet;
+using Parquet.Schema;
+using ParquetDataColumn = Parquet.Data.DataColumn;
+
+namespace Honua.TestKit;
+
+/// <summary>
+/// Shared factory for creating in-memory GeoParquet test files.
+/// Eliminates duplication across preview and integration test classes.
+/// </summary>
+public static class GeoParquetTestFactory
+{
+    private static readonly string[] PointGeometryTypes = ["Point"];
+    private static readonly long?[] SingleObjectId = [1L];
+    private static readonly string?[] SingleName = ["Test Feature"];
+    private static readonly string?[] SingleKey = ["test_key"];
+    private static readonly string?[] SingleValue = ["test_value"];
+    private static readonly byte[]?[] NullGeometryData = [null];
+
+    /// <summary>
+    /// How the CRS is encoded in the GeoParquet "geo" metadata.
+    /// </summary>
+    public enum CrsStyle
+    {
+        /// <summary>PROJJSON format: id.authority = "EPSG", id.code = 4326 (GeoParquet 1.1.0 spec)</summary>
+        ProjJson,
+        /// <summary>GeoJSON-style: properties.name = "EPSG:4326"</summary>
+        PropertiesName,
+        /// <summary>No "crs" key — defaults to OGC:CRS84 per spec</summary>
+        Omitted,
+        /// <summary>PROJJSON format: id.authority = "OGC", id.code = "CRS84"</summary>
+        OgcCrs84ProjJson,
+        /// <summary>GeoJSON-style: properties.name = "OGC:CRS84"</summary>
+        OgcCrs84PropertiesName,
+        /// <summary>Explicit JSON null — "no CRS associated with this data" per GeoParquet 1.1.0 spec</summary>
+        ExplicitNull,
+        /// <summary>PROJJSON format with string code: id.authority = "EPSG", id.code = "4326"</summary>
+        ProjJsonStringCode
+    }
+
+    /// <summary>
+    /// Create a standard GeoParquet file with configurable encoding, CRS, and row count.
+    /// </summary>
+    public static async Task<MemoryStream> CreateStreamAsync(
+        string encoding = "WKB",
+        CrsStyle crs = CrsStyle.ProjJson,
+        int rowCount = 1,
+        bool includeNullGeometryRow = false)
+    {
+        var objectIdField = new DataField<long?>("objectid");
+        var nameField = new DataField<string>("name", true);
+        var geometryField = new DataField<byte[]>("geometry", true);
+        var schema = new ParquetSchema(objectIdField, nameField, geometryField);
+
+        var geomColumnMeta = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["encoding"] = encoding,
+            ["geometry_types"] = PointGeometryTypes
+        };
+
+        if (crs == CrsStyle.ExplicitNull)
+        {
+            geomColumnMeta["crs"] = null;
+        }
+        else if (crs != CrsStyle.Omitted)
+        {
+            geomColumnMeta["crs"] = BuildCrsObject(crs);
+        }
+
+        var metadata = BuildGeoMetadata(
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["geometry"] = geomColumnMeta
+            });
+
+        var point = new Point(-122.4194, 37.7749) { SRID = 4326 };
+        var geometryBytes = new WKBWriter().Write(point);
+
+        var totalRows = includeNullGeometryRow ? rowCount + 1 : rowCount;
+        var ids = new long?[totalRows];
+        var names = new string?[totalRows];
+        var geoms = new byte[]?[totalRows];
+
+        for (var i = 0; i < rowCount; i++)
+        {
+            ids[i] = i + 1L;
+            names[i] = rowCount == 1 ? "Test Feature" : $"Feature {i + 1}";
+            geoms[i] = geometryBytes;
+        }
+
+        if (includeNullGeometryRow)
+        {
+            ids[totalRows - 1] = totalRows;
+            names[totalRows - 1] = "No Geometry";
+            geoms[totalRows - 1] = null;
+        }
+
+        var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
+        {
+            writer.CustomMetadata = metadata;
+            using var rowGroupWriter = writer.CreateRowGroup();
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, ids));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(nameField, names));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(geometryField, geoms));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    /// <summary>
+    /// Create a GeoParquet file with a secondary geometry column.
+    /// </summary>
+    public static async Task<MemoryStream> CreateWithSecondaryGeometryAsync()
+    {
+        var objectIdField = new DataField<long?>("objectid");
+        var nameField = new DataField<string>("name", true);
+        var geometryField = new DataField<byte[]>("geometry", true);
+        var geometry2Field = new DataField<byte[]>("geometry2", true);
+        var schema = new ParquetSchema(objectIdField, nameField, geometryField, geometry2Field);
+
+        var metadata = BuildGeoMetadata(
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["geometry"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["encoding"] = "WKB",
+                    ["geometry_types"] = PointGeometryTypes,
+                    ["crs"] = BuildCrsObject(CrsStyle.ProjJson)
+                },
+                ["geometry2"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["encoding"] = "WKB",
+                    ["geometry_types"] = PointGeometryTypes
+                }
+            });
+
+        var point = new Point(-122.4194, 37.7749) { SRID = 4326 };
+        var geometryBytes = new WKBWriter().Write(point);
+
+        var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
+        {
+            writer.CustomMetadata = metadata;
+            using var rowGroupWriter = writer.CreateRowGroup();
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, SingleObjectId));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(nameField, SingleName));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(geometryField, new[] { geometryBytes }));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(geometry2Field, new[] { geometryBytes }));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    /// <summary>
+    /// Create a GeoParquet file with a nested StructField column.
+    /// </summary>
+    public static async Task<MemoryStream> CreateWithNestedColumnAsync(CrsStyle crs = CrsStyle.ProjJson)
+    {
+        var objectIdField = new DataField<long?>("objectid");
+        var nameField = new DataField<string>("name", true);
+        var geometryField = new DataField<byte[]>("geometry", true);
+        var keyField = new DataField<string>("key", true);
+        var valueField = new DataField<string>("value", true);
+        var nestedField = new StructField("metadata", keyField, valueField);
+        var schema = new ParquetSchema(objectIdField, nameField, geometryField, nestedField);
+
+        var geomColumnMeta = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["encoding"] = "WKB",
+            ["geometry_types"] = PointGeometryTypes,
+            ["crs"] = BuildCrsObject(crs)
+        };
+
+        var metadata = BuildGeoMetadata(
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["geometry"] = geomColumnMeta
+            });
+
+        var point = new Point(-122.4194, 37.7749) { SRID = 4326 };
+        var geometryBytes = new WKBWriter().Write(point);
+
+        var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
+        {
+            writer.CustomMetadata = metadata;
+            using var rowGroupWriter = writer.CreateRowGroup();
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, SingleObjectId));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(nameField, SingleName));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(geometryField, new[] { geometryBytes }));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(keyField, SingleKey));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(valueField, SingleValue));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    /// <summary>
+    /// Create a GeoParquet file with TimeOnly and byte[] attribute columns.
+    /// Exercises the Parquet types that tripped the import/preview JSON context gap.
+    /// </summary>
+    public static async Task<MemoryStream> CreateWithTimeAndBinaryColumnsAsync(CrsStyle crs = CrsStyle.ProjJson)
+    {
+        var objectIdField = new DataField<long?>("objectid");
+        var nameField = new DataField<string>("name", true);
+        var geometryField = new DataField<byte[]>("geometry", true);
+        var timeField = new TimeOnlyDataField("event_time", TimeSpanFormat.MilliSeconds, true);
+        var blobField = new DataField<byte[]>("thumbnail", true);
+        var schema = new ParquetSchema(objectIdField, nameField, geometryField, timeField, blobField);
+
+        var geomColumnMeta = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["encoding"] = "WKB",
+            ["geometry_types"] = PointGeometryTypes,
+            ["crs"] = BuildCrsObject(crs)
+        };
+
+        var metadata = BuildGeoMetadata(
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["geometry"] = geomColumnMeta
+            });
+
+        var point = new Point(-122.4194, 37.7749) { SRID = 4326 };
+        var geometryBytes = new WKBWriter().Write(point);
+        var sampleBlob = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 }; // JPEG header fragment
+
+        var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
+        {
+            writer.CustomMetadata = metadata;
+            using var rowGroupWriter = writer.CreateRowGroup();
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, SingleObjectId));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(nameField, SingleName));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(geometryField, new[] { geometryBytes }));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(timeField, new TimeOnly?[] { new TimeOnly(14, 30, 0) }));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(blobField, new byte[]?[] { sampleBlob }));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    /// <summary>
+    /// Create a GeoParquet file with an INT16 (short) attribute column.
+    /// Exercises Parquet integer widths narrower than Int32 that require
+    /// explicit JsonSerializable metadata for AOT serialization.
+    /// </summary>
+    public static async Task<MemoryStream> CreateWithInt16ColumnAsync(CrsStyle crs = CrsStyle.ProjJson)
+    {
+        var objectIdField = new DataField<long?>("objectid");
+        var nameField = new DataField<string>("name", true);
+        var geometryField = new DataField<byte[]>("geometry", true);
+        var priorityField = new DataField<short?>("priority");
+        var schema = new ParquetSchema(objectIdField, nameField, geometryField, priorityField);
+
+        var geomColumnMeta = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["encoding"] = "WKB",
+            ["geometry_types"] = PointGeometryTypes,
+            ["crs"] = BuildCrsObject(crs)
+        };
+
+        var metadata = BuildGeoMetadata(
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["geometry"] = geomColumnMeta
+            });
+
+        var point = new Point(-122.4194, 37.7749) { SRID = 4326 };
+        var geometryBytes = new WKBWriter().Write(point);
+
+        var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
+        {
+            writer.CustomMetadata = metadata;
+            using var rowGroupWriter = writer.CreateRowGroup();
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, SingleObjectId));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(nameField, SingleName));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(geometryField, new[] { geometryBytes }));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(priorityField, new short?[] { 7 }));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    /// <summary>
+    /// Create a Parquet file with malformed "geo" metadata JSON.
+    /// </summary>
+    public static async Task<MemoryStream> CreateWithMalformedMetadataAsync()
+    {
+        var objectIdField = new DataField<long?>("objectid");
+        var geometryField = new DataField<byte[]>("geometry", true);
+        var schema = new ParquetSchema(objectIdField, geometryField);
+
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["geo"] = "{{not valid json!!"
+        };
+
+        var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
+        {
+            writer.CustomMetadata = metadata;
+            using var rowGroupWriter = writer.CreateRowGroup();
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, SingleObjectId));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(geometryField, NullGeometryData));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    /// <summary>
+    /// Create a Parquet file with structurally invalid "geo" metadata
+    /// (valid JSON but wrong value types, e.g. numeric primary_column).
+    /// </summary>
+    public static async Task<MemoryStream> CreateWithWrongShapedMetadataAsync()
+    {
+        var objectIdField = new DataField<long?>("objectid");
+        var geometryField = new DataField<byte[]>("geometry", true);
+        var schema = new ParquetSchema(objectIdField, geometryField);
+
+        // primary_column is a number instead of a string — valid JSON, wrong shape
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["geo"] = JsonSerializer.Serialize(new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["version"] = "1.1.0",
+                ["primary_column"] = 42,
+                ["columns"] = "not_an_object"
+            })
+        };
+
+        var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
+        {
+            writer.CustomMetadata = metadata;
+            using var rowGroupWriter = writer.CreateRowGroup();
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, SingleObjectId));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(geometryField, NullGeometryData));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    /// <summary>
+    /// Create a GeoParquet file with valid "geo" JSON but no "primary_column" field.
+    /// </summary>
+    public static async Task<MemoryStream> CreateWithMissingPrimaryColumnAsync()
+    {
+        var objectIdField = new DataField<long?>("objectid");
+        var geometryField = new DataField<byte[]>("geometry", true);
+        var schema = new ParquetSchema(objectIdField, geometryField);
+
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["geo"] = JsonSerializer.Serialize(new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["version"] = "1.1.0",
+                // No primary_column!
+                ["columns"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["geometry"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["encoding"] = "WKB",
+                        ["geometry_types"] = PointGeometryTypes
+                    }
+                }
+            })
+        };
+
+        var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
+        {
+            writer.CustomMetadata = metadata;
+            using var rowGroupWriter = writer.CreateRowGroup();
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, SingleObjectId));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(geometryField, NullGeometryData));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    /// <summary>
+    /// Create a GeoParquet file with valid "geo" JSON but no "columns" field.
+    /// </summary>
+    public static async Task<MemoryStream> CreateWithMissingColumnsFieldAsync()
+    {
+        var objectIdField = new DataField<long?>("objectid");
+        var geometryField = new DataField<byte[]>("geometry", true);
+        var schema = new ParquetSchema(objectIdField, geometryField);
+
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["geo"] = JsonSerializer.Serialize(new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["version"] = "1.1.0",
+                ["primary_column"] = "geometry"
+                // No columns!
+            })
+        };
+
+        var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
+        {
+            writer.CustomMetadata = metadata;
+            using var rowGroupWriter = writer.CreateRowGroup();
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, SingleObjectId));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(geometryField, NullGeometryData));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    /// <summary>
+    /// Create a plain Parquet file without any "geo" metadata key.
+    /// </summary>
+    public static async Task<MemoryStream> CreateWithoutGeoMetadataAsync()
+    {
+        var objectIdField = new DataField<long?>("objectid");
+        var nameField = new DataField<string>("name", true);
+        var schema = new ParquetSchema(objectIdField, nameField);
+
+        var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
+        {
+            // No custom metadata — plain Parquet, not GeoParquet
+            using var rowGroupWriter = writer.CreateRowGroup();
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, SingleObjectId));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(nameField, SingleName));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    /// <summary>
+    /// Create a GeoParquet file with a raw CRS object for testing edge-case CRS values
+    /// (e.g. decimal EPSG codes, out-of-range codes).
+    /// </summary>
+    public static async Task<MemoryStream> CreateWithCustomCrsAsync(Dictionary<string, object?> crsObject)
+    {
+        var objectIdField = new DataField<long?>("objectid");
+        var nameField = new DataField<string>("name", true);
+        var geometryField = new DataField<byte[]>("geometry", true);
+        var schema = new ParquetSchema(objectIdField, nameField, geometryField);
+
+        var geomColumnMeta = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["encoding"] = "WKB",
+            ["geometry_types"] = PointGeometryTypes,
+            ["crs"] = crsObject
+        };
+
+        var metadata = BuildGeoMetadata(
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["geometry"] = geomColumnMeta
+            });
+
+        var point = new Point(-122.4194, 37.7749) { SRID = 4326 };
+        var geometryBytes = new WKBWriter().Write(point);
+
+        var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
+        {
+            writer.CustomMetadata = metadata;
+            using var rowGroupWriter = writer.CreateRowGroup();
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, SingleObjectId));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(nameField, SingleName));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(geometryField, new[] { geometryBytes }));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    /// <summary>
+    /// Create a GeoParquet file where the "geo" metadata's primary_column names a column
+    /// that does not exist in the Parquet schema.
+    /// </summary>
+    public static async Task<MemoryStream> CreateWithMismatchedPrimaryColumnAsync()
+    {
+        var objectIdField = new DataField<long?>("objectid");
+        var nameField = new DataField<string>("name", true);
+        // Schema has no "geometry" column — but geo metadata will reference it
+        var schema = new ParquetSchema(objectIdField, nameField);
+
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["geo"] = JsonSerializer.Serialize(new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["version"] = "1.1.0",
+                ["primary_column"] = "geometry",
+                ["columns"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["geometry"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["encoding"] = "WKB",
+                        ["geometry_types"] = PointGeometryTypes
+                    }
+                }
+            })
+        };
+
+        var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
+        {
+            writer.CustomMetadata = metadata;
+            using var rowGroupWriter = writer.CreateRowGroup();
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, SingleObjectId));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(nameField, SingleName));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    /// <summary>
+    /// Create a GeoParquet file where "geo.columns" exists but does not contain
+    /// the declared "primary_column". The Parquet schema DOES have the geometry column,
+    /// so the mismatch is purely in the geo metadata.
+    /// </summary>
+    public static async Task<MemoryStream> CreateWithPrimaryColumnMissingFromGeoColumnsAsync()
+    {
+        var objectIdField = new DataField<long?>("objectid");
+        var nameField = new DataField<string>("name", true);
+        var geometryField = new DataField<byte[]>("geometry", true);
+        var schema = new ParquetSchema(objectIdField, nameField, geometryField);
+
+        // primary_column = "geometry" but columns only describes "other_geom"
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["geo"] = JsonSerializer.Serialize(new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["version"] = "1.1.0",
+                ["primary_column"] = "geometry",
+                ["columns"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["other_geom"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["encoding"] = "WKB",
+                        ["geometry_types"] = PointGeometryTypes
+                    }
+                }
+            })
+        };
+
+        var point = new Point(-122.4194, 37.7749) { SRID = 4326 };
+        var geometryBytes = new WKBWriter().Write(point);
+
+        var stream = new MemoryStream();
+        using (var writer = await ParquetWriter.CreateAsync(schema, stream))
+        {
+            writer.CustomMetadata = metadata;
+            using var rowGroupWriter = writer.CreateRowGroup();
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(objectIdField, SingleObjectId));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(nameField, SingleName));
+            await rowGroupWriter.WriteColumnAsync(new ParquetDataColumn(geometryField, new[] { geometryBytes }));
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    private static Dictionary<string, object?> BuildCrsObject(CrsStyle crs)
+    {
+        return crs switch
+        {
+            CrsStyle.ProjJson => new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["id"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["authority"] = "EPSG",
+                    ["code"] = 4326
+                }
+            },
+            CrsStyle.PropertiesName => new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["type"] = "name",
+                ["properties"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["name"] = "EPSG:4326"
+                }
+            },
+            CrsStyle.OgcCrs84ProjJson => new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["id"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["authority"] = "OGC",
+                    ["code"] = "CRS84"
+                }
+            },
+            CrsStyle.OgcCrs84PropertiesName => new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["type"] = "name",
+                ["properties"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["name"] = "OGC:CRS84"
+                }
+            },
+            CrsStyle.ProjJsonStringCode => new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["id"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["authority"] = "EPSG",
+                    ["code"] = "4326" // String code per PROJJSON spec
+                }
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(crs))
+        };
+    }
+
+    private static Dictionary<string, string> BuildGeoMetadata(
+        Dictionary<string, object?> columns)
+    {
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["geo"] = JsonSerializer.Serialize(new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["version"] = "1.1.0",
+                ["primary_column"] = "geometry",
+                ["columns"] = columns
+            })
+        };
+    }
+}

--- a/tests/Honua.TestKit/Honua.TestKit.csproj
+++ b/tests/Honua.TestKit/Honua.TestKit.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="FsCheck.Xunit" Version="3.3.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageReference Include="NBomber" Version="6.2.0" />
+    <PackageReference Include="Parquet.Net" Version="5.5.0" />
     <PackageReference Include="NBomber.Http" Version="6.1.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #423
## Summary

2. **[low/adjacent_cleanup] Preview null-geometry filter** — Replaced `geoParquetTotalRows.HasValue` with `format.Value == SupportedFileFormat.GeoParquet` at line 1224. More explicit and resilient to future format additions.
## Changes Made

- Added GeoParquet import and preview runtime support.
- Switched the preview null-geometry filter to an explicit GeoParquet format check for clearer behavior.
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Breaking Changes

None
## Additional Context

Decisions:
- The `InvalidDataException` catch benefits ALL formats, not just GeoParquet. Any format reader that throws `InvalidDataException` during streaming will now get its specific message preserved. This is a net improvement over the generic "Import failed." message.
- The preview null-geometry filter change is semantically equivalent but uses the explicit format check for clarity.

Follow-ons:
- Consider widening `FilePreview.TotalFeatureCount` to `long` across the contract if other formats eventually need large file support (carried forward from prior delta).

Code kaizen:
Deferred 1 low-priority finding to cleanup backlog: use an explicit GeoParquet format check for preview TotalFeatureCount instead of the indirect geoParquetTotalRows.HasValue guard.
## Pre-PR Checklist (for contributor)
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit message follows format: `type: description (#issue-number)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [x] Documentation updated if needed
- [ ] If protocol/auth behavior changed, updated MVP compatibility contract and release checklist notes
- [ ] If breaking admin/control-plane API changes: updated migration guide and versioning policy docs
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review and documented in migration guide

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed
