### PR TITLE
feat(export): add GeoArrow IPC export surface (#426)

### DIFF
--- a/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
@@ -284,29 +284,32 @@ internal sealed class FeatureServerQueryHandler(
                 outputSrid ??= wgs84Srid;
             }
 
-            // GeoParquet CRS metadata: the formatter can only emit spec-compliant CRS for
-            // EPSG:4326 (omitted key = OGC:CRS84). Non-4326 outSR would produce a file
-            // with reprojected coordinates but "crs": null, misleading analytics clients.
-            // Only enforce when the response will actually contain geometry metadata —
-            // statistics, count, extent, and IDs queries always return JSON regardless of f=,
-            // and returnGeometry=false omits the geometry column entirely.
-            var requiresParquetOutput = string.Equals(format, "parquet", StringComparison.OrdinalIgnoreCase)
+            // Cloud-native CRS metadata: GeoParquet and GeoArrow formatters can only emit
+            // spec-compliant CRS for EPSG:4326 (omitted key = OGC:CRS84). Non-4326 outSR
+            // would produce a file with reprojected coordinates but "crs": null, misleading
+            // analytics clients. Only enforce when the response will actually contain geometry
+            // metadata — statistics, count, extent, and IDs queries always return JSON
+            // regardless of f=, and returnGeometry=false omits the geometry column entirely.
+            var isCloudNativeFormat = string.Equals(format, "parquet", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(format, "arrow", StringComparison.OrdinalIgnoreCase);
+            var requiresCloudNativeCrs = isCloudNativeFormat
                 && !validatedParams.ReturnCountOnly
                 && !validatedParams.ReturnExtentOnly
                 && !validatedParams.ReturnIdsOnly
                 && validatedParams.ReturnGeometry
                 && layer.HasGeometry
                 && string.IsNullOrWhiteSpace(validatedParams.OutStatistics);
-
-            if (requiresParquetOutput)
+            if (requiresCloudNativeCrs)
             {
                 if (outputSrid.HasValue && outputSrid.Value != wgs84Srid)
                 {
+                    var formatLabel = string.Equals(format, "parquet", StringComparison.OrdinalIgnoreCase)
+                        ? "GeoParquet" : "GeoArrow";
                     return StandardErrorHelpers.CreateBadRequest(context,
-                        "GeoParquet output does not yet support non-4326 outSR. CRS metadata cannot be written correctly for the requested spatial reference.");
+                        $"{formatLabel} output does not yet support non-4326 outSR. CRS metadata cannot be written correctly for the requested spatial reference.");
                 }
 
-                // Force 4326 reprojection for parquet output, matching GeoJSON behavior.
+                // Force 4326 reprojection for cloud-native output, matching GeoJSON behavior.
                 // Without this, a layer natively in e.g. EPSG:3857 would produce a file
                 // with 3857 coordinates but "crs": null metadata, misleading analytics clients.
                 outputSrid ??= wgs84Srid;
@@ -523,7 +526,8 @@ internal sealed class FeatureServerQueryHandler(
             var isFgb = string.Equals(format, "fgb", StringComparison.OrdinalIgnoreCase);
             var isGeobuf = string.Equals(format, "geobuf", StringComparison.OrdinalIgnoreCase);
             var isParquet = string.Equals(format, "parquet", StringComparison.OrdinalIgnoreCase);
-            var useStreaming = effectiveLimit > StreamingThreshold && !isPbf && !isFgb && !isGeobuf && !isParquet;
+            var isArrow = string.Equals(format, "arrow", StringComparison.OrdinalIgnoreCase);
+            var useStreaming = effectiveLimit > StreamingThreshold && !isPbf && !isFgb && !isGeobuf && !isParquet && !isArrow;
 
             if (!useStreaming)
             {
@@ -594,7 +598,7 @@ internal sealed class FeatureServerQueryHandler(
                     : query;
                 QueryResult<Feature> result = await _queryExecutor.QueryWithValidationAsync(layerId, queryForExecution, cancellationToken);
                 queryStopwatch.Stop();
-                var queryOperation = isParquet ? "query_parquet" : "query";
+                var queryOperation = isParquet ? "query_parquet" : isArrow ? "query_arrow" : "query";
                 FeatureServerLog.QueryExecuted(_logger, queryOperation, serviceId, layerId, queryStopwatch.Elapsed.TotalMilliseconds);
 
                 if (shouldApplyDistinct)
@@ -630,6 +634,13 @@ internal sealed class FeatureServerQueryHandler(
                     return await CreateCachedBytesResultAsync(
                         (byte[])formattedResponse!,
                         contentType ?? "application/vnd.apache.parquet");
+                }
+
+                if (isArrow)
+                {
+                    return await CreateCachedBytesResultAsync(
+                        (byte[])formattedResponse!,
+                        contentType ?? "application/vnd.apache.arrow.stream");
                 }
 
                 return format.ToLowerInvariant() switch

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerUtilities.cs
@@ -203,7 +203,7 @@ internal static partial class FeatureServerEndpoints
     private static class SupportedFormats
     {
         public static readonly FrozenSet<string> Query =
-            new[] { "json", "pjson", "geojson", "pbf", "fgb", "geobuf", "parquet" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+            new[] { "json", "pjson", "geojson", "pbf", "fgb", "geobuf", "parquet", "arrow" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
         public static readonly FrozenSet<string> JsonOnly =
             new[] { "json", "pjson" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
@@ -499,6 +499,8 @@ internal static partial class FeatureServerEndpoints
             AddSupportedFormat(normalizedFormats, "GEOBUF");
         }
 
+        AddSupportedFormat(normalizedFormats, "ARROW");
+
         return [.. normalizedFormats];
     }
 
@@ -648,6 +650,12 @@ internal static partial class FeatureServerEndpoints
                 if (mediaType.Equals("application/vnd.apache.parquet", StringComparison.OrdinalIgnoreCase))
                 {
                     format = "parquet";
+                    return true;
+                }
+
+                if (mediaType.Equals("application/vnd.apache.arrow.stream", StringComparison.OrdinalIgnoreCase))
+                {
+                    format = "arrow";
                     return true;
                 }
 

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoArrowQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoArrowQueryFormatter.cs
@@ -1,0 +1,757 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Shared.Models;
+
+namespace Honua.Server.Features.FeatureServer.Services;
+
+/// <summary>
+/// Formats query results as Arrow IPC Stream with GeoArrow metadata.
+/// </summary>
+internal sealed class GeoArrowQueryFormatter
+{
+    private const string GeometryColumnName = "geometry";
+    private const string GeoArrowExtensionName = "geoarrow.wkb";
+    private const string ArrowExtensionNameKey = "ARROW:extension:name";
+    private const string ArrowExtensionMetadataKey = "ARROW:extension:metadata";
+    private const string GeoMetadataKey = "geo";
+
+    /// <summary>
+    /// Formats query result as Arrow IPC Stream with GeoArrow metadata.
+    /// </summary>
+    public static async Task<(byte[] response, string contentType)> FormatAsGeoArrowAsync(
+        QueryResult<Feature> result,
+        LayerDefinition layer,
+        bool returnGeometry,
+        int? outputSrid,
+        bool returnZ,
+        bool returnM,
+        GeometryLimits geometryLimits,
+        string[]? outFields = null,
+        CancellationToken cancellationToken = default)
+    {
+        var selectedFields = GeoParquetQueryFormatter.ResolveSelectedFields(layer, outFields);
+        var objectIdFieldName = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
+        var includeGeometry = returnGeometry && layer.HasGeometry;
+        var srid = outputSrid ?? layer.SpatialReference.Wkid;
+        var features = result.Items;
+        var isEmpty = features.Length == 0;
+
+        // Detect runtime-computed attributes (e.g. "distance" from KNN queries)
+        // that exist in the result set but are not declared in the layer schema.
+        var runtimeFields = GeoParquetQueryFormatter.DetectRuntimeFields(features, layer);
+
+        var schema = BuildSchema(selectedFields, includeGeometry, layer, srid, returnZ, isEmpty, runtimeFields, outFields);
+        var recordBatch = BuildRecordBatch(
+            features,
+            selectedFields,
+            objectIdFieldName,
+            includeGeometry,
+            srid,
+            geometryLimits,
+            returnZ,
+            returnM,
+            schema,
+            runtimeFields);
+
+        using var stream = new MemoryStream();
+        using (var writer = new ArrowStreamWriter(stream, schema, leaveOpen: true))
+        {
+            await writer.WriteRecordBatchAsync(recordBatch, cancellationToken).ConfigureAwait(false);
+            await writer.WriteEndAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return (stream.ToArray(), "application/vnd.apache.arrow.stream");
+    }
+
+    private static Apache.Arrow.Schema BuildSchema(
+        List<FieldDefinition> selectedFields,
+        bool includeGeometry,
+        LayerDefinition layer,
+        int srid,
+        bool returnZ,
+        bool isEmpty,
+        List<(string name, IArrowType type)> runtimeFields,
+        string[]? outFields)
+    {
+        var fields = new List<Apache.Arrow.Field>(selectedFields.Count + (includeGeometry ? 1 : 0));
+
+        foreach (var field in selectedFields)
+        {
+            fields.Add(CreateArrowField(field));
+        }
+
+        if (includeGeometry)
+        {
+            var extensionMetadata = BuildExtensionMetadata(layer, srid, returnZ, isEmpty);
+            var geometryField = new Apache.Arrow.Field(
+                GeometryColumnName,
+                BinaryType.Default,
+                nullable: true,
+                new Dictionary<string, string>
+                {
+                    [ArrowExtensionNameKey] = GeoArrowExtensionName,
+                    [ArrowExtensionMetadataKey] = extensionMetadata
+                });
+            fields.Add(geometryField);
+        }
+
+        // Append runtime-computed attributes (e.g. "distance" from KNN queries) that are
+        // not declared in the layer schema but appear in feature.Attributes.
+        // Only include when outFields is omitted / "*", or the field was explicitly requested,
+        // to match the filtering behavior of JSON/GeoJSON/PBF/GeoParquet formatters.
+        if (runtimeFields.Count > 0)
+        {
+            var includeAllFields = outFields == null || outFields.Length == 0 ||
+                                  (outFields.Length == 1 && outFields[0].Equals("*", StringComparison.Ordinal));
+            foreach (var (name, type) in runtimeFields)
+            {
+                if (includeAllFields || outFields!.Contains(name, StringComparer.OrdinalIgnoreCase))
+                {
+                    fields.Add(new Apache.Arrow.Field(name, type, nullable: true));
+                }
+            }
+        }
+
+        var schemaMetadata = BuildSchemaMetadata(layer, includeGeometry, srid, returnZ, isEmpty);
+        return new Apache.Arrow.Schema(fields, schemaMetadata);
+    }
+
+    private static Apache.Arrow.Field CreateArrowField(FieldDefinition field)
+    {
+        // Note: Date/Time type mappings intentionally diverge from GeoParquet.
+        // Arrow IPC is consumed by analytics clients (PyArrow, DuckDB) that prefer
+        // Timestamp over Date32 for dates, and Time64(μs) over Time32(ms) for times,
+        // because these types offer higher fidelity and are the default in most Arrow
+        // ecosystems. GeoParquet uses Date32/Time32 to match Parquet's native types.
+        IArrowType arrowType = field.Type switch
+        {
+            FieldType.BigInteger => Int64Type.Default,
+            FieldType.Integer => Int32Type.Default,
+            FieldType.Float => FloatType.Default,
+            FieldType.Double => DoubleType.Default,
+            FieldType.Boolean => BooleanType.Default,
+            FieldType.DateTime or FieldType.Date => new TimestampType(TimeUnit.Millisecond, "UTC"),
+            FieldType.Time => new Time64Type(TimeUnit.Microsecond),
+            FieldType.Binary => BinaryType.Default,
+            _ => StringType.Default
+        };
+
+        return new Apache.Arrow.Field(field.Name, arrowType, field.Nullable);
+    }
+
+    private static RecordBatch BuildRecordBatch(
+        IReadOnlyList<Feature> features,
+        List<FieldDefinition> selectedFields,
+        string objectIdFieldName,
+        bool includeGeometry,
+        int outputSrid,
+        GeometryLimits geometryLimits,
+        bool returnZ,
+        bool returnM,
+        Apache.Arrow.Schema schema,
+        IReadOnlyList<(string name, IArrowType type)> runtimeFields)
+    {
+        var arrays = new List<IArrowArray>(schema.FieldsList.Count);
+
+        foreach (var field in selectedFields)
+        {
+            var isObjectIdField = field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase);
+            arrays.Add(BuildAttributeArray(features, field, isObjectIdField));
+        }
+
+        if (includeGeometry)
+        {
+            arrays.Add(BuildGeometryArray(features, outputSrid, geometryLimits, returnZ, returnM));
+        }
+
+        // Build arrays for runtime-computed fields (only those included in the schema).
+        // Match schema field names to ensure we only build arrays for fields that passed
+        // the outFields filter in BuildSchema.
+        var schemaFieldNames = new HashSet<string>(
+            schema.FieldsList.Select(f => f.Name), StringComparer.OrdinalIgnoreCase);
+        foreach (var (name, type) in runtimeFields)
+        {
+            if (schemaFieldNames.Contains(name))
+            {
+                arrays.Add(BuildRuntimeArray(features, name, type));
+            }
+        }
+
+        return new RecordBatch(schema, arrays, features.Count);
+    }
+
+    private static IArrowArray BuildRuntimeArray(
+        IReadOnlyList<Feature> features,
+        string fieldName,
+        IArrowType arrowType)
+    {
+        // Dispatch by Arrow type and build using the same converters as layer-defined fields.
+        return arrowType switch
+        {
+            DoubleType => BuildDoubleArrayByName(features, fieldName),
+            FloatType => BuildFloatArrayByName(features, fieldName),
+            Int32Type => BuildInt32ArrayByName(features, fieldName),
+            Int64Type => BuildInt64ArrayByName(features, fieldName),
+            BooleanType => BuildBooleanArrayByName(features, fieldName),
+            TimestampType => BuildTimestampArrayByName(features, fieldName),
+            _ => BuildStringArrayByName(features, fieldName)
+        };
+    }
+
+    private static DoubleArray BuildDoubleArrayByName(IReadOnlyList<Feature> features, string fieldName)
+    {
+        var builder = new DoubleArray.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = TryConvertDouble(GeoParquetQueryFormatter.GetAttributeValue(features[i], fieldName));
+            if (value.HasValue) builder.Append(value.Value); else builder.AppendNull();
+        }
+        return builder.Build();
+    }
+
+    private static FloatArray BuildFloatArrayByName(IReadOnlyList<Feature> features, string fieldName)
+    {
+        var builder = new FloatArray.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = TryConvertFloat(GeoParquetQueryFormatter.GetAttributeValue(features[i], fieldName));
+            if (value.HasValue) builder.Append(value.Value); else builder.AppendNull();
+        }
+        return builder.Build();
+    }
+
+    private static Int32Array BuildInt32ArrayByName(IReadOnlyList<Feature> features, string fieldName)
+    {
+        var builder = new Int32Array.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = TryConvertInt32(GeoParquetQueryFormatter.GetAttributeValue(features[i], fieldName));
+            if (value.HasValue) builder.Append(value.Value); else builder.AppendNull();
+        }
+        return builder.Build();
+    }
+
+    private static Int64Array BuildInt64ArrayByName(IReadOnlyList<Feature> features, string fieldName)
+    {
+        var builder = new Int64Array.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = TryConvertInt64(GeoParquetQueryFormatter.GetAttributeValue(features[i], fieldName));
+            if (value.HasValue) builder.Append(value.Value); else builder.AppendNull();
+        }
+        return builder.Build();
+    }
+
+    private static BooleanArray BuildBooleanArrayByName(IReadOnlyList<Feature> features, string fieldName)
+    {
+        var builder = new BooleanArray.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = TryConvertBoolean(GeoParquetQueryFormatter.GetAttributeValue(features[i], fieldName));
+            if (value.HasValue) builder.Append(value.Value); else builder.AppendNull();
+        }
+        return builder.Build();
+    }
+
+    private static TimestampArray BuildTimestampArrayByName(IReadOnlyList<Feature> features, string fieldName)
+    {
+        var builder = new TimestampArray.Builder(new TimestampType(TimeUnit.Millisecond, "UTC"));
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = TryConvertDateTimeOffset(GeoParquetQueryFormatter.GetAttributeValue(features[i], fieldName));
+            if (value.HasValue) builder.Append(value.Value); else builder.AppendNull();
+        }
+        return builder.Build();
+    }
+
+    private static StringArray BuildStringArrayByName(IReadOnlyList<Feature> features, string fieldName)
+    {
+        var builder = new StringArray.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = ConvertToStringValue(GeoParquetQueryFormatter.GetAttributeValue(features[i], fieldName));
+            if (value != null) builder.Append(value); else builder.AppendNull();
+        }
+        return builder.Build();
+    }
+
+    private static IArrowArray BuildAttributeArray(
+        IReadOnlyList<Feature> features,
+        FieldDefinition field,
+        bool isObjectIdField)
+    {
+        return field.Type switch
+        {
+            FieldType.BigInteger => BuildInt64Array(features, field, isObjectIdField),
+            FieldType.Integer => BuildInt32Array(features, field, isObjectIdField),
+            FieldType.Float => BuildFloatArray(features, field),
+            FieldType.Double => BuildDoubleArray(features, field),
+            FieldType.Boolean => BuildBooleanArray(features, field),
+            FieldType.DateTime or FieldType.Date => BuildTimestampArray(features, field),
+            FieldType.Time => BuildTime64Array(features, field),
+            FieldType.Binary => BuildBinaryArray(features, field),
+            _ => BuildStringArray(features, field)
+        };
+    }
+
+    private static Int64Array BuildInt64Array(IReadOnlyList<Feature> features, FieldDefinition field, bool isObjectIdField)
+    {
+        var builder = new Int64Array.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = GeoParquetQueryFormatter.GetAttributeValue(features[i], field.Name);
+            var converted = TryConvertInt64(value);
+            if (converted.HasValue)
+            {
+                builder.Append(converted.Value);
+            }
+            else if (isObjectIdField)
+            {
+                builder.Append(features[i].Id);
+            }
+            else
+            {
+                builder.AppendNull();
+            }
+        }
+
+        return builder.Build();
+    }
+
+    private static Int32Array BuildInt32Array(IReadOnlyList<Feature> features, FieldDefinition field, bool isObjectIdField)
+    {
+        var builder = new Int32Array.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = GeoParquetQueryFormatter.GetAttributeValue(features[i], field.Name);
+            var converted = TryConvertInt32(value);
+            if (converted.HasValue)
+            {
+                builder.Append(converted.Value);
+            }
+            else if (isObjectIdField)
+            {
+                builder.Append(Convert.ToInt32(features[i].Id, CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                builder.AppendNull();
+            }
+        }
+
+        return builder.Build();
+    }
+
+    private static FloatArray BuildFloatArray(IReadOnlyList<Feature> features, FieldDefinition field)
+    {
+        var builder = new FloatArray.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = TryConvertFloat(GeoParquetQueryFormatter.GetAttributeValue(features[i], field.Name));
+            if (value.HasValue)
+            {
+                builder.Append(value.Value);
+            }
+            else
+            {
+                builder.AppendNull();
+            }
+        }
+
+        return builder.Build();
+    }
+
+    private static DoubleArray BuildDoubleArray(IReadOnlyList<Feature> features, FieldDefinition field)
+    {
+        var builder = new DoubleArray.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = TryConvertDouble(GeoParquetQueryFormatter.GetAttributeValue(features[i], field.Name));
+            if (value.HasValue)
+            {
+                builder.Append(value.Value);
+            }
+            else
+            {
+                builder.AppendNull();
+            }
+        }
+
+        return builder.Build();
+    }
+
+    private static BooleanArray BuildBooleanArray(IReadOnlyList<Feature> features, FieldDefinition field)
+    {
+        var builder = new BooleanArray.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = TryConvertBoolean(GeoParquetQueryFormatter.GetAttributeValue(features[i], field.Name));
+            if (value.HasValue)
+            {
+                builder.Append(value.Value);
+            }
+            else
+            {
+                builder.AppendNull();
+            }
+        }
+
+        return builder.Build();
+    }
+
+    private static TimestampArray BuildTimestampArray(IReadOnlyList<Feature> features, FieldDefinition field)
+    {
+        var builder = new TimestampArray.Builder(new TimestampType(TimeUnit.Millisecond, "UTC"));
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = TryConvertDateTimeOffset(GeoParquetQueryFormatter.GetAttributeValue(features[i], field.Name));
+            if (value.HasValue)
+            {
+                builder.Append(value.Value);
+            }
+            else
+            {
+                builder.AppendNull();
+            }
+        }
+
+        return builder.Build();
+    }
+
+    private static Time64Array BuildTime64Array(IReadOnlyList<Feature> features, FieldDefinition field)
+    {
+        // Time64 stores microseconds since midnight as int64
+        var builder = new Int64Array.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = TryConvertTimeOnly(GeoParquetQueryFormatter.GetAttributeValue(features[i], field.Name));
+            if (value.HasValue)
+            {
+                var microseconds = value.Value.Ticks / (TimeSpan.TicksPerMillisecond / 1000);
+                builder.Append(microseconds);
+            }
+            else
+            {
+                builder.AppendNull();
+            }
+        }
+
+        var int64Array = builder.Build();
+
+        // Wrap the raw int64 data in a Time64Array with proper type metadata
+        return new Time64Array(
+            new Time64Type(TimeUnit.Microsecond),
+            int64Array.ValueBuffer,
+            int64Array.NullBitmapBuffer,
+            int64Array.Length,
+            int64Array.NullCount,
+            int64Array.Offset);
+    }
+
+    private static BinaryArray BuildBinaryArray(IReadOnlyList<Feature> features, FieldDefinition field)
+    {
+        var builder = new BinaryArray.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = TryConvertBytes(GeoParquetQueryFormatter.GetAttributeValue(features[i], field.Name));
+            if (value != null)
+            {
+                builder.Append(value);
+            }
+            else
+            {
+                builder.AppendNull();
+            }
+        }
+
+        return builder.Build();
+    }
+
+    private static StringArray BuildStringArray(IReadOnlyList<Feature> features, FieldDefinition field)
+    {
+        var builder = new StringArray.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var value = ConvertToStringValue(GeoParquetQueryFormatter.GetAttributeValue(features[i], field.Name));
+            if (value != null)
+            {
+                builder.Append(value);
+            }
+            else
+            {
+                builder.AppendNull();
+            }
+        }
+
+        return builder.Build();
+    }
+
+    private static BinaryArray BuildGeometryArray(
+        IReadOnlyList<Feature> features,
+        int outputSrid,
+        GeometryLimits geometryLimits,
+        bool returnZ,
+        bool returnM)
+    {
+        var builder = new BinaryArray.Builder();
+        for (var i = 0; i < features.Count; i++)
+        {
+            var wkb = GeoParquetQueryFormatter.ProcessGeometry(
+                features[i].Geometry, outputSrid, geometryLimits, returnZ, returnM);
+            if (wkb != null)
+            {
+                builder.Append(wkb);
+            }
+            else
+            {
+                builder.AppendNull();
+            }
+        }
+
+        return builder.Build();
+    }
+
+    private static string BuildExtensionMetadata(LayerDefinition layer, int srid, bool returnZ, bool isEmpty)
+    {
+        // Build JSON manually to avoid AOT issues (no source-generated context for
+        // Dictionary<string, object?>). Follows GeoParquet 1.1.0 CRS rules:
+        //   - Omitting `crs` implies OGC:CRS84 (WGS84 lon/lat).
+        //   - `"crs": null` means undefined/unknown CRS.
+        //   - Any present `crs` value must be a full PROJJSON object.
+        // For EPSG:4326 we omit the key; for other SRIDs we write null.
+        //
+        // GeoParquet 1.1.0 §4.1: geometry_types lists types actually present —
+        // an empty result must use [].
+        var geometryTypesPart = isEmpty
+            ? "[]"
+            : $@"[""{GeoParquetQueryFormatter.MapGeometryTypeToGeoParquet(layer.GeometryType, returnZ)}""]";
+
+        var crsPart = srid == 4326
+            ? ""
+            : @",""crs"":null";
+
+        return $@"{{""geometry_types"":{geometryTypesPart},""edges"":""planar""{crsPart}}}";
+    }
+
+    private static Dictionary<string, string> BuildSchemaMetadata(
+        LayerDefinition layer,
+        bool includeGeometry,
+        int srid,
+        bool returnZ,
+        bool isEmpty)
+    {
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (!includeGeometry)
+        {
+            return metadata;
+        }
+
+        // Build JSON manually to avoid AOT issues (matches GeoParquet pattern).
+        // CRS rules: omit for 4326 (implies OGC:CRS84), null for others.
+        // GeoParquet 1.1.0 §4.1: geometry_types lists types actually present —
+        // an empty result must use [].
+        var geometryTypesPart = isEmpty
+            ? "[]"
+            : $@"[""{GeoParquetQueryFormatter.MapGeometryTypeToGeoParquet(layer.GeometryType, returnZ)}""]";
+
+        var crsPart = srid == 4326
+            ? ""
+            : @",""crs"":null";
+
+        var geoJson = $@"{{""version"":""1.1.0"",""primary_column"":""{GeometryColumnName}"",""columns"":{{""{GeometryColumnName}"":{{""encoding"":""WKB"",""geometry_types"":{geometryTypesPart}{crsPart}}}}}}}";
+
+        metadata[GeoMetadataKey] = geoJson;
+        return metadata;
+    }
+
+    // Type converters — duplicated from GeoParquetQueryFormatter because Arrow builder
+    // API (Append/AppendNull) differs from Parquet's column-array model.
+
+    private static long? TryConvertInt64(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            long longValue => longValue,
+            int intValue => intValue,
+            short shortValue => shortValue,
+            byte byteValue => byteValue,
+            double doubleValue => Convert.ToInt64(doubleValue, CultureInfo.InvariantCulture),
+            decimal decimalValue => Convert.ToInt64(decimalValue, CultureInfo.InvariantCulture),
+            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetInt64(out var jsonLong) => jsonLong,
+            string stringValue when long.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    private static int? TryConvertInt32(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            int intValue => intValue,
+            long longValue => Convert.ToInt32(longValue, CultureInfo.InvariantCulture),
+            short shortValue => shortValue,
+            byte byteValue => byteValue,
+            double doubleValue => Convert.ToInt32(doubleValue, CultureInfo.InvariantCulture),
+            decimal decimalValue => Convert.ToInt32(decimalValue, CultureInfo.InvariantCulture),
+            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetInt32(out var jsonInt) => jsonInt,
+            string stringValue when int.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    private static float? TryConvertFloat(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            float floatValue => floatValue,
+            double doubleValue => Convert.ToSingle(doubleValue, CultureInfo.InvariantCulture),
+            decimal decimalValue => Convert.ToSingle(decimalValue, CultureInfo.InvariantCulture),
+            int intValue => intValue,
+            long longValue => longValue,
+            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetSingle(out var jsonFloat) => jsonFloat,
+            string stringValue when float.TryParse(stringValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    private static double? TryConvertDouble(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            double doubleValue => doubleValue,
+            float floatValue => floatValue,
+            decimal decimalValue => Convert.ToDouble(decimalValue, CultureInfo.InvariantCulture),
+            int intValue => intValue,
+            long longValue => longValue,
+            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetDouble(out var jsonDouble) => jsonDouble,
+            string stringValue when double.TryParse(stringValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    private static bool? TryConvertBoolean(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            bool boolValue => boolValue,
+            JsonElement element when element.ValueKind == JsonValueKind.True => true,
+            JsonElement element when element.ValueKind == JsonValueKind.False => false,
+            string stringValue when bool.TryParse(stringValue, out var parsedBool) => parsedBool,
+            string stringValue when int.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedInt) => parsedInt != 0,
+            int intValue => intValue != 0,
+            long longValue => longValue != 0,
+            _ => null
+        };
+    }
+
+    private static DateTimeOffset? TryConvertDateTimeOffset(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            DateTimeOffset dateTimeOffset => dateTimeOffset.ToUniversalTime(),
+            DateTime dateTime => dateTime.Kind switch
+            {
+                DateTimeKind.Utc => new DateTimeOffset(dateTime, TimeSpan.Zero),
+                DateTimeKind.Local => new DateTimeOffset(dateTime.ToUniversalTime(), TimeSpan.Zero),
+                _ => new DateTimeOffset(DateTime.SpecifyKind(dateTime, DateTimeKind.Utc), TimeSpan.Zero)
+            },
+            DateOnly dateOnly => new DateTimeOffset(dateOnly.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero),
+            JsonElement element when element.ValueKind == JsonValueKind.String => TryConvertDateTimeOffset(element.GetString()),
+            JsonElement element when element.ValueKind == JsonValueKind.Number && element.TryGetInt64(out var milliseconds) =>
+                DateTimeOffset.FromUnixTimeMilliseconds(milliseconds),
+            string stringValue when DateTimeOffset.TryParse(
+                stringValue,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind | DateTimeStyles.AllowWhiteSpaces,
+                out var parsedOffset) => parsedOffset.ToUniversalTime(),
+            string stringValue when DateTime.TryParse(
+                stringValue,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces,
+                out var parsedDateTime) => new DateTimeOffset(parsedDateTime, TimeSpan.Zero),
+            long milliseconds => DateTimeOffset.FromUnixTimeMilliseconds(milliseconds),
+            double milliseconds => DateTimeOffset.FromUnixTimeMilliseconds(Convert.ToInt64(milliseconds, CultureInfo.InvariantCulture)),
+            _ => null
+        };
+    }
+
+    private static TimeOnly? TryConvertTimeOnly(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            TimeOnly timeOnly => timeOnly,
+            TimeSpan timeSpan => TimeOnly.FromTimeSpan(timeSpan),
+            DateTime dateTime => TimeOnly.FromDateTime(dateTime),
+            DateTimeOffset dateTimeOffset => TimeOnly.FromDateTime(dateTimeOffset.UtcDateTime),
+            JsonElement element when element.ValueKind == JsonValueKind.String => TryConvertTimeOnly(element.GetString()),
+            string stringValue when TimeOnly.TryParse(stringValue, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var parsedTime) => parsedTime,
+            string stringValue when TimeSpan.TryParse(stringValue, CultureInfo.InvariantCulture, out var parsedSpan) => TimeOnly.FromTimeSpan(parsedSpan),
+            _ => null
+        };
+    }
+
+    private static byte[]? TryConvertBytes(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            byte[] bytes => bytes,
+            JsonElement element when element.ValueKind == JsonValueKind.String => TryConvertBytes(element.GetString()),
+            string stringValue when TryDecodeBase64(stringValue, out var decoded) => decoded,
+            string stringValue => System.Text.Encoding.UTF8.GetBytes(stringValue),
+            _ => null
+        };
+    }
+
+    private static string? ConvertToStringValue(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string stringValue => stringValue,
+            DateTimeOffset dateTimeOffset => dateTimeOffset.ToString("O", CultureInfo.InvariantCulture),
+            DateTime dateTime => dateTime.ToString("O", CultureInfo.InvariantCulture),
+            DateOnly dateOnly => dateOnly.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            TimeOnly timeOnly => timeOnly.ToString("HH:mm:ss.fffffff", CultureInfo.InvariantCulture),
+            JsonElement element when element.ValueKind is JsonValueKind.Object or JsonValueKind.Array => element.GetRawText(),
+            JsonElement element => element.ToString(),
+            _ => value.ToString()
+        };
+    }
+
+    private static bool TryDecodeBase64(string? value, out byte[] decoded)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            decoded = [];
+            return false;
+        }
+
+        try
+        {
+            decoded = Convert.FromBase64String(value);
+            return true;
+        }
+        catch (FormatException)
+        {
+            decoded = [];
+            return false;
+        }
+    }
+}

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -119,6 +119,34 @@ internal sealed class GeoParquetQueryFormatter
         return (stream.ToArray(), ContentType);
     }
 
+    internal static List<FieldDefinition> ResolveSelectedFields(LayerDefinition layer, string[]? outFields)
+    {
+        var objectIdFieldName = layer.ObjectIdFieldName;
+        var includeAllFields = outFields == null || outFields.Length == 0 ||
+            (outFields.Length == 1 && outFields[0].Equals("*", StringComparison.Ordinal));
+
+        HashSet<string>? requestedFields = null;
+        if (!includeAllFields)
+        {
+            requestedFields = new HashSet<string>(outFields!, StringComparer.OrdinalIgnoreCase)
+            {
+                objectIdFieldName
+            };
+        }
+
+        var selectedFields = layer.Fields
+            .Where(field => !field.IsGeometry)
+            .Where(field => includeAllFields || requestedFields!.Contains(field.Name))
+            .ToList();
+
+        if (!selectedFields.Any(field => field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase)))
+        {
+            selectedFields.Insert(0, new FieldDefinition(objectIdFieldName, FieldType.BigInteger, Nullable: false));
+        }
+
+        return selectedFields;
+    }
+
     /// <summary>
     /// Creates empty GeoParquet file with schema only
     /// </summary>
@@ -168,8 +196,13 @@ internal sealed class GeoParquetQueryFormatter
         bool isEmpty = false)
     {
         var objectIdFieldName = layer.ObjectIdFieldName;
-        var includeAllFields = outFields == null || outFields.Length == 0 ||
-                              (outFields.Length == 1 && outFields[0].Equals("*", StringComparison.Ordinal));
+        var resolvedFields = ResolveSelectedFields(layer, outFields);
+
+        // BuildSchema handles objectId as the first dedicated column, so exclude it
+        // from the attribute fields list to avoid a duplicate column.
+        var fieldsToInclude = resolvedFields
+            .Where(f => !f.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase))
+            .ToList();
 
         var schemaFields = new List<Field>
         {
@@ -180,11 +213,6 @@ internal sealed class GeoParquetQueryFormatter
         {
             schemaFields.Add(new Field(GeometryColumnName, new BinaryType(), true));
         }
-
-        var fieldsToInclude = (includeAllFields
-            ? layer.Fields.Where(f => !f.IsGeometry && !f.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase))
-            : layer.Fields.Where(f => !f.IsGeometry && !f.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase) && outFields!.Contains(f.Name, StringComparer.OrdinalIgnoreCase)))
-            .ToList();
 
         foreach (var field in fieldsToInclude)
         {
@@ -197,6 +225,8 @@ internal sealed class GeoParquetQueryFormatter
         // to match the filtering behavior of JSON/GeoJSON/PBF formatters.
         if (runtimeFields != null)
         {
+            var includeAllFields = outFields == null || outFields.Length == 0 ||
+                                  (outFields.Length == 1 && outFields[0].Equals("*", StringComparison.Ordinal));
             foreach (var (name, type) in runtimeFields)
             {
                 if (includeAllFields || outFields!.Contains(name, StringComparer.OrdinalIgnoreCase))
@@ -271,7 +301,7 @@ internal sealed class GeoParquetQueryFormatter
     /// layer schema (e.g. the "distance" field injected by KNN queries when returnDistance=true).
     /// Internal fields prefixed with "__" are excluded.
     /// </summary>
-    private static List<(string name, IArrowType type)> DetectRuntimeFields(
+    internal static List<(string name, IArrowType type)> DetectRuntimeFields(
         ImmutableArray<Feature> features,
         LayerDefinition layer)
     {
@@ -326,7 +356,7 @@ internal sealed class GeoParquetQueryFormatter
     /// <summary>
     /// Maps layer geometry type to GeoParquet geometry type string
     /// </summary>
-    private static string MapGeometryTypeToGeoParquet(Core.Features.Catalog.Domain.GeometryType geometryType, bool returnZ)
+    internal static string MapGeometryTypeToGeoParquet(Core.Features.Catalog.Domain.GeometryType geometryType, bool returnZ)
     {
         var baseType = geometryType switch
         {
@@ -447,7 +477,7 @@ internal sealed class GeoParquetQueryFormatter
 
         foreach (var feature in features)
         {
-            var (wkb, hasZ) = ProcessGeometry(feature.Geometry, outputSrid, geometryLimits, returnZ, returnM, feature.Id, logger);
+            var (wkb, hasZ) = ProcessGeometryCore(feature.Geometry, outputSrid, geometryLimits, returnZ, returnM, feature.Id, logger);
             anyHasZ |= hasZ;
             if (wkb != null && wkb.Length > 0)
             {
@@ -462,7 +492,25 @@ internal sealed class GeoParquetQueryFormatter
         return (builder.Build(), anyHasZ);
     }
 
-    private static (byte[]? wkb, bool hasZ) ProcessGeometry(
+    internal static object? GetAttributeValue(Feature feature, string fieldName)
+    {
+        return feature.Attributes.TryGetValue(fieldName, out var value) ? value : null;
+    }
+
+    internal static byte[]? ProcessGeometry(
+        byte[]? geometryBytes,
+        int outputSrid,
+        GeometryLimits geometryLimits,
+        bool returnZ,
+        bool returnM,
+        long featureId = 0,
+        ILogger? logger = null)
+    {
+        var (wkb, _) = ProcessGeometryCore(geometryBytes, outputSrid, geometryLimits, returnZ, returnM, featureId, logger);
+        return wkb;
+    }
+
+    private static (byte[]? wkb, bool hasZ) ProcessGeometryCore(
         byte[]? geometryBytes,
         int outputSrid,
         GeometryLimits geometryLimits,

--- a/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
@@ -86,13 +86,74 @@ internal sealed class QueryFormatter : IQueryFormatter
             maxAllowableOffset,
             forceSimplify: maxAllowableOffset is > 0);
 
-        return ValueTask.FromResult(format.ToLowerInvariant() switch
+        return format.ToLowerInvariant() switch
         {
-            "pbf" => _pbfFormatter.FormatAsPbf(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields),
-            "parquet" => GeoParquetQueryFormatter.FormatAsGeoParquet(result, layer, returnGeometry, outputSrid, returnZ, returnM, effectiveLimits, outFields, _logger),
-            "geojson" => FormatAsGeoJson(result, layer, returnGeometry, returnZ, returnM, effectiveLimits, outFields),
-            "json" or _ => FormatAsGeoServicesJson(result, layer, returnGeometry, outputSrid, returnZ, returnM, effectiveLimits, outFields)
-        });
+            "pbf" => ValueTask.FromResult<(object response, string contentType)>(
+                _pbfFormatter.FormatAsPbf(result, layer, returnGeometry, outputSrid, returnZ, returnM, geometryPrecision, maxAllowableOffset, outFields)),
+            "parquet" => ValueTask.FromResult<(object response, string contentType)>(
+                FormatParquet(result, layer, returnGeometry, outputSrid, returnZ, returnM, effectiveLimits, outFields)),
+            "arrow" => new ValueTask<(object response, string contentType)>(
+                FormatArrowAsync(
+                    result,
+                    layer,
+                    returnGeometry,
+                    outputSrid,
+                    returnZ,
+                    returnM,
+                    effectiveLimits,
+                    outFields)),
+            "geojson" => ValueTask.FromResult<(object response, string contentType)>(
+                FormatAsGeoJson(result, layer, returnGeometry, returnZ, returnM, effectiveLimits, outFields)),
+            "json" or _ => ValueTask.FromResult<(object response, string contentType)>(
+                FormatAsGeoServicesJson(result, layer, returnGeometry, outputSrid, returnZ, returnM, effectiveLimits, outFields))
+        };
+    }
+
+    private (object response, string contentType) FormatParquet(
+        QueryResult<Feature> result,
+        LayerDefinition layer,
+        bool returnGeometry,
+        int? outputSrid,
+        bool returnZ,
+        bool returnM,
+        GeometryLimits effectiveLimits,
+        string[]? outFields)
+    {
+        var (response, contentType) = GeoParquetQueryFormatter.FormatAsGeoParquet(
+            result,
+            layer,
+            returnGeometry,
+            outputSrid,
+            returnZ,
+            returnM,
+            effectiveLimits,
+            outFields,
+            _logger);
+
+        return (response, contentType);
+    }
+
+    private static async Task<(object response, string contentType)> FormatArrowAsync(
+        QueryResult<Feature> result,
+        LayerDefinition layer,
+        bool returnGeometry,
+        int? outputSrid,
+        bool returnZ,
+        bool returnM,
+        GeometryLimits effectiveLimits,
+        string[]? outFields)
+    {
+        var (response, contentType) = await GeoArrowQueryFormatter.FormatAsGeoArrowAsync(
+            result,
+            layer,
+            returnGeometry,
+            outputSrid,
+            returnZ,
+            returnM,
+            effectiveLimits,
+            outFields);
+
+        return (response, contentType);
     }
 
     /// <summary>

--- a/src/Honua.Server/Honua.Server.csproj
+++ b/src/Honua.Server/Honua.Server.csproj
@@ -59,7 +59,7 @@
     <PackageReference Include="NetTopologySuite" Version="2.6.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.2" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
-    <PackageReference Include="Apache.Arrow" Version="18.1.0" />
+    <PackageReference Include="Apache.Arrow" Version="22.1.0" />
     <EmbeddedResource Include="Migrations\*.sql" />
   </ItemGroup>
 

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoArrowQueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/GeoArrowQueryFormatterTests.cs
@@ -1,0 +1,423 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
+using FluentAssertions;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Shared.Models;
+using Honua.Server.Features.FeatureServer.Services;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using GeometryType = Honua.Core.Features.Catalog.Domain.GeometryType;
+
+namespace Honua.Server.Tests.Features.FeatureServer.Services;
+
+public sealed class GeoArrowQueryFormatterTests
+{
+    [Fact]
+    public async Task FormatAsGeoArrowAsync_WithFeatures_WritesReadableArrowStreamWithGeoMetadata()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("name", FieldType.String, 255),
+            new FieldDefinition("created", FieldType.DateTime));
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(-157.8583, 21.3069),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["name"] = "Honolulu Harbor",
+                ["created"] = new DateTimeOffset(2024, 01, 02, 03, 04, 05, TimeSpan.Zero)
+            }.ToImmutableDictionary());
+
+        var (payload, contentType) = await GeoArrowQueryFormatter.FormatAsGeoArrowAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryLimits: new GeometryLimits());
+
+        contentType.Should().Be("application/vnd.apache.arrow.stream");
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ArrowStreamReader(stream);
+        var batch = await reader.ReadNextRecordBatchAsync();
+
+        batch.Should().NotBeNull();
+        batch!.Length.Should().Be(1);
+
+        // Verify schema fields
+        var schema = reader.Schema;
+        schema.FieldsList.Select(f => f.Name)
+            .Should().Equal("objectid", "name", "created", "geometry");
+
+        // Verify GeoArrow extension metadata on geometry field
+        var geometryField = schema.GetFieldByName("geometry");
+        geometryField.Metadata.Should().ContainKey("ARROW:extension:name");
+        geometryField.Metadata["ARROW:extension:name"].Should().Be("geoarrow.wkb");
+        geometryField.Metadata.Should().ContainKey("ARROW:extension:metadata");
+
+        // Verify schema-level geo metadata
+        schema.Metadata.Should().ContainKey("geo");
+        using var geoDoc = JsonDocument.Parse(schema.Metadata["geo"]);
+        geoDoc.RootElement.GetProperty("primary_column").GetString().Should().Be("geometry");
+        geoDoc.RootElement.GetProperty("version").GetString().Should().Be("1.1.0");
+
+        // Verify attribute values
+        var nameArray = batch.Column("name") as StringArray;
+        nameArray.Should().NotBeNull();
+        nameArray!.GetString(0).Should().Be("Honolulu Harbor");
+
+        // Verify geometry is readable WKB
+        var geometryArray = batch.Column("geometry") as BinaryArray;
+        geometryArray.Should().NotBeNull();
+        var wkb = geometryArray!.GetBytes(0).ToArray();
+        var point = new WKBReader().Read(wkb);
+        point.Should().BeOfType<Point>();
+        ((Point)point).X.Should().BeApproximately(-157.8583, 0.0001);
+        ((Point)point).Y.Should().BeApproximately(21.3069, 0.0001);
+    }
+
+    [Fact]
+    public async Task FormatAsGeoArrowAsync_EmptyResult_PreservesRequestedSchema()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("name", FieldType.String, 255),
+            new FieldDefinition("created", FieldType.DateTime));
+
+        var (payload, _) = await GeoArrowQueryFormatter.FormatAsGeoArrowAsync(
+            QueryResult<Feature>.Empty(),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryLimits: new GeometryLimits(),
+            outFields: ["name", "created"]);
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ArrowStreamReader(stream);
+
+        // Schema should be present even with no data
+        reader.Schema.FieldsList.Select(f => f.Name)
+            .Should().Equal("objectid", "name", "created", "geometry");
+
+        var batch = await reader.ReadNextRecordBatchAsync();
+        batch.Should().NotBeNull();
+        batch!.Length.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task FormatAsGeoArrowAsync_AppliesGeometryPrecisionAndDimensionFiltering()
+    {
+        var layer = CreateLayer(new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false));
+        var feature = Feature.Create(
+            1,
+            CreatePointWkbWithZm(1.2349, 2.3451, 3.4567, 4.5678),
+            new Dictionary<string, object?> { ["objectid"] = 1L }.ToImmutableDictionary());
+
+        var (payload, _) = await GeoArrowQueryFormatter.FormatAsGeoArrowAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryLimits: new GeometryLimits { MaxCoordinatePrecision = 2 });
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ArrowStreamReader(stream);
+        var batch = await reader.ReadNextRecordBatchAsync();
+
+        var geometryArray = batch!.Column("geometry") as BinaryArray;
+        var wkb = geometryArray!.GetBytes(0).ToArray();
+        var geometry = new WKBReader().Read(wkb);
+        var point = geometry.Should().BeOfType<Point>().Subject;
+
+        point.X.Should().Be(1.23);
+        point.Y.Should().Be(2.35);
+        double.IsNaN(point.Coordinate.Z).Should().BeTrue();
+        double.IsNaN(point.Coordinate.M).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FormatAsGeoArrowAsync_NullGeometry_WritesNullInGeometryColumn()
+    {
+        var layer = CreateLayer(new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false));
+        var feature = Feature.Create(
+            1,
+            null,
+            new Dictionary<string, object?> { ["objectid"] = 1L }.ToImmutableDictionary());
+
+        var (payload, _) = await GeoArrowQueryFormatter.FormatAsGeoArrowAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryLimits: new GeometryLimits());
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ArrowStreamReader(stream);
+        var batch = await reader.ReadNextRecordBatchAsync();
+
+        var geometryArray = batch!.Column("geometry") as BinaryArray;
+        geometryArray!.IsNull(0).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FormatAsGeoArrowAsync_FieldTypeMappings_CorrectArrowTypes()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("id", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("count", FieldType.Integer),
+            new FieldDefinition("rating", FieldType.Float),
+            new FieldDefinition("area", FieldType.Double),
+            new FieldDefinition("active", FieldType.Boolean),
+            new FieldDefinition("label", FieldType.String, 100));
+
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(0, 0),
+            new Dictionary<string, object?>
+            {
+                ["id"] = 42L,
+                ["count"] = 10,
+                ["rating"] = 4.5f,
+                ["area"] = 123.456,
+                ["active"] = true,
+                ["label"] = "test"
+            }.ToImmutableDictionary());
+
+        var (payload, _) = await GeoArrowQueryFormatter.FormatAsGeoArrowAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryLimits: new GeometryLimits());
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ArrowStreamReader(stream);
+        var batch = await reader.ReadNextRecordBatchAsync();
+
+        reader.Schema.GetFieldByName("id").DataType.Should().BeOfType<Int64Type>();
+        reader.Schema.GetFieldByName("count").DataType.Should().BeOfType<Int32Type>();
+        reader.Schema.GetFieldByName("rating").DataType.Should().BeOfType<FloatType>();
+        reader.Schema.GetFieldByName("area").DataType.Should().BeOfType<DoubleType>();
+        reader.Schema.GetFieldByName("active").DataType.Should().BeOfType<BooleanType>();
+        reader.Schema.GetFieldByName("label").DataType.Should().BeOfType<StringType>();
+        reader.Schema.GetFieldByName("geometry").DataType.Should().BeOfType<BinaryType>();
+
+        // Verify values round-trip
+        ((Int64Array)batch!.Column("id")).GetValue(0).Should().Be(42L);
+        ((Int32Array)batch.Column("count")).GetValue(0).Should().Be(10);
+        ((FloatArray)batch.Column("rating")).GetValue(0).Should().Be(4.5f);
+        ((DoubleArray)batch.Column("area")).GetValue(0).Should().Be(123.456);
+        ((BooleanArray)batch.Column("active")).GetValue(0).Should().BeTrue();
+        ((StringArray)batch.Column("label")).GetString(0).Should().Be("test");
+    }
+
+    [Fact]
+    public async Task FormatAsGeoArrowAsync_ExtensionMetadata_ContainsGeometryTypesAndOmitsCrsFor4326()
+    {
+        var layer = CreateLayer(new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false));
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(0, 0),
+            new Dictionary<string, object?> { ["objectid"] = 1L }.ToImmutableDictionary());
+
+        var (payload, _) = await GeoArrowQueryFormatter.FormatAsGeoArrowAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryLimits: new GeometryLimits());
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ArrowStreamReader(stream);
+
+        var geometryField = reader.Schema.GetFieldByName("geometry");
+        var extensionMetadata = geometryField.Metadata["ARROW:extension:metadata"];
+        using var doc = JsonDocument.Parse(extensionMetadata);
+
+        doc.RootElement.GetProperty("geometry_types").EnumerateArray()
+            .Select(e => e.GetString()).Should().Contain("Point");
+
+        // EPSG:4326 omits CRS key (implies OGC:CRS84), matching GeoParquet convention
+        doc.RootElement.TryGetProperty("crs", out _).Should().BeFalse(
+            "CRS key should be omitted for EPSG:4326 (implies OGC:CRS84 per GeoParquet 1.1.0 spec)");
+    }
+
+    [Fact]
+    public async Task FormatAsGeoArrowAsync_WithReturnZ_IncludesZSuffix()
+    {
+        var layer = CreateLayer(new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false));
+        var feature = Feature.Create(
+            1,
+            CreatePointWkbWithZm(1.0, 2.0, 3.0, double.NaN),
+            new Dictionary<string, object?> { ["objectid"] = 1L }.ToImmutableDictionary());
+
+        var (payload, _) = await GeoArrowQueryFormatter.FormatAsGeoArrowAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: true,
+            returnM: false,
+            geometryLimits: new GeometryLimits());
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ArrowStreamReader(stream);
+
+        var extensionMetadata = reader.Schema.GetFieldByName("geometry")
+            .Metadata["ARROW:extension:metadata"];
+        using var doc = JsonDocument.Parse(extensionMetadata);
+        doc.RootElement.GetProperty("geometry_types").EnumerateArray()
+            .Select(e => e.GetString()).Should().Contain("Point Z");
+
+        // Schema-level geo metadata should also show Z
+        using var geoDoc = JsonDocument.Parse(reader.Schema.Metadata["geo"]);
+        var columns = geoDoc.RootElement.GetProperty("columns");
+        var geomCol = columns.GetProperty("geometry");
+        geomCol.GetProperty("geometry_types").EnumerateArray()
+            .Select(e => e.GetString()).Should().Contain("Point Z");
+    }
+
+    [Fact]
+    public async Task FormatAsGeoArrowAsync_WithoutGeometry_OmitsGeometryColumn()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false),
+            new FieldDefinition("name", FieldType.String, 255));
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(0, 0),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["name"] = "test"
+            }.ToImmutableDictionary());
+
+        var (payload, _) = await GeoArrowQueryFormatter.FormatAsGeoArrowAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: false,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryLimits: new GeometryLimits());
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ArrowStreamReader(stream);
+
+        reader.Schema.FieldsList.Select(f => f.Name)
+            .Should().Equal("objectid", "name");
+
+        // When no geometry is included, schema metadata should either be null or not contain "geo"
+        if (reader.Schema.Metadata != null)
+        {
+            reader.Schema.Metadata.Should().NotContainKey("geo");
+        }
+    }
+
+    [Fact]
+    public async Task FormatAsGeoArrowAsync_RuntimeFields_IncludedInSchema()
+    {
+        var layer = CreateLayer(new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false));
+        // Simulate a KNN result with a runtime "distance" attribute not in the layer schema
+        var feature = Feature.Create(
+            1,
+            CreatePointWkb(0, 0),
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 1L,
+                ["distance"] = 42.5
+            }.ToImmutableDictionary());
+
+        var (payload, _) = await GeoArrowQueryFormatter.FormatAsGeoArrowAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryLimits: new GeometryLimits());
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ArrowStreamReader(stream);
+        var batch = await reader.ReadNextRecordBatchAsync();
+
+        reader.Schema.FieldsList.Select(f => f.Name)
+            .Should().Contain("distance", "runtime-computed fields should appear in schema");
+
+        var distanceArray = batch!.Column("distance") as DoubleArray;
+        distanceArray.Should().NotBeNull();
+        distanceArray!.GetValue(0).Should().Be(42.5);
+    }
+
+    [Fact]
+    public async Task FormatAsGeoArrowAsync_EmptyResult_EmitsEmptyGeometryTypes()
+    {
+        var layer = CreateLayer(
+            new FieldDefinition("objectid", FieldType.BigInteger, Nullable: false));
+
+        var (payload, _) = await GeoArrowQueryFormatter.FormatAsGeoArrowAsync(
+            QueryResult<Feature>.Empty(),
+            layer,
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: false,
+            returnM: false,
+            geometryLimits: new GeometryLimits());
+
+        using var stream = new MemoryStream(payload);
+        using var reader = new ArrowStreamReader(stream);
+
+        // Extension metadata on geometry field should have empty geometry_types
+        var geometryField = reader.Schema.GetFieldByName("geometry");
+        var extMeta = geometryField.Metadata["ARROW:extension:metadata"];
+        using var extDoc = JsonDocument.Parse(extMeta);
+        extDoc.RootElement.GetProperty("geometry_types").GetArrayLength().Should().Be(0,
+            "empty results must emit geometry_types: [] per GeoParquet 1.1.0 §4.1");
+
+        // Schema-level geo metadata should also have empty geometry_types
+        using var geoDoc = JsonDocument.Parse(reader.Schema.Metadata["geo"]);
+        geoDoc.RootElement.GetProperty("columns").GetProperty("geometry")
+            .GetProperty("geometry_types").GetArrayLength().Should().Be(0);
+    }
+
+    private static LayerDefinition CreateLayer(params FieldDefinition[] fields)
+        => new(
+            Id: 1,
+            Name: "harbors",
+            Description: "Harbors",
+            GeometryType: GeometryType.Point,
+            SpatialReference: SpatialReference.WGS84,
+            Fields:
+            [
+                .. fields,
+                new FieldDefinition("shape", FieldType.Geometry, Nullable: true)
+            ]);
+
+    private static byte[] CreatePointWkb(double x, double y)
+        => new WKBWriter().Write(new Point(x, y) { SRID = 4326 });
+
+    private static byte[] CreatePointWkbWithZm(double x, double y, double z, double m)
+        => new WKBWriter(ByteOrder.LittleEndian, handleSRID: false, emitZ: true, emitM: true)
+            .Write(new Point(new CoordinateZM(x, y, z, m)) { SRID = 4326 });
+}

--- a/tests/Honua.Server.Tests/Honua.Server.Tests.csproj
+++ b/tests/Honua.Server.Tests/Honua.Server.Tests.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Apache.Arrow" Version="22.1.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #426

## Summary
Adds a GeoArrow IPC export surface for feature queries and aligns the export path with the runtime-computed fields and geometry metadata expected by the format-specific tests.

## Changes Made
- added a dedicated GeoArrow query formatter and wired it into the feature-server export path
- preserved runtime-computed fields in Arrow output and tightened shared export formatting behavior
- added focused formatter test coverage for GeoArrow output and updated related export tests

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] Documentation updated if needed
- [ ] If protocol/auth behavior changed, updated MVP compatibility contract and release checklist notes
- [ ] If breaking admin/control-plane API changes: updated migration guide and versioning policy docs
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review and documented in migration guide
