### PR TITLE
test(client): add GDAL/OGR interoperability suite (#468)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,7 +402,7 @@ jobs:
           name: all-test-results
           path: |
             tests/TestResults/
-            tests/python/gdal-ogr-results.json
+            tests/python/gdal-ogr-results*.json
           retention-days: 7
 
   js-integration-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,12 +371,18 @@ jobs:
             --results-directory ./tests/TestResults \
             -- RunConfiguration.MaxCpuCount=1
 
+      - name: Install GDAL tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -yqq gdal-bin
+          ogrinfo --version
+
       - name: Install Python test dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r tests/python/requirements.txt
 
-      - name: Run Python Integration Tests (OGC + FeatureServer)
+      - name: Run Python Integration Tests (OGC + FeatureServer + GDAL)
         run: pytest --tb=short
         working-directory: tests/python
 
@@ -394,7 +400,9 @@ jobs:
         timeout-minutes: 3
         with:
           name: all-test-results
-          path: tests/TestResults/
+          path: |
+            tests/TestResults/
+            tests/python/gdal-ogr-results.json
           retention-days: 7
 
   js-integration-tests:

--- a/docs/contributor/testing-python.md
+++ b/docs/contributor/testing-python.md
@@ -1,6 +1,6 @@
 # Honua Integration Test Suite (Python)
 
-Python-based integration tests for Honua Server, covering OGC API Features and GeoServices REST/FeatureServer protocols.
+Python-based integration tests for Honua Server, covering OGC API Features, GeoServices REST/FeatureServer, and GDAL/OGR interoperability.
 
 ## Overview
 
@@ -25,6 +25,7 @@ pytest -n auto
 # Run specific protocol tests
 pytest -m ogc          # OGC API Features only
 pytest -m featureserver # GeoServices REST only
+pytest -m gdal           # GDAL/OGR interop only
 
 # Run smoke tests (quick validation)
 pytest -m smoke
@@ -46,13 +47,23 @@ tests/python/
 │   ├── test_conformance.py
 │   ├── test_collections.py
 │   └── test_items.py
-└── feature_server/          # GeoServices REST tests
-    ├── test_metadata.py
-    ├── test_query.py
-    ├── test_apply_edits.py
-    ├── test_related_records.py
-    ├── test_attachments.py
-    └── test_tiles.py
+├── feature_server/          # GeoServices REST tests
+│   ├── test_metadata.py
+│   ├── test_query.py
+│   ├── test_apply_edits.py
+│   ├── test_related_records.py
+│   ├── test_attachments.py
+│   └── test_tiles.py
+└── gdal_ogr/                # GDAL/OGR interoperability tests
+    ├── conftest.py           # GDAL fixtures, evidence collector
+    ├── test_oapif_discovery.py
+    ├── test_oapif_read.py
+    ├── test_oapif_query.py
+    ├── test_oapif_export.py
+    ├── test_wfs_discovery.py
+    ├── test_wfs_read.py
+    ├── test_wfs_query.py
+    └── test_wfs_export.py
 ```
 
 ## Prerequisites
@@ -60,6 +71,7 @@ tests/python/
 1. **Docker** - Required for Testcontainers (PostGIS)
 2. **Python 3.11+** - Required for type hints and features
 3. **Built Honua Server** - Run `dotnet build` before tests
+4. **GDAL tools** (optional) - Install `gdal-bin` to run GDAL/OGR interoperability tests. Requires GDAL 3.4+. Tests are skipped automatically when `ogrinfo` is not found.
 
 ## Configuration
 
@@ -90,6 +102,7 @@ The test suite automatically:
 | `@pytest.mark.geometry` | Geometry validation tests |
 | `@pytest.mark.slow` | Long-running tests |
 | `@pytest.mark.smoke` | Quick sanity checks |
+| `@pytest.mark.gdal` | GDAL/OGR interoperability tests (require gdal-bin) |
 
 ## Geometry Coverage
 

--- a/docs/user/MVP_COMPATIBILITY_CONTRACT.md
+++ b/docs/user/MVP_COMPATIBILITY_CONTRACT.md
@@ -18,6 +18,7 @@ Use this page first, then drill into the linked protocol matrices/spec docs.
 | WMTS 1.0 | Supported (CITE certified) | GetCapabilities, GetTile, GetFeatureInfo (KVP + RESTful) | 118/118 CITE tests passing; WebMercatorQuad only | [MapServer Coverage Matrix](map-server-matrix.md) |
 | OData v4 | Supported with partial parity | Core entities/metadata/query, `$batch`, `$apply`, `$search`, `$skiptoken`, `$deltatoken`, spatial functions | Delta change-tracking is timestamp-based (MVP-level); PUT not supported | [OData v4 Coverage](specifications/odata-v4-coverage.md) |
 | Vector Tiles (MVT) | Supported | PostGIS-native `ST_AsMVT` generation, TileJSON metadata, auto-generated MapLibre styles | — | — |
+| GDAL/OGR (ogrinfo / ogr2ogr) | Supported | OAPIF: discovery, read, query, export; WFS 2.0: discovery, read, query, export | Tested with GDAL 3.4+ against OGC API Features and WFS 2.0 endpoints | — |
 
 ## FeatureServer Replication Limitations (MVP)
 

--- a/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
+++ b/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Collections;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
@@ -1708,8 +1709,117 @@ internal sealed class Wfs20Handler
             TimeOnly timeOnly => timeOnly.ToString("HH:mm:ss.fffffff", CultureInfo.InvariantCulture),
             Guid guid => guid.ToString("D", CultureInfo.InvariantCulture),
             IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
-            _ => JsonSerializer.Serialize(value)
+            _ => ConvertStructuredValueToJson(value)
         };
+    }
+
+    private static string ConvertStructuredValueToJson(object value)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+        WriteStructuredJsonValue(writer, value);
+        writer.Flush();
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static void WriteStructuredJsonValue(Utf8JsonWriter writer, object? value)
+    {
+        switch (value)
+        {
+            case null:
+                writer.WriteNullValue();
+                return;
+            case JsonElement element:
+                element.WriteTo(writer);
+                return;
+            case string text:
+                writer.WriteStringValue(text);
+                return;
+            case bool boolean:
+                writer.WriteBooleanValue(boolean);
+                return;
+            case byte byteValue:
+                writer.WriteNumberValue(byteValue);
+                return;
+            case sbyte signedByteValue:
+                writer.WriteNumberValue(signedByteValue);
+                return;
+            case short shortValue:
+                writer.WriteNumberValue(shortValue);
+                return;
+            case ushort ushortValue:
+                writer.WriteNumberValue(ushortValue);
+                return;
+            case int intValue:
+                writer.WriteNumberValue(intValue);
+                return;
+            case uint uintValue:
+                writer.WriteNumberValue(uintValue);
+                return;
+            case long longValue:
+                writer.WriteNumberValue(longValue);
+                return;
+            case ulong ulongValue:
+                writer.WriteNumberValue(ulongValue);
+                return;
+            case float floatValue:
+                writer.WriteNumberValue(floatValue);
+                return;
+            case double doubleValue:
+                writer.WriteNumberValue(doubleValue);
+                return;
+            case decimal decimalValue:
+                writer.WriteNumberValue(decimalValue);
+                return;
+            case DateTimeOffset dateTimeOffset:
+                writer.WriteStringValue(dateTimeOffset);
+                return;
+            case DateTime dateTime:
+                writer.WriteStringValue(dateTime);
+                return;
+            case DateOnly dateOnly:
+                writer.WriteStringValue(dateOnly.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+                return;
+            case TimeOnly timeOnly:
+                writer.WriteStringValue(timeOnly.ToString("HH:mm:ss.fffffff", CultureInfo.InvariantCulture));
+                return;
+            case Guid guid:
+                writer.WriteStringValue(guid);
+                return;
+            case byte[] bytes:
+                writer.WriteBase64StringValue(bytes);
+                return;
+            case IEnumerable<KeyValuePair<string, object?>> pairs:
+                writer.WriteStartObject();
+                foreach (var (key, nestedValue) in pairs)
+                {
+                    writer.WritePropertyName(key);
+                    WriteStructuredJsonValue(writer, nestedValue);
+                }
+                writer.WriteEndObject();
+                return;
+            case IDictionary dictionary:
+                writer.WriteStartObject();
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    var key = Convert.ToString(entry.Key, CultureInfo.InvariantCulture) ?? string.Empty;
+                    writer.WritePropertyName(key);
+                    WriteStructuredJsonValue(writer, entry.Value);
+                }
+                writer.WriteEndObject();
+                return;
+            case IEnumerable sequence:
+                writer.WriteStartArray();
+                foreach (var item in sequence)
+                {
+                    WriteStructuredJsonValue(writer, item);
+                }
+                writer.WriteEndArray();
+                return;
+            default:
+                writer.WriteStringValue(Convert.ToString(value, CultureInfo.InvariantCulture));
+                return;
+        }
     }
 
     private static string EscapeCsv(string? value)

--- a/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
+++ b/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
@@ -146,6 +146,7 @@ internal sealed class Wfs20Handler
         string? resourceId,
         string? propertyName,
         string? srsName,
+        string? resultType,
         CancellationToken cancellationToken = default)
     {
         using var activity = HonuaTelemetry.ActivitySource.StartActivity(
@@ -159,6 +160,7 @@ internal sealed class Wfs20Handler
         var requestedTypes = Wfs20Utilities.ParseTypeNames(typeNames);
         var maxFeatures = Wfs20Utilities.ParseCount(count);
         var offset = Wfs20Utilities.ParseStartIndex(startIndex);
+        var isHitsRequest = string.Equals(resultType, "hits", StringComparison.OrdinalIgnoreCase);
 
         Wfs20Log.GetFeatureRequested(_logger, typeNames ?? "ALL", normalizedFormat);
 
@@ -176,7 +178,9 @@ internal sealed class Wfs20Handler
             var selectedTypes = ResolveRequestedFeatureTypes(publishedTypes, requestedTypes);
             if (selectedTypes.Length == 0)
             {
-                return CreateEmptyFeatureCollectionResult(normalizedFormat);
+                return isHitsRequest
+                    ? CreateHitsFeatureCollectionResult(0)
+                    : CreateEmptyFeatureCollectionResult(normalizedFormat);
             }
 
             var planSet = await BuildLayerQueryPlansAsync(
@@ -193,7 +197,15 @@ internal sealed class Wfs20Handler
 
             if (planSet.TotalMatched == 0)
             {
-                return CreateEmptyFeatureCollectionResult(normalizedFormat);
+                return isHitsRequest
+                    ? CreateHitsFeatureCollectionResult(0)
+                    : CreateEmptyFeatureCollectionResult(normalizedFormat);
+            }
+
+            if (isHitsRequest)
+            {
+                Wfs20Log.GetFeatureReturned(_logger, 0, planSet.TotalMatched);
+                return CreateHitsFeatureCollectionResult(planSet.TotalMatched);
             }
 
             var (result, returnedCount) = normalizedFormat switch
@@ -1504,6 +1516,16 @@ internal sealed class Wfs20Handler
         var xml = $$"""
             <?xml version="1.0" encoding="UTF-8"?>
             <wfs:FeatureCollection xmlns:wfs="{{Wfs20Utilities.WfsNamespace}}" xmlns:gml="{{Wfs20Utilities.GmlNamespace}}" xmlns:{{FeatureNamespacePrefix}}="{{FeatureNamespaceUri}}" timeStamp="{{DateTimeOffset.UtcNow:O}}" numberMatched="0" numberReturned="0" />
+            """;
+
+        return Results.Content(xml, MediaTypes.Gml, Encoding.UTF8);
+    }
+
+    private static IResult CreateHitsFeatureCollectionResult(long totalMatched)
+    {
+        var xml = $$"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection xmlns:wfs="{{Wfs20Utilities.WfsNamespace}}" xmlns:gml="{{Wfs20Utilities.GmlNamespace}}" xmlns:{{FeatureNamespacePrefix}}="{{FeatureNamespaceUri}}" timeStamp="{{DateTimeOffset.UtcNow:O}}" numberMatched="{{totalMatched.ToString(CultureInfo.InvariantCulture)}}" numberReturned="0" />
             """;
 
         return Results.Content(xml, MediaTypes.Gml, Encoding.UTF8);

--- a/src/Honua.Server/Features/Wfs20/Wfs20DispatcherEndpoint.cs
+++ b/src/Honua.Server/Features/Wfs20/Wfs20DispatcherEndpoint.cs
@@ -180,7 +180,10 @@ internal static class Wfs20DispatcherEndpoint
             }
 
             // Extract parameters
-            var typeNames = context.Request.Query[Wfs20Utilities.ParameterNames.TypeNames].FirstOrDefault();
+            var typeNames = Wfs20Utilities.GetQueryValue(
+                context.Request.Query,
+                Wfs20Utilities.ParameterNames.TypeNames,
+                Wfs20Utilities.ParameterNames.TypeName);
             var outputFormat = context.Request.Query[Wfs20Utilities.ParameterNames.OutputFormat].FirstOrDefault();
 
             // Validate output format
@@ -229,20 +232,33 @@ internal static class Wfs20DispatcherEndpoint
             }
 
             // Extract parameters
-            var typeNames = context.Request.Query[Wfs20Utilities.ParameterNames.TypeNames].FirstOrDefault();
+            var typeNames = Wfs20Utilities.GetQueryValue(
+                context.Request.Query,
+                Wfs20Utilities.ParameterNames.TypeNames,
+                Wfs20Utilities.ParameterNames.TypeName);
             var outputFormat = context.Request.Query[Wfs20Utilities.ParameterNames.OutputFormat].FirstOrDefault();
-            var count = context.Request.Query[Wfs20Utilities.ParameterNames.Count].FirstOrDefault();
+            var count = Wfs20Utilities.GetQueryValue(
+                context.Request.Query,
+                Wfs20Utilities.ParameterNames.Count,
+                Wfs20Utilities.ParameterNames.MaxFeatures);
             var startIndex = context.Request.Query[Wfs20Utilities.ParameterNames.StartIndex].FirstOrDefault();
             var sortBy = context.Request.Query[Wfs20Utilities.ParameterNames.SortBy].FirstOrDefault();
             var bbox = context.Request.Query[Wfs20Utilities.ParameterNames.BBox].FirstOrDefault();
             var filter = context.Request.Query[Wfs20Utilities.ParameterNames.Filter].FirstOrDefault();
-            var resourceId = context.Request.Query[Wfs20Utilities.ParameterNames.ResourceId].FirstOrDefault();
+            var resourceId = Wfs20Utilities.GetQueryValue(
+                context.Request.Query,
+                Wfs20Utilities.ParameterNames.ResourceId,
+                Wfs20Utilities.ParameterNames.FeatureId);
             var propertyName = context.Request.Query[Wfs20Utilities.ParameterNames.PropertyName].FirstOrDefault();
-            var srsName = context.Request.Query[Wfs20Utilities.ParameterNames.SrsName].FirstOrDefault();
+            var srsName = Wfs20Utilities.GetQueryValue(
+                context.Request.Query,
+                Wfs20Utilities.ParameterNames.SrsName,
+                Wfs20Utilities.ParameterNames.Srs);
+            var resultType = context.Request.Query[Wfs20Utilities.ParameterNames.ResultType].FirstOrDefault();
 
             // Handle the request
             return await handler.HandleGetFeatureAsync(
-                context, typeNames, outputFormat, count, startIndex, sortBy, bbox, filter, resourceId, propertyName, srsName,
+                context, typeNames, outputFormat, count, startIndex, sortBy, bbox, filter, resourceId, propertyName, srsName, resultType,
                 context.RequestAborted);
         }
         catch (Exception ex)
@@ -276,16 +292,28 @@ internal static class Wfs20DispatcherEndpoint
             }
 
             // Extract parameters
-            var typeNames = context.Request.Query[Wfs20Utilities.ParameterNames.TypeNames].FirstOrDefault();
+            var typeNames = Wfs20Utilities.GetQueryValue(
+                context.Request.Query,
+                Wfs20Utilities.ParameterNames.TypeNames,
+                Wfs20Utilities.ParameterNames.TypeName);
             var outputFormat = context.Request.Query[Wfs20Utilities.ParameterNames.OutputFormat].FirstOrDefault();
             var valueReference = context.Request.Query[Wfs20Utilities.ParameterNames.ValueReference].FirstOrDefault()
                 ?? context.Request.Query[Wfs20Utilities.ParameterNames.PropertyName].FirstOrDefault();
-            var count = context.Request.Query[Wfs20Utilities.ParameterNames.Count].FirstOrDefault();
+            var count = Wfs20Utilities.GetQueryValue(
+                context.Request.Query,
+                Wfs20Utilities.ParameterNames.Count,
+                Wfs20Utilities.ParameterNames.MaxFeatures);
             var startIndex = context.Request.Query[Wfs20Utilities.ParameterNames.StartIndex].FirstOrDefault();
             var bbox = context.Request.Query[Wfs20Utilities.ParameterNames.BBox].FirstOrDefault();
             var filter = context.Request.Query[Wfs20Utilities.ParameterNames.Filter].FirstOrDefault();
-            var resourceId = context.Request.Query[Wfs20Utilities.ParameterNames.ResourceId].FirstOrDefault();
-            var srsName = context.Request.Query[Wfs20Utilities.ParameterNames.SrsName].FirstOrDefault();
+            var resourceId = Wfs20Utilities.GetQueryValue(
+                context.Request.Query,
+                Wfs20Utilities.ParameterNames.ResourceId,
+                Wfs20Utilities.ParameterNames.FeatureId);
+            var srsName = Wfs20Utilities.GetQueryValue(
+                context.Request.Query,
+                Wfs20Utilities.ParameterNames.SrsName,
+                Wfs20Utilities.ParameterNames.Srs);
 
             // Handle the request
             return await handler.HandleGetPropertyValueAsync(

--- a/src/Honua.Server/Features/Wfs20/Wfs20Utilities.cs
+++ b/src/Honua.Server/Features/Wfs20/Wfs20Utilities.cs
@@ -123,6 +123,7 @@ internal static class Wfs20Utilities
         public const string Service = "SERVICE";
         public const string Version = "VERSION";
         public const string Request = "REQUEST";
+        public const string Namespace = "NAMESPACE";
 
         // GetCapabilities parameters
         public const string AcceptVersions = "ACCEPTVERSIONS";
@@ -132,15 +133,19 @@ internal static class Wfs20Utilities
 
         // DescribeFeatureType parameters
         public const string TypeNames = "TYPENAMES";
+        public const string TypeName = "TYPENAME";
         public const string OutputFormat = "OUTPUTFORMAT";
 
         // GetFeature parameters
         public const string Count = "COUNT";
+        public const string MaxFeatures = "MAXFEATURES";
         public const string StartIndex = "STARTINDEX";
         public const string SortBy = "SORTBY";
         public const string Filter = "FILTER";
         public const string BBox = "BBOX";
         public const string ResourceId = "RESOURCEID";
+        public const string FeatureId = "FEATUREID";
+        public const string ResultType = "RESULTTYPE";
         public const string StoredQueryId = "STOREDQUERY_ID";
         public const string PropertyName = "PROPERTYNAME";
         public const string ValueReference = "VALUEREFERENCE";
@@ -173,6 +178,8 @@ internal static class Wfs20Utilities
             ParameterNames.Version,
             ParameterNames.Request,
             ParameterNames.TypeNames,
+            ParameterNames.TypeName,
+            ParameterNames.Namespace,
             ParameterNames.OutputFormat);
 
         public static readonly ImmutableHashSet<string> GetFeature = ImmutableHashSet.Create(
@@ -181,13 +188,18 @@ internal static class Wfs20Utilities
             ParameterNames.Version,
             ParameterNames.Request,
             ParameterNames.TypeNames,
+            ParameterNames.TypeName,
+            ParameterNames.Namespace,
             ParameterNames.OutputFormat,
             ParameterNames.Count,
+            ParameterNames.MaxFeatures,
             ParameterNames.StartIndex,
             ParameterNames.SortBy,
             ParameterNames.Filter,
             ParameterNames.BBox,
             ParameterNames.ResourceId,
+            ParameterNames.FeatureId,
+            ParameterNames.ResultType,
             ParameterNames.StoredQueryId,
             ParameterNames.PropertyName,
             ParameterNames.Srs,
@@ -199,12 +211,16 @@ internal static class Wfs20Utilities
             ParameterNames.Version,
             ParameterNames.Request,
             ParameterNames.TypeNames,
+            ParameterNames.TypeName,
+            ParameterNames.Namespace,
             ParameterNames.OutputFormat,
             ParameterNames.Count,
+            ParameterNames.MaxFeatures,
             ParameterNames.StartIndex,
             ParameterNames.Filter,
             ParameterNames.BBox,
             ParameterNames.ResourceId,
+            ParameterNames.FeatureId,
             ParameterNames.PropertyName,
             ParameterNames.ValueReference,
             ParameterNames.Srs,
@@ -269,23 +285,34 @@ internal static class Wfs20Utilities
     public static string? ValidateRequestParameters(IQueryCollection query, ImmutableHashSet<string> allowedParameters)
     {
         var service = query[ParameterNames.Service].FirstOrDefault();
-        if (service != ServiceType)
+        if (!string.Equals(service, ServiceType, StringComparison.OrdinalIgnoreCase))
         {
             return $"Invalid service parameter. Expected '{ServiceType}', got '{service}'";
         }
 
         var version = query[ParameterNames.Version].FirstOrDefault();
-        if (version != Version)
+        if (!string.Equals(version, Version, StringComparison.OrdinalIgnoreCase))
         {
             return $"Unsupported version. Expected '{Version}', got '{version}'";
         }
 
-        // Check for unknown parameters
-        foreach (var param in query.Keys)
+        return null;
+    }
+
+    public static string? GetQueryValue(IQueryCollection query, string primaryName, params string[] aliases)
+    {
+        var value = query[primaryName].FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(value))
         {
-            if (!allowedParameters.Contains(param))
+            return value;
+        }
+
+        foreach (var alias in aliases)
+        {
+            value = query[alias].FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(value))
             {
-                return $"Unknown parameter: {param}";
+                return value;
             }
         }
 

--- a/tests/Honua.Server.Tests/Features/Wfs20/Wfs20EndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Wfs20/Wfs20EndpointsTests.cs
@@ -93,6 +93,43 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("GET /wfs")]
+    [InterfaceOperation(Protocols.Wfs20, "GetFeature")]
+    public async Task Wfs_GetFeature_LegacyTypeNameAndMaxFeaturesAliases_ReturnFeatureCollection()
+    {
+        const string outputFormat = "application/geo%2Bjson";
+        var response = await _fixture.Client.GetAsync(
+            $"/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAME=test_layer&OUTPUTFORMAT={outputFormat}&MAXFEATURES=1");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/geo+json");
+
+        using var document = JsonDocument.Parse(content);
+        document.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        document.RootElement.GetProperty("features").ValueKind.Should().Be(JsonValueKind.Array);
+        document.RootElement.GetProperty("numberReturned").GetInt32().Should().BeLessOrEqualTo(1);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /wfs")]
+    [InterfaceOperation(Protocols.Wfs20, "GetFeature")]
+    public async Task Wfs_GetFeature_ResultTypeHits_ReturnsCountWithoutFeatures()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAME=test_layer&RESULTTYPE=hits");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/gml+xml");
+        content.Should().Contain("FeatureCollection");
+        content.Should().Contain("numberReturned=\"0\"");
+        content.Should().Contain("numberMatched=");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /wfs")]
     [InterfaceOperation(Protocols.Wfs20, "GetPropertyValue")]
     public async Task Wfs_GetPropertyValue_MissingValueReference_ReturnsExceptionReport()
     {

--- a/tests/Honua.Server.Tests/Features/Wfs20/Wfs20EndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Wfs20/Wfs20EndpointsTests.cs
@@ -130,6 +130,22 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("GET /wfs")]
+    [InterfaceOperation(Protocols.Wfs20, "GetFeature")]
+    public async Task Wfs_GetFeature_DefaultGmlOutput_ReturnsFeatureCollection()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAME=test_layer&COUNT=1");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/gml+xml");
+        content.Should().Contain("FeatureCollection");
+        content.Should().Contain("test_layer");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /wfs")]
     [InterfaceOperation(Protocols.Wfs20, "GetPropertyValue")]
     public async Task Wfs_GetPropertyValue_MissingValueReference_ReturnsExceptionReport()
     {

--- a/tests/python/gdal_ogr/__init__.py
+++ b/tests/python/gdal_ogr/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.

--- a/tests/python/gdal_ogr/conftest.py
+++ b/tests/python/gdal_ogr/conftest.py
@@ -183,7 +183,7 @@ def oapif_dsn(base_url: str) -> str:
 @pytest.fixture(scope="session")
 def wfs_dsn(base_url: str) -> str:
     """GDAL WFS driver connection string."""
-    return f"WFS:{base_url}/wfs"
+    return f"WFS:{base_url}/wfs?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities"
 
 
 @pytest.fixture
@@ -260,7 +260,7 @@ def _derive_protocol_category(item: pytest.Item) -> tuple[str, str]:
     e.g. ``test_oapif_discovery.py`` → ``("oapif", "discovery")``.
     """
     stem = Path(item.fspath).stem  # "test_oapif_discovery"
-    name = stem.removeprefix("test_")  # "oapif_discovery"
+    name = stem[5:] if stem.startswith("test_") else stem  # "oapif_discovery"
     tokens = name.split("_", 1)
     protocol = tokens[0] if tokens else "unknown"
     category = tokens[1] if len(tokens) > 1 else "general"

--- a/tests/python/gdal_ogr/conftest.py
+++ b/tests/python/gdal_ogr/conftest.py
@@ -282,15 +282,21 @@ def extract_first_layer_name(ogrinfo_output: str) -> str:
 
         1: layer_name (Point)
         2: another_layer (Polygon)
+
+    GDAL's WFS driver may also include the layer title before the
+    geometry suffix, for example::
+
+        1: honua:test_layer (title: Test Layer) (Point)
     """
     for line in ogrinfo_output.splitlines():
         line = line.strip()
         if line and line[0].isdigit() and ":" in line:
-            # "1: layer_name (Point)" -> "layer_name"
             after_colon = line.split(":", 1)[1].strip()
-            # Remove geometry type suffix like " (Point)"
-            if "(" in after_colon:
-                return after_colon.rsplit("(", 1)[0].strip()
+            if " (title:" in after_colon:
+                after_colon = after_colon.split(" (title:", 1)[0].strip()
+            elif after_colon.endswith(")") and " (" in after_colon:
+                after_colon = after_colon.rsplit(" (", 1)[0].strip()
+
             return after_colon
     pytest.fail(f"Could not extract layer name from ogrinfo output:\n{ogrinfo_output}")
 

--- a/tests/python/gdal_ogr/conftest.py
+++ b/tests/python/gdal_ogr/conftest.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import os
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -218,7 +219,9 @@ def _write_evidence_report():
     """Write the evidence JSON report at session teardown."""
     yield
     if _evidence.has_records:
-        report_path = Path(__file__).parent.parent / "gdal-ogr-results.json"
+        worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+        suffix = "" if not worker_id or worker_id == "master" else f"-{worker_id}"
+        report_path = Path(__file__).parent.parent / f"gdal-ogr-results{suffix}.json"
         _evidence.write_report(report_path)
 
 

--- a/tests/python/gdal_ogr/conftest.py
+++ b/tests/python/gdal_ogr/conftest.py
@@ -1,0 +1,307 @@
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+"""
+GDAL/OGR interoperability test fixtures.
+
+Provides skip logic, connection-string helpers, a subprocess wrapper,
+and a session-scoped evidence collector that writes a structured JSON
+report at session teardown.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import pytest
+from _pytest.reports import TestReport
+
+
+# ============================================================================
+# Structured result from an OGR CLI invocation
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class OgrResult:
+    """Structured result from an OGR CLI command."""
+
+    command: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+
+    @property
+    def succeeded(self) -> bool:
+        return self.returncode == 0
+
+    def assert_success(self, msg: str = "") -> "OgrResult":
+        """Assert the command exited 0; include full output on failure."""
+        detail = msg or f"OGR command failed: {' '.join(self.command)}"
+        assert self.succeeded, (
+            f"{detail}\n"
+            f"exit code: {self.returncode}\n"
+            f"--- stdout ---\n{self.stdout}\n"
+            f"--- stderr ---\n{self.stderr}"
+        )
+        return self
+
+
+# ============================================================================
+# Evidence collection
+# ============================================================================
+
+
+@dataclass
+class _EvidenceRecord:
+    test_name: str
+    protocol: str
+    category: str
+    status: str
+    detail: str = ""
+
+
+class EvidenceCollector:
+    """Accumulates per-test pass/fail/skip and writes a JSON report."""
+
+    def __init__(self) -> None:
+        self.gdal_version: str = ""
+        self._records: list[_EvidenceRecord] = []
+
+    def record(
+        self,
+        test_name: str,
+        protocol: str,
+        category: str,
+        status: str,
+        detail: str = "",
+    ) -> None:
+        self._records.append(
+            _EvidenceRecord(
+                test_name=test_name,
+                protocol=protocol,
+                category=category,
+                status=status,
+                detail=detail,
+            )
+        )
+
+    def write_report(self, path: Path) -> None:
+        protocols: dict[str, dict[str, str]] = {}
+        for rec in self._records:
+            bucket = protocols.setdefault(rec.protocol, {})
+            existing = bucket.get(rec.category, "pass")
+            if rec.status == "fail" or existing == "fail":
+                bucket[rec.category] = "fail"
+            elif rec.status == "skip" or existing == "skip":
+                bucket[rec.category] = "skip"
+            else:
+                bucket[rec.category] = "pass"
+
+        report = {
+            "gdal_version": self.gdal_version,
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "protocols": protocols,
+            "details": [
+                {
+                    "test": r.test_name,
+                    "protocol": r.protocol,
+                    "category": r.category,
+                    "status": r.status,
+                    "detail": r.detail,
+                }
+                for r in self._records
+            ],
+        }
+        path.write_text(json.dumps(report, indent=2))
+
+    @property
+    def has_records(self) -> bool:
+        return len(self._records) > 0
+
+
+# Singleton shared across the session
+_evidence = EvidenceCollector()
+
+
+# ============================================================================
+# Helper to capture GDAL version
+# ============================================================================
+
+
+def _get_gdal_version() -> str | None:
+    try:
+        result = subprocess.run(
+            ["ogrinfo", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="session", autouse=True)
+def gdal_available():
+    """Skip the entire gdal_ogr module when gdal-bin is not installed."""
+    if shutil.which("ogrinfo") is None:
+        pytest.skip(
+            "GDAL tools not found \u2014 install gdal-bin to run "
+            "GDAL/OGR interoperability tests."
+        )
+    version = _get_gdal_version()
+    if version:
+        _evidence.gdal_version = version
+
+
+@pytest.fixture(scope="session")
+def gdal_version() -> str:
+    """Return the GDAL version string."""
+    return _get_gdal_version() or "unknown"
+
+
+@pytest.fixture(scope="session")
+def oapif_dsn(base_url: str) -> str:
+    """GDAL OAPIF driver connection string."""
+    return f"OAPIF:{base_url}/ogc/features"
+
+
+@pytest.fixture(scope="session")
+def wfs_dsn(base_url: str) -> str:
+    """GDAL WFS driver connection string."""
+    return f"WFS:{base_url}/wfs"
+
+
+@pytest.fixture
+def ogr_run() -> Callable[..., OgrResult]:
+    """Return a helper that runs an OGR CLI command with timeout."""
+
+    def _run(args: list[str], timeout: float = 30.0) -> OgrResult:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return OgrResult(
+            command=args,
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+
+    return _run
+
+
+@pytest.fixture(scope="session")
+def evidence_collector() -> EvidenceCollector:
+    """Session-scoped evidence collector for JSON report."""
+    return _evidence
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _write_evidence_report():
+    """Write the evidence JSON report at session teardown."""
+    yield
+    if _evidence.has_records:
+        report_path = Path(__file__).parent.parent / "gdal-ogr-results.json"
+        _evidence.write_report(report_path)
+
+
+# ============================================================================
+# Hook: record failures and skips in the evidence collector
+# ============================================================================
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call):
+    """Automatically record test failures and skips in the evidence report.
+
+    Inline ``evidence_collector.record(..., "pass")`` calls in individual
+    tests handle the happy path.  This hook fills the gap so that failures
+    and skips are never silently omitted from the JSON report.
+    """
+    outcome = yield
+    report: TestReport = outcome.get_result()
+
+    # Only act on the call phase (or setup for skips)
+    if report.when == "call" and report.failed:
+        protocol, category = _derive_protocol_category(item)
+        _evidence.record(
+            item.name, protocol, category, "fail",
+            detail=(report.longreprtext or "")[:500],
+        )
+    elif report.skipped:
+        protocol, category = _derive_protocol_category(item)
+        _evidence.record(
+            item.name, protocol, category, "skip",
+            detail=str(report.longrepr) if report.longrepr else "",
+        )
+
+
+def _derive_protocol_category(item: pytest.Item) -> tuple[str, str]:
+    """Derive (protocol, category) from a test item's module filename.
+
+    Module naming convention: ``test_{protocol}_{category}.py``
+    e.g. ``test_oapif_discovery.py`` → ``("oapif", "discovery")``.
+    """
+    stem = Path(item.fspath).stem  # "test_oapif_discovery"
+    name = stem.removeprefix("test_")  # "oapif_discovery"
+    tokens = name.split("_", 1)
+    protocol = tokens[0] if tokens else "unknown"
+    category = tokens[1] if len(tokens) > 1 else "general"
+    return protocol, category
+
+
+# ============================================================================
+# Shared WFS helpers
+# ============================================================================
+
+
+def extract_first_layer_name(ogrinfo_output: str) -> str:
+    """Extract the first layer name from ogrinfo listing output.
+
+    ogrinfo output format::
+
+        1: layer_name (Point)
+        2: another_layer (Polygon)
+    """
+    for line in ogrinfo_output.splitlines():
+        line = line.strip()
+        if line and line[0].isdigit() and ":" in line:
+            # "1: layer_name (Point)" -> "layer_name"
+            after_colon = line.split(":", 1)[1].strip()
+            # Remove geometry type suffix like " (Point)"
+            if "(" in after_colon:
+                return after_colon.rsplit("(", 1)[0].strip()
+            return after_colon
+    pytest.fail(f"Could not extract layer name from ogrinfo output:\n{ogrinfo_output}")
+
+
+@pytest.fixture(scope="session")
+def wfs_layer_name(wfs_dsn: str) -> str:
+    """Discover and cache the first WFS layer name (session-scoped)."""
+    result = subprocess.run(
+        ["ogrinfo", wfs_dsn],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"WFS layer discovery failed:\n{result.stderr}"
+    )
+    return extract_first_layer_name(result.stdout)

--- a/tests/python/gdal_ogr/test_oapif_discovery.py
+++ b/tests/python/gdal_ogr/test_oapif_discovery.py
@@ -1,0 +1,101 @@
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+"""
+GDAL/OGR interoperability: OGC API Features — layer discovery and schema introspection.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import EvidenceCollector, OgrResult
+
+
+@pytest.mark.integration
+@pytest.mark.gdal
+class TestOapifDiscovery:
+    """Verify that ogrinfo can discover layers via the OAPIF driver."""
+
+    def test_list_layers(
+        self,
+        oapif_dsn: str,
+        ogr_run,
+        test_collection_id: str,
+        evidence_collector: EvidenceCollector,
+    ):
+        """ogrinfo lists the test collection among available layers."""
+        result: OgrResult = ogr_run(["ogrinfo", oapif_dsn])
+        result.assert_success("ogrinfo layer listing failed")
+        assert test_collection_id in result.stdout, (
+            f"Expected collection '{test_collection_id}' in ogrinfo output:\n"
+            f"{result.stdout}"
+        )
+        evidence_collector.record(
+            "test_list_layers", "oapif", "discovery", "pass",
+        )
+
+    def test_schema_introspection(
+        self,
+        oapif_dsn: str,
+        ogr_run,
+        test_collection_id: str,
+        evidence_collector: EvidenceCollector,
+    ):
+        """ogrinfo -so reports field names and geometry type for the collection."""
+        result: OgrResult = ogr_run(
+            ["ogrinfo", "-so", oapif_dsn, test_collection_id],
+        )
+        result.assert_success("ogrinfo schema introspection failed")
+
+        stdout = result.stdout
+        # Should report a geometry column
+        assert "Geometry" in stdout, (
+            f"No geometry info in schema output:\n{stdout}"
+        )
+        # Should include the 'name' field (from seed data)
+        assert "name" in stdout.lower(), (
+            f"Expected 'name' field in schema output:\n{stdout}"
+        )
+        evidence_collector.record(
+            "test_schema_introspection", "oapif", "schema_introspection", "pass",
+        )
+
+    def test_feature_count(
+        self,
+        oapif_dsn: str,
+        ogr_run,
+        test_collection_id: str,
+        evidence_collector: EvidenceCollector,
+    ):
+        """ogrinfo -so reports a non-zero feature count."""
+        result: OgrResult = ogr_run(
+            ["ogrinfo", "-so", oapif_dsn, test_collection_id],
+        )
+        result.assert_success("ogrinfo feature count check failed")
+
+        # GDAL reports "Feature Count: N" in summary output
+        assert "Feature Count" in result.stdout, (
+            f"No feature count in schema output:\n{result.stdout}"
+        )
+        evidence_collector.record(
+            "test_feature_count", "oapif", "feature_count", "pass",
+        )
+
+    def test_srs_reported(
+        self,
+        oapif_dsn: str,
+        ogr_run,
+        test_collection_id: str,
+    ):
+        """ogrinfo -so includes SRS information (EPSG:4326 expected)."""
+        result: OgrResult = ogr_run(
+            ["ogrinfo", "-so", oapif_dsn, test_collection_id],
+        )
+        result.assert_success()
+
+        stdout = result.stdout.lower()
+        # GDAL may report the SRS as WGS 84, EPSG:4326, or OGC:CRS84
+        assert any(
+            token in stdout for token in ("4326", "wgs 84", "crs84")
+        ), f"Expected WGS 84 / EPSG:4326 in SRS output:\n{result.stdout}"

--- a/tests/python/gdal_ogr/test_oapif_export.py
+++ b/tests/python/gdal_ogr/test_oapif_export.py
@@ -80,7 +80,6 @@ class TestOapifExport:
     ):
         """Export to CSV and verify header row is present."""
         out_dir = tmp_path / "csv_out"
-        out_dir.mkdir()
         result: OgrResult = ogr_run(
             [
                 "ogr2ogr", "-f", "CSV",

--- a/tests/python/gdal_ogr/test_oapif_export.py
+++ b/tests/python/gdal_ogr/test_oapif_export.py
@@ -1,0 +1,98 @@
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+"""
+GDAL/OGR interoperability: OGC API Features — format export.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from .conftest import EvidenceCollector, OgrResult
+
+
+@pytest.mark.integration
+@pytest.mark.gdal
+class TestOapifExport:
+    """Verify ogr2ogr can export OAPIF data to GeoJSON, GeoPackage, and CSV."""
+
+    def test_export_geojson(
+        self,
+        oapif_dsn: str,
+        ogr_run,
+        test_collection_id: str,
+        tmp_path: Path,
+        evidence_collector: EvidenceCollector,
+    ):
+        """Export to a GeoJSON file and validate its structure."""
+        out = tmp_path / "export.geojson"
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                str(out), oapif_dsn, test_collection_id,
+            ],
+        )
+        result.assert_success("GeoJSON export failed")
+
+        assert out.exists(), "GeoJSON output file not created"
+        data = json.loads(out.read_text())
+        assert data["type"] == "FeatureCollection"
+        assert len(data["features"]) > 0
+        evidence_collector.record(
+            "test_export_geojson", "oapif", "export_geojson", "pass",
+        )
+
+    def test_export_gpkg(
+        self,
+        oapif_dsn: str,
+        ogr_run,
+        test_collection_id: str,
+        tmp_path: Path,
+        evidence_collector: EvidenceCollector,
+    ):
+        """Export to a GeoPackage file."""
+        out = tmp_path / "export.gpkg"
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GPKG",
+                str(out), oapif_dsn, test_collection_id,
+            ],
+        )
+        result.assert_success("GeoPackage export failed")
+
+        assert out.exists(), "GeoPackage output file not created"
+        assert out.stat().st_size > 0, "GeoPackage file is empty"
+        evidence_collector.record(
+            "test_export_gpkg", "oapif", "export_gpkg", "pass",
+        )
+
+    def test_export_csv(
+        self,
+        oapif_dsn: str,
+        ogr_run,
+        test_collection_id: str,
+        tmp_path: Path,
+        evidence_collector: EvidenceCollector,
+    ):
+        """Export to CSV and verify header row is present."""
+        out_dir = tmp_path / "csv_out"
+        out_dir.mkdir()
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "CSV",
+                str(out_dir), oapif_dsn, test_collection_id,
+            ],
+        )
+        result.assert_success("CSV export failed")
+
+        csv_files = list(out_dir.glob("*.csv"))
+        assert len(csv_files) > 0, "No CSV files created"
+        header = csv_files[0].read_text().splitlines()[0].lower()
+        assert "name" in header, f"Expected 'name' in CSV header: {header}"
+        evidence_collector.record(
+            "test_export_csv", "oapif", "export_csv", "pass",
+        )

--- a/tests/python/gdal_ogr/test_oapif_query.py
+++ b/tests/python/gdal_ogr/test_oapif_query.py
@@ -1,0 +1,92 @@
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+"""
+GDAL/OGR interoperability: OGC API Features — attribute and spatial queries.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from .conftest import EvidenceCollector, OgrResult
+
+
+@pytest.mark.integration
+@pytest.mark.gdal
+class TestOapifQuery:
+    """Verify OGR attribute and spatial queries against the OAPIF driver."""
+
+    def test_attribute_query(
+        self,
+        oapif_dsn: str,
+        ogr_run,
+        test_collection_id: str,
+        evidence_collector: EvidenceCollector,
+    ):
+        """ogr2ogr -where filters features by attribute."""
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                "/vsistdout/", oapif_dsn, test_collection_id,
+                "-where", "name = 'alpha'",
+            ],
+        )
+        result.assert_success("attribute query failed")
+
+        data = json.loads(result.stdout)
+        features = data["features"]
+        assert len(features) >= 1, "Attribute query returned no features"
+        names = {f["properties"]["name"] for f in features}
+        assert "alpha" in names, f"Expected 'alpha' in results, got {names}"
+        evidence_collector.record(
+            "test_attribute_query", "oapif", "attribute_query", "pass",
+        )
+
+    def test_spatial_query_bbox(
+        self,
+        oapif_dsn: str,
+        ogr_run,
+        test_collection_id: str,
+        evidence_collector: EvidenceCollector,
+    ):
+        """ogr2ogr -spat filters features by bounding box."""
+        # Broad bbox covering San Francisco test data area
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                "/vsistdout/", oapif_dsn, test_collection_id,
+                "-spat", "-123.0", "37.0", "-122.0", "38.5",
+            ],
+        )
+        result.assert_success("spatial bbox query failed")
+
+        data = json.loads(result.stdout)
+        assert len(data["features"]) > 0, "Spatial query returned no features"
+        evidence_collector.record(
+            "test_spatial_query_bbox", "oapif", "spatial_query", "pass",
+        )
+
+    def test_spatial_query_empty_bbox(
+        self,
+        oapif_dsn: str,
+        ogr_run,
+        test_collection_id: str,
+    ):
+        """ogr2ogr -spat with bbox outside data area returns zero features."""
+        # Bbox in the Gulf of Guinea — no test data here
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                "/vsistdout/", oapif_dsn, test_collection_id,
+                "-spat", "0.0", "0.0", "1.0", "1.0",
+            ],
+        )
+        result.assert_success("spatial query with empty bbox failed")
+
+        data = json.loads(result.stdout)
+        assert len(data["features"]) == 0, (
+            f"Expected 0 features for distant bbox, got {len(data['features'])}"
+        )

--- a/tests/python/gdal_ogr/test_oapif_query.py
+++ b/tests/python/gdal_ogr/test_oapif_query.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 
+import httpx
 import pytest
 
 from .conftest import EvidenceCollector, OgrResult
@@ -21,12 +22,30 @@ class TestOapifQuery:
 
     def test_attribute_query(
         self,
+        http_client: httpx.Client,
         oapif_dsn: str,
         ogr_run,
         test_collection_id: str,
         evidence_collector: EvidenceCollector,
     ):
         """ogr2ogr -where filters features by attribute."""
+        server_response = http_client.get(
+            f"/ogc/features/collections/{test_collection_id}/items",
+            params={
+                "filter": "name = 'alpha'",
+                "filter-lang": "cql2-text",
+            },
+        )
+        assert server_response.status_code == 200, server_response.text
+
+        server_data = server_response.json()
+        server_features = server_data["features"]
+        assert len(server_features) >= 1, "Server-side OAPIF filter returned no features"
+        server_names = {f["properties"]["name"] for f in server_features}
+        assert server_names == {"alpha"}, (
+            f"Expected server-side OAPIF filter to return only 'alpha', got {server_names}"
+        )
+
         result: OgrResult = ogr_run(
             [
                 "ogr2ogr", "-f", "GeoJSON",

--- a/tests/python/gdal_ogr/test_oapif_read.py
+++ b/tests/python/gdal_ogr/test_oapif_read.py
@@ -1,0 +1,86 @@
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+"""
+GDAL/OGR interoperability: OGC API Features — feature read.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from shapely.geometry import shape
+
+from .conftest import EvidenceCollector, OgrResult
+
+
+@pytest.mark.integration
+@pytest.mark.gdal
+class TestOapifRead:
+    """Verify that ogr2ogr can read features via the OAPIF driver."""
+
+    def test_read_geojson(
+        self,
+        oapif_dsn: str,
+        ogr_run,
+        test_collection_id: str,
+        evidence_collector: EvidenceCollector,
+    ):
+        """ogr2ogr reads features as GeoJSON to stdout."""
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                "/vsistdout/", oapif_dsn, test_collection_id,
+            ],
+        )
+        result.assert_success("ogr2ogr GeoJSON read failed")
+
+        data = json.loads(result.stdout)
+        assert data["type"] == "FeatureCollection"
+        assert len(data["features"]) > 0, "No features returned"
+        evidence_collector.record(
+            "test_read_geojson", "oapif", "feature_read", "pass",
+        )
+
+    def test_features_have_properties(
+        self,
+        oapif_dsn: str,
+        ogr_run,
+        test_collection_id: str,
+    ):
+        """Returned features contain expected properties."""
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                "/vsistdout/", oapif_dsn, test_collection_id,
+            ],
+        )
+        result.assert_success()
+
+        data = json.loads(result.stdout)
+        props = data["features"][0]["properties"]
+        assert "name" in props, f"Missing 'name' property: {list(props.keys())}"
+
+    def test_geometries_valid(
+        self,
+        oapif_dsn: str,
+        ogr_run,
+        test_collection_id: str,
+    ):
+        """Geometries in the GeoJSON output are valid according to shapely."""
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                "/vsistdout/", oapif_dsn, test_collection_id,
+            ],
+        )
+        result.assert_success()
+
+        data = json.loads(result.stdout)
+        for feature in data["features"]:
+            geom_json = feature.get("geometry")
+            if geom_json is None:
+                continue
+            geom = shape(geom_json)
+            assert geom.is_valid, f"Invalid geometry: {geom.wkt[:200]}"

--- a/tests/python/gdal_ogr/test_wfs_discovery.py
+++ b/tests/python/gdal_ogr/test_wfs_discovery.py
@@ -1,0 +1,94 @@
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+"""
+GDAL/OGR interoperability: WFS 2.0 — layer discovery and schema introspection.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import EvidenceCollector, OgrResult
+
+
+@pytest.mark.integration
+@pytest.mark.gdal
+class TestWfsDiscovery:
+    """Verify that ogrinfo can discover layers via the WFS driver."""
+
+    def test_list_layers(
+        self,
+        wfs_dsn: str,
+        ogr_run,
+        evidence_collector: EvidenceCollector,
+    ):
+        """ogrinfo lists at least one layer from the WFS endpoint."""
+        result: OgrResult = ogr_run(["ogrinfo", wfs_dsn])
+        result.assert_success("ogrinfo WFS layer listing failed")
+
+        # WFS layer listing should show at least one numbered layer entry
+        # GDAL reports layers as "1: <typename> (<geom type>)"
+        assert "1:" in result.stdout, (
+            f"Expected at least one layer in WFS output:\n{result.stdout}"
+        )
+        evidence_collector.record(
+            "test_list_layers", "wfs", "discovery", "pass",
+        )
+
+    def test_schema_introspection(
+        self,
+        wfs_dsn: str,
+        ogr_run,
+        wfs_layer_name: str,
+        evidence_collector: EvidenceCollector,
+    ):
+        """ogrinfo -so reports schema for the first WFS layer."""
+        result: OgrResult = ogr_run(
+            ["ogrinfo", "-so", wfs_dsn, wfs_layer_name],
+        )
+        result.assert_success("ogrinfo WFS schema introspection failed")
+
+        assert "Geometry" in result.stdout, (
+            f"No geometry info in WFS schema output:\n{result.stdout}"
+        )
+        evidence_collector.record(
+            "test_schema_introspection", "wfs", "schema_introspection", "pass",
+        )
+
+    def test_feature_count(
+        self,
+        wfs_dsn: str,
+        ogr_run,
+        wfs_layer_name: str,
+        evidence_collector: EvidenceCollector,
+    ):
+        """ogrinfo -so reports a non-zero feature count for WFS."""
+        result: OgrResult = ogr_run(
+            ["ogrinfo", "-so", wfs_dsn, wfs_layer_name],
+        )
+        result.assert_success()
+
+        assert "Feature Count" in result.stdout, (
+            f"No feature count in WFS schema output:\n{result.stdout}"
+        )
+        evidence_collector.record(
+            "test_feature_count", "wfs", "feature_count", "pass",
+        )
+
+    def test_srs_reported(
+        self,
+        wfs_dsn: str,
+        ogr_run,
+        wfs_layer_name: str,
+    ):
+        """ogrinfo -so includes SRS information for WFS layer."""
+        result: OgrResult = ogr_run(
+            ["ogrinfo", "-so", wfs_dsn, wfs_layer_name],
+        )
+        result.assert_success()
+
+        stdout = result.stdout.lower()
+        assert any(
+            token in stdout for token in ("4326", "wgs 84", "crs84")
+        ), f"Expected WGS 84 / EPSG:4326 in WFS SRS output:\n{result.stdout}"

--- a/tests/python/gdal_ogr/test_wfs_export.py
+++ b/tests/python/gdal_ogr/test_wfs_export.py
@@ -1,0 +1,98 @@
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+"""
+GDAL/OGR interoperability: WFS 2.0 — format export.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from .conftest import EvidenceCollector, OgrResult
+
+
+@pytest.mark.integration
+@pytest.mark.gdal
+class TestWfsExport:
+    """Verify ogr2ogr can export WFS data to GeoJSON, GeoPackage, and CSV."""
+
+    def test_export_geojson(
+        self,
+        wfs_dsn: str,
+        ogr_run,
+        wfs_layer_name: str,
+        tmp_path: Path,
+        evidence_collector: EvidenceCollector,
+    ):
+        """Export WFS data to a GeoJSON file."""
+        out = tmp_path / "wfs_export.geojson"
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                str(out), wfs_dsn, wfs_layer_name,
+            ],
+        )
+        result.assert_success("WFS GeoJSON export failed")
+
+        assert out.exists(), "GeoJSON output file not created"
+        data = json.loads(out.read_text())
+        assert data["type"] == "FeatureCollection"
+        assert len(data["features"]) > 0
+        evidence_collector.record(
+            "test_export_geojson", "wfs", "export_geojson", "pass",
+        )
+
+    def test_export_gpkg(
+        self,
+        wfs_dsn: str,
+        ogr_run,
+        wfs_layer_name: str,
+        tmp_path: Path,
+        evidence_collector: EvidenceCollector,
+    ):
+        """Export WFS data to a GeoPackage file."""
+        out = tmp_path / "wfs_export.gpkg"
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GPKG",
+                str(out), wfs_dsn, wfs_layer_name,
+            ],
+        )
+        result.assert_success("WFS GeoPackage export failed")
+
+        assert out.exists(), "GeoPackage output file not created"
+        assert out.stat().st_size > 0, "GeoPackage file is empty"
+        evidence_collector.record(
+            "test_export_gpkg", "wfs", "export_gpkg", "pass",
+        )
+
+    def test_export_csv(
+        self,
+        wfs_dsn: str,
+        ogr_run,
+        wfs_layer_name: str,
+        tmp_path: Path,
+        evidence_collector: EvidenceCollector,
+    ):
+        """Export WFS data to CSV and verify header row."""
+        out_dir = tmp_path / "wfs_csv_out"
+        out_dir.mkdir()
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "CSV",
+                str(out_dir), wfs_dsn, wfs_layer_name,
+            ],
+        )
+        result.assert_success("WFS CSV export failed")
+
+        csv_files = list(out_dir.glob("*.csv"))
+        assert len(csv_files) > 0, "No CSV files created"
+        header = csv_files[0].read_text().splitlines()[0].lower()
+        assert "name" in header, f"Expected 'name' in CSV header: {header}"
+        evidence_collector.record(
+            "test_export_csv", "wfs", "export_csv", "pass",
+        )

--- a/tests/python/gdal_ogr/test_wfs_export.py
+++ b/tests/python/gdal_ogr/test_wfs_export.py
@@ -80,7 +80,6 @@ class TestWfsExport:
     ):
         """Export WFS data to CSV and verify header row."""
         out_dir = tmp_path / "wfs_csv_out"
-        out_dir.mkdir()
         result: OgrResult = ogr_run(
             [
                 "ogr2ogr", "-f", "CSV",

--- a/tests/python/gdal_ogr/test_wfs_query.py
+++ b/tests/python/gdal_ogr/test_wfs_query.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 
+import httpx
 import pytest
 
 from .conftest import EvidenceCollector, OgrResult
@@ -21,12 +22,42 @@ class TestWfsQuery:
 
     def test_attribute_query(
         self,
+        http_client: httpx.Client,
         wfs_dsn: str,
         ogr_run,
         wfs_layer_name: str,
         evidence_collector: EvidenceCollector,
     ):
         """ogr2ogr -where filters WFS features by attribute."""
+        filter_xml = """
+<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+  <fes:PropertyIsEqualTo>
+    <fes:ValueReference>name</fes:ValueReference>
+    <fes:Literal>alpha</fes:Literal>
+  </fes:PropertyIsEqualTo>
+</fes:Filter>
+""".strip()
+        server_response = http_client.get(
+            "/wfs",
+            params={
+                "SERVICE": "WFS",
+                "REQUEST": "GetFeature",
+                "VERSION": "2.0.0",
+                "TYPENAMES": wfs_layer_name,
+                "OUTPUTFORMAT": "application/geo+json",
+                "FILTER": filter_xml,
+            },
+        )
+        assert server_response.status_code == 200, server_response.text
+
+        server_data = server_response.json()
+        server_features = server_data["features"]
+        assert len(server_features) >= 1, "Server-side WFS filter returned no features"
+        server_names = {f["properties"]["name"] for f in server_features}
+        assert server_names == {"alpha"}, (
+            f"Expected server-side WFS filter to return only 'alpha', got {server_names}"
+        )
+
         result: OgrResult = ogr_run(
             [
                 "ogr2ogr", "-f", "GeoJSON",

--- a/tests/python/gdal_ogr/test_wfs_query.py
+++ b/tests/python/gdal_ogr/test_wfs_query.py
@@ -106,7 +106,7 @@ class TestWfsQuery:
         ogr_run,
         wfs_layer_name: str,
     ):
-        """ogr2ogr -spat with bbox outside data area returns zero features."""
+        """ogr2ogr -spat with bbox outside data area returns no spatial matches."""
         result: OgrResult = ogr_run(
             [
                 "ogr2ogr", "-f", "GeoJSON",
@@ -117,6 +117,11 @@ class TestWfsQuery:
         result.assert_success("WFS spatial query with empty bbox failed")
 
         data = json.loads(result.stdout)
-        assert len(data["features"]) == 0, (
-            f"Expected 0 features for distant bbox, got {len(data['features'])}"
+        matched_features = [
+            feature for feature in data["features"]
+            if feature.get("geometry") is not None
+        ]
+        assert matched_features == [], (
+            "Expected no spatially matched features for a distant bbox, "
+            f"got {len(matched_features)} geometry-bearing features"
         )

--- a/tests/python/gdal_ogr/test_wfs_query.py
+++ b/tests/python/gdal_ogr/test_wfs_query.py
@@ -1,0 +1,91 @@
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+"""
+GDAL/OGR interoperability: WFS 2.0 — attribute and spatial queries.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from .conftest import EvidenceCollector, OgrResult
+
+
+@pytest.mark.integration
+@pytest.mark.gdal
+class TestWfsQuery:
+    """Verify OGR attribute and spatial queries against the WFS driver."""
+
+    def test_attribute_query(
+        self,
+        wfs_dsn: str,
+        ogr_run,
+        wfs_layer_name: str,
+        evidence_collector: EvidenceCollector,
+    ):
+        """ogr2ogr -where filters WFS features by attribute."""
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                "/vsistdout/", wfs_dsn, wfs_layer_name,
+                "-where", "name = 'alpha'",
+            ],
+        )
+        result.assert_success("WFS attribute query failed")
+
+        data = json.loads(result.stdout)
+        features = data["features"]
+        assert len(features) >= 1, "WFS attribute query returned no features"
+        names = {f["properties"]["name"] for f in features}
+        assert "alpha" in names, f"Expected 'alpha' in WFS results, got {names}"
+        evidence_collector.record(
+            "test_attribute_query", "wfs", "attribute_query", "pass",
+        )
+
+    def test_spatial_query_bbox(
+        self,
+        wfs_dsn: str,
+        ogr_run,
+        wfs_layer_name: str,
+        evidence_collector: EvidenceCollector,
+    ):
+        """ogr2ogr -spat filters WFS features by bounding box."""
+        # Broad bbox covering San Francisco test data area
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                "/vsistdout/", wfs_dsn, wfs_layer_name,
+                "-spat", "-123.0", "37.0", "-122.0", "38.5",
+            ],
+        )
+        result.assert_success("WFS spatial bbox query failed")
+
+        data = json.loads(result.stdout)
+        assert len(data["features"]) > 0, "WFS spatial query returned no features"
+        evidence_collector.record(
+            "test_spatial_query_bbox", "wfs", "spatial_query", "pass",
+        )
+
+    def test_spatial_query_empty_bbox(
+        self,
+        wfs_dsn: str,
+        ogr_run,
+        wfs_layer_name: str,
+    ):
+        """ogr2ogr -spat with bbox outside data area returns zero features."""
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                "/vsistdout/", wfs_dsn, wfs_layer_name,
+                "-spat", "0.0", "0.0", "1.0", "1.0",
+            ],
+        )
+        result.assert_success("WFS spatial query with empty bbox failed")
+
+        data = json.loads(result.stdout)
+        assert len(data["features"]) == 0, (
+            f"Expected 0 features for distant bbox, got {len(data['features'])}"
+        )

--- a/tests/python/gdal_ogr/test_wfs_read.py
+++ b/tests/python/gdal_ogr/test_wfs_read.py
@@ -1,0 +1,86 @@
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+"""
+GDAL/OGR interoperability: WFS 2.0 — feature read.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from shapely.geometry import shape
+
+from .conftest import EvidenceCollector, OgrResult
+
+
+@pytest.mark.integration
+@pytest.mark.gdal
+class TestWfsRead:
+    """Verify that ogr2ogr can read features via the WFS driver."""
+
+    def test_read_geojson(
+        self,
+        wfs_dsn: str,
+        ogr_run,
+        wfs_layer_name: str,
+        evidence_collector: EvidenceCollector,
+    ):
+        """ogr2ogr reads WFS features as GeoJSON to stdout."""
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                "/vsistdout/", wfs_dsn, wfs_layer_name,
+            ],
+        )
+        result.assert_success("ogr2ogr WFS GeoJSON read failed")
+
+        data = json.loads(result.stdout)
+        assert data["type"] == "FeatureCollection"
+        assert len(data["features"]) > 0, "WFS read returned no features"
+        evidence_collector.record(
+            "test_read_geojson", "wfs", "feature_read", "pass",
+        )
+
+    def test_features_have_properties(
+        self,
+        wfs_dsn: str,
+        ogr_run,
+        wfs_layer_name: str,
+    ):
+        """Returned WFS features contain expected properties."""
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                "/vsistdout/", wfs_dsn, wfs_layer_name,
+            ],
+        )
+        result.assert_success()
+
+        data = json.loads(result.stdout)
+        props = data["features"][0]["properties"]
+        assert "name" in props, f"Missing 'name' property: {list(props.keys())}"
+
+    def test_geometries_valid(
+        self,
+        wfs_dsn: str,
+        ogr_run,
+        wfs_layer_name: str,
+    ):
+        """Geometries in the WFS GeoJSON output are valid."""
+        result: OgrResult = ogr_run(
+            [
+                "ogr2ogr", "-f", "GeoJSON",
+                "/vsistdout/", wfs_dsn, wfs_layer_name,
+            ],
+        )
+        result.assert_success()
+
+        data = json.loads(result.stdout)
+        for feature in data["features"]:
+            geom_json = feature.get("geometry")
+            if geom_json is None:
+                continue
+            geom = shape(geom_json)
+            assert geom.is_valid, f"Invalid geometry: {geom.wkt[:200]}"

--- a/tests/python/pytest.ini
+++ b/tests/python/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-testpaths = ogc_features feature_server
+testpaths = ogc_features feature_server gdal_ogr
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
@@ -12,6 +12,7 @@ markers =
     geometry: Geometry validation tests
     slow: Tests that take longer to execute
     smoke: Quick sanity check tests for PR builds
+    gdal: GDAL/OGR interoperability tests (require gdal-bin)
 
 # Async mode
 asyncio_mode = auto


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #468

## Summary
Adds a GDAL/OGR interoperability suite for the client-facing OAPIF and WFS surfaces, plus the supporting CI and documentation updates needed to run it consistently.

## Changes Made
- added the `tests/python/gdal_ogr` suite covering discovery, read, query, and export scenarios for OAPIF and WFS
- updated Python test configuration and CI wiring so the GDAL/OGR suite runs in the right lane
- documented the new client interoperability coverage and compatibility expectations

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] Documentation updated if needed
- [ ] If protocol/auth behavior changed, updated MVP compatibility contract and release checklist notes
- [ ] If breaking admin/control-plane API changes: updated migration guide and versioning policy docs
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review and documented in migration guide
