### PR TITLE
feat: feat(admin-ui): OIDC/PKCE login flow for admin users (#514)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -823,11 +823,12 @@ jobs:
 
       - name: Publish AOT
         run: |
-          dotnet publish \
+          dotnet publish Honua.Server.csproj \
             --configuration Release \
             --runtime linux-x64 \
             --self-contained \
             -p:PublishAot=true \
+            -p:HonuaSkipAdminClientForAotVerification=true \
             -p:StripSymbols=true \
             -o ./publish
         working-directory: src/Honua.Server

--- a/Honua.sln
+++ b/Honua.sln
@@ -37,6 +37,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Core.Security.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Postgres.Security.Tests", "tests\Honua.Postgres.Security.Tests\Honua.Postgres.Security.Tests.csproj", "{BA94AC61-9842-4F07-B871-E4801B39D621}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Admin", "src\Honua.Admin\Honua.Admin.csproj", "{5BCC592E-905B-4B21-BE40-0A27460DD602}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -215,6 +217,18 @@ Global
 		{BA94AC61-9842-4F07-B871-E4801B39D621}.Release|x64.Build.0 = Release|Any CPU
 		{BA94AC61-9842-4F07-B871-E4801B39D621}.Release|x86.ActiveCfg = Release|Any CPU
 		{BA94AC61-9842-4F07-B871-E4801B39D621}.Release|x86.Build.0 = Release|Any CPU
+		{5BCC592E-905B-4B21-BE40-0A27460DD602}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5BCC592E-905B-4B21-BE40-0A27460DD602}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5BCC592E-905B-4B21-BE40-0A27460DD602}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5BCC592E-905B-4B21-BE40-0A27460DD602}.Debug|x64.Build.0 = Debug|Any CPU
+		{5BCC592E-905B-4B21-BE40-0A27460DD602}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5BCC592E-905B-4B21-BE40-0A27460DD602}.Debug|x86.Build.0 = Debug|Any CPU
+		{5BCC592E-905B-4B21-BE40-0A27460DD602}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5BCC592E-905B-4B21-BE40-0A27460DD602}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5BCC592E-905B-4B21-BE40-0A27460DD602}.Release|x64.ActiveCfg = Release|Any CPU
+		{5BCC592E-905B-4B21-BE40-0A27460DD602}.Release|x64.Build.0 = Release|Any CPU
+		{5BCC592E-905B-4B21-BE40-0A27460DD602}.Release|x86.ActiveCfg = Release|Any CPU
+		{5BCC592E-905B-4B21-BE40-0A27460DD602}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -228,5 +242,6 @@ Global
 		{6FA86D72-BAEC-4B23-8EE0-CF7725E4BD3D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{AE285A79-B7A3-40A2-932E-C8F194CBF780} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{BA94AC61-9842-4F07-B871-E4801B39D621} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{5BCC592E-905B-4B21-BE40-0A27460DD602} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/src/Honua.Admin/App.razor
+++ b/src/Honua.Admin/App.razor
@@ -1,0 +1,30 @@
+@* Copyright (c) Honua. All rights reserved. *@
+@* Licensed under the Elastic License 2.0. See LICENSE in the project root. *@
+
+<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(App).Assembly">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(Layout.MainLayout)">
+                <NotAuthorized>
+                    @if (context.User.Identity?.IsAuthenticated == true)
+                    {
+                        <Honua.Admin.Features.Auth.Pages.AccessDenied />
+                    }
+                    else
+                    {
+                        <RedirectToLogin />
+                    }
+                </NotAuthorized>
+                <Authorizing>
+                    <p>Checking authorization...</p>
+                </Authorizing>
+            </AuthorizeRouteView>
+        </Found>
+        <NotFound>
+            <LayoutView Layout="@typeof(Layout.MainLayout)">
+                <h2>Page not found</h2>
+                <p>The requested page could not be found.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>

--- a/src/Honua.Admin/Features/Auth/Models/AuthModels.cs
+++ b/src/Honua.Admin/Features/Auth/Models/AuthModels.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Admin.Features.Auth.Models;
+
+/// <summary>
+/// Client-side representation of the admin auth configuration from the server.
+/// </summary>
+public sealed class AdminAuthConfig
+{
+    [JsonPropertyName("oidcEnabled")]
+    public bool OidcEnabled { get; set; }
+
+    [JsonPropertyName("providers")]
+    public List<AuthProviderInfo> Providers { get; set; } = [];
+
+    [JsonPropertyName("apiKeyFallbackEnabled")]
+    public bool ApiKeyFallbackEnabled { get; set; }
+}
+
+/// <summary>
+/// Client-safe metadata for a single OIDC provider.
+/// </summary>
+public sealed class AuthProviderInfo
+{
+    [JsonPropertyName("key")]
+    public string Key { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = "";
+
+    [JsonPropertyName("authority")]
+    public string Authority { get; set; } = "";
+
+    [JsonPropertyName("clientId")]
+    public string ClientId { get; set; } = "";
+
+    [JsonPropertyName("scopes")]
+    public string[] Scopes { get; set; } = ["openid", "profile", "email"];
+
+    [JsonPropertyName("redirectPath")]
+    public string RedirectPath { get; set; } = "/admin/auth/callback";
+
+    [JsonPropertyName("supportsLogout")]
+    public bool SupportsLogout { get; set; }
+
+    [JsonPropertyName("postLogoutRedirectPath")]
+    public string? PostLogoutRedirectPath { get; set; }
+}
+
+/// <summary>
+/// OIDC discovery document (subset of fields used for PKCE flow).
+/// </summary>
+public sealed class OidcDiscoveryDocument
+{
+    [JsonPropertyName("authorization_endpoint")]
+    public string AuthorizationEndpoint { get; set; } = "";
+
+    [JsonPropertyName("token_endpoint")]
+    public string TokenEndpoint { get; set; } = "";
+
+    [JsonPropertyName("end_session_endpoint")]
+    public string? EndSessionEndpoint { get; set; }
+
+    [JsonPropertyName("userinfo_endpoint")]
+    public string? UserinfoEndpoint { get; set; }
+}
+
+/// <summary>
+/// Token response from the OIDC token endpoint.
+/// </summary>
+public sealed class TokenResponse
+{
+    [JsonPropertyName("access_token")]
+    public string AccessToken { get; set; } = "";
+
+    [JsonPropertyName("id_token")]
+    public string? IdToken { get; set; }
+
+    [JsonPropertyName("refresh_token")]
+    public string? RefreshToken { get; set; }
+
+    [JsonPropertyName("token_type")]
+    public string TokenType { get; set; } = "Bearer";
+
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; set; }
+
+    [JsonPropertyName("scope")]
+    public string? Scope { get; set; }
+}
+
+/// <summary>
+/// Source-generated JSON context for admin auth client models (AOT/trimming compatible).
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(AdminAuthConfig))]
+[JsonSerializable(typeof(AuthProviderInfo))]
+[JsonSerializable(typeof(List<AuthProviderInfo>))]
+[JsonSerializable(typeof(OidcDiscoveryDocument))]
+[JsonSerializable(typeof(TokenResponse))]
+internal sealed partial class AuthJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Admin/Features/Auth/Pages/AccessDenied.razor
+++ b/src/Honua.Admin/Features/Auth/Pages/AccessDenied.razor
@@ -1,0 +1,36 @@
+@* Copyright (c) Honua. All rights reserved. *@
+@* Licensed under the Elastic License 2.0. See LICENSE in the project root. *@
+
+@page "/admin/auth/access-denied"
+@layout Honua.Admin.Layout.MainLayout
+
+@inject OidcSessionService Session
+
+<div class="denied-container">
+    <div class="denied-card">
+        <h1>Access Denied</h1>
+        <p>
+            You have been authenticated, but your account does not have admin privileges.
+        </p>
+        <p class="hint">
+            Contact your administrator to request the admin role for your account.
+        </p>
+        <button class="btn-secondary" @onclick="SignOutAsync">Sign out</button>
+    </div>
+</div>
+
+<style>
+    .denied-container { display: flex; align-items: center; justify-content: center; min-height: 80vh; }
+    .denied-card { background: #fff; border-radius: 8px; padding: 2rem; box-shadow: 0 2px 8px rgba(0,0,0,0.1); max-width: 450px; width: 100%; text-align: center; }
+    .denied-card h1 { color: #c62828; margin-bottom: 1rem; }
+    .hint { color: #666; font-size: 0.9rem; }
+    .btn-secondary { background: transparent; border: 2px solid #666; color: #666; padding: 0.5rem 1.25rem; border-radius: 4px; cursor: pointer; font-size: 0.95rem; margin-top: 1.5rem; }
+    .btn-secondary:hover { border-color: #333; color: #333; }
+</style>
+
+@code {
+    private async Task SignOutAsync()
+    {
+        await Session.LogoutAsync();
+    }
+}

--- a/src/Honua.Admin/Features/Auth/Pages/AuthCallback.razor
+++ b/src/Honua.Admin/Features/Auth/Pages/AuthCallback.razor
@@ -1,0 +1,105 @@
+@* Copyright (c) Honua. All rights reserved. *@
+@* Licensed under the Elastic License 2.0. See LICENSE in the project root. *@
+
+@page "/admin/auth/callback"
+@layout Honua.Admin.Layout.MainLayout
+
+@inject NavigationManager Nav
+@inject OidcSessionService Session
+@inject AuthBootstrapService Bootstrap
+@inject AuthStateStore Store
+@inject AdminAuthStateProvider AuthState
+
+<div class="callback-container">
+    <div class="callback-card">
+        @if (_error is not null)
+        {
+            <h2>Authentication Failed</h2>
+            <p class="error-message">@_error</p>
+            <button class="btn-primary" @onclick="RetryLogin">Try again</button>
+        }
+        else
+        {
+            <p>Completing sign-in...</p>
+        }
+    </div>
+</div>
+
+<style>
+    .callback-container { display: flex; align-items: center; justify-content: center; min-height: 80vh; }
+    .callback-card { background: #fff; border-radius: 8px; padding: 2rem; box-shadow: 0 2px 8px rgba(0,0,0,0.1); max-width: 400px; width: 100%; text-align: center; }
+    .error-message { color: #c62828; margin: 1rem 0; }
+    .btn-primary { background: #1a1a2e; color: #fff; border: none; padding: 0.6rem 1.5rem; border-radius: 4px; cursor: pointer; font-size: 1rem; }
+    .btn-primary:hover { background: #2a2a4e; }
+</style>
+
+@code {
+    [SupplyParameterFromQuery(Name = "code")]
+    public string? Code { get; set; }
+
+    [SupplyParameterFromQuery(Name = "state")]
+    public string? State { get; set; }
+
+    [SupplyParameterFromQuery(Name = "error")]
+    public string? ErrorParam { get; set; }
+
+    [SupplyParameterFromQuery(Name = "error_description")]
+    public string? ErrorDescription { get; set; }
+
+    private string? _error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        // Handle IdP error responses
+        if (!string.IsNullOrEmpty(ErrorParam))
+        {
+            _error = ErrorDescription ?? ErrorParam;
+            return;
+        }
+
+        if (string.IsNullOrEmpty(Code) || string.IsNullOrEmpty(State))
+        {
+            _error = "Missing authorization code or state parameter.";
+            return;
+        }
+
+        // Determine which provider this callback is for
+        var providerKey = await Store.GetProviderKeyAsync();
+        var config = await Bootstrap.GetConfigAsync();
+
+        AuthProviderInfo? provider = null;
+
+        // If we stored a provider key during PKCE, use it. Otherwise try the single provider.
+        if (providerKey is not null)
+        {
+            provider = config.Providers.Find(p => p.Key == providerKey);
+        }
+
+        provider ??= config.Providers.Count == 1 ? config.Providers[0] : null;
+
+        if (provider is null)
+        {
+            _error = "Could not determine which identity provider to use.";
+            return;
+        }
+
+        var (success, error) = await Session.HandleCallbackAsync(Code, State, provider);
+
+        if (!success)
+        {
+            _error = error ?? "Authentication failed.";
+            return;
+        }
+
+        // Notify Blazor that auth state has changed
+        AuthState.NotifyAuthStateChanged();
+
+        // Redirect to the admin dashboard
+        Nav.NavigateTo("/admin", forceLoad: false);
+    }
+
+    private void RetryLogin()
+    {
+        Nav.NavigateTo("/admin/auth/login");
+    }
+}

--- a/src/Honua.Admin/Features/Auth/Pages/Login.razor
+++ b/src/Honua.Admin/Features/Auth/Pages/Login.razor
@@ -1,0 +1,116 @@
+@* Copyright (c) Honua. All rights reserved. *@
+@* Licensed under the Elastic License 2.0. See LICENSE in the project root. *@
+
+@page "/admin/auth/login"
+@layout Honua.Admin.Layout.MainLayout
+
+@inject AuthBootstrapService Bootstrap
+@inject OidcSessionService Session
+@inject NavigationManager Nav
+
+<div class="login-container">
+    <div class="login-card">
+        <h1>Honua Admin</h1>
+
+        @if (_loading)
+        {
+            <p>Preparing login...</p>
+        }
+        else if (_sessionExpired)
+        {
+            <div class="session-expired">
+                <h2>Session Expired</h2>
+                <p>Your session has expired. Please sign in again to continue.</p>
+                <button class="btn-primary" @onclick="LoginWithProviderAsync">Sign in again</button>
+            </div>
+        }
+        else if (_error is not null)
+        {
+            <div class="error-message">
+                <p>@_error</p>
+                <button class="btn-primary" @onclick="RetryAsync">Try again</button>
+            </div>
+        }
+        else if (_authMode == AuthMode.ApiKey)
+        {
+            <div class="api-key-mode">
+                <p>OIDC authentication is not configured. Use API key access.</p>
+            </div>
+        }
+        else
+        {
+            <p>Redirecting to identity provider...</p>
+        }
+    </div>
+</div>
+
+<style>
+    .login-container { display: flex; align-items: center; justify-content: center; min-height: 80vh; }
+    .login-card { background: #fff; border-radius: 8px; padding: 2rem; box-shadow: 0 2px 8px rgba(0,0,0,0.1); max-width: 400px; width: 100%; text-align: center; }
+    .login-card h1 { margin-bottom: 1.5rem; color: #1a1a2e; }
+    .login-card h2 { margin-bottom: 0.75rem; color: #333; font-size: 1.2rem; }
+    .btn-primary { background: #1a1a2e; color: #fff; border: none; padding: 0.6rem 1.5rem; border-radius: 4px; cursor: pointer; font-size: 1rem; margin-top: 1rem; }
+    .btn-primary:hover { background: #2a2a4e; }
+    .error-message { color: #c62828; }
+    .session-expired { color: #e65100; }
+</style>
+
+@code {
+    [SupplyParameterFromQuery(Name = "expired")]
+    public string? Expired { get; set; }
+
+    private bool _loading = true;
+    private bool _sessionExpired;
+    private string? _error;
+    private AuthMode _authMode;
+    private AuthProviderInfo? _singleProvider;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _sessionExpired = !string.IsNullOrEmpty(Expired);
+        _authMode = await Bootstrap.GetAuthModeAsync();
+
+        if (_authMode == AuthMode.OidcMultiProvider)
+        {
+            Nav.NavigateTo("/admin/auth/select-provider");
+            return;
+        }
+
+        if (_authMode == AuthMode.OidcSingleProvider && !_sessionExpired)
+        {
+            _singleProvider = await Bootstrap.GetSingleProviderAsync();
+            if (_singleProvider is not null)
+            {
+                _loading = false;
+                await LoginWithProviderAsync();
+                return;
+            }
+        }
+
+        _loading = false;
+    }
+
+    private async Task LoginWithProviderAsync()
+    {
+        if (_singleProvider is null)
+        {
+            _singleProvider = await Bootstrap.GetSingleProviderAsync();
+        }
+
+        if (_singleProvider is null)
+        {
+            _error = "No OIDC provider configured.";
+            return;
+        }
+
+        await Session.StartLoginAsync(_singleProvider);
+    }
+
+    private async Task RetryAsync()
+    {
+        _error = null;
+        _loading = true;
+        StateHasChanged();
+        await LoginWithProviderAsync();
+    }
+}

--- a/src/Honua.Admin/Features/Auth/Pages/Logout.razor
+++ b/src/Honua.Admin/Features/Auth/Pages/Logout.razor
@@ -1,0 +1,25 @@
+@* Copyright (c) Honua. All rights reserved. *@
+@* Licensed under the Elastic License 2.0. See LICENSE in the project root. *@
+
+@page "/admin/auth/logout"
+@layout Honua.Admin.Layout.MainLayout
+
+@inject OidcSessionService Session
+
+<div class="logout-container">
+    <div class="logout-card">
+        <p>Signing out...</p>
+    </div>
+</div>
+
+<style>
+    .logout-container { display: flex; align-items: center; justify-content: center; min-height: 80vh; }
+    .logout-card { background: #fff; border-radius: 8px; padding: 2rem; box-shadow: 0 2px 8px rgba(0,0,0,0.1); max-width: 400px; width: 100%; text-align: center; }
+</style>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        await Session.LogoutAsync();
+    }
+}

--- a/src/Honua.Admin/Features/Auth/Pages/SelectProvider.razor
+++ b/src/Honua.Admin/Features/Auth/Pages/SelectProvider.razor
@@ -1,0 +1,63 @@
+@* Copyright (c) Honua. All rights reserved. *@
+@* Licensed under the Elastic License 2.0. See LICENSE in the project root. *@
+
+@page "/admin/auth/select-provider"
+@layout Honua.Admin.Layout.MainLayout
+
+@inject AuthBootstrapService Bootstrap
+@inject OidcSessionService Session
+
+<div class="provider-container">
+    <div class="provider-card">
+        <h1>Honua Admin</h1>
+        <h2>Choose your identity provider</h2>
+
+        @if (_loading)
+        {
+            <p>Loading providers...</p>
+        }
+        else if (_providers.Count == 0)
+        {
+            <p>No identity providers are configured.</p>
+        }
+        else
+        {
+            <div class="provider-list">
+                @foreach (var provider in _providers)
+                {
+                    <button class="provider-btn" @onclick="() => SelectProviderAsync(provider)">
+                        <span class="provider-name">@provider.DisplayName</span>
+                    </button>
+                }
+            </div>
+        }
+    </div>
+</div>
+
+<style>
+    .provider-container { display: flex; align-items: center; justify-content: center; min-height: 80vh; }
+    .provider-card { background: #fff; border-radius: 8px; padding: 2rem; box-shadow: 0 2px 8px rgba(0,0,0,0.1); max-width: 400px; width: 100%; text-align: center; }
+    .provider-card h1 { margin-bottom: 0.5rem; color: #1a1a2e; }
+    .provider-card h2 { margin-bottom: 1.5rem; color: #666; font-size: 1rem; font-weight: 400; }
+    .provider-list { display: flex; flex-direction: column; gap: 0.75rem; }
+    .provider-btn { display: flex; align-items: center; justify-content: center; background: #fff; border: 2px solid #e0e0e0; padding: 0.75rem 1rem; border-radius: 6px; cursor: pointer; transition: border-color 0.2s, background 0.2s; font-size: 1rem; }
+    .provider-btn:hover { border-color: #1a1a2e; background: #f8f8fc; }
+    .provider-name { font-weight: 500; color: #333; }
+</style>
+
+@code {
+    private bool _loading = true;
+    private List<AuthProviderInfo> _providers = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        var config = await Bootstrap.GetConfigAsync();
+        _providers = config.Providers;
+        _loading = false;
+    }
+
+    private async Task SelectProviderAsync(AuthProviderInfo provider)
+    {
+        await Session.StartLoginAsync(provider);
+    }
+}

--- a/src/Honua.Admin/Features/Auth/Services/AdminAuthStateProvider.cs
+++ b/src/Honua.Admin/Features/Auth/Services/AdminAuthStateProvider.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace Honua.Admin.Features.Auth.Services;
+
+/// <summary>
+/// Custom AuthenticationStateProvider that reads tokens from sessionStorage
+/// and provides claims-based identity for Blazor authorization.
+/// </summary>
+public sealed class AdminAuthStateProvider : AuthenticationStateProvider
+{
+    private static readonly AuthenticationState AnonymousState = new(new ClaimsPrincipal(new ClaimsIdentity()));
+
+    private readonly AuthStateStore _store;
+    private readonly OidcSessionService _session;
+
+    public AdminAuthStateProvider(AuthStateStore store, OidcSessionService session)
+    {
+        _store = store;
+        _session = session;
+    }
+
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        var accessToken = await _store.GetAccessTokenAsync();
+
+        if (string.IsNullOrEmpty(accessToken))
+            return AnonymousState;
+
+        // Check token expiry and try refresh if needed
+        if (await _store.IsTokenExpiredAsync())
+        {
+            var refreshed = await _session.TryRefreshAsync();
+            if (!refreshed)
+            {
+                return AnonymousState;
+            }
+
+            accessToken = await _store.GetAccessTokenAsync();
+            if (string.IsNullOrEmpty(accessToken))
+                return AnonymousState;
+        }
+
+        var claims = ParseClaimsFromJwt(accessToken);
+        var identity = new ClaimsIdentity(claims, "oidc");
+        var principal = new ClaimsPrincipal(identity);
+
+        return new AuthenticationState(principal);
+    }
+
+    /// <summary>
+    /// Notifies the Blazor authorization system that the auth state has changed.
+    /// Call after login, logout, or token refresh.
+    /// </summary>
+    public void NotifyAuthStateChanged()
+    {
+        NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
+    }
+
+    private static IEnumerable<Claim> ParseClaimsFromJwt(string jwt)
+    {
+        try
+        {
+            var handler = new JwtSecurityTokenHandler();
+            var token = handler.ReadJwtToken(jwt);
+            return token.Claims;
+        }
+        catch
+        {
+            // If token parsing fails, return empty claims rather than crashing the UI
+            return [];
+        }
+    }
+}

--- a/src/Honua.Admin/Features/Auth/Services/AuthBootstrapService.cs
+++ b/src/Honua.Admin/Features/Auth/Services/AuthBootstrapService.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Http.Json;
+using Honua.Admin.Features.Auth.Models;
+
+namespace Honua.Admin.Features.Auth.Services;
+
+/// <summary>
+/// Fetches the auth configuration from the server bootstrap endpoint
+/// and caches it for the lifetime of the WASM app.
+/// </summary>
+public sealed class AuthBootstrapService
+{
+    private readonly HttpClient _http;
+    private AdminAuthConfig? _config;
+
+    public AuthBootstrapService(HttpClient http)
+    {
+        _http = http;
+    }
+
+    /// <summary>
+    /// Gets the cached auth configuration, fetching from the server on first call.
+    /// </summary>
+    public async Task<AdminAuthConfig> GetConfigAsync()
+    {
+        if (_config is not null)
+            return _config;
+
+        _config = await _http.GetFromJsonAsync(
+            "api/v1/admin/auth/config",
+            AuthJsonContext.Default.AdminAuthConfig);
+
+        return _config ?? new AdminAuthConfig();
+    }
+
+    /// <summary>
+    /// Determines the auth mode from the configuration.
+    /// </summary>
+    public async Task<AuthMode> GetAuthModeAsync()
+    {
+        var config = await GetConfigAsync();
+
+        if (!config.OidcEnabled || config.Providers.Count == 0)
+            return AuthMode.ApiKey;
+
+        return config.Providers.Count == 1
+            ? AuthMode.OidcSingleProvider
+            : AuthMode.OidcMultiProvider;
+    }
+
+    /// <summary>
+    /// Gets the single OIDC provider when exactly one is configured.
+    /// Returns null if zero or multiple providers exist.
+    /// </summary>
+    public async Task<AuthProviderInfo?> GetSingleProviderAsync()
+    {
+        var config = await GetConfigAsync();
+        return config.Providers.Count == 1 ? config.Providers[0] : null;
+    }
+}
+
+/// <summary>
+/// Authentication modes determined by server configuration.
+/// </summary>
+public enum AuthMode
+{
+    /// <summary>No OIDC providers configured; use API key authentication.</summary>
+    ApiKey,
+
+    /// <summary>Exactly one OIDC provider configured; auto-redirect to login.</summary>
+    OidcSingleProvider,
+
+    /// <summary>Multiple OIDC providers configured; show provider chooser.</summary>
+    OidcMultiProvider
+}

--- a/src/Honua.Admin/Features/Auth/Services/AuthStateStore.cs
+++ b/src/Honua.Admin/Features/Auth/Services/AuthStateStore.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.JSInterop;
+
+namespace Honua.Admin.Features.Auth.Services;
+
+/// <summary>
+/// Manages auth session state in browser sessionStorage.
+/// Token data lives only for the browser tab lifetime.
+/// </summary>
+public sealed class AuthStateStore
+{
+    private const string AccessTokenKey = "honua_admin_access_token";
+    private const string IdTokenKey = "honua_admin_id_token";
+    private const string RefreshTokenKey = "honua_admin_refresh_token";
+    private const string ExpiresAtKey = "honua_admin_expires_at";
+    private const string ProviderKey = "honua_admin_provider";
+    private const string PkceVerifierKey = "honua_admin_pkce_verifier";
+    private const string PkceStateKey = "honua_admin_pkce_state";
+
+    private readonly IJSRuntime _js;
+
+    public AuthStateStore(IJSRuntime js)
+    {
+        _js = js;
+    }
+
+    public async Task StoreTokensAsync(string accessToken, string? idToken, string? refreshToken, int expiresIn, string providerKey)
+    {
+        var expiresAt = DateTimeOffset.UtcNow.AddSeconds(expiresIn).ToUnixTimeSeconds().ToString(System.Globalization.CultureInfo.InvariantCulture);
+        await SetItemAsync(AccessTokenKey, accessToken);
+        await SetItemAsync(ExpiresAtKey, expiresAt);
+        await SetItemAsync(ProviderKey, providerKey);
+
+        if (idToken is not null)
+            await SetItemAsync(IdTokenKey, idToken);
+
+        if (refreshToken is not null)
+            await SetItemAsync(RefreshTokenKey, refreshToken);
+    }
+
+    public async Task StoreSelectedProviderKeyAsync(string providerKey) =>
+        await SetItemAsync(ProviderKey, providerKey);
+
+    public async Task<string?> GetAccessTokenAsync() => await GetItemAsync(AccessTokenKey);
+    public async Task<string?> GetIdTokenAsync() => await GetItemAsync(IdTokenKey);
+    public async Task<string?> GetRefreshTokenAsync() => await GetItemAsync(RefreshTokenKey);
+    public async Task<string?> GetProviderKeyAsync() => await GetItemAsync(ProviderKey);
+
+    public async Task<DateTimeOffset?> GetExpiresAtAsync()
+    {
+        var raw = await GetItemAsync(ExpiresAtKey);
+        if (raw is not null && long.TryParse(raw, out var unix))
+            return DateTimeOffset.FromUnixTimeSeconds(unix);
+        return null;
+    }
+
+    public async Task<bool> IsTokenExpiredAsync()
+    {
+        var expiresAt = await GetExpiresAtAsync();
+        return expiresAt is null || expiresAt <= DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Returns true when the token will expire within the given buffer window.
+    /// Used to trigger proactive refresh.
+    /// </summary>
+    public async Task<bool> IsTokenExpiringSoonAsync(TimeSpan buffer)
+    {
+        var expiresAt = await GetExpiresAtAsync();
+        return expiresAt is null || expiresAt <= DateTimeOffset.UtcNow.Add(buffer);
+    }
+
+    public async Task StorePkceStateAsync(string verifier, string state)
+    {
+        await SetItemAsync(PkceVerifierKey, verifier);
+        await SetItemAsync(PkceStateKey, state);
+    }
+
+    public async Task<(string? Verifier, string? State)> GetPkceStateAsync()
+    {
+        var verifier = await GetItemAsync(PkceVerifierKey);
+        var state = await GetItemAsync(PkceStateKey);
+        return (verifier, state);
+    }
+
+    public async Task ClearPkceStateAsync()
+    {
+        await RemoveItemAsync(PkceVerifierKey);
+        await RemoveItemAsync(PkceStateKey);
+    }
+
+    /// <summary>
+    /// Clears only token-related storage, preserving PKCE state for in-flight login flows.
+    /// </summary>
+    public async Task ClearTokensAsync()
+    {
+        await RemoveItemAsync(AccessTokenKey);
+        await RemoveItemAsync(IdTokenKey);
+        await RemoveItemAsync(RefreshTokenKey);
+        await RemoveItemAsync(ExpiresAtKey);
+        await RemoveItemAsync(ProviderKey);
+    }
+
+    /// <summary>
+    /// Clears all auth state including tokens and PKCE state.
+    /// </summary>
+    public async Task ClearAsync()
+    {
+        await ClearTokensAsync();
+        await ClearPkceStateAsync();
+    }
+
+    private async Task SetItemAsync(string key, string value) =>
+        await _js.InvokeVoidAsync("sessionStorage.setItem", key, value);
+
+    private async Task<string?> GetItemAsync(string key) =>
+        await _js.InvokeAsync<string?>("sessionStorage.getItem", key);
+
+    private async Task RemoveItemAsync(string key) =>
+        await _js.InvokeVoidAsync("sessionStorage.removeItem", key);
+}

--- a/src/Honua.Admin/Features/Auth/Services/OidcSessionService.cs
+++ b/src/Honua.Admin/Features/Auth/Services/OidcSessionService.cs
@@ -1,0 +1,275 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using Honua.Admin.Features.Auth.Models;
+using Microsoft.AspNetCore.Components;
+
+namespace Honua.Admin.Features.Auth.Services;
+
+/// <summary>
+/// Manages the OIDC authorization-code-with-PKCE flow, token exchange, refresh, and logout.
+/// </summary>
+public sealed class OidcSessionService
+{
+    private static readonly TimeSpan RefreshBuffer = TimeSpan.FromMinutes(2);
+
+    private readonly HttpClient _http;
+    private readonly AuthStateStore _store;
+    private readonly AuthBootstrapService _bootstrap;
+    private readonly NavigationManager _nav;
+
+    // Cache discovery documents per authority to avoid repeated fetches.
+    private readonly Dictionary<string, OidcDiscoveryDocument> _discoveryCache = new(StringComparer.OrdinalIgnoreCase);
+
+    public OidcSessionService(
+        HttpClient http,
+        AuthStateStore store,
+        AuthBootstrapService bootstrap,
+        NavigationManager nav)
+    {
+        _http = http;
+        _store = store;
+        _bootstrap = bootstrap;
+        _nav = nav;
+    }
+
+    /// <summary>
+    /// Initiates the authorization code + PKCE flow by redirecting to the provider's authorization endpoint.
+    /// </summary>
+    public async Task StartLoginAsync(AuthProviderInfo provider)
+    {
+        var discovery = await GetDiscoveryDocumentAsync(provider.Authority);
+
+        var (verifier, challenge) = GeneratePkceParams();
+        var state = GenerateRandomString(32);
+
+        await _store.ClearTokensAsync(); // Clear stale tokens but preserve nothing else
+        await _store.StorePkceStateAsync(verifier, state);
+        await _store.StoreSelectedProviderKeyAsync(provider.Key);
+
+        var redirectUri = BuildAbsoluteUri(provider.RedirectPath);
+        var scope = string.Join(" ", provider.Scopes);
+
+        var authUrl = $"{discovery.AuthorizationEndpoint}" +
+            $"?response_type=code" +
+            $"&client_id={Uri.EscapeDataString(provider.ClientId)}" +
+            $"&redirect_uri={Uri.EscapeDataString(redirectUri)}" +
+            $"&scope={Uri.EscapeDataString(scope)}" +
+            $"&state={Uri.EscapeDataString(state)}" +
+            $"&code_challenge={Uri.EscapeDataString(challenge)}" +
+            $"&code_challenge_method=S256";
+
+        _nav.NavigateTo(authUrl, forceLoad: true);
+    }
+
+    /// <summary>
+    /// Handles the callback from the OIDC provider: validates state, exchanges the code for tokens.
+    /// Returns true on success.
+    /// </summary>
+    public async Task<(bool Success, string? Error)> HandleCallbackAsync(string code, string state, AuthProviderInfo provider)
+    {
+        var (storedVerifier, storedState) = await _store.GetPkceStateAsync();
+
+        if (storedState is null || !string.Equals(storedState, state, StringComparison.Ordinal))
+        {
+            return (false, "Invalid state parameter. Possible CSRF attack.");
+        }
+
+        if (storedVerifier is null)
+        {
+            return (false, "PKCE verifier not found. Please try logging in again.");
+        }
+
+        await _store.ClearPkceStateAsync();
+
+        var discovery = await GetDiscoveryDocumentAsync(provider.Authority);
+        var redirectUri = BuildAbsoluteUri(provider.RedirectPath);
+
+        var tokenRequest = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["code"] = code,
+            ["redirect_uri"] = redirectUri,
+            ["client_id"] = provider.ClientId,
+            ["code_verifier"] = storedVerifier,
+        });
+
+        try
+        {
+            var response = await _http.PostAsync(discovery.TokenEndpoint, tokenRequest);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync();
+                return (false, $"Token exchange failed: {response.StatusCode} - {errorBody}");
+            }
+
+            var tokens = await response.Content.ReadFromJsonAsync(AuthJsonContext.Default.TokenResponse);
+
+            if (tokens is null || string.IsNullOrEmpty(tokens.AccessToken))
+            {
+                return (false, "Empty token response from provider.");
+            }
+
+            await _store.StoreTokensAsync(
+                tokens.AccessToken,
+                tokens.IdToken,
+                tokens.RefreshToken,
+                tokens.ExpiresIn,
+                provider.Key);
+
+            return (true, null);
+        }
+        catch (HttpRequestException ex)
+        {
+            return (false, $"Token exchange request failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Attempts a silent token refresh using the stored refresh token.
+    /// Returns true if tokens were successfully refreshed.
+    /// </summary>
+    public async Task<bool> TryRefreshAsync()
+    {
+        var refreshToken = await _store.GetRefreshTokenAsync();
+        var providerKey = await _store.GetProviderKeyAsync();
+
+        if (refreshToken is null || providerKey is null)
+            return false;
+
+        var config = await _bootstrap.GetConfigAsync();
+        var provider = config.Providers.Find(p => p.Key == providerKey);
+        if (provider is null)
+            return false;
+
+        var discovery = await GetDiscoveryDocumentAsync(provider.Authority);
+
+        var tokenRequest = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = refreshToken,
+            ["client_id"] = provider.ClientId,
+        });
+
+        try
+        {
+            var response = await _http.PostAsync(discovery.TokenEndpoint, tokenRequest);
+            if (!response.IsSuccessStatusCode)
+                return false;
+
+            var tokens = await response.Content.ReadFromJsonAsync(AuthJsonContext.Default.TokenResponse);
+            if (tokens is null || string.IsNullOrEmpty(tokens.AccessToken))
+                return false;
+
+            await _store.StoreTokensAsync(
+                tokens.AccessToken,
+                tokens.IdToken,
+                tokens.RefreshToken ?? refreshToken, // Keep old refresh token if new one not issued
+                tokens.ExpiresIn,
+                provider.Key);
+
+            return true;
+        }
+        catch (HttpRequestException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Checks if a proactive refresh is needed and attempts it.
+    /// Returns true if the session is still valid (either fresh or successfully refreshed).
+    /// </summary>
+    public async Task<bool> EnsureValidSessionAsync()
+    {
+        if (!await _store.IsTokenExpiringSoonAsync(RefreshBuffer))
+            return true;
+
+        return await TryRefreshAsync();
+    }
+
+    /// <summary>
+    /// Clears local session and redirects to IdP logout endpoint when available.
+    /// </summary>
+    public async Task LogoutAsync()
+    {
+        var providerKey = await _store.GetProviderKeyAsync();
+        var idToken = await _store.GetIdTokenAsync();
+
+        await _store.ClearAsync();
+
+        if (providerKey is null)
+        {
+            _nav.NavigateTo("/admin/auth/login", forceLoad: true);
+            return;
+        }
+
+        var config = await _bootstrap.GetConfigAsync();
+        var provider = config.Providers.Find(p => p.Key == providerKey);
+
+        if (provider?.SupportsLogout == true)
+        {
+            var discovery = await GetDiscoveryDocumentAsync(provider.Authority);
+            if (!string.IsNullOrEmpty(discovery.EndSessionEndpoint))
+            {
+                var logoutUrl = discovery.EndSessionEndpoint +
+                    $"?post_logout_redirect_uri={Uri.EscapeDataString(BuildAbsoluteUri(provider.PostLogoutRedirectPath ?? "/admin"))}" +
+                    (idToken is not null ? $"&id_token_hint={Uri.EscapeDataString(idToken)}" : "");
+
+                _nav.NavigateTo(logoutUrl, forceLoad: true);
+                return;
+            }
+        }
+
+        // Fallback: local-only logout
+        _nav.NavigateTo("/admin/auth/login", forceLoad: true);
+    }
+
+    private async Task<OidcDiscoveryDocument> GetDiscoveryDocumentAsync(string authority)
+    {
+        if (_discoveryCache.TryGetValue(authority, out var cached))
+            return cached;
+
+        var discoveryUrl = authority.TrimEnd('/') + "/.well-known/openid-configuration";
+        var doc = await _http.GetFromJsonAsync(discoveryUrl, AuthJsonContext.Default.OidcDiscoveryDocument)
+            ?? throw new InvalidOperationException($"Failed to fetch OIDC discovery document from {discoveryUrl}");
+
+        _discoveryCache[authority] = doc;
+        return doc;
+    }
+
+    private string BuildAbsoluteUri(string path)
+    {
+        return new Uri(_nav.BaseUri).GetLeftPart(UriPartial.Authority) + path;
+    }
+
+    private static (string Verifier, string Challenge) GeneratePkceParams()
+    {
+        var verifier = GenerateRandomString(64);
+        var challengeBytes = SHA256.HashData(Encoding.ASCII.GetBytes(verifier));
+        var challenge = Base64UrlEncode(challengeBytes);
+        return (verifier, challenge);
+    }
+
+    private static string GenerateRandomString(int length)
+    {
+        const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+        var bytes = RandomNumberGenerator.GetBytes(length);
+        var result = new char[length];
+        for (int i = 0; i < length; i++)
+            result[i] = chars[bytes[i] % chars.Length];
+        return new string(result);
+    }
+
+    private static string Base64UrlEncode(byte[] bytes)
+    {
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+}

--- a/src/Honua.Admin/Features/Auth/TokenRefreshTimer.razor
+++ b/src/Honua.Admin/Features/Auth/TokenRefreshTimer.razor
@@ -1,0 +1,51 @@
+@* Copyright (c) Honua. All rights reserved. *@
+@* Licensed under the Elastic License 2.0. See LICENSE in the project root. *@
+
+@* Invisible component that runs a periodic timer to refresh tokens before expiry. *@
+@* Drop this into MainLayout so it runs while the user is active. *@
+
+@implements IDisposable
+
+@inject OidcSessionService Session
+@inject AdminAuthStateProvider AuthState
+@inject NavigationManager Nav
+
+@code {
+    private Timer? _timer;
+
+    protected override void OnInitialized()
+    {
+        // Check every 60 seconds whether the token needs refreshing
+        _timer = new Timer(async _ => await CheckRefreshAsync(), null, TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(60));
+    }
+
+    private async Task CheckRefreshAsync()
+    {
+        try
+        {
+            var valid = await Session.EnsureValidSessionAsync();
+            if (!valid)
+            {
+                // Session could not be refreshed; redirect to re-auth prompt
+                await InvokeAsync(() =>
+                {
+                    Nav.NavigateTo("/admin/auth/login?expired=true", forceLoad: true);
+                });
+            }
+            else
+            {
+                // Token was refreshed; update auth state
+                await InvokeAsync(() => AuthState.NotifyAuthStateChanged());
+            }
+        }
+        catch
+        {
+            // Swallow timer exceptions to avoid crashing the UI
+        }
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+    }
+}

--- a/src/Honua.Admin/Honua.Admin.csproj
+++ b/src/Honua.Admin/Honua.Admin.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.3" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Honua.Admin/Layout/MainLayout.razor
+++ b/src/Honua.Admin/Layout/MainLayout.razor
@@ -1,0 +1,40 @@
+@* Copyright (c) Honua. All rights reserved. *@
+@* Licensed under the Elastic License 2.0. See LICENSE in the project root. *@
+
+@inherits LayoutComponentBase
+
+<div class="admin-layout">
+    <header class="admin-header">
+        <span class="brand">Honua Admin</span>
+        <AuthorizeView>
+            <Authorized>
+                <span class="user-info">@context.User.Identity?.Name</span>
+                <button class="logout-btn" @onclick="LogoutAsync">Sign out</button>
+            </Authorized>
+        </AuthorizeView>
+    </header>
+    <main class="admin-content">
+        @Body
+    </main>
+</div>
+
+<Honua.Admin.Features.Auth.TokenRefreshTimer />
+
+<style>
+    .admin-layout { min-height: 100vh; display: flex; flex-direction: column; }
+    .admin-header { display: flex; align-items: center; justify-content: space-between; padding: 0.75rem 1.5rem; background: #1a1a2e; color: #fff; }
+    .brand { font-weight: 600; font-size: 1.1rem; }
+    .user-info { margin-right: 1rem; opacity: 0.8; font-size: 0.9rem; }
+    .logout-btn { background: transparent; border: 1px solid rgba(255,255,255,0.3); color: #fff; padding: 0.35rem 0.75rem; border-radius: 4px; cursor: pointer; font-size: 0.85rem; }
+    .logout-btn:hover { background: rgba(255,255,255,0.1); }
+    .admin-content { flex: 1; padding: 1.5rem; }
+</style>
+
+@code {
+    [Inject] private OidcSessionService Session { get; set; } = default!;
+
+    private async Task LogoutAsync()
+    {
+        await Session.LogoutAsync();
+    }
+}

--- a/src/Honua.Admin/Pages/Index.razor
+++ b/src/Honua.Admin/Pages/Index.razor
@@ -1,0 +1,9 @@
+@* Copyright (c) Honua. All rights reserved. *@
+@* Licensed under the Elastic License 2.0. See LICENSE in the project root. *@
+
+@page "/admin"
+@page "/admin/"
+@attribute [Authorize]
+
+<h2>Admin Dashboard</h2>
+<p>Welcome to the Honua Admin console.</p>

--- a/src/Honua.Admin/Program.cs
+++ b/src/Honua.Admin/Program.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Admin;
+using Honua.Admin.Features.Auth.Services;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+// Register HttpClient with the server base address.
+// When hosted integrated, the base address matches the server origin.
+builder.Services.AddScoped(sp =>
+    new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+// Register auth services
+builder.Services.AddScoped<AuthStateStore>();
+builder.Services.AddScoped<AuthBootstrapService>();
+builder.Services.AddScoped<OidcSessionService>();
+builder.Services.AddScoped<AdminAuthStateProvider>();
+builder.Services.AddScoped<AuthenticationStateProvider>(sp =>
+    sp.GetRequiredService<AdminAuthStateProvider>());
+
+builder.Services.AddAuthorizationCore();
+
+await builder.Build().RunAsync();

--- a/src/Honua.Admin/RedirectToLogin.razor
+++ b/src/Honua.Admin/RedirectToLogin.razor
@@ -1,0 +1,22 @@
+@* Copyright (c) Honua. All rights reserved. *@
+@* Licensed under the Elastic License 2.0. See LICENSE in the project root. *@
+
+@inject NavigationManager Nav
+@inject AuthBootstrapService Bootstrap
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        var mode = await Bootstrap.GetAuthModeAsync();
+
+        switch (mode)
+        {
+            case AuthMode.OidcMultiProvider:
+                Nav.NavigateTo("/admin/auth/select-provider");
+                break;
+            default:
+                Nav.NavigateTo("/admin/auth/login");
+                break;
+        }
+    }
+}

--- a/src/Honua.Admin/_Imports.razor
+++ b/src/Honua.Admin/_Imports.razor
@@ -1,0 +1,13 @@
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.JSInterop
+@using Honua.Admin
+@using Honua.Admin.Layout
+@using Honua.Admin.Features.Auth.Models
+@using Honua.Admin.Features.Auth.Services

--- a/src/Honua.Admin/wwwroot/index.html
+++ b/src/Honua.Admin/wwwroot/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Honua Admin</title>
+    <base href="/admin/" />
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 0; background: #f5f5f5; color: #333; }
+        .loading { display: flex; align-items: center; justify-content: center; height: 100vh; flex-direction: column; }
+        .loading p { margin-top: 1rem; color: #666; }
+    </style>
+</head>
+<body>
+    <div id="app">
+        <div class="loading">
+            <p>Loading Honua Admin...</p>
+        </div>
+    </div>
+
+    <div id="blazor-error-ui" style="display:none; background:#fdd; padding:1rem; position:fixed; bottom:0; width:100%; text-align:center;">
+        An unhandled error has occurred.
+        <a href="" class="reload">Reload</a>
+    </div>
+
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -20,6 +20,7 @@ public static class EndpointRegistry
         new("GET", "/metrics"),
 
         new("GET", "/api/v1/admin/config"),
+        new("GET", "/api/v1/admin/auth/config"),
         new("GET", "/api/v1/admin/openapi.json"),
         new("GET", "/api/v1/admin/connections/{id}/tables"),
         new("GET", "/api/v1/admin/connections/tables"),

--- a/src/Honua.Server/Features/Admin/AdminAuthEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AdminAuthEndpoints.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Unauthenticated admin auth bootstrap endpoint.
+/// Projects client-safe OIDC provider metadata so the Admin UI can configure its login flow.
+/// </summary>
+internal static class AdminAuthEndpoints
+{
+    /// <summary>
+    /// Registers the admin auth configuration endpoint.
+    /// This endpoint is intentionally anonymous so the Admin UI can bootstrap before authentication.
+    /// </summary>
+    public static void MapAdminAuthEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/auth")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin Auth")
+            .AllowAnonymous();
+
+        _ = group.Map("/config", HandleGetAuthConfig)
+            .WithDisplayName("Get Admin Auth Configuration")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+    }
+
+    /// <summary>
+    /// Handles GET /api/v1/admin/auth/config.
+    /// Returns client-safe OIDC provider metadata. No secrets are exposed.
+    /// </summary>
+    private static async Task HandleGetAuthConfig(
+        HttpContext context,
+        IOptions<OidcAuthenticationOptions> oidcOptions,
+        IWebHostEnvironment environment,
+        ILoggerFactory loggerFactory)
+    {
+        var opts = oidcOptions.Value;
+        var providers = new List<AdminAuthProviderInfo>();
+
+        if (opts.Enabled)
+        {
+            if (opts.AzureAd?.IsValid == true)
+            {
+                providers.Add(BuildAzureAdProvider(opts.AzureAd));
+            }
+
+            if (opts.Google?.IsValid == true)
+            {
+                providers.Add(BuildGoogleProvider(opts.Google));
+            }
+
+            if (opts.Okta?.IsValid == true)
+            {
+                providers.Add(BuildOktaProvider(opts.Okta));
+            }
+
+            if (opts.Auth0?.IsValid == true)
+            {
+                providers.Add(BuildAuth0Provider(opts.Auth0));
+            }
+
+            if (opts.Generic?.IsValid == true)
+            {
+                providers.Add(BuildGenericProvider(opts.Generic));
+            }
+        }
+
+        var response = new AdminAuthConfigResponse
+        {
+            OidcEnabled = opts.Enabled && providers.Count > 0,
+            Providers = providers,
+            ApiKeyFallbackEnabled = providers.Count == 0 && (environment.IsDevelopment() || !opts.Enabled)
+        };
+
+        var logger = loggerFactory.CreateLogger("Admin.Auth");
+        AdminAuthLog.AuthConfigServed(logger, providers.Count);
+
+        context.Response.StatusCode = StatusCodes.Status200OK;
+        context.Response.ContentType = "application/json; charset=utf-8";
+        await JsonSerializer.SerializeAsync(
+            context.Response.Body,
+            response,
+            AdminAuthJsonContext.Default.AdminAuthConfigResponse,
+            context.RequestAborted);
+    }
+
+    private static AdminAuthProviderInfo BuildAzureAdProvider(AzureAdProviderOptions azureAd)
+    {
+        return new AdminAuthProviderInfo
+        {
+            Key = "azuread",
+            DisplayName = "Microsoft Entra ID",
+            Authority = $"{azureAd.Instance}{azureAd.TenantId}/v2.0",
+            ClientId = azureAd.ClientId!,
+            Scopes = azureAd.Scopes,
+            RedirectPath = "/admin/auth/callback",
+            SupportsLogout = true,
+            PostLogoutRedirectPath = "/admin"
+        };
+    }
+
+    private static AdminAuthProviderInfo BuildGoogleProvider(GoogleProviderOptions google)
+    {
+        return new AdminAuthProviderInfo
+        {
+            Key = "google",
+            DisplayName = "Google",
+            Authority = "https://accounts.google.com",
+            ClientId = google.ClientId!,
+            Scopes = google.Scopes,
+            RedirectPath = "/admin/auth/callback",
+            // Google does not support RP-initiated logout via end_session_endpoint
+            SupportsLogout = false,
+            PostLogoutRedirectPath = null
+        };
+    }
+
+    private static AdminAuthProviderInfo BuildOktaProvider(OktaProviderOptions okta)
+    {
+        return new AdminAuthProviderInfo
+        {
+            Key = "okta",
+            DisplayName = "Okta",
+            Authority = okta.GetAuthority(),
+            ClientId = okta.ClientId!,
+            Scopes = okta.Scopes,
+            RedirectPath = "/admin/auth/callback",
+            SupportsLogout = true,
+            PostLogoutRedirectPath = "/admin"
+        };
+    }
+
+    private static AdminAuthProviderInfo BuildAuth0Provider(Auth0ProviderOptions auth0)
+    {
+        return new AdminAuthProviderInfo
+        {
+            Key = "auth0",
+            DisplayName = "Auth0",
+            Authority = auth0.GetAuthority(),
+            ClientId = auth0.ClientId!,
+            Scopes = auth0.Scopes,
+            RedirectPath = "/admin/auth/callback",
+            SupportsLogout = !string.IsNullOrEmpty(auth0.SignedOutCallbackPath),
+            PostLogoutRedirectPath = !string.IsNullOrEmpty(auth0.SignedOutCallbackPath)
+                ? "/admin"
+                : null
+        };
+    }
+
+    private static AdminAuthProviderInfo BuildGenericProvider(GenericOidcProviderOptions generic)
+    {
+        return new AdminAuthProviderInfo
+        {
+            Key = "oidc",
+            DisplayName = generic.DisplayName,
+            Authority = generic.Authority!,
+            ClientId = generic.ClientId!,
+            Scopes = generic.Scopes,
+            RedirectPath = "/admin/auth/callback",
+            SupportsLogout = !string.IsNullOrEmpty(generic.SignedOutCallbackPath),
+            PostLogoutRedirectPath = !string.IsNullOrEmpty(generic.SignedOutCallbackPath)
+                ? "/admin"
+                : null
+        };
+    }
+}

--- a/src/Honua.Server/Features/Admin/AdminAuthLog.cs
+++ b/src/Honua.Server/Features/Admin/AdminAuthLog.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Source-generated logger for Admin auth features (AOT compatible).
+/// </summary>
+internal static partial class AdminAuthLog
+{
+    /// <summary>
+    /// Logs when the auth config endpoint serves provider metadata.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 4006,
+        Level = LogLevel.Debug,
+        Message = "Admin auth config served with {ProviderCount} provider(s)")]
+    public static partial void AuthConfigServed(ILogger logger, int providerCount);
+}

--- a/src/Honua.Server/Features/Admin/Models/AdminAuthJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/AdminAuthJsonContext.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// JSON source generation context for admin auth config API models (AOT compatible).
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(AdminAuthConfigResponse))]
+[JsonSerializable(typeof(AdminAuthProviderInfo))]
+[JsonSerializable(typeof(List<AdminAuthProviderInfo>))]
+internal sealed partial class AdminAuthJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Admin/Models/AdminAuthModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/AdminAuthModels.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Response model for the admin auth bootstrap endpoint.
+/// Exposes only client-safe OIDC provider metadata; no secrets are included.
+/// </summary>
+public sealed class AdminAuthConfigResponse
+{
+    /// <summary>
+    /// Gets or sets whether OIDC authentication is enabled.
+    /// </summary>
+    public bool OidcEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the configured OIDC providers (client-safe metadata only).
+    /// </summary>
+    public List<AdminAuthProviderInfo> Providers { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets whether API key authentication fallback should remain visible.
+    /// True when no OIDC providers are configured and the environment allows API key access.
+    /// </summary>
+    public bool ApiKeyFallbackEnabled { get; set; }
+}
+
+/// <summary>
+/// Client-safe metadata for a single OIDC provider.
+/// Never includes client secrets or server-side configuration.
+/// </summary>
+public sealed class AdminAuthProviderInfo
+{
+    /// <summary>
+    /// Gets or sets the provider key used for selection (e.g., "azuread", "google", "oidc").
+    /// </summary>
+    public required string Key { get; set; }
+
+    /// <summary>
+    /// Gets or sets the display name for the provider shown in the UI.
+    /// </summary>
+    public required string DisplayName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the OIDC authority / issuer URL.
+    /// </summary>
+    public required string Authority { get; set; }
+
+    /// <summary>
+    /// Gets or sets the public client ID for PKCE flow.
+    /// </summary>
+    public required string ClientId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the scopes to request during authorization.
+    /// </summary>
+    public string[] Scopes { get; set; } = ["openid", "profile", "email"];
+
+    /// <summary>
+    /// Gets or sets the redirect callback path for the authorization response.
+    /// </summary>
+    public string RedirectPath { get; set; } = "/admin/auth/callback";
+
+    /// <summary>
+    /// Gets or sets whether the provider supports a logout endpoint.
+    /// </summary>
+    public bool SupportsLogout { get; set; }
+
+    /// <summary>
+    /// Gets or sets the post-logout redirect path.
+    /// </summary>
+    public string? PostLogoutRedirectPath { get; set; }
+}

--- a/src/Honua.Server/Honua.Server.csproj
+++ b/src/Honua.Server/Honua.Server.csproj
@@ -29,7 +29,10 @@
     <!-- Program registers Postgres services via AddPostgreSqlServices -->
     <ProjectReference Include="..\Honua.Postgres\Honua.Postgres.csproj" />
     <ProjectReference Include="..\Honua.ServiceDefaults\Honua.ServiceDefaults.csproj" />
-    <ProjectReference Include="..\Honua.Admin\Honua.Admin.csproj" />
+    <ProjectReference
+      Include="..\Honua.Admin\Honua.Admin.csproj"
+      Condition="'$(HonuaSkipAdminClientForAotVerification)' != 'true'"
+      GlobalPropertiesToRemove="PublishAot;RuntimeIdentifier;SelfContained;StripSymbols" />
   </ItemGroup>
 
 

--- a/src/Honua.Server/Honua.Server.csproj
+++ b/src/Honua.Server/Honua.Server.csproj
@@ -29,6 +29,7 @@
     <!-- Program registers Postgres services via AddPostgreSqlServices -->
     <ProjectReference Include="..\Honua.Postgres\Honua.Postgres.csproj" />
     <ProjectReference Include="..\Honua.ServiceDefaults\Honua.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Honua.Admin\Honua.Admin.csproj" />
   </ItemGroup>
 
 

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -479,6 +479,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Admin.Models.RoleJsonContext.Default,
         Honua.Server.Features.Admin.Models.RateLimitJsonContext.Default,
         Honua.Server.Features.Admin.Models.TableDiscoveryJsonContext.Default,
+        Honua.Server.Features.Admin.Models.AdminAuthJsonContext.Default,
         Honua.Server.Features.Admin.Models.ConfigurationJsonContext.Default,
         Honua.Server.Features.Admin.Models.LicenseAdminJsonContext.Default,
         Honua.Server.Features.Admin.Models.IdentityAdminJsonContext.Default,
@@ -715,6 +716,9 @@ await RunDatabaseMigrationsAsync();
 // Configure health endpoints
 app.MapHealthEndpoints();
 app.MapPrometheusEndpoint();
+
+// Configure admin auth bootstrap endpoint (anonymous - must precede admin group)
+app.MapAdminAuthEndpoints();
 
 // Configure admin endpoints
 app.MapAdminEndpoints();

--- a/tests/Honua.Server.Tests/Features/Admin/AdminAuthEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/AdminAuthEndpointsTests.cs
@@ -1,0 +1,331 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Honua.Server.Features.Admin.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+/// <summary>
+/// Integration tests for the admin auth bootstrap endpoint.
+/// </summary>
+[Collection("Database")]
+[Protocol(Protocols.Admin)]
+[Operation(Operations.Configuration)]
+public sealed class AdminAuthEndpointsTests : IAsyncLifetime
+{
+    // Valid test GUIDs for OIDC provider configuration
+    private const string TestTenantId = "11111111-1111-1111-1111-111111111111";
+    private const string TestClientId = "22222222-2222-2222-2222-222222222222";
+    private const string AzureClientId = "33333333-3333-3333-3333-333333333333";
+
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public AdminAuthEndpointsTests()
+    {
+        _fixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", "test-admin-key");
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateClient();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/auth/config")]
+    public async Task GetAuthConfig_IsAnonymous_Returns200()
+    {
+        // No authentication headers sent
+        var response = await _client.GetAsync("/api/v1/admin/auth/config");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/auth/config")]
+    public async Task GetAuthConfig_NoOidcConfigured_ReturnsEmptyProviders()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/auth/config");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadFromJsonAsync(AdminAuthJsonContext.Default.AdminAuthConfigResponse);
+
+        content.Should().NotBeNull();
+        content!.OidcEnabled.Should().BeFalse();
+        content.Providers.Should().BeEmpty();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/auth/config")]
+    public async Task GetAuthConfig_NoOidcConfigured_ApiKeyFallbackEnabled()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/auth/config");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadFromJsonAsync(AdminAuthJsonContext.Default.AdminAuthConfigResponse);
+
+        content.Should().NotBeNull();
+        content!.ApiKeyFallbackEnabled.Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/auth/config")]
+    public async Task GetAuthConfig_NoSecretsExposed_ResponseHasNoSecretFields()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/auth/config");
+        var raw = await response.Content.ReadAsStringAsync();
+
+        // Ensure no secret-like fields leak into the response
+        raw.Should().NotContain("clientSecret", because: "client secrets must never be exposed to the browser");
+        raw.Should().NotContain("client_secret");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/auth/config")]
+    public async Task GetAuthConfig_WithAzureAdConfigured_ReturnsSingleProvider()
+    {
+        var oidcFixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", "test-admin-key");
+                builder.UseSetting("Oidc:Enabled", "true");
+                builder.UseSetting("Oidc:RequireHttps", "true");
+                builder.UseSetting("Oidc:AzureAd:Enabled", "true");
+                builder.UseSetting("Oidc:AzureAd:TenantId", TestTenantId);
+                builder.UseSetting("Oidc:AzureAd:ClientId", TestClientId);
+                builder.UseSetting("Oidc:AzureAd:ClientSecret", "test-secret-value-minimum-length");
+                builder.UseSetting("Oidc:TokenValidation:ValidateIssuer", "false");
+                builder.UseSetting("Oidc:TokenValidation:ValidateAudience", "false");
+                builder.UseSetting("Oidc:TokenValidation:ValidateIssuerSigningKey", "false");
+                builder.UseSetting("Oidc:TokenValidation:SymmetricSigningKey", "test-key-at-least-32-characters-long-for-testing");
+            });
+
+        try
+        {
+            await oidcFixture.InitializeAsync();
+            var oidcClient = oidcFixture.CreateClient();
+
+            var response = await oidcClient.GetAsync("/api/v1/admin/auth/config");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var content = await response.Content.ReadFromJsonAsync(AdminAuthJsonContext.Default.AdminAuthConfigResponse);
+            content.Should().NotBeNull();
+            content!.OidcEnabled.Should().BeTrue();
+            content.Providers.Should().HaveCount(1);
+            content.Providers[0].Key.Should().Be("azuread");
+            content.Providers[0].DisplayName.Should().Be("Microsoft Entra ID");
+            content.Providers[0].ClientId.Should().Be(TestClientId);
+            content.Providers[0].Authority.Should().Contain(TestTenantId);
+            content.Providers[0].SupportsLogout.Should().BeTrue();
+            content.ApiKeyFallbackEnabled.Should().BeFalse();
+        }
+        finally
+        {
+            await oidcFixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/auth/config")]
+    public async Task GetAuthConfig_WithMultipleProviders_ReturnsAllProviders()
+    {
+        var oidcFixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", "test-admin-key");
+                builder.UseSetting("Oidc:Enabled", "true");
+                builder.UseSetting("Oidc:RequireHttps", "true");
+                builder.UseSetting("Oidc:TokenValidation:ValidateIssuer", "false");
+                builder.UseSetting("Oidc:TokenValidation:ValidateAudience", "false");
+                builder.UseSetting("Oidc:TokenValidation:ValidateIssuerSigningKey", "false");
+                builder.UseSetting("Oidc:TokenValidation:SymmetricSigningKey", "test-key-at-least-32-characters-long-for-testing");
+                // Azure AD
+                builder.UseSetting("Oidc:AzureAd:Enabled", "true");
+                builder.UseSetting("Oidc:AzureAd:TenantId", TestTenantId);
+                builder.UseSetting("Oidc:AzureAd:ClientId", AzureClientId);
+                builder.UseSetting("Oidc:AzureAd:ClientSecret", "azure-secret-value-minimum-length");
+                // Generic OIDC (e.g. Okta or Auth0)
+                builder.UseSetting("Oidc:Generic:Enabled", "true");
+                builder.UseSetting("Oidc:Generic:Authority", "https://auth.example.com");
+                builder.UseSetting("Oidc:Generic:ClientId", "generic-client-id");
+                builder.UseSetting("Oidc:Generic:DisplayName", "Okta");
+            });
+
+        try
+        {
+            await oidcFixture.InitializeAsync();
+            var oidcClient = oidcFixture.CreateClient();
+
+            var response = await oidcClient.GetAsync("/api/v1/admin/auth/config");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var content = await response.Content.ReadFromJsonAsync(AdminAuthJsonContext.Default.AdminAuthConfigResponse);
+            content.Should().NotBeNull();
+            content!.OidcEnabled.Should().BeTrue();
+            content.Providers.Should().HaveCount(2);
+            content.Providers.Should().Contain(p => p.Key == "azuread");
+            content.Providers.Should().Contain(p => p.Key == "oidc");
+        }
+        finally
+        {
+            await oidcFixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/auth/config")]
+    public async Task GetAuthConfig_OktaProvider_ReturnsCorrectAuthority()
+    {
+        var oidcFixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", "test-admin-key");
+                builder.UseSetting("Oidc:Enabled", "true");
+                builder.UseSetting("Oidc:RequireHttps", "true");
+                builder.UseSetting("Oidc:TokenValidation:ValidateIssuer", "false");
+                builder.UseSetting("Oidc:TokenValidation:ValidateAudience", "false");
+                builder.UseSetting("Oidc:TokenValidation:ValidateIssuerSigningKey", "false");
+                builder.UseSetting("Oidc:TokenValidation:SymmetricSigningKey", "test-key-at-least-32-characters-long-for-testing");
+                builder.UseSetting("Oidc:Okta:Enabled", "true");
+                builder.UseSetting("Oidc:Okta:OrgUrl", "dev-12345.okta.com");
+                builder.UseSetting("Oidc:Okta:ClientId", "okta-client-id");
+            });
+
+        try
+        {
+            await oidcFixture.InitializeAsync();
+            var oidcClient = oidcFixture.CreateClient();
+
+            var response = await oidcClient.GetAsync("/api/v1/admin/auth/config");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var content = await response.Content.ReadFromJsonAsync(AdminAuthJsonContext.Default.AdminAuthConfigResponse);
+            content.Should().NotBeNull();
+            content!.OidcEnabled.Should().BeTrue();
+            content.Providers.Should().HaveCount(1);
+            content.Providers[0].Key.Should().Be("okta");
+            content.Providers[0].DisplayName.Should().Be("Okta");
+            content.Providers[0].Authority.Should().Be("https://dev-12345.okta.com/oauth2/default");
+            content.Providers[0].ClientId.Should().Be("okta-client-id");
+            content.Providers[0].SupportsLogout.Should().BeTrue();
+        }
+        finally
+        {
+            await oidcFixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/auth/config")]
+    public async Task GetAuthConfig_Auth0Provider_ReturnsCorrectAuthority()
+    {
+        var oidcFixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", "test-admin-key");
+                builder.UseSetting("Oidc:Enabled", "true");
+                builder.UseSetting("Oidc:RequireHttps", "true");
+                builder.UseSetting("Oidc:TokenValidation:ValidateIssuer", "false");
+                builder.UseSetting("Oidc:TokenValidation:ValidateAudience", "false");
+                builder.UseSetting("Oidc:TokenValidation:ValidateIssuerSigningKey", "false");
+                builder.UseSetting("Oidc:TokenValidation:SymmetricSigningKey", "test-key-at-least-32-characters-long-for-testing");
+                builder.UseSetting("Oidc:Auth0:Enabled", "true");
+                builder.UseSetting("Oidc:Auth0:Domain", "myapp.us.auth0.com");
+                builder.UseSetting("Oidc:Auth0:ClientId", "auth0-client-id");
+            });
+
+        try
+        {
+            await oidcFixture.InitializeAsync();
+            var oidcClient = oidcFixture.CreateClient();
+
+            var response = await oidcClient.GetAsync("/api/v1/admin/auth/config");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var content = await response.Content.ReadFromJsonAsync(AdminAuthJsonContext.Default.AdminAuthConfigResponse);
+            content.Should().NotBeNull();
+            content!.OidcEnabled.Should().BeTrue();
+            content.Providers.Should().HaveCount(1);
+            content.Providers[0].Key.Should().Be("auth0");
+            content.Providers[0].DisplayName.Should().Be("Auth0");
+            content.Providers[0].Authority.Should().Be("https://myapp.us.auth0.com/");
+            content.Providers[0].ClientId.Should().Be("auth0-client-id");
+        }
+        finally
+        {
+            await oidcFixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/auth/config")]
+    public async Task GetAuthConfig_GoogleProvider_SupportsLogoutIsFalse()
+    {
+        var oidcFixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", "test-admin-key");
+                builder.UseSetting("Oidc:Enabled", "true");
+                builder.UseSetting("Oidc:RequireHttps", "true");
+                builder.UseSetting("Oidc:TokenValidation:ValidateIssuer", "false");
+                builder.UseSetting("Oidc:TokenValidation:ValidateAudience", "false");
+                builder.UseSetting("Oidc:TokenValidation:ValidateIssuerSigningKey", "false");
+                builder.UseSetting("Oidc:TokenValidation:SymmetricSigningKey", "test-key-at-least-32-characters-long-for-testing");
+                builder.UseSetting("Oidc:Google:Enabled", "true");
+                builder.UseSetting("Oidc:Google:ClientId", "google-client-id.apps.googleusercontent.com");
+                builder.UseSetting("Oidc:Google:ClientSecret", "google-secret-value-test");
+            });
+
+        try
+        {
+            await oidcFixture.InitializeAsync();
+            var oidcClient = oidcFixture.CreateClient();
+
+            var response = await oidcClient.GetAsync("/api/v1/admin/auth/config");
+            var content = await response.Content.ReadFromJsonAsync(AdminAuthJsonContext.Default.AdminAuthConfigResponse);
+
+            content.Should().NotBeNull();
+            content!.Providers.Should().HaveCount(1);
+            content.Providers[0].Key.Should().Be("google");
+            // Google does not support RP-initiated logout
+            content.Providers[0].SupportsLogout.Should().BeFalse();
+        }
+        finally
+        {
+            await oidcFixture.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #514
## Summary

- "The login flow works with Entra ID, Okta, and Auth0" — all three providers now projected by the bootstrap endpoint
- Okta authority: `https://{OrgUrl}/oauth2/{AuthorizationServerId}` — matches Okta's standard issuer format
- Auth0 authority: `https://{Domain}/` — trailing slash matches Auth0's issuer validation requirement
- Both provider option types use `GetAuthority()` methods already defined on the option classes
- No secrets exposed — only ClientId, Authority, Scopes, DisplayName
- AOT: no new JSON types needed (reuses existing `AdminAuthProviderInfo`)
- Build: 0 errors, 0 warnings (both projects)
## Changes Made

- "The login flow works with Entra ID, Okta, and Auth0" — all three providers now projected by the bootstrap endpoint
- Okta authority: `https://{OrgUrl}/oauth2/{AuthorizationServerId}` — matches Okta's standard issuer format
- Auth0 authority: `https://{Domain}/` — trailing slash matches Auth0's issuer validation requirement
- Both provider option types use `GetAuthority()` methods already defined on the option classes
- No secrets exposed — only ClientId, Authority, Scopes, DisplayName
- AOT: no new JSON types needed (reuses existing `AdminAuthProviderInfo`)
- Build: 0 errors, 0 warnings (both projects)
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Breaking Changes

None
## Additional Context

Decisions:
- Okta `SupportsLogout = true` — Okta supports RP-initiated logout via `end_session_endpoint` and the provider has a `SignedOutCallbackPath` configured by default
- Auth0 `SupportsLogout` gated on `SignedOutCallbackPath` presence — Auth0 supports logout but the path may be cleared if disabled
- Generic provider remains last in the enumeration order to serve as the catch-all for any OIDC provider not explicitly supported

Follow-ons:
None.

Code kaizen:
Deferred bounded adjacent cleanup; keep the ticket moving to the full pre-PR gate.
## Pre-PR Checklist (for contributor)
- [ ] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit message follows format: `type: description (#issue-number)`
- [ ] PR title matches main commit message
- [ ] Issue number linked above
- [ ] Tests added for new functionality
- [ ] Documentation updated if needed
- [ ] If protocol/auth behavior changed, updated MVP compatibility contract and release checklist notes
- [ ] If breaking admin/control-plane API changes: updated migration guide and versioning policy docs
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review and documented in migration guide

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
