### PR TITLE
fix: prevent duplicate geometry column in layer_fields during publish

### DIFF
--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
@@ -434,12 +434,15 @@ internal sealed partial class PostgreSqlLayerPublishingService(
             _ = added.Add(column.Name);
         }
 
-        fields.Add(new LayerFieldInsert(
-            geometryColumn,
-            FieldType.Geometry,
-            null,
-            true,
-            "Geometry"));
+        if (!added.Contains(geometryColumn))
+        {
+            fields.Add(new LayerFieldInsert(
+                geometryColumn,
+                FieldType.Geometry,
+                null,
+                true,
+                "Geometry"));
+        }
 
         return fields;
     }

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlTableDiscoveryService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlTableDiscoveryService.cs
@@ -222,6 +222,7 @@ internal sealed class PostgreSqlTableDiscoveryService(
                 WHERE c.table_schema = @schema
                   AND c.table_name = @tableName
                   AND c.data_type NOT IN ('geometry', 'geography')
+                  AND c.udt_name NOT IN ('geometry', 'geography')
                 ORDER BY c.ordinal_position
                 """;
 

--- a/src/Honua.Server/Features/OgcFeatures/CollectionsEndpoints.cs
+++ b/src/Honua.Server/Features/OgcFeatures/CollectionsEndpoints.cs
@@ -114,15 +114,24 @@ internal static class CollectionsEndpoints
             var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
             var layers = await layerCatalog.ListLayersAsync(cancellationToken);
             var services = await layerCatalog.ListServicesAsync(cancellationToken);
-            var protocolLayerIds = services
+            var ogcServices = services
                 .Where(service => ServiceProtocols.IsProtocolEnabled(service.Metadata, ServiceProtocols.OgcFeatures))
-                .SelectMany(service => service.Layers.Select(layer => layer.Id))
-                .ToHashSet();
+                .ToList();
+            var layerToService = new Dictionary<int, ServiceDefinition>();
+            foreach (var service in ogcServices)
+            {
+                foreach (var sl in service.Layers)
+                {
+                    layerToService.TryAdd(sl.Id, service);
+                }
+            }
+            var protocolLayerIds = layerToService.Keys.ToHashSet();
             var visibleLayers = layers
                 .Where(layer => protocolLayerIds.Count == 0
                     ? ServiceProtocols.IsProtocolEnabled(layer.Metadata, ServiceProtocols.OgcFeatures)
                     : protocolLayerIds.Contains(layer.Id))
-                .Where(layer => AccessPolicyHelpers.IsLayerAccessible(context, layer))
+                .Where(layer => AccessPolicyHelpers.IsLayerAccessible(
+                    context, layer, layerToService.GetValueOrDefault(layer.Id)))
                 .ToList();
             var collectionTasks = visibleLayers
                 .Select(layer => CreateCollectionAsync(layer, baseUrl, featureReader, crsRegistry, cancellationToken));


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #335

## Summary
Fix layer publishing when PostGIS geometry/geography columns would otherwise be inserted into `layer_fields` twice, and carry service-aware access evaluation into the OGC collections listing after merging `trunk`.

## Changes Made
- Excluded `geometry` and `geography` UDTs during table discovery so publish inputs no longer treat the geometry column as a regular attribute.
- Added a defensive dedup guard when building `layer_fields` so the explicit geometry field is only emitted once.
- Resolved the `trunk` merge in OGC collections by keeping service-aware access filtering while taking the latest instruction-sync and protocol updates.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
