### PR TITLE
fix(postgres): remediate alerts persistence audit findings (#560)

### DIFF
--- a/src/Honua.Postgres/Features/Alerts/AlertLog.cs
+++ b/src/Honua.Postgres/Features/Alerts/AlertLog.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Postgres.Features.Alerts;
+
+internal static partial class AlertLog
+{
+    [LoggerMessage(
+        EventId = 5601,
+        Level = LogLevel.Debug,
+        Message = "Enqueued {ChannelCount} dispatch jobs for event {EventId}")]
+    public static partial void DispatchEnqueued(
+        ILogger logger,
+        int channelCount,
+        long eventId);
+
+    [LoggerMessage(
+        EventId = 5602,
+        Level = LogLevel.Debug,
+        Message = "Claimed {Count} pending dispatch jobs")]
+    public static partial void DispatchClaimed(
+        ILogger logger,
+        int count);
+
+    [LoggerMessage(
+        EventId = 5603,
+        Level = LogLevel.Warning,
+        Message = "Dispatch {DispatchId} failed, deadLetter={DeadLetter}")]
+    public static partial void DispatchFailed(
+        ILogger logger,
+        long dispatchId,
+        bool deadLetter);
+
+    [LoggerMessage(
+        EventId = 5604,
+        Level = LogLevel.Debug,
+        Message = "Found {Count} dwell candidates due before {DueBefore}")]
+    public static partial void DwellCandidatesFound(
+        ILogger logger,
+        int count,
+        DateTimeOffset dueBefore);
+
+    [LoggerMessage(
+        EventId = 5605,
+        Level = LogLevel.Debug,
+        Message = "Loaded {RuleCount} active rules for {KeyCount} lookup keys")]
+    public static partial void ActiveRulesLoaded(
+        ILogger logger,
+        int ruleCount,
+        int keyCount);
+
+    [LoggerMessage(
+        EventId = 5606,
+        Level = LogLevel.Warning,
+        Message = "Dispatch {DispatchId} dead-lettered after exhausting retries")]
+    public static partial void DispatchDeadLettered(
+        ILogger logger,
+        long dispatchId);
+}

--- a/src/Honua.Postgres/Features/Alerts/AlertStoreConversions.cs
+++ b/src/Honua.Postgres/Features/Alerts/AlertStoreConversions.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Collections.Immutable;
 using Honua.Core.Features.Alerts.Domain;
+using Npgsql;
 
 namespace Honua.Postgres.Features.Alerts;
 
@@ -166,5 +168,79 @@ internal static class AlertStoreConversions
     public static string ToChannelName(this AlertChannelType value)
     {
         return value.ToExternalName();
+    }
+
+    /// <summary>
+    /// Maps a data reader row to an <see cref="AlertRuleDefinition"/>.
+    /// Expects columns: rule_id, service_id, layer_id, zone_id, rule_name, trigger_type,
+    /// conditions, cooldown_seconds, severity, edition_required, channels, is_active.
+    /// </summary>
+    public static AlertRuleDefinition MapRule(NpgsqlDataReader reader)
+    {
+        return new AlertRuleDefinition
+        {
+            RuleId = reader.GetInt64(0),
+            ServiceId = reader.GetString(1),
+            LayerId = reader.GetInt32(2),
+            ZoneId = reader.IsDBNull(3) ? null : reader.GetInt64(3),
+            RuleName = reader.GetString(4),
+            TriggerType = ToTriggerType(reader.GetInt16(5)),
+            ConditionsJson = reader.IsDBNull(6) ? "{}" : reader.GetString(6),
+            CooldownSeconds = reader.GetInt32(7),
+            Severity = ToSeverity(reader.GetString(8)),
+            EditionRequired = ToEdition(reader.GetInt16(9)),
+            Channels = ParseChannels(reader.IsDBNull(10) ? [] : (string[])reader[10]),
+            IsActive = reader.GetBoolean(11)
+        };
+    }
+
+    /// <summary>
+    /// Parses an array of channel name strings into an immutable array of <see cref="AlertChannelType"/>.
+    /// Skips unrecognized values to remain resilient to data from previous versions.
+    /// </summary>
+    public static ImmutableArray<AlertChannelType> ParseChannels(string[] values)
+    {
+        if (values.Length == 0)
+        {
+            return ImmutableArray<AlertChannelType>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<AlertChannelType>(values.Length);
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            try
+            {
+                builder.Add(ParseChannel(value));
+            }
+            catch (InvalidOperationException)
+            {
+                // Skip unsupported channel values persisted by previous versions.
+            }
+        }
+
+        return builder.Distinct().ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Maps a data reader row to an <see cref="AlertZoneDefinition"/>.
+    /// Expects columns: zone_id, service_id, zone_name, ST_AsBinary(geometry), ST_SRID(geometry), metadata, is_active.
+    /// </summary>
+    public static AlertZoneDefinition MapZone(NpgsqlDataReader reader)
+    {
+        return new AlertZoneDefinition
+        {
+            ZoneId = reader.GetInt64(0),
+            ServiceId = reader.GetString(1),
+            ZoneName = reader.GetString(2),
+            Geometry = reader.IsDBNull(3) ? null : (byte[])reader[3],
+            GeometrySrid = reader.IsDBNull(4) ? null : reader.GetInt32(4),
+            Metadata = AlertMetadataSerializer.Parse(reader.IsDBNull(5) ? "{}" : reader.GetString(5)),
+            IsActive = reader.GetBoolean(6)
+        };
     }
 }

--- a/src/Honua.Postgres/Features/Alerts/AlertStoreConversions.cs
+++ b/src/Honua.Postgres/Features/Alerts/AlertStoreConversions.cs
@@ -175,7 +175,7 @@ internal static class AlertStoreConversions
     /// Expects columns: rule_id, service_id, layer_id, zone_id, rule_name, trigger_type,
     /// conditions, cooldown_seconds, severity, edition_required, channels, is_active.
     /// </summary>
-    public static AlertRuleDefinition MapRule(NpgsqlDataReader reader)
+    internal static AlertRuleDefinition MapRule(NpgsqlDataReader reader)
     {
         return new AlertRuleDefinition
         {
@@ -198,7 +198,7 @@ internal static class AlertStoreConversions
     /// Parses an array of channel name strings into an immutable array of <see cref="AlertChannelType"/>.
     /// Skips unrecognized values to remain resilient to data from previous versions.
     /// </summary>
-    public static ImmutableArray<AlertChannelType> ParseChannels(string[] values)
+    internal static ImmutableArray<AlertChannelType> ParseChannels(string[] values)
     {
         if (values.Length == 0)
         {
@@ -230,7 +230,7 @@ internal static class AlertStoreConversions
     /// Maps a data reader row to an <see cref="AlertZoneDefinition"/>.
     /// Expects columns: zone_id, service_id, zone_name, ST_AsBinary(geometry), ST_SRID(geometry), metadata, is_active.
     /// </summary>
-    public static AlertZoneDefinition MapZone(NpgsqlDataReader reader)
+    internal static AlertZoneDefinition MapZone(NpgsqlDataReader reader)
     {
         return new AlertZoneDefinition
         {

--- a/src/Honua.Postgres/Features/Alerts/PostgresAlertAdminStore.cs
+++ b/src/Honua.Postgres/Features/Alerts/PostgresAlertAdminStore.cs
@@ -40,7 +40,7 @@ internal sealed class PostgresAlertAdminStore : IAlertAdminStore
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            results.Add(MapZone(reader));
+            results.Add(AlertStoreConversions.MapZone(reader));
         }
 
         return results;
@@ -68,7 +68,7 @@ internal sealed class PostgresAlertAdminStore : IAlertAdminStore
             return null;
         }
 
-        return MapZone(reader);
+        return AlertStoreConversions.MapZone(reader);
     }
 
     public async Task<AlertZoneDefinition> CreateZoneAsync(
@@ -98,7 +98,7 @@ internal sealed class PostgresAlertAdminStore : IAlertAdminStore
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         _ = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
-        return MapZone(reader);
+        return AlertStoreConversions.MapZone(reader);
     }
 
     public async Task<AlertZoneDefinition?> UpdateZoneAsync(
@@ -134,7 +134,7 @@ internal sealed class PostgresAlertAdminStore : IAlertAdminStore
             return null;
         }
 
-        return MapZone(reader);
+        return AlertStoreConversions.MapZone(reader);
     }
 
     public async Task<bool> DeleteZoneAsync(long zoneId, CancellationToken cancellationToken = default)
@@ -178,7 +178,7 @@ internal sealed class PostgresAlertAdminStore : IAlertAdminStore
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            rules.Add(MapRule(reader));
+            rules.Add(AlertStoreConversions.MapRule(reader));
         }
 
         return rules;
@@ -208,7 +208,7 @@ internal sealed class PostgresAlertAdminStore : IAlertAdminStore
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         _ = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
-        return MapRule(reader);
+        return AlertStoreConversions.MapRule(reader);
     }
 
     public async Task<AlertRuleDefinition?> UpdateRuleAsync(
@@ -248,7 +248,7 @@ internal sealed class PostgresAlertAdminStore : IAlertAdminStore
             return null;
         }
 
-        return MapRule(reader);
+        return AlertStoreConversions.MapRule(reader);
     }
 
     public async Task<bool> DeleteRuleAsync(long ruleId, CancellationToken cancellationToken = default)
@@ -296,69 +296,8 @@ internal sealed class PostgresAlertAdminStore : IAlertAdminStore
         return command;
     }
 
-    private static AlertZoneDefinition MapZone(NpgsqlDataReader reader)
-    {
-        return new AlertZoneDefinition
-        {
-            ZoneId = reader.GetInt64(0),
-            ServiceId = reader.GetString(1),
-            ZoneName = reader.GetString(2),
-            Geometry = reader.IsDBNull(3) ? null : (byte[])reader[3],
-            GeometrySrid = reader.IsDBNull(4) ? null : reader.GetInt32(4),
-            Metadata = AlertMetadataSerializer.Parse(reader.IsDBNull(5) ? "{}" : reader.GetString(5)),
-            IsActive = reader.GetBoolean(6)
-        };
-    }
-
-    private static AlertRuleDefinition MapRule(NpgsqlDataReader reader)
-    {
-        return new AlertRuleDefinition
-        {
-            RuleId = reader.GetInt64(0),
-            ServiceId = reader.GetString(1),
-            LayerId = reader.GetInt32(2),
-            ZoneId = reader.IsDBNull(3) ? null : reader.GetInt64(3),
-            RuleName = reader.GetString(4),
-            TriggerType = AlertStoreConversions.ToTriggerType(reader.GetInt16(5)),
-            ConditionsJson = reader.IsDBNull(6) ? "{}" : reader.GetString(6),
-            CooldownSeconds = reader.GetInt32(7),
-            Severity = AlertStoreConversions.ToSeverity(reader.GetString(8)),
-            EditionRequired = AlertStoreConversions.ToEdition(reader.GetInt16(9)),
-            Channels = ParseChannels(reader.IsDBNull(10) ? Array.Empty<string>() : (string[])reader[10]),
-            IsActive = reader.GetBoolean(11)
-        };
-    }
-
     private static string SerializeMetadata(ImmutableDictionary<string, string?> metadata)
     {
         return AlertMetadataSerializer.Serialize(metadata);
-    }
-
-    private static ImmutableArray<AlertChannelType> ParseChannels(string[] channels)
-    {
-        if (channels.Length == 0)
-        {
-            return ImmutableArray<AlertChannelType>.Empty;
-        }
-
-        var builder = ImmutableArray.CreateBuilder<AlertChannelType>(channels.Length);
-        foreach (var channel in channels)
-        {
-            if (string.IsNullOrWhiteSpace(channel))
-            {
-                continue;
-            }
-
-            try
-            {
-                builder.Add(AlertStoreConversions.ParseChannel(channel));
-            }
-            catch (InvalidOperationException)
-            {
-                // Ignore unsupported channel values persisted by previous versions.
-            }
-        }
-
-        return builder.Distinct().ToImmutableArray();
     }
 }

--- a/src/Honua.Postgres/Features/Alerts/PostgresAlertDispatchStore.cs
+++ b/src/Honua.Postgres/Features/Alerts/PostgresAlertDispatchStore.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using Honua.Core.Features.Alerts.Abstractions;
 using Honua.Core.Features.Alerts.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -13,10 +14,14 @@ namespace Honua.Postgres.Features.Alerts;
 internal sealed class PostgresAlertDispatchStore : IAlertDispatchStore
 {
     private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly ILogger<PostgresAlertDispatchStore> _logger;
 
-    public PostgresAlertDispatchStore(IDatabaseConnectionProvider connectionProvider)
+    public PostgresAlertDispatchStore(
+        IDatabaseConnectionProvider connectionProvider,
+        ILogger<PostgresAlertDispatchStore> logger)
     {
         _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task EnqueueAsync(
@@ -31,20 +36,21 @@ internal sealed class PostgresAlertDispatchStore : IAlertDispatchStore
 
         const string sql = """
             INSERT INTO honua.alert_dispatch (event_id, channel_type, status, attempts, max_attempts, next_attempt_at)
-            VALUES (@event_id, @channel_type, 0, 0, 5, now())
+            SELECT @event_id, ct, 0, 0, 5, now()
+            FROM unnest(@channel_types) AS ct
             """;
+
+        var channelTypes = channels.Distinct().Select(static c => c.ToDbValue()).ToArray();
 
         await using var connection = (NpgsqlConnection)await _connectionProvider
             .OpenConnectionAsync(cancellationToken)
             .ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("event_id", NpgsqlDbType.Bigint, eventId);
+        command.Parameters.AddWithValue("channel_types", NpgsqlDbType.Array | NpgsqlDbType.Smallint, channelTypes);
+        _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
-        foreach (var channel in channels.Distinct())
-        {
-            await using var command = new NpgsqlCommand(sql, connection);
-            command.Parameters.AddWithValue("event_id", NpgsqlDbType.Bigint, eventId);
-            command.Parameters.AddWithValue("channel_type", NpgsqlDbType.Smallint, channel.ToDbValue());
-            _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
+        AlertLog.DispatchEnqueued(_logger, channelTypes.Length, eventId);
     }
 
     async Task<IReadOnlyList<AlertDispatchItem>> IAlertDispatchStore.ClaimPendingAsync(
@@ -128,6 +134,7 @@ internal sealed class PostgresAlertDispatchStore : IAlertDispatchStore
         }
 
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        AlertLog.DispatchClaimed(_logger, rows.Count);
         return rows;
     }
 
@@ -159,7 +166,7 @@ internal sealed class PostgresAlertDispatchStore : IAlertDispatchStore
         DateTimeOffset attemptedAt,
         DateTimeOffset nextAttemptAt,
         bool deadLetter,
-        string? error,
+        string? errorMessage,
         CancellationToken cancellationToken = default)
     {
         const string sql = """
@@ -182,8 +189,17 @@ internal sealed class PostgresAlertDispatchStore : IAlertDispatchStore
         command.Parameters.AddWithValue("status", NpgsqlDbType.Smallint, deadLetter ? AlertDispatchStatus.DeadLetter.ToDbValue() : AlertDispatchStatus.Failed.ToDbValue());
         command.Parameters.AddWithValue("next_attempt_at", NpgsqlDbType.TimestampTz, nextAttemptAt);
         command.Parameters.AddWithValue("attempted_at", NpgsqlDbType.TimestampTz, attemptedAt);
-        command.Parameters.AddWithValue("last_error", NpgsqlDbType.Text, (object?)error ?? DBNull.Value);
+        command.Parameters.AddWithValue("last_error", NpgsqlDbType.Text, (object?)errorMessage ?? DBNull.Value);
 
         _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+        if (deadLetter)
+        {
+            AlertLog.DispatchDeadLettered(_logger, dispatchId);
+        }
+        else
+        {
+            AlertLog.DispatchFailed(_logger, dispatchId, deadLetter);
+        }
     }
 }

--- a/src/Honua.Postgres/Features/Alerts/PostgresAlertRuleRepository.cs
+++ b/src/Honua.Postgres/Features/Alerts/PostgresAlertRuleRepository.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
-using System.Collections.Immutable;
 using Honua.Core.Features.Alerts.Abstractions;
 using Honua.Core.Features.Alerts.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -13,10 +13,14 @@ namespace Honua.Postgres.Features.Alerts;
 internal sealed class PostgresAlertRuleRepository : IAlertRuleRepository
 {
     private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly ILogger<PostgresAlertRuleRepository> _logger;
 
-    public PostgresAlertRuleRepository(IDatabaseConnectionProvider connectionProvider)
+    public PostgresAlertRuleRepository(
+        IDatabaseConnectionProvider connectionProvider,
+        ILogger<PostgresAlertRuleRepository> logger)
     {
         _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<IReadOnlyList<AlertRuleDefinition>> GetActiveRulesAsync(
@@ -42,15 +46,6 @@ internal sealed class PostgresAlertRuleRepository : IAlertRuleRepository
             return new Dictionary<AlertRuleLookupKey, IReadOnlyList<AlertRuleDefinition>>();
         }
 
-        const string sql = """
-            SELECT rule_id, service_id, layer_id, zone_id, rule_name, trigger_type,
-                   conditions, cooldown_seconds, severity, edition_required, channels, is_active
-            FROM honua.alert_rules
-            WHERE is_active = TRUE
-              AND layer_id = ANY(@layer_ids)
-            ORDER BY layer_id, rule_id
-            """;
-
         var normalizedKeys = lookupKeys
             .Distinct()
             .ToArray();
@@ -59,18 +54,48 @@ internal sealed class PostgresAlertRuleRepository : IAlertRuleRepository
             .Distinct()
             .ToArray();
 
+        // When all lookup keys carry a non-null service_id, push the filter into SQL
+        // to avoid fetching rows for unrelated services.
+        var allKeysHaveServiceId = normalizedKeys.All(static k => k.ServiceId is not null);
+        var serviceIds = allKeysHaveServiceId
+            ? normalizedKeys.Select(static k => k.ServiceId!).Distinct().ToArray()
+            : null;
+
+        var sql = allKeysHaveServiceId
+            ? """
+              SELECT rule_id, service_id, layer_id, zone_id, rule_name, trigger_type,
+                     conditions, cooldown_seconds, severity, edition_required, channels, is_active
+              FROM honua.alert_rules
+              WHERE is_active = TRUE
+                AND layer_id = ANY(@layer_ids)
+                AND service_id = ANY(@service_ids)
+              ORDER BY layer_id, rule_id
+              """
+            : """
+              SELECT rule_id, service_id, layer_id, zone_id, rule_name, trigger_type,
+                     conditions, cooldown_seconds, severity, edition_required, channels, is_active
+              FROM honua.alert_rules
+              WHERE is_active = TRUE
+                AND layer_id = ANY(@layer_ids)
+              ORDER BY layer_id, rule_id
+              """;
+
         await using var connection = (NpgsqlConnection)await _connectionProvider
             .OpenConnectionAsync(cancellationToken)
             .ConfigureAwait(false);
         await using var command = new NpgsqlCommand(sql, connection);
 
         command.Parameters.AddWithValue("layer_ids", NpgsqlDbType.Array | NpgsqlDbType.Integer, layerIds);
+        if (serviceIds is not null)
+        {
+            command.Parameters.AddWithValue("service_ids", NpgsqlDbType.Array | NpgsqlDbType.Text, serviceIds);
+        }
 
         var rulesByLayer = new Dictionary<int, List<AlertRuleDefinition>>();
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            var rule = MapRule(reader);
+            var rule = AlertStoreConversions.MapRule(reader);
             if (!rulesByLayer.TryGetValue(rule.LayerId, out var layerRules))
             {
                 layerRules = new List<AlertRuleDefinition>();
@@ -96,6 +121,8 @@ internal sealed class PostgresAlertRuleRepository : IAlertRuleRepository
                     .ToArray();
         }
 
+        var totalRules = rulesByLayer.Values.Sum(static r => r.Count);
+        AlertLog.ActiveRulesLoaded(_logger, totalRules, normalizedKeys.Length);
         return results;
     }
 
@@ -133,7 +160,7 @@ internal sealed class PostgresAlertRuleRepository : IAlertRuleRepository
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            var rule = MapRule(reader);
+            var rule = AlertStoreConversions.MapRule(reader);
             results[rule.RuleId] = rule;
         }
 
@@ -165,71 +192,11 @@ internal sealed class PostgresAlertRuleRepository : IAlertRuleRepository
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            var zone = new AlertZoneDefinition
-            {
-                ZoneId = reader.GetInt64(0),
-                ServiceId = reader.GetString(1),
-                ZoneName = reader.GetString(2),
-                Geometry = reader.IsDBNull(3) ? null : (byte[])reader[3],
-                GeometrySrid = reader.IsDBNull(4) ? null : reader.GetInt32(4),
-                Metadata = AlertMetadataSerializer.Parse(reader.IsDBNull(5) ? "{}" : reader.GetString(5)),
-                IsActive = reader.GetBoolean(6)
-            };
-
+            var zone = AlertStoreConversions.MapZone(reader);
             zones[zone.ZoneId] = zone;
         }
 
         return zones;
     }
 
-    private static AlertRuleDefinition MapRule(NpgsqlDataReader reader)
-    {
-        var channels = reader.IsDBNull(10)
-            ? ImmutableArray<AlertChannelType>.Empty
-            : ParseChannels((string[])reader[10]);
-
-        return new AlertRuleDefinition
-        {
-            RuleId = reader.GetInt64(0),
-            ServiceId = reader.GetString(1),
-            LayerId = reader.GetInt32(2),
-            ZoneId = reader.IsDBNull(3) ? null : reader.GetInt64(3),
-            RuleName = reader.GetString(4),
-            TriggerType = AlertStoreConversions.ToTriggerType(reader.GetInt16(5)),
-            ConditionsJson = reader.IsDBNull(6) ? "{}" : reader.GetString(6),
-            CooldownSeconds = reader.GetInt32(7),
-            Severity = AlertStoreConversions.ToSeverity(reader.GetString(8)),
-            EditionRequired = AlertStoreConversions.ToEdition(reader.GetInt16(9)),
-            Channels = channels,
-            IsActive = reader.GetBoolean(11)
-        };
-    }
-
-    private static ImmutableArray<AlertChannelType> ParseChannels(string[] values)
-    {
-        if (values.Length == 0)
-        {
-            return ImmutableArray<AlertChannelType>.Empty;
-        }
-
-        var builder = ImmutableArray.CreateBuilder<AlertChannelType>(values.Length);
-        foreach (var value in values)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                continue;
-            }
-
-            try
-            {
-                builder.Add(AlertStoreConversions.ParseChannel(value));
-            }
-            catch (InvalidOperationException)
-            {
-                // Skip unsupported channel values to keep rule loading resilient to bad data.
-            }
-        }
-
-        return builder.Distinct().ToImmutableArray();
-    }
 }

--- a/src/Honua.Postgres/Features/Alerts/PostgresAlertStateStore.cs
+++ b/src/Honua.Postgres/Features/Alerts/PostgresAlertStateStore.cs
@@ -4,6 +4,7 @@
 using Honua.Core.Features.Alerts.Abstractions;
 using Honua.Core.Features.Alerts.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -12,10 +13,14 @@ namespace Honua.Postgres.Features.Alerts;
 internal sealed class PostgresAlertStateStore : IAlertStateStore
 {
     private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly ILogger<PostgresAlertStateStore> _logger;
 
-    public PostgresAlertStateStore(IDatabaseConnectionProvider connectionProvider)
+    public PostgresAlertStateStore(
+        IDatabaseConnectionProvider connectionProvider,
+        ILogger<PostgresAlertStateStore> logger)
     {
         _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<AlertStateSnapshot?> GetAsync(
@@ -131,7 +136,7 @@ internal sealed class PostgresAlertStateStore : IAlertStateStore
               AND s.entered_at IS NOT NULL
               AND s.entered_at <= @due_before
               AND r.is_active = TRUE
-              AND r.trigger_type = 3
+              AND r.trigger_type = @dwell_trigger_type
             ORDER BY s.entered_at
             LIMIT @max_count
             """;
@@ -143,6 +148,7 @@ internal sealed class PostgresAlertStateStore : IAlertStateStore
 
         command.Parameters.AddWithValue("due_before", NpgsqlDbType.TimestampTz, dueBefore);
         command.Parameters.AddWithValue("max_count", NpgsqlDbType.Integer, maxCount);
+        command.Parameters.AddWithValue("dwell_trigger_type", NpgsqlDbType.Smallint, AlertTriggerType.Dwell.ToDbValue());
 
         var rows = new List<AlertStateSnapshot>(Math.Max(1, maxCount));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
@@ -151,6 +157,7 @@ internal sealed class PostgresAlertStateStore : IAlertStateStore
             rows.Add(MapState(reader));
         }
 
+        AlertLog.DwellCandidatesFound(_logger, rows.Count, dueBefore);
         return rows;
     }
 


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #560

## Summary
Remediates the alerts persistence audit findings by consolidating duplicated alert mapping logic, adding structured logging, aligning the failed-dispatch contract, and tightening the alert persistence query paths.

## Changes Made
- Consolidated shared alert rule, channel, and zone mapping into `AlertStoreConversions`.
- Added `AlertLog` structured logging and wired it into the alert admin, dispatch, rule, and state stores.
- Replaced the dwell-trigger magic number and tightened alert query/update SQL behavior called out by the audit.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
