### PR TITLE
fix(postgres): remediate catalog persistence audit findings (#562)

### DIFF
--- a/src/Honua.Postgres/Features/Catalog/PostgresLayerCatalog.cs
+++ b/src/Honua.Postgres/Features/Catalog/PostgresLayerCatalog.cs
@@ -142,7 +142,7 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
                 s.supported_formats,
                 s.capabilities,
                 s.metadata,
-                (to_jsonb(s)->>'connection_id')::uuid as connection_id,
+                s.connection_id,
                 ST_XMin(s.service_extent) as xmin,
                 ST_YMin(s.service_extent) as ymin,
                 ST_XMax(s.service_extent) as xmax,
@@ -180,7 +180,7 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
                 s.supported_formats,
                 s.capabilities,
                 s.metadata,
-                (to_jsonb(s)->>'connection_id')::uuid as connection_id,
+                s.connection_id,
                 ST_XMin(s.service_extent) as xmin,
                 ST_YMin(s.service_extent) as ymin,
                 ST_XMax(s.service_extent) as xmax,
@@ -252,31 +252,12 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
             throw new InvalidDataException($"Invalid geometry type: {geometryTypeString}");
 
         int srid = reader.GetInt32(reader.GetOrdinal("srid"));
-        int extentSrid = srid;
-        int extentSridOrdinal = reader.GetOrdinal("extent_srid");
-        if (!reader.IsDBNull(extentSridOrdinal))
-        {
-            extentSrid = reader.GetInt32(extentSridOrdinal);
-            if (extentSrid <= 0)
-            {
-                extentSrid = srid;
-            }
-        }
+        int extentSrid = ReadExtentSrid(reader, srid);
         double? minScale = reader.IsDBNull(reader.GetOrdinal("min_scale")) ? (double?)null : reader.GetDouble(reader.GetOrdinal("min_scale"));
         double? maxScale = reader.IsDBNull(reader.GetOrdinal("max_scale")) ? (double?)null : reader.GetDouble(reader.GetOrdinal("max_scale"));
         bool defaultVisibility = reader.GetBoolean(reader.GetOrdinal("default_visibility"));
 
-        // Build extent if available
-        FeatureExtent? extent = null;
-        int xminOrdinal = reader.GetOrdinal("xmin");
-        if (!reader.IsDBNull(xminOrdinal))
-        {
-            double xmin = reader.GetDouble(xminOrdinal);
-            double ymin = reader.GetDouble(reader.GetOrdinal("ymin"));
-            double xmax = reader.GetDouble(reader.GetOrdinal("xmax"));
-            double ymax = reader.GetDouble(reader.GetOrdinal("ymax"));
-            extent = FeatureExtent.Create(xmin, ymin, xmax, ymax, extentSrid);
-        }
+        FeatureExtent? extent = ReadExtent(reader, extentSrid);
 
         var spatialReference = SpatialReference.Create(srid);
 
@@ -304,30 +285,11 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
         Guid? connectionId = reader.IsDBNull(reader.GetOrdinal("connection_id"))
             ? null
             : reader.GetGuid(reader.GetOrdinal("connection_id"));
-        int extentSrid = srid;
-        int extentSridOrdinal = reader.GetOrdinal("extent_srid");
-        if (!reader.IsDBNull(extentSridOrdinal))
-        {
-            extentSrid = reader.GetInt32(extentSridOrdinal);
-            if (extentSrid <= 0)
-            {
-                extentSrid = srid;
-            }
-        }
+        int extentSrid = ReadExtentSrid(reader, srid);
         string[] supportedFormats = reader.GetFieldValue<string[]>(reader.GetOrdinal("supported_formats"));
         string[] capabilities = reader.GetFieldValue<string[]>(reader.GetOrdinal("capabilities"));
 
-        // Build service extent if available
-        FeatureExtent? extent = null;
-        int xminOrdinal = reader.GetOrdinal("xmin");
-        if (!reader.IsDBNull(xminOrdinal))
-        {
-            double xmin = reader.GetDouble(xminOrdinal);
-            double ymin = reader.GetDouble(reader.GetOrdinal("ymin"));
-            double xmax = reader.GetDouble(reader.GetOrdinal("xmax"));
-            double ymax = reader.GetDouble(reader.GetOrdinal("ymax"));
-            extent = FeatureExtent.Create(xmin, ymin, xmax, ymax, extentSrid);
-        }
+        FeatureExtent? extent = ReadExtent(reader, extentSrid);
 
         var spatialReference = SpatialReference.Create(srid);
 
@@ -369,21 +331,7 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
 
         while (await reader.ReadAsync(cancellationToken))
         {
-            string fieldName = reader.GetString(reader.GetOrdinal("field_name"));
-
-            string fieldTypeString = reader.GetString(reader.GetOrdinal("field_type"));
-            if (!Enum.TryParse<FieldType>(fieldTypeString, out FieldType fieldType))
-                throw new InvalidDataException($"Invalid field type: {fieldTypeString}");
-
-            int maxLengthOrdinal = reader.GetOrdinal("max_length");
-            int? maxLength = reader.IsDBNull(maxLengthOrdinal) ? null : (int?)reader.GetInt32(maxLengthOrdinal);
-            bool nullable = reader.GetBoolean(reader.GetOrdinal("nullable"));
-            int defaultValueOrdinal = reader.GetOrdinal("default_value");
-            object? defaultValue = reader.IsDBNull(defaultValueOrdinal) ? null : reader.GetValue(defaultValueOrdinal);
-            int descriptionOrdinal = reader.GetOrdinal("description");
-            string? description = reader.IsDBNull(descriptionOrdinal) ? null : reader.GetString(descriptionOrdinal);
-
-            fields.Add(new FieldDefinition(fieldName, fieldType, maxLength, nullable, defaultValue, description));
+            fields.Add(ReadFieldDefinition(reader));
         }
 
         return [.. fields];
@@ -418,19 +366,6 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
         while (await reader.ReadAsync(cancellationToken))
         {
             int layerId = reader.GetInt32(reader.GetOrdinal("layer_id"));
-            string fieldName = reader.GetString(reader.GetOrdinal("field_name"));
-
-            string fieldTypeString = reader.GetString(reader.GetOrdinal("field_type"));
-            if (!Enum.TryParse<FieldType>(fieldTypeString, out FieldType fieldType))
-                throw new InvalidDataException($"Invalid field type: {fieldTypeString}");
-
-            int maxLengthOrdinal = reader.GetOrdinal("max_length");
-            int? maxLength = reader.IsDBNull(maxLengthOrdinal) ? null : (int?)reader.GetInt32(maxLengthOrdinal);
-            bool nullable = reader.GetBoolean(reader.GetOrdinal("nullable"));
-            int defaultValueOrdinal = reader.GetOrdinal("default_value");
-            object? defaultValue = reader.IsDBNull(defaultValueOrdinal) ? null : reader.GetValue(defaultValueOrdinal);
-            int descriptionOrdinal = reader.GetOrdinal("description");
-            string? description = reader.IsDBNull(descriptionOrdinal) ? null : reader.GetString(descriptionOrdinal);
 
             if (!fieldsMap.TryGetValue(layerId, out List<FieldDefinition>? fieldsList))
             {
@@ -438,7 +373,7 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
                 fieldsMap[layerId] = fieldsList;
             }
 
-            fieldsList.Add(new FieldDefinition(fieldName, fieldType, maxLength, nullable, defaultValue, description));
+            fieldsList.Add(ReadFieldDefinition(reader));
         }
 
         return fieldsMap.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToArray());
@@ -447,10 +382,16 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
     private async Task<LayerDefinition[]> GetServiceLayersAsync(string serviceName, CancellationToken cancellationToken)
     {
         string sql = $"""
-            SELECT l.layer_id
+            SELECT
+                l.layer_id, l.layer_name, l.description, l.geometry_type, l.srid,
+                l.min_scale, l.max_scale, l.default_visibility, l.metadata,
+                ST_XMin(l.extent) as xmin, ST_YMin(l.extent) as ymin,
+                ST_XMax(l.extent) as xmax, ST_YMax(l.extent) as ymax,
+                ST_SRID(l.extent) as extent_srid
             FROM {_serviceLayersTable} sl
             JOIN {_layersTable} l ON sl.layer_id = l.layer_id
             WHERE LOWER(sl.service_name) = LOWER(@serviceName)
+              AND l.enabled = TRUE
             ORDER BY sl.layer_order, l.layer_id
             """;
 
@@ -459,36 +400,89 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
         _ = command.Parameters.AddWithValue("@serviceName", serviceName);
 
         await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        var layers = new List<LayerDefinition>();
         var layerIds = new List<int>();
 
         while (await reader.ReadAsync(cancellationToken))
         {
-            layerIds.Add(reader.GetInt32(reader.GetOrdinal("layer_id")));
+            LayerDefinition layer = ReadLayerDefinition(reader);
+            layers.Add(layer);
+            layerIds.Add(layer.Id);
         }
+        reader.Close();
 
-        // Get full layer definitions for these IDs
-        var layers = new List<LayerDefinition>();
-        foreach (int layerId in layerIds)
+        if (layerIds.Count == 0)
+            return [];
+
+        Dictionary<int, FieldDefinition[]> fieldsMap = await GetLayerFieldsBatchAsync([.. layerIds], cancellationToken);
+        Dictionary<int, Relationship[]> relationshipsMap = await GetLayerRelationshipsBatchAsync([.. layerIds], cancellationToken);
+
+        return [.. layers.Select(layer => layer with
         {
-            LayerDefinition? layer = await GetLayerAsync(layerId, cancellationToken);
-            if (layer != null)
-                layers.Add(layer);
-        }
-
-        return [.. layers];
+            Fields = fieldsMap.TryGetValue(layer.Id, out FieldDefinition[]? fields) ? fields : [],
+            Relationships = relationshipsMap.TryGetValue(layer.Id, out Relationship[]? relationships) ? relationships : []
+        })];
     }
 
     private async Task<Dictionary<string, LayerDefinition[]>> GetServiceLayersBatchAsync(string[] serviceNames, CancellationToken cancellationToken)
     {
-        var result = new Dictionary<string, LayerDefinition[]>();
+        if (serviceNames.Length == 0)
+            return [];
 
-        foreach (string serviceName in serviceNames)
+        string sql = $"""
+            SELECT
+                sl.service_name,
+                l.layer_id, l.layer_name, l.description, l.geometry_type, l.srid,
+                l.min_scale, l.max_scale, l.default_visibility, l.metadata,
+                ST_XMin(l.extent) as xmin, ST_YMin(l.extent) as ymin,
+                ST_XMax(l.extent) as xmax, ST_YMax(l.extent) as ymax,
+                ST_SRID(l.extent) as extent_srid
+            FROM {_serviceLayersTable} sl
+            JOIN {_layersTable} l ON sl.layer_id = l.layer_id
+            WHERE LOWER(sl.service_name) = ANY(@serviceNames)
+              AND l.enabled = TRUE
+            ORDER BY sl.service_name, sl.layer_order, l.layer_id
+            """;
+
+        string[] loweredNames = [.. serviceNames.Select(n => n.ToLowerInvariant())];
+
+        await using var connection = (NpgsqlConnection)await _connectionProvider.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        _ = command.Parameters.AddWithValue("@serviceNames", loweredNames);
+
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        var layersMap = new Dictionary<string, List<LayerDefinition>>();
+        var allLayerIds = new HashSet<int>();
+
+        while (await reader.ReadAsync(cancellationToken))
         {
-            LayerDefinition[] layers = await GetServiceLayersAsync(serviceName, cancellationToken);
-            result[serviceName] = layers;
-        }
+            string serviceName = reader.GetString(reader.GetOrdinal("service_name"));
+            LayerDefinition layer = ReadLayerDefinition(reader);
 
-        return result;
+            if (!layersMap.TryGetValue(serviceName, out List<LayerDefinition>? layerList))
+            {
+                layerList = [];
+                layersMap[serviceName] = layerList;
+            }
+
+            layerList.Add(layer);
+            allLayerIds.Add(layer.Id);
+        }
+        reader.Close();
+
+        if (allLayerIds.Count == 0)
+            return layersMap.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToArray());
+
+        Dictionary<int, FieldDefinition[]> fieldsMap = await GetLayerFieldsBatchAsync([.. allLayerIds], cancellationToken);
+        Dictionary<int, Relationship[]> relationshipsMap = await GetLayerRelationshipsBatchAsync([.. allLayerIds], cancellationToken);
+
+        return layersMap.ToDictionary(
+            kvp => kvp.Key,
+            kvp => kvp.Value.Select(layer => layer with
+            {
+                Fields = fieldsMap.TryGetValue(layer.Id, out FieldDefinition[]? fields) ? fields : [],
+                Relationships = relationshipsMap.TryGetValue(layer.Id, out Relationship[]? relationships) ? relationships : []
+            }).ToArray());
     }
 
     /// <inheritdoc />
@@ -611,6 +605,50 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
             originForeignKey,
             destinationForeignKey,
             description);
+    }
+
+    private static int ReadExtentSrid(NpgsqlDataReader reader, int fallbackSrid)
+    {
+        int extentSridOrdinal = reader.GetOrdinal("extent_srid");
+        if (!reader.IsDBNull(extentSridOrdinal))
+        {
+            int extentSrid = reader.GetInt32(extentSridOrdinal);
+            if (extentSrid > 0)
+                return extentSrid;
+        }
+        return fallbackSrid;
+    }
+
+    private static FeatureExtent? ReadExtent(NpgsqlDataReader reader, int extentSrid)
+    {
+        int xminOrdinal = reader.GetOrdinal("xmin");
+        if (reader.IsDBNull(xminOrdinal))
+            return null;
+
+        double xmin = reader.GetDouble(xminOrdinal);
+        double ymin = reader.GetDouble(reader.GetOrdinal("ymin"));
+        double xmax = reader.GetDouble(reader.GetOrdinal("xmax"));
+        double ymax = reader.GetDouble(reader.GetOrdinal("ymax"));
+        return FeatureExtent.Create(xmin, ymin, xmax, ymax, extentSrid);
+    }
+
+    private static FieldDefinition ReadFieldDefinition(NpgsqlDataReader reader)
+    {
+        string fieldName = reader.GetString(reader.GetOrdinal("field_name"));
+
+        string fieldTypeString = reader.GetString(reader.GetOrdinal("field_type"));
+        if (!Enum.TryParse<FieldType>(fieldTypeString, ignoreCase: true, out FieldType fieldType))
+            throw new InvalidDataException($"Invalid field type: {fieldTypeString}");
+
+        int maxLengthOrdinal = reader.GetOrdinal("max_length");
+        int? maxLength = reader.IsDBNull(maxLengthOrdinal) ? null : (int?)reader.GetInt32(maxLengthOrdinal);
+        bool nullable = reader.GetBoolean(reader.GetOrdinal("nullable"));
+        int defaultValueOrdinal = reader.GetOrdinal("default_value");
+        object? defaultValue = reader.IsDBNull(defaultValueOrdinal) ? null : reader.GetValue(defaultValueOrdinal);
+        int descriptionOrdinal = reader.GetOrdinal("description");
+        string? description = reader.IsDBNull(descriptionOrdinal) ? null : reader.GetString(descriptionOrdinal);
+
+        return new FieldDefinition(fieldName, fieldType, maxLength, nullable, defaultValue, description);
     }
 
     private static CatalogMetadata? ReadMetadata(NpgsqlDataReader reader, string columnName)

--- a/tests/Honua.Server.Tests/PostgresLayerCatalogTests.cs
+++ b/tests/Honua.Server.Tests/PostgresLayerCatalogTests.cs
@@ -318,6 +318,217 @@ public class PostgresLayerCatalogTests : IAsyncLifetime
         Assert.Equal("Test category field", categoryField.Description);
     }
 
+    [IntegrationTest]
+    public async Task GetLayerAsync_CaseInsensitiveFieldType_ReturnsLayerDefinition()
+    {
+        const int layerId = 10;
+
+        await _fixture.ExecuteAsync($"""
+            INSERT INTO layers (layer_id, layer_name, description, geometry_type, srid, default_visibility)
+            VALUES ({layerId}, 'test_case_field', 'Case insensitive field type', 'Point', 4326, true);
+
+            INSERT INTO layer_fields (layer_id, field_name, field_type, field_order, max_length, nullable, description)
+            VALUES ({layerId}, 'id', 'biginteger', 1, NULL, false, NULL),
+                   ({layerId}, 'name', 'string', 2, 100, true, NULL);
+            """, _schemaName);
+
+        try
+        {
+            var layer = await _layerCatalog.GetLayerAsync(layerId);
+
+            Assert.NotNull(layer);
+            Assert.Equal(2, layer.Fields.Length);
+            Assert.Equal(FieldType.BigInteger, layer.Fields.First(f => f.Name == "id").Type);
+            Assert.Equal(FieldType.String, layer.Fields.First(f => f.Name == "name").Type);
+        }
+        finally
+        {
+            await _fixture.ExecuteAsync($"""
+                DELETE FROM layer_fields WHERE layer_id = {layerId};
+                DELETE FROM layers WHERE layer_id = {layerId};
+                """, _schemaName);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task GetServiceAsync_DisabledLayerExcluded_ReturnsOnlyEnabledLayers()
+    {
+        const int enabledLayerId = 20;
+        const int disabledLayerId = 21;
+        const string serviceName = "DisabledLayerTest";
+
+        await _fixture.ExecuteAsync($"""
+            INSERT INTO layers (layer_id, layer_name, geometry_type, srid, default_visibility, enabled, description)
+            VALUES ({enabledLayerId}, 'enabled_layer', 'Point', 4326, true, true, 'Enabled'),
+                   ({disabledLayerId}, 'disabled_layer', 'Point', 4326, true, false, 'Disabled');
+
+            INSERT INTO layer_fields (layer_id, field_name, field_type, field_order, nullable)
+            VALUES ({enabledLayerId}, 'id', 'BigInteger', 1, false);
+
+            INSERT INTO services (service_name, description, srid)
+            VALUES ('{serviceName}', 'Disabled layer exclusion test', 4326);
+
+            INSERT INTO service_layers (service_name, layer_id, layer_order)
+            VALUES ('{serviceName}', {enabledLayerId}, 1),
+                   ('{serviceName}', {disabledLayerId}, 2);
+            """, _schemaName);
+
+        try
+        {
+            var service = await _layerCatalog.GetServiceAsync(serviceName);
+
+            Assert.NotNull(service);
+            Assert.Single(service.Layers);
+            Assert.Equal(enabledLayerId, service.Layers[0].Id);
+        }
+        finally
+        {
+            await _fixture.ExecuteAsync($"""
+                DELETE FROM service_layers WHERE service_name = '{serviceName}';
+                DELETE FROM services WHERE service_name = '{serviceName}';
+                DELETE FROM layer_fields WHERE layer_id IN ({enabledLayerId}, {disabledLayerId});
+                DELETE FROM layers WHERE layer_id IN ({enabledLayerId}, {disabledLayerId});
+                """, _schemaName);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task ListServicesAsync_DisabledLayerExcluded_ReturnsOnlyEnabledLayers()
+    {
+        const int enabledLayerId = 40;
+        const int disabledLayerId = 41;
+        const string serviceName = "DisabledBatchTest";
+
+        await _fixture.ExecuteAsync($"""
+            INSERT INTO layers (layer_id, layer_name, geometry_type, srid, default_visibility, enabled, description)
+            VALUES ({enabledLayerId}, 'batch_enabled', 'Point', 4326, true, true, 'Enabled'),
+                   ({disabledLayerId}, 'batch_disabled', 'Point', 4326, true, false, 'Disabled');
+
+            INSERT INTO layer_fields (layer_id, field_name, field_type, field_order, nullable)
+            VALUES ({enabledLayerId}, 'id', 'BigInteger', 1, false);
+
+            INSERT INTO services (service_name, description, srid)
+            VALUES ('{serviceName}', 'Batch disabled layer test', 4326);
+
+            INSERT INTO service_layers (service_name, layer_id, layer_order)
+            VALUES ('{serviceName}', {enabledLayerId}, 1),
+                   ('{serviceName}', {disabledLayerId}, 2);
+            """, _schemaName);
+
+        try
+        {
+            var services = await _layerCatalog.ListServicesAsync();
+
+            var service = services.First(s => s.Name == serviceName);
+            Assert.Single(service.Layers);
+            Assert.Equal(enabledLayerId, service.Layers[0].Id);
+        }
+        finally
+        {
+            await _fixture.ExecuteAsync($"""
+                DELETE FROM service_layers WHERE service_name = '{serviceName}';
+                DELETE FROM services WHERE service_name = '{serviceName}';
+                DELETE FROM layer_fields WHERE layer_id IN ({enabledLayerId}, {disabledLayerId});
+                DELETE FROM layers WHERE layer_id IN ({enabledLayerId}, {disabledLayerId});
+                """, _schemaName);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task GetServiceAsync_WithConnectionId_ReturnsConnectionId()
+    {
+        const string serviceName = "ConnIdTest";
+        Guid connectionId = Guid.Parse("12345678-1234-1234-1234-123456789abc");
+
+        await _fixture.ExecuteAsync($"""
+            INSERT INTO services (service_name, description, srid, connection_id)
+            VALUES ('{serviceName}', 'Connection ID test', 4326, '{connectionId}');
+            """, _schemaName);
+
+        try
+        {
+            var service = await _layerCatalog.GetServiceAsync(serviceName);
+
+            Assert.NotNull(service);
+            Assert.Equal(connectionId, service.ConnectionId);
+        }
+        finally
+        {
+            await _fixture.ExecuteAsync($"""
+                DELETE FROM services WHERE service_name = '{serviceName}';
+                """, _schemaName);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task GetServiceAsync_MultipleLayersWithFieldsAndRelationships_ReturnsComplete()
+    {
+        const int layer1 = 30, layer2 = 31, layer3 = 32;
+        const string serviceName = "MultiLayerTest";
+
+        await _fixture.ExecuteAsync($"""
+            INSERT INTO layers (layer_id, layer_name, geometry_type, srid, default_visibility, description)
+            VALUES ({layer1}, 'multi_points', 'Point', 4326, true, 'Layer 1'),
+                   ({layer2}, 'multi_lines', 'Point', 4326, true, 'Layer 2'),
+                   ({layer3}, 'multi_polygons', 'Polygon', 4326, true, 'Layer 3');
+
+            INSERT INTO layer_fields (layer_id, field_name, field_type, field_order, nullable)
+            VALUES ({layer1}, 'id', 'BigInteger', 1, false),
+                   ({layer1}, 'name', 'String', 2, true),
+                   ({layer2}, 'id', 'BigInteger', 1, false),
+                   ({layer2}, 'length', 'Double', 2, true),
+                   ({layer3}, 'id', 'BigInteger', 1, false),
+                   ({layer3}, 'area', 'Double', 2, true);
+
+            INSERT INTO relationships (layer_id, relationship_id, name, related_layer_id, relationship_type, origin_foreign_key, destination_foreign_key)
+            VALUES ({layer1}, 1, 'points_to_lines', {layer2}, 'OneToMany', 'id', 'point_id'),
+                   ({layer2}, 1, 'lines_to_polygons', {layer3}, 'OneToMany', 'id', 'line_id');
+
+            INSERT INTO services (service_name, description, srid)
+            VALUES ('{serviceName}', 'Multi-layer test', 4326);
+
+            INSERT INTO service_layers (service_name, layer_id, layer_order)
+            VALUES ('{serviceName}', {layer1}, 1),
+                   ('{serviceName}', {layer2}, 2),
+                   ('{serviceName}', {layer3}, 3);
+            """, _schemaName);
+
+        try
+        {
+            var service = await _layerCatalog.GetServiceAsync(serviceName);
+
+            Assert.NotNull(service);
+            Assert.Equal(3, service.Layers.Length);
+
+            // Verify layers are ordered correctly
+            Assert.Equal(layer1, service.Layers[0].Id);
+            Assert.Equal(layer2, service.Layers[1].Id);
+            Assert.Equal(layer3, service.Layers[2].Id);
+
+            // Verify fields are populated for each layer
+            Assert.Equal(2, service.Layers[0].Fields.Length);
+            Assert.Equal(2, service.Layers[1].Fields.Length);
+            Assert.Equal(2, service.Layers[2].Fields.Length);
+
+            // Verify relationships are populated
+            Assert.Single(service.Layers[0].Relationships!);
+            Assert.Equal("points_to_lines", service.Layers[0].Relationships![0].Name);
+            Assert.Single(service.Layers[1].Relationships!);
+            Assert.Equal("lines_to_polygons", service.Layers[1].Relationships![0].Name);
+            Assert.Empty(service.Layers[2].Relationships!);
+        }
+        finally
+        {
+            await _fixture.ExecuteAsync($"""
+                DELETE FROM service_layers WHERE service_name = '{serviceName}';
+                DELETE FROM services WHERE service_name = '{serviceName}';
+                DELETE FROM relationships WHERE layer_id IN ({layer1}, {layer2}, {layer3});
+                DELETE FROM layer_fields WHERE layer_id IN ({layer1}, {layer2}, {layer3});
+                DELETE FROM layers WHERE layer_id IN ({layer1}, {layer2}, {layer3});
+                """, _schemaName);
+        }
+    }
+
     private async Task CreateTestData()
     {
         // Insert test layers


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #562

## Summary
Remediates the catalog persistence audit findings by removing the service-layer N+1 loading path, tightening catalog parsing/query behavior, consolidating duplicated readers, and adding focused regression coverage.

## Changes Made
- Reworked the service-layer loading path to avoid the N+1 pattern and apply the enabled filter in the query path instead of after extra round-trips.
- Made catalog field-type parsing consistent with the intended case-insensitive behavior and removed the unnecessary row-to-JSON UUID extraction.
- Consolidated duplicated field and extent/SRID reader logic inside `PostgresLayerCatalog`.
- Added targeted `PostgresLayerCatalogTests` coverage for the updated loading and parsing behavior.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
