### PR TITLE
feat: docs: developer portal with getting-started guides and API explorer (#526)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Please use these forms instead of blank issues so reports include enough detail 
 | Admin API | `/api/v1/admin` | Admin UI, automation scripts |
 | OpenAPI (OGC Features) | `/openapi.json` | Any HTTP client |
 | OpenAPI (OGC Tiles) | `/ogc/tiles/openapi.json` | Any HTTP client |
+| API Explorer (Scalar) | `/docs` | Browser *(dev mode or `HONUA_SERVE_API_DOCS=true`)* |
 | Health | `/healthz/live`, `/healthz/ready` | Load balancers, orchestrators |
 
 ## Capabilities
@@ -118,6 +119,7 @@ HONUA_ADMIN_PASSWORD="change-me"
 **Common options:**
 ```bash
 HONUA_SERVE_ADMIN_UI=true                 # Serve admin UI at /admin
+HONUA_SERVE_API_DOCS=true                # Interactive API explorer at /docs (default: on in Development)
 HONUA_OBSERVABILITY=true                  # Metrics and health endpoints
 HONUA_OPENTELEMETRY=true                  # Distributed tracing
 ConnectionStrings__Redis="localhost:6379"  # Redis cache
@@ -158,7 +160,8 @@ Full documentation: **[honua.gitbook.io/honuaio](https://honua.gitbook.io/honuai
 | I want to... | Go to |
 |---|---|
 | Deploy to production | [Infrastructure & Deployment](https://honua.gitbook.io/honuaio/devops-guide/infrastructure) |
-| Call the API | [Protocols Overview](https://honua.gitbook.io/honuaio/) |
+| Call the API | [Protocols Overview](https://honua.gitbook.io/honuaio/) / [API Explorer](http://localhost:8080/docs) *(running server)* |
+| Follow a tutorial | [QGIS Getting Started](docs/user/tutorials/qgis-getting-started.md) / [GeoServer Migration](docs/user/tutorials/geoserver-migration-guide.md) |
 | Check MVP compatibility limits | [MVP Compatibility Contract](docs/user/MVP_COMPATIBILITY_CONTRACT.md) |
 | Evaluate performance | [Benchmark Results](docs/user/BENCHMARK_RESULTS.md) |
 | Contribute code | [Contributing](docs/contributor/development/contributing.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,8 @@ Full hosted documentation: **[honua.gitbook.io/honuaio](https://honua.gitbook.io
 
 | I want to... | Go to |
 |---|---|
-| **Consume geospatial data** | [Protocols Overview](user/STANDARDS_APIS.md) / [API Examples](user/API_EXAMPLES.md) |
+| **Consume geospatial data** | [Protocols Overview](user/STANDARDS_APIS.md) / [API Examples](user/API_EXAMPLES.md) / [API Explorer](http://localhost:8080/docs) *(running server)* |
+| **Follow a tutorial** | [QGIS Getting Started](user/tutorials/qgis-getting-started.md) / [GeoServer Migration](user/tutorials/geoserver-migration-guide.md) |
 | **Manage the server** | [Admin API](user/CONTROL_PLANE_API.md) / [Admin UI](user/admin-ui.md) |
 | **Check server/SDK compatibility** | [Server + SDK Compatibility Matrix](user/SDK_COMPATIBILITY_MATRIX.md) / [Control Plane Migration Guide](user/CONTROL_PLANE_MIGRATION_GUIDE.md) |
 | **Standardize SDK release docs** | [SDK Migration Guide Baseline](user/SDK_MIGRATION_GUIDE_BASELINE.md) |
@@ -37,6 +38,8 @@ Full hosted documentation: **[honua.gitbook.io/honuaio](https://honua.gitbook.io
 - [Cross-Client Certification Evidence](user/CROSS_CLIENT_CERTIFICATION_EVIDENCE.md) — standardized `.cert.json` evidence format for certification runs
 - [Admin UI](user/admin-ui.md) — browser interface guide
 - [Data Modeling Guide](user/DATA_MODELING_GUIDE.md) — spatial data modeling
+- [QGIS Getting Started](user/tutorials/qgis-getting-started.md) — zero-to-querying in 5 minutes with QGIS
+- [GeoServer Migration Guide](user/tutorials/geoserver-migration-guide.md) — endpoint mapping, automated import, config differences
 
 ### Coverage Matrices
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -18,12 +18,18 @@
 * [Benchmark Reproduction](user/BENCHMARK_REPRODUCTION.md)
 * [Benchmark Methodology](user/BENCHMARK_METHODOLOGY.md)
 
+## Tutorials
+
+* [QGIS Getting Started](user/tutorials/qgis-getting-started.md)
+* [GeoServer Migration Guide](user/tutorials/geoserver-migration-guide.md)
+
 ## Geospatial Data APIs
 
 * [Protocols Overview](user/STANDARDS_APIS.md)
 * [API Examples](user/API_EXAMPLES.md)
 * [Integration Patterns](user/INTEGRATION_PATTERNS.md)
 * [Interactive API Specs](api-specs/README.md)
+* [Interactive API Explorer](http://localhost:8080/docs) *(requires running server)*
 
 ### Coverage Matrices
 

--- a/docs/contributor/development/getting-started.md
+++ b/docs/contributor/development/getting-started.md
@@ -172,6 +172,7 @@ Once the server is running:
 | `http://localhost:8080/ogc/features/collections` | OGC API collections |
 | `http://localhost:8080/odata` | OData service root |
 | `http://localhost:8080/openapi.json` | OGC API Features OpenAPI spec |
+| `http://localhost:8080/docs` | Interactive API explorer (Scalar; dev mode only, or set `HONUA_SERVE_API_DOCS=true`) |
 | `http://localhost:8080/admin` | Admin UI (requires `HONUA_SERVE_ADMIN_UI=true`, default on) |
 
 ## Debugging

--- a/docs/user/API_EXAMPLES.md
+++ b/docs/user/API_EXAMPLES.md
@@ -244,3 +244,4 @@ const map = new maplibregl.Map({
 - [Protocols Overview](STANDARDS_APIS.md)
 - [Integration Patterns](INTEGRATION_PATTERNS.md)
 - [Admin API Reference](CONTROL_PLANE_API.md)
+- [Interactive API Explorer](http://localhost:8080/docs) *(requires running server)* — try endpoints live with Scalar

--- a/docs/user/STANDARDS_APIS.md
+++ b/docs/user/STANDARDS_APIS.md
@@ -292,5 +292,6 @@ Protocol support is tracked per standard and operation. Use these docs to confir
 - [MVP Compatibility Contract](MVP_COMPATIBILITY_CONTRACT.md)
 - [Geospatial API Examples](API_EXAMPLES.md)
 - [Integration Patterns](INTEGRATION_PATTERNS.md)
+- [Interactive API Explorer](http://localhost:8080/docs) *(requires running server)*
 - [FeatureServer Coverage Matrix](feature-server-matrix.md)
 - [MapServer Coverage Matrix](map-server-matrix.md)

--- a/docs/user/USER_JOURNEYS.md
+++ b/docs/user/USER_JOURNEYS.md
@@ -32,7 +32,9 @@ curl http://localhost:8080/healthz/ready
 - QGIS (OGC API Features): `http://<host>/ogc/features`
 
 **Next Steps:**
+- [QGIS Getting Started Tutorial](tutorials/qgis-getting-started.md)
 - [Geospatial API Examples](API_EXAMPLES.md)
+- [Interactive API Explorer](http://localhost:8080/docs) *(requires running server)*
 - [Client Templates + Smoke Runbook](CLIENT_TEMPLATE_RUNBOOK.md)
 - [FeatureServer Coverage Matrix](feature-server-matrix.md)
 - [MapServer Coverage Matrix](map-server-matrix.md)
@@ -102,6 +104,7 @@ new maplibregl.Map({
 ```
 
 **Next Steps:**
+- [Interactive API Explorer](http://localhost:8080/docs) *(requires running server)* — test endpoints in the browser
 - [Vector Tiles API Examples](API_EXAMPLES.md#vector-tiles-mvt)
 - [OGC API Examples](API_EXAMPLES.md#ogc-api-features)
 - [Integration Patterns](INTEGRATION_PATTERNS.md)

--- a/docs/user/tutorials/geoserver-migration-guide.md
+++ b/docs/user/tutorials/geoserver-migration-guide.md
@@ -1,0 +1,212 @@
+# GeoServer to Honua Migration Guide
+
+Migrate from GeoServer to Honua Server, covering endpoint equivalence, automated import, and key configuration differences.
+
+## Overview
+
+Honua provides built-in GeoServer migration tooling that discovers your existing GeoServer configuration and imports workspaces, layers, and styles into Honua services. After migration, clients that consumed GeoServer WFS/WMS/WMTS endpoints can connect to Honua's equivalent OGC and GeoServices REST endpoints.
+
+## Endpoint Equivalence Mapping
+
+### Feature Data Access
+
+| GeoServer Endpoint | Honua Equivalent | Notes |
+|---|---|---|
+| `GET /geoserver/wfs?service=WFS&request=GetFeature` | `GET /wfs?service=WFS&request=GetFeature` | WFS 2.0 compatible |
+| `GET /geoserver/ows?service=WFS&request=GetCapabilities` | `GET /wfs?service=WFS&request=GetCapabilities` | WFS capabilities |
+| GeoServer REST `/workspaces/{ws}/datastores/{ds}/featuretypes` | `GET /ogc/features/collections` | OGC API Features discovery |
+| GeoServer WFS `GetFeature` with CQL filter | `GET /ogc/features/collections/{id}/items?filter=...` | CQL2 filtering |
+| GeoServer WFS `GetFeature` with bbox | `GET /ogc/features/collections/{id}/items?bbox=...` | Spatial filtering |
+| GeoServer WFS `GetPropertyValue` | `GET /ogc/features/collections/{id}/items?properties=...` | Property selection |
+
+### Map Rendering
+
+| GeoServer Endpoint | Honua Equivalent | Notes |
+|---|---|---|
+| `GET /geoserver/wms?service=WMS&request=GetMap` | `GET /rest/services/{id}/MapServer/export` | Dynamic map rendering |
+| `GET /geoserver/wms?request=GetMap` | `GET /ogc/services/{id}/wms` | WMS 1.3 compatible |
+| `GET /geoserver/gwc/service/wmts` | `GET /rest/services/{id}/MapServer/WMTS` | WMTS tile access |
+| `GET /geoserver/gwc/service/wmts` | `GET /ogc/services/{id}/wmts` | OGC WMTS endpoint |
+| GeoServer tile layer | `GET /tiles/{layerId}/{z}/{x}/{y}.mvt` | Vector tiles (MapLibre-ready) |
+| GeoServer legend graphic | `GET /rest/services/{id}/MapServer/legend` | Layer legend |
+
+### Metadata and Discovery
+
+| GeoServer Endpoint | Honua Equivalent | Notes |
+|---|---|---|
+| `GET /geoserver/rest/about/version` | `GET /api/v1/admin/version` | Server version |
+| `GET /geoserver/rest/workspaces` | `GET /api/v1/admin/services` | Service listing |
+| `GET /geoserver/rest/layers` | `GET /ogc/features/collections` | Layer discovery |
+| `GET /geoserver/rest/styles` | `GET /api/v1/admin/metadata/layers/{id}/style` | Layer styles (MapLibre JSON) |
+
+## Automated Migration
+
+Honua provides admin API endpoints that automate the import of GeoServer configurations.
+
+### Step 1: Discover Your GeoServer
+
+Assess your GeoServer instance before importing. The discover endpoint analyzes workspaces, layers, and styles and returns a compatibility report.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/admin/import/geoserver/discover \
+  -H "Content-Type: application/json" \
+  -d '{
+    "geoServerRestUrl": "http://geoserver-host:8080/geoserver/rest",
+    "username": "admin",
+    "password": "geoserver",
+    "includeCompatibilityAnalysis": true
+  }'
+```
+
+The response includes:
+- Workspace and layer inventory
+- Data store types and connection parameters
+- Style formats and compatibility assessment
+- Feature type counts and geometry types
+
+Review the compatibility report before proceeding. Layers backed by PostGIS data stores have the highest migration fidelity.
+
+### Step 2: Start a Dry-Run Import
+
+> **Note:** The GeoServer import endpoint currently supports **dry-run mode only**. A dry run validates connectivity, discovers resources, and reports what would be imported without making changes.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/admin/import/geoserver/start \
+  -H "Content-Type: application/json" \
+  -d '{
+    "geoServerRestUrl": "http://geoserver-host:8080/geoserver/rest",
+    "username": "admin",
+    "password": "geoserver",
+    "dryRun": true
+  }'
+```
+
+This returns a job ID for tracking progress.
+
+### Step 3: Monitor Progress
+
+```bash
+# Check specific job status
+curl http://localhost:8080/api/v1/admin/import/geoserver/jobs/{jobId}
+
+# List all active import jobs
+curl http://localhost:8080/api/v1/admin/import/geoserver/jobs
+```
+
+### Step 4: Cancel (if needed)
+
+```bash
+curl -X POST http://localhost:8080/api/v1/admin/import/geoserver/jobs/{jobId}/cancel
+```
+
+## Configuration Differences
+
+### Security
+
+| GeoServer | Honua |
+|---|---|
+| Spring Security with role-based access | API key authentication + OIDC |
+| `.properties` file-based user management | Admin API user/role management |
+| Per-workspace security rules | Per-service access policies |
+| GeoFence integration | Built-in RBAC with edition gating |
+
+Honua supports API key authentication for programmatic access and OIDC providers (Azure AD, Google, Okta, Auth0, generic) for interactive users. Configure OIDC via the admin API or environment variables.
+
+### Coordinate Reference Systems
+
+| GeoServer | Honua |
+|---|---|
+| EPSG database bundled with GeoTools | PostGIS `spatial_ref_sys` table |
+| `SRS handling` policy per layer | CRS negotiation per request |
+| Native SRS + declared SRS per feature type | OGC API Features CRS parameter |
+| Reprojection via GeoTools | Reprojection via PostGIS `ST_Transform` |
+
+Honua stores data in the source CRS and reprojects on request using PostGIS. Ensure your PostGIS instance has the required SRID definitions in `spatial_ref_sys`.
+
+### Layer Publishing
+
+| GeoServer | Honua |
+|---|---|
+| Workspace > DataStore > FeatureType | Connection > Service > Layer |
+| Manual layer configuration in web admin | Admin API + Admin UI (Blazor) |
+| SLD/CSS styling | MapLibre GL Style JSON |
+| Layer groups | Service-level layer aggregation |
+
+In Honua, you register a database connection, then publish layers from discovered tables. The Admin UI provides a visual workflow, or use the Admin API:
+
+```bash
+# List tables from a connection
+curl http://localhost:8080/api/v1/admin/connections/{connectionId}/tables
+
+# Publish a layer (one request per layer)
+curl -X POST http://localhost:8080/api/v1/admin/connections/{connectionId}/layers \
+  -H "Content-Type: application/json" \
+  -d '{ "schema": "public", "table": "parcels", "layerName": "parcels", "serviceName": "my-service" }'
+```
+
+### Tile Caching
+
+| GeoServer (GeoWebCache) | Honua |
+|---|---|
+| Integrated GWC with seeding UI | Output caching with optional Redis |
+| Disk-based tile cache | In-memory + Redis distributed cache |
+| Per-layer gridset configuration | Automatic TileJSON + OGC Tiles tiling schemes |
+| Manual seed/truncate operations | Tile operation jobs via Admin API |
+
+Honua uses output caching (in-memory or Redis) rather than a dedicated tile cache. For high-throughput tile serving, enable Redis:
+
+```
+HONUA_REDIS_URL=redis:6379
+```
+
+### Styling
+
+GeoServer uses SLD (Styled Layer Descriptor) or CSS styling. Honua uses MapLibre GL Style JSON. When importing from GeoServer, styles are converted to MapLibre format on a best-effort basis. Complex SLD filters and symbolizers may require manual adjustment.
+
+Manage styles via the Admin API:
+
+```bash
+# Get current style
+curl http://localhost:8080/api/v1/admin/metadata/layers/{layerId}/style
+
+# Update style
+curl -X PUT http://localhost:8080/api/v1/admin/metadata/layers/{layerId}/style \
+  -H "Content-Type: application/json" \
+  -d '{ "version": 8, "layers": [...] }'
+```
+
+## Client Migration Checklist
+
+After migrating server configuration, update client applications:
+
+- [ ] **WFS clients**: Point to `http://honua-host:8080/wfs` (WFS 2.0) or migrate to `http://honua-host:8080/ogc/features` (OGC API Features)
+- [ ] **WMS clients**: Point to `http://honua-host:8080/rest/services/{id}/MapServer/WMS` or `http://honua-host:8080/ogc/services/{id}/wms`
+- [ ] **WMTS clients**: Point to `http://honua-host:8080/rest/services/{id}/MapServer/WMTS` or `http://honua-host:8080/ogc/services/{id}/wmts`
+- [ ] **REST API consumers**: Map GeoServer REST paths to Honua Admin API equivalents (see table above)
+- [ ] **Authentication**: Replace GeoServer credentials with Honua API keys or OIDC tokens
+- [ ] **Styles**: Review imported styles and adjust MapLibre JSON as needed
+- [ ] **CRS configuration**: Verify required SRIDs exist in PostGIS `spatial_ref_sys`
+- [ ] **Tile consumers**: Update tile URLs to Honua vector tile or WMTS endpoints
+
+## GeoServer vs Honua Protocol Support
+
+| Protocol | GeoServer | Honua |
+|---|---|---|
+| WFS 2.0 | Native | Supported |
+| WMS 1.3 | Native | Via MapServer |
+| WMTS 1.0 | Via GeoWebCache | Via MapServer |
+| OGC API Features | Plugin (community) | Native |
+| OGC API Tiles | Plugin (community) | Native |
+| OGC API Maps | Not supported | Native |
+| GeoServices REST (FeatureServer) | Not supported | Native |
+| GeoServices REST (MapServer) | Not supported | Native |
+| OData v4 | Not supported | Native |
+| Vector Tiles (MVT) | Via GeoWebCache | Native |
+| gRPC | Not supported | Native |
+
+## Next Steps
+
+- Explore the [Interactive API Explorer](http://localhost:8080/docs) to test migrated endpoints
+- Review the [API Examples](../API_EXAMPLES.md) for protocol-specific request patterns
+- See the [Protocols Overview](../STANDARDS_APIS.md) for choosing the right protocol per client
+- Check the [Admin API Reference](../CONTROL_PLANE_API.md) for connection and layer management

--- a/docs/user/tutorials/qgis-getting-started.md
+++ b/docs/user/tutorials/qgis-getting-started.md
@@ -1,0 +1,189 @@
+# QGIS Getting Started with Honua
+
+Connect QGIS to Honua Server via OGC API Features and query geospatial data in under 5 minutes.
+
+## Prerequisites
+
+- [QGIS](https://qgis.org/en/site/forusers/download.html) 3.28+ installed
+- Docker and Docker Compose (v2+)
+
+## 1. Start Honua Server
+
+```bash
+docker compose -f infrastructure/docker-compose/docker-compose.yml up -d
+```
+
+Wait for the server to be ready:
+
+```bash
+curl -s http://localhost:8080/healthz/ready
+# Expected: Ready
+```
+
+## 2. Import Sample Data
+
+Upload a GeoJSON file through the Admin API. Save this as `sample.geojson`:
+
+```json
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": { "name": "City Hall", "category": "government", "population": 50000 },
+      "geometry": { "type": "Point", "coordinates": [-122.4194, 37.7749] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Central Park", "category": "park", "population": 0 },
+      "geometry": { "type": "Point", "coordinates": [-73.9654, 40.7829] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Library", "category": "education", "population": 1200 },
+      "geometry": { "type": "Point", "coordinates": [-87.6298, 41.8781] }
+    }
+  ]
+}
+```
+
+Import it:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/admin/import/upload \
+  -F "file=@sample.geojson" \
+  -F "TableName=places"
+```
+
+## 3. Publish the Imported Layer
+
+The upload creates a database table. To make it available as an OGC collection, register a connection and publish the layer.
+
+**Register a connection** (skip if you already have one). Use the credentials from `infrastructure/docker-compose/docker-compose.yml`:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/admin/connections \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "local",
+    "host": "postgres",
+    "port": 5432,
+    "databaseName": "honua_dev",
+    "username": "honua",
+    "password": "honua_dev_password",
+    "sslMode": "Prefer"
+  }'
+# Note the connectionId from the response: { "success": true, "data": { "connectionId": "..." } }
+```
+
+**Discover the imported table** to confirm its schema:
+
+```bash
+curl -s http://localhost:8080/api/v1/admin/connections/{connectionId}/tables | jq '.data'
+# Look for the "places" table — note the schema (typically "honua")
+```
+
+**Publish the imported table** (replace `{connectionId}` and `{schema}` with the discovered values):
+
+```bash
+curl -X POST http://localhost:8080/api/v1/admin/connections/{connectionId}/layers \
+  -H "Content-Type: application/json" \
+  -d '{ "schema": "{schema}", "table": "places", "layerName": "places" }'
+```
+
+## 4. Connect QGIS to Honua
+
+1. Open QGIS
+2. Go to **Layer > Add Layer > Add OGC API Features Layer** (or press `Ctrl+L` and select the **OGC API Features** tab)
+3. Click **New** to create a connection:
+   - **Name:** `Honua Local`
+   - **URL:** `http://localhost:8080/ogc/features`
+4. Click **Connect**
+
+QGIS discovers available collections from the Honua landing page.
+
+## 5. Add a Layer
+
+1. In the connection browser, expand the collections list
+2. Select your imported collection (e.g., `places`)
+3. Click **Add** to load it as a map layer
+
+The features appear on the map canvas and in the attribute table.
+
+## 6. Query Features
+
+### Attribute Filter
+
+1. Right-click the layer > **Filter...**
+2. Enter a filter expression:
+   ```
+   "category" = 'park'
+   ```
+3. Click **OK** -- the map updates to show only matching features
+
+### Spatial Filter
+
+1. Use the **Sketching tool** or **Select by Rectangle** to define a bounding box
+2. Right-click the layer > **Filter...** and add a spatial constraint, or use the **Query Builder** with a bbox expression
+
+### View Attributes
+
+1. Right-click the layer > **Open Attribute Table** (or press `F6`)
+2. Browse feature attributes, sort columns, and select individual features
+
+## 7. Export Data
+
+1. Right-click the layer > **Export > Save Features As...**
+2. Choose format: GeoPackage, GeoJSON, CSV, or Shapefile
+3. Set CRS if needed (default: EPSG:4326)
+4. Click **OK**
+
+## Using the QGIS Project Template
+
+A pre-configured QGIS project template is available in the repository:
+
+```
+docs/user/client-templates/qgis/Honua-Desktop-Smoke.qgs.template
+```
+
+To use it:
+
+```bash
+cd docs/user/client-templates
+cp .env.example .env
+# Edit .env with your server URL and collection ID
+
+set -a; source .env; set +a
+envsubst < qgis/Honua-Desktop-Smoke.qgs.template > qgis/Honua-Desktop-Smoke.qgs
+```
+
+Open the generated `.qgs` file in QGIS.
+
+## Verify OGC API Features Endpoints
+
+These endpoints are used by QGIS under the hood:
+
+| What QGIS Does | Endpoint |
+|---|---|
+| Discover collections | `GET /ogc/features/collections` |
+| Get collection metadata | `GET /ogc/features/collections/{id}` |
+| Fetch features | `GET /ogc/features/collections/{id}/items` |
+| Get queryable properties | `GET /ogc/features/collections/{id}/queryables` |
+| Get API spec | `GET /openapi.json` |
+
+## Troubleshooting
+
+**Connection refused**: Ensure the Docker container is running and port 8080 is accessible.
+
+**No collections found**: Verify data has been imported. Check the admin API:
+```bash
+curl http://localhost:8080/api/v1/admin/connections
+```
+
+**CRS mismatch**: Honua serves data in EPSG:4326 by default. QGIS will reproject to the project CRS automatically.
+
+## Next Steps
+
+- Explore the [API Examples](../API_EXAMPLES.md) for curl-based access patterns
+- Review the [OGC API Features Coverage](../specifications/ogc-api-features-coverage.md) for supported parameters
+- Try the [Interactive API Explorer](http://localhost:8080/docs) to test endpoints directly

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -19,6 +19,9 @@ public static class EndpointRegistry
         new("GET", "/healthz/metrics"),
         new("GET", "/metrics"),
 
+        // Interactive API explorer (Scalar)
+        new("GET", "/docs"),
+
         new("GET", "/api/v1/admin/config"),
         new("GET", "/api/v1/admin/auth/config"),
         new("GET", "/api/v1/admin/openapi.json"),

--- a/src/Honua.Server/Honua.Server.csproj
+++ b/src/Honua.Server/Honua.Server.csproj
@@ -79,6 +79,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.5" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.25" />
     <PackageReference Include="ParquetSharp" Version="21.0.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.13.13" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     <Content Update="openapi.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -44,6 +44,7 @@ using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Npgsql;
+using Scalar.AspNetCore;
 using Serilog;
 using Serilog.Enrichers.Span;
 using StackExchange.Redis;
@@ -64,6 +65,9 @@ var isTestEnvironment = builder.Environment.IsEnvironment("Test");
 var serveAdminUi = builder.Configuration.GetValue(
     "ServeAdminUI",
     builder.Configuration.GetValue("HONUA_SERVE_ADMIN_UI", true));
+var serveApiDocs = builder.Configuration.GetValue(
+    "ServeApiDocs",
+    builder.Configuration.GetValue("HONUA_SERVE_API_DOCS", builder.Environment.IsDevelopment()));
 var adminStaticAssetsManifestPath = Path.Combine(
     AppContext.BaseDirectory,
     "Honua.Admin.staticwebassets.endpoints.json");
@@ -672,6 +676,20 @@ if (serveAdminUi)
             }
             endpoints.MapFallbackToFile("index.html");
         });
+    });
+}
+
+// Map interactive API explorer (Scalar) at /docs when enabled
+if (serveApiDocs)
+{
+    app.MapScalarApiReference("/docs", options =>
+    {
+        options
+            .WithTitle("Honua API Explorer")
+            .WithTheme(ScalarTheme.BluePlanet)
+            .AddDocument("features", "OGC API Features", "/openapi.json", isDefault: true)
+            .AddDocument("tiles", "OGC API Tiles", "/ogc/tiles/openapi.json")
+            .AddDocument("admin", "Admin API", "/api/v1/admin/openapi.json");
     });
 }
 

--- a/tests/Honua.Server.Tests/ApiExplorerEndpointTests.cs
+++ b/tests/Honua.Server.Tests/ApiExplorerEndpointTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests;
+
+/// <summary>
+/// Integration tests for the interactive API explorer (Scalar) at /docs.
+/// </summary>
+[Protocol(Protocols.Infrastructure)]
+[Collection("Database")]
+public sealed class ApiExplorerEndpointTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new WebAppFixture()
+        .ConfigureWebHost(builder => builder.UseSetting("HONUA_SERVE_API_DOCS", "true"));
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /docs")]
+    public async Task Docs_WhenEnabled_ReturnsHtmlPage()
+    {
+        // Act
+        var response = await _fixture.Client.GetAsync("/docs");
+
+        // Assert
+        response.Be200Ok();
+        var contentType = response.Content.Headers.ContentType?.MediaType;
+        contentType.Should().Be("text/html");
+
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("Honua API Explorer");
+    }
+}

--- a/tests/Honua.Server.Tests/Features/API/EndpointRegistryDriftTests.cs
+++ b/tests/Honua.Server.Tests/Features/API/EndpointRegistryDriftTests.cs
@@ -264,6 +264,7 @@ public sealed class EndpointRegistryDriftTests : IDisposable
                path.Equals("/openapi.json", StringComparison.OrdinalIgnoreCase) ||
                path.Equals("/metrics", StringComparison.OrdinalIgnoreCase) ||
                path.Equals("/wfs", StringComparison.OrdinalIgnoreCase) ||
+               path.Equals("/docs", StringComparison.OrdinalIgnoreCase) ||
                path.StartsWith("/api/", StringComparison.OrdinalIgnoreCase) ||
                path.StartsWith("/healthz/", StringComparison.OrdinalIgnoreCase) ||
                path.StartsWith("/odata", StringComparison.OrdinalIgnoreCase) ||

--- a/tests/Honua.Server.Tests/TestWebApplicationFactory.cs
+++ b/tests/Honua.Server.Tests/TestWebApplicationFactory.cs
@@ -71,6 +71,7 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
                 ["Alerts:Enabled"] = "false",
                 ["ConnectionStrings:DefaultConnection"] = "Host=localhost;Database=test;Username=test;Password=test",
                 ["HONUA_SKIP_MIGRATIONS"] = "true",
+                ["HONUA_SERVE_API_DOCS"] = "true",
                 ["FileStorage:Provider"] = "Local",
                 ["FileStorage:LocalStorage:BasePath"] = attachmentsPath,
                 ["FileStorage:LocalStorage:CreateDirectoryIfNotExists"] = "true"


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #526
## Summary

2. **medium/docs_contract — GeoServer migration guide publish payload** (`geoserver-migration-guide.md:144`): Replaced invalid bulk `{ "layers": [{ "tableName": ... }] }` with flat `PublishLayerRequest`: `{ "schema": "public", "table": "parcels", "layerName": "parcels", "serviceName": "my-service" }`. Added "(one request per layer)" note.
## Changes Made

- **medium/docs_contract — GeoServer migration guide publish payload** (`geoserver-migration-guide.md:144`): Replaced invalid bulk `{ "layers": [{ "tableName": ... }] }` with flat `PublishLayerRequest`: `{ "schema": "public", "table": "parcels", "layerName": "parcels", "serviceName": "my-service" }`. Added "(one request per layer)" note.
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Breaking Changes

None
## Additional Context

Decisions:
- Used table discovery step rather than hardcoding `honua` schema, so the tutorial remains correct regardless of PostgreSQL user/search_path configuration.
- Kept the GeoServer migration guide schema as `public` since that section describes a generic migration flow (not tied to the compose quickstart).

Follow-ons:
- Tutorial for web developers (MapLibre + vector tiles) — deferred
- Tutorial for data analysts (OData + Power BI) — deferred
- GitBook sync for tutorials — deferred
- Cross-repo child tickets (JS SDK, Python SDK, site) — separate implementation

Code kaizen:
Deferred 2 low-priority finding(s) to cleanup backlog. Targeted `/docs` and OpenAPI tests passed; the remaining issue is repository-state consistency because the new tutorial files and the `/docs` integration test are still untracked.
## Pre-PR Checklist (for contributor)
- [ ] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit message follows format: `type: description (#issue-number)`
- [ ] PR title matches main commit message
- [ ] Issue number linked above
- [ ] Tests added for new functionality
- [ ] Documentation updated if needed
- [ ] If protocol/auth behavior changed, updated MVP compatibility contract and release checklist notes
- [ ] If breaking admin/control-plane API changes: updated migration guide and versioning policy docs
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review and documented in migration guide

## Reviewer Checklist
- [ ] Code follows project architecture (vertical slices, no controllers)
- [ ] Tests cover happy path and edge cases
- [ ] No reflection in hot paths (AOT compatible)
- [ ] Dependency limits respected (max 5 per endpoint)
- [ ] Error handling follows project patterns
- [ ] Security considerations addressed

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
