### PR TITLE
perf: reduce counted query overhead on feature reads

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -44,8 +44,9 @@ docker-compose*
 # Documentation
 *.md
 docs/
-!docs/api-specs/
-!docs/api-specs/admin-api.json
+!docs/developer/
+!docs/developer/api-specs/
+!docs/developer/api-specs/admin-api.json
 
 # CI/CD
 .github/

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,5 @@
+# Project Instructions
+
+Canonical instructions now live in `AGENTS.md`.
+
+Please read `AGENTS.md` and follow those rules.

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IPagedFeatureReader.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IPagedFeatureReader.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.FeatureStore.Abstractions;
+
+/// <summary>
+/// Optional feature store capability for paged queries that avoid exact total counts.
+/// </summary>
+public interface IPagedFeatureReader
+{
+    /// <summary>
+    /// Queries a single page of features and reports whether additional results exist.
+    /// </summary>
+    /// <param name="layerId">Layer identifier to query.</param>
+    /// <param name="query">Query specification including paging.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Paged query result without requiring an exact total count.</returns>
+    Task<PagedQueryResult<Feature>> QueryPageAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IPagedGeoJsonFeatureStore.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IPagedGeoJsonFeatureStore.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.FeatureStore.Abstractions;
+
+/// <summary>
+/// Optional feature store capability for GeoJSON-encoded paged queries that avoid exact total counts.
+/// </summary>
+public interface IPagedGeoJsonFeatureStore
+{
+    /// <summary>
+    /// Queries a single page of GeoJSON-encoded features and reports whether additional results exist.
+    /// </summary>
+    /// <param name="layerId">Layer identifier.</param>
+    /// <param name="query">Query parameters including paging.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Paged query result without requiring an exact total count.</returns>
+    Task<PagedQueryResult<EncodedGeoJsonFeature>> QueryGeoJsonPageAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/FeatureStore/Domain/FeatureQuery.cs
+++ b/src/Honua.Core/Features/FeatureStore/Domain/FeatureQuery.cs
@@ -34,6 +34,11 @@ public readonly record struct FeatureQuery
     public ImmutableArray<string>? OutFields { get; init; }
 
     /// <summary>
+    /// Excludes the JSON attribute payload entirely when the caller only needs geometry/system columns.
+    /// </summary>
+    public bool ExcludeAttributes { get; init; }
+
+    /// <summary>
     /// Spatial filter for geometry-based queries
     /// </summary>
     public SpatialFilter? SpatialFilter { get; init; }

--- a/src/Honua.Core/Features/FeatureStore/Domain/PagedQueryResult.cs
+++ b/src/Honua.Core/Features/FeatureStore/Domain/PagedQueryResult.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+
+namespace Honua.Core.Features.FeatureStore.Domain;
+
+/// <summary>
+/// Result of a paged feature query when the total count may be omitted.
+/// </summary>
+/// <typeparam name="T">Type of items in the result set.</typeparam>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1000:Do not declare static members on generic types", Justification = "Factory methods improve readability")]
+public readonly record struct PagedQueryResult<T>
+{
+    /// <summary>
+    /// Initializes a paged query result with empty items to keep default struct instances safe.
+    /// </summary>
+    public PagedQueryResult()
+    {
+        Items = ImmutableArray<T>.Empty;
+    }
+
+    /// <summary>
+    /// Total number of records available when known.
+    /// </summary>
+    public long? TotalCount { get; init; }
+
+    /// <summary>
+    /// Items in the current page.
+    /// </summary>
+    public ImmutableArray<T> Items { get; init; } = ImmutableArray<T>.Empty;
+
+    /// <summary>
+    /// Whether there are more results beyond the current page.
+    /// </summary>
+    public bool HasMoreResults { get; init; }
+
+    /// <summary>
+    /// Creates a paged query result.
+    /// </summary>
+    /// <param name="items">Items in the current page.</param>
+    /// <param name="hasMoreResults">Whether more results exist.</param>
+    /// <param name="totalCount">Optional total count when known.</param>
+    /// <returns>New paged query result instance.</returns>
+    public static PagedQueryResult<T> Create(
+        ImmutableArray<T> items,
+        bool hasMoreResults = false,
+        long? totalCount = null)
+        => new() { TotalCount = totalCount, Items = items, HasMoreResults = hasMoreResults };
+
+    /// <summary>
+    /// Creates an empty paged query result.
+    /// </summary>
+    /// <returns>Empty paged query result.</returns>
+    public static PagedQueryResult<T> Empty()
+        => new() { TotalCount = null, Items = ImmutableArray<T>.Empty, HasMoreResults = false };
+}

--- a/src/Honua.Postgres/Features/FeatureStore/PostgresFeatureStore.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/PostgresFeatureStore.cs
@@ -31,7 +31,7 @@ namespace Honua.Postgres.Features.FeatureStore;
 /// 'field = value', 'age > 18') and properly parameterizes all literal values while
 /// validating field names to prevent SQL injection attacks.</para>
 /// </remarks>
-internal sealed class PostgresFeatureStoreRefactored : IFeatureReader, IFeatureWriter, ITileProvider, IRelationshipStore, IGeoJsonFeatureStore, IGeobufFeatureStore, IGmlFeatureStore, IKmlFeatureStore, IStreamingFeatureStore
+internal sealed class PostgresFeatureStoreRefactored : IFeatureReader, IFeatureWriter, ITileProvider, IRelationshipStore, IGeoJsonFeatureStore, IGeobufFeatureStore, IGmlFeatureStore, IKmlFeatureStore, IStreamingFeatureStore, IPagedFeatureReader, IPagedGeoJsonFeatureStore
 {
     private readonly IFeatureQueryBuilder _queryBuilder;
     private readonly IFeatureDataAccess _dataAccess;
@@ -106,6 +106,35 @@ internal sealed class PostgresFeatureStoreRefactored : IFeatureReader, IFeatureW
             cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<PagedQueryResult<Feature>> QueryPageAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        if (!query.Limit.HasValue || query.Limit.Value == int.MaxValue)
+        {
+            var result = await QueryAsync(layerId, query, cancellationToken).ConfigureAwait(false);
+            return PagedQueryResult<Feature>.Create(result.Items, result.HasMoreResults, result.TotalCount);
+        }
+
+        var geometryStorageType = await _cacheManager.GetGeometryStorageTypeAsync(cancellationToken).ConfigureAwait(false);
+        var pageQuery = query with { Limit = query.Limit.Value + 1 };
+        var selectQuery = _queryBuilder.BuildSelectQuery(layerId, pageQuery, geometryStorageType);
+        var features = await _dataAccess.ExecuteSelectQueryAsync(selectQuery, pageQuery, layerId, cancellationToken).ConfigureAwait(false);
+
+        if (features.Length == 0)
+        {
+            return PagedQueryResult<Feature>.Empty();
+        }
+
+        var hasMoreResults = features.Length > query.Limit.Value;
+        var items = hasMoreResults
+            ? features.Take(query.Limit.Value).ToImmutableArray()
+            : features;
+
+        return PagedQueryResult<Feature>.Create(items, hasMoreResults);
+    }
+
     public async Task<byte[]?> QueryFlatGeobufAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
     {
         var geometryStorageType = await _cacheManager.GetGeometryStorageTypeAsync(cancellationToken).ConfigureAwait(false);
@@ -132,6 +161,35 @@ internal sealed class PostgresFeatureStoreRefactored : IFeatureReader, IFeatureW
             _dataAccess.ExecuteSelectGeoJsonQueryAsync,
             QueryOptimizedGeoJsonAsync,
             cancellationToken);
+
+    public async Task<PagedQueryResult<EncodedGeoJsonFeature>> QueryGeoJsonPageAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        if (!query.Limit.HasValue || query.Limit.Value == int.MaxValue)
+        {
+            var result = await QueryGeoJsonAsync(layerId, query, cancellationToken).ConfigureAwait(false);
+            return PagedQueryResult<EncodedGeoJsonFeature>.Create(result.Items, result.HasMoreResults, result.TotalCount);
+        }
+
+        var geometryStorageType = await _cacheManager.GetGeometryStorageTypeAsync(cancellationToken).ConfigureAwait(false);
+        var pageQuery = query with { Limit = query.Limit.Value + 1 };
+        var selectQuery = _queryBuilder.BuildSelectGeoJsonQuery(layerId, pageQuery, geometryStorageType);
+        var features = await _dataAccess.ExecuteSelectGeoJsonQueryAsync(selectQuery, pageQuery, layerId, cancellationToken).ConfigureAwait(false);
+
+        if (features.Length == 0)
+        {
+            return PagedQueryResult<EncodedGeoJsonFeature>.Empty();
+        }
+
+        var hasMoreResults = features.Length > query.Limit.Value;
+        var items = hasMoreResults
+            ? features.Take(query.Limit.Value).ToImmutableArray()
+            : features;
+
+        return PagedQueryResult<EncodedGeoJsonFeature>.Create(items, hasMoreResults);
+    }
 
     public Task<QueryResult<GmlFeature>> QueryGmlAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
         => ExecuteFormatQueryAsync(

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
@@ -37,7 +37,7 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
 
     private delegate void SelectClauseBuilder(
         StringBuilder sql, FeatureQuery query, CoreGeometryStorageType geometryStorageType,
-        bool isKnnQuery, SpatialFilter? spatialFilter, ref int paramIndex);
+        bool isKnnQuery, SpatialFilter? spatialFilter, ref int paramIndex, List<object> parameters);
 
     public CoreParameterizedQuery BuildSelectQuery(
         int layerId,
@@ -78,7 +78,7 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
             var paramIndex = 2;
             var parameters = new List<object>();
 
-            buildSelectClause(sql, query, geometryStorageType, isKnnQuery, spatialFilter, ref paramIndex);
+            buildSelectClause(sql, query, geometryStorageType, isKnnQuery, spatialFilter, ref paramIndex, parameters);
             AppendWhereClause(sql, query, ref paramIndex, parameters);
             AppendTemporalFilter(sql, query, ref paramIndex, parameters);
             AppendSpatialFilter(sql, query, geometryStorageType, ref paramIndex, parameters);

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.EncodedFormats.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.EncodedFormats.cs
@@ -183,9 +183,10 @@ internal sealed partial class FeatureQueryBuilder
             var geometryProjection = aliasGeometry
                 ? $"{geometrySelect} AS {FeatureQueryEncoding.GeometryColumn}"
                 : geometrySelect;
+            var attributesSelect = BuildAttributesSelectExpression(query, ref paramIndex, parameters);
 
             sql.Append(CultureInfo.InvariantCulture, $@"
-                SELECT {DatabaseSchema.ObjectIdColumn}, {geometryProjection}, {DatabaseSchema.AttributesColumn}, COUNT(*) OVER() as {FeatureQueryEncoding.InternalTotalCountColumn}
+                SELECT {DatabaseSchema.ObjectIdColumn}, {geometryProjection}, {attributesSelect} AS {DatabaseSchema.AttributesColumn}, COUNT(*) OVER() as {FeatureQueryEncoding.InternalTotalCountColumn}
                 FROM {_tableName}
                 WHERE {DatabaseSchema.LayerIdColumn} = $1");
 

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.SelectClauses.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.SelectClauses.cs
@@ -17,21 +17,23 @@ internal sealed partial class FeatureQueryBuilder
         CoreGeometryStorageType geometryStorageType,
         bool isKnnQuery,
         SpatialFilter? spatialFilter,
-        ref int paramIndex)
+        ref int paramIndex,
+        List<object> parameters)
     {
         var geometrySelect = _geometryProcessor.GetGeometrySelectExpression(geometryStorageType, query);
+        var attributesSelect = BuildAttributesSelectExpression(query, ref paramIndex, parameters);
 
         if (isKnnQuery && spatialFilter!.Value.ReturnDistance)
         {
             var geographyOperand = _geometryProcessor.GetGeographyOperand(geometryStorageType, query.SpatialReferenceSrid);
             var distanceParamExpression = BuildGeographyFilterExpression(spatialFilter.Value, query, ref paramIndex);
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect}, {DatabaseSchema.AttributesColumn}, ST_Distance({geographyOperand}, {distanceParamExpression}) as {FeatureQueryEncoding.InternalDistanceColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect}, {attributesSelect} AS {DatabaseSchema.AttributesColumn}, ST_Distance({geographyOperand}, {distanceParamExpression}) as {FeatureQueryEncoding.InternalDistanceColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
         }
         else
         {
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect}, {DatabaseSchema.AttributesColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect}, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
         }
     }
 
@@ -41,21 +43,23 @@ internal sealed partial class FeatureQueryBuilder
         CoreGeometryStorageType geometryStorageType,
         bool isKnnQuery,
         SpatialFilter? spatialFilter,
-        ref int paramIndex)
+        ref int paramIndex,
+        List<object> parameters)
     {
         var geometrySelect = _geometryProcessor.GetGeometryGmlExpression(geometryStorageType, query);
+        var attributesSelect = BuildAttributesSelectExpression(query, ref paramIndex, parameters);
 
         if (isKnnQuery && spatialFilter!.Value.ReturnDistance)
         {
             var geographyOperand = _geometryProcessor.GetGeographyOperand(geometryStorageType, query.SpatialReferenceSrid);
             var distanceParamExpression = BuildGeographyFilterExpression(spatialFilter.Value, query, ref paramIndex);
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS {FeatureQueryEncoding.GeometryColumn}, {DatabaseSchema.AttributesColumn}, ST_Distance({geographyOperand}, {distanceParamExpression}) as {FeatureQueryEncoding.InternalDistanceColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS {FeatureQueryEncoding.GeometryColumn}, {attributesSelect} AS {DatabaseSchema.AttributesColumn}, ST_Distance({geographyOperand}, {distanceParamExpression}) as {FeatureQueryEncoding.InternalDistanceColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
         }
         else
         {
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {DatabaseSchema.AttributesColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
         }
     }
 
@@ -65,21 +69,23 @@ internal sealed partial class FeatureQueryBuilder
         CoreGeometryStorageType geometryStorageType,
         bool isKnnQuery,
         SpatialFilter? spatialFilter,
-        ref int paramIndex)
+        ref int paramIndex,
+        List<object> parameters)
     {
         var geometrySelect = _geometryProcessor.GetGeometryGeoJsonExpression(geometryStorageType, query);
+        var attributesSelect = BuildAttributesSelectExpression(query, ref paramIndex, parameters);
 
         if (isKnnQuery && spatialFilter!.Value.ReturnDistance)
         {
             var geographyOperand = _geometryProcessor.GetGeographyOperand(geometryStorageType, query.SpatialReferenceSrid);
             var distanceParamExpression = BuildGeographyFilterExpression(spatialFilter.Value, query, ref paramIndex);
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS {FeatureQueryEncoding.GeometryColumn}, {DatabaseSchema.AttributesColumn}, ST_Distance({geographyOperand}, {distanceParamExpression}) as {FeatureQueryEncoding.InternalDistanceColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS {FeatureQueryEncoding.GeometryColumn}, {attributesSelect} AS {DatabaseSchema.AttributesColumn}, ST_Distance({geographyOperand}, {distanceParamExpression}) as {FeatureQueryEncoding.InternalDistanceColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
         }
         else
         {
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {DatabaseSchema.AttributesColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
         }
     }
 
@@ -89,21 +95,73 @@ internal sealed partial class FeatureQueryBuilder
         CoreGeometryStorageType geometryStorageType,
         bool isKnnQuery,
         SpatialFilter? spatialFilter,
-        ref int paramIndex)
+        ref int paramIndex,
+        List<object> parameters)
     {
         var geometrySelect = _geometryProcessor.GetGeometryKmlExpression(geometryStorageType, query);
+        var attributesSelect = BuildAttributesSelectExpression(query, ref paramIndex, parameters);
 
         if (isKnnQuery && spatialFilter!.Value.ReturnDistance)
         {
             var geographyOperand = _geometryProcessor.GetGeographyOperand(geometryStorageType, query.SpatialReferenceSrid);
             var distanceParamExpression = BuildGeographyFilterExpression(spatialFilter.Value, query, ref paramIndex);
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS {FeatureQueryEncoding.GeometryColumn}, {DatabaseSchema.AttributesColumn}, ST_Distance({geographyOperand}, {distanceParamExpression}) as {FeatureQueryEncoding.InternalDistanceColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS {FeatureQueryEncoding.GeometryColumn}, {attributesSelect} AS {DatabaseSchema.AttributesColumn}, ST_Distance({geographyOperand}, {distanceParamExpression}) as {FeatureQueryEncoding.InternalDistanceColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
         }
         else
         {
             sql.Append(CultureInfo.InvariantCulture,
-                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {DatabaseSchema.AttributesColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                $"SELECT {DatabaseSchema.ObjectIdColumn}, {geometrySelect} AS geometry, {attributesSelect} AS {DatabaseSchema.AttributesColumn} FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
         }
+    }
+
+    private static string BuildAttributesSelectExpression(
+        FeatureQuery query,
+        ref int paramIndex,
+        List<object> parameters)
+    {
+        if (query.ExcludeAttributes)
+        {
+            return "NULL";
+        }
+
+        if (!query.OutFields.HasValue || query.OutFields.Value.IsDefault)
+        {
+            return DatabaseSchema.AttributesColumn;
+        }
+
+        var requestedOutFields = query.OutFields.Value;
+        if (requestedOutFields.IsEmpty)
+        {
+            return "NULL";
+        }
+
+        var projectedFields = new List<string>(requestedOutFields.Length);
+        var seenFields = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var fieldName in requestedOutFields)
+        {
+            if (!IsValidFieldName(fieldName))
+            {
+                throw new ArgumentException($"Invalid field name for projection: {fieldName}");
+            }
+
+            if (!DatabaseSchema.CanUseJsonPath(fieldName) || !seenFields.Add(fieldName))
+            {
+                continue;
+            }
+
+            var fieldParamIndex = paramIndex++;
+            parameters.Add(fieldName);
+            var escapedFieldName = fieldName.Replace("'", "''", StringComparison.Ordinal);
+            projectedFields.Add($"'{escapedFieldName}', {DatabaseSchema.AttributesColumn} -> ${fieldParamIndex}");
+        }
+
+        if (projectedFields.Count == 0)
+        {
+            return "NULL";
+        }
+
+        return $"jsonb_build_object({string.Join(", ", projectedFields)})::text";
     }
 }

--- a/src/Honua.Server/Features/FeatureServer/Services/FeatureServerQueryExecutor.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/FeatureServerQueryExecutor.cs
@@ -53,6 +53,15 @@ internal sealed class FeatureServerQueryExecutor
     {
         try
         {
+            if (ShouldUsePagedQuery(query) && _featureReader is IPagedFeatureReader pagedFeatureReader)
+            {
+                var pagedResult = await pagedFeatureReader.QueryPageAsync(layerId, query, cancellationToken);
+                return QueryResult<Feature>.Create(
+                    totalCount: pagedResult.TotalCount ?? GetLowerBoundTotalCount(pagedResult.Items.Length, pagedResult.HasMoreResults),
+                    items: pagedResult.Items,
+                    hasMoreResults: pagedResult.HasMoreResults);
+            }
+
             return await _featureReader.QueryAsync(layerId, query, cancellationToken);
         }
         catch (ArgumentException ex)
@@ -290,4 +299,10 @@ internal sealed class FeatureServerQueryExecutor
             context.Response.Headers.TransferEncoding = "chunked";
         }
     }
+
+    private static bool ShouldUsePagedQuery(FeatureQuery query)
+        => query.Limit is > 0 and < int.MaxValue;
+
+    private static long GetLowerBoundTotalCount(int itemCount, bool hasMoreResults)
+        => hasMoreResults ? itemCount + 1L : itemCount;
 }

--- a/src/Honua.Server/Features/Infrastructure/Caching/CachingLayerCatalog.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/CachingLayerCatalog.cs
@@ -5,6 +5,7 @@ using Honua.Core.Features.Caching;
 using Honua.Core.Features.Caching.Abstractions;
 using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Server.Features.Infrastructure.Caching;
@@ -22,6 +23,7 @@ internal sealed class CachingLayerCatalog : ILayerCatalog
     private readonly ILayerCatalog _innerCatalog;
     private readonly ICacheService _cacheService;
     private readonly CacheOptions _options;
+    private readonly ISchemaContext? _schemaContext;
 
     // Cache key constants
     private const string LayerKeyPrefix = "layer:";
@@ -35,18 +37,20 @@ internal sealed class CachingLayerCatalog : ILayerCatalog
     public CachingLayerCatalog(
         ILayerCatalog innerCatalog,
         ICacheService cacheService,
-        IOptions<CacheOptions> options)
+        IOptions<CacheOptions> options,
+        ISchemaContext? schemaContext = null)
     {
         _innerCatalog = innerCatalog ?? throw new ArgumentNullException(nameof(innerCatalog));
         _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _schemaContext = schemaContext;
     }
 
     /// <inheritdoc />
     public async Task<LayerDefinition?> GetLayerAsync(int layerId, CancellationToken cancellationToken = default)
     {
-        string cacheKey = $"{LayerKeyPrefix}{layerId}";
-        string existsKey = $"{LayerExistsKeyPrefix}{layerId}";
+        string cacheKey = ScopeKey($"{LayerKeyPrefix}{layerId}");
+        string existsKey = ScopeKey($"{LayerExistsKeyPrefix}{layerId}");
 
         // Single Redis call optimized: Try to get both layer and existence data
         // Use GetOrSetAsync with a factory that checks for cached existence data first
@@ -97,8 +101,10 @@ internal sealed class CachingLayerCatalog : ILayerCatalog
     /// <inheritdoc />
     public async Task<LayerDefinition[]> ListLayersAsync(CancellationToken cancellationToken = default)
     {
+        var listKey = ScopeKey(LayerListKey);
+
         // Use wrapper type for proper serialization
-        CachedLayerList? cached = await _cacheService.GetAsync<CachedLayerList>(LayerListKey, cancellationToken).ConfigureAwait(false);
+        CachedLayerList? cached = await _cacheService.GetAsync<CachedLayerList>(listKey, cancellationToken).ConfigureAwait(false);
         if (cached != null)
             return cached.Layers;
 
@@ -107,7 +113,7 @@ internal sealed class CachingLayerCatalog : ILayerCatalog
 
         // Cache the result
         var ttl = _options.GetLayerTtlWithJitter();
-        await _cacheService.SetAsync(LayerListKey, new CachedLayerList(layers), ttl, cancellationToken).ConfigureAwait(false);
+        await _cacheService.SetAsync(listKey, new CachedLayerList(layers), ttl, cancellationToken).ConfigureAwait(false);
 
         return layers;
     }
@@ -116,8 +122,8 @@ internal sealed class CachingLayerCatalog : ILayerCatalog
     public async Task<ServiceDefinition?> GetServiceAsync(string serviceName, CancellationToken cancellationToken = default)
     {
         string normalizedName = serviceName.ToLowerInvariant();
-        string cacheKey = $"{ServiceKeyPrefix}{normalizedName}";
-        string existsKey = $"{ServiceExistsKeyPrefix}{normalizedName}";
+        string cacheKey = ScopeKey($"{ServiceKeyPrefix}{normalizedName}");
+        string existsKey = ScopeKey($"{ServiceExistsKeyPrefix}{normalizedName}");
 
         // Single Redis call optimized: Try to get both service and existence data
         // Use GetOrSetAsync with a factory that checks for cached existence data first
@@ -168,8 +174,10 @@ internal sealed class CachingLayerCatalog : ILayerCatalog
     /// <inheritdoc />
     public async Task<ServiceDefinition[]> ListServicesAsync(CancellationToken cancellationToken = default)
     {
+        var listKey = ScopeKey(ServiceListKey);
+
         // Use wrapper type for proper serialization
-        CachedServiceList? cached = await _cacheService.GetAsync<CachedServiceList>(ServiceListKey, cancellationToken).ConfigureAwait(false);
+        CachedServiceList? cached = await _cacheService.GetAsync<CachedServiceList>(listKey, cancellationToken).ConfigureAwait(false);
         if (cached != null)
             return cached.Services;
 
@@ -178,7 +186,7 @@ internal sealed class CachingLayerCatalog : ILayerCatalog
 
         // Cache the result
         var ttl = _options.GetServiceTtlWithJitter();
-        await _cacheService.SetAsync(ServiceListKey, new CachedServiceList(services), ttl, cancellationToken).ConfigureAwait(false);
+        await _cacheService.SetAsync(listKey, new CachedServiceList(services), ttl, cancellationToken).ConfigureAwait(false);
 
         return services;
     }
@@ -186,8 +194,8 @@ internal sealed class CachingLayerCatalog : ILayerCatalog
     /// <inheritdoc />
     public async Task<bool> LayerExistsAsync(int layerId, CancellationToken cancellationToken = default)
     {
-        string existsKey = $"{LayerExistsKeyPrefix}{layerId}";
-        string cacheKey = $"{LayerKeyPrefix}{layerId}";
+        string existsKey = ScopeKey($"{LayerExistsKeyPrefix}{layerId}");
+        string cacheKey = ScopeKey($"{LayerKeyPrefix}{layerId}");
 
         // Optimized: Use GetOrSetAsync to avoid double Redis calls while checking both existence and layer cache
         var positiveTtl = _options.GetLayerTtlWithJitter();
@@ -222,8 +230,8 @@ internal sealed class CachingLayerCatalog : ILayerCatalog
     public async Task<bool> ServiceExistsAsync(string serviceName, CancellationToken cancellationToken = default)
     {
         string normalizedName = serviceName.ToLowerInvariant();
-        string existsKey = $"{ServiceExistsKeyPrefix}{normalizedName}";
-        string cacheKey = $"{ServiceKeyPrefix}{normalizedName}";
+        string existsKey = ScopeKey($"{ServiceExistsKeyPrefix}{normalizedName}");
+        string cacheKey = ScopeKey($"{ServiceKeyPrefix}{normalizedName}");
 
         // Optimized: Use GetOrSetAsync to avoid double Redis calls while checking both existence and service cache
         var positiveTtl = _options.GetServiceTtlWithJitter();
@@ -289,14 +297,14 @@ internal sealed class CachingLayerCatalog : ILayerCatalog
     public async Task InvalidateLayerAsync(int layerId, CancellationToken cancellationToken = default)
     {
         // Remove specific layer cache
-        await _cacheService.RemoveAsync($"{LayerKeyPrefix}{layerId}", cancellationToken).ConfigureAwait(false);
-        await _cacheService.RemoveAsync($"{LayerExistsKeyPrefix}{layerId}", cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveAsync(ScopeKey($"{LayerKeyPrefix}{layerId}"), cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveAsync(ScopeKey($"{LayerExistsKeyPrefix}{layerId}"), cancellationToken).ConfigureAwait(false);
 
         // Remove layer list cache (will be rebuilt on next request)
-        await _cacheService.RemoveAsync(LayerListKey, cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveAsync(ScopeKey(LayerListKey), cancellationToken).ConfigureAwait(false);
 
         // Remove relationship caches for this layer
-        await _cacheService.RemoveByPatternAsync($"{RelationshipKeyPrefix}{layerId}:*", cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveByPatternAsync(ScopePattern($"{RelationshipKeyPrefix}{layerId}:*"), cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -307,11 +315,11 @@ internal sealed class CachingLayerCatalog : ILayerCatalog
     public async Task InvalidateServiceAsync(string serviceName, CancellationToken cancellationToken = default)
     {
         // Remove specific service cache
-        await _cacheService.RemoveAsync($"{ServiceKeyPrefix}{serviceName.ToLowerInvariant()}", cancellationToken).ConfigureAwait(false);
-        await _cacheService.RemoveAsync($"{ServiceExistsKeyPrefix}{serviceName.ToLowerInvariant()}", cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveAsync(ScopeKey($"{ServiceKeyPrefix}{serviceName.ToLowerInvariant()}"), cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveAsync(ScopeKey($"{ServiceExistsKeyPrefix}{serviceName.ToLowerInvariant()}"), cancellationToken).ConfigureAwait(false);
 
         // Remove service list cache (will be rebuilt on next request)
-        await _cacheService.RemoveAsync(ServiceListKey, cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveAsync(ScopeKey(ServiceListKey), cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -320,12 +328,24 @@ internal sealed class CachingLayerCatalog : ILayerCatalog
     /// <param name="cancellationToken">Cancellation token</param>
     public async Task InvalidateAllAsync(CancellationToken cancellationToken = default)
     {
-        await _cacheService.RemoveByPatternAsync($"{LayerKeyPrefix}*", cancellationToken).ConfigureAwait(false);
-        await _cacheService.RemoveByPatternAsync($"{LayerExistsKeyPrefix}*", cancellationToken).ConfigureAwait(false);
-        await _cacheService.RemoveByPatternAsync($"{ServiceKeyPrefix}*", cancellationToken).ConfigureAwait(false);
-        await _cacheService.RemoveByPatternAsync($"{ServiceExistsKeyPrefix}*", cancellationToken).ConfigureAwait(false);
-        await _cacheService.RemoveByPatternAsync($"{RelationshipKeyPrefix}*", cancellationToken).ConfigureAwait(false);
-        await _cacheService.RemoveAsync(LayerListKey, cancellationToken).ConfigureAwait(false);
-        await _cacheService.RemoveAsync(ServiceListKey, cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveByPatternAsync(ScopePattern($"{LayerKeyPrefix}*"), cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveByPatternAsync(ScopePattern($"{LayerExistsKeyPrefix}*"), cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveByPatternAsync(ScopePattern($"{ServiceKeyPrefix}*"), cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveByPatternAsync(ScopePattern($"{ServiceExistsKeyPrefix}*"), cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveByPatternAsync(ScopePattern($"{RelationshipKeyPrefix}*"), cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveAsync(ScopeKey(LayerListKey), cancellationToken).ConfigureAwait(false);
+        await _cacheService.RemoveAsync(ScopeKey(ServiceListKey), cancellationToken).ConfigureAwait(false);
+    }
+
+    private string ScopeKey(string key) => $"{GetScopePrefix()}{key}";
+
+    private string ScopePattern(string pattern) => $"{GetScopePrefix()}{pattern}";
+
+    private string GetScopePrefix()
+    {
+        var schema = _schemaContext?.CurrentSchema;
+        return string.IsNullOrWhiteSpace(schema)
+            ? "scope:default:"
+            : $"scope:schema:{schema.Trim().ToLowerInvariant()}:";
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheInvalidationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheInvalidationService.cs
@@ -247,6 +247,18 @@ internal sealed partial class OutputCacheInvalidationService
             }
         }
 
+        foreach (var pattern in GetScopedMetadataPatterns(keys, layerIds))
+        {
+            try
+            {
+                await _metadataCache.RemoveByPatternAsync(pattern, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                LogEvictMetadataPatternFailed(_logger, pattern, ex);
+            }
+        }
+
         foreach (var layerId in layerIds)
         {
             var pattern = $"relationship:{layerId}:*";
@@ -258,6 +270,21 @@ internal sealed partial class OutputCacheInvalidationService
             {
                 LogEvictMetadataPatternFailed(_logger, pattern, ex);
             }
+        }
+    }
+
+    private static IEnumerable<string> GetScopedMetadataPatterns(
+        IEnumerable<string> keys,
+        IReadOnlyCollection<int> layerIds)
+    {
+        foreach (var key in keys.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            yield return $"scope:*:{key}";
+        }
+
+        foreach (var layerId in layerIds.Distinct())
+        {
+            yield return $"scope:*:relationship:{layerId}:*";
         }
     }
 

--- a/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheInvalidationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheInvalidationService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Globalization;
+using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.Caching.Abstractions;
 using Honua.Core.Features.Infrastructure.Caching;
 using Microsoft.AspNetCore.OutputCaching;
@@ -16,28 +17,32 @@ internal sealed partial class OutputCacheInvalidationService
     private readonly IOutputCacheStore? _cacheStore;
     private readonly IResponseCache? _responseCache;
     private readonly ICacheService? _metadataCache;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<OutputCacheInvalidationService> _logger;
 
     public OutputCacheInvalidationService(
         IOutputCacheStore? cacheStore,
         IResponseCache? responseCache,
         ICacheService? metadataCache,
+        IServiceScopeFactory scopeFactory,
         ILogger<OutputCacheInvalidationService> logger)
     {
         _cacheStore = cacheStore;
         _responseCache = responseCache;
         _metadataCache = metadataCache;
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         _logger = logger;
     }
 
-    public Task InvalidateLayerAsync(string? serviceId, int? layerId, CancellationToken cancellationToken)
+    public async Task InvalidateLayerAsync(string? serviceId, int? layerId, CancellationToken cancellationToken)
     {
+        var normalizedServiceIds = await ResolveLayerServiceIdsAsync(serviceId, layerId, cancellationToken).ConfigureAwait(false);
         var tags = new List<string>();
         var responsePatterns = new List<string>();
 
-        if (!string.IsNullOrWhiteSpace(serviceId))
+        foreach (var normalizedServiceId in normalizedServiceIds)
         {
-            tags.Add($"service:{serviceId.Trim().ToLowerInvariant()}");
+            tags.Add($"service:{normalizedServiceId}");
         }
 
         if (layerId.HasValue)
@@ -52,18 +57,21 @@ internal sealed partial class OutputCacheInvalidationService
                 layerId.Value.ToString(CultureInfo.InvariantCulture)));
         }
 
-        if (!string.IsNullOrWhiteSpace(serviceId) && layerId.HasValue)
+        if (layerId.HasValue)
         {
-            responsePatterns.Add(ResponseCacheUtilities.BuildFeatureServerLayerPattern(serviceId, layerId.Value));
+            foreach (var normalizedServiceId in normalizedServiceIds)
+            {
+                responsePatterns.Add(ResponseCacheUtilities.BuildFeatureServerLayerPattern(normalizedServiceId, layerId.Value));
+            }
         }
 
         tags.Add("ogc-metadata");
         tags.Add("ogc-tiles");
         tags.Add("mvt-tiles");
 
-        return Task.WhenAll(
+        await Task.WhenAll(
             EvictTagsAsync(tags, cancellationToken),
-            EvictResponseCacheAsync(responsePatterns, cancellationToken));
+            EvictResponseCacheAsync(responsePatterns, cancellationToken)).ConfigureAwait(false);
     }
 
     public Task InvalidateCollectionAsync(string collectionId, CancellationToken cancellationToken)
@@ -253,6 +261,47 @@ internal sealed partial class OutputCacheInvalidationService
         }
     }
 
+    private async Task<string[]> ResolveLayerServiceIdsAsync(
+        string? serviceId,
+        int? layerId,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(serviceId))
+        {
+            return [NormalizeServiceId(serviceId)];
+        }
+
+        if (!layerId.HasValue)
+        {
+            return [];
+        }
+
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var layerCatalog = scope.ServiceProvider.GetService<ILayerCatalog>();
+            if (layerCatalog == null)
+            {
+                return [];
+            }
+
+            var services = await layerCatalog.ListServicesAsync(cancellationToken).ConfigureAwait(false);
+            return services
+                .Where(service => service.Layers.Any(candidate => candidate.Id == layerId.Value))
+                .Select(service => NormalizeServiceId(service.Name))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogResolveLayerServicesFailed(_logger, layerId.Value, ex);
+            return [];
+        }
+    }
+
+    private static string NormalizeServiceId(string serviceId)
+        => serviceId.Trim().ToLowerInvariant();
+
     [LoggerMessage(EventId = 4510, Level = LogLevel.Warning,
         Message = "Failed to evict output cache tag {Tag}")]
     private static partial void LogEvictTagFailed(ILogger logger, string tag, Exception exception);
@@ -268,4 +317,8 @@ internal sealed partial class OutputCacheInvalidationService
     [LoggerMessage(EventId = 4513, Level = LogLevel.Warning,
         Message = "Failed to evict metadata cache pattern {Pattern}")]
     private static partial void LogEvictMetadataPatternFailed(ILogger logger, string pattern, Exception exception);
+
+    [LoggerMessage(EventId = 4515, Level = LogLevel.Warning,
+        Message = "Failed to resolve owning services for layer {LayerId} during cache invalidation")]
+    private static partial void LogResolveLayerServicesFailed(ILogger logger, int layerId, Exception exception);
 }

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -40,7 +40,7 @@ internal static class FeatureRegistrationExtensions
         services.AddMapServer();
         services.AddOgcFeatures(configuration);
         services.AddOgcMaps();
-        services.AddWfs20();
+        services.AddWfs20(configuration);
         services.AddOData();
         services.AddGeometryService();
         services.AddHonuaGrpc(configuration);

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -38,7 +38,7 @@ internal static class FeatureRegistrationExtensions
         services.AddGeocoding(configuration);
         services.AddImageServer();
         services.AddMapServer();
-        services.AddOgcFeatures();
+        services.AddOgcFeatures(configuration);
         services.AddOgcMaps();
         services.AddWfs20();
         services.AddOData();

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
@@ -5,6 +5,7 @@ using System.Data.Common;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
+using System.Collections.Immutable;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
@@ -345,28 +346,25 @@ internal static partial class MapServerEndpoints
                         filterError ?? "Invalid filter parameter.");
                 }
 
-                var featureQuery = new FeatureQuery
-                {
-                    SpatialFilter = spatialFilter,
-                    SpatialReferenceSrid = serviceSrid,
-                    OutputSrid = imageSrid,
-                    Limit = maxFeatures,
-                    SqlFilter = sqlFilter
-                };
+                var style = await styleCatalog.GetLayerStyleAsync(layer.Id, context.RequestAborted);
+                var styleLayers = StyleTranslator.ParseStyleLayers(style?.MapLibreStyleJson);
+                var featureQuery = CreateRasterFeatureQuery(
+                    styleLayers,
+                    spatialFilter,
+                    serviceSrid,
+                    imageSrid,
+                    maxFeatures,
+                    sqlFilter);
 
-                var queryResult = await featureReader.QueryAsync(layer.Id, featureQuery, context.RequestAborted);
+                var features = await QueryRasterFeaturesAsync(featureReader, layer.Id, featureQuery, context.RequestAborted);
 
-                if (queryResult.Items.Length == 0)
+                if (features.Length == 0)
                 {
                     continue;
                 }
 
-                totalFeatureCount += queryResult.Items.Length;
-
-                var style = await styleCatalog.GetLayerStyleAsync(layer.Id, context.RequestAborted);
-                var styleLayers = StyleTranslator.ParseStyleLayers(style?.MapLibreStyleJson);
-
-                RenderLayerToCanvas(canvas, queryResult.Items, styleLayers, transform, layer.GeometryType);
+                totalFeatureCount += features.Length;
+                RenderLayerToCanvas(canvas, features, styleLayers, transform, layer.GeometryType);
             }
 
             stopwatch.Stop();
@@ -467,7 +465,7 @@ internal static partial class MapServerEndpoints
 
     private static void RenderLayerToCanvas(
         SKCanvas canvas,
-        System.Collections.Immutable.ImmutableArray<Feature> features,
+        ImmutableArray<Feature> features,
         MapLibreStyleLayer[] styleLayers,
         Func<double, double, SKPoint> transform,
         GeometryType geometryType)
@@ -649,6 +647,46 @@ internal static partial class MapServerEndpoints
         }
 
         result.Path?.Dispose();
+    }
+
+    private static FeatureQuery CreateRasterFeatureQuery(
+        MapLibreStyleLayer[] styleLayers,
+        SpatialFilter spatialFilter,
+        int spatialReferenceSrid,
+        int? outputSrid,
+        int limit,
+        SqlFragment? sqlFilter = null)
+    {
+        var referencedFields = StyleTranslator.CollectReferencedFields(styleLayers);
+
+        return new FeatureQuery
+        {
+            SpatialFilter = spatialFilter,
+            SpatialReferenceSrid = spatialReferenceSrid,
+            OutputSrid = outputSrid,
+            Limit = limit,
+            SqlFilter = sqlFilter,
+            OutFields = referencedFields.Length > 0 ? ImmutableArray.CreateRange(referencedFields) : null,
+            ExcludeAttributes = referencedFields.Length == 0
+        };
+    }
+
+    private static async Task<ImmutableArray<Feature>> QueryRasterFeaturesAsync(
+        IFeatureReader featureReader,
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken)
+    {
+        if (featureReader is IPagedFeatureReader pagedFeatureReader &&
+            query.Limit.HasValue &&
+            query.Limit.Value != int.MaxValue)
+        {
+            var pagedResult = await pagedFeatureReader.QueryPageAsync(layerId, query, cancellationToken).ConfigureAwait(false);
+            return pagedResult.Items;
+        }
+
+        var result = await featureReader.QueryAsync(layerId, query, cancellationToken).ConfigureAwait(false);
+        return result.Items;
     }
 
     private static bool TryParseBbox(string? bbox, out SkiaMapRenderer.RenderExtent extent)

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Tile.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Tile.cs
@@ -149,26 +149,23 @@ internal static partial class MapServerEndpoints
                     continue;
                 }
 
-                var featureQuery = new FeatureQuery
-                {
-                    SpatialFilter = spatialFilter,
-                    SpatialReferenceSrid = service.SpatialReference.Srid,
-                    OutputSrid = TileSrid,
-                    Limit = maxFeatures
-                };
+                var style = await styleCatalog.GetLayerStyleAsync(layer.Id, context.RequestAborted);
+                var styleLayers = StyleTranslator.ParseStyleLayers(style?.MapLibreStyleJson);
+                var featureQuery = CreateRasterFeatureQuery(
+                    styleLayers,
+                    spatialFilter,
+                    service.SpatialReference.Srid,
+                    TileSrid,
+                    maxFeatures);
 
-                var queryResult = await featureReader.QueryAsync(layer.Id, featureQuery, context.RequestAborted);
-                if (queryResult.Items.Length == 0)
+                var features = await QueryRasterFeaturesAsync(featureReader, layer.Id, featureQuery, context.RequestAborted);
+                if (features.Length == 0)
                 {
                     continue;
                 }
 
-                totalFeatureCount += queryResult.Items.Length;
-
-                var style = await styleCatalog.GetLayerStyleAsync(layer.Id, context.RequestAborted);
-                var styleLayers = StyleTranslator.ParseStyleLayers(style?.MapLibreStyleJson);
-
-                RenderLayerToCanvas(canvas, queryResult.Items, styleLayers, transform, layer.GeometryType);
+                totalFeatureCount += features.Length;
+                RenderLayerToCanvas(canvas, features, styleLayers, transform, layer.GeometryType);
             }
 
             var imageBytes = SkiaMapRenderer.EncodeSurface(surface, "png");

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Wms.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Wms.cs
@@ -352,26 +352,23 @@ internal static partial class MapServerEndpoints
                 continue;
             }
 
-            var featureQuery = new FeatureQuery
-            {
-                SpatialFilter = spatialFilter,
-                SpatialReferenceSrid = service.SpatialReference.Srid,
-                OutputSrid = requestSrid,
-                Limit = maxFeatures
-            };
+            var style = await styleCatalog.GetLayerStyleAsync(layer.Id, context.RequestAborted);
+            var styleLayers = StyleTranslator.ParseStyleLayers(style?.MapLibreStyleJson);
+            var featureQuery = CreateRasterFeatureQuery(
+                styleLayers,
+                spatialFilter,
+                service.SpatialReference.Srid,
+                requestSrid,
+                maxFeatures);
 
-            var queryResult = await featureReader.QueryAsync(layer.Id, featureQuery, context.RequestAborted);
-            if (queryResult.Items.Length == 0)
+            var features = await QueryRasterFeaturesAsync(featureReader, layer.Id, featureQuery, context.RequestAborted);
+            if (features.Length == 0)
             {
                 continue;
             }
 
-            totalFeatureCount += queryResult.Items.Length;
-
-            var style = await styleCatalog.GetLayerStyleAsync(layer.Id, context.RequestAborted);
-            var styleLayers = StyleTranslator.ParseStyleLayers(style?.MapLibreStyleJson);
-
-            RenderLayerToCanvas(canvas, queryResult.Items, styleLayers, transformFn, layer.GeometryType);
+            totalFeatureCount += features.Length;
+            RenderLayerToCanvas(canvas, features, styleLayers, transformFn, layer.GeometryType);
         }
 
         var imageBytes = SkiaMapRenderer.EncodeSurface(surface, imageFormat);

--- a/src/Honua.Server/Features/MapServer/Rendering/StyleTranslator.cs
+++ b/src/Honua.Server/Features/MapServer/Rendering/StyleTranslator.cs
@@ -56,6 +56,29 @@ internal static class StyleTranslator
     }
 
     /// <summary>
+    /// Collects attribute names referenced by style filters, paint expressions, and layout expressions.
+    /// </summary>
+    public static string[] CollectReferencedFields(MapLibreStyleLayer[] styleLayers)
+    {
+        if (styleLayers.Length == 0)
+        {
+            return [];
+        }
+
+        var fields = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var styleLayer in styleLayers)
+        {
+            CollectReferencedFields(styleLayer.Filter, fields, seen);
+            CollectReferencedFields(styleLayer.Paint, fields, seen);
+            CollectReferencedFields(styleLayer.Layout, fields, seen);
+        }
+
+        return fields.Count == 0 ? [] : [.. fields];
+    }
+
+    /// <summary>
     /// Resolves a fill style from a MapLibre layer for a specific feature.
     /// </summary>
     public static ResolvedFillStyle ResolveFillStyle(
@@ -253,6 +276,57 @@ internal static class StyleTranslator
             MapLibreExpressionKind.Array => ExpressionEvaluator.EvaluateColor(expression, properties),
             _ => defaultColor
         };
+    }
+
+    private static void CollectReferencedFields(
+        Dictionary<string, MapLibreExpression>? expressions,
+        List<string> fields,
+        HashSet<string> seen)
+    {
+        if (expressions == null || expressions.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var expression in expressions.Values)
+        {
+            CollectReferencedFields(expression, fields, seen);
+        }
+    }
+
+    private static void CollectReferencedFields(
+        MapLibreExpression? expression,
+        List<string> fields,
+        HashSet<string> seen)
+    {
+        if (!expression.HasValue || expression.Value.Kind != MapLibreExpressionKind.Array || expression.Value.Items is not { Length: > 0 } items)
+        {
+            return;
+        }
+
+        if (TryGetString(items[0], out var op) && op != null)
+        {
+            if ((string.Equals(op, "get", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(op, "has", StringComparison.OrdinalIgnoreCase)) &&
+                items.Length > 1 &&
+                TryGetString(items[1], out var fieldName) &&
+                !string.IsNullOrWhiteSpace(fieldName) &&
+                seen.Add(fieldName))
+            {
+                fields.Add(fieldName);
+            }
+        }
+
+        foreach (var item in items)
+        {
+            CollectReferencedFields(item, fields, seen);
+        }
+    }
+
+    private static bool TryGetString(MapLibreExpression expression, out string? value)
+    {
+        value = expression.Kind == MapLibreExpressionKind.String ? expression.StringValue : null;
+        return value != null;
     }
 
     private static SKColor? ResolveOptionalColor(

--- a/src/Honua.Server/Features/OgcFeatures/CollectionsEndpoints.cs
+++ b/src/Honua.Server/Features/OgcFeatures/CollectionsEndpoints.cs
@@ -114,16 +114,22 @@ internal static class CollectionsEndpoints
             var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
             var layers = await layerCatalog.ListLayersAsync(cancellationToken);
             var services = await layerCatalog.ListServicesAsync(cancellationToken);
-            var protocolLayerIds = services
+            var ogcServices = services
                 .Where(service => ServiceProtocols.IsProtocolEnabled(service.Metadata, ServiceProtocols.OgcFeatures))
+                .ToArray();
+            var protocolLayerIds = ogcServices
                 .SelectMany(service => service.Layers.Select(layer => layer.Id))
                 .ToHashSet();
-            var visibleLayers = layers
-                .Where(layer => protocolLayerIds.Count == 0
-                    ? ServiceProtocols.IsProtocolEnabled(layer.Metadata, ServiceProtocols.OgcFeatures)
-                    : protocolLayerIds.Contains(layer.Id))
-                .Where(layer => AccessPolicyHelpers.IsLayerAccessible(context, layer))
-                .ToList();
+            var visibleLayers = protocolLayerIds.Count == 0
+                ? layers
+                    .Where(layer => ServiceProtocols.IsProtocolEnabled(layer.Metadata, ServiceProtocols.OgcFeatures))
+                    .Where(layer => AccessPolicyHelpers.IsLayerAccessible(context, layer))
+                    .ToList()
+                : ogcServices
+                    .SelectMany(service => service.Layers
+                        .Where(layer => AccessPolicyHelpers.IsLayerAccessible(context, layer, service)))
+                    .DistinctBy(layer => layer.Id)
+                    .ToList();
             var collectionTasks = visibleLayers
                 .Select(layer => CreateCollectionAsync(layer, baseUrl, featureReader, crsRegistry, cancellationToken));
             var collections = (await Task.WhenAll(collectionTasks)).ToImmutableArray();

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesOptions.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesOptions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.OgcFeatures;
+
+internal sealed class OgcFeaturesOptions
+{
+    public const string SectionName = "OgcFeatures";
+
+    /// <summary>
+    /// Controls whether the items endpoint computes an exact numberMatched value.
+    /// </summary>
+    public OgcFeaturesNumberMatchedPolicy NumberMatchedPolicy { get; set; } = OgcFeaturesNumberMatchedPolicy.Exact;
+
+    /// <summary>
+    /// Controls whether items responses include per-feature links.
+    /// </summary>
+    public bool IncludeFeatureLinks { get; set; } = true;
+}
+
+internal enum OgcFeaturesNumberMatchedPolicy
+{
+    Exact = 0,
+    OmitWhenExpensive = 1
+}

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesQueryDependencies.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesQueryDependencies.cs
@@ -24,7 +24,8 @@ internal sealed class OgcFeaturesQueryDependencies
         OgcFeaturesGeometryServices geometryServices,
         IResponseCache responseCache,
         IETagService etagService,
-        IOptions<CacheOptions> cacheOptions)
+        IOptions<CacheOptions> cacheOptions,
+        IOptions<OgcFeaturesOptions> ogcFeaturesOptions)
     {
         FeatureReader = featureReader ?? throw new ArgumentNullException(nameof(featureReader));
         StreamingFeatureStore = streamingFeatureStore ?? throw new ArgumentNullException(nameof(streamingFeatureStore));
@@ -36,6 +37,7 @@ internal sealed class OgcFeaturesQueryDependencies
         ResponseCache = responseCache ?? throw new ArgumentNullException(nameof(responseCache));
         ETagService = etagService ?? throw new ArgumentNullException(nameof(etagService));
         CacheOptions = cacheOptions?.Value ?? throw new ArgumentNullException(nameof(cacheOptions));
+        OgcFeaturesOptions = ogcFeaturesOptions?.Value ?? throw new ArgumentNullException(nameof(ogcFeaturesOptions));
     }
 
     public IFeatureReader FeatureReader { get; }
@@ -48,4 +50,5 @@ internal sealed class OgcFeaturesQueryDependencies
     public IResponseCache ResponseCache { get; }
     public IETagService ETagService { get; }
     public CacheOptions CacheOptions { get; }
+    public OgcFeaturesOptions OgcFeaturesOptions { get; }
 }

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesQueryHandler.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesQueryHandler.cs
@@ -46,6 +46,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
     private readonly IResponseCache _responseCache = dependencies.ResponseCache;
     private readonly IETagService _etagService = dependencies.ETagService;
     private readonly CacheOptions _cacheOptions = dependencies.CacheOptions;
+    private readonly OgcFeaturesOptions _ogcFeaturesOptions = dependencies.OgcFeaturesOptions;
     private readonly ILogger<OgcFeaturesQueryHandler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private const int StreamingThreshold = 1000;
     private const int StreamingFlushInterval = 32;
@@ -180,7 +181,9 @@ internal sealed partial class OgcFeaturesQueryHandler(
 
             var allowStreaming = string.Equals(outputFormat, MediaTypes.GeoJson, StringComparison.OrdinalIgnoreCase) ||
                                  string.Equals(outputFormat, MediaTypes.Gml, StringComparison.OrdinalIgnoreCase);
+            var omitExactNumberMatched = _ogcFeaturesOptions.NumberMatchedPolicy == OgcFeaturesNumberMatchedPolicy.OmitWhenExpensive;
             var useStreaming = allowStreaming &&
+                               !omitExactNumberMatched &&
                                projectedProperties == null &&
                                effectiveLimit > StreamingThreshold &&
                                !string.Equals(outputFormat, MediaTypes.Html, StringComparison.OrdinalIgnoreCase);
@@ -257,6 +260,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
                         projectedProperties,
                         outputFormat,
                         streamLinks,
+                        _ogcFeaturesOptions.IncludeFeatureLinks,
                         totalCount,
                         filterResult.CrsDefinition.Uri,
                         cancellationToken);
@@ -265,23 +269,75 @@ internal sealed partial class OgcFeaturesQueryHandler(
 
             var useNativeGeoJson = string.Equals(outputFormat, MediaTypes.GeoJson, StringComparison.OrdinalIgnoreCase) ||
                                    string.Equals(outputFormat, MediaTypes.Json, StringComparison.OrdinalIgnoreCase);
+            var includeFeatureLinks = _ogcFeaturesOptions.IncludeFeatureLinks;
             QueryResult<Feature>? featureResult = null;
             QueryResult<EncodedGeoJsonFeature>? encodedResult = null;
+            PagedQueryResult<Feature>? pagedFeatureResult = null;
+            PagedQueryResult<EncodedGeoJsonFeature>? pagedEncodedResult = null;
             GeoJsonFeature[] features;
 
-            if (useNativeGeoJson && _featureReader is IGeoJsonFeatureStore geoJsonFeatureStore)
+            if (omitExactNumberMatched && useNativeGeoJson && _featureReader is IPagedGeoJsonFeatureStore pagedGeoJsonFeatureStore)
+            {
+                pagedEncodedResult = await pagedGeoJsonFeatureStore.QueryGeoJsonPageAsync(layerId, query, cancellationToken);
+                features = pagedEncodedResult.Value.Items
+                    .Select(feature =>
+                    {
+                        ImmutableArray<Link>? links = includeFeatureLinks
+                            ? OgcFeaturesUtilities.BuildFeatureLinks(
+                                request,
+                                collectionId,
+                                FormattableString.Invariant($"{feature.Id}"),
+                                outputFormat)
+                            : null;
+                        return ToOgcFeature(
+                            feature,
+                            layer,
+                            filterResult.CrsDefinition.AxisOrder,
+                            _geometryServices,
+                            projectedProperties,
+                            links);
+                    })
+                    .ToArray();
+            }
+            else if (omitExactNumberMatched && _featureReader is IPagedFeatureReader pagedFeatureReader)
+            {
+                pagedFeatureResult = await pagedFeatureReader.QueryPageAsync(layerId, query, cancellationToken);
+                features = pagedFeatureResult.Value.Items
+                    .Select(feature =>
+                    {
+                        ImmutableArray<Link>? links = includeFeatureLinks
+                            ? OgcFeaturesUtilities.BuildFeatureLinks(
+                                request,
+                                collectionId,
+                                FormattableString.Invariant($"{feature.Id}"),
+                                outputFormat)
+                            : null;
+                        return ToOgcFeature(
+                            feature,
+                            layer,
+                            filterResult.CrsDefinition.AxisOrder,
+                            _geometryServices,
+                            projectedProperties,
+                            links);
+                    })
+                    .ToArray();
+            }
+            else if (useNativeGeoJson && _featureReader is IGeoJsonFeatureStore geoJsonFeatureStore)
             {
                 encodedResult = await geoJsonFeatureStore.QueryGeoJsonAsync(layerId, query, cancellationToken);
                 features = encodedResult.Value.Items
                     .Select(feature =>
                     {
-                        var links = OgcFeaturesUtilities.BuildFeatureLinks(
-                            request,
-                            collectionId,
-                            FormattableString.Invariant($"{feature.Id}"),
-                            outputFormat);
+                        ImmutableArray<Link>? links = includeFeatureLinks
+                            ? OgcFeaturesUtilities.BuildFeatureLinks(
+                                request,
+                                collectionId,
+                                FormattableString.Invariant($"{feature.Id}"),
+                                outputFormat)
+                            : null;
                         return ToOgcFeature(
                             feature,
+                            layer,
                             filterResult.CrsDefinition.AxisOrder,
                             _geometryServices,
                             projectedProperties,
@@ -295,13 +351,16 @@ internal sealed partial class OgcFeaturesQueryHandler(
                 features = featureResult.Value.Items
                     .Select(feature =>
                     {
-                        var links = OgcFeaturesUtilities.BuildFeatureLinks(
-                            request,
-                            collectionId,
-                            FormattableString.Invariant($"{feature.Id}"),
-                            outputFormat);
+                        ImmutableArray<Link>? links = includeFeatureLinks
+                            ? OgcFeaturesUtilities.BuildFeatureLinks(
+                                request,
+                                collectionId,
+                                FormattableString.Invariant($"{feature.Id}"),
+                                outputFormat)
+                            : null;
                         return ToOgcFeature(
                             feature,
+                            layer,
                             filterResult.CrsDefinition.AxisOrder,
                             _geometryServices,
                             projectedProperties,
@@ -310,8 +369,15 @@ internal sealed partial class OgcFeaturesQueryHandler(
                     .ToArray();
             }
             stopwatch.Stop();
-            var queryTotalCount = encodedResult?.TotalCount ?? featureResult?.TotalCount ?? 0;
-            var queryHasMoreResults = encodedResult?.HasMoreResults ?? featureResult?.HasMoreResults ?? false;
+            var queryTotalCount = pagedEncodedResult?.TotalCount
+                                  ?? pagedFeatureResult?.TotalCount
+                                  ?? encodedResult?.TotalCount
+                                  ?? featureResult?.TotalCount;
+            var queryHasMoreResults = pagedEncodedResult?.HasMoreResults
+                                      ?? pagedFeatureResult?.HasMoreResults
+                                      ?? encodedResult?.HasMoreResults
+                                      ?? featureResult?.HasMoreResults
+                                      ?? false;
             OgcFeaturesLog.ItemsQueryCompleted(_logger, collectionId, features.Length, queryTotalCount, stopwatch.Elapsed.TotalMilliseconds);
             HonuaTelemetry.SetSuccess(featureActivity, features.Length);
 
@@ -507,8 +573,10 @@ internal sealed partial class OgcFeaturesQueryHandler(
                 }
 
                 var feature = queryResult.Items[0];
-                var featureLinks = OgcFeaturesUtilities.BuildFeatureLinks(request, collectionId, featureId, outputFormat);
-                ogcFeature = ToOgcFeature(feature, crsDefinition.AxisOrder, _geometryServices, null, featureLinks);
+                ImmutableArray<Link>? featureLinks = _ogcFeaturesOptions.IncludeFeatureLinks
+                    ? OgcFeaturesUtilities.BuildFeatureLinks(request, collectionId, featureId, outputFormat)
+                    : null;
+                ogcFeature = ToOgcFeature(feature, layer, crsDefinition.AxisOrder, _geometryServices, null, featureLinks);
             }
             else
             {
@@ -521,8 +589,10 @@ internal sealed partial class OgcFeaturesQueryHandler(
                 }
 
                 var feature = queryResult.Items[0];
-                var featureLinks = OgcFeaturesUtilities.BuildFeatureLinks(request, collectionId, featureId, outputFormat);
-                ogcFeature = ToOgcFeature(feature, crsDefinition.AxisOrder, _geometryServices, null, featureLinks);
+                ImmutableArray<Link>? featureLinks = _ogcFeaturesOptions.IncludeFeatureLinks
+                    ? OgcFeaturesUtilities.BuildFeatureLinks(request, collectionId, featureId, outputFormat)
+                    : null;
+                ogcFeature = ToOgcFeature(feature, layer, crsDefinition.AxisOrder, _geometryServices, null, featureLinks);
             }
 
             context.Response.Headers["Content-Crs"] = FormatContentCrs(crsDefinition.Uri);
@@ -577,29 +647,14 @@ internal sealed partial class OgcFeaturesQueryHandler(
 
     private static GeoJsonFeature ToOgcFeature(
         Feature feature,
+        LayerDefinition layer,
         AxisOrder axisOrder,
         OgcFeaturesGeometryServices geometryServices,
         ImmutableHashSet<string>? projectedProperties = null,
         ImmutableArray<Link>? links = null)
     {
         var geometry = geometryServices.ConvertWkbToSimpleGeometry(feature.Geometry, axisOrder);
-        Dictionary<string, object?> properties;
-        if (projectedProperties == null)
-        {
-            properties = feature.Attributes.ToDictionary(
-                static kvp => kvp.Key,
-                static kvp => kvp.Value,
-                StringComparer.OrdinalIgnoreCase);
-        }
-        else
-        {
-            properties = feature.Attributes
-                .Where(kvp => projectedProperties.Contains(kvp.Key))
-                .ToDictionary(
-                    static kvp => kvp.Key,
-                    static kvp => kvp.Value,
-                    StringComparer.OrdinalIgnoreCase);
-        }
+        var properties = BuildOgcProperties(feature.Attributes, layer, projectedProperties);
 
         return new GeoJsonFeature
         {
@@ -613,28 +668,13 @@ internal sealed partial class OgcFeaturesQueryHandler(
 
     private static GeoJsonFeature ToOgcFeature(
         EncodedGeoJsonFeature feature,
+        LayerDefinition layer,
         AxisOrder axisOrder,
         OgcFeaturesGeometryServices geometryServices,
         ImmutableHashSet<string>? projectedProperties = null,
         ImmutableArray<Link>? links = null)
     {
-        Dictionary<string, object?> properties;
-        if (projectedProperties == null)
-        {
-            properties = feature.Attributes.ToDictionary(
-                static kvp => kvp.Key,
-                static kvp => kvp.Value,
-                StringComparer.OrdinalIgnoreCase);
-        }
-        else
-        {
-            properties = feature.Attributes
-                .Where(kvp => projectedProperties.Contains(kvp.Key))
-                .ToDictionary(
-                    static kvp => kvp.Key,
-                    static kvp => kvp.Value,
-                    StringComparer.OrdinalIgnoreCase);
-        }
+        var properties = BuildOgcProperties(feature.Attributes, layer, projectedProperties);
 
         return new GeoJsonFeature
         {
@@ -644,6 +684,29 @@ internal sealed partial class OgcFeaturesQueryHandler(
             Properties = properties,
             Links = links
         };
+    }
+
+    private static Dictionary<string, object?> BuildOgcProperties(
+        ImmutableDictionary<string, object?> attributes,
+        LayerDefinition layer,
+        ImmutableHashSet<string>? projectedProperties)
+    {
+        var properties = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var field in layer.AttributeFields)
+        {
+            if (projectedProperties != null && !projectedProperties.Contains(field.Name))
+            {
+                continue;
+            }
+
+            if (attributes.TryGetValue(field.Name, out var value))
+            {
+                properties[field.Name] = value;
+            }
+        }
+
+        return properties;
     }
 
     private static string[] ResolveCsvFieldNames(
@@ -1025,12 +1088,14 @@ internal sealed partial class OgcFeaturesQueryHandler(
     private static async Task StreamFeatureCollectionAsync(
         HttpContext context,
         IAsyncEnumerable<Feature> features,
+        LayerDefinition layer,
         string collectionId,
         AxisOrder axisOrder,
         OgcFeaturesGeometryServices geometryServices,
         ImmutableHashSet<string>? projectedProperties,
         string outputFormat,
         ImmutableArray<Link> links,
+        bool includeFeatureLinks,
         long numberMatched,
         CancellationToken cancellationToken)
     {
@@ -1048,12 +1113,14 @@ internal sealed partial class OgcFeaturesQueryHandler(
         var featuresSinceFlush = 0;
         await foreach (var feature in features.WithCancellation(cancellationToken))
         {
-            var featureLinks = OgcFeaturesUtilities.BuildFeatureLinks(
-                context.Request,
-                collectionId,
-                FormattableString.Invariant($"{feature.Id}"),
-                outputFormat);
-            var ogcFeature = ToOgcFeature(feature, axisOrder, geometryServices, projectedProperties, featureLinks);
+            ImmutableArray<Link>? featureLinks = includeFeatureLinks
+                ? OgcFeaturesUtilities.BuildFeatureLinks(
+                    context.Request,
+                    collectionId,
+                    FormattableString.Invariant($"{feature.Id}"),
+                    outputFormat)
+                : null;
+            var ogcFeature = ToOgcFeature(feature, layer, axisOrder, geometryServices, projectedProperties, featureLinks);
             JsonSerializer.Serialize(writer, ogcFeature, OgcJsonContext.Default.GeoJsonFeature);
 
             numberReturned++;
@@ -1095,6 +1162,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
         private readonly AxisOrder _axisOrder;
         private readonly string _outputFormat;
         private readonly ImmutableArray<Link> _links;
+        private readonly bool _includeFeatureLinks;
         private readonly ImmutableHashSet<string>? _projectedProperties;
         private readonly long _numberMatched;
         private readonly string _crsUri;
@@ -1111,6 +1179,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
             ImmutableHashSet<string>? projectedProperties,
             string outputFormat,
             ImmutableArray<Link> links,
+            bool includeFeatureLinks,
             long numberMatched,
             string crsUri,
             CancellationToken requestCancellationToken)
@@ -1124,6 +1193,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
             _projectedProperties = projectedProperties;
             _outputFormat = outputFormat;
             _links = links;
+            _includeFeatureLinks = includeFeatureLinks;
             _numberMatched = numberMatched;
             _crsUri = crsUri;
             _requestCancellationToken = requestCancellationToken;
@@ -1149,12 +1219,14 @@ internal sealed partial class OgcFeaturesQueryHandler(
             await StreamFeatureCollectionAsync(
                 httpContext,
                 stream,
+                _layer,
                 _collectionId,
                 _axisOrder,
                 _geometryServices,
                 _projectedProperties,
                 _outputFormat,
                 _links,
+                _includeFeatureLinks,
                 _numberMatched,
                 cancellationToken);
         }

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesQueryHandler.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesQueryHandler.cs
@@ -692,9 +692,15 @@ internal sealed partial class OgcFeaturesQueryHandler(
         ImmutableHashSet<string>? projectedProperties)
     {
         var properties = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        var objectIdFieldName = layer.ObjectIdFieldName;
 
         foreach (var field in layer.AttributeFields)
         {
+            if (field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
             if (projectedProperties != null && !projectedProperties.Contains(field.Name))
             {
                 continue;

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesServiceCollectionExtensions.cs
@@ -7,9 +7,13 @@ namespace Honua.Server.Features.OgcFeatures;
 
 internal static class OgcFeaturesServiceCollectionExtensions
 {
-    public static IServiceCollection AddOgcFeatures(this IServiceCollection services)
+    public static IServiceCollection AddOgcFeatures(this IServiceCollection services, IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.Configure<OgcFeaturesOptions>(
+            configuration.GetSection(OgcFeaturesOptions.SectionName));
 
         services.AddScoped<OgcFeaturesGeometryServices>();
         services.AddScoped<OgcFilterProcessor>();

--- a/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
+++ b/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
@@ -45,6 +45,7 @@ internal sealed class Wfs20Handler
     private readonly IGmlFeatureStore _gmlFeatureStore;
     private readonly IFilterExpressionService _filterExpressionService;
     private readonly OgcFeaturesGeometryServices _geometryServices;
+    private readonly Wfs20Options _wfs20Options;
 
     public Wfs20Handler(
         ILogger<Wfs20Handler> logger,
@@ -56,6 +57,7 @@ internal sealed class Wfs20Handler
         _gmlFeatureStore = queryServices.GmlFeatureStore;
         _filterExpressionService = queryServices.FilterExpressionService;
         _geometryServices = queryServices.GeometryServices;
+        _wfs20Options = queryServices.Wfs20Options;
     }
 
     public async Task<WfsCapabilities> HandleGetCapabilitiesAsync(
@@ -184,6 +186,36 @@ internal sealed class Wfs20Handler
                     : CreateEmptyFeatureCollectionResult(normalizedFormat);
             }
 
+            if (ShouldUsePagedGetFeatureFastPath(selectedTypes, normalizedFormat, isHitsRequest, maxFeatures))
+            {
+                var descriptor = selectedTypes[0];
+                var query = BuildFeatureQuery(
+                    descriptor.Layer,
+                    propertyName,
+                    sortBy,
+                    bbox,
+                    filter,
+                    resourceId,
+                    srsName) with
+                {
+                    Offset = offset,
+                    Limit = maxFeatures
+                };
+
+                var pagedResult = await BuildPagedGetFeatureResultAsync(
+                    descriptor,
+                    query,
+                    normalizedFormat,
+                    cancellationToken);
+
+                Wfs20Log.GetFeatureReturned(
+                    _logger,
+                    pagedResult.ReturnedCount,
+                    pagedResult.NumberMatchedSummary);
+
+                return pagedResult.Result;
+            }
+
             var planSet = await BuildLayerQueryPlansAsync(
                 selectedTypes,
                 propertyName,
@@ -205,7 +237,11 @@ internal sealed class Wfs20Handler
 
             if (isHitsRequest)
             {
-                Wfs20Log.GetFeatureReturned(_logger, 0, planSet.TotalMatched);
+                if (_logger.IsEnabled(LogLevel.Information))
+                {
+                    var matchedSummary = planSet.TotalMatched.ToString(CultureInfo.InvariantCulture);
+                    Wfs20Log.GetFeatureReturned(_logger, 0, matchedSummary);
+                }
                 return CreateHitsFeatureCollectionResult(planSet.TotalMatched);
             }
 
@@ -216,10 +252,14 @@ internal sealed class Wfs20Handler
                 _ => await BuildGmlResultAsync(planSet, cancellationToken)
             };
 
-            Wfs20Log.GetFeatureReturned(
-                _logger,
-                returnedCount,
-                planSet.TotalMatched);
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                var matchedSummary = planSet.TotalMatched.ToString(CultureInfo.InvariantCulture);
+                Wfs20Log.GetFeatureReturned(
+                    _logger,
+                    returnedCount,
+                    matchedSummary);
+            }
 
             return result;
         }
@@ -1247,6 +1287,124 @@ internal sealed class Wfs20Handler
         return (Results.Json(payload, OgcJsonContext.Default.FeatureCollection, contentType: contentType), features.Count);
     }
 
+    private async Task<PagedGetFeatureResult> BuildPagedGetFeatureResultAsync(
+        WfsFeatureTypeDescriptor descriptor,
+        FeatureQuery query,
+        string normalizedFormat,
+        CancellationToken cancellationToken)
+    {
+        if (string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.Csv, StringComparison.OrdinalIgnoreCase))
+        {
+            if (_featureReader is not IPagedFeatureReader pagedFeatureReader)
+            {
+                throw new InvalidOperationException("Paged feature queries are not supported by the configured feature store.");
+            }
+
+            var result = await pagedFeatureReader.QueryPageAsync(descriptor.Layer.Id, query, cancellationToken);
+            var rows = new List<Dictionary<string, string?>>();
+            var attributeHeaders = GetProjectedAttributeFields(descriptor.Layer, query)
+                .Select(field => field.Name)
+                .ToArray();
+
+            foreach (var feature in result.Items)
+            {
+                var row = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["typeName"] = descriptor.QualifiedName,
+                    ["id"] = BuildFeatureId(descriptor, feature.Id)
+                };
+
+                foreach (var field in GetProjectedAttributeFields(descriptor.Layer, query))
+                {
+                    row[field.Name] = feature.Attributes.TryGetValue(field.Name, out var value)
+                        ? ConvertToInvariantString(value)
+                        : null;
+                }
+
+                if (descriptor.Layer.HasGeometry)
+                {
+                    row["geometry"] = SerializeGeometryAsJson(feature.Geometry);
+                }
+
+                rows.Add(row);
+            }
+
+            var headers = new List<string> { "typeName", "id" };
+            headers.AddRange(attributeHeaders);
+            if (descriptor.Layer.HasGeometry)
+            {
+                headers.Add("geometry");
+            }
+
+            var csv = new StringBuilder();
+            csv.AppendLine(string.Join(",", headers.Select(EscapeCsv)));
+            foreach (var row in rows)
+            {
+                csv.AppendLine(string.Join(",", headers.Select(header =>
+                    EscapeCsv(row.TryGetValue(header, out var value) ? value : null))));
+            }
+
+            return new PagedGetFeatureResult(
+                Results.Content(csv.ToString(), MediaTypes.Csv, Encoding.UTF8),
+                rows.Count,
+                FormatNumberMatched(result.TotalCount));
+        }
+
+        var features = new List<GeoJsonFeature>();
+        long? totalCount = null;
+
+        if (_featureReader is IPagedGeoJsonFeatureStore pagedGeoJsonFeatureStore)
+        {
+            var result = await pagedGeoJsonFeatureStore.QueryGeoJsonPageAsync(descriptor.Layer.Id, query, cancellationToken);
+            totalCount = result.TotalCount;
+            foreach (var feature in result.Items)
+            {
+                features.Add(new GeoJsonFeature
+                {
+                    Id = BuildFeatureId(descriptor, feature.Id),
+                    Geometry = _geometryServices.ConvertGeoJsonToSimpleGeometry(feature.GeometryGeoJson, AxisOrder.EastNorth),
+                    Properties = BuildGeoJsonProperties(feature.Attributes, descriptor.Layer, query)
+                });
+            }
+        }
+        else if (_featureReader is IPagedFeatureReader pagedFeatureReader)
+        {
+            var result = await pagedFeatureReader.QueryPageAsync(descriptor.Layer.Id, query, cancellationToken);
+            totalCount = result.TotalCount;
+            foreach (var feature in result.Items)
+            {
+                var geometry = _geometryServices.ConvertWkbToSimpleGeometry(feature.Geometry, AxisOrder.EastNorth);
+                features.Add(new GeoJsonFeature
+                {
+                    Id = BuildFeatureId(descriptor, feature.Id),
+                    Geometry = geometry,
+                    Properties = BuildGeoJsonProperties(feature.Attributes, descriptor.Layer, query)
+                });
+            }
+        }
+        else
+        {
+            throw new InvalidOperationException("Paged feature queries are not supported by the configured feature store.");
+        }
+
+        var payload = new FeatureCollection
+        {
+            Features = features.ToArray(),
+            NumberMatched = totalCount,
+            NumberReturned = features.Count,
+            TimeStamp = DateTimeOffset.UtcNow
+        };
+
+        var contentType = string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.Json, StringComparison.OrdinalIgnoreCase)
+            ? MediaTypes.Json
+            : MediaTypes.GeoJson;
+
+        return new PagedGetFeatureResult(
+            Results.Json(payload, OgcJsonContext.Default.FeatureCollection, contentType: contentType),
+            features.Count,
+            FormatNumberMatched(totalCount));
+    }
+
     private async Task<(IResult Result, int ReturnedCount)> BuildCsvResultAsync(
         LayerQueryPlanSet planSet,
         CancellationToken cancellationToken)
@@ -1421,8 +1579,14 @@ internal sealed class Wfs20Handler
         FeatureQuery query)
     {
         var properties = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        var objectIdFieldName = layer.ObjectIdFieldName;
         foreach (var field in GetProjectedAttributeFields(layer, query))
         {
+            if (field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
             if (attributes.TryGetValue(field.Name, out var value))
             {
                 properties[field.Name] = value;
@@ -1838,6 +2002,42 @@ internal sealed class Wfs20Handler
 
     private static string XmlEscape(string value) => SecurityElement.Escape(value) ?? string.Empty;
 
+    private bool ShouldUsePagedGetFeatureFastPath(
+        IReadOnlyList<WfsFeatureTypeDescriptor> selectedTypes,
+        string normalizedFormat,
+        bool isHitsRequest,
+        int maxFeatures)
+    {
+        if (_wfs20Options.NumberMatchedPolicy != Wfs20NumberMatchedPolicy.UnknownWhenExpensive)
+        {
+            return false;
+        }
+
+        if (isHitsRequest || selectedTypes.Count != 1 || maxFeatures <= 0)
+        {
+            return false;
+        }
+
+        if (string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.Csv, StringComparison.OrdinalIgnoreCase))
+        {
+            return _featureReader is IPagedFeatureReader;
+        }
+
+        var isJsonFormat =
+            string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.GeoJson, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.Json, StringComparison.OrdinalIgnoreCase);
+
+        if (!isJsonFormat)
+        {
+            return false;
+        }
+
+        return _featureReader is IPagedGeoJsonFeatureStore || _featureReader is IPagedFeatureReader;
+    }
+
+    private static string FormatNumberMatched(long? totalCount)
+        => totalCount?.ToString(CultureInfo.InvariantCulture) ?? "unknown";
+
     private sealed record WfsFeatureTypeDescriptor(
         LayerDefinition Layer,
         string QualifiedName,
@@ -1861,6 +2061,11 @@ internal sealed class Wfs20Handler
     private readonly record struct LayerValuePlanSet(
         ImmutableArray<LayerValuePlan> Plans,
         long TotalMatched);
+
+    private readonly record struct PagedGetFeatureResult(
+        IResult Result,
+        int ReturnedCount,
+        string NumberMatchedSummary);
 
     private readonly record struct ValueReferenceResolution(
         string RequestedName,

--- a/src/Honua.Server/Features/Wfs20/Services/Wfs20QueryServices.cs
+++ b/src/Honua.Server/Features/Wfs20/Services/Wfs20QueryServices.cs
@@ -6,6 +6,7 @@ using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Queries.Filters;
 using Honua.Server.Features.OgcFeatures;
 using Honua.Server.Features.OgcFeatures.Services;
+using Microsoft.Extensions.Options;
 
 namespace Honua.Server.Features.Wfs20.Services;
 
@@ -18,7 +19,8 @@ internal sealed class Wfs20QueryServices(
     IFeatureReader featureReader,
     IGmlFeatureStore gmlFeatureStore,
     IFilterExpressionService filterExpressionService,
-    OgcFeaturesGeometryServices geometryServices)
+    OgcFeaturesGeometryServices geometryServices,
+    IOptions<Wfs20Options> wfs20Options)
 {
     internal ILayerCatalog LayerCatalog { get; } = layerCatalog;
 
@@ -29,4 +31,6 @@ internal sealed class Wfs20QueryServices(
     internal IFilterExpressionService FilterExpressionService { get; } = filterExpressionService;
 
     internal OgcFeaturesGeometryServices GeometryServices { get; } = geometryServices;
+
+    internal Wfs20Options Wfs20Options { get; } = wfs20Options?.Value ?? throw new ArgumentNullException(nameof(wfs20Options));
 }

--- a/src/Honua.Server/Features/Wfs20/Wfs20Log.cs
+++ b/src/Honua.Server/Features/Wfs20/Wfs20Log.cs
@@ -42,7 +42,7 @@ internal static partial class Wfs20Log
     /// Logs when GetFeature response is returned
     /// </summary>
     [LoggerMessage(Level = LogLevel.Information, Message = "WFS 2.0 GetFeature response returned with {FeatureCount} features, matched: {NumberMatched}")]
-    public static partial void GetFeatureReturned(ILogger logger, int featureCount, long numberMatched);
+    public static partial void GetFeatureReturned(ILogger logger, int featureCount, string numberMatched);
 
     /// <summary>
     /// Logs when a GetPropertyValue request is received

--- a/src/Honua.Server/Features/Wfs20/Wfs20Options.cs
+++ b/src/Honua.Server/Features/Wfs20/Wfs20Options.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Wfs20;
+
+internal sealed class Wfs20Options
+{
+    public const string SectionName = "Wfs20";
+
+    /// <summary>
+    /// Controls whether GetFeature computes an exact numberMatched value for finite page reads.
+    /// </summary>
+    public Wfs20NumberMatchedPolicy NumberMatchedPolicy { get; set; } = Wfs20NumberMatchedPolicy.Exact;
+}
+
+internal enum Wfs20NumberMatchedPolicy
+{
+    Exact = 0,
+    UnknownWhenExpensive = 1
+}

--- a/src/Honua.Server/Features/Wfs20/Wfs20ServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Wfs20/Wfs20ServiceCollectionExtensions.cs
@@ -13,9 +13,13 @@ internal static class Wfs20ServiceCollectionExtensions
     /// <summary>
     /// Registers WFS 2.0 services
     /// </summary>
-    internal static IServiceCollection AddWfs20(this IServiceCollection services)
+    internal static IServiceCollection AddWfs20(this IServiceCollection services, IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.Configure<Wfs20Options>(
+            configuration.GetSection(Wfs20Options.SectionName));
 
         // Register WFS 2.0 core services following established patterns
         services.AddScoped<Wfs20QueryServices>();

--- a/src/Honua.Server/Honua.Server.csproj
+++ b/src/Honua.Server/Honua.Server.csproj
@@ -89,7 +89,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Content Include="..\..\docs\api-specs\admin-api.json" Link="admin-openapi.json">
+    <Content Include="..\..\docs\developer\api-specs\admin-api.json" Link="admin-openapi.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>

--- a/tests/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderSelectProjectionTests.cs
+++ b/tests/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderSelectProjectionTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Postgres.Features.FeatureStore.Services;
+using Microsoft.Extensions.ObjectPool;
+using FeatureStoreStringBuilderPooledObjectPolicy = Honua.Postgres.Features.FeatureStore.Services.StringBuilderPooledObjectPolicy;
+
+namespace Honua.Postgres.Tests.Features.FeatureStore;
+
+public sealed class FeatureQueryBuilderSelectProjectionTests
+{
+    [Fact]
+    public void BuildSelectQuery_WithOutFields_ProjectsRequestedAttributes()
+    {
+        var queryBuilder = CreateQueryBuilder();
+        var query = new FeatureQuery
+        {
+            OutFields = ImmutableArray.Create("population", "objectid", "population")
+        };
+
+        var result = queryBuilder.BuildSelectQuery(layerId: 1, query);
+
+        result.Sql.Should().Contain("jsonb_build_object('population', attributes -> $2)::text AS attributes");
+        result.Sql.Should().NotContain("SELECT objectid, ST_AsBinary(geometry), attributes FROM");
+        result.WhereParameters.Should().Equal("population");
+    }
+
+    [Fact]
+    public void BuildSelectQuery_WithExcludedAttributes_SelectsNullAttributes()
+    {
+        var queryBuilder = CreateQueryBuilder();
+        var query = new FeatureQuery
+        {
+            ExcludeAttributes = true
+        };
+
+        var result = queryBuilder.BuildSelectQuery(layerId: 1, query);
+
+        result.Sql.Should().Contain("NULL AS attributes");
+        result.WhereParameters.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildOptimizedSelectQuery_WithOutFields_ProjectsRequestedAttributes()
+    {
+        var queryBuilder = CreateQueryBuilder();
+        var query = new FeatureQuery
+        {
+            Limit = 10,
+            OutFields = ImmutableArray.Create("category")
+        };
+
+        var result = queryBuilder.BuildOptimizedSelectQuery(layerId: 1, query);
+
+        result.Sql.Should().Contain("jsonb_build_object('category', attributes -> $2)::text AS attributes");
+        result.Sql.Should().Contain("COUNT(*) OVER()");
+        result.WhereParameters.Should().Equal("category", 10);
+    }
+
+    private static FeatureQueryBuilder CreateQueryBuilder()
+    {
+        var poolProvider = new DefaultObjectPoolProvider();
+        var stringBuilderPool = poolProvider.Create(new FeatureStoreStringBuilderPooledObjectPolicy());
+        var geometryProcessor = new GeometryProcessor();
+        return new FeatureQueryBuilder(stringBuilderPool, geometryProcessor);
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Admin/TileOperationJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/TileOperationJobServiceTests.cs
@@ -141,6 +141,7 @@ public sealed class TileOperationJobServiceTests
             cacheStore: null,
             responseCache: null,
             metadataCache: null,
+            scopeFactory: serviceScopeFactory,
             NullLogger<OutputCacheInvalidationService>.Instance);
 
         return new TileOperationJobService(

--- a/tests/Honua.Server.Tests/Features/Caching/CachingLayerCatalogTests.cs
+++ b/tests/Honua.Server.Tests/Features/Caching/CachingLayerCatalogTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Honua.Core.Features.Caching;
 using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Monitoring;
 using Honua.Core.Features.Shared.Models;
 using Honua.Server.Features.Infrastructure.Caching;
@@ -311,6 +312,40 @@ public sealed class CachingLayerCatalogTests : IDisposable
         _innerCatalog.ListLayersCallCount.Should().Be(1);
     }
 
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_DifferentSchemaContexts_DoNotShareCacheEntries()
+    {
+        using var sharedCache = new RedisCacheService(
+            null,
+            Options.Create(_options),
+            new MockLogger<RedisCacheService>(),
+            _performanceMonitor);
+
+        var innerCatalogA = new MockLayerCatalog("A");
+        var innerCatalogB = new MockLayerCatalog("B");
+        var catalogA = new CachingLayerCatalog(
+            innerCatalogA,
+            sharedCache,
+            Options.Create(_options),
+            new TestSchemaContext("schema_a"));
+        var catalogB = new CachingLayerCatalog(
+            innerCatalogB,
+            sharedCache,
+            Options.Create(_options),
+            new TestSchemaContext("schema_b"));
+
+        var layerA = await catalogA.GetLayerAsync(1);
+        var layerB = await catalogB.GetLayerAsync(1);
+
+        layerA.Should().NotBeNull();
+        layerB.Should().NotBeNull();
+        layerA!.Name.Should().Be("ALayer1");
+        layerB!.Name.Should().Be("BLayer1");
+        innerCatalogA.GetLayerCallCount.Should().Be(1);
+        innerCatalogB.GetLayerCallCount.Should().Be(1);
+    }
+
     internal sealed class MockLayerCatalog : ILayerCatalog
     {
         private static readonly string[] _defaultFormats = ["json", "geojson"];
@@ -329,6 +364,12 @@ public sealed class CachingLayerCatalogTests : IDisposable
         public int ServiceExistsCallCount { get; set; }
         public int GetRelationshipCallCount { get; set; }
         public int ListRelationshipsCallCount { get; set; }
+        private readonly string _namePrefix;
+
+        public MockLayerCatalog(string namePrefix = "")
+        {
+            _namePrefix = namePrefix;
+        }
 
         public Task<LayerDefinition?> GetLayerAsync(int layerId, CancellationToken cancellationToken = default)
         {
@@ -337,13 +378,13 @@ public sealed class CachingLayerCatalogTests : IDisposable
             {
                 return Task.FromResult<LayerDefinition?>(null);
             }
-            return Task.FromResult<LayerDefinition?>(CreateTestLayer(layerId));
+            return Task.FromResult<LayerDefinition?>(CreateTestLayer(layerId, _namePrefix));
         }
 
         public Task<LayerDefinition[]> ListLayersAsync(CancellationToken cancellationToken = default)
         {
             ListLayersCallCount++;
-            return Task.FromResult(new[] { CreateTestLayer(1), CreateTestLayer(2) });
+            return Task.FromResult(new[] { CreateTestLayer(1, _namePrefix), CreateTestLayer(2, _namePrefix) });
         }
 
         public Task<ServiceDefinition?> GetServiceAsync(string serviceName, CancellationToken cancellationToken = default)
@@ -353,13 +394,13 @@ public sealed class CachingLayerCatalogTests : IDisposable
             {
                 return Task.FromResult<ServiceDefinition?>(null);
             }
-            return Task.FromResult<ServiceDefinition?>(CreateTestService(serviceName));
+            return Task.FromResult<ServiceDefinition?>(CreateTestService(serviceName, _namePrefix));
         }
 
         public Task<ServiceDefinition[]> ListServicesAsync(CancellationToken cancellationToken = default)
         {
             ListServicesCallCount++;
-            return Task.FromResult(new[] { CreateTestService("Service1"), CreateTestService("Service2") });
+            return Task.FromResult(new[] { CreateTestService("Service1", _namePrefix), CreateTestService("Service2", _namePrefix) });
         }
 
         public Task<bool> LayerExistsAsync(int layerId, CancellationToken cancellationToken = default)
@@ -394,11 +435,11 @@ public sealed class CachingLayerCatalogTests : IDisposable
             return Task.FromResult(Array.Empty<Relationship>());
         }
 
-        private static LayerDefinition CreateTestLayer(int id)
+        private static LayerDefinition CreateTestLayer(int id, string namePrefix)
         {
             return new LayerDefinition(
                 id,
-                $"Layer{id}",
+                $"{namePrefix}Layer{id}",
                 $"Test layer {id}",
                 GeometryType.Point,
                 SpatialReference.WGS84,
@@ -410,16 +451,21 @@ public sealed class CachingLayerCatalogTests : IDisposable
                 Relationships: _defaultRelationships);
         }
 
-        private static ServiceDefinition CreateTestService(string name)
+        private static ServiceDefinition CreateTestService(string name, string namePrefix)
         {
             return new ServiceDefinition(
-                name,
+                $"{namePrefix}{name}",
                 $"Test service {name}",
-                new[] { CreateTestLayer(1) },
+                new[] { CreateTestLayer(1, namePrefix) },
                 SpatialReference.WGS84,
                 _defaultFormats,
                 _defaultCapabilities);
         }
+    }
+
+    private sealed class TestSchemaContext(string currentSchema) : ISchemaContext
+    {
+        public string? CurrentSchema { get; } = currentSchema;
     }
 
     internal sealed class MockLogger<T> : ILogger<T>

--- a/tests/Honua.Server.Tests/Features/Caching/OutputCacheInvalidationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Caching/OutputCacheInvalidationServiceTests.cs
@@ -46,6 +46,14 @@ public sealed class OutputCacheInvalidationServiceTests
         await metadataCache.Received().RemoveAsync("layer:2", Arg.Any<CancellationToken>());
         await metadataCache.Received().RemoveByPatternAsync("relationship:1:*", Arg.Any<CancellationToken>());
         await metadataCache.Received().RemoveByPatternAsync("relationship:2:*", Arg.Any<CancellationToken>());
+        await metadataCache.Received().RemoveByPatternAsync("scope:*:services:all", Arg.Any<CancellationToken>());
+        await metadataCache.Received().RemoveByPatternAsync("scope:*:layers:all", Arg.Any<CancellationToken>());
+        await metadataCache.Received().RemoveByPatternAsync("scope:*:service:testservice", Arg.Any<CancellationToken>());
+        await metadataCache.Received().RemoveByPatternAsync("scope:*:service:exists:testservice", Arg.Any<CancellationToken>());
+        await metadataCache.Received().RemoveByPatternAsync("scope:*:layer:1", Arg.Any<CancellationToken>());
+        await metadataCache.Received().RemoveByPatternAsync("scope:*:layer:2", Arg.Any<CancellationToken>());
+        await metadataCache.Received().RemoveByPatternAsync("scope:*:relationship:1:*", Arg.Any<CancellationToken>());
+        await metadataCache.Received().RemoveByPatternAsync("scope:*:relationship:2:*", Arg.Any<CancellationToken>());
 
         await responseCache.Received().RemoveByPatternAsync("response:query:featureserver:service:testservice:*", Arg.Any<CancellationToken>());
         await responseCache.Received().RemoveByPatternAsync("response:query:featureserver:service:testservice:layer:1:*", Arg.Any<CancellationToken>());

--- a/tests/Honua.Server.Tests/Features/Caching/OutputCacheInvalidationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Caching/OutputCacheInvalidationServiceTests.cs
@@ -3,11 +3,15 @@
 
 using FluentAssertions;
 using Honua.Core.Features.Caching.Abstractions;
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.Infrastructure.Caching;
+using Honua.Core.Features.Shared.Models;
 using Honua.Server.Features.Infrastructure.Caching;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
@@ -23,8 +27,9 @@ public sealed class OutputCacheInvalidationServiceTests
         var outputCacheStore = Substitute.For<IOutputCacheStore>();
         var responseCache = Substitute.For<IResponseCache>();
         var metadataCache = Substitute.For<ICacheService>();
+        var scopeFactory = new ServiceCollection().BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
         var logger = NullLogger<OutputCacheInvalidationService>.Instance;
-        var sut = new OutputCacheInvalidationService(outputCacheStore, responseCache, metadataCache, logger);
+        var sut = new OutputCacheInvalidationService(outputCacheStore, responseCache, metadataCache, scopeFactory, logger);
 
         await sut.InvalidateServiceCatalogAsync("TestService", [1, 2, 2], CancellationToken.None);
 
@@ -56,8 +61,9 @@ public sealed class OutputCacheInvalidationServiceTests
         var outputCacheStore = Substitute.For<IOutputCacheStore>();
         var responseCache = Substitute.For<IResponseCache>();
         var metadataCache = Substitute.For<ICacheService>();
+        var scopeFactory = new ServiceCollection().BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
         var logger = NullLogger<OutputCacheInvalidationService>.Instance;
-        var sut = new OutputCacheInvalidationService(outputCacheStore, responseCache, metadataCache, logger);
+        var sut = new OutputCacheInvalidationService(outputCacheStore, responseCache, metadataCache, scopeFactory, logger);
 
         await sut.InvalidateServiceCatalogAsync("TestService", null, CancellationToken.None);
 
@@ -68,11 +74,54 @@ public sealed class OutputCacheInvalidationServiceTests
     [Operation(Operations.Cache)]
     public async Task InvalidateServiceCatalogAsync_WithNullCaches_DoesNotThrow()
     {
+        var scopeFactory = new ServiceCollection().BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
         var logger = NullLogger<OutputCacheInvalidationService>.Instance;
-        var sut = new OutputCacheInvalidationService(null, null, null, logger);
+        var sut = new OutputCacheInvalidationService(null, null, null, scopeFactory, logger);
 
         var act = async () => await sut.InvalidateServiceCatalogAsync("svc", [3], CancellationToken.None);
 
         await act.Should().NotThrowAsync();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task InvalidateLayerAsync_WithoutServiceId_ResolvesOwningServices()
+    {
+        var outputCacheStore = Substitute.For<IOutputCacheStore>();
+        var responseCache = Substitute.For<IResponseCache>();
+        var metadataCache = Substitute.For<ICacheService>();
+        var layerCatalog = Substitute.For<ILayerCatalog>();
+        layerCatalog.ListServicesAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                CreateService("alpha", 7),
+                CreateService("beta", 7, 9),
+                CreateService("gamma", 9)
+            ]);
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => layerCatalog);
+        var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+        var logger = NullLogger<OutputCacheInvalidationService>.Instance;
+        var sut = new OutputCacheInvalidationService(outputCacheStore, responseCache, metadataCache, scopeFactory, logger);
+
+        await sut.InvalidateLayerAsync(null, 7, CancellationToken.None);
+
+        await outputCacheStore.Received().EvictByTagAsync("service:alpha", Arg.Any<CancellationToken>());
+        await outputCacheStore.Received().EvictByTagAsync("service:beta", Arg.Any<CancellationToken>());
+        await responseCache.Received().RemoveByPatternAsync("response:query:featureserver:service:alpha:layer:7:*", Arg.Any<CancellationToken>());
+        await responseCache.Received().RemoveByPatternAsync("response:query:featureserver:service:beta:layer:7:*", Arg.Any<CancellationToken>());
+    }
+
+    private static ServiceDefinition CreateService(string name, params int[] layerIds)
+    {
+        var layers = layerIds
+            .Select(layerId => LayerDefinition.CreateBasic(layerId, $"Layer {layerId}", GeometryType.Point))
+            .ToArray();
+
+        return new ServiceDefinition(
+            name,
+            $"Service {name}",
+            layers,
+            SpatialReference.Create(4326));
     }
 }

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
@@ -155,6 +155,46 @@ public sealed class FeatureServerQueryExecutorTests
     }
 
     [Fact]
+    public async Task QueryWithValidationAsync_WhenPagedQuerySupported_UsesPagedFastPath()
+    {
+        var featureReader = Substitute.For<IFeatureReader, IPagedFeatureReader>();
+        var expectedItems = ImmutableArray.Create(CreateFeature(1, "alpha"), CreateFeature(2, "beta"));
+        ((IPagedFeatureReader)featureReader)
+            .QueryPageAsync(5, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(PagedQueryResult<Feature>.Create(expectedItems, hasMoreResults: true)));
+
+        var sut = CreateSut(featureReader);
+        var query = new FeatureQuery { Limit = 2 };
+
+        var result = await sut.QueryWithValidationAsync(5, query, CancellationToken.None);
+
+        result.Items.Should().BeEquivalentTo(expectedItems);
+        result.HasMoreResults.Should().BeTrue();
+        result.TotalCount.Should().Be(3);
+        await ((IPagedFeatureReader)featureReader).Received(1).QueryPageAsync(5, query, Arg.Any<CancellationToken>());
+        await featureReader.DidNotReceive().QueryAsync(Arg.Any<int>(), Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task QueryWithValidationAsync_WhenPagedQueryNotSupported_FallsBackToRegularQuery()
+    {
+        var featureReader = Substitute.For<IFeatureReader>();
+        var expected = QueryResult<Feature>.Create(
+            totalCount: 2,
+            items: ImmutableArray.Create(CreateFeature(1, "alpha"), CreateFeature(2, "beta")));
+        featureReader.QueryAsync(5, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var sut = CreateSut(featureReader);
+        var query = new FeatureQuery { Limit = 2 };
+
+        var result = await sut.QueryWithValidationAsync(5, query, CancellationToken.None);
+
+        result.Should().Be(expected);
+        await featureReader.Received(1).QueryAsync(5, query, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task StreamQueryAsync_WithPagedQuery_UsesLimitProbeInsteadOfCount()
     {
         var featureReader = Substitute.For<IFeatureReader>();

--- a/tests/Honua.Server.Tests/Features/MapServer/Rendering/StyleTranslatorTests.cs
+++ b/tests/Honua.Server.Tests/Features/MapServer/Rendering/StyleTranslatorTests.cs
@@ -93,6 +93,32 @@ public class StyleTranslatorTests
     }
 
     [UnitTest]
+    public void CollectReferencedFields_ReturnsDistinctFieldsFromFilterPaintAndLayout()
+    {
+        const string json = """
+        [
+            {
+                "id": "layer1",
+                "type": "circle",
+                "filter": ["all", ["has", "category"], [">", ["get", "temperature"], 20]],
+                "paint": {
+                    "circle-color": ["case", ["==", ["get", "category"], "hot"], "#ff0000", "#0000ff"],
+                    "circle-radius": ["get", "size"]
+                },
+                "layout": {
+                    "visibility": ["case", ["has", "rank"], "visible", "none"]
+                }
+            }
+        ]
+        """;
+
+        var layers = StyleTranslator.ParseStyleLayers(json);
+        var fields = StyleTranslator.CollectReferencedFields(layers);
+
+        fields.Should().Equal("category", "temperature", "size", "rank");
+    }
+
+    [UnitTest]
     public void ResolveFillStyle_NoPaint_ReturnsDefault()
     {
         var layer = new MapLibreStyleLayer { Type = "fill" };

--- a/tests/Honua.Server.Tests/Features/OgcFeatures/OgcFeaturesItemsTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcFeatures/OgcFeaturesItemsTests.cs
@@ -66,6 +66,34 @@ public class OgcFeaturesItemsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    public async Task GetItems_ReturnsOnlyPublishedProperties()
+    {
+        var queryablesResponse = await _fixture.Client.GetAsync($"/ogc/features/collections/{TestLayerId}/queryables");
+        queryablesResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var queryablesJson = JsonDocument.Parse(await queryablesResponse.Content.ReadAsStringAsync());
+        var publishedProperties = queryablesJson.RootElement
+            .GetProperty("properties")
+            .EnumerateObject()
+            .Select(property => property.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var response = await _fixture.Client.GetAsync($"/ogc/features/collections/{TestLayerId}/items?limit=1");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var featureProperties = json.RootElement
+            .GetProperty("features")[0]
+            .GetProperty("properties")
+            .EnumerateObject()
+            .Select(property => property.Name)
+            .ToArray();
+
+        featureProperties.Should().OnlyContain(property => publishedProperties.Contains(property));
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
     public async Task GetItems_WithOffset_ReturnsOffsetFeatures()
     {
         // Act

--- a/tests/Honua.Server.Tests/Features/OgcFeatures/OgcFeaturesItemsTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcFeatures/OgcFeaturesItemsTests.cs
@@ -94,6 +94,26 @@ public class OgcFeaturesItemsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    public async Task GetItems_DoesNotDuplicateTopLevelIdInProperties()
+    {
+        var featureId = await _fixture.InsertFeatureAsync(TestLayerId, "No Duplicate ID");
+
+        var response = await _fixture.Client.GetAsync(
+            $"/ogc/features/collections/{TestLayerId}/items?ids={featureId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var feature = json.RootElement.GetProperty("features").EnumerateArray().Single();
+        var properties = feature.GetProperty("properties");
+
+        feature.GetProperty("id").GetInt64().Should().Be(featureId);
+        properties.TryGetProperty("id", out _).Should().BeFalse();
+        properties.TryGetProperty("objectid", out _).Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
     public async Task GetItems_WithOffset_ReturnsOffsetFeatures()
     {
         // Act

--- a/tests/Honua.Server.Tests/Features/OgcFeatures/OgcFeaturesNumberMatchedPolicyTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcFeatures/OgcFeaturesNumberMatchedPolicyTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Configuration;
+
+namespace Honua.Server.Tests.Features.OgcFeatures;
+
+[Collection("Database")]
+[Protocol(Protocols.OgcApiFeatures)]
+[Operation(Operations.Query)]
+public sealed class OgcFeaturesNumberMatchedPolicyTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new WebAppFixture()
+        .ConfigureWebHost(builder =>
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["OgcFeatures:NumberMatchedPolicy"] = "OmitWhenExpensive",
+                    ["OgcFeatures:IncludeFeatureLinks"] = "false"
+                })));
+
+    private const int TestLayerId = 0;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    public async Task GetItems_WithOmittedNumberMatchedPolicy_OmitsNumberMatchedForPagedResponses()
+    {
+        var response = await _fixture.Client.GetAsync($"/ogc/features/collections/{TestLayerId}/items?limit=2");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+        var features = json.RootElement.GetProperty("features").EnumerateArray().ToArray();
+
+        features.Length.Should().BeLessThanOrEqualTo(2);
+        json.RootElement.TryGetProperty("numberMatched", out _).Should().BeFalse();
+        json.RootElement.GetProperty("numberReturned").GetInt32().Should().Be(features.Length);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    public async Task GetItems_WithFeatureLinksDisabled_OmitsPerFeatureLinks()
+    {
+        var response = await _fixture.Client.GetAsync($"/ogc/features/collections/{TestLayerId}/items?limit=1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+        var feature = json.RootElement.GetProperty("features")[0];
+
+        feature.TryGetProperty("links", out _).Should().BeFalse();
+        json.RootElement.TryGetProperty("links", out _).Should().BeTrue();
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Wfs20/Wfs20NumberMatchedPolicyTests.cs
+++ b/tests/Honua.Server.Tests/Features/Wfs20/Wfs20NumberMatchedPolicyTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Configuration;
+
+namespace Honua.Server.Tests.Features.Wfs20;
+
+[Collection("Database")]
+[Protocol(Protocols.Wfs20)]
+[Operation(Operations.Query)]
+public sealed class Wfs20NumberMatchedPolicyTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new WebAppFixture()
+        .ConfigureWebHost(builder =>
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Wfs20:NumberMatchedPolicy"] = "UnknownWhenExpensive"
+                })));
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /wfs")]
+    public async Task Wfs_GetFeature_GeoJsonOutput_WithUnknownNumberMatchedPolicy_OmitsNumberMatched()
+    {
+        const string outputFormat = "application/geo%2Bjson";
+        var response = await _fixture.Client.GetAsync(
+            $"/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=test_layer&OUTPUTFORMAT={outputFormat}&COUNT=1");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        using var document = JsonDocument.Parse(content);
+        document.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        document.RootElement.TryGetProperty("numberMatched", out _).Should().BeFalse();
+        document.RootElement.GetProperty("numberReturned").GetInt32().Should().BeLessOrEqualTo(1);
+
+        var features = document.RootElement.GetProperty("features").EnumerateArray().ToArray();
+        if (features.Length > 0)
+        {
+            features[0].GetProperty("id").ValueKind.Should().BeOneOf(JsonValueKind.String, JsonValueKind.Number);
+            features[0].GetProperty("properties").TryGetProperty("id", out _).Should().BeFalse();
+            features[0].GetProperty("properties").TryGetProperty("objectid", out _).Should().BeFalse();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /wfs")]
+    public async Task Wfs_GetFeature_ResultTypeHits_WithUnknownNumberMatchedPolicy_StillReturnsExactCount()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAME=test_layer&RESULTTYPE=hits");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        content.Should().Contain("numberMatched=");
+        content.Should().NotContain("numberMatched=\"unknown\"");
+    }
+}

--- a/tests/Honua.Server.Tests/OgcFeaturesEndpointTests.cs
+++ b/tests/Honua.Server.Tests/OgcFeaturesEndpointTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Net.Http.Json;
+using System.Globalization;
 using FluentAssertions;
 using Honua.Server.Features.Ogc.Common;
 using Honua.TestKit;
@@ -178,6 +179,43 @@ public sealed class OgcFeaturesEndpointTests : IAsyncLifetime
         firstCollection.Id.Should().NotBeNullOrEmpty();
         firstCollection.Links.Should().NotBeEmpty();
         firstCollection.ItemType.Should().Be("feature");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /ogc/features/collections")]
+    public async Task GetCollections_UsesServiceAccessPolicyWhenLayerPolicyIsMissing()
+    {
+        var schema = _fixture.CurrentSchema ?? throw new InvalidOperationException("Schema was not initialized.");
+        await using (var connection = await _fixture.Postgres.GetConnectionAsync(schema))
+        await using (var command = connection.CreateCommand())
+        {
+            command.CommandText = """
+                UPDATE honua.layers
+                SET metadata = NULL
+                WHERE layer_id = @layerId;
+
+                UPDATE honua.services
+                SET metadata = jsonb_build_object('accessPolicy', jsonb_build_object('allowAnonymous', true))
+                WHERE service_name IN (
+                    SELECT service_name
+                    FROM honua.service_layers
+                    WHERE layer_id = @layerId
+                );
+                """;
+            command.Parameters.AddWithValue("@layerId", WebAppFixture.TestLayerId);
+            await command.ExecuteNonQueryAsync();
+        }
+
+        var response = await _fixture.Client.GetAsync("/ogc/features/collections");
+
+        response.Be200Ok();
+
+        var collections = await response.Content.ReadFromJsonAsync<Collections>();
+        collections.Should().NotBeNull();
+        collections!.CollectionList.Select(collection => collection.Id)
+            .Should()
+            .Contain(WebAppFixture.TestLayerId.ToString(CultureInfo.InvariantCulture));
     }
 
     [IntegrationTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #614

## Summary
Reduce counted-query overhead and response-shape bloat across Honua feature protocols, then trim raster query/render overhead on the GeoBench hot path. This bundles the feature-read performance work, WFS fast path, raster projection improvements, and the cache/catalog fixes needed to benchmark the branch reliably.

## Changes Made
- add paged feature-store abstractions so OGC, WFS, and FeatureServer can serve finite-limit reads without forcing exact counts on the hot path
- add OGC and WFS count policies, omit duplicated feature ids from `properties`, and keep default item payloads aligned with published fields
- project raster query attributes from style usage so WMS/export/tile requests avoid pulling unused JSON attributes
- tighten scoped metadata invalidation and OGC collections visibility so benchmark-published services become visible without stale catalog state
- add the missing `CODEX.md` instruction stub so instruction sync checks pass in CI

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
