### PR TITLE
feat: H3 spatial indexing: hexagonal grid analytics, aggregation, and visualization (#373)

### DIFF
--- a/src/Honua.Core/Configuration/LimitsOptions.cs
+++ b/src/Honua.Core/Configuration/LimitsOptions.cs
@@ -94,6 +94,13 @@ public sealed class QueryLimits
     public double? MaxBboxAreaSqKm { get; init; } = 100000000d;
 
     /// <summary>
+    /// Maximum number of H3 cells returned by an H3 aggregation query.
+    /// Prevents unbounded result sets at high resolutions. Range: 100-1,000,000.
+    /// </summary>
+    [Range(100, 1000000, ErrorMessage = ErrorMessages.RangeValidation.MaxH3CellsPerQuery)]
+    public int MaxH3CellsPerQuery { get; init; } = 10000;
+
+    /// <summary>
     /// Maximum time allowed for a single query operation.
     /// Range: 5 seconds to 2 minutes.
     /// </summary>

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IFeatureQueryBuilder.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IFeatureQueryBuilder.cs
@@ -173,4 +173,28 @@ internal interface IFeatureQueryBuilder
         TileOptions tileOptions,
         TileLimits tileLimits,
         GeometryStorageType geometryStorageType = GeometryStorageType.Geometry);
+
+    /// <summary>
+    /// Builds an H3 hexagonal grid aggregation query that groups features into
+    /// H3 cells and computes statistics per cell.
+    /// </summary>
+    ParameterizedQuery BuildH3AggregationQuery(
+        int layerId,
+        FeatureQuery query,
+        H3AggregationQuery h3Query,
+        GeometryStorageType geometryStorageType = GeometryStorageType.Geometry);
+
+    /// <summary>
+    /// Builds an MVT tile query that renders H3 cell boundaries as vector tile features.
+    /// </summary>
+    ParameterizedQuery BuildH3TileQuery(
+        int layerId,
+        int x,
+        int y,
+        int z,
+        int resolution,
+        FeatureQuery? query,
+        TileOptions tileOptions,
+        TileLimits tileLimits,
+        GeometryStorageType geometryStorageType = GeometryStorageType.Geometry);
 }

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IFeatureReader.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IFeatureReader.cs
@@ -142,4 +142,19 @@ public interface IFeatureReader
         FeatureQuery query,
         BinDefinition binDefinition,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Queries features aggregated by H3 hexagonal grid cells at a given resolution.
+    /// Returns one row per occupied cell with cell index, boundary geometry, and statistics.
+    /// </summary>
+    /// <param name="layerId">Layer identifier to query</param>
+    /// <param name="query">Query specification including filters</param>
+    /// <param name="h3Query">H3 aggregation parameters (resolution, polyfill, k-ring, statistics)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Rows containing H3 cell index, boundary geometry as GeoJSON, and aggregate values</returns>
+    Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryH3Async(
+        int layerId,
+        FeatureQuery query,
+        H3AggregationQuery h3Query,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IH3CapabilityChecker.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IH3CapabilityChecker.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.FeatureStore.Abstractions;
+
+/// <summary>
+/// Checks whether the database supports H3 operations via the h3-pg extension.
+/// </summary>
+public interface IH3CapabilityChecker
+{
+    /// <summary>
+    /// Returns true if the h3-pg extension is installed and available for queries,
+    /// false if the extension is confirmed absent, or null if the check failed
+    /// due to a transient error (e.g. database unreachable).
+    /// The result may be cached for the lifetime of the application.
+    /// </summary>
+    Task<bool?> IsH3AvailableAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/ITileProvider.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/ITileProvider.cs
@@ -33,4 +33,28 @@ public interface ITileProvider
         Honua.Core.Features.Tiles.TileOptions tileOptions,
         TileLimits tileLimits,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates an MVT tile containing H3 hexagonal cell boundaries with aggregated feature counts.
+    /// </summary>
+    /// <param name="layerId">Layer identifier</param>
+    /// <param name="x">Tile X coordinate</param>
+    /// <param name="y">Tile Y coordinate</param>
+    /// <param name="z">Zoom level</param>
+    /// <param name="resolution">H3 resolution level (0–15)</param>
+    /// <param name="query">Optional query specification for filtering</param>
+    /// <param name="tileOptions">Tile rendering options</param>
+    /// <param name="tileLimits">Tile generation limits</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>MVT tile data as byte array, null if no features in tile</returns>
+    Task<byte[]?> GetH3MvtTileAsync(
+        int layerId,
+        int x,
+        int y,
+        int z,
+        int resolution,
+        FeatureQuery? query,
+        Honua.Core.Features.Tiles.TileOptions tileOptions,
+        TileLimits tileLimits,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Honua.Core/Features/FeatureStore/Domain/H3AggregationQuery.cs
+++ b/src/Honua.Core/Features/FeatureStore/Domain/H3AggregationQuery.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+
+namespace Honua.Core.Features.FeatureStore.Domain;
+
+/// <summary>
+/// Defines an H3 hexagonal grid aggregation query that groups features into
+/// H3 cells at a given resolution and computes aggregate statistics per cell.
+/// </summary>
+public readonly record struct H3AggregationQuery
+{
+    /// <summary>
+    /// H3 resolution level (0–15). Higher resolutions produce smaller cells.
+    /// </summary>
+    public required int Resolution { get; init; }
+
+    /// <summary>
+    /// Optional polyfill geometry in WKB format. When provided, only H3 cells
+    /// that cover this polygon are included in the result.
+    /// </summary>
+    public byte[]? PolyfillGeometry { get; init; }
+
+    /// <summary>
+    /// SRID of the polyfill geometry (null if unspecified, defaults to layer SRID).
+    /// </summary>
+    public int? PolyfillSrid { get; init; }
+
+    /// <summary>
+    /// Optional k-ring (grid-disk) expansion distance. When greater than zero,
+    /// each result cell is expanded to include its neighbors within this distance.
+    /// </summary>
+    public int? KRingDistance { get; init; }
+
+    /// <summary>
+    /// Aggregate statistics to compute per H3 cell. When empty, only the feature
+    /// count per cell is returned.
+    /// </summary>
+    public ImmutableArray<StatisticDefinition>? OutStatistics { get; init; }
+
+    /// <summary>
+    /// Maximum number of H3 cells returned by the aggregation query.
+    /// When greater than zero, a LIMIT is applied after GROUP BY to prevent
+    /// unbounded result sets at high resolutions. Null or zero disables the limit.
+    /// </summary>
+    public int? MaxCells { get; init; }
+
+    /// <summary>
+    /// Minimum H3 resolution (inclusive).
+    /// </summary>
+    public const int MinResolution = 0;
+
+    /// <summary>
+    /// Maximum H3 resolution (inclusive).
+    /// </summary>
+    public const int MaxResolution = 15;
+
+    /// <summary>
+    /// Maximum k-ring expansion distance. Limits resource usage since
+    /// h3_grid_disk generates approximately 3k²+3k+1 cells per input cell.
+    /// </summary>
+    public const int MaxKRingDistance = 20;
+
+    /// <summary>
+    /// Operator-facing error title when H3 operations are requested but the
+    /// h3-pg extension is not installed.
+    /// </summary>
+    public const string CapabilityErrorTitle = "H3 operations are not available";
+
+    /// <summary>
+    /// Operator-facing detail message when h3-pg is missing.
+    /// </summary>
+    public const string CapabilityErrorDetail =
+        "The h3-pg PostgreSQL extension is not installed. Contact your database administrator to install it: https://github.com/zachasme/h3-pg";
+
+    /// <summary>
+    /// Operator-facing detail message when the H3 capability check fails transiently.
+    /// </summary>
+    public const string CapabilityCheckFailedDetail =
+        "Unable to determine h3-pg extension availability. The database may be temporarily unreachable. Please retry the request.";
+}

--- a/src/Honua.Core/Features/Shared/Models/ErrorMessages.cs
+++ b/src/Honua.Core/Features/Shared/Models/ErrorMessages.cs
@@ -161,6 +161,8 @@ MaxOffset = "MaxOffset must be between 1,000 and 1,000,000";
         public const string         /// <inheritdoc/>
 QueryTimeout = "Query.QueryTimeout must be between 5 seconds and 2 minutes";
         public const string         /// <inheritdoc/>
+MaxH3CellsPerQuery = "MaxH3CellsPerQuery must be between 100 and 1,000,000";
+        public const string         /// <inheritdoc/>
 MaxVerticesPerGeometry = "MaxVerticesPerGeometry must be between 1,000 and 1,000,000";
         public const string         /// <inheritdoc/>
 MaxGeometrySize = "MaxGeometrySize must be between 1MB and 100MB";

--- a/src/Honua.Postgres/Features/FeatureStore/PostgresFeatureStore.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/PostgresFeatureStore.cs
@@ -273,6 +273,17 @@ internal sealed class PostgresFeatureStoreRefactored : IFeatureReader, IFeatureW
         return await _dataAccess.ExecuteStatisticsQueryAsync(binsQuery, query, layerId, cancellationToken);
     }
 
+    public async Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryH3Async(
+        int layerId,
+        FeatureQuery query,
+        H3AggregationQuery h3Query,
+        CancellationToken cancellationToken = default)
+    {
+        var geometryStorageType = await _cacheManager.GetGeometryStorageTypeAsync(cancellationToken).ConfigureAwait(false);
+        var h3SqlQuery = _queryBuilder.BuildH3AggregationQuery(layerId, query, h3Query, geometryStorageType);
+        return await _dataAccess.ExecuteStatisticsQueryAsync(h3SqlQuery, query, layerId, cancellationToken);
+    }
+
     #endregion
 
     #region Spatial Operations
@@ -307,6 +318,22 @@ internal sealed class PostgresFeatureStoreRefactored : IFeatureReader, IFeatureW
     {
         var geometryStorageType = await _cacheManager.GetGeometryStorageTypeAsync(cancellationToken).ConfigureAwait(false);
         var tileQuery = _queryBuilder.BuildMvtTileQuery(layerId, x, y, z, query, tileOptions, tileLimits, geometryStorageType);
+        return await _dataAccess.GetMvtTileAsync(layerId, tileQuery, cancellationToken);
+    }
+
+    public async Task<byte[]?> GetH3MvtTileAsync(
+        int layerId,
+        int x,
+        int y,
+        int z,
+        int resolution,
+        FeatureQuery? query,
+        Core.Features.Tiles.TileOptions tileOptions,
+        Core.Configuration.TileLimits tileLimits,
+        CancellationToken cancellationToken = default)
+    {
+        var geometryStorageType = await _cacheManager.GetGeometryStorageTypeAsync(cancellationToken).ConfigureAwait(false);
+        var tileQuery = _queryBuilder.BuildH3TileQuery(layerId, x, y, z, resolution, query, tileOptions, tileLimits, geometryStorageType);
         return await _dataAccess.GetMvtTileAsync(layerId, tileQuery, cancellationToken);
     }
 

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.H3.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.H3.cs
@@ -1,0 +1,394 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Tiles;
+using Honua.Postgres.Features.Infrastructure;
+using CoreGeometryStorageType = Honua.Core.Features.FeatureStore.Abstractions.GeometryStorageType;
+using CoreParameterizedQuery = Honua.Core.Features.FeatureStore.Domain.ParameterizedQuery;
+
+namespace Honua.Postgres.Features.FeatureStore.Services;
+
+internal sealed partial class FeatureQueryBuilder
+{
+    /// <summary>
+    /// Builds an H3 hexagonal grid aggregation query.
+    /// Uses h3-pg functions to convert feature geometries into H3 cell indices,
+    /// then groups by cell and computes requested statistics.
+    /// </summary>
+    /// <remarks>
+    /// H3 operates in geographic coordinates (WGS 84 / SRID 4326).
+    /// Source geometries are transformed to 4326 before indexing.
+    /// The query returns cell index, GeoJSON boundary, and statistics per cell.
+    /// </remarks>
+    public CoreParameterizedQuery BuildH3AggregationQuery(
+        int layerId,
+        FeatureQuery query,
+        H3AggregationQuery h3Query,
+        CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
+    {
+        var sql = _stringBuilderPool.Get();
+        try
+        {
+            var paramIndex = 2;
+            var parameters = new List<object>();
+
+            // Parameterize resolution for defense-in-depth consistency with tile queries
+            var resolutionParam = $"${paramIndex++}";
+            parameters.Add(h3Query.Resolution);
+
+            // Build the geometry expression, transforming to WGS 84 (4326) for H3.
+            // When SpatialReferenceSrid is null, geometry is assumed already in 4326.
+            var geometryOperand = _geometryProcessor.GetGeometryOperand(
+                geometryStorageType, DatabaseSchema.GeometryColumn, query.SpatialReferenceSrid);
+            var geoExpr = EnsureWgs84(geometryOperand, query.SpatialReferenceSrid);
+
+            // H3 cell index from point geometry (centroid for non-point geometries)
+            var h3CellExpr = $"h3_lat_lng_to_cell(ST_Centroid({geoExpr}), {resolutionParam})";
+
+            // Polyfill CTE (optional) — track length so kRing wrapping can split correctly
+            var polyfillCteLength = 0;
+            if (h3Query.PolyfillGeometry != null)
+            {
+                var polyfillSrid = h3Query.PolyfillSrid ?? query.SpatialReferenceSrid ?? 4326;
+                var polyfillGeomParam = $"${paramIndex++}";
+                parameters.Add(h3Query.PolyfillGeometry);
+
+                var polyfillGeom = polyfillSrid != 4326
+                    ? $"ST_Transform(ST_SetSRID(ST_GeomFromWKB({polyfillGeomParam}), {polyfillSrid}), 4326)"
+                    : $"ST_SetSRID(ST_GeomFromWKB({polyfillGeomParam}), 4326)";
+
+                // NOTE: ::polygon cast converts PostGIS geometry to native PostgreSQL polygon.
+                // This only works for simple Polygon geometries — MultiPolygon or
+                // GeometryCollection inputs will fail at runtime. Validate geometry type
+                // before calling when this path is wired to an endpoint.
+                sql.Append("WITH polyfill_cells AS (");
+                sql.Append(CultureInfo.InvariantCulture,
+                    $"SELECT h3_polygon_to_cells({polyfillGeom}::polygon, {resolutionParam}) AS cell");
+                sql.Append(')');
+                polyfillCteLength = sql.Length;
+                sql.Append(' ');
+            }
+
+            // Outer SELECT references pre-computed cell alias from subquery
+            sql.Append("SELECT _h3cell::text AS \"cellIndex\"");
+            sql.Append(", ST_AsGeoJSON(h3_cell_to_boundary(_h3cell)::geometry) AS \"cellGeometry\"");
+
+            AppendH3StatisticsColumns(sql, h3Query);
+
+            // Inner subquery: compute cell once per row, carry all columns for statistics
+            sql.Append(CultureInfo.InvariantCulture,
+                $" FROM (SELECT *, {h3CellExpr} AS _h3cell FROM {_tableName}");
+            sql.Append(CultureInfo.InvariantCulture,
+                $" WHERE {DatabaseSchema.LayerIdColumn} = $1");
+
+            AppendWhereClause(sql, query, ref paramIndex, parameters);
+            AppendTemporalFilter(sql, query, ref paramIndex, parameters);
+            AppendSpatialFilter(sql, query, geometryStorageType, ref paramIndex, parameters);
+
+            // Filter out NULL geometries
+            sql.Append(CultureInfo.InvariantCulture,
+                $" AND {DatabaseSchema.GeometryColumn} IS NOT NULL");
+            sql.Append(") _src");
+
+            // Polyfill filter on pre-computed cell
+            if (h3Query.PolyfillGeometry != null)
+            {
+                sql.Append(" WHERE _h3cell IN (SELECT cell FROM polyfill_cells)");
+            }
+
+            // GROUP BY pre-computed cell
+            sql.Append(" GROUP BY _h3cell");
+
+            if (h3Query.KRingDistance.HasValue && h3Query.KRingDistance.Value > 0)
+            {
+                // Wrap entire query to expand each result cell to its k-ring neighbors.
+                // When polyfill is active, the inner SQL already starts with
+                // "WITH polyfill_cells AS (...)" so we must emit comma-separated CTEs
+                // instead of nesting WITH clauses (which is invalid PostgreSQL syntax).
+                var innerSql = sql.ToString();
+                sql.Clear();
+
+                if (polyfillCteLength > 0)
+                {
+                    // Inner SQL is "WITH polyfill_cells AS (...) SELECT ...".
+                    // Split at the tracked CTE boundary to produce comma-separated CTEs:
+                    // WITH polyfill_cells AS (...), aggregated AS (SELECT ...)
+                    var ctePrefix = innerSql[..polyfillCteLength];
+                    var mainQuery = innerSql[(polyfillCteLength + 1)..]; // +1 for trailing space
+                    sql.Append(ctePrefix);
+                    sql.Append(", aggregated AS (");
+                    sql.Append(mainQuery);
+                }
+                else
+                {
+                    sql.Append("WITH aggregated AS (");
+                    sql.Append(innerSql);
+                }
+
+                var kRingParam = $"${paramIndex++}";
+                parameters.Add(h3Query.KRingDistance.Value);
+
+                // Expand each aggregated cell to its k-ring neighbors using LATERAL,
+                // then GROUP BY neighbor to deduplicate cells that appear in
+                // multiple source cells' neighborhoods. Statistics are re-aggregated
+                // with type-appropriate functions (SUM for counts/sums, MIN/MAX
+                // preserved, AVG approximated as average-of-averages).
+                sql.Append(") SELECT neighbor::text AS \"cellIndex\"");
+                sql.Append(", ST_AsGeoJSON(h3_cell_to_boundary(neighbor)::geometry) AS \"cellGeometry\"");
+                AppendH3KRingReaggregate(sql, h3Query);
+                sql.Append(CultureInfo.InvariantCulture,
+                    $" FROM aggregated a, LATERAL h3_grid_disk(a.\"cellIndex\"::h3index, {kRingParam}) AS neighbor");
+                sql.Append(" GROUP BY neighbor");
+
+                // Apply max-cells limit to the kRing-expanded result
+                if (h3Query.MaxCells.HasValue && h3Query.MaxCells.Value > 0)
+                {
+                    var maxCellsParam = $"${paramIndex++}";
+                    parameters.Add(h3Query.MaxCells.Value);
+                    sql.Append(CultureInfo.InvariantCulture, $" LIMIT {maxCellsParam}");
+                }
+            }
+            else
+            {
+                // ORDER BY count descending for useful default ordering
+                // (only on the non-k-ring path; inside a CTE it would be ignored by PostgreSQL)
+                sql.Append(" ORDER BY COUNT(*) DESC");
+
+                // Apply max-cells limit to prevent unbounded result sets at high resolutions
+                if (h3Query.MaxCells.HasValue && h3Query.MaxCells.Value > 0)
+                {
+                    var maxCellsParam = $"${paramIndex++}";
+                    parameters.Add(h3Query.MaxCells.Value);
+                    sql.Append(CultureInfo.InvariantCulture, $" LIMIT {maxCellsParam}");
+                }
+            }
+
+            return new CoreParameterizedQuery(sql.ToString(), parameters);
+        }
+        finally
+        {
+            _stringBuilderPool.Return(sql);
+        }
+    }
+
+    /// <summary>
+    /// Builds an MVT tile query that renders H3 cell boundaries as vector tile features.
+    /// Resolution is selected explicitly rather than derived from zoom.
+    /// </summary>
+    public CoreParameterizedQuery BuildH3TileQuery(
+        int layerId,
+        int x,
+        int y,
+        int z,
+        int resolution,
+        FeatureQuery? query,
+        Core.Features.Tiles.TileOptions tileOptions,
+        Core.Configuration.TileLimits tileLimits,
+        CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
+    {
+        var sql = _stringBuilderPool.Get();
+        try
+        {
+            var paramIndex = 1;
+            var parameters = new List<object>();
+
+            var tileExtent = tileOptions.TileExtent > 0 ? tileOptions.TileExtent : 4096;
+            var tileBounds = TileMath.GetTileBounds(x, y, z);
+            var tileWidth = tileBounds.XMax - tileBounds.XMin;
+            var bufferMapUnits = tileOptions.TileBuffer > 0
+                ? (tileOptions.TileBuffer / (double)tileExtent) * tileWidth
+                : 0d;
+
+            parameters.Add(layerId);     // $1
+            parameters.Add(z);           // $2
+            parameters.Add(x);           // $3
+            parameters.Add(y);           // $4
+            parameters.Add(bufferMapUnits); // $5
+            parameters.Add(tileExtent);  // $6
+            parameters.Add(tileOptions.TileBuffer); // $7
+            parameters.Add(resolution);  // $8
+            paramIndex = 9;
+
+            var tileEnvelope = "ST_TileEnvelope($2, $3, $4)";
+            var tileEnvelopeWithBuffer = "ST_Expand(ST_TileEnvelope($2, $3, $4), $5)";
+
+            // Build source geometry expression, transforming to WGS 84 (4326) for H3.
+            // When SpatialReferenceSrid is null, geometry is assumed already in 4326.
+            var geometryOperand = _geometryProcessor.GetGeometryOperand(
+                geometryStorageType, "f.geometry", query?.SpatialReferenceSrid);
+            var geoExpr = EnsureWgs84(geometryOperand, query?.SpatialReferenceSrid);
+
+            // H3 cell computed once per row in inner subquery
+            var h3CellExpr = $"h3_lat_lng_to_cell(ST_Centroid({geoExpr}), $8)";
+
+            // Filter envelope in source SRID for index use.
+            // When the layer SRID is known and differs from Web Mercator (3857),
+            // transform the tile envelope into the layer's CRS so the && bbox
+            // filter can use the spatial index. When SRID is unknown, assume
+            // WGS 84 (consistent with EnsureWgs84) and transform accordingly.
+            var tileEnvelopeForFilter = tileEnvelopeWithBuffer;
+            if (query.HasValue && query.Value.SpatialReferenceSrid.HasValue)
+            {
+                var layerSrid = query.Value.SpatialReferenceSrid.Value;
+                if (layerSrid != 3857)
+                {
+                    tileEnvelopeForFilter = $"ST_Transform({tileEnvelopeWithBuffer}, {layerSrid})";
+                }
+            }
+            else
+            {
+                // No SRID available — EnsureWgs84 assumes 4326, so transform
+                // the tile envelope to match for a correct bbox comparison.
+                tileEnvelopeForFilter = $"ST_Transform({tileEnvelopeWithBuffer}, 4326)";
+            }
+
+            // Outer MVT aggregation; middle layer groups by cell; inner subquery computes cell once
+            sql.Append(CultureInfo.InvariantCulture, $@"
+            SELECT ST_AsMVT(tile, 'h3', $6, 'geom') AS mvt
+            FROM (
+                SELECT
+                    _h3cell::text AS cell_index,
+                    COUNT(*) AS feature_count,
+                    ST_AsMVTGeom(
+                        ST_Transform(h3_cell_to_boundary(_h3cell)::geometry, 3857),
+                        {tileEnvelope},
+                        $6,
+                        $7
+                    ) AS geom
+                FROM (
+                    SELECT {h3CellExpr} AS _h3cell
+                    FROM {_tableName} f
+                    WHERE {DatabaseSchema.LayerIdColumn} = $1");
+
+            sql.Append(CultureInfo.InvariantCulture,
+                $" AND f.{DatabaseSchema.GeometryColumn} IS NOT NULL");
+            sql.Append(CultureInfo.InvariantCulture,
+                $" AND f.{DatabaseSchema.GeometryColumn} && {tileEnvelopeForFilter}");
+
+            if (query.HasValue)
+            {
+                AppendWhereClause(sql, query.Value, ref paramIndex, parameters);
+                AppendTemporalFilter(sql, query.Value, ref paramIndex, parameters);
+                AppendSpatialFilter(sql, query.Value, geometryStorageType, ref paramIndex, parameters);
+            }
+
+            sql.Append(") _src");
+            sql.Append(CultureInfo.InvariantCulture,
+                $" GROUP BY _h3cell");
+
+            // Limit the number of aggregated H3 cells per tile (not source rows).
+            // Applied after GROUP BY so that counts per cell remain accurate.
+            if (tileLimits.MaxFeaturesPerTile > 0)
+            {
+                var limitParam = $"${paramIndex++}";
+                parameters.Add(tileLimits.MaxFeaturesPerTile);
+                sql.Append(CultureInfo.InvariantCulture, $" LIMIT {limitParam}");
+            }
+
+            sql.Append(") AS tile WHERE geom IS NOT NULL");
+
+            return new CoreParameterizedQuery(sql.ToString(), parameters);
+        }
+        finally
+        {
+            _stringBuilderPool.Return(sql);
+        }
+    }
+
+    /// <summary>
+    /// Ensures a geometry expression is in WGS 84 (SRID 4326) for H3 operations.
+    /// When <paramref name="sourceSrid"/> is null (layer has no defined spatial reference),
+    /// the geometry is assumed to already be in WGS 84. Layers stored in a different CRS
+    /// without SRID metadata will produce incorrect H3 cell assignments — this is an
+    /// operator configuration issue, not a runtime-recoverable error.
+    /// </summary>
+    private static string EnsureWgs84(string geometryOperand, int? sourceSrid)
+    {
+        if (sourceSrid.HasValue && sourceSrid.Value != 4326)
+        {
+            return $"ST_Transform({geometryOperand}, 4326)";
+        }
+
+        // SRID is null (unknown) or already 4326 — pass through unchanged.
+        // Null-SRID layers are assumed WGS 84 by convention; misconfigured
+        // layers (non-4326 data without SRID) will index into wrong H3 cells.
+        return geometryOperand;
+    }
+
+    private static void AppendH3StatisticsColumns(System.Text.StringBuilder sql, H3AggregationQuery h3Query)
+    {
+        if (h3Query.OutStatistics.HasValue && !h3Query.OutStatistics.Value.IsDefaultOrEmpty)
+        {
+            foreach (var stat in h3Query.OutStatistics.Value)
+            {
+                if (!IsValidFieldName(stat.OnStatisticField))
+                {
+                    throw new ArgumentException($"Invalid statistic field name: {stat.OnStatisticField}");
+                }
+
+                if (!IsValidFieldName(stat.OutStatisticFieldName))
+                {
+                    throw new ArgumentException($"Invalid output statistic field name: {stat.OutStatisticFieldName}");
+                }
+
+                var statFieldExpr = GetFieldExpression(stat.OnStatisticField);
+                var aggregateExpr = BuildAggregateExpression(stat.StatisticType, statFieldExpr);
+                sql.Append(CultureInfo.InvariantCulture,
+                    $", {aggregateExpr} AS {SanitizeAlias(stat.OutStatisticFieldName)}");
+            }
+        }
+        else
+        {
+            sql.Append(CultureInfo.InvariantCulture,
+                $", COUNT({DatabaseSchema.ObjectIdColumn}) AS \"count\"");
+        }
+    }
+
+    /// <summary>
+    /// Appends re-aggregation expressions for the kRing outer GROUP BY.
+    /// Each statistic from the inner aggregation is re-aggregated with a
+    /// type-appropriate function so that overlapping neighbor cells are
+    /// merged correctly rather than producing duplicate rows.
+    /// </summary>
+    private static void AppendH3KRingReaggregate(System.Text.StringBuilder sql, H3AggregationQuery h3Query)
+    {
+        if (h3Query.OutStatistics.HasValue && !h3Query.OutStatistics.Value.IsDefaultOrEmpty)
+        {
+            foreach (var stat in h3Query.OutStatistics.Value)
+            {
+                var outerAgg = GetKRingReaggregateFunction(stat.StatisticType);
+                var alias = SanitizeAlias(stat.OutStatisticFieldName);
+                sql.Append(CultureInfo.InvariantCulture,
+                    $", {outerAgg}(a.{alias}) AS {alias}");
+            }
+        }
+        else
+        {
+            sql.Append(", SUM(a.\"count\") AS \"count\"");
+        }
+    }
+
+    /// <summary>
+    /// Maps an inner-aggregation statistic type to the appropriate outer
+    /// re-aggregation function for kRing deduplication.
+    /// </summary>
+    private static string GetKRingReaggregateFunction(StatisticType statisticType) => statisticType switch
+    {
+        StatisticType.Count => "SUM",
+        StatisticType.Sum => "SUM",
+        StatisticType.Min => "MIN",
+        StatisticType.Max => "MAX",
+        // Average-of-averages is an approximation; exact weighted average
+        // would require carrying per-cell counts which adds query complexity.
+        // For the visualization-oriented kRing use case this is acceptable.
+        StatisticType.Avg => "AVG",
+        // Stddev/Var: AVG-of-stddevs (or variances) is NOT a valid pooled
+        // statistic — the correct formula needs per-cell counts and means.
+        // Used here as a rough central-tendency proxy for visualization only.
+        StatisticType.Stddev => "AVG",
+        StatisticType.Var => "AVG",
+        _ => "SUM"
+    };
+}

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresH3CapabilityChecker.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresH3CapabilityChecker.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+namespace Honua.Postgres.Features.FeatureStore.Services;
+
+/// <summary>
+/// Checks h3-pg extension availability by querying pg_extension.
+/// The result is cached after the first successful check.
+/// </summary>
+internal sealed partial class PostgresH3CapabilityChecker : IH3CapabilityChecker
+{
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly ILogger<PostgresH3CapabilityChecker> _logger;
+
+    // Static cache so the result survives across scoped instances.
+    // Note: assumes a single-database deployment. Multi-tenant setups with
+    // different databases would need a cache keyed by connection string.
+    // Values: 0=unknown, 1=available, 2=unavailable.
+    // Transient failures leave this at 0 and set s_failureCacheExpiryMs instead.
+    private static int s_cachedResult;
+    private static long s_failureCacheExpiryMs;
+    private static readonly SemaphoreSlim s_lock = new(1, 1);
+
+    /// <summary>
+    /// How long to cache a transient failure before re-probing. Prevents repeated
+    /// serialized DB round-trips when the database is unreachable.
+    /// Units: milliseconds (matching <see cref="Environment.TickCount64"/>).
+    /// </summary>
+    private static readonly long FailureCacheDurationMs = (long)TimeSpan.FromSeconds(60).TotalMilliseconds;
+
+    public PostgresH3CapabilityChecker(
+        IDatabaseConnectionProvider connectionProvider,
+        ILogger<PostgresH3CapabilityChecker> logger)
+    {
+        _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<bool?> IsH3AvailableAsync(CancellationToken cancellationToken = default)
+    {
+        // Volatile reads ensure visibility of writes from other threads on
+        // weakly-ordered architectures (ARM). On x86 these compile to plain loads.
+        var cached = Volatile.Read(ref s_cachedResult);
+        if (cached == 1) return true;
+        if (cached == 2) return false;
+
+        // Fast-path: if a transient failure was cached recently, return null
+        // without re-acquiring the semaphore.
+        var expiryMs = Volatile.Read(ref s_failureCacheExpiryMs);
+        if (expiryMs > 0 && Environment.TickCount64 < expiryMs)
+        {
+            return null;
+        }
+
+        await s_lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // Double-check after acquiring lock
+            var cachedInLock = Volatile.Read(ref s_cachedResult);
+            if (cachedInLock == 1) return true;
+            if (cachedInLock == 2) return false;
+
+            // Double-check transient failure cache inside lock
+            if (s_failureCacheExpiryMs > 0 && Environment.TickCount64 < s_failureCacheExpiryMs)
+            {
+                return null;
+            }
+
+            await using var connection = (NpgsqlConnection)await _connectionProvider
+                .OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            await using var command = new NpgsqlCommand(
+                "SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'h3')", connection);
+            command.CommandTimeout = 10;
+
+            var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            var available = result is true;
+            Volatile.Write(ref s_cachedResult, available ? 1 : 2);
+
+            if (available)
+            {
+                LogH3ExtensionAvailable(_logger);
+            }
+            else
+            {
+                LogH3ExtensionMissing(_logger);
+            }
+
+            return available;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Cache the failure for a bounded period so that subsequent requests
+            // fast-fail instead of serializing behind the semaphore while the
+            // database is unreachable.
+            Volatile.Write(ref s_failureCacheExpiryMs, Environment.TickCount64 + FailureCacheDurationMs);
+            LogH3ExtensionCheckFailed(_logger, ex);
+            return null;
+        }
+        finally
+        {
+            s_lock.Release();
+        }
+    }
+
+    [LoggerMessage(
+        EventId = 7900,
+        Level = LogLevel.Information,
+        Message = "h3-pg extension is available. H3 spatial indexing operations are enabled.")]
+    private static partial void LogH3ExtensionAvailable(ILogger logger);
+
+    [LoggerMessage(
+        EventId = 7901,
+        Level = LogLevel.Warning,
+        Message = "h3-pg extension is not installed. H3 spatial indexing operations will return capability errors. Install h3-pg to enable H3 support: https://github.com/zachasme/h3-pg")]
+    private static partial void LogH3ExtensionMissing(ILogger logger);
+
+    [LoggerMessage(
+        EventId = 7902,
+        Level = LogLevel.Error,
+        Message = "Failed to check h3-pg extension availability.")]
+    private static partial void LogH3ExtensionCheckFailed(ILogger logger, Exception ex);
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Honua.Core.Features.Alerts.Abstractions;
+using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.Admin.Abstractions;
 using Honua.Core.Features.AutoDocs;
 using Honua.Core.Features.Import;
@@ -36,6 +37,7 @@ using Honua.Postgres.Features.Infrastructure.Migrations;
 using Honua.Postgres.Features.Infrastructure.Monitoring;
 using Honua.Postgres.Features.Infrastructure.Styling;
 using Honua.Postgres.Features.Metadata;
+using Honua.Postgres.Features.FeatureStore.Services;
 using Honua.Postgres.Features.Raster;
 using Honua.Postgres.Features.Security;
 using Honua.Postgres.Queries.Filters;
@@ -87,6 +89,10 @@ internal static class ServiceCollectionExtensions
 
         // Register database performance metrics provider
         services.AddScoped<IDatabasePerformanceMetricsProvider, PostgresDatabasePerformanceMetricsProvider>();
+
+        // Register H3 capability checker (scoped to access scoped IDatabaseConnectionProvider;
+        // the result is cached statically after the first successful check, assuming single-database deployment)
+        services.AddScoped<IH3CapabilityChecker, PostgresH3CapabilityChecker>();
 
         // Register attachment store implementation (metadata tables live in the honua schema)
         services.AddScoped<IAttachmentStore>(serviceProvider =>

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -266,7 +266,10 @@ public static class EndpointRegistry
         new("POST", "/rest/services/{serviceId}/FeatureServer/{layerId}/queryDateBins"),
         new("GET", "/rest/services/{serviceId}/FeatureServer/{layerId}/queryBins"),
         new("POST", "/rest/services/{serviceId}/FeatureServer/{layerId}/queryBins"),
+        new("GET", "/rest/services/{serviceId}/FeatureServer/{layerId}/queryH3"),
+        new("POST", "/rest/services/{serviceId}/FeatureServer/{layerId}/queryH3"),
         new("GET", "/tiles/{layerId}/{z}/{x}/{y}.mvt"),
+        new("GET", "/tiles/{layerId}/h3/{z}/{x}/{y}.mvt"),
         new("GET", "/tiles/{layerId}/tile.json"),
         new("GET", "/api/styles/{layerId}.json"),
 
@@ -349,6 +352,7 @@ public static class EndpointRegistry
         new("PUT", "/ogc/features/collections/{collectionId}/items/{featureId}"),
         new("PATCH", "/ogc/features/collections/{collectionId}/items/{featureId}"),
         new("DELETE", "/ogc/features/collections/{collectionId}/items/{featureId}"),
+        new("GET", "/ogc/features/collections/{collectionId}/h3"),
 
         new("GET", "/ogc/tiles"),
         new("GET", "/ogc/tiles/conformance"),

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerEndpoints.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerEndpoints.cs
@@ -304,6 +304,30 @@ internal static partial class FeatureServerEndpoints
             .WithDescription("Validates a SQL expression against a layer schema and returns whether it is syntactically valid")
             .WithTags("FeatureServer");
 
+        endpoints.MapGet("/rest/services/{serviceId}/FeatureServer/{layerId:int}/queryH3", HandleQueryH3Get)
+            .WithDisplayName("Query H3 (GET)")
+            .WithName("QueryH3Get")
+            .WithSummary("Query features aggregated by H3 hexagonal grid cells using GET")
+            .WithDescription("Groups features into H3 cells at a configurable resolution and returns aggregate statistics per cell")
+            .WithTags("FeatureServer")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        endpoints.MapPost("/rest/services/{serviceId}/FeatureServer/{layerId:int}/queryH3", HandleQueryH3Post)
+            .WithDisplayName("Query H3 (POST)")
+            .WithName("QueryH3Post")
+            .WithSummary("Query features aggregated by H3 hexagonal grid cells using POST")
+            .WithDescription("Groups features into H3 cells at a configurable resolution and returns aggregate statistics per cell")
+            .WithTags("FeatureServer")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+
+        endpoints.MapGet("/tiles/{layerId:int}/h3/{z:int}/{x:int}/{y:int}.mvt", HandleH3Tile)
+            .WithDisplayName("Get H3 MVT Tile")
+            .WithName("GetH3MvtTile")
+            .WithSummary("Get MVT tile containing H3 hexagonal cell boundaries")
+            .WithDescription("Generates vector tiles with H3 cell boundaries and feature counts, with resolution from zoom or query parameter")
+            .WithTags("Tiles")
+            .CacheOutput("H3MvtTile");
+
         return endpoints;
     }
 }

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.H3.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.H3.cs
@@ -1,0 +1,467 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Shared.Models;
+using Honua.Core.Features.Tiles;
+using Honua.Core.Features.Validation.Abstractions;
+using Honua.Core.Queries.Filters;
+using Honua.Server.Features.FeatureServer.Models;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Validation;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace Honua.Server.Features.FeatureServer;
+
+internal static partial class FeatureServerEndpoints
+{
+    private static async Task<IResult> HandleQueryH3Get(
+        string serviceId,
+        int layerId,
+        HttpContext context)
+    {
+        var queryValidator = context.RequestServices.GetRequiredService<ICommonQueryValidator>();
+        if (!TryValidateAllowedParameters(context.Request.Query, queryValidator, AllowedQueryParameters.QueryH3, out var error))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "Invalid query parameters",
+                [error ?? "Invalid query parameter."]);
+        }
+
+        var values = ToCaseInsensitiveDictionary(context.Request.Query);
+        return await HandleQueryH3Core(serviceId, layerId, values, context);
+    }
+
+    private static async Task<IResult> HandleQueryH3Post(
+        string serviceId,
+        int layerId,
+        HttpContext context)
+    {
+        var queryValidator = context.RequestServices.GetRequiredService<ICommonQueryValidator>();
+        if (!TryValidateAllowedParameters(context.Request.Query, queryValidator, AllowedQueryParameters.QueryH3, out var error))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "Invalid query parameters",
+                [error ?? "Invalid query parameter."]);
+        }
+
+        var cancellationToken = GetTimeoutAwareCancellationToken(context);
+        var (values, readError) = await TryReadRequestValuesAsync(context.Request, cancellationToken);
+        if (values == null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "Invalid request body",
+                [readError ?? "Invalid request body."]);
+        }
+
+        if (!TryValidateAllowedParameters(values, queryValidator, AllowedQueryParameters.QueryH3, out error))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "Invalid query parameters",
+                [error ?? "Invalid query parameter."]);
+        }
+
+        return await HandleQueryH3Core(serviceId, layerId, values, context);
+    }
+
+    private static async Task<IResult> HandleQueryH3Core(
+        string serviceId,
+        int layerId,
+        IReadOnlyDictionary<string, StringValues> values,
+        HttpContext context)
+    {
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("featureserver.queryH3");
+        activity?.SetTag(HonuaTelemetry.Tags.ServiceId, serviceId);
+        activity?.SetTag(HonuaTelemetry.Tags.LayerId, layerId);
+
+        var cancellationToken = GetTimeoutAwareCancellationToken(context);
+
+        // Parse resolution (required) — validate input before checking server capabilities
+        var resolutionStr = GetValueString(values, "resolution");
+        if (string.IsNullOrWhiteSpace(resolutionStr) ||
+            !int.TryParse(resolutionStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out var resolution))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "resolution parameter is required",
+                [$"resolution must be an integer between {H3AggregationQuery.MinResolution} and {H3AggregationQuery.MaxResolution}."]);
+        }
+
+        if (resolution < H3AggregationQuery.MinResolution || resolution > H3AggregationQuery.MaxResolution)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "Invalid resolution",
+                [$"resolution must be between {H3AggregationQuery.MinResolution} and {H3AggregationQuery.MaxResolution}."]);
+        }
+
+        activity?.SetTag("h3.resolution", resolution);
+
+        // Parse optional kRingDistance — validate all client inputs before checking
+        // server capabilities so clients get actionable 400 errors first
+        int? kRingDistance = null;
+        var kRingStr = GetValueString(values, "kRingDistance");
+        if (!string.IsNullOrWhiteSpace(kRingStr))
+        {
+            if (!int.TryParse(kRingStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out var kRing) || kRing < 0)
+            {
+                return StandardErrorHelpers.CreateBadRequest(context,
+                    "Invalid kRingDistance",
+                    ["kRingDistance must be a non-negative integer."]);
+            }
+
+            if (kRing > H3AggregationQuery.MaxKRingDistance)
+            {
+                return StandardErrorHelpers.CreateBadRequest(context,
+                    "Invalid kRingDistance",
+                    [$"kRingDistance must not exceed {H3AggregationQuery.MaxKRingDistance}."]);
+            }
+
+            kRingDistance = kRing;
+        }
+
+        // Parse optional outStatistics
+        ImmutableArray<StatisticDefinition>? outStatistics = null;
+        var outStatsJson = GetValueString(values, "outStatistics");
+        if (!string.IsNullOrWhiteSpace(outStatsJson))
+        {
+            // POST bodies with native JSON arrays are flattened by TryReadRequestValuesAsync
+            // into comma-separated StringValues; re-wrap as a JSON array for TryParseOutStatistics
+            if (!outStatsJson.TrimStart().StartsWith('['))
+            {
+                outStatsJson = $"[{outStatsJson}]";
+            }
+
+            if (!TryParseOutStatistics(outStatsJson, out var outStats, out var statsError))
+            {
+                return StandardErrorHelpers.CreateBadRequest(context,
+                    "Invalid outStatistics parameter",
+                    [statsError ?? "outStatistics must be valid JSON."]);
+            }
+
+            outStatistics = outStats;
+        }
+
+        // Validate service/layer access
+        var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
+        var validationResult = await FeatureServerResourceValidationHelpers.ValidateServiceLayerAsync(
+            resourceValidator,
+            serviceId,
+            layerId,
+            context,
+            logger: null,
+            cancellationToken: cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            return validationResult.ErrorResult!;
+        }
+
+        var service = validationResult.Service!;
+        var layer = validationResult.Layer!;
+        var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer, service);
+        if (accessError != null)
+        {
+            return accessError;
+        }
+
+        // Check h3-pg extension availability
+        var h3Error = await H3CapabilityHelpers.ValidateH3AvailabilityAsync(context, cancellationToken);
+        if (h3Error is not null)
+        {
+            return h3Error;
+        }
+
+        var queryLimits = context.RequestServices.GetRequiredService<IOptions<LimitsOptions>>().Value.Query;
+        var h3Query = new H3AggregationQuery
+        {
+            Resolution = resolution,
+            KRingDistance = kRingDistance,
+            OutStatistics = outStatistics,
+            MaxCells = queryLimits.MaxH3CellsPerQuery
+        };
+
+        var where = GetValueString(values, "where");
+        SqlFragment? sqlFilter = null;
+        if (!string.IsNullOrWhiteSpace(where))
+        {
+            var filterService = context.RequestServices.GetRequiredService<IFilterExpressionService>();
+            var parseResult = filterService.Parse(FilterLanguage.ArcGisSql, where);
+            if (!parseResult.IsSuccess)
+            {
+                return StandardErrorHelpers.CreateBadRequest(context,
+                    ErrorMessages.Validation.InvalidParameter,
+                    [parseResult.ErrorMessage ?? "Invalid filter syntax."]);
+            }
+
+            if (parseResult.Expression != null)
+            {
+                var translationResult = filterService.Translate(parseResult.Expression, layer);
+                if (!translationResult.IsSuccess)
+                {
+                    return StandardErrorHelpers.CreateBadRequest(context,
+                        ErrorMessages.Validation.InvalidParameter,
+                        [translationResult.ErrorMessage ?? "Invalid filter syntax."]);
+                }
+
+                sqlFilter = translationResult.SqlFilter;
+            }
+        }
+
+        var featureQuery = new FeatureQuery
+        {
+            Where = where,
+            SqlFilter = sqlFilter,
+            SpatialReferenceSrid = layer.SpatialReference.ToSrid()
+        };
+
+        var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
+        var rows = await featureReader.QueryH3Async(layer.Id, featureQuery, h3Query, cancellationToken);
+
+        var responseFeatures = rows.Select(row =>
+        {
+            var attributes = new Dictionary<string, object?>(row);
+            GeoServicesGeometry? geometry = null;
+
+            // Extract cellGeometry (GeoJSON Polygon) and convert to Esri Rings format.
+            // H3 boundaries are always WGS 84 Polygons, so coordinates map directly.
+            if (attributes.Remove("cellGeometry", out var cellGeoJson) && cellGeoJson is string geoJsonStr)
+            {
+                geometry = TryParseH3CellGeometry(geoJsonStr);
+                if (geometry == null)
+                {
+                    // Parsing failed — preserve as attribute so the data is not silently lost
+                    attributes["cellGeometry"] = cellGeoJson;
+                }
+            }
+
+            return new GeoServicesFeature
+            {
+                Attributes = attributes,
+                Geometry = geometry,
+                IncludeGeometry = true
+            };
+        }).ToArray();
+
+        var response = new QueryResponse
+        {
+            Features = responseFeatures
+        };
+
+        return Results.Json(response, FeatureServerJsonContext.Default.QueryResponse, contentType: "application/json");
+    }
+
+    private static async Task<IResult> HandleH3Tile(
+        int layerId,
+        int z,
+        int x,
+        int y,
+        HttpContext context,
+        CancellationToken cancellationToken)
+    {
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("featureserver.h3Tile");
+        activity?.SetTag(HonuaTelemetry.Tags.LayerId, layerId);
+        activity?.SetTag("tile.z", z);
+        activity?.SetTag("tile.x", x);
+        activity?.SetTag("tile.y", y);
+
+        var queryValidator = context.RequestServices.GetRequiredService<ICommonQueryValidator>();
+        if (!TryValidateAllowedParameters(context.Request.Query, queryValidator, AllowedQueryParameters.H3Tiles, out var error))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "Invalid query parameters",
+                [error ?? "Invalid query parameter."]);
+        }
+
+        var tileOptions = context.RequestServices.GetRequiredService<IOptions<TileOptions>>().Value;
+        var tileLimits = context.RequestServices.GetRequiredService<IOptions<LimitsOptions>>().Value.Tiles;
+        if (z < tileLimits.MinTileZoom || z > tileLimits.MaxTileZoom)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                $"Zoom level {z} is outside supported range",
+                [$"Supported zoom range is {tileLimits.MinTileZoom}-{tileLimits.MaxTileZoom}"]);
+        }
+
+        var maxIndex = 1 << z;
+        if (x < 0 || y < 0 || x >= maxIndex || y >= maxIndex)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                $"Invalid tile coordinates: x={x}, y={y}, z={z}");
+        }
+
+        // Parse resolution (default from zoom level)
+        var queryValues = ToCaseInsensitiveDictionary(context.Request.Query);
+        var resolutionStr = GetValueString(queryValues, "resolution");
+        int resolution;
+        if (!string.IsNullOrWhiteSpace(resolutionStr))
+        {
+            if (!int.TryParse(resolutionStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out resolution) ||
+                resolution < H3AggregationQuery.MinResolution || resolution > H3AggregationQuery.MaxResolution)
+            {
+                return StandardErrorHelpers.CreateBadRequest(context,
+                    "Invalid resolution",
+                    [$"resolution must be between {H3AggregationQuery.MinResolution} and {H3AggregationQuery.MaxResolution}."]);
+            }
+        }
+        else
+        {
+            // Default zoom-to-resolution mapping
+            resolution = ZoomToH3Resolution(z);
+        }
+
+        activity?.SetTag("h3.resolution", resolution);
+
+        // Validate layer access before checking server capabilities
+        var layerValidation = await LayerValidationHelpers.ValidateLayerWithAccessAsync(
+            context,
+            layerId,
+            requiredProtocol: ServiceProtocols.FeatureServer,
+            cancellationToken: cancellationToken);
+        if (!layerValidation.IsValid)
+        {
+            return layerValidation.ErrorResult!;
+        }
+        var layer = layerValidation.Layer!;
+
+        // Check h3-pg extension availability (after auth, consistent with HandleQueryH3Core)
+        var h3Error = await H3CapabilityHelpers.ValidateH3AvailabilityAsync(context, cancellationToken);
+        if (h3Error is not null)
+        {
+            return h3Error;
+        }
+
+        var where = GetValueString(queryValues, "where");
+        SqlFragment? sqlFilter = null;
+        if (!string.IsNullOrWhiteSpace(where))
+        {
+            var filterService = context.RequestServices.GetRequiredService<IFilterExpressionService>();
+            var parseResult = filterService.Parse(FilterLanguage.ArcGisSql, where);
+            if (!parseResult.IsSuccess)
+            {
+                return StandardErrorHelpers.CreateBadRequest(context,
+                    ErrorMessages.Validation.InvalidParameter,
+                    [parseResult.ErrorMessage ?? "Invalid filter syntax."]);
+            }
+
+            if (parseResult.Expression != null)
+            {
+                var translationResult = filterService.Translate(parseResult.Expression, layer);
+                if (!translationResult.IsSuccess)
+                {
+                    return StandardErrorHelpers.CreateBadRequest(context,
+                        ErrorMessages.Validation.InvalidParameter,
+                        [translationResult.ErrorMessage ?? "Invalid filter syntax."]);
+                }
+
+                sqlFilter = translationResult.SqlFilter;
+            }
+        }
+
+        var query = new FeatureQuery
+        {
+            Where = where,
+            SqlFilter = sqlFilter,
+            SpatialReferenceSrid = layer.SpatialReference.ToSrid()
+        };
+
+        var tileProvider = context.RequestServices.GetRequiredService<ITileProvider>();
+        var tileData = await tileProvider.GetH3MvtTileAsync(
+            layerId,
+            x,
+            y,
+            z,
+            resolution,
+            query,
+            tileOptions,
+            tileLimits,
+            cancellationToken);
+
+        if (tileData == null || tileData.Length == 0)
+        {
+            return Results.NoContent();
+        }
+
+        context.Response.Headers["Cache-Control"] = $"public, max-age={tileOptions.CacheMaxAge}";
+        return Results.Bytes(tileData, "application/vnd.mapbox-vector-tile");
+    }
+
+    /// <summary>
+    /// Maps zoom level to a reasonable default H3 resolution.
+    /// Lower zoom = coarser cells, higher zoom = finer cells.
+    /// </summary>
+    private static int ZoomToH3Resolution(int zoom) => zoom switch
+    {
+        <= 2 => 1,
+        3 => 2,
+        4 => 3,
+        5 => 3,
+        6 => 4,
+        7 => 4,
+        8 => 5,
+        9 => 5,
+        10 => 6,
+        11 => 7,
+        12 => 7,
+        13 => 8,
+        14 => 9,
+        15 => 9,
+        16 => 10,
+        17 => 11,
+        18 => 11,
+        _ => 12
+    };
+
+    /// <summary>
+    /// Parses a GeoJSON Polygon string (H3 cell boundary) into an Esri-compatible
+    /// <see cref="GeoServicesGeometry"/> with Rings. Returns null on parse failure.
+    /// </summary>
+    private static GeoServicesGeometry? TryParseH3CellGeometry(string geoJsonStr)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(geoJsonStr);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("coordinates", out var coordinates))
+            {
+                return null;
+            }
+
+            // GeoJSON Polygon coordinates: [[[lng, lat], ...], ...] → Esri Rings: double[][][]
+            var ringsCount = coordinates.GetArrayLength();
+            var rings = new double[ringsCount][][];
+            for (var r = 0; r < ringsCount; r++)
+            {
+                var ring = coordinates[r];
+                var pointCount = ring.GetArrayLength();
+                var points = new double[pointCount][];
+                for (var p = 0; p < pointCount; p++)
+                {
+                    var point = ring[p];
+                    points[p] = point.GetArrayLength() switch
+                    {
+                        >= 3 => [point[0].GetDouble(), point[1].GetDouble(), point[2].GetDouble()],
+                        _ => [point[0].GetDouble(), point[1].GetDouble()]
+                    };
+                }
+                rings[r] = points;
+            }
+
+            return new GeoServicesGeometry
+            {
+                Rings = rings,
+                SpatialReference = new GeoServicesSpatialReference { Wkid = 4326 }
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerUtilities.cs
@@ -193,6 +193,19 @@ internal static partial class FeatureServerEndpoints
 
         public static readonly FrozenSet<string> Tiles =
             new[] { "where" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+        public static readonly FrozenSet<string> H3Tiles =
+            new[] { "where", "resolution" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+        public static readonly FrozenSet<string> QueryH3 = new[]
+            {
+                "resolution",
+                "where",
+                "kRingDistance",
+                "outStatistics",
+                "f"
+            }
+            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
     }
 
     internal static FrozenSet<string> FeatureServerQueryAllowedParameters => AllowedQueryParameters.Query;

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
@@ -273,6 +273,16 @@ internal static class ObservabilityServiceCollectionExtensions
                 policy.Tag("mvt-tiles", "tiles");
             });
 
+            // H3 MVT tile caching policy — same TTL as standard tiles but also
+            // varies by resolution since different resolutions produce different cells
+            options.AddPolicy("H3MvtTile", policy =>
+            {
+                policy.Expire(ttl.MvtTile);
+                policy.SetVaryByRouteValue("layerId", "z", "x", "y");
+                policy.SetVaryByQuery("where", "resolution");
+                policy.Tag("mvt-tiles", "tiles", "h3");
+            });
+
             // TileJSON metadata caching policy
             options.AddPolicy("TileJson", policy =>
             {

--- a/src/Honua.Server/Features/Infrastructure/Validation/H3CapabilityHelpers.cs
+++ b/src/Honua.Server/Features/Infrastructure/Validation/H3CapabilityHelpers.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Server.Features.Infrastructure.Models;
+
+namespace Honua.Server.Features.Infrastructure.Validation;
+
+/// <summary>
+/// Shared validation for H3 capability checks across FeatureServer and OGC endpoints.
+/// </summary>
+internal static class H3CapabilityHelpers
+{
+    /// <summary>
+    /// Checks whether the h3-pg extension is available and returns an appropriate
+    /// error result if not. Returns null when H3 is available.
+    /// </summary>
+    internal static async Task<IResult?> ValidateH3AvailabilityAsync(
+        HttpContext context, CancellationToken cancellationToken)
+    {
+        var h3Checker = context.RequestServices.GetRequiredService<IH3CapabilityChecker>();
+        var h3Available = await h3Checker.IsH3AvailableAsync(cancellationToken);
+        if (h3Available == false)
+        {
+            return StandardErrorHelpers.CreateNotImplemented(context,
+                H3AggregationQuery.CapabilityErrorTitle,
+                [H3AggregationQuery.CapabilityErrorDetail]);
+        }
+
+        if (h3Available is null)
+        {
+            return StandardErrorHelpers.CreateServiceUnavailable(context,
+                H3AggregationQuery.CapabilityCheckFailedDetail, retryAfterSeconds: 60);
+        }
+
+        return null;
+    }
+}

--- a/src/Honua.Server/Features/OgcFeatures/H3Endpoints.cs
+++ b/src/Honua.Server/Features/OgcFeatures/H3Endpoints.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Shared.Models;
+using Honua.Server.Features.Ogc.Common;
+using Honua.Server.Features.Infrastructure.Helpers;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Validation;
+using Honua.Server.Features.OgcFeatures.Models;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.OgcFeatures;
+
+/// <summary>
+/// OGC API Features extension for H3 hexagonal grid aggregation
+/// </summary>
+internal static class H3Endpoints
+{
+    /// <summary>
+    /// Maps H3 aggregation endpoint for OGC API Features collections
+    /// </summary>
+    public static IEndpointRouteBuilder MapH3Endpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/ogc/features/collections/{collectionId}/h3", HandleGetH3)
+            .WithDisplayName("OGC API Features H3 Aggregation")
+            .WithName("OgcFeaturesH3")
+            .WithSummary("H3 hexagonal grid aggregation for a collection")
+            .WithDescription("Groups collection features into H3 cells at a configurable resolution and returns GeoJSON features with aggregate statistics per cell")
+            .WithTags("OGC API Features");
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleGetH3(
+        string collectionId,
+        HttpContext context,
+        CancellationToken cancellationToken)
+    {
+        // Use timeout-aware token (consistent with other OGC endpoints)
+        cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+
+        // Validate query parameters before any work
+        var validationError = OgcCommonUtilities.ValidateQueryParameters(
+            context.Request, OgcFeaturesUtilities.AllowedQueryParameters.H3);
+        if (validationError is not null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, validationError.Value ?? "Invalid query parameters.");
+        }
+
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("ogc.features.h3");
+        activity?.SetTag("ogc.collectionId", collectionId);
+
+        // Parse resolution (required) — validate input before checking server capabilities
+        var resolutionStr = context.Request.Query["resolution"].FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(resolutionStr) ||
+            !int.TryParse(resolutionStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out var resolution))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "resolution parameter is required",
+                [$"resolution must be an integer between {H3AggregationQuery.MinResolution} and {H3AggregationQuery.MaxResolution}."]);
+        }
+
+        if (resolution < H3AggregationQuery.MinResolution || resolution > H3AggregationQuery.MaxResolution)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "Invalid resolution",
+                [$"resolution must be between {H3AggregationQuery.MinResolution} and {H3AggregationQuery.MaxResolution}."]);
+        }
+
+        activity?.SetTag("h3.resolution", resolution);
+
+        // Validate collection access with OGC protocol check
+        var layerValidation = await LayerValidationHelpers.ValidateCollectionWithAccessAsync(
+            context,
+            collectionId,
+            cancellationToken: cancellationToken,
+            requiredProtocol: ServiceProtocols.OgcFeatures);
+        if (!layerValidation.IsValid)
+        {
+            return layerValidation.ErrorResult!;
+        }
+        var layer = layerValidation.Layer!;
+
+        // Check h3-pg extension availability
+        var h3Error = await H3CapabilityHelpers.ValidateH3AvailabilityAsync(context, cancellationToken);
+        if (h3Error is not null)
+        {
+            return h3Error;
+        }
+
+        var queryLimits = context.RequestServices.GetRequiredService<IOptions<LimitsOptions>>().Value.Query;
+        var h3Query = new H3AggregationQuery
+        {
+            Resolution = resolution,
+            MaxCells = queryLimits.MaxH3CellsPerQuery
+        };
+
+        var featureQuery = new FeatureQuery
+        {
+            SpatialReferenceSrid = layer.SpatialReference.ToSrid()
+        };
+
+        var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
+        var rows = await featureReader.QueryH3Async(layer.Id, featureQuery, h3Query, cancellationToken);
+
+        // Return as GeoJSON FeatureCollection using typed models for AOT safety
+        var features = rows.Select(row =>
+        {
+            var properties = new Dictionary<string, object?>(row);
+
+            // Extract cellGeometry and convert to typed geometry
+            SimpleGeoJsonGeometry? geometry = null;
+            if (properties.Remove("cellGeometry", out var cellGeoJson) && cellGeoJson is string geoJsonStr)
+            {
+                try
+                {
+                    using var doc = JsonDocument.Parse(geoJsonStr);
+                    var root = doc.RootElement;
+                    var geoType = root.GetProperty("type").GetString() ?? "Polygon";
+                    string? coordsJson = root.TryGetProperty("coordinates", out var coords)
+                        ? coords.GetRawText()
+                        : null;
+
+                    geometry = new SimpleGeoJsonGeometry
+                    {
+                        Type = geoType,
+                        CoordinatesJson = coordsJson
+                    };
+                }
+                catch (JsonException)
+                {
+                    // If parsing fails, include as string property
+                    properties["cellGeometry"] = cellGeoJson;
+                }
+            }
+
+            return new GeoJsonFeature
+            {
+                Geometry = geometry,
+                Properties = properties
+            };
+        }).ToArray();
+
+        var featureCollection = new FeatureCollection
+        {
+            Features = features,
+            NumberReturned = features.Length
+        };
+
+        return Results.Json(featureCollection, OgcJsonContext.Default.FeatureCollection, contentType: "application/geo+json");
+    }
+}

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesEndpoints.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesEndpoints.cs
@@ -29,6 +29,9 @@ internal static partial class OgcFeaturesEndpoints
         // Register features/items CRUD endpoints
         endpoints.MapFeaturesEndpoints();
 
+        // Register H3 hexagonal grid aggregation endpoints
+        endpoints.MapH3Endpoints();
+
         return endpoints;
     }
 

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesUtilities.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesUtilities.cs
@@ -63,6 +63,12 @@ internal static class OgcFeaturesUtilities
 
         public static readonly FrozenSet<string> Transactions =
             Array.Empty<string>().ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+        public static readonly FrozenSet<string> H3 = new[]
+            {
+                "resolution"
+            }
+            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Honua.Server/openapi.json
+++ b/src/Honua.Server/openapi.json
@@ -802,6 +802,61 @@
           }
         }
       }
+    },
+    "/collections/{collectionId}/h3": {
+      "get": {
+        "summary": "H3 hexagonal grid aggregation for a collection",
+        "description": "Groups collection features into H3 cells at a configurable resolution and returns GeoJSON features with aggregate statistics per cell",
+        "tags": [
+          "OGC API Features"
+        ],
+        "parameters": [
+          {
+            "name": "collectionId",
+            "in": "path",
+            "required": true,
+            "description": "Collection identifier",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "resolution",
+            "in": "query",
+            "required": true,
+            "description": "H3 resolution level (0-15)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 15
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "H3 aggregation as GeoJSON FeatureCollection",
+            "content": {
+              "application/geo+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureCollection"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid parameters"
+          },
+          "404": {
+            "description": "Collection not found"
+          },
+          "501": {
+            "description": "H3 extension not available — the h3-pg PostgreSQL extension is not installed"
+          },
+          "503": {
+            "description": "H3 capability check failed — the database may be temporarily unreachable"
+          }
+        }
+      }
     }
   },
   "components": {

--- a/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerH3TileTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerH3TileTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.FeatureServer;
+
+[Collection("Database")]
+[Protocol(Protocols.FeatureServer)]
+public sealed class FeatureServerH3TileTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /tiles/{layerId}/h3/{z}/{x}/{y}.mvt")]
+    public async Task H3Tile_ValidCoords_ReturnsOkOrCapabilityError()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/tiles/{WebAppFixture.TestLayerId}/h3/5/16/11.mvt");
+
+        // Accept OK/NoContent (h3-pg available), 501 (missing), or 503 (transient)
+        response.StatusCode.Should().BeOneOf(
+            HttpStatusCode.OK, HttpStatusCode.NoContent, HttpStatusCode.NotImplemented, HttpStatusCode.ServiceUnavailable);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.mapbox-vector-tile");
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /tiles/{layerId}/h3/{z}/{x}/{y}.mvt")]
+    public async Task H3Tile_WithExplicitResolution_ReturnsOkOrCapabilityError()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/tiles/{WebAppFixture.TestLayerId}/h3/5/16/11.mvt?resolution=5");
+
+        response.StatusCode.Should().BeOneOf(
+            HttpStatusCode.OK, HttpStatusCode.NoContent, HttpStatusCode.NotImplemented, HttpStatusCode.ServiceUnavailable);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /tiles/{layerId}/h3/{z}/{x}/{y}.mvt")]
+    public async Task H3Tile_InvalidResolution_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/tiles/{WebAppFixture.TestLayerId}/h3/5/16/11.mvt?resolution=99");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /tiles/{layerId}/h3/{z}/{x}/{y}.mvt")]
+    public async Task H3Tile_InvalidCoords_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/tiles/{WebAppFixture.TestLayerId}/h3/5/999/999.mvt");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerQueryH3Tests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerQueryH3Tests.cs
@@ -1,0 +1,191 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.FeatureServer;
+
+[Collection("Database")]
+[Protocol(Protocols.FeatureServer)]
+public sealed class FeatureServerQueryH3Tests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryH3")]
+    public async Task QueryH3_ValidResolution_ReturnsOkOrCapabilityError()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryH3?resolution=7&f=json");
+
+        // The test database may not have h3-pg installed, so accept OK, 501 (missing), or 503 (transient)
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotImplemented, HttpStatusCode.ServiceUnavailable);
+
+        var content = await response.Content.ReadAsStringAsync();
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            using var document = JsonDocument.Parse(content);
+            var root = document.RootElement;
+            root.TryGetProperty("features", out var features).Should().BeTrue();
+            features.ValueKind.Should().Be(JsonValueKind.Array);
+        }
+        else
+        {
+            // Capability error should mention h3-pg
+            content.Should().Contain("h3-pg");
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryH3")]
+    public async Task QueryH3_MissingResolution_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryH3?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("resolution");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryH3")]
+    public async Task QueryH3_InvalidResolution_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryH3?resolution=20&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("resolution");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryH3")]
+    public async Task QueryH3_InvalidService_ReturnsNotFound()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/rest/services/nonexistent/FeatureServer/0/queryH3?resolution=7&f=json");
+
+        // Resolution is valid so validation passes; service lookup fails before h3 capability check
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/queryH3")]
+    public async Task QueryH3Post_ValidRequest_ReturnsOkOrCapabilityError()
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            resolution = 7,
+            f = "json"
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryH3",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+
+        // Accept OK (h3-pg available), 501 (missing), or 503 (transient)
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotImplemented, HttpStatusCode.ServiceUnavailable);
+
+        var content = await response.Content.ReadAsStringAsync();
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            using var document = JsonDocument.Parse(content);
+            var root = document.RootElement;
+            root.TryGetProperty("features", out var features).Should().BeTrue();
+            features.ValueKind.Should().Be(JsonValueKind.Array);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryH3")]
+    public async Task QueryH3_NegativeResolution_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryH3?resolution=-1&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryH3")]
+    public async Task QueryH3_WithKRingDistance_ReturnsOkOrCapabilityError()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryH3?resolution=7&kRingDistance=1&f=json");
+
+        // kRingDistance=1 is valid; outcome depends on h3-pg availability
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotImplemented, HttpStatusCode.ServiceUnavailable);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryH3")]
+    public async Task QueryH3_KRingDistanceZero_ReturnsOkOrCapabilityError()
+    {
+        // kRingDistance=0 is valid and should take the non-kRing code path
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryH3?resolution=7&kRingDistance=0&f=json");
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotImplemented, HttpStatusCode.ServiceUnavailable);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryH3")]
+    public async Task QueryH3_ExcessiveKRingDistance_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryH3?resolution=7&kRingDistance=99&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("kRingDistance");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/queryH3")]
+    public async Task QueryH3Post_WithOutStatisticsArray_ReturnsOkOrCapabilityError()
+    {
+        // Verify that a POST body with a native JSON array for outStatistics is accepted
+        // (regression test: TryReadRequestValuesAsync flattens JSON arrays into StringValues)
+        var payload = JsonSerializer.Serialize(new
+        {
+            resolution = 7,
+            outStatistics = new[]
+            {
+                new { statisticType = "count", onStatisticField = "objectid", outStatisticFieldName = "cnt" }
+            },
+            f = "json"
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryH3",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+
+        // Accept OK (h3-pg available), 501 (missing), or 503 (transient) — but NOT 400
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotImplemented, HttpStatusCode.ServiceUnavailable);
+    }
+}

--- a/tests/Honua.Server.Tests/Features/OgcFeatures/OgcFeaturesH3Tests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcFeatures/OgcFeaturesH3Tests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.OgcFeatures;
+
+[Collection("Database")]
+[Protocol(Protocols.OgcApiFeatures)]
+public sealed class OgcFeaturesH3Tests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/h3")]
+    public async Task H3_ValidResolution_ReturnsOkOrCapabilityError()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/ogc/features/collections/{WebAppFixture.TestLayerId}/h3?resolution=7");
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotImplemented, HttpStatusCode.ServiceUnavailable);
+
+        var content = await response.Content.ReadAsStringAsync();
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            using var document = JsonDocument.Parse(content);
+            var root = document.RootElement;
+            root.TryGetProperty("type", out var type).Should().BeTrue();
+            type.GetString().Should().Be("FeatureCollection");
+        }
+        else
+        {
+            content.Should().Contain("h3-pg");
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/h3")]
+    public async Task H3_MissingResolution_ReturnsBadRequest()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/ogc/features/collections/{WebAppFixture.TestLayerId}/h3");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/h3")]
+    public async Task H3_InvalidCollection_ReturnsNotFound()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/ogc/features/collections/99999/h3?resolution=7");
+
+        // Collection validation runs before H3 capability check, so
+        // an invalid collection always yields NotFound.
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryH3)]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/h3")]
+    public async Task H3_UnknownQueryParameter_ReturnsBadRequestWithStandardFormat()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/ogc/features/collections/{WebAppFixture.TestLayerId}/h3?resolution=7&bogus=1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        // Verify the error uses the standard problem response format (not a plain string)
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("Bad Request");
+    }
+}

--- a/tests/Honua.TestKit/Constants/Operations.cs
+++ b/tests/Honua.TestKit/Constants/Operations.cs
@@ -126,6 +126,7 @@ public static class Operations
     public const string QueryTopFeatures = "QueryTopFeatures";
     public const string QueryDateBins = "QueryDateBins";
     public const string QueryBins = "QueryBins";
+    public const string QueryH3 = "QueryH3";
 
     // Streaming Operations
     public const string Streaming = "Streaming";

--- a/tests/Honua.TestKit/Infrastructure/TestFeatureStore.cs
+++ b/tests/Honua.TestKit/Infrastructure/TestFeatureStore.cs
@@ -1191,4 +1191,35 @@ public sealed class TestFeatureStore : IFeatureReader, IFeatureWriter, ITileProv
         };
         return Task.FromResult(ImmutableArray.Create<IReadOnlyDictionary<string, object?>>(row));
     }
+
+    public Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryH3Async(
+        int layerId,
+        FeatureQuery query,
+        H3AggregationQuery h3Query,
+        CancellationToken cancellationToken = default)
+    {
+        // Return a simple test H3 cell result
+        var row = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["cellIndex"] = "8928308280fffff",
+            ["cellGeometry"] = "{\"type\":\"Polygon\",\"coordinates\":[[[-122.5,37.5],[-122.4,37.5],[-122.4,37.6],[-122.5,37.6],[-122.5,37.5]]]}",
+            ["count"] = 3L
+        };
+        return Task.FromResult(ImmutableArray.Create<IReadOnlyDictionary<string, object?>>(row));
+    }
+
+    public Task<byte[]?> GetH3MvtTileAsync(
+        int layerId,
+        int x,
+        int y,
+        int z,
+        int resolution,
+        FeatureQuery? query,
+        Core.Features.Tiles.TileOptions tileOptions,
+        Core.Configuration.TileLimits tileLimits,
+        CancellationToken cancellationToken = default)
+    {
+        // Return empty tile for test
+        return Task.FromResult<byte[]?>(null);
+    }
 }


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #373
## Summary

Clean tree, 2 commits ahead of `origin/trunk`. Commit hashes changed again (another rebase) but the implementation content is unchanged.
## Changes Made

- Clean tree, 2 commits ahead of `origin/trunk`. Commit hashes changed again (another rebase) but the implementation content is unchanged.
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally

## Additional Context

Decisions:
All findings `[low]` — deferred.

Follow-ons:
1. **[low/dry]** Extract `TryParseArcGisSqlFilter` into `FilterExpressionHelpers.cs`
2. **[low/adjacent_cleanup]** Add filtering params to OGC H3 endpoint
3. **[pre-existing]** Fix missing `docs/api-specs/admin-api.json` on trunk

Code kaizen:
Deferred 3 low-priority finding(s) to cleanup backlog. Confirmed three low-severity follow-ups; no new production correctness regressions found, and the targeted H3 tests passed.
