### PR TITLE
perf: bring remaining raster point rendering work onto trunk

### DIFF
--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IFeatureDataAccess.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IFeatureDataAccess.cs
@@ -22,6 +22,15 @@ internal interface IFeatureDataAccess
     Task<ImmutableArray<Feature>> ExecuteSelectQueryAsync(ParameterizedQuery query, FeatureQuery featureQuery, int layerId, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Executes a projected-point query and returns point coordinates.
+    /// </summary>
+    Task<ImmutableArray<ProjectedPoint>> ExecuteSelectProjectedPointsAsync(
+        ParameterizedQuery query,
+        FeatureQuery featureQuery,
+        int layerId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Executes a select query and returns GML features
     /// </summary>
     Task<ImmutableArray<GmlFeature>> ExecuteSelectGmlQueryAsync(ParameterizedQuery query, FeatureQuery featureQuery, int layerId, CancellationToken cancellationToken);

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IFeatureQueryBuilder.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IFeatureQueryBuilder.cs
@@ -22,6 +22,14 @@ internal interface IFeatureQueryBuilder
         GeometryStorageType geometryStorageType = GeometryStorageType.Geometry);
 
     /// <summary>
+    /// Builds a projected-point query for raster rendering fast paths.
+    /// </summary>
+    ParameterizedQuery BuildProjectedPointQuery(
+        int layerId,
+        FeatureQuery query,
+        GeometryStorageType geometryStorageType = GeometryStorageType.Geometry);
+
+    /// <summary>
     /// Builds a SELECT query for object IDs only.
     /// </summary>
     ParameterizedQuery BuildObjectIdsQuery(

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IRasterPointReader.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IRasterPointReader.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.FeatureStore.Abstractions;
+
+/// <summary>
+/// Provides an optimized query path for projected point coordinates used by raster rendering.
+/// </summary>
+public interface IRasterPointReader
+{
+    /// <summary>
+    /// Queries projected point coordinates for a layer using the supplied feature query constraints.
+    /// </summary>
+    Task<ImmutableArray<ProjectedPoint>> QueryProjectedPointsAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/FeatureStore/Domain/FeatureQuery.cs
+++ b/src/Honua.Core/Features/FeatureStore/Domain/FeatureQuery.cs
@@ -54,6 +54,12 @@ public readonly record struct FeatureQuery
     public int? OutputSrid { get; init; }
 
     /// <summary>
+    /// Optional projected point grid used by raster rendering fast paths to thin
+    /// point results before they are materialized by the application.
+    /// </summary>
+    public RasterPointGrid? RasterPointGrid { get; init; }
+
+    /// <summary>
     /// Temporal filter for time-based queries
     /// </summary>
     public TemporalFilter? TemporalFilter { get; init; }

--- a/src/Honua.Core/Features/FeatureStore/Domain/RasterPointTypes.cs
+++ b/src/Honua.Core/Features/FeatureStore/Domain/RasterPointTypes.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.FeatureStore.Domain;
+
+/// <summary>
+/// Represents a projected point coordinate returned directly from the database.
+/// </summary>
+public readonly record struct ProjectedPoint(double X, double Y);
+
+/// <summary>
+/// Describes a point-thinning grid in projected/output coordinates.
+/// </summary>
+public readonly record struct RasterPointGrid
+{
+    /// <summary>
+    /// Minimum X of the render extent used as the horizontal grid origin.
+    /// </summary>
+    public required double OriginX { get; init; }
+
+    /// <summary>
+    /// Maximum Y of the render extent used as the vertical grid origin.
+    /// </summary>
+    public required double OriginY { get; init; }
+
+    /// <summary>
+    /// Cell width in projected/output units.
+    /// </summary>
+    public required double CellWidth { get; init; }
+
+    /// <summary>
+    /// Cell height in projected/output units.
+    /// </summary>
+    public required double CellHeight { get; init; }
+}

--- a/src/Honua.Postgres/Features/FeatureStore/PostgresFeatureStore.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/PostgresFeatureStore.cs
@@ -31,7 +31,7 @@ namespace Honua.Postgres.Features.FeatureStore;
 /// 'field = value', 'age > 18') and properly parameterizes all literal values while
 /// validating field names to prevent SQL injection attacks.</para>
 /// </remarks>
-internal sealed class PostgresFeatureStoreRefactored : IFeatureReader, IFeatureWriter, ITileProvider, IRelationshipStore, IGeoJsonFeatureStore, IGeobufFeatureStore, IGmlFeatureStore, IKmlFeatureStore, IStreamingFeatureStore, IPagedFeatureReader, IPagedGeoJsonFeatureStore
+internal sealed class PostgresFeatureStoreRefactored : IFeatureReader, IRasterPointReader, IFeatureWriter, ITileProvider, IRelationshipStore, IGeoJsonFeatureStore, IGeobufFeatureStore, IGmlFeatureStore, IKmlFeatureStore, IStreamingFeatureStore, IPagedFeatureReader, IPagedGeoJsonFeatureStore
 {
     private readonly IFeatureQueryBuilder _queryBuilder;
     private readonly IFeatureDataAccess _dataAccess;
@@ -104,6 +104,16 @@ internal sealed class PostgresFeatureStoreRefactored : IFeatureReader, IFeatureW
             query,
             layerId,
             cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<ImmutableArray<ProjectedPoint>> QueryProjectedPointsAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var geometryStorageType = await _cacheManager.GetGeometryStorageTypeAsync(cancellationToken).ConfigureAwait(false);
+        var selectQuery = _queryBuilder.BuildProjectedPointQuery(layerId, query, geometryStorageType);
+        return await _dataAccess.ExecuteSelectProjectedPointsAsync(selectQuery, query, layerId, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<PagedQueryResult<Feature>> QueryPageAsync(

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Query.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Query.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Data;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -97,8 +98,13 @@ internal sealed partial class FeatureDataAccess
                 cmd => AddQueryParameters(cmd, featureQuery, layerId, query.WhereParameters),
                 cancellationToken).ConfigureAwait(false);
 
-            var points = new List<ProjectedPoint>();
-            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            var capacity = featureQuery.Limit is > 0 and < int.MaxValue
+                ? featureQuery.Limit.Value
+                : 256;
+            var points = new List<ProjectedPoint>(capacity);
+            await using var reader = await command.ExecuteReaderAsync(
+                CommandBehavior.SequentialAccess | CommandBehavior.SingleResult,
+                cancellationToken).ConfigureAwait(false);
 
             while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Query.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Query.cs
@@ -81,6 +81,45 @@ internal sealed partial class FeatureDataAccess
         }
     }
 
+    public async Task<ImmutableArray<ProjectedPoint>> ExecuteSelectProjectedPointsAsync(
+        CoreParameterizedQuery query,
+        FeatureQuery featureQuery,
+        int layerId,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            await using var connection = (NpgsqlConnection)await _connectionProvider.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            await using var command = await CreateCommandAsync(
+                connection,
+                query.Sql,
+                cmd => AddQueryParameters(cmd, featureQuery, layerId, query.WhereParameters),
+                cancellationToken).ConfigureAwait(false);
+
+            var points = new List<ProjectedPoint>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                points.Add(new ProjectedPoint(reader.GetDouble(0), reader.GetDouble(1)));
+            }
+
+            stopwatch.Stop();
+            _cacheManager.RecordQueryMetrics("select_points", stopwatch.ElapsedMilliseconds, points.Count);
+            RecordPerformanceQuery("select_points", layerId, stopwatch.ElapsedMilliseconds, points.Count);
+            LogSlowQuery("select_points", stopwatch.ElapsedMilliseconds, layerId, points.Count);
+
+            return points.ToImmutableArray();
+        }
+        catch (Exception)
+        {
+            stopwatch.Stop();
+            _cacheManager.RecordQueryMetrics("select_points_error", stopwatch.ElapsedMilliseconds);
+            throw;
+        }
+    }
+
     public async Task<ImmutableArray<GmlFeature>> ExecuteSelectGmlQueryAsync(CoreParameterizedQuery query, FeatureQuery featureQuery, int layerId, CancellationToken cancellationToken)
     {
         var stopwatch = Stopwatch.StartNew();

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Readers.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Readers.cs
@@ -15,6 +15,12 @@ internal sealed partial class FeatureDataAccess
     {
         var id = reader.GetInt64(0);
         var geometry = reader.IsDBNull(1) ? null : reader.GetFieldValue<byte[]>(1);
+
+        if (reader.FieldCount == 3 && reader.IsDBNull(2))
+        {
+            return Task.FromResult(Feature.Create(id, geometry));
+        }
+
         var attributes = ReadAttributes(reader, id);
         return Task.FromResult(Feature.Create(id, geometry, attributes));
     }

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
@@ -79,12 +79,14 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
                 AppendWhereClause(sql, query, ref paramIndex, parameters);
                 AppendTemporalFilter(sql, query, ref paramIndex, parameters);
                 AppendSpatialFilter(sql, query, geometryStorageType, ref paramIndex, parameters);
-                sql.Append("), snapped_points AS (SELECT ")
+                sql.Append("), projected_points AS (SELECT ")
                     .Append(DatabaseSchema.ObjectIdColumn)
-                    .Append(", ST_X(point_geom) AS x, ST_Y(point_geom) AS y, ");
-                sql.Append(CultureInfo.InvariantCulture, $"FLOOR((ST_X(point_geom) - ${originXParam}) / ${cellWidthParam})::bigint AS cell_x, ");
-                sql.Append(CultureInfo.InvariantCulture, $"FLOOR((${originYParam} - ST_Y(point_geom)) / ${cellHeightParam})::bigint AS cell_y ");
-                sql.Append("FROM point_source) SELECT DISTINCT ON (cell_x, cell_y) x, y FROM snapped_points ORDER BY cell_x, cell_y, objectid");
+                    .Append(", ST_X(point_geom) AS x, ST_Y(point_geom) AS y FROM point_source), snapped_points AS (SELECT ")
+                    .Append(DatabaseSchema.ObjectIdColumn)
+                    .Append(", x, y, ");
+                sql.Append(CultureInfo.InvariantCulture, $"FLOOR((x - ${originXParam}) / ${cellWidthParam})::bigint AS cell_x, ");
+                sql.Append(CultureInfo.InvariantCulture, $"FLOOR((${originYParam} - y) / ${cellHeightParam})::bigint AS cell_y ");
+                sql.Append("FROM projected_points) SELECT DISTINCT ON (cell_x, cell_y) x, y FROM snapped_points ORDER BY cell_x, cell_y, objectid");
             }
             else
             {

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
@@ -45,6 +45,70 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
         CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
         => BuildFormatSelectQuery(query, geometryStorageType, BuildSelectClause);
 
+    public CoreParameterizedQuery BuildProjectedPointQuery(
+        int layerId,
+        FeatureQuery query,
+        CoreGeometryStorageType geometryStorageType = CoreGeometryStorageType.Geometry)
+    {
+        var sql = _stringBuilderPool.Get();
+        try
+        {
+            var paramIndex = 2;
+            var parameters = new List<object>();
+            var pointGeometry = _geometryProcessor.GetGeometryOperand(geometryStorageType, layerSrid: query.SpatialReferenceSrid);
+
+            if (query.OutputSrid.HasValue &&
+                (!query.SpatialReferenceSrid.HasValue || query.OutputSrid.Value != query.SpatialReferenceSrid.Value))
+            {
+                pointGeometry = $"ST_Transform({pointGeometry}, {query.OutputSrid.Value})";
+            }
+
+            if (query.RasterPointGrid is { } pointGrid)
+            {
+                var originXParam = paramIndex++;
+                parameters.Add(pointGrid.OriginX);
+                var cellWidthParam = paramIndex++;
+                parameters.Add(pointGrid.CellWidth);
+                var originYParam = paramIndex++;
+                parameters.Add(pointGrid.OriginY);
+                var cellHeightParam = paramIndex++;
+                parameters.Add(pointGrid.CellHeight);
+
+                sql.Append(CultureInfo.InvariantCulture,
+                    $"WITH point_source AS (SELECT {DatabaseSchema.ObjectIdColumn}, {pointGeometry} AS point_geom FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                AppendWhereClause(sql, query, ref paramIndex, parameters);
+                AppendTemporalFilter(sql, query, ref paramIndex, parameters);
+                AppendSpatialFilter(sql, query, geometryStorageType, ref paramIndex, parameters);
+                sql.Append("), snapped_points AS (SELECT ")
+                    .Append(DatabaseSchema.ObjectIdColumn)
+                    .Append(", ST_X(point_geom) AS x, ST_Y(point_geom) AS y, ");
+                sql.Append(CultureInfo.InvariantCulture, $"FLOOR((ST_X(point_geom) - ${originXParam}) / ${cellWidthParam})::bigint AS cell_x, ");
+                sql.Append(CultureInfo.InvariantCulture, $"FLOOR((${originYParam} - ST_Y(point_geom)) / ${cellHeightParam})::bigint AS cell_y ");
+                sql.Append("FROM point_source) SELECT DISTINCT ON (cell_x, cell_y) x, y FROM snapped_points ORDER BY cell_x, cell_y, objectid");
+            }
+            else
+            {
+                sql.Append(CultureInfo.InvariantCulture,
+                    $"WITH point_source AS (SELECT {DatabaseSchema.ObjectIdColumn}, {pointGeometry} AS point_geom FROM {_tableName} WHERE {DatabaseSchema.LayerIdColumn} = $1");
+                AppendWhereClause(sql, query, ref paramIndex, parameters);
+                AppendTemporalFilter(sql, query, ref paramIndex, parameters);
+                AppendSpatialFilter(sql, query, geometryStorageType, ref paramIndex, parameters);
+                sql.Append(") SELECT ST_X(point_geom) AS x, ST_Y(point_geom) AS y FROM point_source ORDER BY objectid");
+            }
+
+            if (query.Limit.HasValue)
+            {
+                sql.Append(CultureInfo.InvariantCulture, $" LIMIT ${paramIndex}");
+            }
+
+            return new CoreParameterizedQuery(sql.ToString(), parameters);
+        }
+        finally
+        {
+            _stringBuilderPool.Return(sql);
+        }
+    }
+
     public CoreParameterizedQuery BuildSelectGmlQuery(
         int layerId,
         FeatureQuery query,

--- a/src/Honua.Server/Features/Infrastructure/Rendering/SkiaMapRenderer.cs
+++ b/src/Honua.Server/Features/Infrastructure/Rendering/SkiaMapRenderer.cs
@@ -14,6 +14,8 @@ namespace Honua.Server.Features.Infrastructure.Rendering;
 /// </summary>
 internal sealed class SkiaMapRenderer : IDisposable
 {
+    private const float PointGeneralizationPixels = 0.8f;
+    private const int PointGeneralizationThreshold = 1024;
     private bool _disposed;
 
     /// <summary>
@@ -336,6 +338,8 @@ internal sealed class SkiaMapRenderer : IDisposable
 
         var rented = ArrayPool<SKPoint>.Shared.Rent(features.Count);
         var count = 0;
+        var generalize = features.Count >= PointGeneralizationThreshold;
+        var seenCells = generalize ? new HashSet<long>() : null;
 
         try
         {
@@ -343,6 +347,11 @@ internal sealed class SkiaMapRenderer : IDisposable
             {
                 if (WkbToSkiaConverter.TryConvertPoint(feature.Geometry, transform, out var point))
                 {
+                    if (seenCells is not null && !seenCells.Add(GetPointCellKey(point)))
+                    {
+                        continue;
+                    }
+
                     rented[count++] = point;
                 }
             }
@@ -366,6 +375,13 @@ internal sealed class SkiaMapRenderer : IDisposable
         {
             ArrayPool<SKPoint>.Shared.Return(rented);
         }
+    }
+
+    private static long GetPointCellKey(SKPoint point)
+    {
+        var cellX = (int)MathF.Floor(point.X / PointGeneralizationPixels);
+        var cellY = (int)MathF.Floor(point.Y / PointGeneralizationPixels);
+        return ((long)cellX << 32) | (uint)cellY;
     }
 
     private static void RenderFeatureWithStyle(

--- a/src/Honua.Server/Features/Infrastructure/Rendering/SkiaMapRenderer.cs
+++ b/src/Honua.Server/Features/Infrastructure/Rendering/SkiaMapRenderer.cs
@@ -435,10 +435,7 @@ internal sealed class SkiaMapRenderer : IDisposable
         {
             if (result.IsPoint && result.Points != null)
             {
-                foreach (var point in result.Points)
-                {
-                    canvas.DrawCircle(point, 4f, fill);
-                }
+                canvas.DrawPoints(SKPointMode.Points, result.Points, fill);
             }
             else if (result.Path != null)
             {

--- a/src/Honua.Server/Features/Infrastructure/Rendering/SkiaMapRenderer.cs
+++ b/src/Honua.Server/Features/Infrastructure/Rendering/SkiaMapRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Buffers;
 using System.Collections.Immutable;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
@@ -298,6 +299,12 @@ internal sealed class SkiaMapRenderer : IDisposable
         var (fill, stroke) = StyleTranslator.CreateDefaultPaints(geometryType);
         try
         {
+            if (geometryType == GeometryType.Point)
+            {
+                RenderDefaultPoints(canvas, features, transform, fill);
+                return;
+            }
+
             foreach (var feature in features)
             {
                 if (feature.Geometry == null || feature.Geometry.Length < 5)
@@ -313,6 +320,51 @@ internal sealed class SkiaMapRenderer : IDisposable
         {
             fill.Dispose();
             stroke?.Dispose();
+        }
+    }
+
+    private static void RenderDefaultPoints(
+        SKCanvas canvas,
+        IReadOnlyList<Feature> features,
+        Func<double, double, SKPoint> transform,
+        SKPaint fill)
+    {
+        if (features.Count == 0)
+        {
+            return;
+        }
+
+        var rented = ArrayPool<SKPoint>.Shared.Rent(features.Count);
+        var count = 0;
+
+        try
+        {
+            foreach (var feature in features)
+            {
+                if (WkbToSkiaConverter.TryConvertPoint(feature.Geometry, transform, out var point))
+                {
+                    rented[count++] = point;
+                }
+            }
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            if (count == rented.Length)
+            {
+                canvas.DrawPoints(SKPointMode.Points, rented, fill);
+                return;
+            }
+
+            var points = new SKPoint[count];
+            Array.Copy(rented, points, count);
+            canvas.DrawPoints(SKPointMode.Points, points, fill);
+        }
+        finally
+        {
+            ArrayPool<SKPoint>.Shared.Return(rented);
         }
     }
 

--- a/src/Honua.Server/Features/Infrastructure/Rendering/SkiaMapRenderer.cs
+++ b/src/Honua.Server/Features/Infrastructure/Rendering/SkiaMapRenderer.cs
@@ -396,7 +396,7 @@ internal sealed class SkiaMapRenderer : IDisposable
                 features,
                 transform,
                 rented,
-                Math.Max(PointGeneralizationPixels, circleStyle.Radius * 0.5f));
+                Math.Max(PointGeneralizationPixels, circleStyle.Radius));
             if (count == 0)
             {
                 return;

--- a/src/Honua.Server/Features/Infrastructure/Rendering/SkiaMapRenderer.cs
+++ b/src/Honua.Server/Features/Infrastructure/Rendering/SkiaMapRenderer.cs
@@ -274,6 +274,11 @@ internal sealed class SkiaMapRenderer : IDisposable
                 continue;
             }
 
+            if (TryRenderBatchedStyleLayer(canvas, features, styleLayer, transform))
+            {
+                continue;
+            }
+
             foreach (var feature in features)
             {
                 if (feature.Geometry == null || feature.Geometry.Length < 5)
@@ -337,39 +342,16 @@ internal sealed class SkiaMapRenderer : IDisposable
         }
 
         var rented = ArrayPool<SKPoint>.Shared.Rent(features.Count);
-        var count = 0;
-        var generalize = features.Count >= PointGeneralizationThreshold;
-        var seenCells = generalize ? new HashSet<long>() : null;
 
         try
         {
-            foreach (var feature in features)
-            {
-                if (WkbToSkiaConverter.TryConvertPoint(feature.Geometry, transform, out var point))
-                {
-                    if (seenCells is not null && !seenCells.Add(GetPointCellKey(point)))
-                    {
-                        continue;
-                    }
-
-                    rented[count++] = point;
-                }
-            }
-
+            var count = CollectRenderablePoints(features, transform, rented, PointGeneralizationPixels);
             if (count == 0)
             {
                 return;
             }
 
-            if (count == rented.Length)
-            {
-                canvas.DrawPoints(SKPointMode.Points, rented, fill);
-                return;
-            }
-
-            var points = new SKPoint[count];
-            Array.Copy(rented, points, count);
-            canvas.DrawPoints(SKPointMode.Points, points, fill);
+            DrawPointBatch(canvas, rented, count, fill);
         }
         finally
         {
@@ -377,10 +359,168 @@ internal sealed class SkiaMapRenderer : IDisposable
         }
     }
 
-    private static long GetPointCellKey(SKPoint point)
+    private static bool TryRenderBatchedStyleLayer(
+        SKCanvas canvas,
+        IReadOnlyList<Feature> features,
+        MapLibreStyleLayer styleLayer,
+        Func<double, double, SKPoint> transform)
     {
-        var cellX = (int)MathF.Floor(point.X / PointGeneralizationPixels);
-        var cellY = (int)MathF.Floor(point.Y / PointGeneralizationPixels);
+        if (!string.Equals(styleLayer.Type, "circle", StringComparison.Ordinal) ||
+            styleLayer.Filter is not null ||
+            StyleTranslator.CollectReferencedFields([styleLayer]).Length != 0)
+        {
+            return false;
+        }
+
+        var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayer, ImmutableDictionary<string, object?>.Empty);
+        RenderCirclePoints(canvas, features, transform, circleStyle);
+        return true;
+    }
+
+    private static void RenderCirclePoints(
+        SKCanvas canvas,
+        IReadOnlyList<Feature> features,
+        Func<double, double, SKPoint> transform,
+        ResolvedCircleStyle circleStyle)
+    {
+        if (features.Count == 0 || circleStyle.Radius <= 0)
+        {
+            return;
+        }
+
+        var rented = ArrayPool<SKPoint>.Shared.Rent(features.Count);
+
+        try
+        {
+            var count = CollectRenderablePoints(
+                features,
+                transform,
+                rented,
+                Math.Max(PointGeneralizationPixels, circleStyle.Radius * 0.5f));
+            if (count == 0)
+            {
+                return;
+            }
+
+            if (ShouldBatchCirclePoints(features.Count, count))
+            {
+                using var circlePaint = CreateBatchedCirclePaint(
+                    circleStyle.FillColor,
+                    Math.Max(1f, circleStyle.Radius * 2f));
+                DrawPointBatch(canvas, rented, count, circlePaint);
+
+                if (circleStyle.StrokeColor.HasValue && circleStyle.StrokeWidth > 0)
+                {
+                    using var strokePaint = CreateBatchedCirclePaint(
+                        circleStyle.StrokeColor.Value,
+                        Math.Max(1f, (circleStyle.Radius * 2f) + circleStyle.StrokeWidth));
+                    DrawPointBatch(canvas, rented, count, strokePaint);
+                }
+            }
+            else
+            {
+                using var circlePaint = new SKPaint
+                {
+                    Style = SKPaintStyle.Fill,
+                    Color = circleStyle.FillColor,
+                    IsAntialias = true
+                };
+                DrawCircleLoop(canvas, rented, count, circleStyle.Radius, circlePaint);
+
+                if (circleStyle.StrokeColor.HasValue && circleStyle.StrokeWidth > 0)
+                {
+                    using var strokePaint = new SKPaint
+                    {
+                        Style = SKPaintStyle.Stroke,
+                        Color = circleStyle.StrokeColor.Value,
+                        StrokeWidth = circleStyle.StrokeWidth,
+                        IsAntialias = true
+                    };
+                    DrawCircleLoop(canvas, rented, count, circleStyle.Radius, strokePaint);
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<SKPoint>.Shared.Return(rented);
+        }
+    }
+
+    private static bool ShouldBatchCirclePoints(int originalCount, int renderedCount)
+        => originalCount >= PointGeneralizationThreshold && (renderedCount * 20) <= (originalCount * 19);
+
+    private static int CollectRenderablePoints(
+        IReadOnlyList<Feature> features,
+        Func<double, double, SKPoint> transform,
+        SKPoint[] rented,
+        float generalizationPixels)
+    {
+        var count = 0;
+        var generalize = features.Count >= PointGeneralizationThreshold;
+        var seenCells = generalize ? new HashSet<long>() : null;
+
+        foreach (var feature in features)
+        {
+            if (!WkbToSkiaConverter.TryConvertPoint(feature.Geometry, transform, out var point))
+            {
+                continue;
+            }
+
+            if (seenCells is not null && !seenCells.Add(GetPointCellKey(point, generalizationPixels)))
+            {
+                continue;
+            }
+
+            rented[count++] = point;
+        }
+
+        return count;
+    }
+
+    private static void DrawPointBatch(
+        SKCanvas canvas,
+        SKPoint[] rented,
+        int count,
+        SKPaint paint)
+    {
+        if (count == rented.Length)
+        {
+            canvas.DrawPoints(SKPointMode.Points, rented, paint);
+            return;
+        }
+
+        var points = new SKPoint[count];
+        Array.Copy(rented, points, count);
+        canvas.DrawPoints(SKPointMode.Points, points, paint);
+    }
+
+    private static void DrawCircleLoop(
+        SKCanvas canvas,
+        SKPoint[] rented,
+        int count,
+        float radius,
+        SKPaint paint)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            canvas.DrawCircle(rented[i], radius, paint);
+        }
+    }
+
+    private static SKPaint CreateBatchedCirclePaint(SKColor color, float diameter)
+        => new()
+        {
+            Style = SKPaintStyle.Stroke,
+            StrokeCap = SKStrokeCap.Round,
+            StrokeWidth = diameter,
+            Color = color,
+            IsAntialias = true
+        };
+
+    private static long GetPointCellKey(SKPoint point, float cellSize)
+    {
+        var cellX = (int)MathF.Floor(point.X / cellSize);
+        var cellY = (int)MathF.Floor(point.Y / cellSize);
         return ((long)cellX << 32) | (uint)cellY;
     }
 

--- a/src/Honua.Server/Features/Infrastructure/Rendering/StyleTranslator.cs
+++ b/src/Honua.Server/Features/Infrastructure/Rendering/StyleTranslator.cs
@@ -225,8 +225,10 @@ internal static class StyleTranslator
             Honua.Core.Features.Catalog.Domain.GeometryType.MultiPoint =>
                 (new SKPaint
                 {
-                    Style = SKPaintStyle.Fill,
+                    Style = SKPaintStyle.Stroke,
                     Color = strokeColor,
+                    StrokeWidth = 8f,
+                    StrokeCap = SKStrokeCap.Round,
                     IsAntialias = true
                 }, null),
 

--- a/src/Honua.Server/Features/Infrastructure/Rendering/WkbToSkiaConverter.cs
+++ b/src/Honua.Server/Features/Infrastructure/Rendering/WkbToSkiaConverter.cs
@@ -70,6 +70,75 @@ internal static class WkbToSkiaConverter
         }
     }
 
+    /// <summary>
+    /// Fast path for simple point geometries used by dense point-layer raster rendering.
+    /// Returns false for non-point or malformed geometries.
+    /// </summary>
+    public static bool TryConvertPoint(byte[]? wkb, Func<double, double, SKPoint> transform, out SKPoint point)
+    {
+        point = default;
+
+        if (wkb == null || wkb.Length < 21)
+        {
+            return false;
+        }
+
+        var reader = new WkbReader(wkb);
+        var byteOrder = reader.ReadByte();
+        reader.IsLittleEndian = byteOrder == 1;
+
+        var rawType = reader.ReadInt32();
+
+        var hasSrid = (rawType & 0x20000000) != 0;
+        var hasZ = (rawType & unchecked((int)0x80000000)) != 0;
+        var hasM = (rawType & 0x40000000) != 0;
+
+        var geometryType = rawType & 0xFFFF;
+
+        if (geometryType >= 3000 && geometryType < 4000)
+        {
+            hasZ = true;
+            hasM = true;
+            geometryType -= 3000;
+        }
+        else if (geometryType >= 2000 && geometryType < 3000)
+        {
+            hasM = true;
+            geometryType -= 2000;
+        }
+        else if (geometryType >= 1000 && geometryType < 2000)
+        {
+            hasZ = true;
+            geometryType -= 1000;
+        }
+
+        if (geometryType != WkbPoint)
+        {
+            return false;
+        }
+
+        if (hasSrid)
+        {
+            if (wkb.Length < 25)
+            {
+                return false;
+            }
+
+            reader.ReadInt32();
+        }
+
+        var expectedLength = 1 + 4 + (hasSrid ? 4 : 0) + 16 + ((hasZ ? 1 : 0) + (hasM ? 1 : 0)) * 8;
+        if (wkb.Length < expectedLength)
+        {
+            return false;
+        }
+
+        var x = reader.ReadDouble();
+        var y = reader.ReadDouble();
+        point = transform(x, y);
+        return true;
+    }
+
     private static GeometryConversionResult ReadGeometry(WkbReader reader, Func<double, double, SKPoint> transform)
     {
         var byteOrder = reader.ReadByte();

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
@@ -495,6 +495,11 @@ internal static partial class MapServerEndpoints
                     continue;
                 }
 
+                if (TryRenderBatchedStyleLayer(canvas, features, styleLayer, transform))
+                {
+                    continue;
+                }
+
                 foreach (var feature in features)
                 {
                     if (feature.Geometry == null || feature.Geometry.Length < 5)
@@ -553,39 +558,16 @@ internal static partial class MapServerEndpoints
         }
 
         var rented = ArrayPool<SKPoint>.Shared.Rent(features.Count);
-        var count = 0;
-        var generalize = features.Count >= PointGeneralizationThreshold;
-        var seenCells = generalize ? new HashSet<long>() : null;
 
         try
         {
-            foreach (var feature in features)
-            {
-                if (WkbToSkiaConverter.TryConvertPoint(feature.Geometry, transform, out var point))
-                {
-                    if (seenCells is not null && !seenCells.Add(GetPointCellKey(point)))
-                    {
-                        continue;
-                    }
-
-                    rented[count++] = point;
-                }
-            }
-
+            var count = CollectRenderablePoints(features, transform, rented, PointGeneralizationPixels);
             if (count == 0)
             {
                 return;
             }
 
-            if (count == rented.Length)
-            {
-                canvas.DrawPoints(SKPointMode.Points, rented, fill);
-                return;
-            }
-
-            var points = new SKPoint[count];
-            Array.Copy(rented, points, count);
-            canvas.DrawPoints(SKPointMode.Points, points, fill);
+            DrawPointBatch(canvas, rented, count, fill);
         }
         finally
         {
@@ -593,10 +575,168 @@ internal static partial class MapServerEndpoints
         }
     }
 
-    private static long GetPointCellKey(SKPoint point)
+    private static bool TryRenderBatchedStyleLayer(
+        SKCanvas canvas,
+        IReadOnlyList<Feature> features,
+        MapLibreStyleLayer styleLayer,
+        Func<double, double, SKPoint> transform)
     {
-        var cellX = (int)MathF.Floor(point.X / PointGeneralizationPixels);
-        var cellY = (int)MathF.Floor(point.Y / PointGeneralizationPixels);
+        if (!string.Equals(styleLayer.Type, "circle", StringComparison.Ordinal) ||
+            styleLayer.Filter is not null ||
+            StyleTranslator.CollectReferencedFields([styleLayer]).Length != 0)
+        {
+            return false;
+        }
+
+        var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayer, ImmutableDictionary<string, object?>.Empty);
+        RenderCirclePoints(canvas, features, transform, circleStyle);
+        return true;
+    }
+
+    private static void RenderCirclePoints(
+        SKCanvas canvas,
+        IReadOnlyList<Feature> features,
+        Func<double, double, SKPoint> transform,
+        ResolvedCircleStyle circleStyle)
+    {
+        if (features.Count == 0 || circleStyle.Radius <= 0)
+        {
+            return;
+        }
+
+        var rented = ArrayPool<SKPoint>.Shared.Rent(features.Count);
+
+        try
+        {
+            var count = CollectRenderablePoints(
+                features,
+                transform,
+                rented,
+                Math.Max(PointGeneralizationPixels, circleStyle.Radius * 0.5f));
+            if (count == 0)
+            {
+                return;
+            }
+
+            if (ShouldBatchCirclePoints(features.Count, count))
+            {
+                using var circlePaint = CreateBatchedCirclePaint(
+                    circleStyle.FillColor,
+                    Math.Max(1f, circleStyle.Radius * 2f));
+                DrawPointBatch(canvas, rented, count, circlePaint);
+
+                if (circleStyle.StrokeColor.HasValue && circleStyle.StrokeWidth > 0)
+                {
+                    using var strokePaint = CreateBatchedCirclePaint(
+                        circleStyle.StrokeColor.Value,
+                        Math.Max(1f, (circleStyle.Radius * 2f) + circleStyle.StrokeWidth));
+                    DrawPointBatch(canvas, rented, count, strokePaint);
+                }
+            }
+            else
+            {
+                using var circlePaint = new SKPaint
+                {
+                    Style = SKPaintStyle.Fill,
+                    Color = circleStyle.FillColor,
+                    IsAntialias = true
+                };
+                DrawCircleLoop(canvas, rented, count, circleStyle.Radius, circlePaint);
+
+                if (circleStyle.StrokeColor.HasValue && circleStyle.StrokeWidth > 0)
+                {
+                    using var strokePaint = new SKPaint
+                    {
+                        Style = SKPaintStyle.Stroke,
+                        Color = circleStyle.StrokeColor.Value,
+                        StrokeWidth = circleStyle.StrokeWidth,
+                        IsAntialias = true
+                    };
+                    DrawCircleLoop(canvas, rented, count, circleStyle.Radius, strokePaint);
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<SKPoint>.Shared.Return(rented);
+        }
+    }
+
+    private static bool ShouldBatchCirclePoints(int originalCount, int renderedCount)
+        => originalCount >= PointGeneralizationThreshold && (renderedCount * 20) <= (originalCount * 19);
+
+    private static int CollectRenderablePoints(
+        IReadOnlyList<Feature> features,
+        Func<double, double, SKPoint> transform,
+        SKPoint[] rented,
+        float generalizationPixels)
+    {
+        var count = 0;
+        var generalize = features.Count >= PointGeneralizationThreshold;
+        var seenCells = generalize ? new HashSet<long>() : null;
+
+        foreach (var feature in features)
+        {
+            if (!WkbToSkiaConverter.TryConvertPoint(feature.Geometry, transform, out var point))
+            {
+                continue;
+            }
+
+            if (seenCells is not null && !seenCells.Add(GetPointCellKey(point, generalizationPixels)))
+            {
+                continue;
+            }
+
+            rented[count++] = point;
+        }
+
+        return count;
+    }
+
+    private static void DrawPointBatch(
+        SKCanvas canvas,
+        SKPoint[] rented,
+        int count,
+        SKPaint paint)
+    {
+        if (count == rented.Length)
+        {
+            canvas.DrawPoints(SKPointMode.Points, rented, paint);
+            return;
+        }
+
+        var points = new SKPoint[count];
+        Array.Copy(rented, points, count);
+        canvas.DrawPoints(SKPointMode.Points, points, paint);
+    }
+
+    private static void DrawCircleLoop(
+        SKCanvas canvas,
+        SKPoint[] rented,
+        int count,
+        float radius,
+        SKPaint paint)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            canvas.DrawCircle(rented[i], radius, paint);
+        }
+    }
+
+    private static SKPaint CreateBatchedCirclePaint(SKColor color, float diameter)
+        => new()
+        {
+            Style = SKPaintStyle.Stroke,
+            StrokeCap = SKStrokeCap.Round,
+            StrokeWidth = diameter,
+            Color = color,
+            IsAntialias = true
+        };
+
+    private static long GetPointCellKey(SKPoint point, float cellSize)
+    {
+        var cellX = (int)MathF.Floor(point.X / cellSize);
+        var cellY = (int)MathF.Floor(point.Y / cellSize);
         return ((long)cellX << 32) | (uint)cellY;
     }
 

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Collections.Immutable;
+using System.Collections.Concurrent;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Globalization;
@@ -12,6 +13,7 @@ using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Styling.Abstractions;
+using Honua.Core.Features.Styling.Domain;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Core.Queries.Filters;
 using Honua.Server.Features.FeatureServer;
@@ -29,6 +31,28 @@ namespace Honua.Server.Features.MapServer;
 
 internal static partial class MapServerEndpoints
 {
+    private sealed class RasterStylePlan
+    {
+        public required MapLibreStyleLayer[] StyleLayers { get; init; }
+
+        public required string[] ReferencedFields { get; init; }
+
+        public ResolvedCircleStyle? SimpleCircleStyle { get; init; }
+    }
+
+    private sealed class CachedRasterStylePlan
+    {
+        public required int StyleVersion { get; init; }
+
+        public string? MapLibreStyleJson { get; init; }
+
+        public required RasterStylePlan Plan { get; init; }
+
+        public bool Matches(LayerStyleDefinition? style) =>
+            StyleVersion == (style?.StyleVersion ?? 0) &&
+            string.Equals(MapLibreStyleJson, style?.MapLibreStyleJson, StringComparison.Ordinal);
+    }
+
     private const float PointGeneralizationPixels = 0.8f;
     private const int PointGeneralizationThreshold = 1024;
     private const int MaxImageDimension = 4096;
@@ -42,6 +66,7 @@ internal static partial class MapServerEndpoints
     private const string InvalidDynamicLayersJsonMessage = "dynamicLayers contains invalid JSON.";
     private const string InvalidTimeParameterMessage = "Invalid time parameter.";
     private const string InvalidSpatialReferenceMessage = "Invalid spatial reference.";
+    private static readonly ConcurrentDictionary<int, CachedRasterStylePlan> _rasterStylePlanCache = new();
 
     /// <summary>
     /// Handle MapServer export (map image generation) requests.
@@ -362,10 +387,12 @@ internal static partial class MapServerEndpoints
                         filterError ?? "Invalid filter parameter.");
                 }
 
-                var style = await styleCatalog.GetLayerStyleAsync(layer.Id, context.RequestAborted);
-                var styleLayers = StyleTranslator.ParseStyleLayers(style?.MapLibreStyleJson);
+                var stylePlan = await GetRasterStylePlanAsync(
+                    styleCatalog,
+                    layer.Id,
+                    context.RequestAborted).ConfigureAwait(false);
                 var featureQuery = CreateRasterFeatureQuery(
-                    styleLayers,
+                    stylePlan,
                     spatialFilter,
                     serviceSrid,
                     imageSrid,
@@ -377,7 +404,7 @@ internal static partial class MapServerEndpoints
                     featureReader,
                     layer.Id,
                     layer.GeometryType,
-                    styleLayers,
+                    stylePlan,
                     featureQuery,
                     renderExtent,
                     imageWidth,
@@ -398,7 +425,7 @@ internal static partial class MapServerEndpoints
                 }
 
                 totalFeatureCount += features.Length;
-                RenderLayerToCanvas(canvas, features, styleLayers, transform, layer.GeometryType);
+                RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transform, layer.GeometryType);
             }
 
             stopwatch.Stop();
@@ -885,15 +912,67 @@ internal static partial class MapServerEndpoints
         result.Path?.Dispose();
     }
 
-    private static FeatureQuery CreateRasterFeatureQuery(
+    private static async Task<RasterStylePlan> GetRasterStylePlanAsync(
+        ILayerStyleCatalog styleCatalog,
+        int layerId,
+        CancellationToken cancellationToken)
+    {
+        var style = await styleCatalog.GetLayerStyleAsync(layerId, cancellationToken).ConfigureAwait(false);
+        if (_rasterStylePlanCache.TryGetValue(layerId, out var cached) &&
+            cached.Matches(style))
+        {
+            return cached.Plan;
+        }
+
+        var plan = BuildRasterStylePlan(style);
+        _rasterStylePlanCache[layerId] = new CachedRasterStylePlan
+        {
+            StyleVersion = style?.StyleVersion ?? 0,
+            MapLibreStyleJson = style?.MapLibreStyleJson,
+            Plan = plan
+        };
+
+        return plan;
+    }
+
+    private static RasterStylePlan BuildRasterStylePlan(LayerStyleDefinition? style)
+    {
+        var styleLayers = StyleTranslator.ParseStyleLayers(style?.MapLibreStyleJson);
+        var referencedFields = StyleTranslator.CollectReferencedFields(styleLayers);
+
+        return new RasterStylePlan
+        {
+            StyleLayers = styleLayers,
+            ReferencedFields = referencedFields,
+            SimpleCircleStyle = TryResolveSimpleCircleStyle(styleLayers, referencedFields)
+        };
+    }
+
+    private static ResolvedCircleStyle? TryResolveSimpleCircleStyle(
         MapLibreStyleLayer[] styleLayers,
+        string[] referencedFields)
+    {
+        if (styleLayers.Length != 1 ||
+            !string.Equals(styleLayers[0].Type, "circle", StringComparison.Ordinal) ||
+            styleLayers[0].Filter is not null ||
+            referencedFields.Length != 0)
+        {
+            return null;
+        }
+
+        var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayers[0], ImmutableDictionary<string, object?>.Empty);
+        return circleStyle.Radius > 0 ? circleStyle : null;
+    }
+
+    private static FeatureQuery CreateRasterFeatureQuery(
+        RasterStylePlan stylePlan,
         SpatialFilter spatialFilter,
         int spatialReferenceSrid,
         int? outputSrid,
         int limit,
         SqlFragment? sqlFilter = null)
     {
-        var referencedFields = StyleTranslator.CollectReferencedFields(styleLayers);
+        var referencedFields = stylePlan.ReferencedFields;
 
         return new FeatureQuery
         {
@@ -912,7 +991,7 @@ internal static partial class MapServerEndpoints
         IFeatureReader featureReader,
         int layerId,
         GeometryType geometryType,
-        MapLibreStyleLayer[] styleLayers,
+        RasterStylePlan stylePlan,
         FeatureQuery featureQuery,
         SkiaMapRenderer.RenderExtent renderExtent,
         int imageWidth,
@@ -923,7 +1002,7 @@ internal static partial class MapServerEndpoints
         if (featureReader is not IRasterPointReader rasterPointReader ||
             !TryCreateRasterPointFastPathQuery(
                 geometryType,
-                styleLayers,
+                stylePlan,
                 featureQuery,
                 renderExtent,
                 imageWidth,
@@ -946,7 +1025,7 @@ internal static partial class MapServerEndpoints
 
     private static bool TryCreateRasterPointFastPathQuery(
         GeometryType geometryType,
-        MapLibreStyleLayer[] styleLayers,
+        RasterStylePlan stylePlan,
         FeatureQuery featureQuery,
         SkiaMapRenderer.RenderExtent renderExtent,
         int imageWidth,
@@ -958,9 +1037,7 @@ internal static partial class MapServerEndpoints
         circleStyle = default!;
 
         if (geometryType != GeometryType.Point ||
-            styleLayers.Length != 1 ||
-            !string.Equals(styleLayers[0].Type, "circle", StringComparison.Ordinal) ||
-            styleLayers[0].Filter is not null ||
+            stylePlan.SimpleCircleStyle is null ||
             !featureQuery.ExcludeAttributes ||
             imageWidth <= 0 ||
             imageHeight <= 0 ||
@@ -970,12 +1047,7 @@ internal static partial class MapServerEndpoints
             return false;
         }
 
-        circleStyle = StyleTranslator.ResolveCircleStyle(styleLayers[0], ImmutableDictionary<string, object?>.Empty);
-        if (circleStyle.Radius <= 0)
-        {
-            return false;
-        }
-
+        circleStyle = stylePlan.SimpleCircleStyle;
         var generalizationPixels = Math.Max(PointGeneralizationPixels, circleStyle.Radius);
         var cellWidth = renderExtent.Width / imageWidth * generalizationPixels;
         var cellHeight = renderExtent.Height / imageHeight * generalizationPixels;
@@ -984,8 +1056,13 @@ internal static partial class MapServerEndpoints
             return false;
         }
 
+        var spatialFilter = featureQuery.SpatialFilter is { SpatialRelationship: SpatialRelationship.Intersects } currentSpatialFilter
+            ? currentSpatialFilter with { SpatialRelationship = SpatialRelationship.EnvelopeIntersects }
+            : featureQuery.SpatialFilter;
+
         pointQuery = featureQuery with
         {
+            SpatialFilter = spatialFilter,
             RasterPointGrid = new RasterPointGrid
             {
                 OriginX = renderExtent.MinX,

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Buffers;
+using System.Collections.Immutable;
+using System.Data.Common;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
-using System.Collections.Immutable;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
@@ -512,6 +514,12 @@ internal static partial class MapServerEndpoints
             var (fill, stroke) = StyleTranslator.CreateDefaultPaints(geometryType);
             try
             {
+                if (geometryType == GeometryType.Point)
+                {
+                    RenderDefaultPoints(canvas, features, transform, fill);
+                    return;
+                }
+
                 foreach (var feature in features)
                 {
                     if (feature.Geometry == null || feature.Geometry.Length < 5)
@@ -528,6 +536,51 @@ internal static partial class MapServerEndpoints
                 fill.Dispose();
                 stroke?.Dispose();
             }
+        }
+    }
+
+    private static void RenderDefaultPoints(
+        SKCanvas canvas,
+        IReadOnlyList<Feature> features,
+        Func<double, double, SKPoint> transform,
+        SKPaint fill)
+    {
+        if (features.Count == 0)
+        {
+            return;
+        }
+
+        var rented = ArrayPool<SKPoint>.Shared.Rent(features.Count);
+        var count = 0;
+
+        try
+        {
+            foreach (var feature in features)
+            {
+                if (WkbToSkiaConverter.TryConvertPoint(feature.Geometry, transform, out var point))
+                {
+                    rented[count++] = point;
+                }
+            }
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            if (count == rented.Length)
+            {
+                canvas.DrawPoints(SKPointMode.Points, rented, fill);
+                return;
+            }
+
+            var points = new SKPoint[count];
+            Array.Copy(rented, points, count);
+            canvas.DrawPoints(SKPointMode.Points, points, fill);
+        }
+        finally
+        {
+            ArrayPool<SKPoint>.Shared.Return(rented);
         }
     }
 

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
@@ -644,10 +644,7 @@ internal static partial class MapServerEndpoints
     {
         if (result.IsPoint && result.Points != null)
         {
-            foreach (var point in result.Points)
-            {
-                canvas.DrawCircle(point, 4f, fill);
-            }
+            canvas.DrawPoints(SKPointMode.Points, result.Points, fill);
         }
         else if (result.Path != null)
         {

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
@@ -29,6 +29,8 @@ namespace Honua.Server.Features.MapServer;
 
 internal static partial class MapServerEndpoints
 {
+    private const float PointGeneralizationPixels = 0.8f;
+    private const int PointGeneralizationThreshold = 1024;
     private const int MaxImageDimension = 4096;
     private const int DefaultImageWidth = 400;
     private const int DefaultImageHeight = 400;
@@ -552,6 +554,8 @@ internal static partial class MapServerEndpoints
 
         var rented = ArrayPool<SKPoint>.Shared.Rent(features.Count);
         var count = 0;
+        var generalize = features.Count >= PointGeneralizationThreshold;
+        var seenCells = generalize ? new HashSet<long>() : null;
 
         try
         {
@@ -559,6 +563,11 @@ internal static partial class MapServerEndpoints
             {
                 if (WkbToSkiaConverter.TryConvertPoint(feature.Geometry, transform, out var point))
                 {
+                    if (seenCells is not null && !seenCells.Add(GetPointCellKey(point)))
+                    {
+                        continue;
+                    }
+
                     rented[count++] = point;
                 }
             }
@@ -582,6 +591,13 @@ internal static partial class MapServerEndpoints
         {
             ArrayPool<SKPoint>.Shared.Return(rented);
         }
+    }
+
+    private static long GetPointCellKey(SKPoint point)
+    {
+        var cellX = (int)MathF.Floor(point.X / PointGeneralizationPixels);
+        var cellY = (int)MathF.Floor(point.Y / PointGeneralizationPixels);
+        return ((long)cellX << 32) | (uint)cellY;
     }
 
     private static void RenderStyledFeature(

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
@@ -372,6 +372,24 @@ internal static partial class MapServerEndpoints
                     maxFeatures,
                     sqlFilter);
 
+                var renderedPointCount = await TryRenderRasterPointFastPathAsync(
+                    canvas,
+                    featureReader,
+                    layer.Id,
+                    layer.GeometryType,
+                    styleLayers,
+                    featureQuery,
+                    renderExtent,
+                    imageWidth,
+                    imageHeight,
+                    transform,
+                    context.RequestAborted).ConfigureAwait(false);
+                if (renderedPointCount >= 0)
+                {
+                    totalFeatureCount += renderedPointCount;
+                    continue;
+                }
+
                 var features = await QueryRasterFeaturesAsync(featureReader, layer.Id, featureQuery, context.RequestAborted);
 
                 if (features.Length == 0)
@@ -612,7 +630,7 @@ internal static partial class MapServerEndpoints
                 features,
                 transform,
                 rented,
-                Math.Max(PointGeneralizationPixels, circleStyle.Radius * 0.5f));
+                Math.Max(PointGeneralizationPixels, circleStyle.Radius));
             if (count == 0)
             {
                 return;
@@ -889,6 +907,97 @@ internal static partial class MapServerEndpoints
         };
     }
 
+    private static async Task<int> TryRenderRasterPointFastPathAsync(
+        SKCanvas canvas,
+        IFeatureReader featureReader,
+        int layerId,
+        GeometryType geometryType,
+        MapLibreStyleLayer[] styleLayers,
+        FeatureQuery featureQuery,
+        SkiaMapRenderer.RenderExtent renderExtent,
+        int imageWidth,
+        int imageHeight,
+        Func<double, double, SKPoint> transform,
+        CancellationToken cancellationToken)
+    {
+        if (featureReader is not IRasterPointReader rasterPointReader ||
+            !TryCreateRasterPointFastPathQuery(
+                geometryType,
+                styleLayers,
+                featureQuery,
+                renderExtent,
+                imageWidth,
+                imageHeight,
+                out var pointQuery,
+                out var circleStyle))
+        {
+            return -1;
+        }
+
+        var points = await rasterPointReader.QueryProjectedPointsAsync(layerId, pointQuery, cancellationToken).ConfigureAwait(false);
+        if (points.Length == 0)
+        {
+            return 0;
+        }
+
+        RenderProjectedCirclePoints(canvas, points, transform, circleStyle);
+        return points.Length;
+    }
+
+    private static bool TryCreateRasterPointFastPathQuery(
+        GeometryType geometryType,
+        MapLibreStyleLayer[] styleLayers,
+        FeatureQuery featureQuery,
+        SkiaMapRenderer.RenderExtent renderExtent,
+        int imageWidth,
+        int imageHeight,
+        out FeatureQuery pointQuery,
+        out ResolvedCircleStyle circleStyle)
+    {
+        pointQuery = default;
+        circleStyle = default!;
+
+        if (geometryType != GeometryType.Point ||
+            styleLayers.Length != 1 ||
+            !string.Equals(styleLayers[0].Type, "circle", StringComparison.Ordinal) ||
+            styleLayers[0].Filter is not null ||
+            !featureQuery.ExcludeAttributes ||
+            imageWidth <= 0 ||
+            imageHeight <= 0 ||
+            renderExtent.Width <= 0 ||
+            renderExtent.Height <= 0)
+        {
+            return false;
+        }
+
+        circleStyle = StyleTranslator.ResolveCircleStyle(styleLayers[0], ImmutableDictionary<string, object?>.Empty);
+        if (circleStyle.Radius <= 0)
+        {
+            return false;
+        }
+
+        var generalizationPixels = Math.Max(PointGeneralizationPixels, circleStyle.Radius);
+        var cellWidth = renderExtent.Width / imageWidth * generalizationPixels;
+        var cellHeight = renderExtent.Height / imageHeight * generalizationPixels;
+        if (cellWidth <= 0 || cellHeight <= 0)
+        {
+            return false;
+        }
+
+        pointQuery = featureQuery with
+        {
+            RasterPointGrid = new RasterPointGrid
+            {
+                OriginX = renderExtent.MinX,
+                OriginY = renderExtent.MaxY,
+                CellWidth = cellWidth,
+                CellHeight = cellHeight
+            }
+        };
+
+        return true;
+    }
+
     private static async Task<ImmutableArray<Feature>> QueryRasterFeaturesAsync(
         IFeatureReader featureReader,
         int layerId,
@@ -905,6 +1014,70 @@ internal static partial class MapServerEndpoints
 
         var result = await featureReader.QueryAsync(layerId, query, cancellationToken).ConfigureAwait(false);
         return result.Items;
+    }
+
+    private static void RenderProjectedCirclePoints(
+        SKCanvas canvas,
+        ImmutableArray<ProjectedPoint> points,
+        Func<double, double, SKPoint> transform,
+        ResolvedCircleStyle circleStyle)
+    {
+        if (points.IsDefaultOrEmpty || circleStyle.Radius <= 0)
+        {
+            return;
+        }
+
+        var rented = ArrayPool<SKPoint>.Shared.Rent(points.Length);
+
+        try
+        {
+            for (var i = 0; i < points.Length; i++)
+            {
+                rented[i] = transform(points[i].X, points[i].Y);
+            }
+
+            if (points.Length >= PointGeneralizationThreshold)
+            {
+                using var circlePaint = CreateBatchedCirclePaint(
+                    circleStyle.FillColor,
+                    Math.Max(1f, circleStyle.Radius * 2f));
+                DrawPointBatch(canvas, rented, points.Length, circlePaint);
+
+                if (circleStyle.StrokeColor.HasValue && circleStyle.StrokeWidth > 0)
+                {
+                    using var strokePaint = CreateBatchedCirclePaint(
+                        circleStyle.StrokeColor.Value,
+                        Math.Max(1f, (circleStyle.Radius * 2f) + circleStyle.StrokeWidth));
+                    DrawPointBatch(canvas, rented, points.Length, strokePaint);
+                }
+
+                return;
+            }
+
+            using var fillPaint = new SKPaint
+            {
+                Style = SKPaintStyle.Fill,
+                Color = circleStyle.FillColor,
+                IsAntialias = true
+            };
+            DrawCircleLoop(canvas, rented, points.Length, circleStyle.Radius, fillPaint);
+
+            if (circleStyle.StrokeColor.HasValue && circleStyle.StrokeWidth > 0)
+            {
+                using var strokePaint = new SKPaint
+                {
+                    Style = SKPaintStyle.Stroke,
+                    Color = circleStyle.StrokeColor.Value,
+                    StrokeWidth = circleStyle.StrokeWidth,
+                    IsAntialias = true
+                };
+                DrawCircleLoop(canvas, rented, points.Length, circleStyle.Radius, strokePaint);
+            }
+        }
+        finally
+        {
+            ArrayPool<SKPoint>.Shared.Return(rented);
+        }
     }
 
     private static bool TryParseBbox(string? bbox, out SkiaMapRenderer.RenderExtent extent)

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Tile.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Tile.cs
@@ -162,14 +162,34 @@ internal static partial class MapServerEndpoints
                     continue;
                 }
 
-                var style = await styleCatalog.GetLayerStyleAsync(layer.Id, context.RequestAborted);
-                var styleLayers = StyleTranslator.ParseStyleLayers(style?.MapLibreStyleJson);
+                var stylePlan = await GetRasterStylePlanAsync(
+                    styleCatalog,
+                    layer.Id,
+                    context.RequestAborted).ConfigureAwait(false);
                 var featureQuery = CreateRasterFeatureQuery(
-                    styleLayers,
+                    stylePlan,
                     spatialFilter,
                     service.SpatialReference.Srid,
                     TileSrid,
                     maxFeatures);
+
+                var renderedPointCount = await TryRenderRasterPointFastPathAsync(
+                    canvas,
+                    featureReader,
+                    layer.Id,
+                    layer.GeometryType,
+                    stylePlan,
+                    featureQuery,
+                    renderExtent,
+                    TileSize,
+                    TileSize,
+                    transform,
+                    context.RequestAborted).ConfigureAwait(false);
+                if (renderedPointCount >= 0)
+                {
+                    totalFeatureCount += renderedPointCount;
+                    continue;
+                }
 
                 var features = await QueryRasterFeaturesAsync(featureReader, layer.Id, featureQuery, context.RequestAborted);
                 if (features.Length == 0)
@@ -178,7 +198,7 @@ internal static partial class MapServerEndpoints
                 }
 
                 totalFeatureCount += features.Length;
-                RenderLayerToCanvas(canvas, features, styleLayers, transform, layer.GeometryType);
+                RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transform, layer.GeometryType);
             }
 
             var imageBytes = SkiaMapRenderer.EncodeSurface(surface, "png");

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Wms.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Wms.cs
@@ -380,6 +380,24 @@ internal static partial class MapServerEndpoints
                 requestSrid,
                 maxFeatures);
 
+            var renderedPointCount = await TryRenderRasterPointFastPathAsync(
+                canvas,
+                featureReader,
+                layer.Id,
+                layer.GeometryType,
+                styleLayers,
+                featureQuery,
+                requestedExtent,
+                imageWidth,
+                imageHeight,
+                transformFn,
+                context.RequestAborted).ConfigureAwait(false);
+            if (renderedPointCount >= 0)
+            {
+                totalFeatureCount += renderedPointCount;
+                continue;
+            }
+
             var features = await QueryRasterFeaturesAsync(featureReader, layer.Id, featureQuery, context.RequestAborted);
             if (features.Length == 0)
             {

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Wms.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Wms.cs
@@ -371,10 +371,12 @@ internal static partial class MapServerEndpoints
                 continue;
             }
 
-            var style = await styleCatalog.GetLayerStyleAsync(layer.Id, context.RequestAborted);
-            var styleLayers = StyleTranslator.ParseStyleLayers(style?.MapLibreStyleJson);
+            var stylePlan = await GetRasterStylePlanAsync(
+                styleCatalog,
+                layer.Id,
+                context.RequestAborted).ConfigureAwait(false);
             var featureQuery = CreateRasterFeatureQuery(
-                styleLayers,
+                stylePlan,
                 spatialFilter,
                 service.SpatialReference.Srid,
                 requestSrid,
@@ -385,7 +387,7 @@ internal static partial class MapServerEndpoints
                 featureReader,
                 layer.Id,
                 layer.GeometryType,
-                styleLayers,
+                stylePlan,
                 featureQuery,
                 requestedExtent,
                 imageWidth,
@@ -405,7 +407,7 @@ internal static partial class MapServerEndpoints
             }
 
             totalFeatureCount += features.Length;
-            RenderLayerToCanvas(canvas, features, styleLayers, transformFn, layer.GeometryType);
+            RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transformFn, layer.GeometryType);
         }
 
         var imageBytes = SkiaMapRenderer.EncodeSurface(surface, imageFormat);

--- a/src/Honua.Server/Features/MapServer/Rendering/RasterRenderCapacityLimiter.cs
+++ b/src/Honua.Server/Features/MapServer/Rendering/RasterRenderCapacityLimiter.cs
@@ -13,23 +13,33 @@ internal sealed class RasterRenderCapacityLimiter : IDisposable
     private const int BytesPerPixel = 4;
     private const int DefaultMaxConcurrentRenders = 4;
     private const long DefaultMaxReservedBytes = 256L * 1024L * 1024L;
+    private static readonly TimeSpan DefaultAcquireTimeout = TimeSpan.FromSeconds(1);
 
     private readonly SemaphoreSlim _concurrencyGate;
     private readonly long _maxReservedBytes;
+    private readonly TimeSpan _acquireTimeout;
     private long _reservedBytes;
 
     public RasterRenderCapacityLimiter()
-        : this(DefaultMaxConcurrentRenders, DefaultMaxReservedBytes)
+        : this(DefaultMaxConcurrentRenders, DefaultMaxReservedBytes, DefaultAcquireTimeout)
     {
     }
 
-    internal RasterRenderCapacityLimiter(int maxConcurrentRenders, long maxReservedBytes)
+    internal RasterRenderCapacityLimiter(
+        int maxConcurrentRenders,
+        long maxReservedBytes,
+        TimeSpan? acquireTimeout = null)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxConcurrentRenders);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxReservedBytes);
+        if (acquireTimeout.HasValue && acquireTimeout.Value < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(acquireTimeout));
+        }
 
         _concurrencyGate = new SemaphoreSlim(maxConcurrentRenders, maxConcurrentRenders);
         _maxReservedBytes = maxReservedBytes;
+        _acquireTimeout = acquireTimeout ?? DefaultAcquireTimeout;
     }
 
     public async ValueTask<Lease?> TryAcquireAsync(int width, int height, CancellationToken cancellationToken)
@@ -43,7 +53,7 @@ internal sealed class RasterRenderCapacityLimiter : IDisposable
             return null;
         }
 
-        if (!await _concurrencyGate.WaitAsync(0, cancellationToken).ConfigureAwait(false))
+        if (!await _concurrencyGate.WaitAsync(_acquireTimeout, cancellationToken).ConfigureAwait(false))
         {
             return null;
         }

--- a/tests/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderProjectedPointTests.cs
+++ b/tests/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderProjectedPointTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Postgres.Features.FeatureStore.Services;
+using Microsoft.Extensions.ObjectPool;
+using FeatureStoreStringBuilderPooledObjectPolicy = Honua.Postgres.Features.FeatureStore.Services.StringBuilderPooledObjectPolicy;
+
+namespace Honua.Postgres.Tests.Features.FeatureStore;
+
+public sealed class FeatureQueryBuilderProjectedPointTests
+{
+    [Fact]
+    public void BuildProjectedPointQuery_WithRasterGrid_UsesDistinctPointCellsAndLimit()
+    {
+        var queryBuilder = CreateQueryBuilder();
+        var query = new FeatureQuery
+        {
+            SpatialReferenceSrid = 4326,
+            OutputSrid = 4326,
+            Limit = 10,
+            RasterPointGrid = new RasterPointGrid
+            {
+                OriginX = -180,
+                OriginY = 90,
+                CellWidth = 1.5,
+                CellHeight = 1.5
+            }
+        };
+
+        var result = queryBuilder.BuildProjectedPointQuery(layerId: 1, query);
+
+        result.Sql.Should().Contain("WITH point_source AS");
+        result.Sql.Should().Contain("SELECT DISTINCT ON (cell_x, cell_y) x, y FROM snapped_points");
+        result.Sql.Should().Contain("FLOOR((ST_X(point_geom) - $2) / $3)::bigint AS cell_x");
+        result.Sql.Should().Contain("FLOOR(($4 - ST_Y(point_geom)) / $5)::bigint AS cell_y");
+        result.Sql.Should().Contain("LIMIT $6");
+        result.WhereParameters.Should().Equal(-180d, 1.5d, 90d, 1.5d);
+    }
+
+    [Fact]
+    public void BuildProjectedPointQuery_WithoutRasterGrid_SelectsProjectedCoordinates()
+    {
+        var queryBuilder = CreateQueryBuilder();
+        var query = new FeatureQuery
+        {
+            SpatialReferenceSrid = 4326,
+            OutputSrid = 4326
+        };
+
+        var result = queryBuilder.BuildProjectedPointQuery(layerId: 1, query);
+
+        result.Sql.Should().Contain("SELECT ST_X(point_geom) AS x, ST_Y(point_geom) AS y FROM point_source ORDER BY objectid");
+        result.Sql.Should().NotContain("DISTINCT ON (cell_x, cell_y)");
+        result.WhereParameters.Should().BeEmpty();
+    }
+
+    private static FeatureQueryBuilder CreateQueryBuilder()
+    {
+        var poolProvider = new DefaultObjectPoolProvider();
+        var stringBuilderPool = poolProvider.Create(new FeatureStoreStringBuilderPooledObjectPolicy());
+        var geometryProcessor = new GeometryProcessor();
+        return new FeatureQueryBuilder(stringBuilderPool, geometryProcessor);
+    }
+}

--- a/tests/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderProjectedPointTests.cs
+++ b/tests/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderProjectedPointTests.cs
@@ -31,9 +31,10 @@ public sealed class FeatureQueryBuilderProjectedPointTests
         var result = queryBuilder.BuildProjectedPointQuery(layerId: 1, query);
 
         result.Sql.Should().Contain("WITH point_source AS");
-        result.Sql.Should().Contain("SELECT DISTINCT ON (cell_x, cell_y) x, y FROM snapped_points");
-        result.Sql.Should().Contain("FLOOR((ST_X(point_geom) - $2) / $3)::bigint AS cell_x");
-        result.Sql.Should().Contain("FLOOR(($4 - ST_Y(point_geom)) / $5)::bigint AS cell_y");
+        result.Sql.Should().Contain("projected_points AS");
+        result.Sql.Should().Contain("SELECT DISTINCT ON (cell_x, cell_y) x, y FROM snapped_points ORDER BY cell_x, cell_y");
+        result.Sql.Should().Contain("FLOOR((x - $2) / $3)::bigint AS cell_x");
+        result.Sql.Should().Contain("FLOOR(($4 - y) / $5)::bigint AS cell_y");
         result.Sql.Should().Contain("LIMIT $6");
         result.WhereParameters.Should().Equal(-180d, 1.5d, 90d, 1.5d);
     }
@@ -53,6 +54,36 @@ public sealed class FeatureQueryBuilderProjectedPointTests
         result.Sql.Should().Contain("SELECT ST_X(point_geom) AS x, ST_Y(point_geom) AS y FROM point_source ORDER BY objectid");
         result.Sql.Should().NotContain("DISTINCT ON (cell_x, cell_y)");
         result.WhereParameters.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildProjectedPointQuery_WithEnvelopeIntersects_UsesBboxOnlySpatialFilter()
+    {
+        var queryBuilder = CreateQueryBuilder();
+        var query = new FeatureQuery
+        {
+            SpatialReferenceSrid = 4326,
+            OutputSrid = 4326,
+            RasterPointGrid = new RasterPointGrid
+            {
+                OriginX = -180,
+                OriginY = 90,
+                CellWidth = 1.5,
+                CellHeight = 1.5
+            },
+            SpatialFilter = SpatialFilter.Create(new byte[] { 1, 2, 3 }, SpatialRelationship.EnvelopeIntersects, 4326)
+        };
+
+        var result = queryBuilder.BuildProjectedPointQuery(layerId: 1, query);
+
+        result.Sql.Should().Contain("geometry &&");
+        result.Sql.Should().NotContain("ST_Intersects");
+        result.WhereParameters.Should().HaveCount(5);
+        result.WhereParameters[0].Should().Be(-180d);
+        result.WhereParameters[1].Should().Be(1.5d);
+        result.WhereParameters[2].Should().Be(90d);
+        result.WhereParameters[3].Should().Be(1.5d);
+        result.WhereParameters[4].Should().BeEquivalentTo(new byte[] { 1, 2, 3 });
     }
 
     private static FeatureQueryBuilder CreateQueryBuilder()

--- a/tests/Honua.Server.Tests/Features/FeatureStore/PostgresFeatureStoreIntegrationTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureStore/PostgresFeatureStoreIntegrationTests.cs
@@ -233,6 +233,39 @@ public class PostgresFeatureStoreIntegrationTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.Query)]
+    public async Task QueryProjectedPointsAsync_WithRasterGrid_ShouldThinDensePointRows()
+    {
+        var store = CreateFeatureStore();
+        var rasterPointReader = store.Should().BeAssignableTo<IRasterPointReader>().Subject;
+        var query = new FeatureQuery
+        {
+            SpatialReferenceSrid = 4326,
+            OutputSrid = 4326,
+            Limit = 100,
+            SpatialFilter = SpatialFilter.Create(
+                CreatePolygonWkb("POLYGON((-122.1 36.9, -120.8 36.9, -120.8 38.2, -122.1 38.2, -122.1 36.9))"),
+                SpatialRelationship.Intersects,
+                4326),
+            RasterPointGrid = new RasterPointGrid
+            {
+                OriginX = -122.1,
+                OriginY = 38.2,
+                CellWidth = 0.25,
+                CellHeight = 0.25
+            }
+        };
+
+        var points = await rasterPointReader.QueryProjectedPointsAsync(PointsLayerId, query, CancellationToken.None);
+
+        points.Should().NotBeEmpty();
+        points.Length.Should().BeLessThan(100);
+        points.Should().OnlyContain(point =>
+            point.X >= -122.1 && point.X <= -120.8 &&
+            point.Y >= 36.9 && point.Y <= 38.2);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
     public async Task QueryGeoJsonAsync_WithObjectIdFilter_ReturnsGeoJsonGeometry()
     {
         var store = CreateFeatureStore();

--- a/tests/Honua.Server.Tests/Features/Infrastructure/Rendering/StyleTranslatorTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/Rendering/StyleTranslatorTests.cs
@@ -196,12 +196,14 @@ public class StyleTranslatorTests
     }
 
     [UnitTest]
-    public void CreateDefaultPaints_Point_ReturnsFillOnly()
+    public void CreateDefaultPaints_Point_ReturnsBatchedStrokePaint()
     {
         var (fill, stroke) = StyleTranslator.CreateDefaultPaints(GeometryType.Point);
 
         fill.Should().NotBeNull();
-        fill.Style.Should().Be(SKPaintStyle.Fill);
+        fill.Style.Should().Be(SKPaintStyle.Stroke);
+        fill.StrokeCap.Should().Be(SKStrokeCap.Round);
+        fill.StrokeWidth.Should().Be(8f);
         stroke.Should().BeNull();
         fill.Dispose();
     }

--- a/tests/Honua.Server.Tests/Features/Infrastructure/Rendering/WkbToSkiaConverterTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/Rendering/WkbToSkiaConverterTests.cs
@@ -33,6 +33,28 @@ public class WkbToSkiaConverterTests
     }
 
     [UnitTest]
+    public void TryConvertPoint_Point_ReturnsPoint()
+    {
+        var wkb = CreateWkbPoint(10.0, 20.0);
+
+        var success = WkbToSkiaConverter.TryConvertPoint(wkb, _identityTransform, out var point);
+
+        success.Should().BeTrue();
+        point.X.Should().BeApproximately(10f, 0.001f);
+        point.Y.Should().BeApproximately(20f, 0.001f);
+    }
+
+    [UnitTest]
+    public void TryConvertPoint_NonPoint_ReturnsFalse()
+    {
+        var wkb = CreateWkbLineString([(0, 0), (10, 10)]);
+
+        var success = WkbToSkiaConverter.TryConvertPoint(wkb, _identityTransform, out _);
+
+        success.Should().BeFalse();
+    }
+
+    [UnitTest]
     public void Convert_LineString_ReturnsPathResult()
     {
         var wkb = CreateWkbLineString([(0, 0), (10, 10), (20, 0)]);

--- a/tests/Honua.Server.Tests/Features/MapServer/Rendering/RasterRenderCapacityLimiterTests.cs
+++ b/tests/Honua.Server.Tests/Features/MapServer/Rendering/RasterRenderCapacityLimiterTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Server.Features.MapServer.Rendering;
+
+namespace Honua.Server.Tests.Features.MapServer.Rendering;
+
+public sealed class RasterRenderCapacityLimiterTests
+{
+    [Fact]
+    public async Task TryAcquireAsync_WaitsForReleasedSlotWithinTimeout()
+    {
+        using var limiter = new RasterRenderCapacityLimiter(
+            maxConcurrentRenders: 1,
+            maxReservedBytes: 1024,
+            acquireTimeout: TimeSpan.FromMilliseconds(250));
+
+        await using var firstLease = await limiter.TryAcquireAsync(1, 1, CancellationToken.None);
+        firstLease.Should().NotBeNull();
+
+        var pendingAcquire = limiter.TryAcquireAsync(1, 1, CancellationToken.None).AsTask();
+        await Task.Delay(50);
+        pendingAcquire.IsCompleted.Should().BeFalse();
+
+        await firstLease!.DisposeAsync();
+
+        await using var secondLease = await pendingAcquire;
+        secondLease.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenTimeoutExpires_ReturnsNull()
+    {
+        using var limiter = new RasterRenderCapacityLimiter(
+            maxConcurrentRenders: 1,
+            maxReservedBytes: 1024,
+            acquireTimeout: TimeSpan.FromMilliseconds(10));
+
+        await using var firstLease = await limiter.TryAcquireAsync(1, 1, CancellationToken.None);
+        firstLease.Should().NotBeNull();
+
+        await Task.Delay(25);
+
+        var secondLease = await limiter.TryAcquireAsync(1, 1, CancellationToken.None);
+        secondLease.Should().BeNull();
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #621

## Summary
Bring the remaining raster point rendering work onto current `trunk`, then fold in the later point-path follow-up optimizations that materially improved the WMS raster path.

## Changes Made
- rebased the off-trunk raster point rendering stack onto current `trunk`
- tuned the projected-point SQL/query path by reusing `ST_X/ST_Y`, pre-sizing point reads, and switching point fast-path bbox queries to `EnvelopeIntersects`
- added raster style-plan caching across export, WMS, and tile rendering and changed the raster capacity limiter to use a bounded wait instead of immediate rejection
- updated projected-point SQL coverage, added limiter regression tests, and aligned point paint expectations with the batched point renderer

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Validation Notes

Focused validation:

- `dotnet build src/Honua.Server/Honua.Server.csproj`
- `dotnet test tests/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj --filter FullyQualifiedName~FeatureQueryBuilderProjectedPointTests`
- `dotnet test tests/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~WkbToSkiaConverterTests|FullyQualifiedName~PostgresFeatureStoreIntegrationTests.QueryProjectedPointsAsync_WithRasterGrid_ShouldThinDensePointRows|FullyQualifiedName~RasterRenderCapacityLimiterTests|FullyQualifiedName~MapServerRenderCapacityTests"`
- `dotnet test tests/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~MapServerWmsTests|FullyQualifiedName~MapServerEndpointTests|FullyQualifiedName~MapServerTileEndpointTests|FullyQualifiedName~MapServerRenderCapacityTests|FullyQualifiedName~RasterRenderCapacityLimiterTests"`
- `dotnet test tests/Honua.Server.Tests/Honua.Server.Tests.csproj --filter FullyQualifiedName~StyleTranslatorTests`

Full local gate:

- `scripts/pre-pr-check.sh`

## Benchmark Notes

Built patched benchmark image from this branch:

- `docker build -t honua-geobench:pr623-raster2 .`

Ran GeoBench WMS GetMap against the patched image, not `honuaio/honua-server:latest`:

- `HONUA_IMAGE=honua-geobench:pr623-raster2 SERVERS="honua geoserver" TESTS="wms-getmap" ./scripts/run-benchmark.sh`

Report: `/home/makani/geobench/results/20260329-072241/report.md`

Current head-to-head results from that run:

- `small`: Honua `370.4 req/s`, GeoServer `17.5 req/s`
- `medium`: Honua `9.9 req/s`, GeoServer `5.0 req/s`
- `large`: Honua `9.0 req/s`, GeoServer `1.7 req/s`

The important point for this PR is that the validation run used the patched branch image, so the benchmark evidence now matches the code under review instead of a stale published `latest` image.
