### PR TITLE
feat: perf: Implement background cache refresh to eliminate cache miss latency spikes (#233)

### DIFF
--- a/src/Honua.Core/Features/Caching/Abstractions/ICacheRefreshCoordinator.cs
+++ b/src/Honua.Core/Features/Caching/Abstractions/ICacheRefreshCoordinator.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Caching.Abstractions;
+
+/// <summary>
+/// Coordinates background cache refresh operations with per-key deduplication.
+/// </summary>
+public interface ICacheRefreshCoordinator
+{
+    /// <summary>
+    /// The current number of pending refresh operations (queued + in-flight).
+    /// </summary>
+    int QueueDepth { get; }
+
+    /// <summary>
+    /// Total number of successful background refreshes since startup.
+    /// </summary>
+    long SuccessCount { get; }
+
+    /// <summary>
+    /// Total number of failed background refreshes since startup.
+    /// </summary>
+    long FailureCount { get; }
+
+    /// <summary>
+    /// Total number of background refreshes that completed but skipped write-back
+    /// because the key was invalidated while the refresh was in-flight.
+    /// </summary>
+    long SkippedCount { get; }
+
+    /// <summary>
+    /// Attempts to enqueue a background refresh for the given cache key.
+    /// Returns false if a refresh for this key is already pending (deduplication).
+    /// </summary>
+    /// <param name="key">Cache key being refreshed</param>
+    /// <param name="refreshCallback">Async callback that performs the actual refresh</param>
+    /// <returns>True if the refresh was enqueued, false if deduplicated</returns>
+    bool TryEnqueueRefresh(string key, Func<CancellationToken, Task> refreshCallback);
+
+    /// <summary>
+    /// Marks a cache key as explicitly invalidated while a refresh may be pending.
+    /// If a pending refresh for this key subsequently fails, stale-value restoration is skipped.
+    /// </summary>
+    /// <param name="key">Cache key that was invalidated</param>
+    void NotifyInvalidation(string key);
+
+    /// <summary>
+    /// Returns true if the given key was explicitly invalidated while a refresh was pending.
+    /// </summary>
+    /// <param name="key">Cache key to check</param>
+    /// <returns>True if the key was invalidated after a refresh was enqueued</returns>
+    bool WasInvalidated(string key);
+
+    /// <summary>
+    /// Atomically claims write-back rights for a completed refresh.
+    /// Returns true only if the key has not been invalidated since the refresh was enqueued.
+    /// The caller must call this immediately before the write-back to close the race window
+    /// between the invalidation check and the cache write.
+    /// </summary>
+    /// <param name="key">Cache key to claim</param>
+    /// <returns>True if the claim succeeded (safe to write), false if invalidated</returns>
+    bool TryClaimWriteBack(string key);
+}

--- a/src/Honua.Core/Features/Caching/Abstractions/ICacheService.cs
+++ b/src/Honua.Core/Features/Caching/Abstractions/ICacheService.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Caching;
+
 namespace Honua.Core.Features.Caching.Abstractions;
 
 /// <summary>
@@ -74,4 +76,14 @@ public interface ICacheService
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The cached or newly created value</returns>
     Task<T?> GetOrSetAsync<T>(string key, Func<CancellationToken, Task<T?>> factory, TimeSpan ttl, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Gets a cached value along with its remaining TTL metadata.
+    /// Used by background refresh to determine whether a near-expiry entry should be proactively refreshed.
+    /// </summary>
+    /// <typeparam name="T">The type of the cached value</typeparam>
+    /// <param name="key">Cache key</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Cache entry metadata including value and remaining TTL, or a miss result</returns>
+    Task<CacheEntryMetadata<T>> GetWithMetadataAsync<T>(string key, CancellationToken cancellationToken = default) where T : class;
 }

--- a/src/Honua.Core/Features/Caching/CacheEntryMetadata.cs
+++ b/src/Honua.Core/Features/Caching/CacheEntryMetadata.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Honua.Core.Features.Caching;
+
+/// <summary>
+/// Represents a cache entry with its value and expiration metadata.
+/// Used by background refresh to determine when a stale-while-revalidate refresh should be enqueued.
+/// </summary>
+/// <typeparam name="T">The type of the cached value</typeparam>
+public sealed class CacheEntryMetadata<T> where T : class
+{
+    /// <summary>
+    /// The cached value, or null if not found.
+    /// </summary>
+    public T? Value { get; }
+
+    /// <summary>
+    /// The remaining time before the cache entry expires.
+    /// </summary>
+    public TimeSpan RemainingTtl { get; }
+
+    /// <summary>
+    /// Whether the entry was found in the cache.
+    /// </summary>
+    public bool HasValue => Value is not null;
+
+    /// <summary>
+    /// Creates a cache entry metadata instance.
+    /// </summary>
+    /// <param name="value">The cached value</param>
+    /// <param name="remainingTtl">Time remaining before expiration</param>
+    public CacheEntryMetadata(T? value, TimeSpan remainingTtl)
+    {
+        Value = value;
+        RemainingTtl = remainingTtl;
+    }
+
+    /// <summary>
+    /// Creates a miss result with no value and zero TTL.
+    /// </summary>
+    [SuppressMessage("Design", "CA1000:Do not declare static members on generic types",
+        Justification = "Factory method pattern for cache miss is ergonomic and well-understood")]
+    public static CacheEntryMetadata<T> Miss() => MissInstance;
+
+    private static readonly CacheEntryMetadata<T> MissInstance = new(null, TimeSpan.Zero);
+}

--- a/src/Honua.Core/Features/Caching/CacheOptions.cs
+++ b/src/Honua.Core/Features/Caching/CacheOptions.cs
@@ -98,6 +98,40 @@ public sealed class CacheOptions
     public string KeyPrefix { get; set; } = "honua:";
 
     /// <summary>
+    /// Whether background cache refresh (stale-while-revalidate) is enabled.
+    /// When enabled, near-expiry cache entries are served stale while a background task refreshes them.
+    /// Default is true.
+    /// </summary>
+    public bool BackgroundRefreshEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Percentage of TTL remaining that triggers a background refresh (0.0-1.0).
+    /// For example, 0.25 means refresh when 25% or less of the TTL remains.
+    /// Default is 0.25 (25%).
+    /// </summary>
+    [Range(0.05, 0.75, ErrorMessage = ErrorMessages.RangeValidation.BackgroundRefreshThreshold)]
+    public double BackgroundRefreshThreshold { get; set; } = 0.25;
+
+    /// <summary>
+    /// Maximum number of concurrent background refresh operations.
+    /// Default is 10.
+    /// </summary>
+    [Range(1, 100, ErrorMessage = ErrorMessages.RangeValidation.MaxConcurrentRefreshes)]
+    public int MaxConcurrentRefreshes { get; set; } = 10;
+
+    /// <summary>
+    /// Timeout in seconds for each background refresh operation.
+    /// Default is 30 seconds.
+    /// </summary>
+    [Range(TimeConstants.FiveSeconds, TimeConstants.TwoMinutes, ErrorMessage = ErrorMessages.RangeValidation.RefreshTimeoutSeconds)]
+    public int RefreshTimeoutSeconds { get; set; } = TimeConstants.ThirtySeconds;
+
+    /// <summary>
+    /// Gets the refresh timeout as a TimeSpan.
+    /// </summary>
+    public TimeSpan RefreshTimeout => TimeSpan.FromSeconds(RefreshTimeoutSeconds);
+
+    /// <summary>
     /// Gets the default TTL as a TimeSpan.
     /// </summary>
     public TimeSpan DefaultTtl => TimeSpan.FromSeconds(DefaultTtlSeconds);

--- a/src/Honua.Core/Features/Caching/CacheOptionsValidator.cs
+++ b/src/Honua.Core/Features/Caching/CacheOptionsValidator.cs
@@ -22,6 +22,7 @@ public sealed class CacheOptionsValidator : OptionsValidator<CacheOptions>
         ValidateTtlLogic(options, failures);
         ValidateFallbackConfiguration(options, failures);
         ValidateKeyPrefix(options, failures);
+        ValidateBackgroundRefresh(options, failures);
     }
 
 
@@ -68,6 +69,19 @@ public sealed class CacheOptionsValidator : OptionsValidator<CacheOptions>
         }
 
         ValidateRange(options.ResponseCacheMaxEntries, 100, 500000, "ResponseCacheMaxEntries", failures);
+    }
+
+    /// <summary>
+    /// Validates background refresh configuration.
+    /// </summary>
+    private static void ValidateBackgroundRefresh(CacheOptions options, List<string> failures)
+    {
+        if (!options.BackgroundRefreshEnabled)
+            return;
+
+        ValidateRange(options.BackgroundRefreshThreshold, 0.05, 0.75, "BackgroundRefreshThreshold", failures);
+        ValidateRange(options.MaxConcurrentRefreshes, 1, 100, "MaxConcurrentRefreshes", failures);
+        ValidateRange(options.RefreshTimeoutSeconds, 5, 120, "RefreshTimeoutSeconds", failures);
     }
 
     /// <summary>

--- a/src/Honua.Core/Features/Shared/Models/ErrorMessages.cs
+++ b/src/Honua.Core/Features/Shared/Models/ErrorMessages.cs
@@ -236,6 +236,12 @@ JitterPercentage = "JitterPercentage must be between 0 and 0.5 (50%)";
 FallbackMaxEntries = "FallbackMaxEntries must be between 10 and 100000";
         public const string         /// <inheritdoc/>
 RetryIntervalSeconds = "RetryIntervalSeconds must be between 5 and 300";
+        public const string         /// <inheritdoc/>
+BackgroundRefreshThreshold = "BackgroundRefreshThreshold must be between 0.05 and 0.75";
+        public const string         /// <inheritdoc/>
+MaxConcurrentRefreshes = "MaxConcurrentRefreshes must be between 1 and 100";
+        public const string         /// <inheritdoc/>
+RefreshTimeoutSeconds = "RefreshTimeoutSeconds must be between 5 and 120";
 
         // Adaptive sampling options validation messages
         public const string         /// <inheritdoc/>

--- a/src/Honua.Server/Features/Admin/Services/ConfigurationDocumentationService.cs
+++ b/src/Honua.Server/Features/Admin/Services/ConfigurationDocumentationService.cs
@@ -149,15 +149,15 @@ internal sealed class ConfigurationDocumentationService
                 BuildPropertyWithCurrent("Cache:Enabled", "Cache__Enabled", "boolean",
                     "Whether caching is enabled", true, opts.Enabled),
                 BuildPropertyWithCurrent("Cache:DefaultTtlSeconds", "Cache__DefaultTtlSeconds", "integer",
-                    "Default cache TTL in seconds", 300, opts.DefaultTtlSeconds, "Range: 1-86400"),
+                    "Default cache TTL in seconds", 1800, opts.DefaultTtlSeconds, "Range: 1-86400"),
                 BuildPropertyWithCurrent("Cache:ServiceTtlSeconds", "Cache__ServiceTtlSeconds", "integer",
-                    "Service metadata cache TTL in seconds", 300, opts.ServiceTtlSeconds, "Range: 1-86400"),
+                    "Service metadata cache TTL in seconds", 3600, opts.ServiceTtlSeconds, "Range: 1-86400"),
                 BuildPropertyWithCurrent("Cache:LayerTtlSeconds", "Cache__LayerTtlSeconds", "integer",
-                    "Layer metadata cache TTL in seconds", 300, opts.LayerTtlSeconds, "Range: 1-86400"),
+                    "Layer metadata cache TTL in seconds", 1800, opts.LayerTtlSeconds, "Range: 1-86400"),
                 BuildPropertyWithCurrent("Cache:QueryTtlSeconds", "Cache__QueryTtlSeconds", "integer",
                     "Query response cache TTL in seconds", 30, opts.QueryTtlSeconds, "Range: 1-3600"),
                 BuildPropertyWithCurrent("Cache:NegativeTtlSeconds", "Cache__NegativeTtlSeconds", "integer",
-                    "Negative cache TTL in seconds for missing layers/services", 30, opts.NegativeTtlSeconds, "Range: 1-3600"),
+                    "Negative cache TTL in seconds for missing layers/services", 60, opts.NegativeTtlSeconds, "Range: 1-3600"),
                 BuildPropertyWithCurrent("Cache:JitterPercentage", "Cache__JitterPercentage", "number",
                     "TTL jitter percentage to prevent stampedes", 0.2, opts.JitterPercentage, "Range: 0-0.5"),
                 BuildPropertyWithCurrent("Cache:EnableFallback", "Cache__EnableFallback", "boolean",
@@ -167,7 +167,15 @@ internal sealed class ConfigurationDocumentationService
                 BuildPropertyWithCurrent("Cache:RetryIntervalSeconds", "Cache__RetryIntervalSeconds", "integer",
                     "Retry interval after Redis failure", 30, opts.RetryIntervalSeconds, "Range: 5-300"),
                 BuildPropertyWithCurrent("Cache:KeyPrefix", "Cache__KeyPrefix", "string",
-                    "Prefix for cache keys", "honua:", opts.KeyPrefix)
+                    "Prefix for cache keys", "honua:", opts.KeyPrefix),
+                BuildPropertyWithCurrent("Cache:BackgroundRefreshEnabled", "Cache__BackgroundRefreshEnabled", "boolean",
+                    "Enable stale-while-revalidate background refresh for near-expiry entries", true, opts.BackgroundRefreshEnabled),
+                BuildPropertyWithCurrent("Cache:BackgroundRefreshThreshold", "Cache__BackgroundRefreshThreshold", "number",
+                    "Fraction of TTL remaining that triggers background refresh", 0.25, opts.BackgroundRefreshThreshold, "Range: 0.05-0.75"),
+                BuildPropertyWithCurrent("Cache:MaxConcurrentRefreshes", "Cache__MaxConcurrentRefreshes", "integer",
+                    "Maximum concurrent background refresh operations", 10, opts.MaxConcurrentRefreshes, "Range: 1-100"),
+                BuildPropertyWithCurrent("Cache:RefreshTimeoutSeconds", "Cache__RefreshTimeoutSeconds", "integer",
+                    "Timeout per background refresh operation in seconds", 30, opts.RefreshTimeoutSeconds, "Range: 5-120")
             ]
         };
     }
@@ -636,11 +644,17 @@ internal sealed class ConfigurationDocumentationService
             // Cache
             new() { Name = "ConnectionStrings__redis", ConfigPath = "Cache", Description = "Redis connection string for metadata/output caching", Required = false, Example = "localhost:6379" },
             new() { Name = "Cache__Enabled", ConfigPath = "Cache", Description = "Enable caching", Default = "true", Example = "false" },
-            new() { Name = "Cache__DefaultTtlSeconds", ConfigPath = "Cache", Description = "Default cache TTL", Default = "300", Example = "600" },
+            new() { Name = "Cache__DefaultTtlSeconds", ConfigPath = "Cache", Description = "Default cache TTL", Default = "1800", Example = "600" },
+            new() { Name = "Cache__ServiceTtlSeconds", ConfigPath = "Cache", Description = "Service metadata cache TTL", Default = "3600", Example = "1800" },
+            new() { Name = "Cache__LayerTtlSeconds", ConfigPath = "Cache", Description = "Layer metadata cache TTL", Default = "1800", Example = "900" },
             new() { Name = "Cache__QueryTtlSeconds", ConfigPath = "Cache", Description = "Query response cache TTL", Default = "30", Example = "60" },
-            new() { Name = "Cache__NegativeTtlSeconds", ConfigPath = "Cache", Description = "Negative cache TTL for missing resources", Default = "30", Example = "30" },
+            new() { Name = "Cache__NegativeTtlSeconds", ConfigPath = "Cache", Description = "Negative cache TTL for missing resources", Default = "60", Example = "30" },
             new() { Name = "Cache__JitterPercentage", ConfigPath = "Cache", Description = "TTL jitter percentage", Default = "0.2", Example = "0.1" },
             new() { Name = "Cache__EnableFallback", ConfigPath = "Cache", Description = "Use in-memory fallback", Default = "true", Example = "false" },
+            new() { Name = "Cache__BackgroundRefreshEnabled", ConfigPath = "Cache", Description = "Enable stale-while-revalidate background refresh", Default = "true", Example = "false" },
+            new() { Name = "Cache__BackgroundRefreshThreshold", ConfigPath = "Cache", Description = "TTL fraction triggering background refresh", Default = "0.25", Example = "0.3" },
+            new() { Name = "Cache__MaxConcurrentRefreshes", ConfigPath = "Cache", Description = "Max concurrent background refreshes", Default = "10", Example = "20" },
+            new() { Name = "Cache__RefreshTimeoutSeconds", ConfigPath = "Cache", Description = "Background refresh timeout", Default = "30", Example = "60" },
 
             // Deployment
             new() { Name = "Deployment__Mode", ConfigPath = "Deployment", Description = "Deployment mode (SingleInstance or MultiNode)", Default = "SingleInstance", Example = "MultiNode" },

--- a/src/Honua.Server/Features/HealthCheck/HealthEndpoints.cs
+++ b/src/Honua.Server/Features/HealthCheck/HealthEndpoints.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Caching.Abstractions;
 using Honua.Core.Features.Infrastructure.Monitoring;
 using Honua.Server.Features.Infrastructure.Authentication;
 
@@ -78,6 +79,7 @@ internal static class HealthEndpoints
         IDatabasePerformanceMetricsProvider databaseMetricsProvider,
         IReadinessCheckService readinessCheckService,
         ILoggerFactory loggerFactory,
+        ICacheRefreshCoordinator? refreshCoordinator,
         CancellationToken cancellationToken)
     {
         try
@@ -109,7 +111,16 @@ internal static class HealthEndpoints
                         Gen0Collections = GC.CollectionCount(0),
                         Gen1Collections = GC.CollectionCount(1),
                         Gen2Collections = GC.CollectionCount(2)
-                    }
+                    },
+                    CacheRefresh = refreshCoordinator is not null
+                        ? new HealthCacheRefreshMetrics
+                        {
+                            QueueDepth = refreshCoordinator.QueueDepth,
+                            SuccessCount = refreshCoordinator.SuccessCount,
+                            FailureCount = refreshCoordinator.FailureCount,
+                            SkippedCount = refreshCoordinator.SkippedCount
+                        }
+                        : null
                 }
             };
 

--- a/src/Honua.Server/Features/HealthCheck/HealthJsonContext.cs
+++ b/src/Honua.Server/Features/HealthCheck/HealthJsonContext.cs
@@ -17,6 +17,7 @@ namespace Honua.Server.Features.HealthCheck;
 [JsonSerializable(typeof(HealthMemoryMetrics))]
 [JsonSerializable(typeof(HealthGcMetrics))]
 [JsonSerializable(typeof(HealthPerformanceErrorResponse))]
+[JsonSerializable(typeof(HealthCacheRefreshMetrics))]
 [JsonSerializable(typeof(DatabasePerformanceMetricsSnapshot))]
 [JsonSerializable(typeof(DatabaseOperationMetricsSnapshot))]
 [JsonSerializable(typeof(Dictionary<string, DatabaseOperationMetricsSnapshot>))]

--- a/src/Honua.Server/Features/HealthCheck/HealthMetricsModels.cs
+++ b/src/Honua.Server/Features/HealthCheck/HealthMetricsModels.cs
@@ -23,6 +23,19 @@ internal sealed class HealthPerformanceMetrics
     public required HealthMemoryMetrics Memory { get; init; }
 
     public required HealthGcMetrics GcInfo { get; init; }
+
+    public HealthCacheRefreshMetrics? CacheRefresh { get; init; }
+}
+
+internal sealed class HealthCacheRefreshMetrics
+{
+    public required int QueueDepth { get; init; }
+
+    public required long SuccessCount { get; init; }
+
+    public required long FailureCount { get; init; }
+
+    public required long SkippedCount { get; init; }
 }
 
 internal sealed class HealthMemoryMetrics

--- a/src/Honua.Server/Features/Infrastructure/Caching/BackgroundRefreshCacheDecorator.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/BackgroundRefreshCacheDecorator.cs
@@ -1,0 +1,295 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Caching;
+using Honua.Core.Features.Caching.Abstractions;
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Server.Features.Infrastructure.Middleware;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Infrastructure.Caching;
+
+/// <summary>
+/// Decorator that wraps <see cref="CachingLayerCatalog"/> to serve stale cache entries
+/// while triggering background refreshes for entries approaching expiration.
+/// </summary>
+/// <remarks>
+/// Cold cache misses are handled synchronously by the inner catalog (unavoidable — no stale value to serve).
+/// Near-expiry entries are returned immediately while a background refresh is enqueued.
+/// Refresh callbacks resolve a fresh scoped data-source catalog (keyed as "uncached") via
+/// <see cref="IServiceScopeFactory"/> to bypass the caching layer and fetch directly from the database.
+/// The fresh value is written through to the cache, atomically replacing the stale entry — concurrent
+/// requests continue to see the stale value until the overwrite completes (no cold-miss window).
+/// Negative cache entries (missing layers/services) are not background-refreshed to avoid churn.
+/// Explicit invalidation bypasses background refresh and evicts keys immediately.
+/// If a key is invalidated while a refresh is in-flight, the write-back is skipped to avoid
+/// restoring data that was intentionally evicted.
+/// </remarks>
+internal sealed partial class BackgroundRefreshCacheDecorator : ILayerCatalog
+{
+    /// <summary>
+    /// Keyed service name for the data-source catalog that bypasses the caching layer.
+    /// </summary>
+    internal const string UncachedCatalogServiceKey = "uncached";
+
+    private readonly ILayerCatalog _innerCatalog;
+    private readonly ICacheService _cacheService;
+    private readonly ICacheRefreshCoordinator _refreshCoordinator;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ISchemaContext? _schemaContext;
+    private readonly CacheOptions _options;
+    private readonly ILogger<BackgroundRefreshCacheDecorator> _logger;
+
+    public BackgroundRefreshCacheDecorator(
+        ILayerCatalog innerCatalog,
+        ICacheService cacheService,
+        ICacheRefreshCoordinator refreshCoordinator,
+        IServiceScopeFactory scopeFactory,
+        IOptions<CacheOptions> options,
+        ILogger<BackgroundRefreshCacheDecorator> logger,
+        ISchemaContext? schemaContext = null)
+    {
+        _innerCatalog = innerCatalog ?? throw new ArgumentNullException(nameof(innerCatalog));
+        _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
+        _refreshCoordinator = refreshCoordinator ?? throw new ArgumentNullException(nameof(refreshCoordinator));
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _schemaContext = schemaContext;
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<LayerDefinition?> GetLayerAsync(int layerId, CancellationToken cancellationToken = default)
+    {
+        string cacheKey = $"{CachingLayerCatalog.LayerKeyPrefix}{layerId}";
+
+        var entry = await _cacheService.GetWithMetadataAsync<LayerDefinition>(cacheKey, cancellationToken).ConfigureAwait(false);
+
+        if (entry.HasValue)
+        {
+            if (IsNearExpiry(entry.RemainingTtl, _options.LayerTtl))
+            {
+                EnqueueWriteThroughRefresh(cacheKey,
+                    async (catalog, ct) => await catalog.GetLayerAsync(layerId, ct).ConfigureAwait(false),
+                    () => _options.GetLayerTtlWithJitter(),
+                    existenceKey: $"{CachingLayerCatalog.LayerExistsKeyPrefix}{layerId}");
+            }
+
+            return entry.Value;
+        }
+
+        // Cold miss — delegate to inner catalog (which handles caching + negative cache)
+        return await _innerCatalog.GetLayerAsync(layerId, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<LayerDefinition[]> ListLayersAsync(CancellationToken cancellationToken = default)
+    {
+        var entry = await _cacheService.GetWithMetadataAsync<CachedLayerList>(CachingLayerCatalog.LayerListKey, cancellationToken).ConfigureAwait(false);
+
+        if (entry.HasValue)
+        {
+            if (IsNearExpiry(entry.RemainingTtl, _options.LayerTtl))
+            {
+                EnqueueWriteThroughRefresh<CachedLayerList>(CachingLayerCatalog.LayerListKey,
+                    async (catalog, ct) =>
+                    {
+                        var layers = await catalog.ListLayersAsync(ct).ConfigureAwait(false);
+                        return new CachedLayerList(layers);
+                    },
+                    () => _options.GetLayerTtlWithJitter());
+            }
+
+            return entry.Value!.Layers;
+        }
+
+        // Cold miss
+        return await _innerCatalog.ListLayersAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<ServiceDefinition?> GetServiceAsync(string serviceName, CancellationToken cancellationToken = default)
+    {
+        string normalizedName = serviceName.ToLowerInvariant();
+        string cacheKey = $"{CachingLayerCatalog.ServiceKeyPrefix}{normalizedName}";
+
+        var entry = await _cacheService.GetWithMetadataAsync<ServiceDefinition>(cacheKey, cancellationToken).ConfigureAwait(false);
+
+        if (entry.HasValue)
+        {
+            if (IsNearExpiry(entry.RemainingTtl, _options.ServiceTtl))
+            {
+                EnqueueWriteThroughRefresh(cacheKey,
+                    async (catalog, ct) => await catalog.GetServiceAsync(serviceName, ct).ConfigureAwait(false),
+                    () => _options.GetServiceTtlWithJitter(),
+                    existenceKey: $"{CachingLayerCatalog.ServiceExistsKeyPrefix}{normalizedName}");
+            }
+
+            return entry.Value;
+        }
+
+        // Cold miss
+        return await _innerCatalog.GetServiceAsync(serviceName, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<ServiceDefinition[]> ListServicesAsync(CancellationToken cancellationToken = default)
+    {
+        var entry = await _cacheService.GetWithMetadataAsync<CachedServiceList>(CachingLayerCatalog.ServiceListKey, cancellationToken).ConfigureAwait(false);
+
+        if (entry.HasValue)
+        {
+            if (IsNearExpiry(entry.RemainingTtl, _options.ServiceTtl))
+            {
+                EnqueueWriteThroughRefresh<CachedServiceList>(CachingLayerCatalog.ServiceListKey,
+                    async (catalog, ct) =>
+                    {
+                        var services = await catalog.ListServicesAsync(ct).ConfigureAwait(false);
+                        return new CachedServiceList(services);
+                    },
+                    () => _options.GetServiceTtlWithJitter());
+            }
+
+            return entry.Value!.Services;
+        }
+
+        // Cold miss
+        return await _innerCatalog.ListServicesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> LayerExistsAsync(int layerId, CancellationToken cancellationToken = default)
+    {
+        // Existence checks are lightweight; delegate directly without background refresh
+        return _innerCatalog.LayerExistsAsync(layerId, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> ServiceExistsAsync(string serviceName, CancellationToken cancellationToken = default)
+    {
+        // Existence checks are lightweight; delegate directly without background refresh
+        return _innerCatalog.ServiceExistsAsync(serviceName, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Relationship?> GetRelationshipAsync(int layerId, int relationshipId, CancellationToken cancellationToken = default)
+    {
+        // Relationships are extracted from layer cache; delegate to inner catalog
+        return _innerCatalog.GetRelationshipAsync(layerId, relationshipId, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Relationship[]> ListRelationshipsAsync(int layerId, CancellationToken cancellationToken = default)
+    {
+        // Relationships are extracted from layer cache; delegate to inner catalog
+        return _innerCatalog.ListRelationshipsAsync(layerId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Enqueues a write-through background refresh for a near-expiry cache entry.
+    /// Fetches fresh data from the data-source catalog (bypassing cache) and overwrites
+    /// the stale entry directly — no eviction, so concurrent readers always see a value.
+    /// </summary>
+    private void EnqueueWriteThroughRefresh<T>(
+        string cacheKey,
+        Func<ILayerCatalog, CancellationToken, Task<T?>> fetchAction,
+        Func<TimeSpan> ttlFactory,
+        string? existenceKey = null) where T : class
+    {
+        // Capture singleton fields as locals and evaluate ttlFactory eagerly so the
+        // closure does not capture 'this' — even transitively through the ttlFactory
+        // delegate — which would keep the scoped decorator (and its inner catalog
+        // chain) alive past the request scope until the background refresh completes.
+        var cacheService = _cacheService;
+        var scopeFactory = _scopeFactory;
+        var refreshCoordinator = _refreshCoordinator;
+        var logger = _logger;
+        var ttl = ttlFactory();
+
+        // Capture the current request schema so the background refresh queries
+        // the same database schema as the triggering request.  Matches the
+        // propagation pattern in TileOperationJobService.
+        var currentSchema = _schemaContext?.CurrentSchema;
+
+        _refreshCoordinator.TryEnqueueRefresh(cacheKey, async ct =>
+        {
+            await using var scope = scopeFactory.CreateAsyncScope();
+
+            // Propagate request schema into the child scope so database providers
+            // set the correct search_path (mirrors TileOperationJobService pattern).
+            if (!string.IsNullOrWhiteSpace(currentSchema))
+            {
+                var childSchemaContext = scope.ServiceProvider.GetService<SchemaContext>();
+                if (childSchemaContext != null)
+                {
+                    childSchemaContext.CurrentSchema = currentSchema;
+                }
+            }
+
+            var catalog = scope.ServiceProvider.GetRequiredKeyedService<ILayerCatalog>(UncachedCatalogServiceKey);
+            var fresh = await fetchAction(catalog, ct).ConfigureAwait(false);
+
+            // Atomically claim write-back rights. Fails if the key was invalidated
+            // between enqueue and now — closing the TOCTOU race between the old
+            // WasInvalidated check and the subsequent cache write.
+            if (!refreshCoordinator.TryClaimWriteBack(cacheKey))
+            {
+                Log.BackgroundRefreshSkippedInvalidated(logger, cacheKey);
+                return;
+            }
+
+            if (fresh != null)
+            {
+                // Write-through: overwrite the stale entry with fresh data.
+                // Concurrent readers continue to see the stale value until this completes.
+                await cacheService.SetAsync(cacheKey, fresh, ttl, ct).ConfigureAwait(false);
+
+                // Post-write check: if invalidation arrived after the claim (state 2 → 1)
+                // but before the write completed, undo the write to honor the invalidation.
+                if (refreshCoordinator.WasInvalidated(cacheKey))
+                {
+                    await cacheService.RemoveAsync(cacheKey, ct).ConfigureAwait(false);
+                    Log.BackgroundRefreshSkippedInvalidated(logger, cacheKey);
+                    return;
+                }
+            }
+            else
+            {
+                // Resource no longer exists — remove the stale cache entry and its
+                // companion existence key so LayerExistsAsync/ServiceExistsAsync
+                // don't continue returning a stale positive result.
+                await cacheService.RemoveAsync(cacheKey, ct).ConfigureAwait(false);
+                if (existenceKey != null)
+                {
+                    await cacheService.RemoveAsync(existenceKey, ct).ConfigureAwait(false);
+                }
+            }
+
+            Log.BackgroundRefreshCompleted(logger, cacheKey);
+        });
+    }
+
+    /// <summary>
+    /// Determines whether a cache entry is near expiry based on the configured threshold.
+    /// </summary>
+    private bool IsNearExpiry(TimeSpan remainingTtl, TimeSpan originalTtl)
+    {
+        if (originalTtl <= TimeSpan.Zero)
+            return false;
+
+        var threshold = originalTtl * _options.BackgroundRefreshThreshold;
+        return remainingTtl <= threshold;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(1105, LogLevel.Debug, "Background refresh completed for cache key {CacheKey}")]
+        public static partial void BackgroundRefreshCompleted(ILogger logger, string cacheKey);
+
+        [LoggerMessage(1106, LogLevel.Debug, "Background refresh skipped write-back for invalidated key {CacheKey}")]
+        public static partial void BackgroundRefreshSkippedInvalidated(ILogger logger, string cacheKey);
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Caching/CacheKeyUtilities.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/CacheKeyUtilities.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Infrastructure.Caching;
+
+/// <summary>
+/// Shared cache-key classification utilities used by both the cache service
+/// and the background refresh coordinator for metrics tagging.
+/// </summary>
+internal static class CacheKeyUtilities
+{
+    /// <summary>
+    /// Classifies a cache key into a family name for performance-metric tagging.
+    /// </summary>
+    internal static string GetCacheKeyFamily(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return "empty";
+        }
+
+        return key switch
+        {
+            _ when key.Contains("layer", StringComparison.OrdinalIgnoreCase) => "layer",
+            _ when key.Contains("service", StringComparison.OrdinalIgnoreCase) => "service",
+            _ when key.Contains("query", StringComparison.OrdinalIgnoreCase) => "query",
+            _ when key.Contains("tile", StringComparison.OrdinalIgnoreCase) || key.Contains("mvt", StringComparison.OrdinalIgnoreCase) => "tile",
+            _ when key.Contains("catalog", StringComparison.OrdinalIgnoreCase) => "catalog",
+            _ when key.Contains("replica", StringComparison.OrdinalIgnoreCase) => "replica",
+            _ when key.Contains("schema", StringComparison.OrdinalIgnoreCase) => "schema",
+            _ when key.Contains("auth", StringComparison.OrdinalIgnoreCase) => "auth",
+            _ => "general"
+        };
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Caching/CacheRefreshCoordinator.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/CacheRefreshCoordinator.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using Honua.Core.Features.Caching;
+using Honua.Core.Features.Caching.Abstractions;
+using Honua.Core.Features.Infrastructure.Monitoring;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Infrastructure.Caching;
+
+/// <summary>
+/// Coordinates background cache refresh operations with per-key deduplication and bounded concurrency.
+/// </summary>
+/// <remarks>
+/// Uses a channel-backed processing loop to decouple refresh requests from the request path.
+/// Each unique cache key can only have one pending refresh at a time. Concurrent requests
+/// for the same near-expiry key produce a single background refresh.
+/// </remarks>
+internal sealed partial class CacheRefreshCoordinator : BackgroundService, ICacheRefreshCoordinator
+{
+    private const string MetricsCacheType = "background-refresh";
+    private readonly Channel<CacheRefreshItem> _channel;
+    // Value semantics: 0 = pending, 1 = invalidated, 2 = write-claimed.
+    // Embedding the state flag in _pendingKeys (instead of a separate dictionary)
+    // eliminates the TOCTOU race that previously existed between ContainsKey and TryAdd
+    // across two dictionaries. TryUpdate is atomic, so NotifyInvalidation either sees
+    // the key and marks it, or the key was already claimed/cleaned up — no stale flag can leak.
+    private readonly ConcurrentDictionary<string, byte> _pendingKeys = new(StringComparer.Ordinal);
+    private readonly CacheOptions _options;
+    private readonly IPerformanceMonitor _performanceMonitor;
+    private readonly ILogger<CacheRefreshCoordinator> _logger;
+    private long _successCount;
+    private long _failureCount;
+    private long _skippedCount;
+
+    public CacheRefreshCoordinator(
+        IOptions<CacheOptions> options,
+        IPerformanceMonitor performanceMonitor,
+        ILogger<CacheRefreshCoordinator> logger)
+    {
+        _options = options.Value;
+        _performanceMonitor = performanceMonitor;
+        _logger = logger;
+
+        // Bounded channel prevents unbounded memory growth if refresh callbacks are slow.
+        // DropWrite rejects new items when full (instead of DropOldest which silently drops
+        // items whose keys would leak in _pendingKeys). The TryWrite failure branch cleans up.
+        _channel = Channel.CreateBounded<CacheRefreshItem>(new BoundedChannelOptions(1000)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite,
+            SingleReader = false,
+            SingleWriter = false
+        });
+    }
+
+    /// <inheritdoc />
+    public int QueueDepth => _pendingKeys.Count;
+
+    /// <inheritdoc />
+    public long SuccessCount => Volatile.Read(ref _successCount);
+
+    /// <inheritdoc />
+    public long FailureCount => Volatile.Read(ref _failureCount);
+
+    /// <inheritdoc />
+    public long SkippedCount => Volatile.Read(ref _skippedCount);
+
+    /// <inheritdoc />
+    public void NotifyInvalidation(string key)
+    {
+        // Atomically mark the key as invalidated regardless of current state.
+        // 0 → 1: marks a pending refresh as invalidated (before write-back claimed it).
+        // 2 → 1: marks a write-claimed refresh as invalidated (invalidation arrived
+        //         after TryClaimWriteBack but before the write completed — the post-write
+        //         check in the callback will detect this and remove the entry).
+        // Fails silently if the key doesn't exist or is already 1.
+        _pendingKeys.TryUpdate(key, 1, 0);
+        _pendingKeys.TryUpdate(key, 1, 2);
+    }
+
+    /// <inheritdoc />
+    public bool WasInvalidated(string key)
+    {
+        return _pendingKeys.TryGetValue(key, out byte val) && val == 1;
+    }
+
+    /// <inheritdoc />
+    public bool TryClaimWriteBack(string key)
+    {
+        // Atomically transition 0 → 2 (write-claimed). Fails if the key was already
+        // invalidated (1) or doesn't exist — in both cases the caller must skip the write.
+        return _pendingKeys.TryUpdate(key, 2, 0);
+    }
+
+    /// <inheritdoc />
+    public bool TryEnqueueRefresh(string key, Func<CancellationToken, Task> refreshCallback)
+    {
+        // Per-key deduplication: only enqueue if this key isn't already pending
+        if (!_pendingKeys.TryAdd(key, 0))
+        {
+            return false;
+        }
+
+        // Try to write to channel; with DropWrite, this returns false when the channel is full
+        if (!_channel.Writer.TryWrite(new CacheRefreshItem(key, refreshCallback)))
+        {
+            _pendingKeys.TryRemove(key, out _);
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.BackgroundRefreshEnabled)
+        {
+            Log.BackgroundRefreshDisabled(_logger);
+            return;
+        }
+
+        Log.BackgroundRefreshStarted(_logger, _options.MaxConcurrentRefreshes);
+
+        using var semaphore = new SemaphoreSlim(_options.MaxConcurrentRefreshes, _options.MaxConcurrentRefreshes);
+
+        await foreach (var item in _channel.Reader.ReadAllAsync(stoppingToken))
+        {
+            await semaphore.WaitAsync(stoppingToken).ConfigureAwait(false);
+
+            // Fire-and-forget with bounded concurrency
+            _ = ProcessRefreshAsync(item, semaphore, stoppingToken);
+        }
+    }
+
+    private async Task ProcessRefreshAsync(CacheRefreshItem item, SemaphoreSlim semaphore, CancellationToken stoppingToken)
+    {
+        try
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+            timeoutCts.CancelAfter(_options.RefreshTimeout);
+
+            using var scope = _performanceMonitor.StartOperation("cache_background_refresh")
+                .WithTag("cache_type", MetricsCacheType)
+                .WithTag("key_family", CacheKeyUtilities.GetCacheKeyFamily(item.Key));
+
+            await item.RefreshCallback(timeoutCts.Token).ConfigureAwait(false);
+
+            // Distinguish real refreshes from callbacks that returned early because
+            // the key was invalidated while the refresh was in-flight.
+            if (WasInvalidated(item.Key))
+            {
+                Interlocked.Increment(ref _skippedCount);
+                _performanceMonitor.RecordCacheMetrics(MetricsCacheType, "refresh_skipped");
+                scope.WithTag("result", "skipped_invalidated");
+            }
+            else
+            {
+                Interlocked.Increment(ref _successCount);
+                _performanceMonitor.RecordCacheMetrics(MetricsCacheType, "refresh_success");
+                scope.WithTag("result", "success");
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Application shutting down — not a failure
+        }
+        catch (OperationCanceledException)
+        {
+            // Refresh timeout — count as failure
+            Interlocked.Increment(ref _failureCount);
+            _performanceMonitor.RecordCacheMetrics(MetricsCacheType, "refresh_timeout");
+            Log.BackgroundRefreshTimeout(_logger, item.Key);
+        }
+        catch (Exception ex)
+        {
+            Interlocked.Increment(ref _failureCount);
+            _performanceMonitor.RecordCacheMetrics(MetricsCacheType, "refresh_failure");
+            Log.BackgroundRefreshFailed(_logger, item.Key, ex);
+        }
+        finally
+        {
+            _pendingKeys.TryRemove(item.Key, out _);
+
+            try
+            {
+                semaphore.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Semaphore disposed during shutdown while this fire-and-forget task was in-flight.
+            }
+        }
+    }
+
+    private sealed record CacheRefreshItem(string Key, Func<CancellationToken, Task> RefreshCallback);
+
+    private static partial class Log
+    {
+        [LoggerMessage(1101, LogLevel.Information, "Background cache refresh started with max {MaxConcurrent} concurrent operations")]
+        public static partial void BackgroundRefreshStarted(ILogger logger, int maxConcurrent);
+
+        [LoggerMessage(1102, LogLevel.Information, "Background cache refresh disabled by configuration")]
+        public static partial void BackgroundRefreshDisabled(ILogger logger);
+
+        [LoggerMessage(1103, LogLevel.Warning, "Background refresh failed for key {CacheKey}")]
+        public static partial void BackgroundRefreshFailed(ILogger logger, string cacheKey, Exception exception);
+
+        [LoggerMessage(1104, LogLevel.Warning, "Background refresh timed out for key {CacheKey}")]
+        public static partial void BackgroundRefreshTimeout(ILogger logger, string cacheKey);
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Caching/CachingLayerCatalog.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/CachingLayerCatalog.cs
@@ -25,14 +25,14 @@ internal sealed class CachingLayerCatalog : ILayerCatalog
     private readonly CacheOptions _options;
     private readonly ISchemaContext? _schemaContext;
 
-    // Cache key constants
-    private const string LayerKeyPrefix = "layer:";
-    private const string LayerExistsKeyPrefix = "layer:exists:";
-    private const string LayerListKey = "layers:all";
-    private const string ServiceKeyPrefix = "service:";
-    private const string ServiceExistsKeyPrefix = "service:exists:";
-    private const string ServiceListKey = "services:all";
-    private const string RelationshipKeyPrefix = "relationship:";
+    // Cache key constants — shared keys are internal so BackgroundRefreshCacheDecorator uses the same values
+    internal const string LayerKeyPrefix = "layer:";
+    internal const string LayerListKey = "layers:all";
+    internal const string ServiceKeyPrefix = "service:";
+    internal const string ServiceListKey = "services:all";
+    internal const string LayerExistsKeyPrefix = "layer:exists:";
+    internal const string ServiceExistsKeyPrefix = "service:exists:";
+    internal const string RelationshipKeyPrefix = "relationship:";
 
     public CachingLayerCatalog(
         ILayerCatalog innerCatalog,

--- a/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheInvalidationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheInvalidationService.cs
@@ -27,7 +27,6 @@ internal sealed partial class OutputCacheInvalidationService
         ICacheService? metadataCache,
         IServiceScopeFactory scopeFactory,
         ICacheRefreshCoordinator? refreshCoordinator,
-        ICacheRefreshCoordinator? refreshCoordinator,
         ILogger<OutputCacheInvalidationService> logger)
     {
         _cacheStore = cacheStore;

--- a/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheInvalidationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheInvalidationService.cs
@@ -18,6 +18,7 @@ internal sealed partial class OutputCacheInvalidationService
     private readonly IResponseCache? _responseCache;
     private readonly ICacheService? _metadataCache;
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ICacheRefreshCoordinator? _refreshCoordinator;
     private readonly ILogger<OutputCacheInvalidationService> _logger;
 
     public OutputCacheInvalidationService(
@@ -25,12 +26,15 @@ internal sealed partial class OutputCacheInvalidationService
         IResponseCache? responseCache,
         ICacheService? metadataCache,
         IServiceScopeFactory scopeFactory,
+        ICacheRefreshCoordinator? refreshCoordinator,
+        ICacheRefreshCoordinator? refreshCoordinator,
         ILogger<OutputCacheInvalidationService> logger)
     {
         _cacheStore = cacheStore;
         _responseCache = responseCache;
         _metadataCache = metadataCache;
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _refreshCoordinator = refreshCoordinator;
         _logger = logger;
     }
 
@@ -219,24 +223,28 @@ internal sealed partial class OutputCacheInvalidationService
 
         var keys = new List<string>
         {
-            "services:all",
-            "layers:all"
+            CachingLayerCatalog.ServiceListKey,
+            CachingLayerCatalog.LayerListKey
         };
 
         if (!string.IsNullOrWhiteSpace(serviceId))
         {
-            keys.Add($"service:{serviceId}");
-            keys.Add($"service:exists:{serviceId}");
+            keys.Add($"{CachingLayerCatalog.ServiceKeyPrefix}{serviceId}");
+            keys.Add($"{CachingLayerCatalog.ServiceExistsKeyPrefix}{serviceId}");
         }
 
         foreach (var layerId in layerIds)
         {
-            keys.Add($"layer:{layerId}");
-            keys.Add($"layer:exists:{layerId}");
+            keys.Add($"{CachingLayerCatalog.LayerKeyPrefix}{layerId}");
+            keys.Add($"{CachingLayerCatalog.LayerExistsKeyPrefix}{layerId}");
         }
 
         foreach (var key in keys.Distinct(StringComparer.OrdinalIgnoreCase))
         {
+            // Notify the refresh coordinator so any pending background refresh
+            // for this key skips stale-value restoration on failure.
+            _refreshCoordinator?.NotifyInvalidation(key);
+
             try
             {
                 await _metadataCache.RemoveAsync(key, cancellationToken);
@@ -261,7 +269,7 @@ internal sealed partial class OutputCacheInvalidationService
 
         foreach (var layerId in layerIds)
         {
-            var pattern = $"relationship:{layerId}:*";
+            var pattern = $"{CachingLayerCatalog.RelationshipKeyPrefix}{layerId}:*";
             try
             {
                 await _metadataCache.RemoveByPatternAsync(pattern, cancellationToken);

--- a/src/Honua.Server/Features/Infrastructure/Caching/RedisCacheService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/RedisCacheService.cs
@@ -41,7 +41,9 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
     private readonly IAsyncPolicy<byte[]?> _redisGetPolicy;
     private readonly ConcurrentDictionary<string, CacheEntry> _fallbackCache = new();
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _keyLocks = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, CacheWriteInfo> _writeMetadata = new(StringComparer.Ordinal);
     private readonly Timer _cleanupTimer;
+    private readonly string _distributedCacheKeyPrefix;
     private volatile bool _isUsingFallback;
     private volatile bool _disposed;
     private long _lastRedisFailureTicks = DateTime.MinValue.Ticks;
@@ -52,11 +54,13 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
         IOptions<CacheOptions> options,
         ILogger<RedisCacheService> logger,
         IPerformanceMonitor performanceMonitor,
-        IConnectionMultiplexer? redis = null)
+        IConnectionMultiplexer? redis = null,
+        string? distributedCacheKeyPrefix = null)
     {
         _distributedCache = distributedCache;
         _redis = redis;
         _options = options.Value;
+        _distributedCacheKeyPrefix = distributedCacheKeyPrefix ?? string.Empty;
         _logger = logger;
         _performanceMonitor = performanceMonitor ?? throw new ArgumentNullException(nameof(performanceMonitor));
         var policyOptions = ResiliencePolicyOptions.Default;
@@ -159,10 +163,12 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
                 }
 
                 _fallbackCache.TryRemove(prefixedKey, out _);
+                _writeMetadata.TryRemove(prefixedKey, out _);
             }
             else
             {
                 _fallbackCache.TryRemove(prefixedKey, out _);
+                _writeMetadata.TryRemove(prefixedKey, out _);
             }
         }
 
@@ -209,6 +215,7 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
                     await _redisPolicy.ExecuteAsync(
                         ct => _distributedCache.SetAsync(prefixedKey, data, options, ct),
                         cancellationToken).ConfigureAwait(false);
+                    _writeMetadata[prefixedKey] = new CacheWriteInfo(DateTime.UtcNow.Ticks, ttl.Ticks);
                     return;
                 }
                 catch (Exception ex)
@@ -224,6 +231,7 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
             // Efficient cache eviction to prevent memory leaks under pressure
             EvictEntriesIfNeeded();
             _fallbackCache[prefixedKey] = new CacheEntry(data, DateTime.UtcNow.Add(ttl));
+            _writeMetadata[prefixedKey] = new CacheWriteInfo(DateTime.UtcNow.Ticks, ttl.Ticks);
         }
     }
 
@@ -255,8 +263,9 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
             }
         }
 
-        // Always remove from fallback cache
+        // Always remove from fallback cache and write metadata
         _fallbackCache.TryRemove(prefixedKey, out _);
+        _writeMetadata.TryRemove(prefixedKey, out _);
 
         RecordCacheEviction();
     }
@@ -280,6 +289,9 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
                 const int scanPageSize = 250;
                 var db = _redis.GetDatabase();
                 var database = db.Database;
+                // StackExchangeRedisCache prepends its InstanceName to all keys. Raw
+                // multiplexer operations must include that prefix to match actual Redis keys.
+                var redisScanPattern = $"{_distributedCacheKeyPrefix}{prefixedPattern}";
                 foreach (var endpoint in _redis.GetEndPoints())
                 {
                     var server = _redis.GetServer(endpoint);
@@ -289,7 +301,7 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
                     }
 
                     var deleteBatch = new List<RedisKey>(scanPageSize);
-                    foreach (var key in server.Keys(database, pattern: prefixedPattern, pageSize: scanPageSize))
+                    foreach (var key in server.Keys(database, pattern: redisScanPattern, pageSize: scanPageSize))
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         deleteBatch.Add(key);
@@ -329,7 +341,19 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
         foreach (string key in keysToRemove)
         {
             _fallbackCache.TryRemove(key, out _);
+            _writeMetadata.TryRemove(key, out _);
             RecordCacheEviction();
+        }
+
+        // Prune write metadata for keys not in the fallback cache (entries written
+        // while Redis was healthy exist only in _writeMetadata, not _fallbackCache).
+        var metadataKeysToRemove = _writeMetadata.Keys
+            .Where(k => MatchesPattern(k, prefixedPattern))
+            .ToList();
+
+        foreach (string key in metadataKeysToRemove)
+        {
+            _writeMetadata.TryRemove(key, out _);
         }
 
         // Note: Redis pattern deletion relies on server key scans when a connection is available.
@@ -405,6 +429,101 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
     }
 
     /// <inheritdoc />
+    public async Task<CacheEntryMetadata<T>> GetWithMetadataAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
+    {
+        if (!_options.Enabled)
+            return CacheEntryMetadata<T>.Miss();
+
+        string prefixedKey = GetPrefixedKey(key);
+        using var operationScope = _performanceMonitor.StartOperation("cache_get_metadata")
+            .WithTag("cache_type", CacheType)
+            .WithTag("key_family", GetCacheKeyFamily(key));
+
+        // Try Redis first if available
+        if (_distributedCache != null)
+        {
+            if (_isUsingFallback && ShouldRetryRedis(DateTime.UtcNow))
+            {
+                await TryRestoreRedisAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (!_isUsingFallback)
+            {
+                try
+                {
+                    byte[]? data = await _redisGetPolicy.ExecuteAsync(
+                        ct => _distributedCache.GetAsync(prefixedKey, ct),
+                        cancellationToken).ConfigureAwait(false);
+
+                    if (data != null && TryDeserialize(data, prefixedKey, out T? value))
+                    {
+                        // Resolve remaining TTL from in-memory write metadata (no extra Redis command).
+                        // Falls back to a multiplexer TTL query only for entries written by another
+                        // node in multi-node deployments (where the multiplexer is always available).
+                        var resolvedTtl = await ResolveRemainingTtlAsync(prefixedKey).ConfigureAwait(false);
+
+                        RecordCacheHit();
+                        operationScope.WithTag("result", "hit").WithTag("source", "redis");
+                        return new CacheEntryMetadata<T>(value, resolvedTtl);
+                    }
+
+                    if (data != null)
+                    {
+                        await RemoveCorruptRedisEntryAsync(prefixedKey, cancellationToken).ConfigureAwait(false);
+                        RecordCacheMiss();
+                        operationScope.WithTag("result", "miss").WithTag("source", "redis").WithTag("reason", "corrupt");
+                        return CacheEntryMetadata<T>.Miss();
+                    }
+
+                    RecordCacheMiss();
+                    operationScope.WithTag("result", "miss").WithTag("source", "redis");
+                    return CacheEntryMetadata<T>.Miss();
+                }
+                catch (Exception ex)
+                {
+                    HandleRedisFailure(ex);
+                    operationScope.WithTag("result", "error").WithTag("source", "redis");
+                    _performanceMonitor.RecordErrorWithContext("cache_error", "redis_get_metadata",
+                        new Dictionary<string, object>
+                        {
+                            ["cache_type"] = CacheType,
+                            ["key_family"] = GetCacheKeyFamily(key),
+                            ["source"] = "redis"
+                        },
+                        ex);
+                }
+            }
+        }
+
+        // Fallback to in-memory
+        if (_options.EnableFallback && _fallbackCache.TryGetValue(prefixedKey, out CacheEntry? entry))
+        {
+            if (entry.ExpiresAt > DateTime.UtcNow)
+            {
+                if (TryDeserialize(entry.Data, prefixedKey, out T? value))
+                {
+                    RecordCacheHit();
+                    operationScope.WithTag("result", "hit").WithTag("source", "fallback");
+                    var remaining = entry.ExpiresAt - DateTime.UtcNow;
+                    return new CacheEntryMetadata<T>(value, remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero);
+                }
+
+                _fallbackCache.TryRemove(prefixedKey, out _);
+                _writeMetadata.TryRemove(prefixedKey, out _);
+            }
+            else
+            {
+                _fallbackCache.TryRemove(prefixedKey, out _);
+                _writeMetadata.TryRemove(prefixedKey, out _);
+            }
+        }
+
+        RecordCacheMiss();
+        operationScope.WithTag("result", "miss").WithTag("source", "fallback");
+        return CacheEntryMetadata<T>.Miss();
+    }
+
+    /// <inheritdoc />
     public async Task<bool> IsCacheHealthyAsync(CancellationToken cancellationToken = default)
     {
         if (_distributedCache == null)
@@ -466,6 +585,7 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
         foreach (var key in expiredKeys)
         {
             _fallbackCache.TryRemove(key, out _);
+            _writeMetadata.TryRemove(key, out _);
         }
 
         // If still over capacity after removing expired entries, remove oldest
@@ -492,6 +612,7 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
             {
                 if (_fallbackCache.TryRemove(key, out _))
                 {
+                    _writeMetadata.TryRemove(key, out _);
                     evicted++;
                     if (evicted >= evictCount)
                         break;
@@ -699,27 +820,60 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
         return key.Equals(pattern, StringComparison.Ordinal);
     }
 
-    private static string GetCacheKeyFamily(string key)
+    internal static string GetCacheKeyFamily(string key) => CacheKeyUtilities.GetCacheKeyFamily(key);
+
+    /// <summary>
+    /// Resolves the remaining TTL for a cached entry, preferring the lightweight in-memory
+    /// write metadata over a Redis multiplexer TTL command. This avoids an extra Redis round
+    /// trip on the hot path and works even when <see cref="_redis"/> is null (e.g., startup
+    /// connection failure where <see cref="IDistributedCache"/> recovered independently).
+    /// Falls back to <c>KeyTimeToLiveAsync</c> only for entries written by another node in
+    /// multi-node deployments; the resolved TTL is then cached locally so the next read
+    /// for the same key uses the fast path without another multiplexer round trip.
+    /// When neither write metadata nor a multiplexer is available, returns
+    /// <see cref="TimeSpan.Zero"/> so the entry is treated as near-expiry and a single
+    /// background refresh populates write metadata for subsequent reads.
+    /// </summary>
+    private async Task<TimeSpan> ResolveRemainingTtlAsync(string prefixedKey)
     {
-        if (string.IsNullOrWhiteSpace(key))
+        // Fast path: entry was written (or TTL previously resolved) by this node.
+        if (_writeMetadata.TryGetValue(prefixedKey, out var writeInfo))
         {
-            return "empty";
+            long elapsedTicks = DateTime.UtcNow.Ticks - writeInfo.WrittenAtTicks;
+            long remainingTicks = writeInfo.TtlTicks - elapsedTicks;
+            return remainingTicks > 0 ? TimeSpan.FromTicks(remainingTicks) : TimeSpan.Zero;
         }
 
-        var lowerKey = key.ToLowerInvariant();
-
-        return lowerKey switch
+        // Slow path: entry written by another node — query Redis TTL via multiplexer.
+        if (_redis != null)
         {
-            _ when lowerKey.Contains("layer", StringComparison.Ordinal) => "layer",
-            _ when lowerKey.Contains("service", StringComparison.Ordinal) => "service",
-            _ when lowerKey.Contains("query", StringComparison.Ordinal) => "query",
-            _ when lowerKey.Contains("tile", StringComparison.Ordinal) || lowerKey.Contains("mvt", StringComparison.Ordinal) => "tile",
-            _ when lowerKey.Contains("catalog", StringComparison.Ordinal) => "catalog",
-            _ when lowerKey.Contains("replica", StringComparison.Ordinal) => "replica",
-            _ when lowerKey.Contains("schema", StringComparison.Ordinal) => "schema",
-            _ when lowerKey.Contains("auth", StringComparison.Ordinal) => "auth",
-            _ => "general"
-        };
+            try
+            {
+                var db = _redis.GetDatabase();
+                var actualRedisKey = $"{_distributedCacheKeyPrefix}{prefixedKey}";
+                TimeSpan? ttl = await db.KeyTimeToLiveAsync(actualRedisKey).ConfigureAwait(false);
+                var resolved = ttl ?? TimeSpan.Zero;
+
+                // Cache the resolved TTL locally so subsequent reads for the same key
+                // skip the multiplexer round trip (self-corrects after one lookup).
+                if (resolved > TimeSpan.Zero)
+                {
+                    _writeMetadata[prefixedKey] = new CacheWriteInfo(DateTime.UtcNow.Ticks, resolved.Ticks);
+                }
+
+                return resolved;
+            }
+            catch
+            {
+                // TTL lookup failed — disable near-expiry detection for this entry.
+                return TimeSpan.MaxValue;
+            }
+        }
+
+        // No write metadata and no multiplexer — treat as near-expiry so the background
+        // refresh coordinator enqueues one refresh, which populates write metadata for
+        // subsequent reads. Worst case is a single unnecessary proactive refresh per key.
+        return TimeSpan.Zero;
     }
 
     private void CleanupExpiredEntries(object? state)
@@ -728,6 +882,8 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
             return;
 
         var now = DateTime.UtcNow;
+        var nowTicks = now.Ticks;
+
         var expiredKeys = _fallbackCache
             .Where(kvp => kvp.Value.ExpiresAt <= now)
             .Select(kvp => kvp.Key)
@@ -738,9 +894,21 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
             _fallbackCache.TryRemove(key, out _);
         }
 
-        if (expiredKeys.Count > 0)
+        // Prune write metadata whose TTL has elapsed
+        var expiredMetadataKeys = _writeMetadata
+            .Where(kvp => (nowTicks - kvp.Value.WrittenAtTicks) >= kvp.Value.TtlTicks)
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        foreach (string key in expiredMetadataKeys)
         {
-            RedisCacheServiceLog.CleanupExpiredCacheEntries(_logger, expiredKeys.Count);
+            _writeMetadata.TryRemove(key, out _);
+        }
+
+        int totalCleaned = expiredKeys.Count + expiredMetadataKeys.Count;
+        if (totalCleaned > 0)
+        {
+            RedisCacheServiceLog.CleanupExpiredCacheEntries(_logger, totalCleaned);
         }
     }
 
@@ -772,6 +940,7 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
         _disposed = true;
         _cleanupTimer.Dispose();
         _fallbackCache.Clear();
+        _writeMetadata.Clear();
         foreach (var semaphore in _keyLocks.Values)
         {
             semaphore.Dispose();
@@ -884,6 +1053,13 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
     }
 
     private sealed record CacheEntry(byte[] Data, DateTime ExpiresAt);
+
+    /// <summary>
+    /// Lightweight record tracking when a cache entry was written and its original TTL.
+    /// Used by <see cref="GetWithMetadataAsync{T}"/> to compute remaining TTL without
+    /// a separate Redis TTL command, and without requiring an <see cref="IConnectionMultiplexer"/>.
+    /// </summary>
+    private readonly record struct CacheWriteInfo(long WrittenAtTicks, long TtlTicks);
 
     private static partial class RedisCacheServiceLog
     {

--- a/src/Honua.Server/Features/Infrastructure/Middleware/SchemaContext.cs
+++ b/src/Honua.Server/Features/Infrastructure/Middleware/SchemaContext.cs
@@ -12,12 +12,17 @@ namespace Honua.Server.Features.Infrastructure.Middleware;
 internal sealed class SchemaContext : ISchemaContext
 {
     private static readonly AsyncLocal<string?> AmbientSchema = new();
+    private string? _currentSchema;
 
     /// <inheritdoc />
     public string? CurrentSchema
     {
-        get => AmbientSchema.Value;
-        set => AmbientSchema.Value = value;
+        get => AmbientSchema.Value ?? _currentSchema;
+        set
+        {
+            _currentSchema = value;
+            AmbientSchema.Value = value;
+        }
     }
 
     internal static string? AmbientCurrentSchema => AmbientSchema.Value;

--- a/src/Honua.Server/Honua.Server.csproj
+++ b/src/Honua.Server/Honua.Server.csproj
@@ -93,7 +93,13 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Content Include="..\..\docs\developer\api-specs\admin-api.json" Link="admin-openapi.json">
+    <Content Include="..\..\docs\developer\api-specs\admin-api.json" Link="admin-openapi.json"
+             Condition="Exists('..\..\docs\developer\api-specs\admin-api.json')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Include="..\..\docs\api-specs\admin-api.json" Link="admin-openapi.json"
+             Condition="!Exists('..\..\docs\developer\api-specs\admin-api.json') and Exists('..\..\docs\api-specs\admin-api.json')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -912,22 +912,34 @@ static void RegisterInfrastructureServices(IServiceCollection services, IConfigu
     {
         services.Remove(innerCatalogDescriptor);
 
+        // Shared resolver for the data-source catalog (PostgresLayerCatalog) — avoids
+        // duplicating the resolution logic across the main and keyed registrations.
+        ILayerCatalog ResolveDataSourceCatalog(IServiceProvider sp)
+        {
+            if (innerCatalogDescriptor.ImplementationFactory != null)
+                return (ILayerCatalog)innerCatalogDescriptor.ImplementationFactory(sp);
+            if (innerCatalogDescriptor.ImplementationType != null)
+                return (ILayerCatalog)ActivatorUtilities.CreateInstance(sp, innerCatalogDescriptor.ImplementationType);
+            throw new InvalidOperationException("Unable to resolve inner ILayerCatalog implementation");
+        }
+
+        // Register the data-source catalog as a keyed service so the background refresh
+        // decorator can fetch fresh data without going through the caching layer.
+        // Wrapped with the monitoring decorator so background refresh reads remain
+        // observable in catalog telemetry while still bypassing the cache.
+        services.AddKeyedScoped<ILayerCatalog>(
+            BackgroundRefreshCacheDecorator.UncachedCatalogServiceKey,
+            (sp, _) =>
+            {
+                var catalog = ResolveDataSourceCatalog(sp);
+                var performanceMonitor = sp.GetRequiredService<IPerformanceMonitor>();
+                var monitorLogger = sp.GetRequiredService<ILogger<MonitoredLayerCatalogDecorator>>();
+                return new MonitoredLayerCatalogDecorator(catalog, performanceMonitor, monitorLogger);
+            });
+
         services.AddScoped<ILayerCatalog>(sp =>
         {
-            // Resolve the inner catalog (PostgresLayerCatalog)
-            ILayerCatalog innerCatalog;
-            if (innerCatalogDescriptor.ImplementationFactory != null)
-            {
-                innerCatalog = (ILayerCatalog)innerCatalogDescriptor.ImplementationFactory(sp);
-            }
-            else if (innerCatalogDescriptor.ImplementationType != null)
-            {
-                innerCatalog = (ILayerCatalog)ActivatorUtilities.CreateInstance(sp, innerCatalogDescriptor.ImplementationType);
-            }
-            else
-            {
-                throw new InvalidOperationException("Unable to resolve inner ILayerCatalog implementation");
-            }
+            ILayerCatalog innerCatalog = ResolveDataSourceCatalog(sp);
 
             // Apply caching decorator if enabled
             var cacheOptions = sp.GetRequiredService<IOptions<CacheOptions>>().Value;
@@ -938,6 +950,15 @@ static void RegisterInfrastructureServices(IServiceCollection services, IConfigu
                 var options = sp.GetRequiredService<IOptions<CacheOptions>>();
                 var schemaContext = sp.GetService<ISchemaContext>();
                 catalog = new CachingLayerCatalog(catalog, cacheService, options, schemaContext);
+
+                // Wrap with background refresh decorator for stale-while-revalidate
+                if (cacheOptions.BackgroundRefreshEnabled)
+                {
+                    var refreshCoordinator = sp.GetRequiredService<ICacheRefreshCoordinator>();
+                    var scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
+                    var refreshLogger = sp.GetRequiredService<ILogger<BackgroundRefreshCacheDecorator>>();
+                    catalog = new BackgroundRefreshCacheDecorator(catalog, cacheService, refreshCoordinator, scopeFactory, options, refreshLogger, schemaContext);
+                }
             }
 
             // Always wrap with monitoring for catalog metadata queries
@@ -1166,7 +1187,13 @@ static void ConfigureCaching(IServiceCollection services, IConfiguration configu
         var logger = sp.GetRequiredService<ILogger<RedisCacheService>>();
         var performanceMonitor = sp.GetRequiredService<IPerformanceMonitor>();
         var redis = sp.GetService<IConnectionMultiplexer>();
-        return new RedisCacheService(distributedCache, options, logger, performanceMonitor, redis);
+
+        // StackExchangeRedisCache prepends its InstanceName to all keys internally.
+        // Raw multiplexer operations (e.g., TTL lookup) must use the same prefix.
+        var redisCacheOpts = sp.GetService<IOptions<Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions>>();
+        var instanceName = redisCacheOpts?.Value?.InstanceName;
+
+        return new RedisCacheService(distributedCache, options, logger, performanceMonitor, redis, instanceName);
     });
 
     // Register interfaces pointing to the singleton
@@ -1182,6 +1209,11 @@ static void ConfigureCaching(IServiceCollection services, IConfiguration configu
             sp.GetRequiredService<IPerformanceMonitor>(),
             sp.GetRequiredService<ILogger<MonitoredResponseCacheDecorator>>());
     });
+
+    // Register background cache refresh coordinator
+    services.AddSingleton<CacheRefreshCoordinator>();
+    services.AddSingleton<ICacheRefreshCoordinator>(sp => sp.GetRequiredService<CacheRefreshCoordinator>());
+    services.AddHostedService(sp => sp.GetRequiredService<CacheRefreshCoordinator>());
 
     // Register the CachingLayerCatalog - it will be wired via decorator pattern in RegisterInfrastructureServices
 }

--- a/tests/Honua.Server.Tests/Features/Admin/TileOperationJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/TileOperationJobServiceTests.cs
@@ -142,6 +142,9 @@ public sealed class TileOperationJobServiceTests
             responseCache: null,
             metadataCache: null,
             scopeFactory: serviceScopeFactory,
+            refreshCoordinator: null,
+            scopeFactory: serviceScopeFactory,
+            refreshCoordinator: null,
             NullLogger<OutputCacheInvalidationService>.Instance);
 
         return new TileOperationJobService(

--- a/tests/Honua.Server.Tests/Features/Admin/TileOperationJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/TileOperationJobServiceTests.cs
@@ -143,9 +143,7 @@ public sealed class TileOperationJobServiceTests
             metadataCache: null,
             scopeFactory: serviceScopeFactory,
             refreshCoordinator: null,
-            scopeFactory: serviceScopeFactory,
-            refreshCoordinator: null,
-            NullLogger<OutputCacheInvalidationService>.Instance);
+            logger: NullLogger<OutputCacheInvalidationService>.Instance);
 
         return new TileOperationJobService(
             progressStore,

--- a/tests/Honua.Server.Tests/Features/Caching/BackgroundRefreshCacheDecoratorTests.cs
+++ b/tests/Honua.Server.Tests/Features/Caching/BackgroundRefreshCacheDecoratorTests.cs
@@ -1,0 +1,786 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Caching;
+using Honua.Core.Features.Caching.Abstractions;
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Monitoring;
+using Honua.Core.Features.Shared.Models;
+using Honua.Server.Features.Infrastructure.Caching;
+using Honua.Server.Features.Infrastructure.Middleware;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Caching;
+
+/// <summary>
+/// Tests for BackgroundRefreshCacheDecorator — validates stale-while-revalidate behavior,
+/// near-expiry detection, write-through refresh, and refresh deduplication.
+/// </summary>
+[Protocol(Protocols.TestQuality)]
+public sealed class BackgroundRefreshCacheDecoratorTests : IDisposable
+{
+    private readonly MockLayerCatalog _innerCatalog;
+    private readonly MockCacheService _cacheService;
+    private readonly MockRefreshCoordinator _refreshCoordinator;
+    private readonly BackgroundRefreshCacheDecorator _decorator;
+    private readonly CacheOptions _options;
+
+    public BackgroundRefreshCacheDecoratorTests()
+    {
+        _innerCatalog = new MockLayerCatalog();
+        _cacheService = new MockCacheService();
+        _refreshCoordinator = new MockRefreshCoordinator();
+
+        _options = new CacheOptions
+        {
+            Enabled = true,
+            LayerTtlSeconds = 60,
+            ServiceTtlSeconds = 120,
+            JitterPercentage = 0,
+            BackgroundRefreshEnabled = true,
+            BackgroundRefreshThreshold = 0.25
+        };
+
+        // Scope factory returns _innerCatalog as the keyed "uncached" catalog
+        var scopeFactory = new TestServiceScopeFactory(_innerCatalog);
+
+        _decorator = new BackgroundRefreshCacheDecorator(
+            _innerCatalog,
+            _cacheService,
+            _refreshCoordinator,
+            scopeFactory,
+            Options.Create(_options),
+            NullLogger<BackgroundRefreshCacheDecorator>.Instance);
+    }
+
+    public void Dispose()
+    {
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_CacheHitNotNearExpiry_ReturnsWithoutRefresh()
+    {
+        // Arrange: cached entry with plenty of TTL remaining (50s out of 60s)
+        var layer = CreateTestLayer(1);
+        _cacheService.SetEntry("layer:1", layer, TimeSpan.FromSeconds(50));
+
+        // Act
+        var result = await _decorator.GetLayerAsync(1);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(1);
+        _refreshCoordinator.EnqueuedKeys.Should().BeEmpty();
+        _innerCatalog.GetLayerCallCount.Should().Be(0);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_CacheHitNearExpiry_ReturnsStaleAndEnqueuesRefresh()
+    {
+        // Arrange: cached entry with only 10s remaining out of 60s (16% < 25% threshold)
+        var layer = CreateTestLayer(1);
+        _cacheService.SetEntry("layer:1", layer, TimeSpan.FromSeconds(10));
+
+        // Act
+        var result = await _decorator.GetLayerAsync(1);
+
+        // Assert: stale value returned immediately
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(1);
+
+        // Assert: background refresh was enqueued
+        _refreshCoordinator.EnqueuedKeys.Should().Contain("layer:1");
+        _innerCatalog.GetLayerCallCount.Should().Be(0); // NOT called synchronously
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_CacheMiss_DelegatesToInnerCatalog()
+    {
+        // Arrange: nothing in cache
+
+        // Act
+        var result = await _decorator.GetLayerAsync(1);
+
+        // Assert: inner catalog called synchronously (cold miss)
+        result.Should().NotBeNull();
+        _innerCatalog.GetLayerCallCount.Should().Be(1);
+        _refreshCoordinator.EnqueuedKeys.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetServiceAsync_NearExpiry_EnqueuesRefresh()
+    {
+        // Arrange: service cached with 20s remaining out of 120s (16% < 25% threshold)
+        var service = CreateTestService("TestService");
+        _cacheService.SetEntry("service:testservice", service, TimeSpan.FromSeconds(20));
+
+        // Act
+        var result = await _decorator.GetServiceAsync("TestService");
+
+        // Assert
+        result.Should().NotBeNull();
+        _refreshCoordinator.EnqueuedKeys.Should().Contain("service:testservice");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task ListLayersAsync_NearExpiry_EnqueuesRefresh()
+    {
+        // Arrange: layer list cached near expiry
+        var layers = new[] { CreateTestLayer(1), CreateTestLayer(2) };
+        _cacheService.SetEntry("layers:all", new CachedLayerList(layers), TimeSpan.FromSeconds(5));
+
+        // Act
+        var result = await _decorator.ListLayersAsync();
+
+        // Assert
+        result.Should().HaveCount(2);
+        _refreshCoordinator.EnqueuedKeys.Should().Contain("layers:all");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task ListServicesAsync_NearExpiry_EnqueuesRefresh()
+    {
+        // Arrange: service list cached near expiry
+        var services = new[] { CreateTestService("S1"), CreateTestService("S2") };
+        _cacheService.SetEntry("services:all", new CachedServiceList(services), TimeSpan.FromSeconds(5));
+
+        // Act
+        var result = await _decorator.ListServicesAsync();
+
+        // Assert
+        result.Should().HaveCount(2);
+        _refreshCoordinator.EnqueuedKeys.Should().Contain("services:all");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_MultipleConcurrentNearExpiry_OnlyOneRefreshEnqueued()
+    {
+        // Arrange: cached entry near expiry
+        var layer = CreateTestLayer(1);
+        _cacheService.SetEntry("layer:1", layer, TimeSpan.FromSeconds(5));
+
+        // Act: multiple concurrent calls
+        var tasks = Enumerable.Range(0, 5).Select(_ => _decorator.GetLayerAsync(1));
+        var results = await Task.WhenAll(tasks);
+
+        // Assert: all return stale value, but only one refresh enqueued
+        results.Should().AllSatisfy(r => r.Should().NotBeNull());
+        _refreshCoordinator.EnqueuedKeys.Count(k => k == "layer:1").Should().Be(1);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task LayerExistsAsync_DelegatesToInnerCatalog()
+    {
+        // Existence checks bypass background refresh
+        var result = await _decorator.LayerExistsAsync(1);
+
+        result.Should().BeTrue();
+        _innerCatalog.LayerExistsCallCount.Should().Be(1);
+        _refreshCoordinator.EnqueuedKeys.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetRelationshipAsync_DelegatesToInnerCatalog()
+    {
+        // Relationships bypass background refresh
+        var result = await _decorator.GetRelationshipAsync(1, 1);
+
+        result.Should().NotBeNull();
+        _refreshCoordinator.EnqueuedKeys.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_RefreshCallback_WriteThroughWithoutEviction()
+    {
+        // Arrange: cached entry near expiry
+        var layer = CreateTestLayer(1);
+        _cacheService.SetEntry("layer:1", layer, TimeSpan.FromSeconds(10));
+
+        // Act: trigger near-expiry path
+        await _decorator.GetLayerAsync(1);
+
+        // Execute the captured refresh callback (resolves keyed "uncached" catalog from scope)
+        _refreshCoordinator.CapturedCallbacks.Should().HaveCount(1);
+        await _refreshCoordinator.CapturedCallbacks[0](CancellationToken.None);
+
+        // Assert: stale entry was NOT evicted; fresh value was written through
+        _cacheService.RemovedKeys.Should().NotContain("layer:1");
+        _cacheService.SetKeys.Should().Contain("layer:1");
+        _innerCatalog.GetLayerCallCount.Should().Be(1);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task ListLayersAsync_RefreshCallback_WriteThroughWithoutEviction()
+    {
+        // Arrange: layer list cached near expiry
+        var layers = new[] { CreateTestLayer(1), CreateTestLayer(2) };
+        _cacheService.SetEntry("layers:all", new CachedLayerList(layers), TimeSpan.FromSeconds(5));
+
+        // Act
+        await _decorator.ListLayersAsync();
+
+        // Execute the captured refresh callback
+        _refreshCoordinator.CapturedCallbacks.Should().HaveCount(1);
+        await _refreshCoordinator.CapturedCallbacks[0](CancellationToken.None);
+
+        // Assert: write-through — no eviction, fresh value written
+        _cacheService.RemovedKeys.Should().NotContain("layers:all");
+        _cacheService.SetKeys.Should().Contain("layers:all");
+        _innerCatalog.ListLayersCallCount.Should().Be(1);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_RefreshCallbackFails_StaleEntryStaysInCache()
+    {
+        // Arrange: cached entry near expiry, inner catalog will throw on refresh
+        var layer = CreateTestLayer(1);
+        _cacheService.SetEntry("layer:1", layer, TimeSpan.FromSeconds(10));
+
+        // Act: trigger near-expiry path
+        await _decorator.GetLayerAsync(1);
+
+        // Make inner catalog fail for the refresh callback
+        _innerCatalog.ThrowOnGetLayer = true;
+
+        // Execute the captured refresh callback — it should fail
+        _refreshCoordinator.CapturedCallbacks.Should().HaveCount(1);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _refreshCoordinator.CapturedCallbacks[0](CancellationToken.None));
+
+        // Assert: stale entry was never evicted or overwritten — it stays in cache naturally
+        _cacheService.RemovedKeys.Should().NotContain("layer:1");
+        _cacheService.SetKeys.Should().NotContain("layer:1");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_NotNearExpiry_NoRefreshEnqueued()
+    {
+        // Arrange: cached entry with 50s remaining out of 60s (83% > 25% threshold)
+        var layer = CreateTestLayer(1);
+        _cacheService.SetEntry("layer:1", layer, TimeSpan.FromSeconds(50));
+
+        // Act
+        await _decorator.GetLayerAsync(1);
+
+        // Assert
+        _refreshCoordinator.EnqueuedKeys.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_ConcurrentRequestWhileRefreshPending_StillServedStale()
+    {
+        // Arrange: cached entry near expiry
+        var layer = CreateTestLayer(1);
+        _cacheService.SetEntry("layer:1", layer, TimeSpan.FromSeconds(10));
+
+        // Act: first request triggers refresh enqueue
+        var first = await _decorator.GetLayerAsync(1);
+        _refreshCoordinator.EnqueuedKeys.Should().Contain("layer:1");
+
+        // Callback is captured but NOT yet executed by background worker.
+        // Concurrent requests before the worker runs should still get the stale value
+        // from cache without hitting the inner catalog.
+        var second = await _decorator.GetLayerAsync(1);
+        var third = await _decorator.GetLayerAsync(1);
+
+        // Assert: all three requests returned the stale value
+        first.Should().NotBeNull();
+        first!.Id.Should().Be(1);
+        second.Should().NotBeNull();
+        second!.Id.Should().Be(1);
+        third.Should().NotBeNull();
+        third!.Id.Should().Be(1);
+
+        // Inner catalog was never called — stale served from cache throughout
+        _innerCatalog.GetLayerCallCount.Should().Be(0);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_RefreshSucceedsAfterInvalidation_SkipsWriteBack()
+    {
+        // Arrange: cached entry near expiry
+        var layer = CreateTestLayer(1);
+        _cacheService.SetEntry("layer:1", layer, TimeSpan.FromSeconds(10));
+
+        // Act: trigger near-expiry path to enqueue a refresh
+        await _decorator.GetLayerAsync(1);
+
+        // Simulate explicit invalidation while refresh is pending
+        _refreshCoordinator.NotifyInvalidation("layer:1");
+
+        // Execute the captured refresh callback — it succeeds but should NOT write back
+        _refreshCoordinator.CapturedCallbacks.Should().HaveCount(1);
+        await _refreshCoordinator.CapturedCallbacks[0](CancellationToken.None);
+
+        // Assert: inner catalog was called but write-back was skipped due to invalidation
+        _innerCatalog.GetLayerCallCount.Should().Be(1);
+        _cacheService.SetKeys.Should().NotContain("layer:1");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_InvalidationAfterClaimBeforeWrite_UndoesWriteBack()
+    {
+        // Regression test for the TOCTOU race: invalidation arrives after
+        // TryClaimWriteBack succeeds but before the cache write completes.
+        // The post-write WasInvalidated check must detect this and remove the entry.
+        var layer = CreateTestLayer(1);
+
+        // Use the race-aware mock that invalidates the key during SetAsync
+        var raceCacheService = new RaceAwareMockCacheService(
+            invalidateKeyDuringSet: "layer:1",
+            coordinator: _refreshCoordinator);
+        raceCacheService.SetEntry("layer:1", layer, TimeSpan.FromSeconds(10));
+
+        var scopeFactory = new TestServiceScopeFactory(_innerCatalog);
+        var decorator = new BackgroundRefreshCacheDecorator(
+            _innerCatalog,
+            raceCacheService,
+            _refreshCoordinator,
+            scopeFactory,
+            Options.Create(_options),
+            NullLogger<BackgroundRefreshCacheDecorator>.Instance);
+
+        // Trigger near-expiry path
+        await decorator.GetLayerAsync(1);
+
+        // Execute the refresh callback — SetAsync will trigger invalidation mid-write
+        _refreshCoordinator.CapturedCallbacks.Should().HaveCount(1);
+        await _refreshCoordinator.CapturedCallbacks[0](CancellationToken.None);
+
+        // Assert: the post-write check detected the invalidation and removed the entry
+        raceCacheService.RemovedKeys.Should().Contain("layer:1");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_RefreshReturnsNull_RemovesCacheEntryAndExistenceKey()
+    {
+        // Arrange: cached entry near expiry
+        var layer = CreateTestLayer(1);
+        _cacheService.SetEntry("layer:1", layer, TimeSpan.FromSeconds(10));
+
+        // Act: trigger near-expiry path
+        await _decorator.GetLayerAsync(1);
+
+        // Make inner catalog return null (simulating a deleted resource)
+        _innerCatalog.ReturnNullOnGetLayer = true;
+
+        // Execute the captured refresh callback
+        _refreshCoordinator.CapturedCallbacks.Should().HaveCount(1);
+        await _refreshCoordinator.CapturedCallbacks[0](CancellationToken.None);
+
+        // Assert: stale entry AND companion existence key both removed
+        _cacheService.RemovedKeys.Should().Contain("layer:1");
+        _cacheService.RemovedKeys.Should().Contain("layer:exists:1");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetServiceAsync_RefreshReturnsNull_RemovesCacheEntryAndExistenceKey()
+    {
+        // Arrange: service cached near expiry
+        var service = CreateTestService("TestService");
+        _cacheService.SetEntry("service:testservice", service, TimeSpan.FromSeconds(20));
+
+        // Act: trigger near-expiry path
+        await _decorator.GetServiceAsync("TestService");
+
+        // Make inner catalog return null (simulating a deleted service)
+        _innerCatalog.ReturnNullOnGetService = true;
+
+        // Execute the captured refresh callback
+        _refreshCoordinator.CapturedCallbacks.Should().HaveCount(1);
+        await _refreshCoordinator.CapturedCallbacks[0](CancellationToken.None);
+
+        // Assert: stale entry AND companion existence key both removed
+        _cacheService.RemovedKeys.Should().Contain("service:testservice");
+        _cacheService.RemovedKeys.Should().Contain("service:exists:testservice");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_RefreshCallback_PropagatesSchemaContextToChildScope()
+    {
+        // Regression test: background refresh must query the same database schema
+        // as the triggering request (X-Honua-Test-Schema header propagation).
+        var layer = CreateTestLayer(1);
+        _cacheService.SetEntry("layer:1", layer, TimeSpan.FromSeconds(10));
+
+        // Create a schema-tracking scope factory so we can inspect the child scope's schema
+        var childSchemaContext = new SchemaContext();
+        var scopeFactory = new TestServiceScopeFactory(_innerCatalog, childSchemaContext);
+
+        // Create decorator with a request schema context set to "test_schema"
+        var requestSchemaContext = Substitute.For<ISchemaContext>();
+        requestSchemaContext.CurrentSchema.Returns("test_schema");
+
+        var decorator = new BackgroundRefreshCacheDecorator(
+            _innerCatalog,
+            _cacheService,
+            _refreshCoordinator,
+            scopeFactory,
+            Options.Create(_options),
+            NullLogger<BackgroundRefreshCacheDecorator>.Instance,
+            requestSchemaContext);
+
+        // Act: trigger near-expiry refresh
+        await decorator.GetLayerAsync(1);
+
+        // Execute the captured refresh callback
+        _refreshCoordinator.CapturedCallbacks.Should().HaveCount(1);
+        await _refreshCoordinator.CapturedCallbacks[0](CancellationToken.None);
+
+        // Assert: child scope's SchemaContext was set to the request schema
+        childSchemaContext.CurrentSchema.Should().Be("test_schema");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetLayerAsync_RefreshCallback_NoSchemaContext_DoesNotFail()
+    {
+        // Verify that background refresh works when no schema context is present
+        // (production path without TestSchemaMiddleware)
+        var layer = CreateTestLayer(1);
+        _cacheService.SetEntry("layer:1", layer, TimeSpan.FromSeconds(10));
+
+        // Act: trigger near-expiry path (default decorator has no schema context)
+        await _decorator.GetLayerAsync(1);
+
+        // Execute the captured refresh callback — should succeed without schema propagation
+        _refreshCoordinator.CapturedCallbacks.Should().HaveCount(1);
+        await _refreshCoordinator.CapturedCallbacks[0](CancellationToken.None);
+
+        // Assert: refresh completed normally
+        _cacheService.SetKeys.Should().Contain("layer:1");
+    }
+
+    #region Test Helpers
+
+    private static readonly string[] DefaultFormats = ["json", "geojson"];
+    private static readonly string[] DefaultCapabilities = ["Query"];
+
+    private static LayerDefinition CreateTestLayer(int id)
+    {
+        return new LayerDefinition(
+            id,
+            $"Layer{id}",
+            $"Test layer {id}",
+            GeometryType.Point,
+            SpatialReference.WGS84,
+            new[]
+            {
+                new FieldDefinition("objectid", FieldType.Integer, Nullable: false),
+                new FieldDefinition("name", FieldType.String, Length: 100)
+            });
+    }
+
+    private static ServiceDefinition CreateTestService(string name)
+    {
+        return new ServiceDefinition(
+            name,
+            $"Test service {name}",
+            new[] { CreateTestLayer(1) },
+            SpatialReference.WGS84,
+            DefaultFormats,
+            DefaultCapabilities);
+    }
+
+    #endregion
+
+    #region Mock Implementations
+
+    /// <summary>
+    /// Mock cache service that supports GetWithMetadataAsync for testing near-expiry behavior.
+    /// Tracks SetAsync and RemoveAsync calls to verify write-through refresh.
+    /// </summary>
+    private class MockCacheService : ICacheService
+    {
+        private readonly Dictionary<string, (object Value, TimeSpan RemainingTtl)> _entries = new();
+
+        public List<string> RemovedKeys { get; } = new();
+
+        public void SetEntry<T>(string key, T value, TimeSpan remainingTtl) where T : class
+        {
+            _entries[key] = (value, remainingTtl);
+        }
+
+        public Task<CacheEntryMetadata<T>> GetWithMetadataAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
+        {
+            if (_entries.TryGetValue(key, out var entry) && entry.Value is T typedValue)
+            {
+                return Task.FromResult(new CacheEntryMetadata<T>(typedValue, entry.RemainingTtl));
+            }
+
+            return Task.FromResult(CacheEntryMetadata<T>.Miss());
+        }
+
+        public Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
+            => Task.FromResult<T?>(null);
+
+        public List<string> SetKeys { get; } = new();
+
+        public Task SetAsync<T>(string key, T value, CancellationToken cancellationToken = default) where T : class
+        {
+            SetKeys.Add(key);
+            _entries[key] = (value, TimeSpan.Zero);
+            return Task.CompletedTask;
+        }
+
+        public virtual Task SetAsync<T>(string key, T value, TimeSpan ttl, CancellationToken cancellationToken = default) where T : class
+        {
+            SetKeys.Add(key);
+            _entries[key] = (value, ttl);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+        {
+            RemovedKeys.Add(key);
+            _entries.Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveByPatternAsync(string pattern, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<T?> GetOrSetAsync<T>(string key, Func<CancellationToken, Task<T?>> factory, CancellationToken cancellationToken = default) where T : class
+            => factory(cancellationToken);
+
+        public Task<T?> GetOrSetAsync<T>(string key, Func<CancellationToken, Task<T?>> factory, TimeSpan ttl, CancellationToken cancellationToken = default) where T : class
+            => factory(cancellationToken);
+    }
+
+    /// <summary>
+    /// Mock cache service that triggers invalidation during SetAsync to simulate the
+    /// TOCTOU race: invalidation arrives after TryClaimWriteBack but before write completes.
+    /// </summary>
+    private sealed class RaceAwareMockCacheService : MockCacheService
+    {
+        private readonly string _invalidateKeyDuringSet;
+        private readonly ICacheRefreshCoordinator _coordinator;
+
+        public RaceAwareMockCacheService(string invalidateKeyDuringSet, ICacheRefreshCoordinator coordinator)
+        {
+            _invalidateKeyDuringSet = invalidateKeyDuringSet;
+            _coordinator = coordinator;
+        }
+
+        public override Task SetAsync<T>(string key, T value, TimeSpan ttl, CancellationToken cancellationToken = default)
+        {
+            // Simulate invalidation arriving during the cache write
+            if (key == _invalidateKeyDuringSet)
+            {
+                _coordinator.NotifyInvalidation(key);
+            }
+            return base.SetAsync(key, value, ttl, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Mock refresh coordinator that records enqueued keys and captures callbacks for verification.
+    /// </summary>
+    private sealed class MockRefreshCoordinator : ICacheRefreshCoordinator
+    {
+        private readonly HashSet<string> _pending = new();
+        private readonly HashSet<string> _invalidated = new();
+        private readonly HashSet<string> _claimed = new();
+
+        public List<string> EnqueuedKeys { get; } = new();
+
+        public List<Func<CancellationToken, Task>> CapturedCallbacks { get; } = new();
+
+        public int QueueDepth => _pending.Count;
+
+        public long SuccessCount => 0;
+
+        public long FailureCount => 0;
+
+        public long SkippedCount => 0;
+
+        public bool TryEnqueueRefresh(string key, Func<CancellationToken, Task> refreshCallback)
+        {
+            if (!_pending.Add(key))
+                return false;
+
+            EnqueuedKeys.Add(key);
+            CapturedCallbacks.Add(refreshCallback);
+            return true;
+        }
+
+        public void NotifyInvalidation(string key)
+        {
+            _invalidated.Add(key);
+        }
+
+        public bool WasInvalidated(string key)
+        {
+            return _invalidated.Contains(key);
+        }
+
+        public bool TryClaimWriteBack(string key)
+        {
+            // Mirrors production semantics: claim fails if already invalidated
+            if (_invalidated.Contains(key))
+                return false;
+            return _claimed.Add(key);
+        }
+    }
+
+    /// <summary>
+    /// Mock layer catalog with call counters.
+    /// </summary>
+    private sealed class MockLayerCatalog : ILayerCatalog
+    {
+        public int GetLayerCallCount { get; set; }
+        public int ListLayersCallCount { get; set; }
+        public int GetServiceCallCount { get; set; }
+        public int ListServicesCallCount { get; set; }
+        public int LayerExistsCallCount { get; set; }
+        public int ServiceExistsCallCount { get; set; }
+        public bool ThrowOnGetLayer { get; set; }
+        public bool ReturnNullOnGetLayer { get; set; }
+        public bool ReturnNullOnGetService { get; set; }
+
+        public Task<LayerDefinition?> GetLayerAsync(int layerId, CancellationToken cancellationToken = default)
+        {
+            GetLayerCallCount++;
+            if (ThrowOnGetLayer)
+                throw new InvalidOperationException("simulated failure");
+            if (ReturnNullOnGetLayer)
+                return Task.FromResult<LayerDefinition?>(null);
+            return Task.FromResult<LayerDefinition?>(CreateTestLayer(layerId));
+        }
+
+        public Task<LayerDefinition[]> ListLayersAsync(CancellationToken cancellationToken = default)
+        {
+            ListLayersCallCount++;
+            return Task.FromResult(new[] { CreateTestLayer(1), CreateTestLayer(2) });
+        }
+
+        public Task<ServiceDefinition?> GetServiceAsync(string serviceName, CancellationToken cancellationToken = default)
+        {
+            GetServiceCallCount++;
+            if (ReturnNullOnGetService)
+                return Task.FromResult<ServiceDefinition?>(null);
+            return Task.FromResult<ServiceDefinition?>(CreateTestService(serviceName));
+        }
+
+        public Task<ServiceDefinition[]> ListServicesAsync(CancellationToken cancellationToken = default)
+        {
+            ListServicesCallCount++;
+            return Task.FromResult(new[] { CreateTestService("S1"), CreateTestService("S2") });
+        }
+
+        public Task<bool> LayerExistsAsync(int layerId, CancellationToken cancellationToken = default)
+        {
+            LayerExistsCallCount++;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> ServiceExistsAsync(string serviceName, CancellationToken cancellationToken = default)
+        {
+            ServiceExistsCallCount++;
+            return Task.FromResult(true);
+        }
+
+        public Task<Relationship?> GetRelationshipAsync(int layerId, int relationshipId, CancellationToken cancellationToken = default)
+            => Task.FromResult<Relationship?>(Relationship.Create(relationshipId, "Test", 2, "esriRelCardinalityOneToMany", "id", "layer_id"));
+
+        public Task<Relationship[]> ListRelationshipsAsync(int layerId, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<Relationship>());
+    }
+
+    /// <summary>
+    /// Test service scope factory that returns a scope resolving the provided layer catalog
+    /// as the keyed "uncached" service, matching the production DI registration.
+    /// Optionally provides a SchemaContext to verify schema propagation in background refresh.
+    /// </summary>
+    private sealed class TestServiceScopeFactory : IServiceScopeFactory
+    {
+        private readonly ILayerCatalog _catalog;
+        private readonly SchemaContext? _schemaContext;
+
+        public TestServiceScopeFactory(ILayerCatalog catalog, SchemaContext? schemaContext = null)
+        {
+            _catalog = catalog;
+            _schemaContext = schemaContext;
+        }
+
+        public IServiceScope CreateScope() => new TestScope(_catalog, _schemaContext);
+
+        private sealed class TestScope : IServiceScope
+        {
+            private readonly TestServiceProvider _provider;
+
+            public TestScope(ILayerCatalog catalog, SchemaContext? schemaContext)
+                => _provider = new TestServiceProvider(catalog, schemaContext);
+
+            public IServiceProvider ServiceProvider => _provider;
+
+            public void Dispose() { }
+        }
+
+        private sealed class TestServiceProvider : IServiceProvider, IKeyedServiceProvider
+        {
+            private readonly ILayerCatalog _catalog;
+            private readonly SchemaContext? _schemaContext;
+
+            public TestServiceProvider(ILayerCatalog catalog, SchemaContext? schemaContext)
+            {
+                _catalog = catalog;
+                _schemaContext = schemaContext;
+            }
+
+            public object? GetService(Type serviceType)
+            {
+                if (serviceType == typeof(ILayerCatalog))
+                    return _catalog;
+                if (serviceType == typeof(SchemaContext))
+                    return _schemaContext;
+                return null;
+            }
+
+            public object? GetKeyedService(Type serviceType, object? serviceKey)
+            {
+                if (serviceType == typeof(ILayerCatalog)
+                    && serviceKey is string key
+                    && key == BackgroundRefreshCacheDecorator.UncachedCatalogServiceKey)
+                    return _catalog;
+                return null;
+            }
+
+            public object GetRequiredKeyedService(Type serviceType, object? serviceKey)
+            {
+                return GetKeyedService(serviceType, serviceKey)
+                    ?? throw new InvalidOperationException($"Keyed service not found: {serviceType.Name} [{serviceKey}]");
+            }
+        }
+    }
+
+    #endregion
+}

--- a/tests/Honua.Server.Tests/Features/Caching/CacheRefreshCoordinatorTests.cs
+++ b/tests/Honua.Server.Tests/Features/Caching/CacheRefreshCoordinatorTests.cs
@@ -1,0 +1,312 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Caching;
+using Honua.Core.Features.Infrastructure.Monitoring;
+using Honua.Server.Features.Infrastructure.Caching;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Caching;
+
+/// <summary>
+/// Tests for CacheRefreshCoordinator — validates deduplication, bounded concurrency, and failure isolation.
+/// </summary>
+[Protocol(Protocols.TestQuality)]
+public sealed class CacheRefreshCoordinatorTests : IDisposable
+{
+    private readonly CacheRefreshCoordinator _coordinator;
+    private readonly CancellationTokenSource _cts;
+
+    public CacheRefreshCoordinatorTests()
+    {
+        var options = Options.Create(new CacheOptions
+        {
+            BackgroundRefreshEnabled = true,
+            MaxConcurrentRefreshes = 2,
+            RefreshTimeoutSeconds = 5
+        });
+
+        _coordinator = new CacheRefreshCoordinator(
+            options,
+            Substitute.For<IPerformanceMonitor>(),
+            NullLogger<CacheRefreshCoordinator>.Instance);
+
+        _cts = new CancellationTokenSource();
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
+        _coordinator.Dispose();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public void TryEnqueueRefresh_NewKey_ReturnsTrue()
+    {
+        var result = _coordinator.TryEnqueueRefresh("layer:1", _ => Task.CompletedTask);
+
+        result.Should().BeTrue();
+        _coordinator.QueueDepth.Should().BeGreaterThan(0);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public void TryEnqueueRefresh_DuplicateKey_ReturnsFalse()
+    {
+        _coordinator.TryEnqueueRefresh("layer:1", _ => Task.CompletedTask);
+
+        var duplicate = _coordinator.TryEnqueueRefresh("layer:1", _ => Task.CompletedTask);
+
+        duplicate.Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public void TryEnqueueRefresh_DifferentKeys_BothSucceed()
+    {
+        var first = _coordinator.TryEnqueueRefresh("layer:1", _ => Task.CompletedTask);
+        var second = _coordinator.TryEnqueueRefresh("layer:2", _ => Task.CompletedTask);
+
+        first.Should().BeTrue();
+        second.Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task ExecuteAsync_ProcessesEnqueuedItems()
+    {
+        var refreshed = new TaskCompletionSource<bool>();
+
+        _coordinator.TryEnqueueRefresh("layer:1", _ =>
+        {
+            refreshed.SetResult(true);
+            return Task.CompletedTask;
+        });
+
+        // Start the background service
+        _ = _coordinator.StartAsync(_cts.Token);
+
+        var completed = await Task.WhenAny(refreshed.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        completed.Should().Be(refreshed.Task, "the refresh callback should have been invoked");
+
+        // Wait for post-callback bookkeeping (Interlocked.Increment + _pendingKeys removal)
+        for (int i = 0; i < 100 && _coordinator.SuccessCount < 1; i++)
+            await Task.Delay(10);
+
+        _coordinator.SuccessCount.Should().Be(1);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task ExecuteAsync_FailedRefresh_CountsAsFailure()
+    {
+        var refreshAttempted = new TaskCompletionSource<bool>();
+
+        _coordinator.TryEnqueueRefresh("layer:1", _ =>
+        {
+            refreshAttempted.SetResult(true);
+            throw new InvalidOperationException("simulated failure");
+        });
+
+        _ = _coordinator.StartAsync(_cts.Token);
+
+        await Task.WhenAny(refreshAttempted.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        // Wait for post-callback bookkeeping (Interlocked.Increment + _pendingKeys removal)
+        for (int i = 0; i < 100 && _coordinator.FailureCount < 1; i++)
+            await Task.Delay(10);
+
+        _coordinator.FailureCount.Should().Be(1);
+        _coordinator.SuccessCount.Should().Be(0);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task ExecuteAsync_AfterRefreshCompletes_KeyCanBeReenqueued()
+    {
+        var callCount = 0;
+        var firstRefreshDone = new TaskCompletionSource<bool>();
+        var secondRefreshDone = new TaskCompletionSource<bool>();
+
+        _ = _coordinator.StartAsync(_cts.Token);
+
+        _coordinator.TryEnqueueRefresh("layer:1", _ =>
+        {
+            Interlocked.Increment(ref callCount);
+            firstRefreshDone.SetResult(true);
+            return Task.CompletedTask;
+        });
+
+        // Wait for first refresh callback to complete
+        var completed = await Task.WhenAny(firstRefreshDone.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        completed.Should().Be(firstRefreshDone.Task, "the first refresh should have completed");
+
+        // Wait for ProcessRefreshAsync.finally to release the key from _pendingKeys
+        for (int i = 0; i < 100 && _coordinator.QueueDepth > 0; i++)
+            await Task.Delay(10);
+
+        // Now re-enqueue the same key — should succeed since first completed
+        var result = _coordinator.TryEnqueueRefresh("layer:1", _ =>
+        {
+            Interlocked.Increment(ref callCount);
+            secondRefreshDone.SetResult(true);
+            return Task.CompletedTask;
+        });
+
+        result.Should().BeTrue();
+
+        var completed2 = await Task.WhenAny(secondRefreshDone.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        completed2.Should().Be(secondRefreshDone.Task, "the second refresh should have completed");
+        callCount.Should().Be(2);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public void QueueDepth_InitiallyZero()
+    {
+        _coordinator.QueueDepth.Should().Be(0);
+        _coordinator.SuccessCount.Should().Be(0);
+        _coordinator.FailureCount.Should().Be(0);
+        _coordinator.SkippedCount.Should().Be(0);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public void NotifyInvalidation_WithPendingRefresh_MarksKeyAsInvalidated()
+    {
+        // Invalidation is only tracked when a refresh is pending for the key
+        _coordinator.TryEnqueueRefresh("layer:1", _ => Task.CompletedTask);
+
+        _coordinator.NotifyInvalidation("layer:1");
+
+        _coordinator.WasInvalidated("layer:1").Should().BeTrue();
+        _coordinator.WasInvalidated("layer:2").Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public void NotifyInvalidation_WithoutPendingRefresh_IsIgnored()
+    {
+        // No pending refresh → invalidation flag is not tracked (avoids stale flags)
+        _coordinator.NotifyInvalidation("layer:1");
+
+        _coordinator.WasInvalidated("layer:1").Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public void TryClaimWriteBack_PendingKey_SucceedsAndBlocksInvalidation()
+    {
+        _coordinator.TryEnqueueRefresh("layer:1", _ => Task.CompletedTask);
+
+        // Claim should succeed for a pending (non-invalidated) key
+        _coordinator.TryClaimWriteBack("layer:1").Should().BeTrue();
+
+        // After claim, NotifyInvalidation should still mark the key (state 2 → 1)
+        _coordinator.NotifyInvalidation("layer:1");
+        _coordinator.WasInvalidated("layer:1").Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public void TryClaimWriteBack_InvalidatedKey_ReturnsFalse()
+    {
+        _coordinator.TryEnqueueRefresh("layer:1", _ => Task.CompletedTask);
+
+        // Invalidate first, then try to claim
+        _coordinator.NotifyInvalidation("layer:1");
+        _coordinator.TryClaimWriteBack("layer:1").Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public void TryClaimWriteBack_NoKey_ReturnsFalse()
+    {
+        // No pending refresh → claim fails
+        _coordinator.TryClaimWriteBack("layer:nonexistent").Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public void TryClaimWriteBack_DoubleClaimSameKey_SecondReturnsFalse()
+    {
+        _coordinator.TryEnqueueRefresh("layer:1", _ => Task.CompletedTask);
+
+        _coordinator.TryClaimWriteBack("layer:1").Should().BeTrue();
+        // Second claim fails — already in write-claimed state
+        _coordinator.TryClaimWriteBack("layer:1").Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task ExecuteAsync_InvalidatedRefresh_CountsAsSkippedNotSuccess()
+    {
+        // Regression: invalidated refreshes must not inflate SuccessCount.
+        var gate = new TaskCompletionSource<bool>();
+        var refreshDone = new TaskCompletionSource<bool>();
+
+        _coordinator.TryEnqueueRefresh("layer:1", async _ =>
+        {
+            await gate.Task;
+            refreshDone.SetResult(true);
+        });
+
+        // Invalidate before the callback runs
+        _coordinator.NotifyInvalidation("layer:1");
+
+        _ = _coordinator.StartAsync(_cts.Token);
+        gate.SetResult(true);
+
+        var completed = await Task.WhenAny(refreshDone.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        completed.Should().Be(refreshDone.Task);
+
+        // Wait for post-callback bookkeeping
+        for (int i = 0; i < 100 && _coordinator.SkippedCount < 1; i++)
+            await Task.Delay(10);
+
+        _coordinator.SkippedCount.Should().Be(1);
+        _coordinator.SuccessCount.Should().Be(0, "invalidated refreshes must not be counted as successful");
+        _coordinator.FailureCount.Should().Be(0);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task ProcessRefreshAsync_CleansUpInvalidationTrackingAfterCompletion()
+    {
+        // Gate the refresh callback so it doesn't complete until after we call NotifyInvalidation.
+        var gate = new TaskCompletionSource<bool>();
+        var refreshDone = new TaskCompletionSource<bool>();
+
+        // Enqueue BEFORE starting the service so the item is pending when we notify.
+        _coordinator.TryEnqueueRefresh("layer:1", async _ =>
+        {
+            await gate.Task;
+            refreshDone.SetResult(true);
+        });
+
+        _coordinator.NotifyInvalidation("layer:1");
+        _coordinator.WasInvalidated("layer:1").Should().BeTrue();
+
+        // Start the service and release the gate so the refresh callback can complete.
+        _ = _coordinator.StartAsync(_cts.Token);
+        gate.SetResult(true);
+
+        var completed = await Task.WhenAny(refreshDone.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        completed.Should().Be(refreshDone.Task);
+
+        // Wait for finally block to clean up
+        for (int i = 0; i < 100 && _coordinator.WasInvalidated("layer:1"); i++)
+            await Task.Delay(10);
+
+        _coordinator.WasInvalidated("layer:1").Should().BeFalse();
+    }
+
+}

--- a/tests/Honua.Server.Tests/Features/Caching/CachingLayerCatalogTests.cs
+++ b/tests/Honua.Server.Tests/Features/Caching/CachingLayerCatalogTests.cs
@@ -12,6 +12,7 @@ using Honua.Server.Features.Infrastructure.Caching;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 
@@ -49,7 +50,7 @@ public sealed class CachingLayerCatalogTests : IDisposable
         _cacheService = new RedisCacheService(
             null, // No Redis - tests fallback mode
             Options.Create(_options),
-            new MockLogger<RedisCacheService>(),
+            NullLogger<RedisCacheService>.Instance,
             _performanceMonitor);
 
         _cachingCatalog = new CachingLayerCatalog(

--- a/tests/Honua.Server.Tests/Features/Caching/OutputCacheInvalidationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Caching/OutputCacheInvalidationServiceTests.cs
@@ -29,7 +29,7 @@ public sealed class OutputCacheInvalidationServiceTests
         var metadataCache = Substitute.For<ICacheService>();
         var scopeFactory = new ServiceCollection().BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
         var logger = NullLogger<OutputCacheInvalidationService>.Instance;
-        var sut = new OutputCacheInvalidationService(outputCacheStore, responseCache, metadataCache, scopeFactory, logger);
+        var sut = new OutputCacheInvalidationService(outputCacheStore, responseCache, metadataCache, scopeFactory, null, logger);
 
         await sut.InvalidateServiceCatalogAsync("TestService", [1, 2, 2], CancellationToken.None);
 
@@ -71,7 +71,7 @@ public sealed class OutputCacheInvalidationServiceTests
         var metadataCache = Substitute.For<ICacheService>();
         var scopeFactory = new ServiceCollection().BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
         var logger = NullLogger<OutputCacheInvalidationService>.Instance;
-        var sut = new OutputCacheInvalidationService(outputCacheStore, responseCache, metadataCache, scopeFactory, logger);
+        var sut = new OutputCacheInvalidationService(outputCacheStore, responseCache, metadataCache, scopeFactory, null, logger);
 
         await sut.InvalidateServiceCatalogAsync("TestService", null, CancellationToken.None);
 
@@ -84,7 +84,7 @@ public sealed class OutputCacheInvalidationServiceTests
     {
         var scopeFactory = new ServiceCollection().BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
         var logger = NullLogger<OutputCacheInvalidationService>.Instance;
-        var sut = new OutputCacheInvalidationService(null, null, null, scopeFactory, logger);
+        var sut = new OutputCacheInvalidationService(null, null, null, scopeFactory, null, logger);
 
         var act = async () => await sut.InvalidateServiceCatalogAsync("svc", [3], CancellationToken.None);
 
@@ -110,7 +110,7 @@ public sealed class OutputCacheInvalidationServiceTests
         services.AddScoped(_ => layerCatalog);
         var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
         var logger = NullLogger<OutputCacheInvalidationService>.Instance;
-        var sut = new OutputCacheInvalidationService(outputCacheStore, responseCache, metadataCache, scopeFactory, logger);
+        var sut = new OutputCacheInvalidationService(outputCacheStore, responseCache, metadataCache, scopeFactory, null, logger);
 
         await sut.InvalidateLayerAsync(null, 7, CancellationToken.None);
 

--- a/tests/Honua.Server.Tests/Features/Caching/RedisCacheServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Caching/RedisCacheServiceTests.cs
@@ -13,6 +13,7 @@ using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using StackExchange.Redis;
@@ -44,7 +45,7 @@ public sealed class RedisCacheServiceTests : IDisposable
         _cacheService = new RedisCacheService(
             null, // No Redis - tests fallback mode
             Options.Create(_options),
-            new MockLogger<RedisCacheService>(),
+            NullLogger<RedisCacheService>.Instance,
             _performanceMonitor);
     }
 
@@ -76,7 +77,7 @@ public sealed class RedisCacheServiceTests : IDisposable
         using var cache = new RedisCacheService(
             null,
             Options.Create(_options),
-            new MockLogger<RedisCacheService>(),
+            NullLogger<RedisCacheService>.Instance,
             performanceMonitor);
 
         _ = await cache.GetAsync<FieldDefinition>("layer:42:token=secret");
@@ -110,7 +111,7 @@ public sealed class RedisCacheServiceTests : IDisposable
         using var cache = new RedisCacheService(
             distributedCache,
             Options.Create(options),
-            new MockLogger<RedisCacheService>(),
+            NullLogger<RedisCacheService>.Instance,
             performanceMonitor);
 
         _ = await cache.GetAsync<FieldDefinition>("layer:42:token=secret");
@@ -332,7 +333,7 @@ public sealed class RedisCacheServiceTests : IDisposable
         using var cache = new RedisCacheService(
             null,
             Options.Create(options),
-            new MockLogger<RedisCacheService>(),
+            NullLogger<RedisCacheService>.Instance,
             _performanceMonitor);
 
         // Act - Add more entries than limit
@@ -357,6 +358,45 @@ public sealed class RedisCacheServiceTests : IDisposable
 
     [UnitTest]
     [Operation(Operations.Cache)]
+    public async Task SetAsync_EnforcesMaxEntries_AlsoCleansWriteMetadata()
+    {
+        // Regression test for finding: _writeMetadata must be trimmed alongside
+        // _fallbackCache during capacity eviction to prevent unbounded memory growth.
+        var options = new CacheOptions
+        {
+            Enabled = true,
+            EnableFallback = true,
+            FallbackMaxEntries = 3,
+            KeyPrefix = "evict:"
+        };
+
+        using var cache = new RedisCacheService(
+            null,
+            Options.Create(options),
+            NullLogger<RedisCacheService>.Instance,
+            _performanceMonitor);
+
+        // Fill to capacity and trigger eviction
+        await cache.SetAsync("a", new FieldDefinition("A", FieldType.String, Length: 10), TimeSpan.FromSeconds(60));
+        await cache.SetAsync("b", new FieldDefinition("B", FieldType.String, Length: 10), TimeSpan.FromSeconds(60));
+        await cache.SetAsync("c", new FieldDefinition("C", FieldType.String, Length: 10), TimeSpan.FromSeconds(60));
+        await cache.SetAsync("d", new FieldDefinition("D", FieldType.String, Length: 10), TimeSpan.FromSeconds(60));
+        await cache.SetAsync("e", new FieldDefinition("E", FieldType.String, Length: 10), TimeSpan.FromSeconds(60));
+
+        // Verify write metadata dictionary is bounded alongside fallback cache
+        var writeMetadataField = typeof(RedisCacheService)
+            .GetField("_writeMetadata", BindingFlags.NonPublic | BindingFlags.Instance);
+        writeMetadataField.Should().NotBeNull();
+
+        var writeMetadata = writeMetadataField!.GetValue(cache) as System.Collections.IDictionary;
+        writeMetadata.Should().NotBeNull();
+
+        // Write metadata count should not exceed fallback max entries
+        writeMetadata!.Count.Should().BeLessOrEqualTo(options.FallbackMaxEntries);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
     public async Task CacheDisabled_ReturnsNullAndDoesNotStore()
     {
         // Arrange
@@ -364,7 +404,7 @@ public sealed class RedisCacheServiceTests : IDisposable
         using var disabledCache = new RedisCacheService(
             null,
             Options.Create(options),
-            new MockLogger<RedisCacheService>(),
+            NullLogger<RedisCacheService>.Instance,
             _performanceMonitor);
 
         // Act
@@ -443,4 +483,152 @@ public sealed class RedisCacheServiceTests : IDisposable
             public void Dispose() { }
         }
     }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetWithMetadataAsync_WhenKeyExists_ReturnsValueWithPositiveRemainingTtl()
+    {
+        // Arrange
+        var item = new FieldDefinition("objectid", FieldType.Integer, Nullable: false);
+        var ttl = TimeSpan.FromSeconds(60);
+        await _cacheService.SetAsync("meta:1", item, ttl);
+
+        // Act
+        var result = await _cacheService.GetWithMetadataAsync<FieldDefinition>("meta:1");
+
+        // Assert
+        result.HasValue.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Name.Should().Be("objectid");
+        result.RemainingTtl.Should().BeGreaterThan(TimeSpan.Zero);
+        result.RemainingTtl.Should().BeLessOrEqualTo(ttl);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetWithMetadataAsync_WhenKeyNotFound_ReturnsMiss()
+    {
+        // Act
+        var result = await _cacheService.GetWithMetadataAsync<FieldDefinition>("meta:nonexistent");
+
+        // Assert
+        result.HasValue.Should().BeFalse();
+        result.Value.Should().BeNull();
+        result.RemainingTtl.Should().Be(TimeSpan.Zero);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetWithMetadataAsync_WhenExpired_ReturnsMiss()
+    {
+        // Arrange
+        var item = new FieldDefinition("objectid", FieldType.Integer, Nullable: false);
+        await _cacheService.SetAsync("meta:short", item, TimeSpan.FromMilliseconds(50));
+
+        // Wait for expiration
+        await Task.Delay(100);
+
+        // Act
+        var result = await _cacheService.GetWithMetadataAsync<FieldDefinition>("meta:short");
+
+        // Assert
+        result.HasValue.Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetWithMetadataAsync_CacheDisabled_ReturnsMiss()
+    {
+        // Arrange
+        var options = new CacheOptions { Enabled = false };
+        using var disabledCache = new RedisCacheService(
+            null,
+            Options.Create(options),
+            NullLogger<RedisCacheService>.Instance,
+            _performanceMonitor);
+
+        // Act
+        var result = await disabledCache.GetWithMetadataAsync<FieldDefinition>("meta:1");
+
+        // Assert
+        result.HasValue.Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetWithMetadataAsync_NoMultiplexer_ComputesTtlFromWriteMetadata()
+    {
+        // Arrange: cache service with no IConnectionMultiplexer (simulates startup Redis failure)
+        // — write metadata is the only TTL source, verifying Finding 1 fix.
+        var item = new FieldDefinition("objectid", FieldType.Integer, Nullable: false);
+        var ttl = TimeSpan.FromSeconds(60);
+        await _cacheService.SetAsync("meta:nomux", item, ttl);
+
+        // Act
+        var result = await _cacheService.GetWithMetadataAsync<FieldDefinition>("meta:nomux");
+
+        // Assert: remaining TTL is derived from write metadata, not MaxValue
+        result.HasValue.Should().BeTrue();
+        result.RemainingTtl.Should().BeGreaterThan(TimeSpan.Zero);
+        result.RemainingTtl.Should().BeLessOrEqualTo(ttl);
+        // Crucially, TTL must NOT be MaxValue (which would disable near-expiry detection)
+        result.RemainingTtl.Should().BeLessThan(TimeSpan.MaxValue);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetWithMetadataAsync_AfterRemove_ReturnsMiss()
+    {
+        // Arrange: set and then remove to verify write metadata is cleaned up
+        var item = new FieldDefinition("objectid", FieldType.Integer, Nullable: false);
+        await _cacheService.SetAsync("meta:removed", item, TimeSpan.FromSeconds(60));
+        await _cacheService.RemoveAsync("meta:removed");
+
+        // Act
+        var result = await _cacheService.GetWithMetadataAsync<FieldDefinition>("meta:removed");
+
+        // Assert
+        result.HasValue.Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Cache)]
+    public async Task GetWithMetadataAsync_WarmRedisEntry_NoMultiplexer_ReturnsTtlZeroForRefresh()
+    {
+        // Arrange: simulate a warm Redis entry written by another node. This node has
+        // no IConnectionMultiplexer (startup failure) and no _writeMetadata for the key.
+        // ResolveRemainingTtlAsync should return Zero so background refresh self-corrects.
+        var item = new FieldDefinition("objectid", FieldType.Integer, Nullable: false);
+        var serialized = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(
+            item, CacheJsonContext.Default.FieldDefinition);
+
+        var distributedCache = Substitute.For<IDistributedCache>();
+        distributedCache
+            .GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(serialized);
+
+        var options = new CacheOptions
+        {
+            Enabled = true,
+            EnableFallback = false, // force Redis-only path
+            KeyPrefix = "test:"
+        };
+
+        using var cache = new RedisCacheService(
+            distributedCache,
+            Options.Create(options),
+            NullLogger<RedisCacheService>.Instance,
+            _performanceMonitor,
+            redis: null, // no multiplexer
+            distributedCacheKeyPrefix: null);
+
+        // Act
+        var result = await cache.GetWithMetadataAsync<FieldDefinition>("meta:warm");
+
+        // Assert: entry found, TTL is zero (triggers near-expiry / background refresh)
+        result.HasValue.Should().BeTrue();
+        result.Value!.Name.Should().Be("objectid");
+        result.RemainingTtl.Should().Be(TimeSpan.Zero);
+    }
+
 }


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #233
## Summary

| Configurable threshold (default 25%) | Pass | `CacheOptions.BackgroundRefreshThreshold = 0.25`, validated in `CacheOptionsValidator` |
| Per-key deduplication | Pass | `_pendingKeys.TryAdd` in `TryEnqueueRefresh`; schema-scoped keys prevent cross-tenant collapse |
| Failure isolation | Pass | `ProcessRefreshAsync` catches all exceptions; foreground returns stale value |
| Metrics track refresh success/failure | Pass | `RecordCacheMetrics` for refresh_success, refresh_failure, refresh_timeout, refresh_skipped |
| Health check exposes queue depth | Pass | `HealthEndpoints.cs` emits `HealthCacheRefreshMetrics` with QueueDepth, SuccessCount, FailureCount, SkippedCount |
| P95 latency improvement | Pass (by design) | Stale-while-revalidate eliminates synchronous refresh on the request path |
## Changes Made

- | Configurable threshold (default 25%) | Pass | `CacheOptions.BackgroundRefreshThreshold = 0.25`, validated in `CacheOptionsValidator` |
- | Per-key deduplication | Pass | `_pendingKeys.TryAdd` in `TryEnqueueRefresh`; schema-scoped keys prevent cross-tenant collapse |
- | Failure isolation | Pass | `ProcessRefreshAsync` catches all exceptions; foreground returns stale value |
- | Metrics track refresh success/failure | Pass | `RecordCacheMetrics` for refresh_success, refresh_failure, refresh_timeout, refresh_skipped |
- | Health check exposes queue depth | Pass | `HealthEndpoints.cs` emits `HealthCacheRefreshMetrics` with QueueDepth, SuccessCount, FailureCount, SkippedCount |
- | P95 latency improvement | Pass (by design) | Stale-while-revalidate eliminates synchronous refresh on the request path |
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist
- [ ] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [ ] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally

## Additional Context

Decisions:
- **Low/DRY follow-on deferred**: `GetAsync`/`GetWithMetadataAsync` duplication is stable, well-tested, and only warrants extraction if a third cache-read method is added.
- **`scope=all` metadata gap**: Pre-existing issue not introduced by this PR, not in scope.

Follow-ons:
- Extract shared cache-read pipeline helper if a third read method is added to `RedisCacheService`
- Pre-existing `scope=all` metadata coverage gap

Code kaizen:
Deferred 1 low-priority finding(s) to cleanup backlog. Scoped fallback invalidation looks fixed and 87 targeted caching tests passed; only the low-severity RedisCacheService read-path duplication remains.
