### PR TITLE
refactor: unify vector protocol geojson and tile execution (#653)

### DIFF
--- a/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.Tiles.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.Tiles.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Tiles;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Core.Queries.Filters;
 using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Tiles;
 using Honua.Server.Features.Infrastructure.Validation;
 using Microsoft.Extensions.Options;
 
@@ -86,16 +87,16 @@ internal static partial class FeatureServerEndpoints
                 sqlFilter = translationResult.SqlFilter;
             }
         }
-        var query = new FeatureQuery
-        {
-            Where = where,
-            SqlFilter = sqlFilter,
-            SpatialReferenceSrid = layer.SpatialReference.ToSrid()
-        };
+        var query = VectorTileExecution.CreateQuery(
+            layer.SpatialReference.ToSrid(),
+            where,
+            sqlFilter);
 
         var tileProvider = context.RequestServices.GetRequiredService<ITileProvider>();
-        var tileData = await tileProvider.GetMvtTileAsync(
-            layerId,
+        return await VectorTileExecution.ExecuteAsync(
+            context,
+            tileProvider,
+            layer,
             x,
             y,
             z,
@@ -103,13 +104,5 @@ internal static partial class FeatureServerEndpoints
             tileOptions,
             tileLimits,
             cancellationToken);
-
-        if (tileData == null || tileData.Length == 0)
-        {
-            return Results.NoContent();
-        }
-
-        context.Response.Headers["Cache-Control"] = $"public, max-age={tileOptions.CacheMaxAge}";
-        return Results.Bytes(tileData, "application/vnd.mapbox-vector-tile");
     }
 }

--- a/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
@@ -9,6 +9,7 @@ using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Shared.Models;
 using Honua.Server.Features.FeatureServer.Models;
+using Honua.Server.Features.Infrastructure.GeoJson;
 using Honua.Server.Features.Infrastructure.Services;
 using Microsoft.Extensions.Options;
 using NetTopologySuite.Geometries;
@@ -216,9 +217,10 @@ internal sealed class QueryFormatter : IQueryFormatter
         GeometryLimits geometryLimits,
         string[]? outFields)
     {
-        var objectIdFieldName = layer.ObjectIdFieldName;
+        var projectedProperties = CreateProjectedProperties(outFields);
+        var buildOptions = CreateFeatureServerGeoJsonBuildOptions(layer, projectedProperties);
         GeoJsonFeature[] features = result.Items
-            .Select(f => ConvertToGeoJsonFeature(f, returnGeometry, outFields, objectIdFieldName, returnZ, returnM, geometryLimits))
+            .Select(f => ConvertToGeoJsonFeature(f, layer, returnGeometry, buildOptions, returnZ, returnM, geometryLimits))
             .ToArray();
 
         var exceededTransferLimit = result.HasMoreResults;
@@ -272,49 +274,16 @@ internal sealed class QueryFormatter : IQueryFormatter
     /// </summary>
     private static GeoJsonFeature ConvertToGeoJsonFeature(
         Feature feature,
+        LayerDefinition layer,
         bool returnGeometry,
-        string[]? outFields,
-        string objectIdFieldName,
+        GeoJsonFeatureBuildOptions buildOptions,
         bool returnZ,
         bool returnM,
         GeometryLimits geometryLimits)
     {
-        Dictionary<string, object?> properties = FilterAttributes(feature.Attributes, outFields, objectIdFieldName, feature.Id);
-
-        // Extract the ID from attributes if available
-        // Normalize numeric values to ensure type consistency
-        object? id = null;
-        if (properties.TryGetValue(FieldNames.ObjectId, out object? objectId))
-        {
-            // Normalize numeric types to avoid JsonElement vs primitive mismatches
-            id = objectId switch
-            {
-                System.Text.Json.JsonElement jsonElement when jsonElement.ValueKind == System.Text.Json.JsonValueKind.Number =>
-                    jsonElement.TryGetInt64(out long longVal) ? longVal : (object)jsonElement.GetDouble(),
-                _ => objectId
-            };
-        }
-        else if (properties.TryGetValue("id", out object? idValue))
-        {
-            id = idValue switch
-            {
-                System.Text.Json.JsonElement jsonElement when jsonElement.ValueKind == System.Text.Json.JsonValueKind.Number =>
-                    jsonElement.TryGetInt64(out long longVal) ? longVal : (object)jsonElement.GetDouble(),
-                _ => idValue
-            };
-        }
-
-        if (id == null)
-        {
-            id = feature.Id;
-        }
-
-        return new GeoJsonFeature
-        {
-            Properties = properties,
-            Geometry = returnGeometry ? ConvertGeometryToGeoJsonFormat(feature.Geometry, geometryLimits, returnZ, returnM) : null,
-            Id = id
-        };
+        var featureBase = GeoJsonFeatureBaseBuilder.Create(feature, layer, buildOptions);
+        var geometry = returnGeometry ? ConvertGeometryToGeoJsonFormat(feature.Geometry, geometryLimits, returnZ, returnM) : null;
+        return featureBase.ToGeoJsonFeature(geometry);
     }
 
     /// <summary>
@@ -375,6 +344,29 @@ internal sealed class QueryFormatter : IQueryFormatter
             target["OBJECTID"] = objectIdValue;
         }
     }
+
+    internal static IReadOnlySet<string>? CreateProjectedProperties(string[]? outFields)
+    {
+        if (outFields == null || outFields.Length == 0)
+        {
+            return null;
+        }
+
+        return outFields.Length == 1 && outFields[0].Equals("*", StringComparison.Ordinal)
+            ? null
+            : outFields.ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal static GeoJsonFeatureBuildOptions CreateFeatureServerGeoJsonBuildOptions(
+        LayerDefinition layer,
+        IReadOnlySet<string>? projectedProperties)
+        => new(
+            ProjectedProperties: projectedProperties,
+            IncludeObjectIdProperty: true,
+            IncludeObjectIdAlias: projectedProperties is null &&
+                                  layer.ObjectIdFieldName.Equals(FieldNames.ObjectId, StringComparison.OrdinalIgnoreCase),
+            IncludeAdditionalAttributes: true,
+            ResolveIdFromProperties: true);
 
     internal static GeoServicesFieldInfo[] BuildQueryFields(
         LayerDefinition layer,
@@ -785,8 +777,8 @@ internal sealed class StreamingQueryFormatter
             SkipValidation = false
         });
 
-        var objectIdFieldName = layer.ObjectIdFieldName;
-        var outFieldLookup = CreateFieldLookup(outFields);
+        var projectedProperties = QueryFormatter.CreateProjectedProperties(outFields);
+        var buildOptions = QueryFormatter.CreateFeatureServerGeoJsonBuildOptions(layer, projectedProperties);
 
         // Start GeoJSON FeatureCollection
         writer.WriteStartObject();
@@ -807,9 +799,9 @@ internal sealed class StreamingQueryFormatter
             await WriteGeoJsonFeatureAsync(
                 writer,
                 feature,
+                layer,
                 returnGeometry,
-                outFieldLookup,
-                objectIdFieldName,
+                buildOptions,
                 returnZ,
                 returnM,
                 effectiveLimits,
@@ -918,16 +910,20 @@ internal sealed class StreamingQueryFormatter
     private static async Task WriteGeoJsonFeatureAsync(
         Utf8JsonWriter writer,
         Feature feature,
+        LayerDefinition layer,
         bool returnGeometry,
-        HashSet<string>? outFieldLookup,
-        string objectIdFieldName,
+        GeoJsonFeatureBuildOptions buildOptions,
         bool returnZ,
         bool returnM,
         GeometryLimits geometryLimits,
         CancellationToken cancellationToken)
     {
+        var featureBase = GeoJsonFeatureBaseBuilder.Create(feature, layer, buildOptions);
+
         writer.WriteStartObject();
         writer.WriteString("type", "Feature");
+        writer.WritePropertyName("id");
+        JsonSerializer.Serialize(writer, featureBase.Id);
 
         // Write geometry if requested and available
         if (returnGeometry && feature.Geometry != null)
@@ -954,21 +950,9 @@ internal sealed class StreamingQueryFormatter
 
         // Write properties
         writer.WriteStartObject("properties");
-
-        if (feature.Attributes != null)
+        foreach (var kvp in featureBase.Properties)
         {
-            foreach (var kvp in feature.Attributes)
-            {
-                var fieldName = kvp.Key;
-
-                // Skip fields not in outFields if specified
-                if (outFieldLookup != null && !outFieldLookup.Contains(fieldName))
-                {
-                    continue;
-                }
-
-                await WriteJsonValueAsync(writer, fieldName, kvp.Value, cancellationToken);
-            }
+            await WriteJsonValueAsync(writer, kvp.Key, kvp.Value, cancellationToken);
         }
 
         writer.WriteEndObject(); // End properties

--- a/src/Honua.Server/Features/Infrastructure/GeoJson/GeoJsonFeatureBaseBuilder.cs
+++ b/src/Honua.Server/Features/Infrastructure/GeoJson/GeoJsonFeatureBaseBuilder.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Shared.Models;
+
+namespace Honua.Server.Features.Infrastructure.GeoJson;
+
+internal readonly record struct GeoJsonFeatureBuildOptions(
+    IReadOnlySet<string>? ProjectedProperties = null,
+    Func<long, object?>? IdFactory = null,
+    bool IncludeObjectIdProperty = false,
+    bool IncludeObjectIdAlias = false,
+    bool IncludeAdditionalAttributes = false,
+    bool ResolveIdFromProperties = false);
+
+internal static class GeoJsonFeatureBaseBuilder
+{
+    internal static GeoJsonFeatureBase Create(
+        Feature feature,
+        LayerDefinition layer,
+        GeoJsonFeatureBuildOptions options = default)
+        => CreateCore(
+            feature.Id,
+            feature.Attributes,
+            layer,
+            feature.Geometry != null,
+            options);
+
+    internal static GeoJsonFeatureBase Create(
+        EncodedGeoJsonFeature feature,
+        LayerDefinition layer,
+        GeoJsonFeatureBuildOptions options = default)
+        => CreateCore(
+            feature.Id,
+            feature.Attributes,
+            layer,
+            !string.IsNullOrWhiteSpace(feature.GeometryGeoJson),
+            options);
+
+    private static GeoJsonFeatureBase CreateCore(
+        long featureId,
+        IReadOnlyDictionary<string, object?> attributes,
+        LayerDefinition layer,
+        bool hasGeometry,
+        GeoJsonFeatureBuildOptions options)
+    {
+        var properties = BuildProperties(featureId, attributes, layer, options);
+        var id = options.IdFactory?.Invoke(featureId)
+            ?? (options.ResolveIdFromProperties
+                ? ResolveId(properties, layer.ObjectIdFieldName, featureId)
+                : featureId);
+
+        return GeoJsonFeatureBase.Create(id, properties, hasGeometry);
+    }
+
+    private static Dictionary<string, object?> BuildProperties(
+        long featureId,
+        IReadOnlyDictionary<string, object?> attributes,
+        LayerDefinition layer,
+        GeoJsonFeatureBuildOptions options)
+    {
+        var properties = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        var objectIdFieldName = layer.ObjectIdFieldName;
+        var projectedProperties = options.ProjectedProperties;
+        var shouldProjectAll = projectedProperties is null;
+        var shouldIncludeObjectId = options.IncludeObjectIdProperty;
+
+        foreach (var field in layer.AttributeFields)
+        {
+            var fieldName = field.Name;
+            var isObjectIdField = fieldName.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase);
+
+            if (isObjectIdField && !shouldIncludeObjectId)
+            {
+                continue;
+            }
+
+            if (!shouldProjectAll && !projectedProperties!.Contains(fieldName))
+            {
+                continue;
+            }
+
+            if (attributes.TryGetValue(fieldName, out var value))
+            {
+                properties[fieldName] = value;
+            }
+            else if (isObjectIdField && shouldIncludeObjectId)
+            {
+                properties[fieldName] = featureId;
+            }
+        }
+
+        if (options.IncludeAdditionalAttributes)
+        {
+            foreach (var (fieldName, value) in attributes)
+            {
+                if (properties.ContainsKey(fieldName))
+                {
+                    continue;
+                }
+
+                if (fieldName.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (shouldIncludeObjectId)
+                    {
+                        properties[fieldName] = value ?? featureId;
+                    }
+
+                    continue;
+                }
+
+                if (!shouldProjectAll && !projectedProperties!.Contains(fieldName))
+                {
+                    continue;
+                }
+
+                properties[fieldName] = value;
+            }
+        }
+
+        if (shouldIncludeObjectId && !properties.ContainsKey(objectIdFieldName))
+        {
+            properties[objectIdFieldName] = featureId;
+        }
+
+        if (options.IncludeObjectIdAlias &&
+            objectIdFieldName.Equals(FieldNames.ObjectId, StringComparison.OrdinalIgnoreCase) &&
+            !properties.ContainsKey("OBJECTID") &&
+            properties.TryGetValue(objectIdFieldName, out var objectIdValue))
+        {
+            properties["OBJECTID"] = objectIdValue;
+        }
+
+        return properties;
+    }
+
+    private static object ResolveId(
+        Dictionary<string, object?> properties,
+        string objectIdFieldName,
+        long featureId)
+    {
+        if (properties.TryGetValue(objectIdFieldName, out var objectId))
+        {
+            return NormalizeIdValue(objectId) ?? featureId;
+        }
+
+        if (properties.TryGetValue("id", out var idValue))
+        {
+            return NormalizeIdValue(idValue) ?? featureId;
+        }
+
+        return featureId;
+    }
+
+    private static object? NormalizeIdValue(object? value)
+        => value switch
+        {
+            JsonElement jsonElement when jsonElement.ValueKind == JsonValueKind.Number =>
+                jsonElement.TryGetInt64(out var longValue) ? longValue : jsonElement.GetDouble(),
+            JsonElement jsonElement when jsonElement.ValueKind == JsonValueKind.String =>
+                jsonElement.GetString(),
+            JsonElement jsonElement when jsonElement.ValueKind == JsonValueKind.True => true,
+            JsonElement jsonElement when jsonElement.ValueKind == JsonValueKind.False => false,
+            JsonElement jsonElement when jsonElement.ValueKind == JsonValueKind.Null => null,
+            _ => value
+        };
+}

--- a/src/Honua.Server/Features/Infrastructure/GeoJson/GeoJsonFeatureBaseBuilder.cs
+++ b/src/Honua.Server/Features/Infrastructure/GeoJson/GeoJsonFeatureBaseBuilder.cs
@@ -62,7 +62,7 @@ internal static class GeoJsonFeatureBaseBuilder
         LayerDefinition layer,
         GeoJsonFeatureBuildOptions options)
     {
-        var properties = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        var properties = new Dictionary<string, object?>(StringComparer.Ordinal);
         var objectIdFieldName = layer.ObjectIdFieldName;
         var projectedProperties = options.ProjectedProperties;
         var shouldProjectAll = projectedProperties is null;
@@ -97,18 +97,18 @@ internal static class GeoJsonFeatureBaseBuilder
         {
             foreach (var (fieldName, value) in attributes)
             {
-                if (properties.ContainsKey(fieldName))
-                {
-                    continue;
-                }
-
                 if (fieldName.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (shouldIncludeObjectId)
+                    if (shouldIncludeObjectId && !properties.ContainsKey(fieldName))
                     {
                         properties[fieldName] = value ?? featureId;
                     }
 
+                    continue;
+                }
+
+                if (ContainsKeyIgnoreCase(properties, fieldName))
+                {
                     continue;
                 }
 
@@ -129,7 +129,7 @@ internal static class GeoJsonFeatureBaseBuilder
         if (options.IncludeObjectIdAlias &&
             objectIdFieldName.Equals(FieldNames.ObjectId, StringComparison.OrdinalIgnoreCase) &&
             !properties.ContainsKey("OBJECTID") &&
-            properties.TryGetValue(objectIdFieldName, out var objectIdValue))
+            TryGetValueIgnoreCase(properties, objectIdFieldName, out var objectIdValue))
         {
             properties["OBJECTID"] = objectIdValue;
         }
@@ -142,17 +142,40 @@ internal static class GeoJsonFeatureBaseBuilder
         string objectIdFieldName,
         long featureId)
     {
-        if (properties.TryGetValue(objectIdFieldName, out var objectId))
+        if (TryGetValueIgnoreCase(properties, objectIdFieldName, out var objectId))
         {
             return NormalizeIdValue(objectId) ?? featureId;
         }
 
-        if (properties.TryGetValue("id", out var idValue))
+        if (TryGetValueIgnoreCase(properties, "id", out var idValue))
         {
             return NormalizeIdValue(idValue) ?? featureId;
         }
 
         return featureId;
+    }
+
+    private static bool ContainsKeyIgnoreCase(
+        IReadOnlyDictionary<string, object?> properties,
+        string key)
+        => TryGetValueIgnoreCase(properties, key, out _);
+
+    private static bool TryGetValueIgnoreCase(
+        IReadOnlyDictionary<string, object?> properties,
+        string key,
+        out object? value)
+    {
+        foreach (var (candidateKey, candidateValue) in properties)
+        {
+            if (candidateKey.Equals(key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = candidateValue;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
     }
 
     private static object? NormalizeIdValue(object? value)

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesQueryHandler.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesQueryHandler.cs
@@ -393,14 +393,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
                 effectiveOffset,
                 queryHasMoreResults);
 
-            var response = new FeatureCollection
-            {
-                Features = features,
-                NumberMatched = queryTotalCount,
-                NumberReturned = features.Length,
-                Links = links,
-                TimeStamp = DateTimeOffset.UtcNow
-            };
+            var response = OgcGeoJsonFeatureBuilder.CreateCollection(features, queryTotalCount, links);
 
             context.Response.Headers["Content-Crs"] = FormatContentCrs(filterResult.CrsDefinition.Uri);
 
@@ -652,19 +645,13 @@ internal sealed partial class OgcFeaturesQueryHandler(
         OgcFeaturesGeometryServices geometryServices,
         ImmutableHashSet<string>? projectedProperties = null,
         ImmutableArray<Link>? links = null)
-    {
-        var geometry = geometryServices.ConvertWkbToSimpleGeometry(feature.Geometry, axisOrder);
-        var properties = BuildOgcProperties(feature.Attributes, layer, projectedProperties);
-
-        return new GeoJsonFeature
-        {
-            Type = "Feature",
-            Id = feature.Id,
-            Geometry = geometry,
-            Properties = properties,
-            Links = links
-        };
-    }
+        => OgcGeoJsonFeatureBuilder.Create(
+            feature,
+            layer,
+            axisOrder,
+            geometryServices,
+            projectedProperties,
+            links: links);
 
     private static GeoJsonFeature ToOgcFeature(
         EncodedGeoJsonFeature feature,
@@ -673,46 +660,13 @@ internal sealed partial class OgcFeaturesQueryHandler(
         OgcFeaturesGeometryServices geometryServices,
         ImmutableHashSet<string>? projectedProperties = null,
         ImmutableArray<Link>? links = null)
-    {
-        var properties = BuildOgcProperties(feature.Attributes, layer, projectedProperties);
-
-        return new GeoJsonFeature
-        {
-            Type = "Feature",
-            Id = feature.Id,
-            Geometry = geometryServices.ConvertGeoJsonToSimpleGeometry(feature.GeometryGeoJson, axisOrder),
-            Properties = properties,
-            Links = links
-        };
-    }
-
-    private static Dictionary<string, object?> BuildOgcProperties(
-        ImmutableDictionary<string, object?> attributes,
-        LayerDefinition layer,
-        ImmutableHashSet<string>? projectedProperties)
-    {
-        var properties = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-        var objectIdFieldName = layer.ObjectIdFieldName;
-
-        foreach (var field in layer.AttributeFields)
-        {
-            if (field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-            if (projectedProperties != null && !projectedProperties.Contains(field.Name))
-            {
-                continue;
-            }
-
-            if (attributes.TryGetValue(field.Name, out var value))
-            {
-                properties[field.Name] = value;
-            }
-        }
-
-        return properties;
-    }
+        => OgcGeoJsonFeatureBuilder.Create(
+            feature,
+            layer,
+            axisOrder,
+            geometryServices,
+            projectedProperties,
+            links: links);
 
     private static string[] ResolveCsvFieldNames(
         LayerDefinition layer,

--- a/src/Honua.Server/Features/OgcFeatures/Services/OgcGeoJsonFeatureBuilder.cs
+++ b/src/Honua.Server/Features/OgcFeatures/Services/OgcGeoJsonFeatureBuilder.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Shared.Models;
+using Honua.Server.Features.Infrastructure.GeoJson;
+using Honua.Server.Features.Ogc.Common;
+using Honua.Server.Features.OgcFeatures.Models;
+
+namespace Honua.Server.Features.OgcFeatures.Services;
+
+internal static class OgcGeoJsonFeatureBuilder
+{
+    internal static GeoJsonFeature Create(
+        Feature feature,
+        LayerDefinition layer,
+        AxisOrder axisOrder,
+        OgcFeaturesGeometryServices geometryServices,
+        IReadOnlySet<string>? projectedProperties = null,
+        Func<long, object?>? idFactory = null,
+        ImmutableArray<Link>? links = null)
+    {
+        var geometry = geometryServices.ConvertWkbToSimpleGeometry(feature.Geometry, axisOrder);
+        return CreateCore(
+            GeoJsonFeatureBaseBuilder.Create(
+                feature,
+                layer,
+                new GeoJsonFeatureBuildOptions(
+                    ProjectedProperties: projectedProperties,
+                    IdFactory: idFactory)),
+            geometry,
+            links);
+    }
+
+    internal static GeoJsonFeature Create(
+        EncodedGeoJsonFeature feature,
+        LayerDefinition layer,
+        AxisOrder axisOrder,
+        OgcFeaturesGeometryServices geometryServices,
+        IReadOnlySet<string>? projectedProperties = null,
+        Func<long, object?>? idFactory = null,
+        ImmutableArray<Link>? links = null)
+    {
+        var geometry = geometryServices.ConvertGeoJsonToSimpleGeometry(feature.GeometryGeoJson, axisOrder);
+        return CreateCore(
+            GeoJsonFeatureBaseBuilder.Create(
+                feature,
+                layer,
+                new GeoJsonFeatureBuildOptions(
+                    ProjectedProperties: projectedProperties,
+                    IdFactory: idFactory)),
+            geometry,
+            links);
+    }
+
+    internal static FeatureCollection CreateCollection(
+        IReadOnlyCollection<GeoJsonFeature> features,
+        long? numberMatched,
+        ImmutableArray<Link>? links = null)
+        => new()
+        {
+            Features = [.. features],
+            NumberMatched = numberMatched,
+            NumberReturned = features.Count,
+            Links = links,
+            TimeStamp = DateTimeOffset.UtcNow
+        };
+
+    internal static GeoJsonFeature Create(
+        object? id,
+        IReadOnlyDictionary<string, object?> properties,
+        SimpleGeoJsonGeometry? geometry = null,
+        ImmutableArray<Link>? links = null)
+        => CreateCore(
+            GeoJsonFeatureBase.Create(id, properties, geometry is not null),
+            geometry,
+            links);
+
+    private static GeoJsonFeature CreateCore(
+        GeoJsonFeatureBase featureBase,
+        SimpleGeoJsonGeometry? geometry,
+        ImmutableArray<Link>? links)
+        => featureBase.ToOgcGeoJsonFeature(geometry, links);
+}

--- a/src/Honua.Server/Features/OgcTiles/TilesEndpoints.cs
+++ b/src/Honua.Server/Features/OgcTiles/TilesEndpoints.cs
@@ -16,6 +16,7 @@ using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.OgcFeatures;
+using Honua.Server.Features.Tiles;
 using Honua.Server.Features.OgcTiles.Models;
 using Honua.ServiceDefaults;
 using Microsoft.AspNetCore.Mvc;
@@ -231,7 +232,7 @@ internal static class TilesEndpoints
             crs,
             subsetCrs,
             OgcTilesUtilities.AllowedQueryParameters.DatasetTiles,
-            cancellationToken => ResolveDatasetLayerAsync(collections, layerCatalog, context, cancellationToken),
+            cancellationToken => ResolveDatasetLayerAsync(collections, layerCatalog, context, cancellationToken, requireCollection: true),
             layer => layer.SpatialReference.Wkid,
             tileProvider,
             tileOptions,
@@ -518,23 +519,22 @@ internal static class TilesEndpoints
         }
 
         // Vector (MVT) tile path
-        var query = new FeatureQuery
-        {
-            SpatialReferenceSrid = getSpatialReferenceSrid(layer),
-            TemporalFilter = temporalFilter
-        };
+        var query = VectorTileExecution.CreateQuery(
+            getSpatialReferenceSrid(layer),
+            temporalFilter: temporalFilter);
 
-        var tileData = await tileProvider.GetMvtTileAsync(layer.Id, tileCol, tileRow, zoomLevel, query, tileOptionsValue, tileLimits, cancellationToken);
-        if (tileData == null || tileData.Length == 0)
-        {
-            activity?.SetStatus(ActivityStatusCode.Ok);
-            activity?.SetTag(HonuaTelemetry.Tags.FeatureCount, 0);
-            return Results.NoContent();
-        }
-
-        activity?.SetStatus(ActivityStatusCode.Ok);
-        activity?.SetTag("honua.tile.bytes", tileData.Length);
-        return CreateTileResult(tileData, tileOptionsValue.CacheMaxAge);
+        return await VectorTileExecution.ExecuteAsync(
+            context,
+            tileProvider,
+            layer,
+            tileCol,
+            tileRow,
+            zoomLevel,
+            query,
+            tileOptionsValue,
+            tileLimits,
+            cancellationToken,
+            activity);
     }
 
     private static async Task<IResult> HandleRasterTileAsync(
@@ -800,7 +800,7 @@ internal static class TilesEndpoints
             {
                 return (null, StandardErrorHelpers.CreateBadRequest(
                     context,
-                    "The collections parameter is required for dataset tiles."));
+                    "The collections parameter is required for dataset tile resources."));
             }
 
             var layers = await layerCatalog.ListLayersAsync(cancellationToken);

--- a/src/Honua.Server/Features/Tiles/VectorTileExecution.cs
+++ b/src/Honua.Server/Features/Tiles/VectorTileExecution.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Shared.Models;
+using Honua.Core.Features.Tiles;
+using Honua.Core.Queries.Filters;
+using Honua.Server.Features.Ogc.Common;
+using Honua.ServiceDefaults;
+
+namespace Honua.Server.Features.Tiles;
+
+internal static class VectorTileExecution
+{
+    internal static FeatureQuery CreateQuery(
+        int spatialReferenceSrid,
+        string? where = null,
+        SqlFragment? sqlFilter = null,
+        TemporalFilter? temporalFilter = null)
+        => new()
+        {
+            Where = where,
+            SqlFilter = sqlFilter,
+            SpatialReferenceSrid = spatialReferenceSrid,
+            TemporalFilter = temporalFilter
+        };
+
+    internal static async Task<IResult> ExecuteAsync(
+        HttpContext context,
+        ITileProvider tileProvider,
+        LayerDefinition layer,
+        int tileCol,
+        int tileRow,
+        int zoomLevel,
+        FeatureQuery query,
+        TileOptions tileOptions,
+        TileLimits tileLimits,
+        CancellationToken cancellationToken,
+        Activity? activity = null)
+    {
+        var tileData = await tileProvider.GetMvtTileAsync(
+            layer.Id,
+            tileCol,
+            tileRow,
+            zoomLevel,
+            query,
+            tileOptions,
+            tileLimits,
+            cancellationToken);
+
+        if (tileData == null || tileData.Length == 0)
+        {
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            activity?.SetTag(HonuaTelemetry.Tags.FeatureCount, 0);
+            return Results.NoContent();
+        }
+
+        activity?.SetStatus(ActivityStatusCode.Ok);
+        activity?.SetTag("honua.tile.bytes", tileData.Length);
+        context.Response.Headers["Cache-Control"] = $"public, max-age={tileOptions.CacheMaxAge}";
+        return Results.Bytes(tileData, MediaTypes.Mvt);
+    }
+}

--- a/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
+++ b/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
@@ -1360,17 +1360,20 @@ internal sealed class Wfs20Handler
 
         foreach (var plan in planSet.Plans)
         {
+            var projectedProperties = GetProjectedProperties(plan.Query);
+
             if (geoJsonFeatureStore is not null)
             {
                 var result = await geoJsonFeatureStore.QueryGeoJsonAsync(plan.Descriptor.Layer.Id, plan.Query, cancellationToken);
                 foreach (var feature in result.Items)
                 {
-                    features.Add(new GeoJsonFeature
-                    {
-                        Id = BuildFeatureId(plan.Descriptor, feature.Id),
-                        Geometry = _geometryServices.ConvertGeoJsonToSimpleGeometry(feature.GeometryGeoJson, AxisOrder.EastNorth),
-                        Properties = BuildGeoJsonProperties(feature.Attributes, plan.Descriptor.Layer, plan.Query)
-                    });
+                    features.Add(OgcGeoJsonFeatureBuilder.Create(
+                        feature,
+                        plan.Descriptor.Layer,
+                        AxisOrder.EastNorth,
+                        _geometryServices,
+                        projectedProperties,
+                        featureId => BuildFeatureId(plan.Descriptor, featureId)));
                 }
 
                 continue;
@@ -1379,23 +1382,17 @@ internal sealed class Wfs20Handler
             var fallbackResult = await _featureReader.QueryAsync(plan.Descriptor.Layer.Id, plan.Query, cancellationToken);
             foreach (var feature in fallbackResult.Items)
             {
-                var geometry = _geometryServices.ConvertWkbToSimpleGeometry(feature.Geometry, AxisOrder.EastNorth);
-                features.Add(new GeoJsonFeature
-                {
-                    Id = BuildFeatureId(plan.Descriptor, feature.Id),
-                    Geometry = geometry,
-                    Properties = BuildGeoJsonProperties(feature.Attributes, plan.Descriptor.Layer, plan.Query)
-                });
+                features.Add(OgcGeoJsonFeatureBuilder.Create(
+                    feature,
+                    plan.Descriptor.Layer,
+                    AxisOrder.EastNorth,
+                    _geometryServices,
+                    projectedProperties,
+                    featureId => BuildFeatureId(plan.Descriptor, featureId)));
             }
         }
 
-        var payload = new FeatureCollection
-        {
-            Features = features.ToArray(),
-            NumberMatched = planSet.TotalMatched,
-            NumberReturned = features.Count,
-            TimeStamp = DateTimeOffset.UtcNow
-        };
+        var payload = OgcGeoJsonFeatureBuilder.CreateCollection(features, planSet.TotalMatched);
 
         var contentType = string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.Json, StringComparison.OrdinalIgnoreCase)
             ? MediaTypes.Json
@@ -1474,29 +1471,32 @@ internal sealed class Wfs20Handler
         {
             var result = await pagedGeoJsonFeatureStore.QueryGeoJsonPageAsync(descriptor.Layer.Id, query, cancellationToken);
             totalCount = result.TotalCount;
+            var projectedProperties = GetProjectedProperties(query);
             foreach (var feature in result.Items)
             {
-                features.Add(new GeoJsonFeature
-                {
-                    Id = BuildFeatureId(descriptor, feature.Id),
-                    Geometry = _geometryServices.ConvertGeoJsonToSimpleGeometry(feature.GeometryGeoJson, AxisOrder.EastNorth),
-                    Properties = BuildGeoJsonProperties(feature.Attributes, descriptor.Layer, query)
-                });
+                features.Add(OgcGeoJsonFeatureBuilder.Create(
+                    feature,
+                    descriptor.Layer,
+                    AxisOrder.EastNorth,
+                    _geometryServices,
+                    projectedProperties,
+                    featureId => BuildFeatureId(descriptor, featureId)));
             }
         }
         else if (_featureReader is IPagedFeatureReader pagedFeatureReader)
         {
             var result = await pagedFeatureReader.QueryPageAsync(descriptor.Layer.Id, query, cancellationToken);
             totalCount = result.TotalCount;
+            var projectedProperties = GetProjectedProperties(query);
             foreach (var feature in result.Items)
             {
-                var geometry = _geometryServices.ConvertWkbToSimpleGeometry(feature.Geometry, AxisOrder.EastNorth);
-                features.Add(new GeoJsonFeature
-                {
-                    Id = BuildFeatureId(descriptor, feature.Id),
-                    Geometry = geometry,
-                    Properties = BuildGeoJsonProperties(feature.Attributes, descriptor.Layer, query)
-                });
+                features.Add(OgcGeoJsonFeatureBuilder.Create(
+                    feature,
+                    descriptor.Layer,
+                    AxisOrder.EastNorth,
+                    _geometryServices,
+                    projectedProperties,
+                    featureId => BuildFeatureId(descriptor, featureId)));
             }
         }
         else
@@ -1504,13 +1504,7 @@ internal sealed class Wfs20Handler
             throw new InvalidOperationException("Paged feature queries are not supported by the configured feature store.");
         }
 
-        var payload = new FeatureCollection
-        {
-            Features = features.ToArray(),
-            NumberMatched = totalCount,
-            NumberReturned = features.Count,
-            TimeStamp = DateTimeOffset.UtcNow
-        };
+        var payload = OgcGeoJsonFeatureBuilder.CreateCollection(features, totalCount);
 
         var contentType = string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.Json, StringComparison.OrdinalIgnoreCase)
             ? MediaTypes.Json
@@ -1663,6 +1657,7 @@ internal sealed class Wfs20Handler
             var featureResult = await _featureReader.QueryAsync(plan.Descriptor.Layer.Id, plan.Query, cancellationToken);
             foreach (var feature in featureResult.Items)
             {
+                var featureId = BuildFeatureId(plan.Descriptor, feature.Id);
                 var properties = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
                 SimpleGeoJsonGeometry? geometry = null;
 
@@ -1674,29 +1669,18 @@ internal sealed class Wfs20Handler
                 }
                 else if (plan.ValueReference.IsFeatureId)
                 {
-                    properties["id"] = BuildFeatureId(plan.Descriptor, feature.Id);
+                    properties["id"] = featureId;
                 }
                 else
                 {
                     properties[plan.ValueReference.CanonicalName] = ExtractValue(feature, plan.ValueReference);
                 }
 
-                features.Add(new GeoJsonFeature
-                {
-                    Id = BuildFeatureId(plan.Descriptor, feature.Id),
-                    Geometry = geometry,
-                    Properties = properties
-                });
+                features.Add(OgcGeoJsonFeatureBuilder.Create(featureId, properties, geometry));
             }
         }
 
-        var payload = new FeatureCollection
-        {
-            Features = features.ToArray(),
-            NumberMatched = planSet.TotalMatched,
-            NumberReturned = features.Count,
-            TimeStamp = DateTimeOffset.UtcNow
-        };
+        var payload = OgcGeoJsonFeatureBuilder.CreateCollection(features, planSet.TotalMatched);
 
         var contentType = string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.Json, StringComparison.OrdinalIgnoreCase)
             ? MediaTypes.Json
@@ -1744,27 +1728,16 @@ internal sealed class Wfs20Handler
     private static string BuildFeatureId(WfsFeatureTypeDescriptor descriptor, long featureId)
         => $"{descriptor.LocalName}.{featureId.ToString(CultureInfo.InvariantCulture)}";
 
-    private static Dictionary<string, object?> BuildGeoJsonProperties(
-        ImmutableDictionary<string, object?> attributes,
-        LayerDefinition layer,
-        FeatureQuery query)
+    private static ImmutableHashSet<string>? GetProjectedProperties(FeatureQuery query)
     {
-        var properties = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-        var objectIdFieldName = layer.ObjectIdFieldName;
-        foreach (var field in GetProjectedAttributeFields(layer, query))
+        if (query.OutFields is not { } outFields)
         {
-            if (field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            if (attributes.TryGetValue(field.Name, out var value))
-            {
-                properties[field.Name] = value;
-            }
+            return null;
         }
 
-        return properties;
+        return outFields.IsDefaultOrEmpty
+            ? ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase)
+            : outFields.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
     private string? SerializeGeometryAsJson(byte[]? geometry)
@@ -1837,13 +1810,7 @@ internal sealed class Wfs20Handler
         if (string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.GeoJson, StringComparison.OrdinalIgnoreCase) ||
             string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.Json, StringComparison.OrdinalIgnoreCase))
         {
-            var payload = new FeatureCollection
-            {
-                Features = [],
-                NumberMatched = 0,
-                NumberReturned = 0,
-                TimeStamp = DateTimeOffset.UtcNow
-            };
+            var payload = OgcGeoJsonFeatureBuilder.CreateCollection(Array.Empty<GeoJsonFeature>(), 0);
 
             var contentType = string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.Json, StringComparison.OrdinalIgnoreCase)
                 ? MediaTypes.Json
@@ -1880,13 +1847,7 @@ internal sealed class Wfs20Handler
         if (string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.GeoJson, StringComparison.OrdinalIgnoreCase) ||
             string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.Json, StringComparison.OrdinalIgnoreCase))
         {
-            var payload = new FeatureCollection
-            {
-                Features = [],
-                NumberMatched = 0,
-                NumberReturned = 0,
-                TimeStamp = DateTimeOffset.UtcNow
-            };
+            var payload = OgcGeoJsonFeatureBuilder.CreateCollection(Array.Empty<GeoJsonFeature>(), 0);
 
             var contentType = string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.Json, StringComparison.OrdinalIgnoreCase)
                 ? MediaTypes.Json

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
@@ -305,6 +305,39 @@ public sealed class FeatureServerQueryExecutorTests
         geometry.GetProperty("spatialReference").GetProperty("wkid").GetInt32().Should().Be(3857);
     }
 
+    [Fact]
+    public async Task StreamQueryAsync_WithGeoJson_UsesSharedIdAndObjectIdProperties()
+    {
+        var featureReader = Substitute.For<IFeatureReader>();
+        var streamingStore = Substitute.For<IStreamingFeatureStore>();
+        streamingStore.StreamFeaturesAsync(7, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(_ => (IAsyncEnumerable<Feature>)StreamFeatures(
+            [
+                CreateFeature(42, "alpha")
+            ]));
+
+        var sut = CreateSut(featureReader, streamingStore);
+        var context = CreateHttpContext();
+
+        await sut.StreamQueryAsync(
+            7,
+            new FeatureQuery { Limit = 1 },
+            CreateLayer(),
+            new QueryParameters { F = "geojson", ReturnGeometry = false, OutFields = "name" },
+            outputSrid: null,
+            context,
+            CancellationToken.None);
+
+        var json = await ReadResponseAsync(context);
+        using var document = JsonDocument.Parse(json);
+        var feature = document.RootElement.GetProperty("features")[0];
+        feature.GetProperty("id").GetInt64().Should().Be(42);
+        var properties = feature.GetProperty("properties");
+        properties.GetProperty("objectid").GetInt64().Should().Be(42);
+        properties.GetProperty("name").GetString().Should().Be("alpha");
+        properties.TryGetProperty("OBJECTID", out _).Should().BeFalse();
+    }
+
     private static FeatureServerQueryExecutor CreateSut(
         IFeatureReader featureReader,
         IStreamingFeatureStore? streamingStore = null)

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
@@ -338,6 +338,39 @@ public sealed class FeatureServerQueryExecutorTests
         properties.TryGetProperty("OBJECTID", out _).Should().BeFalse();
     }
 
+    [Fact]
+    public async Task StreamQueryAsync_WithGeoJson_AllFields_PreservesObjectIdAlias()
+    {
+        var featureReader = Substitute.For<IFeatureReader>();
+        var streamingStore = Substitute.For<IStreamingFeatureStore>();
+        streamingStore.StreamFeaturesAsync(7, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(_ => (IAsyncEnumerable<Feature>)StreamFeatures(
+            [
+                CreateFeature(42, "alpha")
+            ]));
+
+        var sut = CreateSut(featureReader, streamingStore);
+        var context = CreateHttpContext();
+
+        await sut.StreamQueryAsync(
+            7,
+            new FeatureQuery { Limit = 1 },
+            CreateLayer(),
+            new QueryParameters { F = "geojson", ReturnGeometry = false },
+            outputSrid: null,
+            context,
+            CancellationToken.None);
+
+        var json = await ReadResponseAsync(context);
+        using var document = JsonDocument.Parse(json);
+        var feature = document.RootElement.GetProperty("features")[0];
+        feature.GetProperty("id").GetInt64().Should().Be(42);
+        var properties = feature.GetProperty("properties");
+        properties.GetProperty("objectid").GetInt64().Should().Be(42);
+        properties.GetProperty("OBJECTID").GetInt64().Should().Be(42);
+        properties.GetProperty("name").GetString().Should().Be("alpha");
+    }
+
     private static FeatureServerQueryExecutor CreateSut(
         IFeatureReader featureReader,
         IStreamingFeatureStore? streamingStore = null)

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/QueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/QueryFormatterTests.cs
@@ -94,6 +94,43 @@ public sealed class QueryFormatterTests
         geoJson.Features[0].Properties.Should().NotContainKey("OBJECTID");
     }
 
+    [Fact]
+    public async Task FormatQueryResultAsync_WithGeoJson_AllFields_PreservesObjectIdAlias()
+    {
+        var limitsOptions = Options.Create(new LimitsOptions());
+        var formatter = new QueryFormatter(
+            limitsOptions,
+            new PbfQueryFormatter(limitsOptions),
+            NullLogger<QueryFormatter>.Instance);
+
+        var feature = Feature.Create(
+            42,
+            geometry: null,
+            new Dictionary<string, object?>
+            {
+                ["name"] = "alpha"
+            }.ToImmutableDictionary());
+
+        var (response, contentType) = await formatter.FormatQueryResultAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            CreatePointLayer(),
+            format: "geojson",
+            returnGeometry: false,
+            outputSrid: null,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        contentType.Should().Be("application/geo+json");
+        var geoJson = response.Should().BeOfType<GeoJsonFeatureSet>().Subject;
+        geoJson.Features.Should().HaveCount(1);
+        geoJson.Features[0].Id.Should().Be(42L);
+        geoJson.Features[0].Properties.Should().Contain("objectid", 42L);
+        geoJson.Features[0].Properties.Should().Contain("OBJECTID", 42L);
+        geoJson.Features[0].Properties.Should().Contain("name", "alpha");
+    }
+
     private static LayerDefinition CreatePointLayer()
         => new(
             7,

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/QueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/QueryFormatterTests.cs
@@ -54,6 +54,46 @@ public sealed class QueryFormatterTests
         queryResponse.Features[0].Geometry?.SpatialReference?.Wkid.Should().Be(3857);
     }
 
+    [Fact]
+    public async Task FormatQueryResultAsync_WithGeoJson_UsesSharedIdAndPropertyProjection()
+    {
+        var limitsOptions = Options.Create(new LimitsOptions());
+        var formatter = new QueryFormatter(
+            limitsOptions,
+            new PbfQueryFormatter(limitsOptions),
+            NullLogger<QueryFormatter>.Instance);
+
+        var feature = Feature.Create(
+            42,
+            geometry: null,
+            new Dictionary<string, object?>
+            {
+                ["name"] = "alpha",
+                ["distance"] = 12.5
+            }.ToImmutableDictionary());
+
+        var (response, contentType) = await formatter.FormatQueryResultAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            CreatePointLayer(),
+            format: "geojson",
+            returnGeometry: false,
+            outputSrid: null,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null,
+            outFields: ["distance"]);
+
+        contentType.Should().Be("application/geo+json");
+        var geoJson = response.Should().BeOfType<GeoJsonFeatureSet>().Subject;
+        geoJson.Features.Should().HaveCount(1);
+        geoJson.Features[0].Id.Should().Be(42L);
+        geoJson.Features[0].Properties.Should().Contain("objectid", 42L);
+        geoJson.Features[0].Properties.Should().Contain("distance", 12.5);
+        geoJson.Features[0].Properties.Should().NotContainKey("name");
+        geoJson.Features[0].Properties.Should().NotContainKey("OBJECTID");
+    }
+
     private static LayerDefinition CreatePointLayer()
         => new(
             7,

--- a/tests/Honua.Server.Tests/Features/Wfs20/Wfs20EndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Wfs20/Wfs20EndpointsTests.cs
@@ -128,8 +128,14 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
 
         using var document = JsonDocument.Parse(content);
         document.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
-        document.RootElement.GetProperty("features").ValueKind.Should().Be(JsonValueKind.Array);
+        var features = document.RootElement.GetProperty("features");
+        features.ValueKind.Should().Be(JsonValueKind.Array);
         document.RootElement.GetProperty("numberReturned").GetInt32().Should().BeLessOrEqualTo(1);
+
+        var feature = features.EnumerateArray().Single();
+        feature.GetProperty("id").GetString().Should().StartWith("test_layer.");
+        feature.GetProperty("properties").TryGetProperty("id", out _).Should().BeFalse();
+        feature.GetProperty("properties").TryGetProperty("objectid", out _).Should().BeFalse();
     }
 
     [IntegrationTest]
@@ -355,7 +361,18 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
 
         using var document = JsonDocument.Parse(content);
         document.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
-        document.RootElement.GetProperty("features").GetArrayLength().Should().BeLessOrEqualTo(1);
+        var features = document.RootElement.GetProperty("features");
+        features.GetArrayLength().Should().BeLessOrEqualTo(1);
+
+        if (features.GetArrayLength() > 0)
+        {
+            var feature = features[0];
+            feature.GetProperty("id").GetString().Should().StartWith("test_layer.");
+            var properties = feature.GetProperty("properties");
+            properties.GetProperty("name").GetString().Should().NotBeNullOrWhiteSpace();
+            properties.TryGetProperty("id", out _).Should().BeFalse();
+            properties.TryGetProperty("objectid", out _).Should().BeFalse();
+        }
     }
 
     [IntegrationTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #653

## Summary
Unifies the remaining duplicated vector protocol response paths so GeoJSON feature shaping and MVT tile execution are shared across FeatureServer, OGC API Features, WFS, and OGC Tiles instead of drifting in parallel.

## Changes Made
- added a shared GeoJSON feature-base builder and routed OGC API Features, WFS GeoJSON, and FeatureServer GeoJSON through it
- extracted shared vector tile query/execution so FeatureServer tiles and OGC Tiles use the same MVT response path
- removed the last WFS `GetPropertyValue` GeoJSON hand-assembly path and added regressions for top-level `id` and property shaping consistency

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Validation Notes
- `scripts/pre-pr-check.sh`
- `dotnet test tests/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~QueryFormatterTests|FullyQualifiedName~FeatureServerQueryExecutorTests|FullyQualifiedName~Wfs20EndpointsTests|FullyQualifiedName~Wfs20NumberMatchedPolicyTests|FullyQualifiedName~OgcFeaturesItemsTests"`
- `dotnet test tests/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~Wfs20EndpointsTests|FullyQualifiedName~OgcFeatures|FullyQualifiedName~FeatureServer|FullyQualifiedName~OgcTilesEndpointTests|FullyQualifiedName~MapServerTileEndpointTests|FullyQualifiedName~TileJsonEndpointTests"`
