### PR TITLE
feat: STAC (SpatioTemporal Asset Catalog): metadata catalog for raster, imagery, and data discovery (#378)

### DIFF
--- a/src/Honua.Core/Features/Catalog/Domain/ServiceProtocols.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/ServiceProtocols.cs
@@ -26,10 +26,13 @@ public static class ServiceProtocols
     /// <summary>gRPC/gRPC-Web protocol.</summary>
     public const string Grpc = "Grpc";
 
+    /// <summary>STAC (SpatioTemporal Asset Catalog) protocol.</summary>
+    public const string Stac = "Stac";
+
     /// <summary>
     /// All supported protocol identifiers.
     /// </summary>
-    public static readonly string[] All = [FeatureServer, MapServer, OgcFeatures, Wfs20, OData, Grpc];
+    public static readonly string[] All = [FeatureServer, MapServer, OgcFeatures, Wfs20, OData, Grpc, Stac];
 
     /// <summary>
     /// Checks whether a protocol is enabled for a service based on its metadata.

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -410,6 +410,15 @@ public static class EndpointRegistry
         new("GET", "/rest/services/Utilities/PrintingTools/GPServer/Export Web Map Task/jobs/{jobId}"),
         new("GET", "/rest/services/Utilities/PrintingTools/GPServer/Export Web Map Task/jobs/{jobId}/results/Output_File"),
         new("GET", "/rest/services/Utilities/PrintingTools/GPServer/Get Layout Templates Info Task/execute"),
+
+        // STAC (SpatioTemporal Asset Catalog)
+        new("GET", "/stac"),
+        new("GET", "/stac/collections"),
+        new("GET", "/stac/collections/{collectionId}"),
+        new("GET", "/stac/collections/{collectionId}/items"),
+        new("GET", "/stac/collections/{collectionId}/items/{itemId}"),
+        new("GET", "/stac/search"),
+        new("POST", "/stac/search"),
     ];
 }
 

--- a/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheTtlOptions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheTtlOptions.cs
@@ -148,4 +148,19 @@ public sealed class OutputCacheTtlOptions
     /// OGC queryables cache duration. Default: 10 minutes.
     /// </summary>
     public TimeSpan OgcQueryables { get; set; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// STAC catalog (root landing page) cache duration. Default: 30 minutes.
+    /// </summary>
+    public TimeSpan StacCatalog { get; set; } = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// STAC collections list cache duration. Default: 10 minutes.
+    /// </summary>
+    public TimeSpan StacCollections { get; set; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// STAC single collection cache duration. Default: 10 minutes.
+    /// </summary>
+    public TimeSpan StacCollection { get; set; } = TimeSpan.FromMinutes(10);
 }

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -16,6 +16,7 @@ using Honua.Server.Features.OData;
 using Honua.Server.Features.OgcFeatures;
 using Honua.Server.Features.OgcMaps;
 using Honua.Server.Features.OgcTiles;
+using Honua.Server.Features.Stac;
 using Honua.Server.Features.Tiles;
 using Honua.Server.Features.Wfs20;
 
@@ -47,6 +48,7 @@ internal static class FeatureRegistrationExtensions
         services.AddObservability(configuration);
         services.AddAlerts(configuration);
         services.AddNlQuery(configuration);
+        services.AddStac();
 
         return services;
     }
@@ -72,6 +74,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapWfs20Endpoints();
         endpoints.MapODataEndpoints();
         endpoints.MapGeometryServiceEndpoints();
+        endpoints.MapStacEndpoints();
 
         return endpoints;
     }

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
@@ -318,6 +318,34 @@ internal static class ObservabilityServiceCollectionExtensions
                 policy.Tag("ogc-metadata", "metadata");
             });
 
+            // STAC catalog (root landing page) caching policy
+            options.AddPolicy("StacCatalog", policy =>
+            {
+                policy.Expire(ttl.StacCatalog);
+                policy.SetVaryByQuery("f");
+                policy.SetVaryByHeader("Accept");
+                policy.Tag("stac-metadata", "metadata");
+            });
+
+            // STAC collections list caching policy
+            options.AddPolicy("StacCollections", policy =>
+            {
+                policy.Expire(ttl.StacCollections);
+                policy.SetVaryByQuery("f");
+                policy.SetVaryByHeader("Accept");
+                policy.Tag("stac-metadata", "metadata");
+            });
+
+            // STAC single collection caching policy
+            options.AddPolicy("StacCollection", policy =>
+            {
+                policy.Expire(ttl.StacCollection);
+                policy.SetVaryByRouteValue("collectionId");
+                policy.SetVaryByQuery("f");
+                policy.SetVaryByHeader("Accept");
+                policy.Tag("stac-metadata", "metadata");
+            });
+
             // Note: No default base policy - endpoints must explicitly opt into caching for security
         });
 

--- a/src/Honua.Server/Features/Stac/CatalogEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/CatalogEndpoints.cs
@@ -4,12 +4,11 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using Honua.Core.Features.Catalog.Abstractions;
-using Honua.Core.Features.Catalog.Domain;
-using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.Stac.Models;
+using Honua.Server.Features.Stac.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Honua.Server.Features.Stac;
@@ -57,23 +56,8 @@ internal static class CatalogEndpoints
             var baseUrl = BaseUrlResolver.GetBaseUrl(context);
             var stacBase = $"{baseUrl}/stac";
 
-            var layers = await layerCatalog.ListLayersAsync(cancellationToken);
-            var services = await layerCatalog.ListServicesAsync(cancellationToken);
-
-            // Filter to layers visible via enabled services (or all if no protocol gating)
-            var layerToService = new Dictionary<int, ServiceDefinition>();
-            foreach (var service in services)
-            {
-                foreach (var serviceLayer in service.Layers)
-                {
-                    layerToService.TryAdd(serviceLayer.Id, service);
-                }
-            }
-
-            var visibleLayers = layers
-                .Where(layer => AccessPolicyHelpers.IsLayerAccessible(
-                    context, layer, layerToService.GetValueOrDefault(layer.Id)))
-                .ToArray();
+            var visibleLayers = await StacFilterHelpers.ResolveStacVisibleLayersAsync(
+                context, layerCatalog, cancellationToken);
 
             var links = ImmutableArray.CreateBuilder<Link>();
 

--- a/src/Honua.Server/Features/Stac/CatalogEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/CatalogEndpoints.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Helpers;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Ogc.Common;
+using Honua.Server.Features.Stac.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Stac;
+
+/// <summary>
+/// STAC Catalog landing page endpoint.
+/// </summary>
+internal static class CatalogEndpoints
+{
+    /// <summary>
+    /// Maps the STAC catalog root endpoint.
+    /// </summary>
+    public static IEndpointRouteBuilder MapStacCatalogEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/stac", HandleGetCatalog)
+            .WithDisplayName("STAC Catalog")
+            .WithName("StacCatalog")
+            .WithSummary("Get the STAC root catalog")
+            .WithDescription("Returns the root STAC catalog with links to child collections and search")
+            .WithTags("STAC")
+            .CacheOutput("StacCatalog")
+            .Produces<StacCatalog>(200, MediaTypes.Json)
+            .Produces(404);
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleGetCatalog(
+        HttpContext context,
+        [FromServices] ILayerCatalog layerCatalog,
+        [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
+    {
+        StacLog.CatalogRequested(logger);
+
+        var validationError = OgcCommonUtilities.ValidateQueryParameters(
+            context.Request, StacConstants.AllowedQueryParameters.Catalog);
+        if (validationError is not null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, validationError.Value ?? "Invalid query parameters.");
+        }
+
+        try
+        {
+            var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+            var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+            var stacBase = $"{baseUrl}/stac";
+
+            var layers = await layerCatalog.ListLayersAsync(cancellationToken);
+            var services = await layerCatalog.ListServicesAsync(cancellationToken);
+
+            // Filter to layers visible via enabled services (or all if no protocol gating)
+            var layerToService = new Dictionary<int, ServiceDefinition>();
+            foreach (var service in services)
+            {
+                foreach (var serviceLayer in service.Layers)
+                {
+                    layerToService.TryAdd(serviceLayer.Id, service);
+                }
+            }
+
+            var visibleLayers = layers
+                .Where(layer => AccessPolicyHelpers.IsLayerAccessible(
+                    context, layer, layerToService.GetValueOrDefault(layer.Id)))
+                .ToArray();
+
+            var links = ImmutableArray.CreateBuilder<Link>();
+
+            // Self
+            links.Add(Link.Create(
+                href: stacBase,
+                rel: RelationTypes.Self,
+                type: MediaTypes.Json,
+                title: "STAC Catalog"));
+
+            // Root
+            links.Add(Link.Create(
+                href: stacBase,
+                rel: StacConstants.StacRelations.Root,
+                type: MediaTypes.Json,
+                title: "STAC Catalog"));
+
+            // Service description (OpenAPI)
+            links.Add(Link.Create(
+                href: $"{baseUrl}/openapi.json",
+                rel: RelationTypes.ServiceDesc,
+                type: MediaTypes.OpenApi,
+                title: "API definition"));
+
+            // Collections
+            links.Add(Link.Create(
+                href: $"{stacBase}/collections",
+                rel: "data",
+                type: MediaTypes.Json,
+                title: "Collections"));
+
+            // Search
+            links.Add(Link.Create(
+                href: $"{stacBase}/search",
+                rel: StacConstants.StacRelations.Search,
+                type: MediaTypes.GeoJson,
+                title: "STAC Search"));
+
+            // Child collection links
+            foreach (var layer in visibleLayers)
+            {
+                var collectionId = layer.Id.ToString(CultureInfo.InvariantCulture);
+                links.Add(Link.Create(
+                    href: $"{stacBase}/collections/{collectionId}",
+                    rel: StacConstants.StacRelations.Child,
+                    type: MediaTypes.Json,
+                    title: layer.Name));
+            }
+
+            var catalog = new StacCatalog
+            {
+                Id = StacConstants.CatalogId,
+                Title = "Honua STAC Catalog",
+                Description = "SpatioTemporal Asset Catalog for Honua geospatial data discovery",
+                ConformsTo = ImmutableArray.Create(
+                    StacConstants.Conformance.Core,
+                    StacConstants.Conformance.ItemSearch,
+                    StacConstants.Conformance.OgcApiFeatures,
+                    StacConstants.Conformance.Collections,
+                    StacConstants.Conformance.FieldsExtension,
+                    StacConstants.Conformance.SortExtension,
+                    StacConstants.Conformance.FilterExtension),
+                Links = links.ToImmutable()
+            };
+
+            StacLog.CatalogReturned(logger, visibleLayers.Length);
+            return Results.Json(catalog, StacJsonContext.Default.StacCatalog, MediaTypes.Json);
+        }
+        catch (OperationCanceledException)
+            when (TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context).IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            StacLog.OperationFailed(logger, ex);
+            return StandardErrorHelpers.CreateInternalServerError(
+                context, "An error occurred while retrieving the STAC catalog.");
+        }
+    }
+}

--- a/src/Honua.Server/Features/Stac/CollectionEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/CollectionEndpoints.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Helpers;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Ogc.Common;
+using Honua.Server.Features.Stac.Models;
+using Honua.Server.Features.Stac.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Stac;
+
+/// <summary>
+/// STAC collection listing and detail endpoints.
+/// </summary>
+internal static class CollectionEndpoints
+{
+    /// <summary>
+    /// Maps STAC collection endpoints.
+    /// </summary>
+    public static IEndpointRouteBuilder MapStacCollectionEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/stac/collections", HandleGetCollections)
+            .WithDisplayName("STAC Collections")
+            .WithName("StacCollections")
+            .WithSummary("Get all STAC collections")
+            .WithDescription("Lists all available STAC collections")
+            .WithTags("STAC")
+            .CacheOutput("StacCollections")
+            .Produces<StacCollectionsResponse>(200, MediaTypes.Json)
+            .Produces(404);
+
+        endpoints.MapGet("/stac/collections/{collectionId}", HandleGetCollection)
+            .WithDisplayName("STAC Collection")
+            .WithName("StacCollection")
+            .WithSummary("Get a STAC collection by ID")
+            .WithDescription("Returns a single STAC collection with extent and links")
+            .WithTags("STAC")
+            .CacheOutput("StacCollection")
+            .Produces<StacCollection>(200, MediaTypes.Json)
+            .Produces(404);
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleGetCollections(
+        HttpContext context,
+        [FromServices] ILayerCatalog layerCatalog,
+        [FromServices] IFeatureReader featureReader,
+
+        [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
+    {
+        StacLog.CollectionsRequested(logger);
+
+        var validationError = OgcCommonUtilities.ValidateQueryParameters(
+            context.Request, StacConstants.AllowedQueryParameters.Collections);
+        if (validationError is not null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, validationError.Value ?? "Invalid query parameters.");
+        }
+
+        try
+        {
+            var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+            var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+            var stacBase = $"{baseUrl}/stac";
+
+            var layers = await layerCatalog.ListLayersAsync(cancellationToken);
+            var services = await layerCatalog.ListServicesAsync(cancellationToken);
+
+            var layerToService = new Dictionary<int, ServiceDefinition>();
+            foreach (var service in services)
+            {
+                foreach (var serviceLayer in service.Layers)
+                {
+                    layerToService.TryAdd(serviceLayer.Id, service);
+                }
+            }
+
+            var visibleLayers = layers
+                .Where(layer => AccessPolicyHelpers.IsLayerAccessible(
+                    context, layer, layerToService.GetValueOrDefault(layer.Id)))
+                .ToList();
+
+            var collectionTasks = visibleLayers
+                .Select(layer => StacMappingService.MapLayerToCollectionAsync(layer, featureReader, baseUrl, cancellationToken));
+            var collections = (await Task.WhenAll(collectionTasks)).ToImmutableArray();
+
+            var links = ImmutableArray.Create(
+                Link.Create(
+                    href: $"{stacBase}/collections",
+                    rel: RelationTypes.Self,
+                    type: MediaTypes.Json,
+                    title: "Collections"),
+                Link.Create(
+                    href: stacBase,
+                    rel: StacConstants.StacRelations.Root,
+                    type: MediaTypes.Json,
+                    title: "STAC Catalog"));
+
+            var response = new StacCollectionsResponse
+            {
+                Collections = collections,
+                Links = links
+            };
+
+            StacLog.CollectionsReturned(logger, collections.Length);
+            return Results.Json(response, StacJsonContext.Default.StacCollectionsResponse, MediaTypes.Json);
+        }
+        catch (OperationCanceledException)
+            when (TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context).IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            StacLog.OperationFailed(logger, ex);
+            return StandardErrorHelpers.CreateInternalServerError(
+                context, "An error occurred while retrieving STAC collections.");
+        }
+    }
+
+    private static async Task<IResult> HandleGetCollection(
+        string collectionId,
+        HttpContext context,
+        [FromServices] ILayerCatalog layerCatalog,
+        [FromServices] IFeatureReader featureReader,
+
+        [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
+    {
+        StacLog.CollectionRequested(logger, collectionId);
+
+        try
+        {
+            if (!int.TryParse(collectionId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId))
+            {
+                StacLog.CollectionNotFound(logger, collectionId);
+                return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
+            }
+
+            var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+            var layer = await layerCatalog.GetLayerAsync(layerId, cancellationToken);
+            if (layer is null)
+            {
+                StacLog.CollectionNotFound(logger, collectionId);
+                return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
+            }
+
+            var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+            var collection = await StacMappingService.MapLayerToCollectionAsync(layer, featureReader, baseUrl, cancellationToken);
+
+            return Results.Json(collection, StacJsonContext.Default.StacCollection, MediaTypes.Json);
+        }
+        catch (OperationCanceledException)
+            when (TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context).IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            StacLog.OperationFailed(logger, ex);
+            return StandardErrorHelpers.CreateInternalServerError(
+                context, "An error occurred while retrieving the STAC collection.");
+        }
+    }
+}
+
+/// <summary>
+/// Response wrapper for the STAC collections list.
+/// </summary>
+public sealed record StacCollectionsResponse
+{
+    /// <summary>
+    /// Available collections.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("collections")]
+    public required ImmutableArray<StacCollection> Collections { get; init; }
+
+    /// <summary>
+    /// Hypermedia links.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("links")]
+    public required ImmutableArray<Link> Links { get; init; }
+}

--- a/src/Honua.Server/Features/Stac/CollectionEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/CollectionEndpoints.cs
@@ -2,13 +2,12 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
-using System.Globalization;
 using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
-using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Validation;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.Stac.Models;
 using Honua.Server.Features.Stac.Services;
@@ -71,22 +70,8 @@ internal static class CollectionEndpoints
             var baseUrl = BaseUrlResolver.GetBaseUrl(context);
             var stacBase = $"{baseUrl}/stac";
 
-            var layers = await layerCatalog.ListLayersAsync(cancellationToken);
-            var services = await layerCatalog.ListServicesAsync(cancellationToken);
-
-            var layerToService = new Dictionary<int, ServiceDefinition>();
-            foreach (var service in services)
-            {
-                foreach (var serviceLayer in service.Layers)
-                {
-                    layerToService.TryAdd(serviceLayer.Id, service);
-                }
-            }
-
-            var visibleLayers = layers
-                .Where(layer => AccessPolicyHelpers.IsLayerAccessible(
-                    context, layer, layerToService.GetValueOrDefault(layer.Id)))
-                .ToList();
+            var visibleLayers = await StacFilterHelpers.ResolveStacVisibleLayersAsync(
+                context, layerCatalog, cancellationToken);
 
             var collectionTasks = visibleLayers
                 .Select(layer => StacMappingService.MapLayerToCollectionAsync(layer, featureReader, baseUrl, cancellationToken));
@@ -129,29 +114,23 @@ internal static class CollectionEndpoints
     private static async Task<IResult> HandleGetCollection(
         string collectionId,
         HttpContext context,
-        [FromServices] ILayerCatalog layerCatalog,
         [FromServices] IFeatureReader featureReader,
-
         [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
     {
         StacLog.CollectionRequested(logger, collectionId);
 
         try
         {
-            if (!int.TryParse(collectionId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId))
-            {
-                StacLog.CollectionNotFound(logger, collectionId);
-                return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
-            }
-
             var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
-            var layer = await layerCatalog.GetLayerAsync(layerId, cancellationToken);
-            if (layer is null)
+            var validation = await LayerValidationHelpers.ValidateCollectionWithAccessAsync(
+                context, collectionId, requiredProtocol: ServiceProtocols.Stac, cancellationToken: cancellationToken);
+            if (!validation.IsValid)
             {
                 StacLog.CollectionNotFound(logger, collectionId);
-                return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
+                return validation.ErrorResult!;
             }
 
+            var layer = validation.Layer!;
             var baseUrl = BaseUrlResolver.GetBaseUrl(context);
             var collection = await StacMappingService.MapLayerToCollectionAsync(layer, featureReader, baseUrl, cancellationToken);
 
@@ -169,22 +148,4 @@ internal static class CollectionEndpoints
                 context, "An error occurred while retrieving the STAC collection.");
         }
     }
-}
-
-/// <summary>
-/// Response wrapper for the STAC collections list.
-/// </summary>
-public sealed record StacCollectionsResponse
-{
-    /// <summary>
-    /// Available collections.
-    /// </summary>
-    [System.Text.Json.Serialization.JsonPropertyName("collections")]
-    public required ImmutableArray<StacCollection> Collections { get; init; }
-
-    /// <summary>
-    /// Hypermedia links.
-    /// </summary>
-    [System.Text.Json.Serialization.JsonPropertyName("links")]
-    public required ImmutableArray<Link> Links { get; init; }
 }

--- a/src/Honua.Server/Features/Stac/ItemEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/ItemEndpoints.cs
@@ -1,0 +1,216 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Server.Features.Infrastructure.Helpers;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Ogc.Common;
+using Honua.Server.Features.Stac.Models;
+using Honua.Server.Features.Stac.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Stac;
+
+/// <summary>
+/// STAC item listing and detail endpoints for a collection.
+/// </summary>
+internal static class ItemEndpoints
+{
+    /// <summary>
+    /// Maps STAC item endpoints.
+    /// </summary>
+    public static IEndpointRouteBuilder MapStacItemEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/stac/collections/{collectionId}/items", HandleGetItems)
+            .WithDisplayName("STAC Items")
+            .WithName("StacItems")
+            .WithSummary("Get items in a STAC collection")
+            .WithDescription("Lists items in a collection with optional spatial/temporal filtering")
+            .WithTags("STAC")
+            .Produces<StacItemCollection>(200, MediaTypes.GeoJson)
+            .Produces(404);
+
+        endpoints.MapGet("/stac/collections/{collectionId}/items/{itemId}", HandleGetItem)
+            .WithDisplayName("STAC Item")
+            .WithName("StacItem")
+            .WithSummary("Get a single STAC item")
+            .WithDescription("Returns a single STAC item by ID")
+            .WithTags("STAC")
+            .Produces<StacItem>(200, MediaTypes.GeoJson)
+            .Produces(404);
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleGetItems(
+        string collectionId,
+        HttpContext context,
+        [FromQuery] int? limit,
+        [FromQuery] string? bbox,
+        [FromQuery] string? datetime,
+        [FromServices] ILayerCatalog layerCatalog,
+        [FromServices] IFeatureReader featureReader,
+        [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
+    {
+        StacLog.ItemsRequested(logger, collectionId, limit);
+
+        var validationError = OgcCommonUtilities.ValidateQueryParameters(
+            context.Request, StacConstants.AllowedQueryParameters.Items);
+        if (validationError is not null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, validationError.Value ?? "Invalid query parameters.");
+        }
+
+        try
+        {
+            if (!int.TryParse(collectionId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId))
+            {
+                StacLog.CollectionNotFound(logger, collectionId);
+                return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
+            }
+
+            var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+            var layer = await layerCatalog.GetLayerAsync(layerId, cancellationToken);
+            if (layer is null)
+            {
+                StacLog.CollectionNotFound(logger, collectionId);
+                return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
+            }
+
+            var effectiveLimit = Math.Clamp(limit ?? StacConstants.DefaultSearchLimit, 1, StacConstants.MaxSearchLimit);
+
+            var query = new FeatureQuery
+            {
+                Limit = effectiveLimit
+            };
+
+            // Apply bbox filter
+            if (!string.IsNullOrWhiteSpace(bbox))
+            {
+                var spatialFilter = StacFilterHelpers.ParseBbox(bbox);
+                if (spatialFilter is not null)
+                {
+                    query = query with { SpatialFilter = spatialFilter };
+                }
+            }
+
+            // Apply datetime filter
+            if (!string.IsNullOrWhiteSpace(datetime))
+            {
+                var temporalFilter = StacFilterHelpers.ParseDatetime(datetime, layer);
+                if (temporalFilter is not null)
+                {
+                    query = query with { TemporalFilter = temporalFilter };
+                }
+            }
+
+            var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+            var result = await featureReader.QueryAsync(layerId, query, cancellationToken);
+
+            var items = result.Features
+                .Select(f => StacMappingService.MapFeatureToItem(f, layer, baseUrl))
+                .ToImmutableArray();
+
+            var stacBase = $"{baseUrl}/stac";
+            var links = ImmutableArray.Create(
+                Link.Create(
+                    href: $"{stacBase}/collections/{collectionId}/items",
+                    rel: RelationTypes.Self,
+                    type: MediaTypes.GeoJson,
+                    title: "Items"),
+                Link.Create(
+                    href: $"{stacBase}/collections/{collectionId}",
+                    rel: RelationTypes.Collection,
+                    type: MediaTypes.Json,
+                    title: layer.Name),
+                Link.Create(
+                    href: stacBase,
+                    rel: StacConstants.StacRelations.Root,
+                    type: MediaTypes.Json,
+                    title: "STAC Catalog"));
+
+            var response = new StacItemCollection
+            {
+                Features = items,
+                Links = links,
+                NumberReturned = items.Length,
+                NumberMatched = result.TotalCount,
+                Context = new StacSearchContext
+                {
+                    Returned = items.Length,
+                    Matched = result.TotalCount,
+                    Limit = effectiveLimit
+                }
+            };
+
+            StacLog.ItemsReturned(logger, items.Length, collectionId);
+            return Results.Json(response, StacJsonContext.Default.StacItemCollection, MediaTypes.GeoJson);
+        }
+        catch (OperationCanceledException)
+            when (TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context).IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            StacLog.OperationFailed(logger, ex);
+            return StandardErrorHelpers.CreateInternalServerError(
+                context, "An error occurred while retrieving STAC items.");
+        }
+    }
+
+    private static async Task<IResult> HandleGetItem(
+        string collectionId,
+        string itemId,
+        HttpContext context,
+        [FromServices] ILayerCatalog layerCatalog,
+        [FromServices] IFeatureReader featureReader,
+        [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
+    {
+        StacLog.ItemRequested(logger, collectionId, itemId);
+
+        try
+        {
+            if (!int.TryParse(collectionId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId) ||
+                !long.TryParse(itemId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
+            {
+                return StandardErrorHelpers.CreateNotFound(context, $"Item '{itemId}' not found.");
+            }
+
+            var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+            var layer = await layerCatalog.GetLayerAsync(layerId, cancellationToken);
+            if (layer is null)
+            {
+                StacLog.CollectionNotFound(logger, collectionId);
+                return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
+            }
+
+            var feature = await featureReader.GetAsync(layerId, objectId, cancellationToken);
+            if (feature is null)
+            {
+                StacLog.ItemNotFound(logger, collectionId, itemId);
+                return StandardErrorHelpers.CreateNotFound(context, $"Item '{itemId}' not found in collection '{collectionId}'.");
+            }
+
+            var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+            var item = StacMappingService.MapFeatureToItem(feature.Value, layer, baseUrl);
+
+            return Results.Json(item, StacJsonContext.Default.StacItem, MediaTypes.GeoJson);
+        }
+        catch (OperationCanceledException)
+            when (TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context).IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            StacLog.OperationFailed(logger, ex);
+            return StandardErrorHelpers.CreateInternalServerError(
+                context, "An error occurred while retrieving the STAC item.");
+        }
+    }
+}

--- a/src/Honua.Server/Features/Stac/ItemEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/ItemEndpoints.cs
@@ -3,11 +3,12 @@
 
 using System.Collections.Immutable;
 using System.Globalization;
-using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Validation;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.Stac.Models;
 using Honua.Server.Features.Stac.Services;
@@ -50,9 +51,9 @@ internal static class ItemEndpoints
         string collectionId,
         HttpContext context,
         [FromQuery] int? limit,
+        [FromQuery] int? offset,
         [FromQuery] string? bbox,
         [FromQuery] string? datetime,
-        [FromServices] ILayerCatalog layerCatalog,
         [FromServices] IFeatureReader featureReader,
         [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
     {
@@ -67,25 +68,24 @@ internal static class ItemEndpoints
 
         try
         {
-            if (!int.TryParse(collectionId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId))
-            {
-                StacLog.CollectionNotFound(logger, collectionId);
-                return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
-            }
-
             var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
-            var layer = await layerCatalog.GetLayerAsync(layerId, cancellationToken);
-            if (layer is null)
+            var validation = await LayerValidationHelpers.ValidateCollectionWithAccessAsync(
+                context, collectionId, requiredProtocol: ServiceProtocols.Stac, cancellationToken: cancellationToken);
+            if (!validation.IsValid)
             {
                 StacLog.CollectionNotFound(logger, collectionId);
-                return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
+                return validation.ErrorResult!;
             }
 
+            var layer = validation.Layer!;
+            var layerId = layer.Id;
             var effectiveLimit = Math.Clamp(limit ?? StacConstants.DefaultSearchLimit, 1, StacConstants.MaxSearchLimit);
+            var effectiveOffset = Math.Max(offset ?? 0, 0);
 
             var query = new FeatureQuery
             {
-                Limit = effectiveLimit
+                Limit = effectiveLimit,
+                Offset = effectiveOffset > 0 ? effectiveOffset : null
             };
 
             // Apply bbox filter
@@ -116,27 +116,39 @@ internal static class ItemEndpoints
                 .ToImmutableArray();
 
             var stacBase = $"{baseUrl}/stac";
-            var links = ImmutableArray.Create(
-                Link.Create(
-                    href: $"{stacBase}/collections/{collectionId}/items",
-                    rel: RelationTypes.Self,
+            var itemsPath = $"{stacBase}/collections/{collectionId}/items";
+            var linksBuilder = ImmutableArray.CreateBuilder<Link>();
+            linksBuilder.Add(Link.Create(
+                href: $"{itemsPath}?{BuildItemsFilterQuery(effectiveLimit, effectiveOffset, bbox, datetime)}",
+                rel: RelationTypes.Self,
+                type: MediaTypes.GeoJson,
+                title: "Items"));
+            linksBuilder.Add(Link.Create(
+                href: $"{stacBase}/collections/{collectionId}",
+                rel: RelationTypes.Collection,
+                type: MediaTypes.Json,
+                title: layer.Name));
+            linksBuilder.Add(Link.Create(
+                href: stacBase,
+                rel: StacConstants.StacRelations.Root,
+                type: MediaTypes.Json,
+                title: "STAC Catalog"));
+
+            // Add next link when more items exist
+            var nextOffset = effectiveOffset + items.Length;
+            if (result.TotalCount > nextOffset)
+            {
+                linksBuilder.Add(Link.Create(
+                    href: $"{itemsPath}?{BuildItemsFilterQuery(effectiveLimit, nextOffset, bbox, datetime)}",
+                    rel: "next",
                     type: MediaTypes.GeoJson,
-                    title: "Items"),
-                Link.Create(
-                    href: $"{stacBase}/collections/{collectionId}",
-                    rel: RelationTypes.Collection,
-                    type: MediaTypes.Json,
-                    title: layer.Name),
-                Link.Create(
-                    href: stacBase,
-                    rel: StacConstants.StacRelations.Root,
-                    type: MediaTypes.Json,
-                    title: "STAC Catalog"));
+                    title: "Next page"));
+            }
 
             var response = new StacItemCollection
             {
                 Features = items,
-                Links = links,
+                Links = linksBuilder.ToImmutable(),
                 NumberReturned = items.Length,
                 NumberMatched = result.TotalCount,
                 Context = new StacSearchContext
@@ -167,7 +179,6 @@ internal static class ItemEndpoints
         string collectionId,
         string itemId,
         HttpContext context,
-        [FromServices] ILayerCatalog layerCatalog,
         [FromServices] IFeatureReader featureReader,
         [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
     {
@@ -175,21 +186,22 @@ internal static class ItemEndpoints
 
         try
         {
-            if (!int.TryParse(collectionId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId) ||
-                !long.TryParse(itemId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
+            var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+            var validation = await LayerValidationHelpers.ValidateCollectionWithAccessAsync(
+                context, collectionId, requiredProtocol: ServiceProtocols.Stac, cancellationToken: cancellationToken);
+            if (!validation.IsValid)
+            {
+                StacLog.CollectionNotFound(logger, collectionId);
+                return validation.ErrorResult!;
+            }
+
+            if (!long.TryParse(itemId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
             {
                 return StandardErrorHelpers.CreateNotFound(context, $"Item '{itemId}' not found.");
             }
 
-            var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
-            var layer = await layerCatalog.GetLayerAsync(layerId, cancellationToken);
-            if (layer is null)
-            {
-                StacLog.CollectionNotFound(logger, collectionId);
-                return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
-            }
-
-            var feature = await featureReader.GetAsync(layerId, objectId, cancellationToken);
+            var layer = validation.Layer!;
+            var feature = await featureReader.GetAsync(layer.Id, objectId, cancellationToken);
             if (feature is null)
             {
                 StacLog.ItemNotFound(logger, collectionId, itemId);
@@ -212,5 +224,15 @@ internal static class ItemEndpoints
             return StandardErrorHelpers.CreateInternalServerError(
                 context, "An error occurred while retrieving the STAC item.");
         }
+    }
+
+    private static string BuildItemsFilterQuery(int limit, int offset, string? bbox, string? datetime)
+    {
+        var query = $"limit={limit}&offset={offset}";
+        if (!string.IsNullOrWhiteSpace(bbox))
+            query += $"&bbox={bbox}";
+        if (!string.IsNullOrWhiteSpace(datetime))
+            query += $"&datetime={datetime}";
+        return query;
     }
 }

--- a/src/Honua.Server/Features/Stac/Models/StacConstants.cs
+++ b/src/Honua.Server/Features/Stac/Models/StacConstants.cs
@@ -66,12 +66,12 @@ internal static class StacConstants
 
         public static readonly HashSet<string> Items = new(StringComparer.OrdinalIgnoreCase)
         {
-            "f", "limit", "bbox", "datetime"
+            "f", "limit", "offset", "bbox", "datetime"
         };
 
         public static readonly HashSet<string> SearchGet = new(StringComparer.OrdinalIgnoreCase)
         {
-            "f", "limit", "bbox", "datetime", "collections", "ids"
+            "f", "limit", "offset", "bbox", "datetime", "collections", "ids"
         };
     }
 }

--- a/src/Honua.Server/Features/Stac/Models/StacConstants.cs
+++ b/src/Honua.Server/Features/Stac/Models/StacConstants.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Stac.Models;
+
+/// <summary>
+/// Constants for the STAC API implementation.
+/// </summary>
+internal static class StacConstants
+{
+    /// <summary>
+    /// STAC specification version implemented.
+    /// </summary>
+    public const string StacVersion = "1.0.0";
+
+    /// <summary>
+    /// Catalog identifier.
+    /// </summary>
+    public const string CatalogId = "honua-stac-catalog";
+
+    /// <summary>
+    /// Default limit for search results.
+    /// </summary>
+    public const int DefaultSearchLimit = 10;
+
+    /// <summary>
+    /// Maximum allowed limit for search results.
+    /// </summary>
+    public const int MaxSearchLimit = 10_000;
+
+    /// <summary>
+    /// STAC API conformance URIs.
+    /// </summary>
+    internal static class Conformance
+    {
+        public const string Core = "https://api.stacspec.org/v1.0.0/core";
+        public const string ItemSearch = "https://api.stacspec.org/v1.0.0/item-search";
+        public const string OgcApiFeatures = "https://api.stacspec.org/v1.0.0/ogcapi-features";
+        public const string Collections = "https://api.stacspec.org/v1.0.0/collections";
+        public const string FieldsExtension = "https://api.stacspec.org/v1.0.0/item-search#fields";
+        public const string SortExtension = "https://api.stacspec.org/v1.0.0/item-search#sort";
+        public const string FilterExtension = "https://api.stacspec.org/v1.0.0/item-search#filter";
+    }
+
+    /// <summary>
+    /// STAC-specific link relation types.
+    /// </summary>
+    internal static class StacRelations
+    {
+        public const string Root = "root";
+        public const string Parent = "parent";
+        public const string Child = "child";
+        public const string Item = "item";
+        public const string Items = "items";
+        public const string Search = "search";
+    }
+
+    /// <summary>
+    /// Allowed query parameters by endpoint.
+    /// </summary>
+    internal static class AllowedQueryParameters
+    {
+        public static readonly HashSet<string> Catalog = new(StringComparer.OrdinalIgnoreCase) { "f" };
+
+        public static readonly HashSet<string> Collections = new(StringComparer.OrdinalIgnoreCase) { "f" };
+
+        public static readonly HashSet<string> Items = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "f", "limit", "bbox", "datetime"
+        };
+
+        public static readonly HashSet<string> SearchGet = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "f", "limit", "bbox", "datetime", "collections", "ids"
+        };
+    }
+}

--- a/src/Honua.Server/Features/Stac/Models/StacModels.cs
+++ b/src/Honua.Server/Features/Stac/Models/StacModels.cs
@@ -1,0 +1,437 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Server.Features.Ogc.Common;
+
+namespace Honua.Server.Features.Stac.Models;
+
+/// <summary>
+/// STAC Catalog root object per the STAC API specification.
+/// </summary>
+public sealed record StacCatalog
+{
+    /// <summary>
+    /// STAC specification version.
+    /// </summary>
+    [JsonPropertyName("stac_version")]
+    public string StacVersion { get; init; } = StacConstants.StacVersion;
+
+    /// <summary>
+    /// Type identifier — always "Catalog" for the root.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "Catalog";
+
+    /// <summary>
+    /// Catalog identifier.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Human-readable title.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Description of the catalog contents.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// Conformance classes supported by this STAC API.
+    /// </summary>
+    [JsonPropertyName("conformsTo")]
+    public ImmutableArray<string>? ConformsTo { get; init; }
+
+    /// <summary>
+    /// Hypermedia links.
+    /// </summary>
+    [JsonPropertyName("links")]
+    public required ImmutableArray<Link> Links { get; init; }
+}
+
+/// <summary>
+/// STAC Collection with extent, provider, and license metadata.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "STAC specification type name")]
+public sealed record StacCollection
+{
+    /// <summary>
+    /// STAC specification version.
+    /// </summary>
+    [JsonPropertyName("stac_version")]
+    public string StacVersion { get; init; } = StacConstants.StacVersion;
+
+    /// <summary>
+    /// Type identifier.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "Collection";
+
+    /// <summary>
+    /// Collection identifier.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Human-readable title.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Description of the collection.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// Keywords for discovery.
+    /// </summary>
+    [JsonPropertyName("keywords")]
+    public ImmutableArray<string>? Keywords { get; init; }
+
+    /// <summary>
+    /// License identifier (SPDX or "proprietary" / "various").
+    /// </summary>
+    [JsonPropertyName("license")]
+    public required string License { get; init; }
+
+    /// <summary>
+    /// Spatial and temporal extent.
+    /// </summary>
+    [JsonPropertyName("extent")]
+    public required StacExtent Extent { get; init; }
+
+    /// <summary>
+    /// Hypermedia links.
+    /// </summary>
+    [JsonPropertyName("links")]
+    public required ImmutableArray<Link> Links { get; init; }
+
+    /// <summary>
+    /// STAC extensions in use.
+    /// </summary>
+    [JsonPropertyName("stac_extensions")]
+    public ImmutableArray<string>? StacExtensions { get; init; }
+}
+
+/// <summary>
+/// STAC Item — a GeoJSON Feature with STAC metadata.
+/// </summary>
+public sealed record StacItem
+{
+    /// <summary>
+    /// STAC specification version.
+    /// </summary>
+    [JsonPropertyName("stac_version")]
+    public string StacVersion { get; init; } = StacConstants.StacVersion;
+
+    /// <summary>
+    /// Type identifier — always "Feature".
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "Feature";
+
+    /// <summary>
+    /// Item identifier.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// GeoJSON geometry.
+    /// </summary>
+    [JsonPropertyName("geometry")]
+    public JsonElement? Geometry { get; init; }
+
+    /// <summary>
+    /// Bounding box [minx, miny, maxx, maxy].
+    /// </summary>
+    [JsonPropertyName("bbox")]
+    public ImmutableArray<double>? Bbox { get; init; }
+
+    /// <summary>
+    /// STAC properties including required datetime.
+    /// </summary>
+    [JsonPropertyName("properties")]
+    public required Dictionary<string, object?> Properties { get; init; }
+
+    /// <summary>
+    /// Links to related resources.
+    /// </summary>
+    [JsonPropertyName("links")]
+    public required ImmutableArray<Link> Links { get; init; }
+
+    /// <summary>
+    /// Asset dictionary keyed by role.
+    /// </summary>
+    [JsonPropertyName("assets")]
+    public Dictionary<string, StacAsset>? Assets { get; init; }
+
+    /// <summary>
+    /// Parent collection identifier.
+    /// </summary>
+    [JsonPropertyName("collection")]
+    public string? Collection { get; init; }
+
+    /// <summary>
+    /// STAC extensions in use.
+    /// </summary>
+    [JsonPropertyName("stac_extensions")]
+    public ImmutableArray<string>? StacExtensions { get; init; }
+}
+
+/// <summary>
+/// Asset with href and media type for a STAC item.
+/// </summary>
+public sealed record StacAsset
+{
+    /// <summary>
+    /// URI to the asset.
+    /// </summary>
+    [JsonPropertyName("href")]
+    public required string Href { get; init; }
+
+    /// <summary>
+    /// Human-readable title.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Asset description.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Media type of the asset.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    /// <summary>
+    /// Semantic roles (e.g., "data", "thumbnail", "metadata").
+    /// </summary>
+    [JsonPropertyName("roles")]
+    public ImmutableArray<string>? Roles { get; init; }
+}
+
+/// <summary>
+/// STAC spatial and temporal extent.
+/// </summary>
+public sealed record StacExtent
+{
+    /// <summary>
+    /// Spatial extent with bounding box(es).
+    /// </summary>
+    [JsonPropertyName("spatial")]
+    public required StacSpatialExtent Spatial { get; init; }
+
+    /// <summary>
+    /// Temporal extent with interval(s).
+    /// </summary>
+    [JsonPropertyName("temporal")]
+    public required StacTemporalExtent Temporal { get; init; }
+}
+
+/// <summary>
+/// Spatial extent as one or more bounding boxes.
+/// </summary>
+public sealed record StacSpatialExtent
+{
+    /// <summary>
+    /// Bounding boxes in CRS84 [west, south, east, north].
+    /// </summary>
+    [JsonPropertyName("bbox")]
+    public required ImmutableArray<ImmutableArray<double>> Bbox { get; init; }
+}
+
+/// <summary>
+/// Temporal extent as one or more intervals.
+/// </summary>
+public sealed record StacTemporalExtent
+{
+    /// <summary>
+    /// Temporal intervals [[start, end], ...] — null values indicate open bounds.
+    /// </summary>
+    [JsonPropertyName("interval")]
+    public required ImmutableArray<ImmutableArray<string?>> Interval { get; init; }
+}
+
+/// <summary>
+/// STAC search request body for POST /stac/search.
+/// </summary>
+public sealed record StacSearchRequest
+{
+    /// <summary>
+    /// Bounding box filter [west, south, east, north].
+    /// </summary>
+    [JsonPropertyName("bbox")]
+    public ImmutableArray<double>? Bbox { get; init; }
+
+    /// <summary>
+    /// GeoJSON geometry for spatial intersection.
+    /// </summary>
+    [JsonPropertyName("intersects")]
+    public JsonElement? Intersects { get; init; }
+
+    /// <summary>
+    /// RFC 3339 datetime or interval ("../end", "start/..", "start/end").
+    /// </summary>
+    [JsonPropertyName("datetime")]
+    public string? Datetime { get; init; }
+
+    /// <summary>
+    /// Collection IDs to search within.
+    /// </summary>
+    [JsonPropertyName("collections")]
+    public ImmutableArray<string>? Collections { get; init; }
+
+    /// <summary>
+    /// Item IDs to filter by.
+    /// </summary>
+    [JsonPropertyName("ids")]
+    public ImmutableArray<string>? Ids { get; init; }
+
+    /// <summary>
+    /// Maximum number of items to return.
+    /// </summary>
+    [JsonPropertyName("limit")]
+    public int? Limit { get; init; }
+
+    /// <summary>
+    /// Fields extension: include/exclude field lists.
+    /// </summary>
+    [JsonPropertyName("fields")]
+    public StacFieldsExtension? Fields { get; init; }
+
+    /// <summary>
+    /// Sort extension: ordering specification.
+    /// </summary>
+    [JsonPropertyName("sortby")]
+    public ImmutableArray<StacSortDefinition>? Sortby { get; init; }
+
+    /// <summary>
+    /// CQL2 filter expression (query extension).
+    /// </summary>
+    [JsonPropertyName("filter")]
+    public JsonElement? Filter { get; init; }
+
+    /// <summary>
+    /// Filter language (defaults to cql2-json for POST).
+    /// </summary>
+    [JsonPropertyName("filter-lang")]
+    public string? FilterLang { get; init; }
+}
+
+/// <summary>
+/// Fields extension for selecting properties to include/exclude.
+/// </summary>
+public sealed record StacFieldsExtension
+{
+    /// <summary>
+    /// Properties to include.
+    /// </summary>
+    [JsonPropertyName("includes")]
+    public ImmutableArray<string>? Includes { get; init; }
+
+    /// <summary>
+    /// Properties to exclude.
+    /// </summary>
+    [JsonPropertyName("excludes")]
+    public ImmutableArray<string>? Excludes { get; init; }
+}
+
+/// <summary>
+/// Sort definition for the sort extension.
+/// </summary>
+public sealed record StacSortDefinition
+{
+    /// <summary>
+    /// Property name to sort by.
+    /// </summary>
+    [JsonPropertyName("field")]
+    public required string Field { get; init; }
+
+    /// <summary>
+    /// Sort direction: "asc" or "desc".
+    /// </summary>
+    [JsonPropertyName("direction")]
+    public string Direction { get; init; } = "asc";
+}
+
+/// <summary>
+/// STAC Item Collection (search response).
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "STAC specification type name")]
+public sealed record StacItemCollection
+{
+    /// <summary>
+    /// Type identifier.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "FeatureCollection";
+
+    /// <summary>
+    /// Matched items.
+    /// </summary>
+    [JsonPropertyName("features")]
+    public required ImmutableArray<StacItem> Features { get; init; }
+
+    /// <summary>
+    /// Hypermedia links (pagination).
+    /// </summary>
+    [JsonPropertyName("links")]
+    public required ImmutableArray<Link> Links { get; init; }
+
+    /// <summary>
+    /// Context with matched/returned/limit counts.
+    /// </summary>
+    [JsonPropertyName("context")]
+    public StacSearchContext? Context { get; init; }
+
+    /// <summary>
+    /// Total number of matched items (numberMatched).
+    /// </summary>
+    [JsonPropertyName("numberMatched")]
+    public long? NumberMatched { get; init; }
+
+    /// <summary>
+    /// Number of items returned.
+    /// </summary>
+    [JsonPropertyName("numberReturned")]
+    public int? NumberReturned { get; init; }
+}
+
+/// <summary>
+/// Search context with matched/returned/limit counts.
+/// </summary>
+public sealed record StacSearchContext
+{
+    /// <summary>
+    /// Number of items returned in this response.
+    /// </summary>
+    [JsonPropertyName("returned")]
+    public required int Returned { get; init; }
+
+    /// <summary>
+    /// Total number of items matching the query.
+    /// </summary>
+    [JsonPropertyName("matched")]
+    public long? Matched { get; init; }
+
+    /// <summary>
+    /// Maximum number of items requested.
+    /// </summary>
+    [JsonPropertyName("limit")]
+    public int? Limit { get; init; }
+}

--- a/src/Honua.Server/Features/Stac/Models/StacModels.cs
+++ b/src/Honua.Server/Features/Stac/Models/StacModels.cs
@@ -435,3 +435,21 @@ public sealed record StacSearchContext
     [JsonPropertyName("limit")]
     public int? Limit { get; init; }
 }
+
+/// <summary>
+/// Response wrapper for the STAC collections list.
+/// </summary>
+public sealed record StacCollectionsResponse
+{
+    /// <summary>
+    /// Available collections.
+    /// </summary>
+    [JsonPropertyName("collections")]
+    public required ImmutableArray<StacCollection> Collections { get; init; }
+
+    /// <summary>
+    /// Hypermedia links.
+    /// </summary>
+    [JsonPropertyName("links")]
+    public required ImmutableArray<Link> Links { get; init; }
+}

--- a/src/Honua.Server/Features/Stac/SearchEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/SearchEndpoints.cs
@@ -1,0 +1,286 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Helpers;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Ogc.Common;
+using Honua.Server.Features.Stac.Models;
+using Honua.Server.Features.Stac.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Stac;
+
+/// <summary>
+/// STAC Item Search endpoint (GET and POST).
+/// </summary>
+internal static class SearchEndpoints
+{
+    /// <summary>
+    /// Maps the STAC search endpoints.
+    /// </summary>
+    public static IEndpointRouteBuilder MapStacSearchEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/stac/search", HandleSearchGet)
+            .WithDisplayName("STAC Search (GET)")
+            .WithName("StacSearchGet")
+            .WithSummary("Search STAC items via GET")
+            .WithDescription("Searches STAC items across collections with spatial, temporal, and property filters")
+            .WithTags("STAC")
+            .Produces<StacItemCollection>(200, MediaTypes.GeoJson)
+            .Produces(400);
+
+        endpoints.MapPost("/stac/search", HandleSearchPost)
+            .WithDisplayName("STAC Search (POST)")
+            .WithName("StacSearchPost")
+            .WithSummary("Search STAC items via POST")
+            .WithDescription("Searches STAC items across collections with a JSON request body")
+            .WithTags("STAC")
+            .Accepts<StacSearchRequest>(MediaTypes.Json)
+            .Produces<StacItemCollection>(200, MediaTypes.GeoJson)
+            .Produces(400);
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleSearchGet(
+        HttpContext context,
+        [FromQuery] int? limit,
+        [FromQuery] string? bbox,
+        [FromQuery] string? datetime,
+        [FromQuery] string? collections,
+        [FromQuery] string? ids,
+        [FromServices] ILayerCatalog layerCatalog,
+        [FromServices] IFeatureReader featureReader,
+        [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
+    {
+        var validationError = OgcCommonUtilities.ValidateQueryParameters(
+            context.Request, StacConstants.AllowedQueryParameters.SearchGet);
+        if (validationError is not null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, validationError.Value ?? "Invalid query parameters.");
+        }
+
+        // Convert GET parameters to a search request
+        var request = new StacSearchRequest
+        {
+            Limit = limit,
+            Datetime = datetime
+        };
+
+        if (!string.IsNullOrWhiteSpace(bbox))
+        {
+            var parts = bbox.Split(',');
+            if (parts.Length >= 4)
+            {
+                var bboxValues = new List<double>();
+                foreach (var part in parts)
+                {
+                    if (double.TryParse(part, NumberStyles.Float, CultureInfo.InvariantCulture, out var val))
+                    {
+                        bboxValues.Add(val);
+                    }
+                }
+
+                if (bboxValues.Count >= 4)
+                {
+                    request = request with { Bbox = bboxValues.ToImmutableArray() };
+                }
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(collections))
+        {
+            request = request with { Collections = collections.Split(',').ToImmutableArray() };
+        }
+
+        if (!string.IsNullOrWhiteSpace(ids))
+        {
+            request = request with { Ids = ids.Split(',').ToImmutableArray() };
+        }
+
+        return await ExecuteSearchAsync(request, context, layerCatalog, featureReader, logger);
+    }
+
+    private static async Task<IResult> HandleSearchPost(
+        HttpContext context,
+        [FromBody] StacSearchRequest request,
+        [FromServices] ILayerCatalog layerCatalog,
+        [FromServices] IFeatureReader featureReader,
+        [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
+    {
+        return await ExecuteSearchAsync(request, context, layerCatalog, featureReader, logger);
+    }
+
+    private static async Task<IResult> ExecuteSearchAsync(
+        StacSearchRequest request,
+        HttpContext context,
+        ILayerCatalog layerCatalog,
+        IFeatureReader featureReader,
+        ILogger logger)
+    {
+        var effectiveLimit = Math.Clamp(
+            request.Limit ?? StacConstants.DefaultSearchLimit,
+            1,
+            StacConstants.MaxSearchLimit);
+
+        var collectionCount = request.Collections is { IsDefault: false } c ? c.Length : 0;
+        StacLog.SearchRequested(logger, collectionCount, effectiveLimit);
+
+        try
+        {
+            var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+            var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+
+            // Resolve target layers
+            var allLayers = await layerCatalog.ListLayersAsync(cancellationToken);
+            var services = await layerCatalog.ListServicesAsync(cancellationToken);
+            var layerToService = new Dictionary<int, ServiceDefinition>();
+            foreach (var service in services)
+            {
+                foreach (var serviceLayer in service.Layers)
+                {
+                    layerToService.TryAdd(serviceLayer.Id, service);
+                }
+            }
+
+            var targetLayers = allLayers
+                .Where(layer => AccessPolicyHelpers.IsLayerAccessible(
+                    context, layer, layerToService.GetValueOrDefault(layer.Id)));
+
+            // Filter by collection IDs if specified
+            if (request.Collections is { IsDefault: false } requestedCollections && requestedCollections.Length > 0)
+            {
+                var collectionIds = requestedCollections
+                    .Where(id => int.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+                    .Select(id => int.Parse(id, CultureInfo.InvariantCulture))
+                    .ToHashSet();
+                targetLayers = targetLayers.Where(l => collectionIds.Contains(l.Id));
+            }
+
+            var layerList = targetLayers.ToArray();
+            var allItems = ImmutableArray.CreateBuilder<StacItem>();
+            long totalMatched = 0;
+
+            // Query each target layer
+            foreach (var layer in layerList)
+            {
+                if (allItems.Count >= effectiveLimit)
+                {
+                    break;
+                }
+
+                var remaining = effectiveLimit - allItems.Count;
+                var query = new FeatureQuery
+                {
+                    Limit = remaining
+                };
+
+                // Apply bbox filter
+                if (request.Bbox is { IsDefault: false } bboxArr && bboxArr.Length >= 4)
+                {
+                    var bboxStr = string.Join(",", bboxArr.Select(v => v.ToString(CultureInfo.InvariantCulture)));
+                    var spatialFilter = StacFilterHelpers.ParseBbox(bboxStr);
+                    if (spatialFilter is not null)
+                    {
+                        query = query with { SpatialFilter = spatialFilter };
+                    }
+                }
+
+                // Apply datetime filter
+                if (!string.IsNullOrWhiteSpace(request.Datetime))
+                {
+                    var temporalFilter = StacFilterHelpers.ParseDatetime(request.Datetime, layer);
+                    if (temporalFilter is not null)
+                    {
+                        query = query with { TemporalFilter = temporalFilter };
+                    }
+                }
+
+                // Apply ID filter
+                if (request.Ids is { IsDefault: false } requestedIds && requestedIds.Length > 0)
+                {
+                    var objectIds = requestedIds
+                        .Where(id => long.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+                        .Select(id => long.Parse(id, CultureInfo.InvariantCulture))
+                        .ToImmutableArray();
+                    if (objectIds.Length > 0)
+                    {
+                        query = query with { ObjectIds = objectIds };
+                    }
+                }
+
+                // Apply sort
+                if (request.Sortby is { IsDefault: false } sortby && sortby.Length > 0)
+                {
+                    var orderBy = sortby.Select(s =>
+                        string.Equals(s.Direction, "desc", StringComparison.OrdinalIgnoreCase)
+                            ? OrderByClause.Desc(s.Field)
+                            : OrderByClause.Asc(s.Field))
+                        .ToImmutableArray();
+                    query = query with { OrderBy = orderBy };
+                }
+
+                // Apply field selection
+                if (request.Fields is { Includes: { IsDefault: false } includes } && includes.Length > 0)
+                {
+                    query = query with { OutFields = includes };
+                }
+
+                var result = await featureReader.QueryAsync(layer.Id, query, cancellationToken);
+                totalMatched += result.TotalCount;
+
+                var items = result.Features
+                    .Select(f => StacMappingService.MapFeatureToItem(f, layer, baseUrl));
+                allItems.AddRange(items);
+            }
+
+            var stacBase = $"{baseUrl}/stac";
+            var links = ImmutableArray.Create(
+                Link.Create(
+                    href: $"{stacBase}/search",
+                    rel: RelationTypes.Self,
+                    type: MediaTypes.GeoJson,
+                    title: "Search results"),
+                Link.Create(
+                    href: stacBase,
+                    rel: StacConstants.StacRelations.Root,
+                    type: MediaTypes.Json,
+                    title: "STAC Catalog"));
+
+            var response = new StacItemCollection
+            {
+                Features = allItems.ToImmutable(),
+                Links = links,
+                NumberReturned = allItems.Count,
+                NumberMatched = totalMatched,
+                Context = new StacSearchContext
+                {
+                    Returned = allItems.Count,
+                    Matched = totalMatched,
+                    Limit = effectiveLimit
+                }
+            };
+
+            StacLog.SearchReturned(logger, allItems.Count);
+            return Results.Json(response, StacJsonContext.Default.StacItemCollection, MediaTypes.GeoJson);
+        }
+        catch (OperationCanceledException)
+            when (TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context).IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            StacLog.OperationFailed(logger, ex);
+            return StandardErrorHelpers.CreateInternalServerError(
+                context, "An error occurred during STAC search.");
+        }
+    }
+}

--- a/src/Honua.Server/Features/Stac/SearchEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/SearchEndpoints.cs
@@ -4,10 +4,8 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using Honua.Core.Features.Catalog.Abstractions;
-using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
-using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
 using Honua.Server.Features.Ogc.Common;
@@ -52,6 +50,7 @@ internal static class SearchEndpoints
     private static async Task<IResult> HandleSearchGet(
         HttpContext context,
         [FromQuery] int? limit,
+        [FromQuery] int? offset,
         [FromQuery] string? bbox,
         [FromQuery] string? datetime,
         [FromQuery] string? collections,
@@ -73,24 +72,27 @@ internal static class SearchEndpoints
             Limit = limit,
             Datetime = datetime
         };
+        var effectiveOffset = Math.Max(offset ?? 0, 0);
 
         if (!string.IsNullOrWhiteSpace(bbox))
         {
             var parts = bbox.Split(',');
-            if (parts.Length >= 4)
+            if (parts.Length is 4 or 6)
             {
-                var bboxValues = new List<double>();
-                foreach (var part in parts)
+                var bboxValues = new double[parts.Length];
+                var allValid = true;
+                for (var i = 0; i < parts.Length; i++)
                 {
-                    if (double.TryParse(part, NumberStyles.Float, CultureInfo.InvariantCulture, out var val))
+                    if (!double.TryParse(parts[i], NumberStyles.Float, CultureInfo.InvariantCulture, out bboxValues[i]))
                     {
-                        bboxValues.Add(val);
+                        allValid = false;
+                        break;
                     }
                 }
 
-                if (bboxValues.Count >= 4)
+                if (allValid)
                 {
-                    request = request with { Bbox = bboxValues.ToImmutableArray() };
+                    request = request with { Bbox = ImmutableArray.Create(bboxValues) };
                 }
             }
         }
@@ -105,7 +107,7 @@ internal static class SearchEndpoints
             request = request with { Ids = ids.Split(',').ToImmutableArray() };
         }
 
-        return await ExecuteSearchAsync(request, context, layerCatalog, featureReader, logger);
+        return await ExecuteSearchAsync(request, effectiveOffset, context, layerCatalog, featureReader, logger);
     }
 
     private static async Task<IResult> HandleSearchPost(
@@ -115,11 +117,12 @@ internal static class SearchEndpoints
         [FromServices] IFeatureReader featureReader,
         [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
     {
-        return await ExecuteSearchAsync(request, context, layerCatalog, featureReader, logger);
+        return await ExecuteSearchAsync(request, 0, context, layerCatalog, featureReader, logger);
     }
 
     private static async Task<IResult> ExecuteSearchAsync(
         StacSearchRequest request,
+        int offset,
         HttpContext context,
         ILayerCatalog layerCatalog,
         IFeatureReader featureReader,
@@ -138,21 +141,11 @@ internal static class SearchEndpoints
             var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
             var baseUrl = BaseUrlResolver.GetBaseUrl(context);
 
-            // Resolve target layers
-            var allLayers = await layerCatalog.ListLayersAsync(cancellationToken);
-            var services = await layerCatalog.ListServicesAsync(cancellationToken);
-            var layerToService = new Dictionary<int, ServiceDefinition>();
-            foreach (var service in services)
-            {
-                foreach (var serviceLayer in service.Layers)
-                {
-                    layerToService.TryAdd(serviceLayer.Id, service);
-                }
-            }
+            // Resolve target layers with STAC protocol gating + access policy
+            var visibleLayers = await StacFilterHelpers.ResolveStacVisibleLayersAsync(
+                context, layerCatalog, cancellationToken);
 
-            var targetLayers = allLayers
-                .Where(layer => AccessPolicyHelpers.IsLayerAccessible(
-                    context, layer, layerToService.GetValueOrDefault(layer.Id)));
+            IEnumerable<Core.Features.Catalog.Domain.LayerDefinition> targetLayers = visibleLayers;
 
             // Filter by collection IDs if specified
             if (request.Collections is { IsDefault: false } requestedCollections && requestedCollections.Length > 0)
@@ -164,100 +157,110 @@ internal static class SearchEndpoints
                 targetLayers = targetLayers.Where(l => collectionIds.Contains(l.Id));
             }
 
+            // Pre-parse IDs filter; if provided but none are valid, return empty results
+            ImmutableArray<long>? parsedObjectIds = null;
+            if (request.Ids is { IsDefault: false } requestedIds && requestedIds.Length > 0)
+            {
+                var objectIds = requestedIds
+                    .Where(id => long.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+                    .Select(id => long.Parse(id, CultureInfo.InvariantCulture))
+                    .ToImmutableArray();
+                if (objectIds.Length == 0)
+                {
+                    // IDs were provided but none could be parsed — zero results
+                    parsedObjectIds = ImmutableArray<long>.Empty;
+                }
+                else
+                {
+                    parsedObjectIds = objectIds;
+                }
+            }
+
             var layerList = targetLayers.ToArray();
             var allItems = ImmutableArray.CreateBuilder<StacItem>();
             long totalMatched = 0;
 
-            // Query each target layer
+            // Short-circuit: if IDs filter resolved to empty, skip all queries
+            var hasEmptyIdFilter = parsedObjectIds is { Length: 0 };
+            var remainingSkip = offset;
+
+            // Query each target layer — continue for all layers to accumulate totalMatched
             foreach (var layer in layerList)
             {
-                if (allItems.Count >= effectiveLimit)
+                if (hasEmptyIdFilter)
                 {
                     break;
                 }
 
-                var remaining = effectiveLimit - allItems.Count;
-                var query = new FeatureQuery
-                {
-                    Limit = remaining
-                };
+                var query = BuildLayerQuery(request, layer, parsedObjectIds);
 
-                // Apply bbox filter
-                if (request.Bbox is { IsDefault: false } bboxArr && bboxArr.Length >= 4)
+                if (remainingSkip > 0)
                 {
-                    var bboxStr = string.Join(",", bboxArr.Select(v => v.ToString(CultureInfo.InvariantCulture)));
-                    var spatialFilter = StacFilterHelpers.ParseBbox(bboxStr);
-                    if (spatialFilter is not null)
+                    // Count this layer to decide how much to skip
+                    var layerCount = await featureReader.CountAsync(layer.Id, query, cancellationToken);
+                    totalMatched += layerCount;
+
+                    if (remainingSkip >= layerCount)
                     {
-                        query = query with { SpatialFilter = spatialFilter };
+                        remainingSkip -= (int)Math.Min(layerCount, int.MaxValue);
+                        continue;
                     }
-                }
 
-                // Apply datetime filter
-                if (!string.IsNullOrWhiteSpace(request.Datetime))
+                    // Partial skip: fetch from offset within this layer
+                    var remaining = effectiveLimit - allItems.Count;
+                    query = query with { Offset = remainingSkip, Limit = remaining };
+                    remainingSkip = 0;
+
+                    var result = await featureReader.QueryAsync(layer.Id, query, cancellationToken);
+                    allItems.AddRange(result.Features
+                        .Select(f => StacMappingService.MapFeatureToItem(f, layer, baseUrl)));
+                }
+                else if (allItems.Count < effectiveLimit)
                 {
-                    var temporalFilter = StacFilterHelpers.ParseDatetime(request.Datetime, layer);
-                    if (temporalFilter is not null)
-                    {
-                        query = query with { TemporalFilter = temporalFilter };
-                    }
-                }
+                    var remaining = effectiveLimit - allItems.Count;
+                    query = query with { Limit = remaining };
 
-                // Apply ID filter
-                if (request.Ids is { IsDefault: false } requestedIds && requestedIds.Length > 0)
+                    var result = await featureReader.QueryAsync(layer.Id, query, cancellationToken);
+                    totalMatched += result.TotalCount;
+
+                    allItems.AddRange(result.Features
+                        .Select(f => StacMappingService.MapFeatureToItem(f, layer, baseUrl)));
+                }
+                else
                 {
-                    var objectIds = requestedIds
-                        .Where(id => long.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
-                        .Select(id => long.Parse(id, CultureInfo.InvariantCulture))
-                        .ToImmutableArray();
-                    if (objectIds.Length > 0)
-                    {
-                        query = query with { ObjectIds = objectIds };
-                    }
+                    // Page is full — count only to get accurate totalMatched
+                    totalMatched += await featureReader.CountAsync(layer.Id, query, cancellationToken);
                 }
-
-                // Apply sort
-                if (request.Sortby is { IsDefault: false } sortby && sortby.Length > 0)
-                {
-                    var orderBy = sortby.Select(s =>
-                        string.Equals(s.Direction, "desc", StringComparison.OrdinalIgnoreCase)
-                            ? OrderByClause.Desc(s.Field)
-                            : OrderByClause.Asc(s.Field))
-                        .ToImmutableArray();
-                    query = query with { OrderBy = orderBy };
-                }
-
-                // Apply field selection
-                if (request.Fields is { Includes: { IsDefault: false } includes } && includes.Length > 0)
-                {
-                    query = query with { OutFields = includes };
-                }
-
-                var result = await featureReader.QueryAsync(layer.Id, query, cancellationToken);
-                totalMatched += result.TotalCount;
-
-                var items = result.Features
-                    .Select(f => StacMappingService.MapFeatureToItem(f, layer, baseUrl));
-                allItems.AddRange(items);
             }
 
             var stacBase = $"{baseUrl}/stac";
-            var links = ImmutableArray.Create(
-                Link.Create(
-                    href: $"{stacBase}/search",
-                    rel: RelationTypes.Self,
+            var linksBuilder = ImmutableArray.CreateBuilder<Link>();
+            linksBuilder.Add(Link.Create(
+                href: $"{stacBase}/search?{BuildSearchQuery(effectiveLimit, offset, request)}",
+                rel: RelationTypes.Self,
+                type: MediaTypes.GeoJson,
+                title: "Search results"));
+            linksBuilder.Add(Link.Create(
+                href: stacBase,
+                rel: StacConstants.StacRelations.Root,
+                type: MediaTypes.Json,
+                title: "STAC Catalog"));
+
+            // Add next link when more items exist beyond the current page
+            var nextOffset = offset + allItems.Count;
+            if (totalMatched > nextOffset)
+            {
+                linksBuilder.Add(Link.Create(
+                    href: $"{stacBase}/search?{BuildSearchQuery(effectiveLimit, nextOffset, request)}",
+                    rel: "next",
                     type: MediaTypes.GeoJson,
-                    title: "Search results"),
-                Link.Create(
-                    href: stacBase,
-                    rel: StacConstants.StacRelations.Root,
-                    type: MediaTypes.Json,
-                    title: "STAC Catalog"));
+                    title: "Next page"));
+            }
 
             var response = new StacItemCollection
             {
                 Features = allItems.ToImmutable(),
-                Links = links,
+                Links = linksBuilder.ToImmutable(),
                 NumberReturned = allItems.Count,
                 NumberMatched = totalMatched,
                 Context = new StacSearchContext
@@ -282,5 +285,70 @@ internal static class SearchEndpoints
             return StandardErrorHelpers.CreateInternalServerError(
                 context, "An error occurred during STAC search.");
         }
+    }
+
+    private static FeatureQuery BuildLayerQuery(
+        StacSearchRequest request,
+        Core.Features.Catalog.Domain.LayerDefinition layer,
+        ImmutableArray<long>? parsedObjectIds)
+    {
+        var query = new FeatureQuery();
+
+        // Apply bbox filter
+        if (request.Bbox is { IsDefault: false } bboxArr && bboxArr.Length >= 4)
+        {
+            var spatialFilter = StacFilterHelpers.CreateBboxSpatialFilter(
+                west: bboxArr[0], south: bboxArr[1], east: bboxArr[2], north: bboxArr[3]);
+            query = query with { SpatialFilter = spatialFilter };
+        }
+
+        // Apply datetime filter
+        if (!string.IsNullOrWhiteSpace(request.Datetime))
+        {
+            var temporalFilter = StacFilterHelpers.ParseDatetime(request.Datetime, layer);
+            if (temporalFilter is not null)
+            {
+                query = query with { TemporalFilter = temporalFilter };
+            }
+        }
+
+        // Apply ID filter
+        if (parsedObjectIds is { Length: > 0 } objectIds)
+        {
+            query = query with { ObjectIds = objectIds };
+        }
+
+        // Apply sort
+        if (request.Sortby is { IsDefault: false } sortby && sortby.Length > 0)
+        {
+            var orderBy = sortby.Select(s =>
+                string.Equals(s.Direction, "desc", StringComparison.OrdinalIgnoreCase)
+                    ? OrderByClause.Desc(s.Field)
+                    : OrderByClause.Asc(s.Field))
+                .ToImmutableArray();
+            query = query with { OrderBy = orderBy };
+        }
+
+        // Apply field selection
+        if (request.Fields is { Includes: { IsDefault: false } includes } && includes.Length > 0)
+        {
+            query = query with { OutFields = includes };
+        }
+
+        return query;
+    }
+
+    private static string BuildSearchQuery(int limit, int offset, StacSearchRequest request)
+    {
+        var query = $"limit={limit}&offset={offset}";
+        if (request.Bbox is { IsDefault: false } bboxArr && bboxArr.Length >= 4)
+            query += "&bbox=" + string.Join(",", bboxArr.Select(v => v.ToString(CultureInfo.InvariantCulture)));
+        if (!string.IsNullOrWhiteSpace(request.Datetime))
+            query += $"&datetime={request.Datetime}";
+        if (request.Collections is { IsDefault: false } cols && cols.Length > 0)
+            query += $"&collections={string.Join(",", cols)}";
+        if (request.Ids is { IsDefault: false } ids && ids.Length > 0)
+            query += $"&ids={string.Join(",", ids)}";
+        return query;
     }
 }

--- a/src/Honua.Server/Features/Stac/Services/StacFilterHelpers.cs
+++ b/src/Honua.Server/Features/Stac/Services/StacFilterHelpers.cs
@@ -2,8 +2,10 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Globalization;
+using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Server.Features.Infrastructure.Authentication;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 
@@ -14,6 +16,47 @@ namespace Honua.Server.Features.Stac.Services;
 /// </summary>
 internal static class StacFilterHelpers
 {
+    private static readonly GeometryFactory Wgs84Factory = new(new PrecisionModel(), 4326);
+
+    [ThreadStatic]
+    private static WKBWriter? _wkbWriter;
+
+    private static WKBWriter GetWkbWriter() => _wkbWriter ??= new WKBWriter();
+    /// <summary>
+    /// Resolves layers that are visible through the STAC protocol, applying both
+    /// protocol gating and access-policy filtering.
+    /// </summary>
+    public static async Task<LayerDefinition[]> ResolveStacVisibleLayersAsync(
+        HttpContext context,
+        ILayerCatalog layerCatalog,
+        CancellationToken cancellationToken)
+    {
+        var allLayers = await layerCatalog.ListLayersAsync(cancellationToken);
+        var services = await layerCatalog.ListServicesAsync(cancellationToken);
+
+        var stacServices = services
+            .Where(service => ServiceProtocols.IsProtocolEnabled(service.Metadata, ServiceProtocols.Stac))
+            .ToArray();
+
+        var layerToService = new Dictionary<int, ServiceDefinition>();
+        foreach (var service in stacServices)
+        {
+            foreach (var serviceLayer in service.Layers)
+            {
+                layerToService.TryAdd(serviceLayer.Id, service);
+            }
+        }
+
+        var protocolLayerIds = layerToService.Keys.ToHashSet();
+        return allLayers
+            .Where(layer => protocolLayerIds.Count == 0
+                ? ServiceProtocols.IsProtocolEnabled(layer.Metadata, ServiceProtocols.Stac)
+                : protocolLayerIds.Contains(layer.Id))
+            .Where(layer => AccessPolicyHelpers.IsLayerAccessible(
+                context, layer, layerToService.GetValueOrDefault(layer.Id)))
+            .ToArray();
+    }
+
     /// <summary>
     /// Parses a STAC bbox parameter (comma-separated: west,south,east,north) into a <see cref="SpatialFilter"/>.
     /// </summary>
@@ -33,11 +76,18 @@ internal static class StacFilterHelpers
             return null;
         }
 
+        return CreateBboxSpatialFilter(west, south, east, north);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="SpatialFilter"/> from pre-parsed bbox coordinates.
+    /// Avoids the string round-trip when the caller already has numeric values.
+    /// </summary>
+    public static SpatialFilter CreateBboxSpatialFilter(double west, double south, double east, double north)
+    {
         var envelope = new Envelope(west, east, south, north);
-        var geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
-        var geometry = geometryFactory.ToGeometry(envelope);
-        var wkbWriter = new WKBWriter();
-        var wkb = wkbWriter.Write(geometry);
+        var geometry = Wgs84Factory.ToGeometry(envelope);
+        var wkb = GetWkbWriter().Write(geometry);
 
         return SpatialFilter.Create(wkb, SpatialRelationship.Intersects, srid: 4326);
     }

--- a/src/Honua.Server/Features/Stac/Services/StacFilterHelpers.cs
+++ b/src/Honua.Server/Features/Stac/Services/StacFilterHelpers.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace Honua.Server.Features.Stac.Services;
+
+/// <summary>
+/// Helpers for converting STAC search parameters to Honua query filters.
+/// </summary>
+internal static class StacFilterHelpers
+{
+    /// <summary>
+    /// Parses a STAC bbox parameter (comma-separated: west,south,east,north) into a <see cref="SpatialFilter"/>.
+    /// </summary>
+    public static SpatialFilter? ParseBbox(string bbox)
+    {
+        var parts = bbox.Split(',');
+        if (parts.Length < 4)
+        {
+            return null;
+        }
+
+        if (!double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var west) ||
+            !double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var south) ||
+            !double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var east) ||
+            !double.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var north))
+        {
+            return null;
+        }
+
+        var envelope = new Envelope(west, east, south, north);
+        var geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+        var geometry = geometryFactory.ToGeometry(envelope);
+        var wkbWriter = new WKBWriter();
+        var wkb = wkbWriter.Write(geometry);
+
+        return SpatialFilter.Create(wkb, SpatialRelationship.Intersects, srid: 4326);
+    }
+
+    /// <summary>
+    /// Parses an RFC 3339 datetime or interval into a <see cref="TemporalFilter"/>.
+    /// Supports: instant, ../end, start/.., start/end.
+    /// </summary>
+    public static TemporalFilter? ParseDatetime(string datetime, LayerDefinition layer)
+    {
+        var timeField = layer.Metadata?.TimeInfo?.StartTimeField;
+        if (string.IsNullOrWhiteSpace(timeField))
+        {
+            return null;
+        }
+
+        var parts = datetime.Split('/');
+        DateTimeOffset? start = null;
+        DateTimeOffset? end = null;
+
+        if (parts.Length == 1)
+        {
+            // Single instant
+            if (DateTimeOffset.TryParse(parts[0], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var instant))
+            {
+                start = instant;
+                end = instant;
+            }
+            else
+            {
+                return null;
+            }
+        }
+        else if (parts.Length == 2)
+        {
+            // Interval: start/end, ../end, start/..
+            if (!string.Equals(parts[0], "..", StringComparison.Ordinal) &&
+                DateTimeOffset.TryParse(parts[0], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var s))
+            {
+                start = s;
+            }
+
+            if (!string.Equals(parts[1], "..", StringComparison.Ordinal) &&
+                DateTimeOffset.TryParse(parts[1], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var e))
+            {
+                end = e;
+            }
+        }
+        else
+        {
+            return null;
+        }
+
+        if (start is null && end is null)
+        {
+            return null;
+        }
+
+        return new TemporalFilter
+        {
+            PropertyName = timeField,
+            PropertyType = TemporalPropertyType.DateTime,
+            Start = start,
+            End = end
+        };
+    }
+}

--- a/src/Honua.Server/Features/Stac/Services/StacMappingService.cs
+++ b/src/Honua.Server/Features/Stac/Services/StacMappingService.cs
@@ -1,0 +1,231 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Server.Features.Ogc.Common;
+using Honua.Server.Features.OgcFeatures;
+using Honua.Server.Features.Stac.Models;
+using NetTopologySuite.IO;
+
+namespace Honua.Server.Features.Stac.Services;
+
+/// <summary>
+/// Maps Honua catalog entities (layers, services, features) to STAC representations.
+/// </summary>
+internal sealed class StacMappingService
+{
+    /// <summary>
+    /// Builds a STAC Collection from a layer definition.
+    /// </summary>
+    public static async Task<StacCollection> MapLayerToCollectionAsync(
+        LayerDefinition layer,
+        IFeatureReader featureReader,
+        string baseUrl,
+        CancellationToken cancellationToken)
+    {
+        var collectionId = layer.Id.ToString(CultureInfo.InvariantCulture);
+        var stacBase = $"{baseUrl}/stac";
+
+        var links = ImmutableArray.CreateBuilder<Link>();
+
+        // Self
+        links.Add(Link.Create(
+            href: $"{stacBase}/collections/{collectionId}",
+            rel: RelationTypes.Self,
+            type: MediaTypes.Json,
+            title: layer.Name));
+
+        // Root
+        links.Add(Link.Create(
+            href: stacBase,
+            rel: StacConstants.StacRelations.Root,
+            type: MediaTypes.Json,
+            title: "STAC Catalog"));
+
+        // Parent
+        links.Add(Link.Create(
+            href: stacBase,
+            rel: StacConstants.StacRelations.Parent,
+            type: MediaTypes.Json,
+            title: "STAC Catalog"));
+
+        // Items
+        links.Add(Link.Create(
+            href: $"{stacBase}/collections/{collectionId}/items",
+            rel: StacConstants.StacRelations.Items,
+            type: MediaTypes.GeoJson,
+            title: "Items"));
+
+        // Cross-protocol links: OGC API Features
+        links.Add(Link.Create(
+            href: $"{baseUrl}/ogc/features/collections/{collectionId}",
+            rel: RelationTypes.Alternate,
+            type: MediaTypes.Json,
+            title: "OGC API Features collection"));
+
+        var extent = BuildStacExtent(layer, featureReader, cancellationToken);
+
+        return new StacCollection
+        {
+            Id = collectionId,
+            Title = layer.Name,
+            Description = layer.Description ?? $"STAC collection for {layer.Name}",
+            License = "proprietary",
+            Extent = await extent,
+            Links = links.ToImmutable()
+        };
+    }
+
+    /// <summary>
+    /// Maps a Honua feature to a STAC Item.
+    /// </summary>
+    public static StacItem MapFeatureToItem(
+        Feature feature,
+        LayerDefinition layer,
+        string baseUrl)
+    {
+        var collectionId = layer.Id.ToString(CultureInfo.InvariantCulture);
+        var itemId = feature.ObjectId?.ToString(CultureInfo.InvariantCulture) ?? "0";
+        var stacBase = $"{baseUrl}/stac";
+
+        var properties = new Dictionary<string, object?>();
+
+        // STAC requires a "datetime" property — use the layer's time field if available,
+        // otherwise null (valid per spec when start_datetime/end_datetime are present or no temporal info exists).
+        var datetimeResolved = false;
+        if (layer.Metadata?.TimeInfo is { StartTimeField: { } startField })
+        {
+            if (feature.Attributes.TryGetValue(startField, out var startVal) && startVal is DateTimeOffset dto)
+            {
+                properties["datetime"] = dto.ToString("o", CultureInfo.InvariantCulture);
+                datetimeResolved = true;
+            }
+        }
+
+        if (!datetimeResolved)
+        {
+            properties["datetime"] = null;
+        }
+
+        // Copy feature attributes
+        foreach (var kvp in feature.Attributes)
+        {
+            if (!string.Equals(kvp.Key, "objectid", StringComparison.OrdinalIgnoreCase))
+            {
+                properties[kvp.Key] = kvp.Value;
+            }
+        }
+
+        // Build geometry as JSON element
+        JsonElement? geometry = null;
+        if (feature.Geometry is { Length: > 0 })
+        {
+            geometry = ConvertWkbToGeoJsonElement(feature.Geometry);
+        }
+
+        var links = ImmutableArray.Create(
+            Link.Create(
+                href: $"{stacBase}/collections/{collectionId}/items/{itemId}",
+                rel: RelationTypes.Self,
+                type: MediaTypes.GeoJson,
+                title: $"Item {itemId}"),
+            Link.Create(
+                href: $"{stacBase}/collections/{collectionId}",
+                rel: RelationTypes.Collection,
+                type: MediaTypes.Json,
+                title: layer.Name),
+            Link.Create(
+                href: stacBase,
+                rel: StacConstants.StacRelations.Root,
+                type: MediaTypes.Json,
+                title: "STAC Catalog"));
+
+        // Cross-protocol asset links
+        var assets = new Dictionary<string, StacAsset>
+        {
+            ["geojson"] = new StacAsset
+            {
+                Href = $"{baseUrl}/ogc/features/collections/{collectionId}/items/{itemId}",
+                Title = "GeoJSON",
+                Type = MediaTypes.GeoJson,
+                Roles = ImmutableArray.Create("data")
+            }
+        };
+
+        return new StacItem
+        {
+            Id = itemId,
+            Geometry = geometry,
+            Properties = properties,
+            Links = links,
+            Assets = assets,
+            Collection = collectionId
+        };
+    }
+
+    /// <summary>
+    /// Builds the STAC extent from a layer's spatial and temporal metadata.
+    /// </summary>
+    private static async Task<StacExtent> BuildStacExtent(
+        LayerDefinition layer,
+        IFeatureReader featureReader,
+        CancellationToken cancellationToken)
+    {
+        // Spatial extent
+        var bbox = ImmutableArray.Create(ImmutableArray.Create(-180.0, -90.0, 180.0, 90.0));
+        if (layer.Extent is { } extent)
+        {
+            var srid = extent.SpatialReference;
+            if (srid == 4326)
+            {
+                bbox = ImmutableArray.Create(ImmutableArray.Create(
+                    extent.MinX, extent.MinY, extent.MaxX, extent.MaxY));
+            }
+            else if (OgcExtentTransformer.TryTransformToCrs84(extent.MinX, extent.MinY, srid, out var min) &&
+                     OgcExtentTransformer.TryTransformToCrs84(extent.MaxX, extent.MaxY, srid, out var max))
+            {
+                bbox = ImmutableArray.Create(ImmutableArray.Create(min.Lon, min.Lat, max.Lon, max.Lat));
+            }
+        }
+
+        // Temporal extent
+        var temporalInterval = ImmutableArray.Create(ImmutableArray.Create<string?>(null, null));
+        var temporalExtent = await OgcFeaturesUtilities.BuildTemporalExtentAsync(layer, featureReader, cancellationToken);
+        if (temporalExtent is not null)
+        {
+            temporalInterval = temporalExtent.Interval;
+        }
+
+        return new StacExtent
+        {
+            Spatial = new StacSpatialExtent { Bbox = bbox },
+            Temporal = new StacTemporalExtent { Interval = temporalInterval }
+        };
+    }
+
+    /// <summary>
+    /// Converts WKB geometry bytes to a GeoJSON JsonElement.
+    /// Returns null if conversion fails — STAC allows null geometry.
+    /// </summary>
+    private static JsonElement? ConvertWkbToGeoJsonElement(byte[] wkb)
+    {
+        try
+        {
+            var reader = new WKBReader();
+            var geom = reader.Read(wkb);
+            var writer = new GeoJsonWriter();
+            var json = writer.Write(geom);
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.Clone();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/Honua.Server/Features/Stac/Services/StacMappingService.cs
+++ b/src/Honua.Server/Features/Stac/Services/StacMappingService.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Server.Features.Infrastructure.Services;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.OgcFeatures;
 using Honua.Server.Features.Stac.Models;
@@ -19,6 +20,10 @@ namespace Honua.Server.Features.Stac.Services;
 /// </summary>
 internal sealed class StacMappingService
 {
+    [ThreadStatic]
+    private static GeoJsonWriter? _geoJsonWriter;
+
+    private static GeoJsonWriter GetGeoJsonWriter() => _geoJsonWriter ??= new GeoJsonWriter();
     /// <summary>
     /// Builds a STAC Collection from a layer definition.
     /// </summary>
@@ -216,10 +221,8 @@ internal sealed class StacMappingService
     {
         try
         {
-            var reader = new WKBReader();
-            var geom = reader.Read(wkb);
-            var writer = new GeoJsonWriter();
-            var json = writer.Write(geom);
+            var geom = WkbReaderCache.Get().Read(wkb);
+            var json = GetGeoJsonWriter().Write(geom);
             using var doc = JsonDocument.Parse(json);
             return doc.RootElement.Clone();
         }

--- a/src/Honua.Server/Features/Stac/StacEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/StacEndpoints.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Stac;
+
+/// <summary>
+/// Extension methods to register STAC API endpoints.
+/// </summary>
+internal static class StacEndpoints
+{
+    /// <summary>
+    /// Logging class for STAC endpoints.
+    /// </summary>
+    internal sealed class StacEndpointsLog
+    {
+    }
+
+    /// <summary>
+    /// Maps all STAC API endpoints by delegating to specialized endpoint classes.
+    /// </summary>
+    public static IEndpointRouteBuilder MapStacEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapStacCatalogEndpoints();
+        endpoints.MapStacCollectionEndpoints();
+        endpoints.MapStacItemEndpoints();
+        endpoints.MapStacSearchEndpoints();
+
+        return endpoints;
+    }
+}

--- a/src/Honua.Server/Features/Stac/StacJsonContext.cs
+++ b/src/Honua.Server/Features/Stac/StacJsonContext.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Server.Features.Ogc.Common;
+using Honua.Server.Features.Stac.Models;
+
+namespace Honua.Server.Features.Stac;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(StacCatalog))]
+[JsonSerializable(typeof(StacCollection))]
+[JsonSerializable(typeof(StacCollection[]))]
+[JsonSerializable(typeof(StacItem))]
+[JsonSerializable(typeof(StacItem[]))]
+[JsonSerializable(typeof(StacAsset))]
+[JsonSerializable(typeof(StacExtent))]
+[JsonSerializable(typeof(StacSpatialExtent))]
+[JsonSerializable(typeof(StacTemporalExtent))]
+[JsonSerializable(typeof(StacItemCollection))]
+[JsonSerializable(typeof(StacCollectionsResponse))]
+[JsonSerializable(typeof(StacSearchRequest))]
+[JsonSerializable(typeof(StacSearchContext))]
+[JsonSerializable(typeof(StacFieldsExtension))]
+[JsonSerializable(typeof(StacSortDefinition))]
+[JsonSerializable(typeof(Link))]
+[JsonSerializable(typeof(ImmutableArray<Link>))]
+[JsonSerializable(typeof(ImmutableArray<string>))]
+[JsonSerializable(typeof(ImmutableArray<double>))]
+[JsonSerializable(typeof(ImmutableArray<ImmutableArray<double>>))]
+[JsonSerializable(typeof(ImmutableArray<ImmutableArray<string?>>))]
+[JsonSerializable(typeof(ImmutableArray<StacItem>))]
+[JsonSerializable(typeof(ImmutableArray<StacSortDefinition>))]
+[JsonSerializable(typeof(Dictionary<string, object?>))]
+[JsonSerializable(typeof(Dictionary<string, StacAsset>))]
+[JsonSerializable(typeof(JsonElement))]
+[JsonSerializable(typeof(object))]
+internal sealed partial class StacJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Stac/StacLog.cs
+++ b/src/Honua.Server/Features/Stac/StacLog.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Stac;
+
+/// <summary>
+/// Source-generated log messages for STAC API endpoints.
+/// Event IDs: 5800–5849.
+/// </summary>
+internal static partial class StacLog
+{
+    // 5800–5809: Catalog
+
+    [LoggerMessage(EventId = 5800, Level = LogLevel.Information,
+        Message = "STAC catalog requested")]
+    public static partial void CatalogRequested(ILogger logger);
+
+    [LoggerMessage(EventId = 5801, Level = LogLevel.Debug,
+        Message = "STAC catalog returned with {CollectionCount} child collections")]
+    public static partial void CatalogReturned(ILogger logger, int collectionCount);
+
+    // 5810–5819: Collections
+
+    [LoggerMessage(EventId = 5810, Level = LogLevel.Information,
+        Message = "STAC collections list requested")]
+    public static partial void CollectionsRequested(ILogger logger);
+
+    [LoggerMessage(EventId = 5811, Level = LogLevel.Debug,
+        Message = "STAC collections returned: {Count}")]
+    public static partial void CollectionsReturned(ILogger logger, int count);
+
+    [LoggerMessage(EventId = 5812, Level = LogLevel.Information,
+        Message = "STAC collection {CollectionId} requested")]
+    public static partial void CollectionRequested(ILogger logger, string collectionId);
+
+    [LoggerMessage(EventId = 5813, Level = LogLevel.Warning,
+        Message = "STAC collection {CollectionId} not found")]
+    public static partial void CollectionNotFound(ILogger logger, string collectionId);
+
+    // 5820–5829: Items
+
+    [LoggerMessage(EventId = 5820, Level = LogLevel.Information,
+        Message = "STAC items requested for collection {CollectionId} (limit={Limit})")]
+    public static partial void ItemsRequested(ILogger logger, string collectionId, int? limit);
+
+    [LoggerMessage(EventId = 5821, Level = LogLevel.Debug,
+        Message = "STAC items returned: {Count} for collection {CollectionId}")]
+    public static partial void ItemsReturned(ILogger logger, int count, string collectionId);
+
+    [LoggerMessage(EventId = 5822, Level = LogLevel.Information,
+        Message = "STAC item {ItemId} requested from collection {CollectionId}")]
+    public static partial void ItemRequested(ILogger logger, string collectionId, string itemId);
+
+    [LoggerMessage(EventId = 5823, Level = LogLevel.Warning,
+        Message = "STAC item {ItemId} not found in collection {CollectionId}")]
+    public static partial void ItemNotFound(ILogger logger, string collectionId, string itemId);
+
+    // 5830–5839: Search
+
+    [LoggerMessage(EventId = 5830, Level = LogLevel.Information,
+        Message = "STAC search requested (collections={CollectionCount}, limit={Limit})")]
+    public static partial void SearchRequested(ILogger logger, int collectionCount, int? limit);
+
+    [LoggerMessage(EventId = 5831, Level = LogLevel.Debug,
+        Message = "STAC search returned {Count} items")]
+    public static partial void SearchReturned(ILogger logger, int count);
+
+    // 5840–5849: Errors
+
+    [LoggerMessage(EventId = 5840, Level = LogLevel.Error,
+        Message = "STAC operation failed")]
+    public static partial void OperationFailed(ILogger logger, Exception exception);
+}

--- a/src/Honua.Server/Features/Stac/StacLog.cs
+++ b/src/Honua.Server/Features/Stac/StacLog.cs
@@ -5,69 +5,67 @@ namespace Honua.Server.Features.Stac;
 
 /// <summary>
 /// Source-generated log messages for STAC API endpoints.
-/// Event IDs: 5800–5849.
+/// Event IDs: 5950–5999.
 /// </summary>
 internal static partial class StacLog
 {
-    // 5800–5809: Catalog
+    // 5950–5955: Catalog & Collections
 
-    [LoggerMessage(EventId = 5800, Level = LogLevel.Information,
+    [LoggerMessage(EventId = 5950, Level = LogLevel.Information,
         Message = "STAC catalog requested")]
     public static partial void CatalogRequested(ILogger logger);
 
-    [LoggerMessage(EventId = 5801, Level = LogLevel.Debug,
+    [LoggerMessage(EventId = 5951, Level = LogLevel.Debug,
         Message = "STAC catalog returned with {CollectionCount} child collections")]
     public static partial void CatalogReturned(ILogger logger, int collectionCount);
 
-    // 5810–5819: Collections
-
-    [LoggerMessage(EventId = 5810, Level = LogLevel.Information,
+    [LoggerMessage(EventId = 5952, Level = LogLevel.Information,
         Message = "STAC collections list requested")]
     public static partial void CollectionsRequested(ILogger logger);
 
-    [LoggerMessage(EventId = 5811, Level = LogLevel.Debug,
+    [LoggerMessage(EventId = 5953, Level = LogLevel.Debug,
         Message = "STAC collections returned: {Count}")]
     public static partial void CollectionsReturned(ILogger logger, int count);
 
-    [LoggerMessage(EventId = 5812, Level = LogLevel.Information,
+    [LoggerMessage(EventId = 5954, Level = LogLevel.Information,
         Message = "STAC collection {CollectionId} requested")]
     public static partial void CollectionRequested(ILogger logger, string collectionId);
 
-    [LoggerMessage(EventId = 5813, Level = LogLevel.Warning,
+    [LoggerMessage(EventId = 5955, Level = LogLevel.Warning,
         Message = "STAC collection {CollectionId} not found")]
     public static partial void CollectionNotFound(ILogger logger, string collectionId);
 
-    // 5820–5829: Items
+    // 5960–5963: Items
 
-    [LoggerMessage(EventId = 5820, Level = LogLevel.Information,
+    [LoggerMessage(EventId = 5960, Level = LogLevel.Information,
         Message = "STAC items requested for collection {CollectionId} (limit={Limit})")]
     public static partial void ItemsRequested(ILogger logger, string collectionId, int? limit);
 
-    [LoggerMessage(EventId = 5821, Level = LogLevel.Debug,
+    [LoggerMessage(EventId = 5961, Level = LogLevel.Debug,
         Message = "STAC items returned: {Count} for collection {CollectionId}")]
     public static partial void ItemsReturned(ILogger logger, int count, string collectionId);
 
-    [LoggerMessage(EventId = 5822, Level = LogLevel.Information,
+    [LoggerMessage(EventId = 5962, Level = LogLevel.Information,
         Message = "STAC item {ItemId} requested from collection {CollectionId}")]
     public static partial void ItemRequested(ILogger logger, string collectionId, string itemId);
 
-    [LoggerMessage(EventId = 5823, Level = LogLevel.Warning,
+    [LoggerMessage(EventId = 5963, Level = LogLevel.Warning,
         Message = "STAC item {ItemId} not found in collection {CollectionId}")]
     public static partial void ItemNotFound(ILogger logger, string collectionId, string itemId);
 
-    // 5830–5839: Search
+    // 5970–5971: Search
 
-    [LoggerMessage(EventId = 5830, Level = LogLevel.Information,
+    [LoggerMessage(EventId = 5970, Level = LogLevel.Information,
         Message = "STAC search requested (collections={CollectionCount}, limit={Limit})")]
     public static partial void SearchRequested(ILogger logger, int collectionCount, int? limit);
 
-    [LoggerMessage(EventId = 5831, Level = LogLevel.Debug,
+    [LoggerMessage(EventId = 5971, Level = LogLevel.Debug,
         Message = "STAC search returned {Count} items")]
     public static partial void SearchReturned(ILogger logger, int count);
 
-    // 5840–5849: Errors
+    // 5980: Errors
 
-    [LoggerMessage(EventId = 5840, Level = LogLevel.Error,
+    [LoggerMessage(EventId = 5980, Level = LogLevel.Error,
         Message = "STAC operation failed")]
     public static partial void OperationFailed(ILogger logger, Exception exception);
 }

--- a/src/Honua.Server/Features/Stac/StacServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Stac/StacServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Stac;
+
+/// <summary>
+/// Registers STAC API services in the dependency injection container.
+/// </summary>
+internal static class StacServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds STAC API services.
+    /// </summary>
+    public static IServiceCollection AddStac(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // All STAC mapping/filter helpers are static — no scoped registrations needed currently.
+
+        return services;
+    }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -571,7 +571,8 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Infrastructure.Middleware.LimitsEnforcementJsonContext.Default,
         Honua.Server.Features.Infrastructure.Security.CspViolationJsonContext.Default,
         Honua.Server.Features.GeometryService.Models.GeometryServiceJsonContext.Default,
-        Honua.Server.Features.Export.ExportJsonContext.Default);
+        Honua.Server.Features.Export.ExportJsonContext.Default,
+        Honua.Server.Features.Stac.StacJsonContext.Default);
 });
 
 // Add comprehensive IOptions configuration validation

--- a/tests/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
+++ b/tests/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
@@ -40,6 +40,7 @@ public sealed class VerticalSliceIsolationTests
         "FileStorage",
         "PrintingTools",
         "HealthCheck",
+        "Stac",
         "Streaming",
         "Infrastructure" // Infrastructure is allowed to be referenced by others
     };

--- a/tests/Honua.Server.Tests/Features/Stac/StacCatalogTests.cs
+++ b/tests/Honua.Server.Tests/Features/Stac/StacCatalogTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Stac;
+
+/// <summary>
+/// Integration tests for the STAC Catalog (root) endpoint.
+/// </summary>
+[Collection("Database")]
+[Protocol(Protocols.Stac)]
+public sealed class StacCatalogTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.StacCatalog)]
+    [Endpoint("GET /stac")]
+    public async Task GetCatalog_ReturnsValidStacCatalog()
+    {
+        var response = await _fixture.Client.GetAsync("/stac");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/json");
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        json.RootElement.GetProperty("type").GetString().Should().Be("Catalog");
+        json.RootElement.GetProperty("id").GetString().Should().NotBeNullOrEmpty();
+        json.RootElement.GetProperty("stac_version").GetString().Should().Be("1.0.0");
+        json.RootElement.GetProperty("description").GetString().Should().NotBeNullOrEmpty();
+        json.RootElement.GetProperty("links").EnumerateArray().Should().NotBeEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.StacCatalog)]
+    [Endpoint("GET /stac")]
+    public async Task GetCatalog_ContainsConformanceClasses()
+    {
+        var response = await _fixture.Client.GetAsync("/stac");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        var conformsTo = json.RootElement.GetProperty("conformsTo")
+            .EnumerateArray()
+            .Select(e => e.GetString()!)
+            .ToList();
+
+        conformsTo.Should().Contain("https://api.stacspec.org/v1.0.0/core");
+        conformsTo.Should().Contain("https://api.stacspec.org/v1.0.0/item-search");
+        conformsTo.Should().Contain("https://api.stacspec.org/v1.0.0/collections");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.StacCatalog)]
+    [Endpoint("GET /stac")]
+    public async Task GetCatalog_HasSearchAndCollectionsLinks()
+    {
+        var response = await _fixture.Client.GetAsync("/stac");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        var links = json.RootElement.GetProperty("links")
+            .EnumerateArray()
+            .Select(l => l.GetProperty("rel").GetString()!)
+            .ToList();
+
+        links.Should().Contain("self");
+        links.Should().Contain("root");
+        links.Should().Contain("search");
+        links.Should().Contain("data");
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Stac/StacCollectionsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Stac/StacCollectionsTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Stac;
+
+/// <summary>
+/// Integration tests for the STAC Collections endpoints.
+/// </summary>
+[Collection("Database")]
+[Protocol(Protocols.Stac)]
+public sealed class StacCollectionsTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /stac/collections")]
+    public async Task GetCollections_ReturnsCollectionsList()
+    {
+        var response = await _fixture.Client.GetAsync("/stac/collections");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/json");
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        json.RootElement.GetProperty("collections").EnumerateArray().Should().NotBeEmpty();
+        json.RootElement.GetProperty("links").EnumerateArray().Should().NotBeEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /stac/collections")]
+    public async Task GetCollections_EachHasRequiredStacFields()
+    {
+        var response = await _fixture.Client.GetAsync("/stac/collections");
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        foreach (var collection in json.RootElement.GetProperty("collections").EnumerateArray())
+        {
+            collection.GetProperty("type").GetString().Should().Be("Collection");
+            collection.GetProperty("id").GetString().Should().NotBeNullOrEmpty();
+            collection.GetProperty("stac_version").GetString().Should().Be("1.0.0");
+            collection.GetProperty("description").GetString().Should().NotBeNullOrEmpty();
+            collection.GetProperty("license").GetString().Should().NotBeNullOrEmpty();
+            collection.GetProperty("extent").ValueKind.Should().Be(JsonValueKind.Object);
+            collection.GetProperty("links").EnumerateArray().Should().NotBeEmpty();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetById)]
+    [Endpoint("GET /stac/collections/{collectionId}")]
+    public async Task GetCollection_ById_ReturnsStacCollection()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var response = await _fixture.Client.GetAsync($"/stac/collections/{collectionId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        json.RootElement.GetProperty("type").GetString().Should().Be("Collection");
+        json.RootElement.GetProperty("id").GetString().Should().Be(collectionId);
+        json.RootElement.GetProperty("stac_version").GetString().Should().Be("1.0.0");
+        json.RootElement.GetProperty("extent").GetProperty("spatial").ValueKind
+            .Should().Be(JsonValueKind.Object);
+        json.RootElement.GetProperty("extent").GetProperty("temporal").ValueKind
+            .Should().Be(JsonValueKind.Object);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetById)]
+    [Endpoint("GET /stac/collections/{collectionId}")]
+    public async Task GetCollection_NotFound_Returns404()
+    {
+        var response = await _fixture.Client.GetAsync("/stac/collections/99999");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetById)]
+    [Endpoint("GET /stac/collections/{collectionId}")]
+    public async Task GetCollection_HasCrossProtocolLinks()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var response = await _fixture.Client.GetAsync($"/stac/collections/{collectionId}");
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        var links = json.RootElement.GetProperty("links")
+            .EnumerateArray()
+            .Select(l => new
+            {
+                Rel = l.GetProperty("rel").GetString(),
+                Href = l.GetProperty("href").GetString()
+            })
+            .ToArray();
+
+        links.Should().Contain(l => l.Rel == "self");
+        links.Should().Contain(l => l.Rel == "root");
+        links.Should().Contain(l => l.Rel == "items");
+        links.Should().Contain(l => l.Rel == "alternate" &&
+                                    l.Href!.Contains("/ogc/features/collections/"));
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Stac/StacItemsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Stac/StacItemsTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Stac;
+
+/// <summary>
+/// Integration tests for the STAC Items endpoints.
+/// </summary>
+[Collection("Database")]
+[Protocol(Protocols.Stac)]
+public sealed class StacItemsTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /stac/collections/{collectionId}/items")]
+    public async Task GetItems_ReturnsFeatureCollection()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var response = await _fixture.Client.GetAsync(
+            $"/stac/collections/{collectionId}/items");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        json.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        json.RootElement.GetProperty("features").EnumerateArray().Should().NotBeEmpty();
+        json.RootElement.GetProperty("context").ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /stac/collections/{collectionId}/items")]
+    public async Task GetItems_EachItemHasRequiredStacFields()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var response = await _fixture.Client.GetAsync(
+            $"/stac/collections/{collectionId}/items?limit=3");
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        foreach (var item in json.RootElement.GetProperty("features").EnumerateArray())
+        {
+            item.GetProperty("type").GetString().Should().Be("Feature");
+            item.GetProperty("id").GetString().Should().NotBeNullOrEmpty();
+            item.GetProperty("stac_version").GetString().Should().Be("1.0.0");
+            item.GetProperty("properties").ValueKind.Should().Be(JsonValueKind.Object);
+            item.GetProperty("links").EnumerateArray().Should().NotBeEmpty();
+
+            // STAC requires "datetime" in properties (may be null)
+            item.GetProperty("properties").TryGetProperty("datetime", out _).Should().BeTrue();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /stac/collections/{collectionId}/items")]
+    public async Task GetItems_WithLimit_RespectsLimit()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var response = await _fixture.Client.GetAsync(
+            $"/stac/collections/{collectionId}/items?limit=2");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        var items = json.RootElement.GetProperty("features").EnumerateArray().ToArray();
+        items.Length.Should().BeLessThanOrEqualTo(2);
+
+        json.RootElement.GetProperty("context").GetProperty("limit")
+            .GetInt32().Should().Be(2);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /stac/collections/{collectionId}/items")]
+    public async Task GetItems_NonExistentCollection_Returns404()
+    {
+        var response = await _fixture.Client.GetAsync("/stac/collections/99999/items");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetById)]
+    [Endpoint("GET /stac/collections/{collectionId}/items/{itemId}")]
+    public async Task GetItem_ById_ReturnsStacItem()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var featureId = await _fixture.InsertFeatureAsync(WebAppFixture.TestLayerId, "STAC Test Item");
+
+        var response = await _fixture.Client.GetAsync(
+            $"/stac/collections/{collectionId}/items/{featureId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        json.RootElement.GetProperty("type").GetString().Should().Be("Feature");
+        json.RootElement.GetProperty("id").GetString().Should().Be(featureId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        json.RootElement.GetProperty("collection").GetString().Should().Be(collectionId);
+        json.RootElement.GetProperty("links").EnumerateArray().Should().NotBeEmpty();
+
+        // Should have cross-protocol asset links
+        json.RootElement.GetProperty("assets").GetProperty("geojson")
+            .GetProperty("href").GetString().Should().Contain("/ogc/features/collections/");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetById)]
+    [Endpoint("GET /stac/collections/{collectionId}/items/{itemId}")]
+    public async Task GetItem_NotFound_Returns404()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var response = await _fixture.Client.GetAsync(
+            $"/stac/collections/{collectionId}/items/999999");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Stac/StacSearchTests.cs
+++ b/tests/Honua.Server.Tests/Features/Stac/StacSearchTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Stac;
+
+/// <summary>
+/// Integration tests for the STAC Search endpoints.
+/// </summary>
+[Collection("Database")]
+[Protocol(Protocols.Stac)]
+public sealed class StacSearchTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.StacSearch)]
+    [Endpoint("GET /stac/search")]
+    public async Task SearchGet_NoFilters_ReturnsItems()
+    {
+        var response = await _fixture.Client.GetAsync("/stac/search");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        json.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        json.RootElement.GetProperty("features").EnumerateArray().Should().NotBeEmpty();
+        json.RootElement.GetProperty("context").ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.StacSearch)]
+    [Endpoint("GET /stac/search")]
+    public async Task SearchGet_WithLimit_RespectsLimit()
+    {
+        var response = await _fixture.Client.GetAsync("/stac/search?limit=2");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        var features = json.RootElement.GetProperty("features").EnumerateArray().ToArray();
+        features.Length.Should().BeLessThanOrEqualTo(2);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.StacSearch)]
+    [Endpoint("GET /stac/search")]
+    public async Task SearchGet_WithCollections_FiltersResults()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var response = await _fixture.Client.GetAsync(
+            $"/stac/search?collections={collectionId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        foreach (var item in json.RootElement.GetProperty("features").EnumerateArray())
+        {
+            item.GetProperty("collection").GetString().Should().Be(collectionId);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.StacSearch)]
+    [Endpoint("POST /stac/search")]
+    public async Task SearchPost_WithBody_ReturnsItems()
+    {
+        var body = JsonSerializer.Serialize(new
+        {
+            limit = 5,
+            collections = new[] { WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture) }
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            "/stac/search",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        json.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        json.RootElement.GetProperty("features").EnumerateArray().Should().NotBeEmpty();
+        json.RootElement.GetProperty("context").GetProperty("limit")
+            .GetInt32().Should().Be(5);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.StacSearch)]
+    [Endpoint("POST /stac/search")]
+    public async Task SearchPost_WithBbox_ReturnsFilteredResults()
+    {
+        var body = JsonSerializer.Serialize(new
+        {
+            bbox = new[] { -180.0, -90.0, 180.0, 90.0 },
+            limit = 5
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            "/stac/search",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        json.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.StacSearch)]
+    [Endpoint("POST /stac/search")]
+    public async Task SearchPost_AllItemsHaveStacFields()
+    {
+        var body = JsonSerializer.Serialize(new { limit = 3 });
+
+        var response = await _fixture.Client.PostAsync(
+            "/stac/search",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        foreach (var item in json.RootElement.GetProperty("features").EnumerateArray())
+        {
+            item.GetProperty("type").GetString().Should().Be("Feature");
+            item.GetProperty("stac_version").GetString().Should().Be("1.0.0");
+            item.GetProperty("properties").TryGetProperty("datetime", out _).Should().BeTrue();
+            item.GetProperty("links").EnumerateArray().Should().NotBeEmpty();
+        }
+    }
+}

--- a/tests/Honua.TestKit/Constants/Operations.cs
+++ b/tests/Honua.TestKit/Constants/Operations.cs
@@ -132,6 +132,10 @@ public static class Operations
     // Streaming Operations
     public const string Streaming = "Streaming";
 
+    // STAC Operations
+    public const string StacCatalog = "StacCatalog";
+    public const string StacSearch = "StacSearch";
+
     // Test Quality Operations
     public const string TestQuality = "TestQuality";
     public const string FuzzTesting = "FuzzTesting";

--- a/tests/Honua.TestKit/Constants/Protocols.cs
+++ b/tests/Honua.TestKit/Constants/Protocols.cs
@@ -108,4 +108,9 @@ public static class Protocols
     /// GeoServices PrintingTools (GP Server) endpoints.
     /// </summary>
     public const string PrintingTools = "PrintingTools";
+
+    /// <summary>
+    /// STAC (SpatioTemporal Asset Catalog) API.
+    /// </summary>
+    public const string Stac = "STAC";
 }


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #378
## Summary

Background format check confirmed — exit code 0, no issues. Both fixes are clean.
## Changes Made

- Background format check confirmed — exit code 0, no issues. Both fixes are clean.
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally

## Additional Context

Decisions:
1. **Offset-based pagination** chosen over cursor-based for simplicity and consistency with existing FeatureQuery.Offset support. Cross-layer offset skips entire layers when count allows, then uses per-layer offset for partial skips.
2. **Cross-slice architecture finding deferred** — extracting `OgcExtentTransformer` to `Ogc.Common` would modify the OgcFeatures slice boundary, which is beyond the safe scope of this fix pass.
3. **Thread-static caching** for WKBWriter/GeoJsonWriter follows the established `WkbReaderCache` pattern rather than introducing a new caching mechanism.

Follow-ons:
- Extract `OgcExtentTransformer` and `OgcFeaturesUtilities.BuildTemporalExtentAsync` to `Ogc.Common` or `Infrastructure.Services` to resolve the Stac→OgcFeatures cross-slice dependency (medium/architecture).

Code kaizen:
Auto-deferred by kaizen policy.
