### PR TITLE
feat: Geocoding Beta expansion: batch + autocomplete/suggest + provider fallback chain (#414)

### DIFF
--- a/docs/GEOCODING_PROVIDERS_ARCHITECTURE.md
+++ b/docs/GEOCODING_PROVIDERS_ARCHITECTURE.md
@@ -198,25 +198,30 @@ var mockConfig = new MockGeocodeProviderConfiguration
 services.AddMockGeocodeProvider(mockConfig);
 ```
 
-## Future Enhancements
+## Beta Capability Status
 
-The architecture is designed to support future enhancements:
+The following documents the current state of geocoding capabilities as of the beta release:
 
-1. **Caching Layer** - Redis-based result caching
-2. **Analytics** - Provider performance tracking
-3. **Rate Limiting** - Request throttling per provider
-4. **Circuit Breaker** - Automatic provider failover
-5. **Load Balancing** - Distribute requests across providers
-6. **Custom Providers** - Plugin architecture for custom implementations
+### Implemented and Validated
 
-## Migration from Existing Code
+- **Forward geocoding** (`findAddressCandidates`): Fully implemented. Nominatim, Azure Maps, and Amazon Location providers supported. GET and POST methods. GET-only alias route without locator name.
+- **Reverse geocoding** (`reverseGeocode`): Fully implemented. All active providers supported. GET and POST methods. GET-only alias route without locator name.
+- **Suggest/autocomplete** (`suggest`): Fully implemented. Azure Maps and Amazon Location support native suggest. Nominatim supports suggest when `EnableSuggestFromSearch` is enabled (reuses the search endpoint). GET and POST methods. GET-only alias route without locator name.
+- **Batch geocoding** (`geocodeAddresses`): Implemented at handler level with full request parsing, validation, and response mapping. Pipeline-validated via MockGeocodeProvider. No external provider supports native batch yet; when they do, they participate automatically via the coordinator. GET and POST methods. GET-only alias route without locator name.
+- **Failover**: Fully implemented for all operations (forward, reverse, suggest, batch) via `GeocodeCoordinatorService`. Configurable via `EnableFailover` and `MaxFailoverAttempts`. For batch and suggest, the coordinator skips providers that lack the required capability and continues to the next provider in the failover chain. When a client explicitly requests a specific provider via the `provider` parameter and that provider lacks the required capability, a 400 is returned without attempting failover.
+- **Provider health checks**: Each provider exposes `CheckHealthAsync` for monitoring.
 
-The current Honua.Server geocoding implementation can be gradually migrated:
+### Known Limits
 
-1. Keep existing endpoints unchanged
-2. Replace internal provider calls with coordinator service
-3. Move provider implementations to use core abstractions
-4. Add new providers incrementally
-5. Enable failover and coordination features
+- **Spatial reference**: Only `outSR=4326` (WGS 84) is currently supported. Requests for other SRIDs return 400.
+- **Batch OBJECTID**: No OBJECTID tracking in batch responses. Results are returned in input order.
+- **No fan-out**: Batch requests require native provider batch support. Sequential forward-geocode fan-out (dispatching individual calls when no provider supports native batch) is deferred.
+- **Batch size**: When an explicit `provider` parameter is supplied, capped by that provider's `MaxBatchSize`. Otherwise, a default cap of 100 is applied.
 
-This maintains backward compatibility while enabling the new architecture.
+### Future Enhancements
+
+1. **Fan-out batch strategy** - Sequential forward calls for providers without native batch support
+2. **Caching layer** - Redis-based result caching
+3. **Additional SRIDs** - Coordinate reprojection for non-4326 output
+4. **OBJECTID tracking** - Per-record OBJECTID in batch responses per GeoServices spec
+5. **Custom providers** - Plugin architecture for custom implementations

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -233,6 +233,7 @@ public static class EndpointRegistry
         new("GET", "/rest/services/GeocodeServer/findAddressCandidates"),
         new("GET", "/rest/services/GeocodeServer/reverseGeocode"),
         new("GET", "/rest/services/GeocodeServer/suggest"),
+        new("GET", "/rest/services/GeocodeServer/geocodeAddresses"),
 
         new("GET", "/rest/services/{serviceId}/FeatureServer"),
         new("GET", "/rest/services/{serviceId}/FeatureServer/{layerId}"),

--- a/src/Honua.Server/Features/Geocoding/GeocodingEndpoints.cs
+++ b/src/Honua.Server/Features/Geocoding/GeocodingEndpoints.cs
@@ -98,6 +98,12 @@ internal static class GeocodingEndpoints
             .WithName("SuggestAddressesAlias")
             .WithTags("GeocodeServer");
 
+        endpoints.MapGet("/rest/services/GeocodeServer/geocodeAddresses", static (HttpContext context, GeocodingHandler handler) =>
+                handler.HandleBatchGeocodeAsync(context, locatorName: null, TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context)))
+            .WithDisplayName("Batch Geocode Addresses (Alias)")
+            .WithName("BatchGeocodeAddressesAlias")
+            .WithTags("GeocodeServer");
+
         return endpoints;
     }
 

--- a/src/Honua.Server/Features/Geocoding/GeocodingHandler.cs
+++ b/src/Honua.Server/Features/Geocoding/GeocodingHandler.cs
@@ -137,6 +137,12 @@ internal sealed class GeocodingHandler(
             var requestedProviderName = GetValue(values, "provider");
             var providerName = NormalizeProviderName(requestedProviderName);
             var resolvedProviderName = ResolveProviderName(requestedProviderName);
+
+            if (!string.IsNullOrWhiteSpace(requestedProviderName) && _providerRegistry.GetProvider(resolvedProviderName) == null)
+            {
+                return StandardErrorHelpers.CreateBadRequest(context, $"Geocoding provider '{requestedProviderName}' not found.");
+            }
+
             var providerRequest = new Core.Features.Geocoding.Domain.ForwardGeocodeRequest(
                 Query: query,
                 MaxResults: maxLocations,
@@ -150,29 +156,8 @@ internal sealed class GeocodingHandler(
             if (!result.IsSuccess)
             {
                 var errorMessage = result.ErrorMessage ?? "Geocoding request failed";
-
                 GeocodingLog.OperationFailed(_logger, "findAddressCandidates", resolvedProviderName, errorMessage, new InvalidOperationException(errorMessage));
-
-                // Check error message content to determine response type
-                if (errorMessage.Contains("authentication", StringComparison.OrdinalIgnoreCase) ||
-                    errorMessage.Contains("unauthorized", StringComparison.OrdinalIgnoreCase))
-                {
-                    return StandardErrorHelpers.CreateUnauthorized(context, "Authentication failed for geocoding service");
-                }
-                else if (errorMessage.Contains("rate limit", StringComparison.OrdinalIgnoreCase) ||
-                         errorMessage.Contains("too many requests", StringComparison.OrdinalIgnoreCase))
-                {
-                    return StandardErrorHelpers.CreateServiceUnavailable(context, "Rate limit exceeded");
-                }
-                else if (errorMessage.Contains("invalid", StringComparison.OrdinalIgnoreCase) ||
-                         errorMessage.Contains("bad request", StringComparison.OrdinalIgnoreCase))
-                {
-                    return StandardErrorHelpers.CreateBadRequest(context, errorMessage);
-                }
-                else
-                {
-                    return StandardErrorHelpers.CreateInternalServerError(context, "Geocoding service error");
-                }
+                return MapCoordinatorErrorToResult(context, errorMessage, "Geocoding service error");
             }
 
             var candidates = result.Data ?? [];
@@ -201,10 +186,7 @@ internal sealed class GeocodingHandler(
                 })]
             };
 
-            var provider = _providerRegistry.GetProvider(resolvedProviderName);
-            var usedProviderName = provider?.Name ?? resolvedProviderName;
-
-            GeocodingLog.OperationCompleted(_logger, "findAddressCandidates", usedProviderName, response.Candidates.Length, stopwatch.Elapsed.TotalMilliseconds);
+            GeocodingLog.OperationCompleted(_logger, "findAddressCandidates", result.ProviderName, response.Candidates.Length, stopwatch.Elapsed.TotalMilliseconds);
 
             return Results.Json(response, GeocodingJsonContext.Default.FindAddressCandidatesResponse, contentType: JsonContentType);
         }
@@ -261,6 +243,12 @@ internal sealed class GeocodingHandler(
             var requestedProviderName = GetValue(values, "provider");
             var providerName = NormalizeProviderName(requestedProviderName);
             var resolvedProviderName = ResolveProviderName(requestedProviderName);
+
+            if (!string.IsNullOrWhiteSpace(requestedProviderName) && _providerRegistry.GetProvider(resolvedProviderName) == null)
+            {
+                return StandardErrorHelpers.CreateBadRequest(context, $"Geocoding provider '{requestedProviderName}' not found.");
+            }
+
             var providerRequest = new Core.Features.Geocoding.Domain.ReverseGeocodeRequest(x, y, outSrid);
 
             var stopwatch = Stopwatch.StartNew();
@@ -270,34 +258,9 @@ internal sealed class GeocodingHandler(
             if (!result.IsSuccess)
             {
                 var errorMessage = result.ErrorMessage ?? "Reverse geocoding request failed";
-
                 GeocodingLog.OperationFailed(_logger, "reverseGeocode", resolvedProviderName, errorMessage, new InvalidOperationException(errorMessage));
-
-                // Check error message content to determine response type
-                if (errorMessage.Contains("authentication", StringComparison.OrdinalIgnoreCase) ||
-                    errorMessage.Contains("unauthorized", StringComparison.OrdinalIgnoreCase))
-                {
-                    return StandardErrorHelpers.CreateUnauthorized(context, "Authentication failed for geocoding service");
-                }
-                else if (errorMessage.Contains("rate limit", StringComparison.OrdinalIgnoreCase) ||
-                         errorMessage.Contains("too many requests", StringComparison.OrdinalIgnoreCase))
-                {
-                    return StandardErrorHelpers.CreateServiceUnavailable(context, "Rate limit exceeded");
-                }
-                else if (errorMessage.Contains("invalid", StringComparison.OrdinalIgnoreCase) ||
-                         errorMessage.Contains("bad request", StringComparison.OrdinalIgnoreCase))
-                {
-                    return StandardErrorHelpers.CreateBadRequest(context, errorMessage);
-                }
-                else if (errorMessage.Contains("no results", StringComparison.OrdinalIgnoreCase) ||
-                         errorMessage.Contains("not found", StringComparison.OrdinalIgnoreCase))
-                {
-                    return StandardErrorHelpers.CreateNotFound(context, "No matching address was found for the supplied location");
-                }
-                else
-                {
-                    return StandardErrorHelpers.CreateInternalServerError(context, "Reverse geocoding service error");
-                }
+                return MapCoordinatorErrorToResult(context, errorMessage, "Reverse geocoding service error",
+                    notFoundMessage: "No matching address was found for the supplied location");
             }
 
             var match = result.Data;
@@ -327,10 +290,7 @@ internal sealed class GeocodingHandler(
                 }
             };
 
-            var provider = _providerRegistry.GetProvider(resolvedProviderName);
-            var usedProviderName = provider?.Name ?? resolvedProviderName;
-
-            GeocodingLog.OperationCompleted(_logger, "reverseGeocode", usedProviderName, 1, stopwatch.Elapsed.TotalMilliseconds);
+            GeocodingLog.OperationCompleted(_logger, "reverseGeocode", result.ProviderName, 1, stopwatch.Elapsed.TotalMilliseconds);
 
             return Results.Json(response, GeocodingJsonContext.Default.ReverseGeocodeResponse, contentType: JsonContentType);
         }
@@ -384,7 +344,15 @@ internal sealed class GeocodingHandler(
             var providerName = NormalizeProviderName(requestedProviderName);
             var resolvedProviderName = ResolveProviderName(requestedProviderName);
             var provider = _providerRegistry.GetProvider(resolvedProviderName);
-            if (provider != null && !provider.Capabilities.SupportsSuggest)
+
+            // When the user explicitly requested a provider, validate it exists and supports the operation.
+            // When using the default provider, let the coordinator handle failover to a capable provider.
+            if (!string.IsNullOrWhiteSpace(requestedProviderName) && provider == null)
+            {
+                return StandardErrorHelpers.CreateBadRequest(context, $"Geocoding provider '{requestedProviderName}' not found.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(requestedProviderName) && provider != null && !provider.Capabilities.SupportsSuggest)
             {
                 GeocodingLog.CapabilityNotSupported(_logger, "suggest", provider.Name);
                 return StandardErrorHelpers.CreateBadRequest(
@@ -405,29 +373,8 @@ internal sealed class GeocodingHandler(
             if (!result.IsSuccess)
             {
                 var errorMessage = result.ErrorMessage ?? "Suggest request failed";
-
                 GeocodingLog.OperationFailed(_logger, "suggest", resolvedProviderName, errorMessage, new InvalidOperationException(errorMessage));
-
-                // Check error message content to determine response type
-                if (errorMessage.Contains("authentication", StringComparison.OrdinalIgnoreCase) ||
-                    errorMessage.Contains("unauthorized", StringComparison.OrdinalIgnoreCase))
-                {
-                    return StandardErrorHelpers.CreateUnauthorized(context, "Authentication failed for geocoding service");
-                }
-                else if (errorMessage.Contains("rate limit", StringComparison.OrdinalIgnoreCase) ||
-                         errorMessage.Contains("too many requests", StringComparison.OrdinalIgnoreCase))
-                {
-                    return StandardErrorHelpers.CreateServiceUnavailable(context, "Rate limit exceeded");
-                }
-                else if (errorMessage.Contains("invalid", StringComparison.OrdinalIgnoreCase) ||
-                         errorMessage.Contains("bad request", StringComparison.OrdinalIgnoreCase))
-                {
-                    return StandardErrorHelpers.CreateBadRequest(context, errorMessage);
-                }
-                else
-                {
-                    return StandardErrorHelpers.CreateInternalServerError(context, "Suggest service error");
-                }
+                return MapCoordinatorErrorToResult(context, errorMessage, "Suggest service error");
             }
 
             var suggestions = result.Data ?? [];
@@ -441,9 +388,7 @@ internal sealed class GeocodingHandler(
                 })]
             };
 
-            var usedProviderName = provider?.Name ?? resolvedProviderName;
-
-            GeocodingLog.OperationCompleted(_logger, "suggest", usedProviderName, response.Suggestions.Length, stopwatch.Elapsed.TotalMilliseconds);
+            GeocodingLog.OperationCompleted(_logger, "suggest", result.ProviderName, response.Suggestions.Length, stopwatch.Elapsed.TotalMilliseconds);
 
             return Results.Json(response, GeocodingJsonContext.Default.SuggestResponse, contentType: JsonContentType);
         }
@@ -478,8 +423,17 @@ internal sealed class GeocodingHandler(
 
         var requestedProviderName = GetValue(values, "provider");
         var providerName = ResolveProviderName(requestedProviderName);
+        var resolvedProviderName = providerName;
         var provider = _providerRegistry.GetProvider(providerName);
-        if (provider != null && !provider.Capabilities.SupportsBatch)
+
+        if (!string.IsNullOrWhiteSpace(requestedProviderName) && provider == null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, $"Geocoding provider '{requestedProviderName}' not found.");
+        }
+
+        // Only block when the user explicitly requested a specific provider that lacks batch support.
+        // When using the default provider, let the coordinator handle failover to a capable provider.
+        if (!string.IsNullOrWhiteSpace(requestedProviderName) && provider != null && !provider.Capabilities.SupportsBatch)
         {
             GeocodingLog.CapabilityNotSupported(_logger, "geocodeAddresses", provider.Name);
             return StandardErrorHelpers.CreateBadRequest(
@@ -487,9 +441,273 @@ internal sealed class GeocodingHandler(
                 "Batch geocoding is not supported by the configured geocode provider.");
         }
 
-        return StandardErrorHelpers.CreateBadRequest(
-            context,
-            "Batch geocoding request parsing is not yet available in this release.");
+        var recordsJson = GetValue(values, "records");
+        if (!TryParseRecords(recordsJson, out var queries, out var parseError))
+        {
+            GeocodingLog.BatchRecordsParseFailed(_logger, parseError ?? "Unknown parse error");
+            return StandardErrorHelpers.CreateBadRequest(context, parseError ?? "Invalid records parameter.");
+        }
+
+        if (queries is null || queries.Count == 0)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "records parameter is required and must contain at least one address.");
+        }
+
+        // Use the explicit provider's limit when one was requested; otherwise use a
+        // default cap since the coordinator may route to a different provider via failover.
+        var maxBatchSize = !string.IsNullOrWhiteSpace(requestedProviderName)
+            ? (provider?.Capabilities.MaxBatchSize ?? 100)
+            : 100;
+        if (queries.Count > maxBatchSize)
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                $"Batch size {queries.Count} exceeds the maximum allowed batch size of {maxBatchSize}.");
+        }
+
+        if (!TryParseSpatialReference(GetValue(values, "outSR"), _options.DefaultSpatialReferenceWkid, out var outSrid))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Invalid outSR parameter.");
+        }
+
+        if (outSrid != _options.DefaultSpatialReferenceWkid)
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                $"Only outSR={_options.DefaultSpatialReferenceWkid} is currently supported.");
+        }
+
+        try
+        {
+            var batchRequest = new Core.Features.Geocoding.Domain.BatchGeocodeRequest(
+                Queries: queries,
+                SpatialReferenceWkid: outSrid,
+                CountryCodes: GetValue(values, "countryCodes") ?? GetValue(values, "countryCode"));
+
+            var stopwatch = Stopwatch.StartNew();
+            var result = await _coordinatorService.BatchGeocodeAsync(batchRequest, NormalizeProviderName(requestedProviderName), cancellationToken).ConfigureAwait(false);
+            stopwatch.Stop();
+
+            if (!result.IsSuccess)
+            {
+                var errorMessage = result.ErrorMessage ?? "Batch geocoding request failed";
+                GeocodingLog.OperationFailed(_logger, "geocodeAddresses", resolvedProviderName, errorMessage, new InvalidOperationException(errorMessage));
+                return MapCoordinatorErrorToResult(context, errorMessage, "Batch geocoding service error");
+            }
+
+            var candidates = result.Data ?? [];
+            var response = new GeocodeAddressesResponse
+            {
+                SpatialReference = new GeocodeSpatialReference
+                {
+                    Wkid = outSrid,
+                    LatestWkid = outSrid
+                },
+                Locations = [.. candidates.Select(candidate => new GeocodeAddressLocation
+                {
+                    Address = candidate.Address,
+                    Score = candidate.Score,
+                    Location = new GeocodePoint
+                    {
+                        X = candidate.X,
+                        Y = candidate.Y,
+                        SpatialReference = new GeocodeSpatialReference
+                        {
+                            Wkid = outSrid,
+                            LatestWkid = outSrid
+                        }
+                    },
+                    Attributes = candidate.Attributes
+                })]
+            };
+
+            GeocodingLog.OperationCompleted(_logger, "geocodeAddresses", result.ProviderName, response.Locations.Length, stopwatch.Elapsed.TotalMilliseconds);
+
+            return Results.Json(response, GeocodingJsonContext.Default.GeocodeAddressesResponse, contentType: JsonContentType);
+        }
+        catch (Exception ex)
+        {
+            GeocodingLog.OperationFailed(_logger, "geocodeAddresses", resolvedProviderName, ex.Message, ex);
+            return StandardErrorHelpers.CreateInternalServerError(context, "Batch geocoding request failed.");
+        }
+    }
+
+    private static bool TryParseRecords(string? recordsJson, out List<string>? queries, out string? error)
+    {
+        queries = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(recordsJson))
+        {
+            error = "records parameter is required and must contain at least one address.";
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(recordsJson);
+            var root = document.RootElement;
+
+            JsonElement recordsArray;
+            if (root.ValueKind == JsonValueKind.Array)
+            {
+                recordsArray = root;
+            }
+            else if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("records", out var nested) && nested.ValueKind == JsonValueKind.Array)
+            {
+                recordsArray = nested;
+            }
+            else
+            {
+                error = "records must be a JSON array or an object with a 'records' array property.";
+                return false;
+            }
+
+            queries = new List<string>(recordsArray.GetArrayLength());
+            List<int>? invalidIndices = null;
+            var index = 0;
+            foreach (var record in recordsArray.EnumerateArray())
+            {
+                var address = ExtractAddressFromRecord(record);
+                if (!string.IsNullOrWhiteSpace(address))
+                {
+                    queries.Add(address);
+                }
+                else
+                {
+                    invalidIndices ??= [];
+                    invalidIndices.Add(index);
+                }
+
+                index++;
+            }
+
+            if (invalidIndices is { Count: > 0 })
+            {
+                queries = null;
+                error = invalidIndices.Count == 1
+                    ? $"Record at index {invalidIndices[0]} does not contain a valid address."
+                    : $"Records at indices {string.Join(", ", invalidIndices)} do not contain valid addresses.";
+                return false;
+            }
+
+            if (queries.Count == 0)
+            {
+                error = "No valid address records found in the request.";
+                return false;
+            }
+
+            return true;
+        }
+        catch (JsonException)
+        {
+            error = "records parameter contains invalid JSON.";
+            return false;
+        }
+    }
+
+    private static string? ExtractAddressFromRecord(JsonElement record)
+    {
+        if (record.ValueKind == JsonValueKind.String)
+        {
+            return record.GetString();
+        }
+
+        if (record.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        // Try attributes.SingleLine first
+        if (record.TryGetProperty("attributes", out var attributes) && attributes.ValueKind == JsonValueKind.Object)
+        {
+            if (attributes.TryGetProperty("SingleLine", out var singleLine) && singleLine.ValueKind == JsonValueKind.String)
+            {
+                var value = singleLine.GetString();
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    return value;
+                }
+            }
+
+            // Concatenate structured fields
+            var parts = new[]
+            {
+                TryGetStringProperty(attributes, "Address"),
+                TryGetStringProperty(attributes, "City"),
+                TryGetStringProperty(attributes, "Region"),
+                TryGetStringProperty(attributes, "Postal"),
+                TryGetStringProperty(attributes, "CountryCode")
+            }
+            .Where(static part => !string.IsNullOrWhiteSpace(part))
+            .Select(static part => part!.Trim());
+
+            var joined = string.Join(", ", parts);
+            if (!string.IsNullOrWhiteSpace(joined))
+            {
+                return joined;
+            }
+        }
+
+        // Try top-level address/singleLine as fallback
+        if (record.TryGetProperty("address", out var addr) && addr.ValueKind == JsonValueKind.String)
+        {
+            return addr.GetString();
+        }
+
+        if (record.TryGetProperty("singleLine", out var sl) && sl.ValueKind == JsonValueKind.String)
+        {
+            return sl.GetString();
+        }
+
+        return null;
+    }
+
+    private static string? TryGetStringProperty(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var prop) && prop.ValueKind == JsonValueKind.String
+            ? prop.GetString()
+            : null;
+    }
+
+    private static IResult MapCoordinatorErrorToResult(
+        HttpContext context,
+        string errorMessage,
+        string fallbackMessage,
+        string? notFoundMessage = null)
+    {
+        if (errorMessage.Contains("authentication", StringComparison.OrdinalIgnoreCase) ||
+            errorMessage.Contains("unauthorized", StringComparison.OrdinalIgnoreCase))
+        {
+            return StandardErrorHelpers.CreateUnauthorized(context, "Authentication failed for geocoding service");
+        }
+
+        if (errorMessage.Contains("rate limit", StringComparison.OrdinalIgnoreCase) ||
+            errorMessage.Contains("too many requests", StringComparison.OrdinalIgnoreCase))
+        {
+            return StandardErrorHelpers.CreateServiceUnavailable(context, "Rate limit exceeded");
+        }
+
+        if (errorMessage.Contains("invalid", StringComparison.OrdinalIgnoreCase) ||
+            errorMessage.Contains("bad request", StringComparison.OrdinalIgnoreCase))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, errorMessage);
+        }
+
+        if (notFoundMessage is not null &&
+            (errorMessage.Contains("no results", StringComparison.OrdinalIgnoreCase) ||
+             errorMessage.Contains("not found", StringComparison.OrdinalIgnoreCase)))
+        {
+            return StandardErrorHelpers.CreateNotFound(context, notFoundMessage);
+        }
+
+        if (errorMessage.Contains("no providers available", StringComparison.OrdinalIgnoreCase))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "No configured geocoding provider supports this operation.");
+        }
+
+        return StandardErrorHelpers.CreateInternalServerError(context, fallbackMessage);
     }
 
     private static string? NormalizeProviderName(string? providerName)

--- a/src/Honua.Server/Features/Geocoding/GeocodingJsonContext.cs
+++ b/src/Honua.Server/Features/Geocoding/GeocodingJsonContext.cs
@@ -10,6 +10,7 @@ namespace Honua.Server.Features.Geocoding;
 [JsonSerializable(typeof(FindAddressCandidatesResponse))]
 [JsonSerializable(typeof(ReverseGeocodeResponse))]
 [JsonSerializable(typeof(SuggestResponse))]
+[JsonSerializable(typeof(GeocodeAddressesResponse))]
 [JsonSerializable(typeof(GeocodeCandidateResponse[]))]
 [JsonSerializable(typeof(GeocodeSuggestionResponse[]))]
 [JsonSerializable(typeof(Dictionary<string, string?>))]

--- a/src/Honua.Server/Features/Geocoding/GeocodingLog.cs
+++ b/src/Honua.Server/Features/Geocoding/GeocodingLog.cs
@@ -35,6 +35,14 @@ internal static partial class GeocodingLog
         string provider,
         string errorMessage,
         Exception exception);
+
+    [LoggerMessage(
+        EventId = 9804,
+        Level = LogLevel.Warning,
+        Message = "Batch geocode records parse failed: {ErrorMessage}")]
+    public static partial void BatchRecordsParseFailed(
+        ILogger logger,
+        string errorMessage);
 }
 
 internal sealed class GeocodingLogCategory

--- a/src/Honua.Server/Features/Geocoding/GeocodingModels.cs
+++ b/src/Honua.Server/Features/Geocoding/GeocodingModels.cs
@@ -178,3 +178,27 @@ internal sealed record GeocodeSuggestionResponse
     [JsonPropertyName("isCollection")]
     public bool IsCollection { get; init; }
 }
+
+internal sealed record GeocodeAddressesResponse
+{
+    [JsonPropertyName("spatialReference")]
+    public required GeocodeSpatialReference SpatialReference { get; init; }
+
+    [JsonPropertyName("locations")]
+    public required GeocodeAddressLocation[] Locations { get; init; }
+}
+
+internal sealed record GeocodeAddressLocation
+{
+    [JsonPropertyName("address")]
+    public required string Address { get; init; }
+
+    [JsonPropertyName("location")]
+    public required GeocodePoint Location { get; init; }
+
+    [JsonPropertyName("score")]
+    public required double Score { get; init; }
+
+    [JsonPropertyName("attributes")]
+    public required IReadOnlyDictionary<string, string?> Attributes { get; init; }
+}

--- a/tests/Honua.Server.Tests/Features/Geocoding/GeocodingEndpointTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geocoding/GeocodingEndpointTests.cs
@@ -14,6 +14,7 @@ using CoreReverseGeocodeRequest = Honua.Core.Features.Geocoding.Domain.ReverseGe
 using CoreSuggestGeocodeRequest = Honua.Core.Features.Geocoding.Domain.SuggestGeocodeRequest;
 using CoreBatchGeocodeRequest = Honua.Core.Features.Geocoding.Domain.BatchGeocodeRequest;
 using CoreGeocodeSuggestion = Honua.Core.Features.Geocoding.Domain.GeocodeSuggestion;
+using CoreGeocodeProviderException = Honua.Core.Features.Geocoding.Domain.GeocodeProviderException;
 using Honua.Server.Features.Geocoding;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -77,7 +78,7 @@ public sealed class GeocodingEndpointTests
     [Endpoint("GET /rest/services/{locatorName}/GeocodeServer/suggest")]
     [Endpoint("POST /rest/services/{locatorName}/GeocodeServer/suggest")]
     [Endpoint("GET /rest/services/GeocodeServer/suggest")]
-    public async Task Suggest_ReturnsBadRequest_WhenProviderDoesNotSupportSuggest()
+    public async Task Suggest_ReturnsBadRequest_WhenExplicitProviderDoesNotSupportSuggest()
     {
         using var factory = CreateFactory(new FakeGeocodeProvider(new CoreGeocodeProviderCapabilities(
             SupportsSuggest: false,
@@ -86,23 +87,28 @@ public sealed class GeocodingEndpointTests
             SupportsBiasing: true)));
         using var client = factory.CreateClient();
 
-        using var response = await client.GetAsync("/rest/services/World/GeocodeServer/suggest?text=hon&f=json");
+        using var response = await client.GetAsync("/rest/services/World/GeocodeServer/suggest?text=hon&provider=fake&f=json");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("not supported", body, StringComparison.OrdinalIgnoreCase);
     }
 
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("GET /rest/services/{locatorName}/GeocodeServer/geocodeAddresses")]
     [Endpoint("POST /rest/services/{locatorName}/GeocodeServer/geocodeAddresses")]
-    public async Task BatchGeocode_ReturnsBadRequest_WhenProviderDoesNotSupportBatch()
+    public async Task BatchGeocode_ReturnsBadRequest_WhenExplicitProviderDoesNotSupportBatch()
     {
         using var factory = CreateDefaultFactory();
         using var client = factory.CreateClient();
 
-        using var response = await client.GetAsync("/rest/services/World/GeocodeServer/geocodeAddresses?f=json");
+        var records = """[{"attributes":{"SingleLine":"test address"}}]""";
+        using var response = await client.GetAsync($"/rest/services/World/GeocodeServer/geocodeAddresses?records={Uri.EscapeDataString(records)}&provider=fake&f=json");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("not supported", body, StringComparison.OrdinalIgnoreCase);
     }
 
     [IntegrationTest]
@@ -149,7 +155,69 @@ public sealed class GeocodingEndpointTests
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("GET /rest/services/{locatorName}/GeocodeServer/geocodeAddresses")]
-    public async Task BatchGeocode_WhenProviderSupports_PassesCapabilityCheck()
+    [Endpoint("GET /rest/services/GeocodeServer/geocodeAddresses")]
+    public async Task BatchGeocode_HappyPath_ReturnsLocationsArray()
+    {
+        using var factory = CreateFactory(new FakeGeocodeProvider(new CoreGeocodeProviderCapabilities(
+            SupportsSuggest: true,
+            SupportsBatch: true,
+            SupportsStructuredInput: false,
+            SupportsBiasing: true)));
+        using var client = factory.CreateClient();
+
+        var records = """[{"attributes":{"SingleLine":"1600 Pennsylvania Ave NW"}},{"attributes":{"SingleLine":"350 Fifth Avenue, New York"}}]""";
+
+        using var response = await client.GetAsync($"/rest/services/World/GeocodeServer/geocodeAddresses?records={Uri.EscapeDataString(records)}&f=json");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = payload.RootElement;
+
+        Assert.True(root.TryGetProperty("locations", out var locations));
+        Assert.Equal(JsonValueKind.Array, locations.ValueKind);
+        Assert.Equal(2, locations.GetArrayLength());
+
+        var firstLocation = locations[0];
+        Assert.Equal("1600 Pennsylvania Ave NW", firstLocation.GetProperty("address").GetString());
+        Assert.True(firstLocation.TryGetProperty("location", out _));
+        Assert.True(firstLocation.TryGetProperty("score", out _));
+        Assert.True(firstLocation.TryGetProperty("attributes", out _));
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /rest/services/{locatorName}/GeocodeServer/geocodeAddresses")]
+    public async Task BatchGeocode_Post_ReturnsLocationsArray()
+    {
+        using var factory = CreateFactory(new FakeGeocodeProvider(new CoreGeocodeProviderCapabilities(
+            SupportsSuggest: true,
+            SupportsBatch: true,
+            SupportsStructuredInput: false,
+            SupportsBiasing: true)));
+        using var client = factory.CreateClient();
+
+        var records = """[{"attributes":{"SingleLine":"1600 Pennsylvania Ave NW"}}]""";
+        var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["records"] = records,
+            ["f"] = "json"
+        });
+
+        using var response = await client.PostAsync("/rest/services/World/GeocodeServer/geocodeAddresses", content);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.True(payload.RootElement.TryGetProperty("locations", out var locations));
+        Assert.Equal(1, locations.GetArrayLength());
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{locatorName}/GeocodeServer/geocodeAddresses")]
+    public async Task BatchGeocode_MissingRecords_Returns400()
     {
         using var factory = CreateFactory(new FakeGeocodeProvider(new CoreGeocodeProviderCapabilities(
             SupportsSuggest: true,
@@ -160,11 +228,69 @@ public sealed class GeocodingEndpointTests
 
         using var response = await client.GetAsync("/rest/services/World/GeocodeServer/geocodeAddresses?f=json");
 
-        // Batch geocode parsing is not yet available — but the capability check passes
-        // (unlike unsupported case which returns "not supported by the configured geocode provider")
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{locatorName}/GeocodeServer/geocodeAddresses")]
+    public async Task BatchGeocode_MalformedRecordsJson_Returns400()
+    {
+        using var factory = CreateFactory(new FakeGeocodeProvider(new CoreGeocodeProviderCapabilities(
+            SupportsSuggest: true,
+            SupportsBatch: true,
+            SupportsStructuredInput: false,
+            SupportsBiasing: true)));
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/rest/services/World/GeocodeServer/geocodeAddresses?records=not-valid-json&f=json");
+
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        Assert.DoesNotContain("not supported by the configured geocode provider", body, StringComparison.Ordinal);
+        Assert.Contains("invalid JSON", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{locatorName}/GeocodeServer/geocodeAddresses")]
+    public async Task BatchGeocode_ExceedsMaxBatchSize_Returns400()
+    {
+        using var factory = CreateFactory(new FakeGeocodeProvider(new CoreGeocodeProviderCapabilities(
+            SupportsSuggest: true,
+            SupportsBatch: true,
+            SupportsStructuredInput: false,
+            SupportsBiasing: true)
+        { MaxBatchSize = 2 }));
+        using var client = factory.CreateClient();
+
+        var records = """[{"attributes":{"SingleLine":"addr1"}},{"attributes":{"SingleLine":"addr2"}},{"attributes":{"SingleLine":"addr3"}}]""";
+
+        using var response = await client.GetAsync($"/rest/services/World/GeocodeServer/geocodeAddresses?records={Uri.EscapeDataString(records)}&provider=fake&f=json");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("exceeds the maximum", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{locatorName}/GeocodeServer/geocodeAddresses")]
+    public async Task BatchGeocode_InvalidRecordInBatch_Returns400WithIndex()
+    {
+        using var factory = CreateFactory(new FakeGeocodeProvider(new CoreGeocodeProviderCapabilities(
+            SupportsSuggest: true,
+            SupportsBatch: true,
+            SupportsStructuredInput: false,
+            SupportsBiasing: true)));
+        using var client = factory.CreateClient();
+
+        var records = """[{"attributes":{"SingleLine":"valid address"}},{"attributes":{}},{"attributes":{"SingleLine":"another valid"}}]""";
+
+        using var response = await client.GetAsync($"/rest/services/World/GeocodeServer/geocodeAddresses?records={Uri.EscapeDataString(records)}&f=json");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("index 1", body, StringComparison.OrdinalIgnoreCase);
     }
 
     [IntegrationTest]
@@ -289,6 +415,116 @@ public sealed class GeocodingEndpointTests
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{locatorName}/GeocodeServer/findAddressCandidates")]
+    public async Task ForwardGeocode_ReturnsBadRequest_WhenExplicitProviderNotFound()
+    {
+        using var factory = CreateDefaultFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/rest/services/World/GeocodeServer/findAddressCandidates?singleLine=test&provider=nonexistent&f=json");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("not found", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{locatorName}/GeocodeServer/reverseGeocode")]
+    public async Task ReverseGeocode_ReturnsBadRequest_WhenExplicitProviderNotFound()
+    {
+        using var factory = CreateDefaultFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/rest/services/World/GeocodeServer/reverseGeocode?location=-77.03,38.89&provider=nonexistent&f=json");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("not found", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{locatorName}/GeocodeServer/findAddressCandidates")]
+    public async Task ForwardGeocode_PrimaryFails_FallsBackToSecondary()
+    {
+        using var factory = CreateFailoverFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/rest/services/World/GeocodeServer/findAddressCandidates?singleLine=test+address&f=json");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var candidates = payload.RootElement.GetProperty("candidates");
+        Assert.True(candidates.GetArrayLength() > 0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{locatorName}/GeocodeServer/geocodeAddresses")]
+    public async Task BatchGeocode_PrimaryFails_FallsBackToSecondary()
+    {
+        using var factory = CreateFailoverFactory();
+        using var client = factory.CreateClient();
+
+        var records = """[{"attributes":{"SingleLine":"1600 Pennsylvania Ave NW"}}]""";
+
+        using var response = await client.GetAsync($"/rest/services/World/GeocodeServer/geocodeAddresses?records={Uri.EscapeDataString(records)}&f=json");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var locations = payload.RootElement.GetProperty("locations");
+        Assert.Equal(1, locations.GetArrayLength());
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{locatorName}/GeocodeServer/findAddressCandidates")]
+    public async Task ForwardGeocode_AllProvidersFail_ReturnsError()
+    {
+        var failingProvider = new FailingGeocodeProvider("only-failing");
+        // Override all auto-registered providers to ensure all providers fail
+        var nominatimOverride = new FailingGeocodeProvider("nominatim");
+        var azureOverride = new FailingGeocodeProvider("azuremaps");
+        var amazonOverride = new FailingGeocodeProvider("amazonlocation");
+        using var factory = new TestWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Geocoding:Enabled"] = "true",
+                    ["Geocoding:DefaultProvider"] = failingProvider.Name,
+                    ["Geocoding:LocatorName"] = "World",
+                    ["Geocoding:DefaultSpatialReferenceWkid"] = "4326",
+                    ["Geocoding:EnableFailover"] = "true",
+                    ["Geocoding:MaxFailoverAttempts"] = "10"
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                services.AddGeocodeProvider(failingProvider.Name, _ => failingProvider, ServiceLifetime.Singleton);
+                services.AddGeocodeProvider(nominatimOverride.Name, _ => nominatimOverride, ServiceLifetime.Singleton);
+                services.AddGeocodeProvider(azureOverride.Name, _ => azureOverride, ServiceLifetime.Singleton);
+                services.AddGeocodeProvider(amazonOverride.Name, _ => amazonOverride, ServiceLifetime.Singleton);
+            });
+        });
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/rest/services/World/GeocodeServer/findAddressCandidates?singleLine=test&f=json");
+
+        // The coordinator catches the exception and returns a failure result; handler maps to error
+        Assert.True(
+            response.StatusCode == HttpStatusCode.InternalServerError ||
+            response.StatusCode == HttpStatusCode.BadRequest,
+            $"Expected error status code but got {response.StatusCode}");
+    }
+
     private static readonly CoreGeocodeProviderCapabilities DefaultCapabilities = new(
         SupportsSuggest: true,
         SupportsBatch: false,
@@ -316,6 +552,39 @@ public sealed class GeocodingEndpointTests
             builder.ConfigureServices(services =>
             {
                 services.AddGeocodeProvider(fakeProvider.Name, _ => fakeProvider, ServiceLifetime.Singleton);
+            });
+        });
+    }
+
+    private static WebApplicationFactory<Program> CreateFailoverFactory()
+    {
+        var failingProvider = new FailingGeocodeProvider("failing-primary");
+        var workingProvider = new FakeGeocodeProvider(new CoreGeocodeProviderCapabilities(
+            SupportsSuggest: true,
+            SupportsBatch: true,
+            SupportsStructuredInput: false,
+            SupportsBiasing: true));
+
+        return new TestWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Geocoding:Enabled"] = "true",
+                    ["Geocoding:DefaultProvider"] = failingProvider.Name,
+                    ["Geocoding:LocatorName"] = "World",
+                    ["Geocoding:DefaultSpatialReferenceWkid"] = "4326",
+                    ["Geocoding:EnableFailover"] = "true",
+                    // High enough to exhaust all auto-registered providers before reaching fake
+                    ["Geocoding:MaxFailoverAttempts"] = "10"
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                services.AddGeocodeProvider(failingProvider.Name, _ => failingProvider, ServiceLifetime.Singleton);
+                services.AddGeocodeProvider(workingProvider.Name, _ => workingProvider, ServiceLifetime.Singleton);
             });
         });
     }
@@ -366,9 +635,55 @@ public sealed class GeocodingEndpointTests
         }
 
         public Task<IReadOnlyList<CoreGeocodeCandidate>> BatchGeocodeAsync(CoreBatchGeocodeRequest request, CancellationToken cancellationToken)
-            => Task.FromResult<IReadOnlyList<CoreGeocodeCandidate>>([]);
+        {
+            var results = new List<CoreGeocodeCandidate>();
+            for (int i = 0; i < request.Queries.Count; i++)
+            {
+                results.Add(new CoreGeocodeCandidate(
+                    Address: request.Queries[i],
+                    X: -77.03655 + i,
+                    Y: 38.89768 + i,
+                    Score: 95.0,
+                    Attributes: new Dictionary<string, string?>(StringComparer.Ordinal)
+                    {
+                        ["Provider"] = Name,
+                        ["Match_addr"] = request.Queries[i]
+                    },
+                    ProviderId: $"fake-batch-{i}"));
+            }
+
+            return Task.FromResult<IReadOnlyList<CoreGeocodeCandidate>>(results);
+        }
 
         public Task<CoreGeocodeProviderHealth> CheckHealthAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(new CoreGeocodeProviderHealth(Name, true));
+    }
+
+    private sealed class FailingGeocodeProvider(string name) : CoreGeocodeProvider
+    {
+        private static readonly CoreGeocodeProviderCapabilities FailingCapabilities = new(
+            SupportsSuggest: true,
+            SupportsBatch: true,
+            SupportsStructuredInput: false,
+            SupportsBiasing: true);
+
+        public string Name => name;
+
+        public CoreGeocodeProviderCapabilities Capabilities => FailingCapabilities;
+
+        public Task<IReadOnlyList<CoreGeocodeCandidate>> ForwardGeocodeAsync(CoreForwardGeocodeRequest request, CancellationToken cancellationToken)
+            => throw new CoreGeocodeProviderException("Provider unavailable");
+
+        public Task<CoreReverseGeocodeMatch?> ReverseGeocodeAsync(CoreReverseGeocodeRequest request, CancellationToken cancellationToken)
+            => throw new CoreGeocodeProviderException("Provider unavailable");
+
+        public Task<IReadOnlyList<CoreGeocodeSuggestion>> SuggestAsync(CoreSuggestGeocodeRequest request, CancellationToken cancellationToken)
+            => throw new CoreGeocodeProviderException("Provider unavailable");
+
+        public Task<IReadOnlyList<CoreGeocodeCandidate>> BatchGeocodeAsync(CoreBatchGeocodeRequest request, CancellationToken cancellationToken)
+            => throw new CoreGeocodeProviderException("Provider unavailable");
+
+        public Task<CoreGeocodeProviderHealth> CheckHealthAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new CoreGeocodeProviderHealth(Name, false));
     }
 }


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #414
## Summary

Geocoding Beta expansion: batch + autocomplete/suggest + provider fallback chain
## Changes Made

- Geocoding Beta expansion: batch + autocomplete/suggest + provider fallback chain
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally

## Additional Context

Decisions:
- Used `_providerRegistry.GetProvider(resolvedProviderName)` inline rather than storing in a local variable, since forward/reverse handlers don't need the provider object for capability checks — just the existence check.

Follow-ons:
None.

Code kaizen:
Deferred low-severity cleanup follow-ons from local review:
- Error classification block duplicated 4x across handlers (src/honua.server/features/geocoding/geocodinghandler.cs:540): Extract to a private helper method like MapCoordinatorErrorToResult(HttpContext, string errorMessage, string operationName).
- Missing trailing newline at end of file (docs/geocoding_providers_architecture.md:227): Add trailing newline.
