### PR TITLE
[codex] Speed up geoservices query formatting and projected raster point queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ Honua's admin UI and admin API are intended to become the foundation of a Honua-
 - Change management, deploy coordination, and instance lifecycle workflows are expected to live in the Honua control plane.
 - The public admin API is the substrate for those workflows; operator-grade AI DevOps/copilot tooling may be delivered through private enterprise surfaces on top of it rather than through the open-core server repository.
 
+## Recent Benchmark Snapshot
+
+Recent GeoBench runs on the 100K-point dataset show Honua ahead of GeoServer on throughput across the tracked comparative suites in the current full-suite snapshot.
+
+- WMS reprojection improved from `10.3 -> 27.8 req/s` on medium bboxes and `4.0 -> 29.2 req/s` on large bboxes after replacing per-point Web Mercator `ST_Transform` work with an inline projected-point fast path.
+- Concurrent mixed-workload throughput on the current image measured `43.8 / 191.9 / 203.8 / 191.3 req/s` at `1 / 10 / 50 / 100` VUs.
+- GeoServices `FeatureServer/query` measured `489.5 / 212.4 / 74.0 req/s` on small, medium, and large bbox scenarios.
+
+See [Benchmark Results](docs/operator/BENCHMARK_RESULTS.md) for methodology and comparative tracks.
+
 ## Documentation
 
 Full documentation: **[honua.gitbook.io/honuaio](https://honua.gitbook.io/honuaio/)**

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Build.cs
@@ -20,6 +20,9 @@ namespace Honua.Postgres.Features.FeatureStore.Services;
 /// </summary>
 internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
 {
+    private const double WebMercatorEarthRadius = 6378137d;
+    private const double WebMercatorMaxLatitude = 85.05112878d;
+
     private readonly ObjectPool<StringBuilder> _stringBuilderPool;
     private readonly IGeometryProcessor _geometryProcessor;
     private readonly string _tableName;
@@ -56,8 +59,15 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
             var paramIndex = 2;
             var parameters = new List<object>();
             var pointGeometry = _geometryProcessor.GetGeometryOperand(geometryStorageType, layerSrid: query.SpatialReferenceSrid);
+            var pointXExpression = "ST_X(point_geom)";
+            var pointYExpression = "ST_Y(point_geom)";
 
-            if (query.OutputSrid.HasValue &&
+            if (ShouldUseFastWebMercatorProjection(query))
+            {
+                pointXExpression = BuildWebMercatorXExpression("point_geom");
+                pointYExpression = BuildWebMercatorYExpression("point_geom");
+            }
+            else if (query.OutputSrid.HasValue &&
                 (!query.SpatialReferenceSrid.HasValue || query.OutputSrid.Value != query.SpatialReferenceSrid.Value))
             {
                 pointGeometry = $"ST_Transform({pointGeometry}, {query.OutputSrid.Value})";
@@ -81,7 +91,11 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
                 AppendSpatialFilter(sql, query, geometryStorageType, ref paramIndex, parameters);
                 sql.Append("), projected_points AS (SELECT ")
                     .Append(DatabaseSchema.ObjectIdColumn)
-                    .Append(", ST_X(point_geom) AS x, ST_Y(point_geom) AS y FROM point_source), snapped_points AS (SELECT ")
+                    .Append(", ")
+                    .Append(pointXExpression)
+                    .Append(" AS x, ")
+                    .Append(pointYExpression)
+                    .Append(" AS y FROM point_source), snapped_points AS (SELECT ")
                     .Append(DatabaseSchema.ObjectIdColumn)
                     .Append(", x, y, ");
                 sql.Append(CultureInfo.InvariantCulture, $"FLOOR((x - ${originXParam}) / ${cellWidthParam})::bigint AS cell_x, ");
@@ -95,7 +109,11 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
                 AppendWhereClause(sql, query, ref paramIndex, parameters);
                 AppendTemporalFilter(sql, query, ref paramIndex, parameters);
                 AppendSpatialFilter(sql, query, geometryStorageType, ref paramIndex, parameters);
-                sql.Append(") SELECT ST_X(point_geom) AS x, ST_Y(point_geom) AS y FROM point_source ORDER BY objectid");
+                sql.Append(") SELECT ")
+                    .Append(pointXExpression)
+                    .Append(" AS x, ")
+                    .Append(pointYExpression)
+                    .Append(" AS y FROM point_source ORDER BY objectid");
             }
 
             if (query.Limit.HasValue)
@@ -109,6 +127,30 @@ internal sealed partial class FeatureQueryBuilder : IFeatureQueryBuilder
         {
             _stringBuilderPool.Return(sql);
         }
+    }
+
+    private static bool ShouldUseFastWebMercatorProjection(FeatureQuery query)
+        => query.SpatialReferenceSrid == 4326 &&
+           query.OutputSrid.HasValue &&
+           IsWebMercatorSrid(query.OutputSrid.Value);
+
+    private static bool IsWebMercatorSrid(int srid)
+        => srid is 3857 or 900913 or 102100 or 102113 or 3785;
+
+    // Raster point queries are point-only call sites, so inline the same 4326->3857
+    // math Honua uses in-process and avoid per-row PostGIS ST_Transform overhead.
+    private static string BuildWebMercatorXExpression(string geometryExpression)
+        => FormattableString.Invariant(
+            $"(ST_X({geometryExpression}) * PI() / 180.0 * {WebMercatorEarthRadius.ToString(CultureInfo.InvariantCulture)})");
+
+    private static string BuildWebMercatorYExpression(string geometryExpression)
+    {
+        var minLatitude = (-WebMercatorMaxLatitude).ToString(CultureInfo.InvariantCulture);
+        var maxLatitude = WebMercatorMaxLatitude.ToString(CultureInfo.InvariantCulture);
+        var clampedLatitude = FormattableString.Invariant(
+            $"LEAST(GREATEST(ST_Y({geometryExpression}), {minLatitude}), {maxLatitude})");
+        return FormattableString.Invariant(
+            $"(LN(TAN((90.0 + {clampedLatitude}) * PI() / 360.0)) * {WebMercatorEarthRadius.ToString(CultureInfo.InvariantCulture)})");
     }
 
     public CoreParameterizedQuery BuildSelectGmlQuery(

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoServicesGeometryConverter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoServicesGeometryConverter.cs
@@ -679,6 +679,8 @@ internal static class GeoServicesGeometryConverter
             ? new GeoServicesSpatialReference { Wkid = srid.Value, LatestWkid = srid.Value }
             : null;
 
+    private static bool? NormalizeDimensionFlag(bool value) => value ? true : null;
+
     private static int ReadInt32(ReadOnlySpan<byte> span, bool littleEndian)
         => littleEndian
             ? BinaryPrimitives.ReadInt32LittleEndian(span)

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoServicesGeometryConverter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoServicesGeometryConverter.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Buffers.Binary;
+using System.Text.Json;
 using Honua.Server.Features.FeatureServer.Models;
 using Honua.Server.Features.Infrastructure.Services;
 using NetTopologySuite;
@@ -15,6 +17,13 @@ namespace Honua.Server.Features.FeatureServer.Services;
 /// </summary>
 internal static class GeoServicesGeometryConverter
 {
+    private readonly record struct FastPointGeometry(
+        double X,
+        double Y,
+        double? Z,
+        double? M,
+        bool HasZ,
+        bool HasM);
 
     /// <summary>
     /// Converts WKB geometry to GeoServices format.
@@ -26,6 +35,11 @@ internal static class GeoServicesGeometryConverter
         bool includeZ = true,
         bool includeM = true)
     {
+        if (TryConvertFastPointWkb(wkbGeometry, srid, geometryLimits, includeZ, includeM, out var fastGeometry))
+        {
+            return fastGeometry;
+        }
+
         if (wkbGeometry == null || wkbGeometry.Length == 0)
             return null;
 
@@ -66,6 +80,23 @@ internal static class GeoServicesGeometryConverter
             : null;
 
         return ConvertGeometryToGeoServicesGeometry(geometry, spatialReference);
+    }
+
+    internal static bool TryWriteWkbAsGeoServicesGeometry(
+        Utf8JsonWriter writer,
+        byte[]? wkbGeometry,
+        int? srid = null,
+        Honua.Core.Configuration.GeometryLimits? geometryLimits = null,
+        bool includeZ = true,
+        bool includeM = true)
+    {
+        if (!TryReadFastPointGeometry(wkbGeometry, geometryLimits, includeZ, includeM, out var point))
+        {
+            return false;
+        }
+
+        WritePointGeometry(writer, point, srid);
+        return true;
     }
 
     /// <summary>
@@ -444,6 +475,222 @@ internal static class GeoServicesGeometryConverter
             SpatialReference = spatialReference
         };
     }
+
+    private static bool TryConvertFastPointWkb(
+        byte[]? wkbGeometry,
+        int? srid,
+        Honua.Core.Configuration.GeometryLimits? geometryLimits,
+        bool includeZ,
+        bool includeM,
+        out GeoServicesGeometry? geometry)
+    {
+        geometry = null;
+        if (!TryReadFastPointGeometry(wkbGeometry, geometryLimits, includeZ, includeM, out var point))
+        {
+            return false;
+        }
+
+        geometry = new GeoServicesGeometry
+        {
+            HasZ = NormalizeDimensionFlag(point.HasZ),
+            HasM = NormalizeDimensionFlag(point.HasM),
+            X = point.X,
+            Y = point.Y,
+            Z = point.Z,
+            M = point.M,
+            SpatialReference = CreateSpatialReference(srid)
+        };
+        return true;
+    }
+
+    private static bool TryReadFastPointGeometry(
+        byte[]? wkbGeometry,
+        Honua.Core.Configuration.GeometryLimits? geometryLimits,
+        bool includeZ,
+        bool includeM,
+        out FastPointGeometry point)
+    {
+        point = default;
+
+        if (wkbGeometry is null || wkbGeometry.Length < 1 + 4 + 16)
+        {
+            return false;
+        }
+
+        var span = wkbGeometry.AsSpan();
+        var byteOrder = span[0];
+        if (byteOrder is not 0 and not 1)
+        {
+            return false;
+        }
+
+        var littleEndian = byteOrder == 1;
+        var rawType = ReadInt32(span.Slice(1, 4), littleEndian);
+
+        var hasSrid = (rawType & 0x20000000) != 0;
+        var hasZ = (rawType & unchecked((int)0x80000000)) != 0;
+        var hasM = (rawType & 0x40000000) != 0;
+
+        var geometryType = rawType & 0xFFFF;
+        if (geometryType >= 3000 && geometryType < 4000)
+        {
+            hasZ = true;
+            hasM = true;
+            geometryType -= 3000;
+        }
+        else if (geometryType >= 2000 && geometryType < 3000)
+        {
+            hasM = true;
+            geometryType -= 2000;
+        }
+        else if (geometryType >= 1000 && geometryType < 2000)
+        {
+            hasZ = true;
+            geometryType -= 1000;
+        }
+
+        if (geometryType != 1)
+        {
+            return false;
+        }
+
+        var offset = 5;
+        if (hasSrid)
+        {
+            if (span.Length < offset + 4)
+            {
+                return false;
+            }
+
+            offset += 4;
+        }
+
+        var dimensions = 2 + (hasZ ? 1 : 0) + (hasM ? 1 : 0);
+        if (span.Length < offset + dimensions * 8)
+        {
+            return false;
+        }
+
+        var x = ReadDouble(span.Slice(offset, 8), littleEndian);
+        var y = ReadDouble(span.Slice(offset + 8, 8), littleEndian);
+        offset += 16;
+
+        if (double.IsNaN(x) || double.IsNaN(y))
+        {
+            return false;
+        }
+
+        double? z = null;
+        if (hasZ)
+        {
+            var zValue = ReadDouble(span.Slice(offset, 8), littleEndian);
+            offset += 8;
+            if (!double.IsNaN(zValue))
+            {
+                z = zValue;
+            }
+        }
+
+        double? m = null;
+        if (hasM)
+        {
+            var mValue = ReadDouble(span.Slice(offset, 8), littleEndian);
+            if (!double.IsNaN(mValue))
+            {
+                m = mValue;
+            }
+        }
+
+        if (!includeZ)
+        {
+            z = null;
+        }
+
+        if (!includeM)
+        {
+            m = null;
+        }
+
+        if (geometryLimits?.MaxCoordinatePrecision is >= 0 and var precision)
+        {
+            x = RoundCoordinate(x, precision);
+            y = RoundCoordinate(y, precision);
+            if (z.HasValue)
+            {
+                z = RoundCoordinate(z.Value, precision);
+            }
+
+            if (m.HasValue)
+            {
+                m = RoundCoordinate(m.Value, precision);
+            }
+        }
+
+        point = new FastPointGeometry(
+            x,
+            y,
+            z,
+            m,
+            z.HasValue,
+            m.HasValue);
+        return true;
+    }
+
+    private static void WritePointGeometry(Utf8JsonWriter writer, FastPointGeometry point, int? srid)
+    {
+        writer.WriteStartObject();
+
+        if (point.HasZ)
+        {
+            writer.WriteBoolean("hasZ", true);
+        }
+
+        if (point.HasM)
+        {
+            writer.WriteBoolean("hasM", true);
+        }
+
+        writer.WriteNumber("x", point.X);
+        writer.WriteNumber("y", point.Y);
+
+        if (point.Z.HasValue)
+        {
+            writer.WriteNumber("z", point.Z.Value);
+        }
+
+        if (point.M.HasValue)
+        {
+            writer.WriteNumber("m", point.M.Value);
+        }
+
+        if (CreateSpatialReference(srid) is { } spatialReference)
+        {
+            writer.WriteStartObject("spatialReference");
+            writer.WriteNumber("wkid", spatialReference.Wkid!.Value);
+            writer.WriteNumber("latestWkid", (spatialReference.LatestWkid ?? spatialReference.Wkid)!.Value);
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static GeoServicesSpatialReference? CreateSpatialReference(int? srid)
+        => srid.HasValue && srid.Value > 0
+            ? new GeoServicesSpatialReference { Wkid = srid.Value, LatestWkid = srid.Value }
+            : null;
+
+    private static int ReadInt32(ReadOnlySpan<byte> span, bool littleEndian)
+        => littleEndian
+            ? BinaryPrimitives.ReadInt32LittleEndian(span)
+            : BinaryPrimitives.ReadInt32BigEndian(span);
+
+    private static double ReadDouble(ReadOnlySpan<byte> span, bool littleEndian)
+        => littleEndian
+            ? BinaryPrimitives.ReadDoubleLittleEndian(span)
+            : BinaryPrimitives.ReadDoubleBigEndian(span);
+
+    private static double RoundCoordinate(double value, int precision)
+        => Math.Round(value, Math.Clamp(precision, 0, 15), MidpointRounding.AwayFromZero);
 
     private static GeoServicesGeometry ConvertMultiPoint(MultiPoint multiPoint, GeoServicesSpatialReference? spatialReference)
     {

--- a/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
@@ -261,7 +261,7 @@ internal sealed class QueryFormatter : IQueryFormatter
             Geometry = returnGeometry
                 ? GeoServicesGeometryConverter.ConvertWkbToGeoServicesGeometry(
                     feature.Geometry,
-                    outputSrid,
+                    srid: null,
                     geometryLimits,
                     returnZ,
                     returnM)
@@ -721,7 +721,7 @@ internal sealed class StreamingQueryFormatter
 
         await foreach (var feature in features.WithCancellation(cancellationToken))
         {
-            await WriteGeoServicesFeatureAsync(
+            WriteGeoServicesFeature(
                 writer,
                 feature,
                 returnGeometry,
@@ -796,7 +796,7 @@ internal sealed class StreamingQueryFormatter
 
         await foreach (var feature in features.WithCancellation(cancellationToken))
         {
-            await WriteGeoJsonFeatureAsync(
+            WriteGeoJsonFeature(
                 writer,
                 feature,
                 layer,
@@ -834,7 +834,7 @@ internal sealed class StreamingQueryFormatter
     /// <summary>
     /// Writes a single feature in GeoServices format
     /// </summary>
-    private static async Task WriteGeoServicesFeatureAsync(
+    private static void WriteGeoServicesFeature(
         Utf8JsonWriter writer,
         Feature feature,
         bool returnGeometry,
@@ -870,7 +870,7 @@ internal sealed class StreamingQueryFormatter
                     objectIdWritten = true;
                 }
 
-                await WriteJsonValueAsync(writer, fieldName, kvp.Value, cancellationToken);
+                WriteJsonValue(writer, fieldName, kvp.Value, cancellationToken);
             }
         }
 
@@ -889,11 +889,17 @@ internal sealed class StreamingQueryFormatter
             {
                 writer.WriteNullValue();
             }
-            else
+            else if (!GeoServicesGeometryConverter.TryWriteWkbAsGeoServicesGeometry(
+                         writer,
+                         feature.Geometry,
+                         srid: null,
+                         geometryLimits,
+                         returnZ,
+                         returnM))
             {
                 var geoServicesGeometry = GeoServicesGeometryConverter.ConvertWkbToGeoServicesGeometry(
                     feature.Geometry,
-                    outputSrid,
+                    srid: null,
                     geometryLimits,
                     returnZ,
                     returnM);
@@ -907,7 +913,7 @@ internal sealed class StreamingQueryFormatter
     /// <summary>
     /// Writes a single feature in GeoJSON format
     /// </summary>
-    private static async Task WriteGeoJsonFeatureAsync(
+    private static void WriteGeoJsonFeature(
         Utf8JsonWriter writer,
         Feature feature,
         LayerDefinition layer,
@@ -952,7 +958,7 @@ internal sealed class StreamingQueryFormatter
         writer.WriteStartObject("properties");
         foreach (var kvp in featureBase.Properties)
         {
-            await WriteJsonValueAsync(writer, kvp.Key, kvp.Value, cancellationToken);
+            WriteJsonValue(writer, kvp.Key, kvp.Value, cancellationToken);
         }
 
         writer.WriteEndObject(); // End properties
@@ -972,7 +978,7 @@ internal sealed class StreamingQueryFormatter
     /// <summary>
     /// Writes a JSON value with proper type handling
     /// </summary>
-    private static async Task WriteJsonValueAsync(
+    private static void WriteJsonValue(
         Utf8JsonWriter writer,
         string propertyName,
         object? value,
@@ -1019,10 +1025,7 @@ internal sealed class StreamingQueryFormatter
         }
 
         // Allow for cancellation during long attribute writing
-        if (cancellationToken.IsCancellationRequested)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-        }
+        cancellationToken.ThrowIfCancellationRequested();
     }
 
     /// <summary>

--- a/tests/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderProjectedPointTests.cs
+++ b/tests/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderProjectedPointTests.cs
@@ -40,6 +40,32 @@ public sealed class FeatureQueryBuilderProjectedPointTests
     }
 
     [Fact]
+    public void BuildProjectedPointQuery_WithRasterGridAndWebMercatorOutput_UsesInlineProjectionFormula()
+    {
+        var queryBuilder = CreateQueryBuilder();
+        var query = new FeatureQuery
+        {
+            SpatialReferenceSrid = 4326,
+            OutputSrid = 3857,
+            Limit = 10,
+            RasterPointGrid = new RasterPointGrid
+            {
+                OriginX = -20037508.342789244,
+                OriginY = 20037508.342789244,
+                CellWidth = 512d,
+                CellHeight = 512d
+            }
+        };
+
+        var result = queryBuilder.BuildProjectedPointQuery(layerId: 1, query);
+
+        result.Sql.Should().Contain("ST_X(point_geom) * PI() / 180.0 * 6378137");
+        result.Sql.Should().Contain("LEAST(GREATEST(ST_Y(point_geom), -85.05112878), 85.05112878)");
+        result.Sql.Should().NotContain("ST_Transform(geometry, 3857)");
+        result.WhereParameters.Should().Equal(-20037508.342789244d, 512d, 20037508.342789244d, 512d);
+    }
+
+    [Fact]
     public void BuildProjectedPointQuery_WithoutRasterGrid_SelectsProjectedCoordinates()
     {
         var queryBuilder = CreateQueryBuilder();

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
@@ -275,7 +275,7 @@ public sealed class FeatureServerQueryExecutorTests
     }
 
     [Fact]
-    public async Task StreamQueryAsync_WithOutputSrid_SetsFeatureGeometrySpatialReference()
+    public async Task StreamQueryAsync_WithOutputSrid_SetsTopLevelSpatialReferenceOnly()
     {
         var featureReader = Substitute.For<IFeatureReader>();
         var streamingStore = Substitute.For<IStreamingFeatureStore>();
@@ -299,10 +299,50 @@ public sealed class FeatureServerQueryExecutorTests
 
         var json = await ReadResponseAsync(context);
         using var document = JsonDocument.Parse(json);
+        document.RootElement
+            .GetProperty("spatialReference")
+            .GetProperty("wkid")
+            .GetInt32()
+            .Should()
+            .Be(3857);
+        document.RootElement
+            .GetProperty("features")[0]
+            .GetProperty("geometry")
+            .TryGetProperty("spatialReference", out _)
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public async Task StreamQueryAsync_WithPointGeometryPrecision_RoundsCoordinates()
+    {
+        var featureReader = Substitute.For<IFeatureReader>();
+        var streamingStore = Substitute.For<IStreamingFeatureStore>();
+        streamingStore.StreamFeaturesAsync(7, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(_ => (IAsyncEnumerable<Feature>)StreamFeatures(
+            [
+                CreateFeature(1, "alpha", CreatePointGeometry(1.1234567, 2.7654321, 4326))
+            ]));
+
+        var sut = CreateSut(featureReader, streamingStore);
+        var context = CreateHttpContext();
+
+        await sut.StreamQueryAsync(
+            7,
+            new FeatureQuery { Limit = 1 },
+            CreatePointLayer(),
+            new QueryParameters { F = "json", ReturnGeometry = true, GeometryPrecision = 2 },
+            outputSrid: 4326,
+            context,
+            CancellationToken.None);
+
+        var json = await ReadResponseAsync(context);
+        using var document = JsonDocument.Parse(json);
         var geometry = document.RootElement
             .GetProperty("features")[0]
             .GetProperty("geometry");
-        geometry.GetProperty("spatialReference").GetProperty("wkid").GetInt32().Should().Be(3857);
+        geometry.GetProperty("x").GetDouble().Should().Be(1.12);
+        geometry.GetProperty("y").GetDouble().Should().Be(2.77);
     }
 
     [Fact]

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/QueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/QueryFormatterTests.cs
@@ -262,6 +262,18 @@ public sealed class QueryFormatterTests
                 new FieldDefinition("name", FieldType.String, Length: 128)
             ]);
 
+    private static LayerDefinition CreateIdBackedPointLayer()
+        => new(
+            8,
+            "id-backed-test-layer",
+            null,
+            Honua.Core.Features.Catalog.Domain.GeometryType.Point,
+            SpatialReference.WGS84,
+            [
+                new FieldDefinition("id", FieldType.Integer, Nullable: false),
+                new FieldDefinition("name", FieldType.String, Length: 128)
+            ]);
+
     private static byte[] CreatePointGeometry(double x, double y, int srid)
     {
         var writer = new WKBWriter();

--- a/tests/Honua.Server.Tests/Features/FeatureServer/Services/QueryFormatterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/Services/QueryFormatterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Text.Json;
 using FluentAssertions;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Catalog.Domain;
@@ -19,7 +20,7 @@ namespace Honua.Server.Tests.Features.FeatureServer.Services;
 public sealed class QueryFormatterTests
 {
     [Fact]
-    public async Task FormatQueryResultAsync_WithOutputSrid_SetsFeatureGeometrySpatialReference()
+    public async Task FormatQueryResultAsync_WithOutputSrid_SetsTopLevelSpatialReferenceOnly()
     {
         var limitsOptions = Options.Create(new LimitsOptions());
         var formatter = new QueryFormatter(
@@ -51,7 +52,7 @@ public sealed class QueryFormatterTests
         var queryResponse = response.Should().BeOfType<QueryResponse>().Subject;
         queryResponse.SpatialReference?.Wkid.Should().Be(3857);
         queryResponse.Features.Should().HaveCount(1);
-        queryResponse.Features[0].Geometry?.SpatialReference?.Wkid.Should().Be(3857);
+        queryResponse.Features[0].Geometry?.SpatialReference.Should().BeNull();
     }
 
     [Fact]
@@ -129,6 +130,124 @@ public sealed class QueryFormatterTests
         geoJson.Features[0].Properties.Should().Contain("objectid", 42L);
         geoJson.Features[0].Properties.Should().Contain("OBJECTID", 42L);
         geoJson.Features[0].Properties.Should().Contain("name", "alpha");
+    }
+
+    [Fact]
+    public async Task FormatQueryResultAsync_WithJson_OmitsNullExtentAndFalseDimensionFlags()
+    {
+        var limitsOptions = Options.Create(new LimitsOptions());
+        var formatter = new QueryFormatter(
+            limitsOptions,
+            new PbfQueryFormatter(limitsOptions),
+            NullLogger<QueryFormatter>.Instance);
+
+        var result = QueryResult<Feature>.Create(
+            1,
+            [
+                Feature.Create(
+                    1,
+                    CreatePointGeometry(1, 2, 4326),
+                    ImmutableDictionary<string, object?>.Empty.Add("name", "alpha"))
+            ]);
+
+        var (response, contentType) = await formatter.FormatQueryResultAsync(
+            result,
+            CreatePointLayer(),
+            format: "json",
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: true,
+            returnM: true,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        contentType.Should().Be("application/json");
+
+        var json = JsonSerializer.Serialize(
+            response,
+            FeatureServerJsonContext.Default.QueryResponse);
+
+        using var document = JsonDocument.Parse(json);
+        document.RootElement.TryGetProperty("extent", out _).Should().BeFalse();
+        document.RootElement.TryGetProperty("hasZ", out _).Should().BeFalse();
+        document.RootElement.TryGetProperty("hasM", out _).Should().BeFalse();
+        var geometry = document.RootElement.GetProperty("features")[0].GetProperty("geometry");
+        geometry.TryGetProperty("hasZ", out _).Should().BeFalse();
+        geometry.TryGetProperty("hasM", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task FormatQueryResultAsync_WithJson_PointPrecision_RoundsCoordinates()
+    {
+        var limitsOptions = Options.Create(new LimitsOptions());
+        var formatter = new QueryFormatter(
+            limitsOptions,
+            new PbfQueryFormatter(limitsOptions),
+            NullLogger<QueryFormatter>.Instance);
+
+        var result = QueryResult<Feature>.Create(
+            1,
+            [
+                Feature.Create(
+                    1,
+                    CreatePointGeometry(1.1234567, 2.7654321, 4326),
+                    ImmutableDictionary<string, object?>.Empty.Add("name", "alpha"))
+            ]);
+
+        var (response, contentType) = await formatter.FormatQueryResultAsync(
+            result,
+            CreatePointLayer(),
+            format: "json",
+            returnGeometry: true,
+            outputSrid: 4326,
+            returnZ: true,
+            returnM: true,
+            geometryPrecision: 2,
+            maxAllowableOffset: null);
+
+        contentType.Should().Be("application/json");
+        var queryResponse = response.Should().BeOfType<QueryResponse>().Subject;
+        queryResponse.Features.Should().HaveCount(1);
+        queryResponse.Features[0].Geometry!.X.Should().Be(1.12);
+        queryResponse.Features[0].Geometry!.Y.Should().Be(2.77);
+    }
+
+    [Fact]
+    public async Task FormatQueryResultAsync_WithJson_ExcludesUndeclaredAttributes()
+    {
+        var limitsOptions = Options.Create(new LimitsOptions());
+        var formatter = new QueryFormatter(
+            limitsOptions,
+            new PbfQueryFormatter(limitsOptions),
+            NullLogger<QueryFormatter>.Instance);
+
+        var feature = Feature.Create(
+            42,
+            geometry: null,
+            new Dictionary<string, object?>
+            {
+                ["id"] = 42L,
+                ["name"] = "alpha",
+                ["objectid"] = 999L
+            }.ToImmutableDictionary());
+
+        var (response, contentType) = await formatter.FormatQueryResultAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            CreateIdBackedPointLayer(),
+            format: "json",
+            returnGeometry: false,
+            outputSrid: null,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        contentType.Should().Be("application/json");
+        var queryResponse = response.Should().BeOfType<QueryResponse>().Subject;
+        var attributes = queryResponse.Features.Should().ContainSingle().Subject.Attributes;
+        attributes.Should().Contain("id", 42L);
+        attributes.Should().Contain("name", "alpha");
+        attributes.Should().NotContainKey("objectid");
     }
 
     private static LayerDefinition CreatePointLayer()

--- a/tests/Honua.Server.Tests/Features/FeatureStore/PostgresFeatureStoreIntegrationTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureStore/PostgresFeatureStoreIntegrationTests.cs
@@ -12,6 +12,7 @@ using Honua.Core.Features.Shared.Models;
 using Honua.Core.Queries.Filters;
 using Honua.Postgres.Features.FeatureStore;
 using Honua.Postgres.Features.FeatureStore.Services;
+using Honua.Server.Features.Infrastructure.Rendering;
 using Honua.Server.Tests.Infrastructure;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -300,6 +301,35 @@ public class PostgresFeatureStoreIntegrationTests : IAsyncLifetime
         points.Should().OnlyContain(point =>
             point.X >= -122.1 && point.X <= -120.8 &&
             point.Y >= 36.9 && point.Y <= 38.2);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    public async Task QueryProjectedPointsAsync_WithWebMercatorOutput_ProjectsCoordinatesAccurately()
+    {
+        var store = CreateFeatureStore();
+        var rasterPointReader = store.Should().BeAssignableTo<IRasterPointReader>().Subject;
+        var query = new FeatureQuery
+        {
+            ObjectIds = ImmutableArray.Create(1L),
+            SpatialReferenceSrid = 4326,
+            OutputSrid = 3857,
+            Limit = 10,
+            RasterPointGrid = new RasterPointGrid
+            {
+                OriginX = -20037508.342789244,
+                OriginY = 20037508.342789244,
+                CellWidth = 500000d,
+                CellHeight = 500000d
+            }
+        };
+
+        var points = await rasterPointReader.QueryProjectedPointsAsync(PointsLayerId, query, CancellationToken.None);
+        var expected = CoordinateTransformer.TransformPoint(-122d, 37d, 4326, 3857);
+
+        points.Should().ContainSingle();
+        points[0].X.Should().BeApproximately(expected.X, 0.001);
+        points[0].Y.Should().BeApproximately(expected.Y, 0.001);
     }
 
     [IntegrationTest]


### PR DESCRIPTION
## What changed

- speed up native `FeatureServer/query` formatting on the current branch baseline
- inline the `4326 -> Web Mercator` projection math in projected raster point queries so the MapServer/WMS raster fast path no longer pays `ST_Transform` per point
- add focused projected-point unit and integration coverage
- add a short benchmark snapshot to the README
- keep the current test suite/build green with the small helper updates needed by the branch

## Why

Full GeoBench work on the 100K-point dataset showed two things:

1. the native geoservices query path still had formatting headroom
2. WMS reprojection had a real throughput deficit on medium and large bbox scenarios

After rerunning the corrupted benchmark rows cleanly, the remaining material gap was raster reprojection. The projected-point fast path was still transforming every point in PostGIS, so this change moves that hot path to inline projected coordinate math for the Web Mercator case.

## Impact

- `GeoServices FeatureServer/query`: `489.5 / 212.4 / 74.0 req/s` on small / medium / large bbox scenarios
- `WMS GetMap reprojection`: improved from `10.3 -> 27.8 req/s` on medium and `4.0 -> 29.2 req/s` on large bbox scenarios
- clean concurrent mixed-workload run on the current image: `43.8 / 191.9 / 203.8 / 191.3 req/s` at `1 / 10 / 50 / 100` VUs

## Validation

- `dotnet test tests/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj --filter FullyQualifiedName~FeatureQueryBuilderProjectedPointTests`
- `dotnet test tests/Honua.Server.Tests/Honua.Server.Tests.csproj --filter FullyQualifiedName~QueryProjectedPointsAsync_WithWebMercatorOutput_ProjectsCoordinatesAccurately`
- clean GeoBench reruns for `geoservices-query`, `wms-reprojection`, and `concurrent` on the 100K-point dataset