### PR TITLE
fix: harden protocol security and conformance

### DIFF
--- a/src/Honua.Core/Features/Raster/Abstractions/IRasterStore.cs
+++ b/src/Honua.Core/Features/Raster/Abstractions/IRasterStore.cs
@@ -95,6 +95,14 @@ public interface IRasterStore
     Task<RasterExtent?> GetExtentAsync(int layerId, long rasterId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Retrieves the primary raster metadata for a layer.
+    /// </summary>
+    /// <param name="layerId">Layer identifier to query</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Most recent raster metadata for the layer, or null if none exists</returns>
+    Task<RasterInfo?> GetPrimaryRasterInfoAsync(int layerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Lists all rasters in a layer.
     /// </summary>
     /// <param name="layerId">Layer identifier to query</param>

--- a/src/Honua.Core/Features/Security/Abstractions/IAccessPolicyEvaluator.cs
+++ b/src/Honua.Core/Features/Security/Abstractions/IAccessPolicyEvaluator.cs
@@ -12,7 +12,7 @@ namespace Honua.Core.Features.Security.Abstractions;
 public interface IAccessPolicyEvaluator
 {
     /// <summary>
-    /// Evaluates layer/service access policies and returns an access decision.
+    /// Evaluates layer/service access policies and returns a composed access decision.
     /// </summary>
     /// <param name="principal">The current user principal.</param>
     /// <param name="layerPolicy">Layer-specific policy (highest precedence).</param>

--- a/src/Honua.Core/Features/Security/AccessPolicyEvaluator.cs
+++ b/src/Honua.Core/Features/Security/AccessPolicyEvaluator.cs
@@ -19,7 +19,38 @@ public sealed class AccessPolicyEvaluator : IAccessPolicyEvaluator
         AccessPolicy? servicePolicy,
         AccessScope scope = AccessScope.Read)
     {
-        var policy = layerPolicy ?? servicePolicy ?? new AccessPolicy { AllowAnonymous = false };
+        var layerDecision = EvaluatePolicy(principal, layerPolicy, scope);
+        var serviceDecision = EvaluatePolicy(principal, servicePolicy, scope);
+
+        if (layerDecision is null && serviceDecision is null)
+        {
+            return principal?.Identity?.IsAuthenticated == true
+                ? AccessDecision.Allowed()
+                : AccessDecision.RequiresAuth("Authentication is required.");
+        }
+
+        if (layerDecision is not null && !layerDecision.IsAllowed)
+        {
+            return layerDecision;
+        }
+
+        if (serviceDecision is not null && !serviceDecision.IsAllowed)
+        {
+            return serviceDecision;
+        }
+
+        return AccessDecision.Allowed();
+    }
+
+    private static AccessDecision? EvaluatePolicy(
+        ClaimsPrincipal principal,
+        AccessPolicy? policy,
+        AccessScope scope)
+    {
+        if (policy is null)
+        {
+            return null;
+        }
 
         var allowAnonymous = scope == AccessScope.Read
             ? policy.AllowAnonymous

--- a/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
@@ -472,6 +472,45 @@ internal sealed class PostgresRasterStore : IRasterStore
     }
 
     /// <inheritdoc />
+    public async Task<RasterInfo?> GetPrimaryRasterInfoAsync(int layerId, CancellationToken cancellationToken = default)
+    {
+        await using var connection = await _connectionProvider.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            SELECT id, layer_id, name, width, height, band_count, pixel_type, srid,
+                   ST_BandNoDataValue(raster, 1) AS nodata_value,
+                   ST_UpperLeftX(raster) AS upper_left_x,
+                   ST_ScaleX(raster) AS scale_x,
+                   ST_SkewX(raster) AS skew_x,
+                   ST_UpperLeftY(raster) AS upper_left_y,
+                   ST_SkewY(raster) AS skew_y,
+                   ST_ScaleY(raster) AS scale_y,
+                   ST_XMin(ST_Envelope(raster)) AS xmin,
+                   ST_YMin(ST_Envelope(raster)) AS ymin,
+                   ST_XMax(ST_Envelope(raster)) AS xmax,
+                   ST_YMax(ST_Envelope(raster)) AS ymax,
+                   created_at, updated_at
+            FROM {_rasterDataTable}
+            WHERE layer_id = @layerId
+            ORDER BY created_at DESC
+            LIMIT 1
+            """;
+        AddParameter(command, "@layerId", layerId);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            PostgresRasterLog.RasterListRetrieved(_logger, layerId, 0);
+            return null;
+        }
+
+        var info = ReadRasterInfo(reader);
+        PostgresRasterLog.RasterInfoRetrieved(_logger, layerId, info.Id, info.Width, info.Height);
+        return info;
+    }
+
+    /// <inheritdoc />
     public async Task<RasterInfo[]> ListRastersAsync(int layerId, CancellationToken cancellationToken = default)
     {
         await using var connection = await _connectionProvider.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerLog.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerLog.cs
@@ -118,12 +118,12 @@ internal static partial class FeatureServerLog
     /// <param name="logger">The logger instance.</param>
     /// <param name="serviceId">The service identifier.</param>
     /// <param name="layerId">The layer identifier.</param>
-    /// <param name="whereClause">The WHERE clause for the query.</param>
+    /// <param name="hasWhereClause">Whether the request supplied a WHERE clause.</param>
     [LoggerMessage(
         EventId = 2201,
         Level = LogLevel.Information,
-        Message = "Query requested: {ServiceId}/FeatureServer/{LayerId}/query with WHERE: {WhereClause}")]
-    public static partial void QueryRequested(ILogger logger, string serviceId, int layerId, string? whereClause);
+        Message = "Query requested: {ServiceId}/FeatureServer/{LayerId}/query (WHERE clause present: {HasWhereClause})")]
+    public static partial void QueryRequested(ILogger logger, string serviceId, int layerId, bool hasWhereClause);
 
     /// <summary>
     /// Logs when a query is successfully completed.

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerQueryHandler.cs
@@ -95,7 +95,12 @@ internal sealed class FeatureServerQueryHandler(
         Activity? featureActivity = null;
         try
         {
-            FeatureServerLog.QueryRequested(_logger, serviceId, layerId, queryParams.Where);
+            var hasWhereClause = !string.IsNullOrWhiteSpace(queryParams.Where);
+            FeatureServerLog.QueryRequested(
+                _logger,
+                serviceId,
+                layerId,
+                hasWhereClause);
 
             var resourceValidationResult = await FeatureServerResourceValidationHelpers.ValidateServiceLayerAsync(
                 _resourceValidator,
@@ -264,11 +269,6 @@ internal sealed class FeatureServerQueryHandler(
                 return StandardErrorHelpers.CreateBadRequest(context,
                     "Invalid output spatial reference",
                     [$"Unsupported outSR value: {validatedParams.OutSr}"]);
-            }
-
-            if (!string.IsNullOrWhiteSpace(validatedParams.DatumTransformation))
-            {
-                FeatureServerLog.DatumTransformationRequested(_logger, validatedParams.DatumTransformation);
             }
 
             var wgs84Srid = SpatialReference.WGS84.Wkid;
@@ -1131,6 +1131,11 @@ internal sealed class FeatureServerQueryHandler(
         if (queryParams.ReturnCentroid)
         {
             unsupported.Add("returnCentroid");
+        }
+
+        if (!string.IsNullOrWhiteSpace(queryParams.DatumTransformation))
+        {
+            unsupported.Add("datumTransformation");
         }
 
         if (unsupported.Count == 0)

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.Bins.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.Bins.cs
@@ -56,6 +56,8 @@ internal static partial class FeatureServerEndpoints
         HttpContext context)
     {
         using var activity = HonuaTelemetry.ActivitySource.StartActivity("featureserver.queryBins");
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.FeatureServer);
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, "queryBins");
         activity?.SetTag(HonuaTelemetry.Tags.ServiceId, serviceId);
         activity?.SetTag(HonuaTelemetry.Tags.LayerId, layerId);
 

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.Estimates.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.Estimates.cs
@@ -17,6 +17,8 @@ internal static partial class FeatureServerEndpoints
         HttpContext context)
     {
         using var activity = HonuaTelemetry.ActivitySource.StartActivity("featureserver.getEstimates");
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.FeatureServer);
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, "getEstimates");
         activity?.SetTag(HonuaTelemetry.Tags.ServiceId, serviceId);
         activity?.SetTag(HonuaTelemetry.Tags.LayerId, layerId);
 

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.H3.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.H3.cs
@@ -80,6 +80,8 @@ internal static partial class FeatureServerEndpoints
         HttpContext context)
     {
         using var activity = HonuaTelemetry.ActivitySource.StartActivity("featureserver.queryH3");
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.FeatureServer);
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, "queryH3");
         activity?.SetTag(HonuaTelemetry.Tags.ServiceId, serviceId);
         activity?.SetTag(HonuaTelemetry.Tags.LayerId, layerId);
 

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.TopFeatures.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.TopFeatures.cs
@@ -56,6 +56,8 @@ internal static partial class FeatureServerEndpoints
         HttpContext context)
     {
         using var activity = HonuaTelemetry.ActivitySource.StartActivity("featureserver.queryTopFeatures");
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.FeatureServer);
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, "queryTopFeatures");
         activity?.SetTag(HonuaTelemetry.Tags.ServiceId, serviceId);
         activity?.SetTag(HonuaTelemetry.Tags.LayerId, layerId);
 

--- a/src/Honua.Server/Features/FeatureServer/Models/GeoServicesFeatureJsonConverter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Models/GeoServicesFeatureJsonConverter.cs
@@ -53,7 +53,10 @@ internal sealed class GeoServicesFeatureJsonConverter : JsonConverter<GeoService
         writer.WriteStartObject();
 
         writer.WritePropertyName("attributes");
-        JsonSerializer.Serialize(writer, value.Attributes, _attributesTypeInfo);
+        JsonSerializer.Serialize(
+            writer,
+            GeoServicesValueNormalizer.NormalizeAttributes(value.Attributes),
+            _attributesTypeInfo);
 
         if (value.IncludeGeometry)
         {

--- a/src/Honua.Server/Features/FeatureServer/Models/GeoServicesValueNormalizer.cs
+++ b/src/Honua.Server/Features/FeatureServer/Models/GeoServicesValueNormalizer.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.FeatureServer.Models;
+
+/// <summary>
+/// Normalizes payload values to GeoServices-compatible wire representations.
+/// </summary>
+internal static class GeoServicesValueNormalizer
+{
+    /// <summary>
+    /// Converts booleans to GeoServices small-integer values while leaving other types unchanged.
+    /// </summary>
+    public static object? Normalize(object? value)
+        => value switch
+        {
+            bool b => b ? 1 : 0,
+            _ => value
+        };
+
+    /// <summary>
+    /// Creates a normalized copy of an attribute dictionary.
+    /// </summary>
+    public static Dictionary<string, object?> NormalizeAttributes(IReadOnlyDictionary<string, object?> attributes)
+    {
+        var normalized = new Dictionary<string, object?>(attributes.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var kvp in attributes)
+        {
+            normalized[kvp.Key] = Normalize(kvp.Value);
+        }
+
+        return normalized;
+    }
+}

--- a/src/Honua.Server/Features/FeatureServer/Models/Query/GeoServicesGeometry.cs
+++ b/src/Honua.Server/Features/FeatureServer/Models/Query/GeoServicesGeometry.cs
@@ -13,14 +13,16 @@ public sealed class GeoServicesGeometry
     /// <summary>
     /// Indicates whether the geometry includes Z values
     /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("hasZ")]
-    public bool? HasZ { get; init; }
+    public bool HasZ { get; init; }
 
     /// <summary>
     /// Indicates whether the geometry includes M values
     /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("hasM")]
-    public bool? HasM { get; init; }
+    public bool HasM { get; init; }
 
     /// <summary>
     /// X coordinate (longitude)

--- a/src/Honua.Server/Features/FeatureServer/Models/Query/QueryResponse.cs
+++ b/src/Honua.Server/Features/FeatureServer/Models/Query/QueryResponse.cs
@@ -37,16 +37,16 @@ public sealed class QueryResponse : ICollectionResponse<GeoServicesFeature>
     /// <summary>
     /// Whether returned geometries include Z values.
     /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("hasZ")]
-    public bool? HasZ { get; init; }
+    public bool HasZ { get; init; }
 
     /// <summary>
     /// Whether returned geometries include M values.
     /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("hasM")]
-    public bool? HasM { get; init; }
+    public bool HasM { get; init; }
 
     /// <summary>
     /// Object ID field name for the layer

--- a/src/Honua.Server/Features/FeatureServer/Models/Query/QueryResponse.cs
+++ b/src/Honua.Server/Features/FeatureServer/Models/Query/QueryResponse.cs
@@ -67,7 +67,7 @@ public sealed class QueryResponse : ICollectionResponse<GeoServicesFeature>
     /// <summary>
     /// Extent returned by the query (when returnExtentOnly=true)
     /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ExtentInfo? Extent { get; init; }
 
     /// <summary>

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoServicesGeometryConverter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoServicesGeometryConverter.cs
@@ -142,8 +142,8 @@ internal static class GeoServicesGeometryConverter
         if (geometry.X.HasValue && geometry.Y.HasValue)
         {
             var ordinates = new List<double>(4) { geometry.X.Value, geometry.Y.Value };
-            var hasZ = geometry.HasZ ?? geometry.Z.HasValue;
-            var hasM = geometry.HasM ?? geometry.M.HasValue;
+            var hasZ = geometry.HasZ || geometry.Z.HasValue;
+            var hasM = geometry.HasM || geometry.M.HasValue;
 
             if (hasZ && geometry.Z.HasValue)
             {
@@ -466,8 +466,8 @@ internal static class GeoServicesGeometryConverter
 
         return new GeoServicesGeometry
         {
-            HasZ = NormalizeDimensionFlag(hasZ),
-            HasM = NormalizeDimensionFlag(hasM),
+            HasZ = hasZ,
+            HasM = hasM,
             X = point.X,
             Y = point.Y,
             Z = z,
@@ -492,8 +492,8 @@ internal static class GeoServicesGeometryConverter
 
         geometry = new GeoServicesGeometry
         {
-            HasZ = NormalizeDimensionFlag(point.HasZ),
-            HasM = NormalizeDimensionFlag(point.HasM),
+            HasZ = point.HasZ,
+            HasM = point.HasM,
             X = point.X,
             Y = point.Y,
             Z = point.Z,
@@ -679,8 +679,6 @@ internal static class GeoServicesGeometryConverter
             ? new GeoServicesSpatialReference { Wkid = srid.Value, LatestWkid = srid.Value }
             : null;
 
-    private static bool? NormalizeDimensionFlag(bool value) => value ? true : null;
-
     private static int ReadInt32(ReadOnlySpan<byte> span, bool littleEndian)
         => littleEndian
             ? BinaryPrimitives.ReadInt32LittleEndian(span)
@@ -706,8 +704,8 @@ internal static class GeoServicesGeometryConverter
 
         return new GeoServicesGeometry
         {
-            HasZ = NormalizeDimensionFlag(hasZ),
-            HasM = NormalizeDimensionFlag(hasM),
+            HasZ = hasZ,
+            HasM = hasM,
             Points = points,
             SpatialReference = spatialReference
         };
@@ -718,8 +716,8 @@ internal static class GeoServicesGeometryConverter
         var (hasZ, hasM) = GetHasZandM(lineString);
         return new GeoServicesGeometry
         {
-            HasZ = NormalizeDimensionFlag(hasZ),
-            HasM = NormalizeDimensionFlag(hasM),
+            HasZ = hasZ,
+            HasM = hasM,
             Paths = [BuildLineCoordinates(lineString)],
             SpatialReference = spatialReference
         };
@@ -736,8 +734,8 @@ internal static class GeoServicesGeometryConverter
 
         return new GeoServicesGeometry
         {
-            HasZ = NormalizeDimensionFlag(hasZ),
-            HasM = NormalizeDimensionFlag(hasM),
+            HasZ = hasZ,
+            HasM = hasM,
             Paths = paths,
             SpatialReference = spatialReference
         };
@@ -748,8 +746,8 @@ internal static class GeoServicesGeometryConverter
         var (hasZ, hasM) = GetHasZandM(polygon);
         return new GeoServicesGeometry
         {
-            HasZ = NormalizeDimensionFlag(hasZ),
-            HasM = NormalizeDimensionFlag(hasM),
+            HasZ = hasZ,
+            HasM = hasM,
             Rings = BuildPolygonRings(polygon).ToArray(),
             SpatialReference = spatialReference
         };
@@ -767,8 +765,8 @@ internal static class GeoServicesGeometryConverter
 
         return new GeoServicesGeometry
         {
-            HasZ = NormalizeDimensionFlag(hasZ),
-            HasM = NormalizeDimensionFlag(hasM),
+            HasZ = hasZ,
+            HasM = hasM,
             Rings = rings.ToArray(),
             SpatialReference = spatialReference
         };

--- a/src/Honua.Server/Features/FeatureServer/Services/GeoServicesGeometryConverter.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/GeoServicesGeometryConverter.cs
@@ -466,8 +466,8 @@ internal static class GeoServicesGeometryConverter
 
         return new GeoServicesGeometry
         {
-            HasZ = hasZ,
-            HasM = hasM,
+            HasZ = NormalizeDimensionFlag(hasZ),
+            HasM = NormalizeDimensionFlag(hasM),
             X = point.X,
             Y = point.Y,
             Z = z,
@@ -704,7 +704,13 @@ internal static class GeoServicesGeometryConverter
             points[i] = BuildCoordinateArray(point.CoordinateSequence, 0);
         }
 
-        return new GeoServicesGeometry { HasZ = hasZ, HasM = hasM, Points = points, SpatialReference = spatialReference };
+        return new GeoServicesGeometry
+        {
+            HasZ = NormalizeDimensionFlag(hasZ),
+            HasM = NormalizeDimensionFlag(hasM),
+            Points = points,
+            SpatialReference = spatialReference
+        };
     }
 
     private static GeoServicesGeometry ConvertLineString(LineString lineString, GeoServicesSpatialReference? spatialReference)
@@ -712,8 +718,8 @@ internal static class GeoServicesGeometryConverter
         var (hasZ, hasM) = GetHasZandM(lineString);
         return new GeoServicesGeometry
         {
-            HasZ = hasZ,
-            HasM = hasM,
+            HasZ = NormalizeDimensionFlag(hasZ),
+            HasM = NormalizeDimensionFlag(hasM),
             Paths = [BuildLineCoordinates(lineString)],
             SpatialReference = spatialReference
         };
@@ -728,7 +734,13 @@ internal static class GeoServicesGeometryConverter
             paths[i] = BuildLineCoordinates((LineString)multiLineString.GetGeometryN(i));
         }
 
-        return new GeoServicesGeometry { HasZ = hasZ, HasM = hasM, Paths = paths, SpatialReference = spatialReference };
+        return new GeoServicesGeometry
+        {
+            HasZ = NormalizeDimensionFlag(hasZ),
+            HasM = NormalizeDimensionFlag(hasM),
+            Paths = paths,
+            SpatialReference = spatialReference
+        };
     }
 
     private static GeoServicesGeometry ConvertPolygon(Polygon polygon, GeoServicesSpatialReference? spatialReference)
@@ -736,8 +748,8 @@ internal static class GeoServicesGeometryConverter
         var (hasZ, hasM) = GetHasZandM(polygon);
         return new GeoServicesGeometry
         {
-            HasZ = hasZ,
-            HasM = hasM,
+            HasZ = NormalizeDimensionFlag(hasZ),
+            HasM = NormalizeDimensionFlag(hasM),
             Rings = BuildPolygonRings(polygon).ToArray(),
             SpatialReference = spatialReference
         };
@@ -753,7 +765,13 @@ internal static class GeoServicesGeometryConverter
             rings.AddRange(BuildPolygonRings(polygon));
         }
 
-        return new GeoServicesGeometry { HasZ = hasZ, HasM = hasM, Rings = rings.ToArray(), SpatialReference = spatialReference };
+        return new GeoServicesGeometry
+        {
+            HasZ = NormalizeDimensionFlag(hasZ),
+            HasM = NormalizeDimensionFlag(hasM),
+            Rings = rings.ToArray(),
+            SpatialReference = spatialReference
+        };
     }
 
     private static GeoServicesGeometry? ConvertGeometryCollection(GeometryCollection collection, GeoServicesSpatialReference? spatialReference)

--- a/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
@@ -171,8 +171,21 @@ internal sealed class QueryFormatter : IQueryFormatter
         string[]? outFields)
     {
         var objectIdFieldName = layer.ObjectIdFieldName;
+        var declaredAttributeFields = layer.Fields
+            .Where(field => !field.IsGeometry)
+            .Select(field => field.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
         GeoServicesFeature[] features = result.Items
-            .Select(f => ConvertToGeoServicesFeature(f, returnGeometry, outputSrid, outFields, objectIdFieldName, returnZ, returnM, geometryLimits))
+            .Select(f => ConvertToGeoServicesFeature(
+                f,
+                returnGeometry,
+                outputSrid,
+                outFields,
+                declaredAttributeFields,
+                objectIdFieldName,
+                returnZ,
+                returnM,
+                geometryLimits))
             .ToArray();
         var queryFields = BuildQueryFields(layer, outFields, objectIdFieldName);
         var displayFieldName = ResolveDisplayFieldName(queryFields, objectIdFieldName);
@@ -180,8 +193,8 @@ internal sealed class QueryFormatter : IQueryFormatter
         bool? hasM = null;
         if (layer.HasGeometry && returnGeometry)
         {
-            hasZ = features.Any(feature => feature.Geometry?.HasZ == true);
-            hasM = features.Any(feature => feature.Geometry?.HasM == true);
+            hasZ = features.Any(feature => feature.Geometry?.HasZ == true) ? true : null;
+            hasM = features.Any(feature => feature.Geometry?.HasM == true) ? true : null;
         }
 
         var srid = outputSrid ?? layer.SpatialReference.Wkid;
@@ -247,12 +260,18 @@ internal sealed class QueryFormatter : IQueryFormatter
         bool returnGeometry,
         int? outputSrid,
         string[]? outFields,
+        IReadOnlySet<string> declaredAttributeFields,
         string objectIdFieldName,
         bool returnZ,
         bool returnM,
         GeometryLimits geometryLimits)
     {
-        Dictionary<string, object?> attributes = FilterAttributes(feature.Attributes, outFields, objectIdFieldName, feature.Id);
+        Dictionary<string, object?> attributes = FilterAttributes(
+            feature.Attributes,
+            outFields,
+            declaredAttributeFields,
+            objectIdFieldName,
+            feature.Id);
 
         return new GeoServicesFeature
         {
@@ -292,13 +311,22 @@ internal sealed class QueryFormatter : IQueryFormatter
     private static Dictionary<string, object?> FilterAttributes(
         ImmutableDictionary<string, object?> attributes,
         string[]? outFields,
+        IReadOnlySet<string> declaredAttributeFields,
         string objectIdFieldName,
         long objectIdValue)
     {
         if (outFields == null || outFields.Length == 0 ||
             (outFields.Length == 1 && outFields[0].Equals("*", StringComparison.Ordinal)))
         {
-            var all = attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            var all = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (name, value) in attributes)
+            {
+                if (declaredAttributeFields.Contains(name))
+                {
+                    all[name] = GeoServicesValueNormalizer.Normalize(value);
+                }
+            }
+
             if (!all.ContainsKey(objectIdFieldName))
             {
                 all[objectIdFieldName] = objectIdValue;
@@ -307,12 +335,12 @@ internal sealed class QueryFormatter : IQueryFormatter
             return all;
         }
 
-        var filtered = new Dictionary<string, object?>();
+        var filtered = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
 
         // Always include objectid field for GeoServices compatibility
         if (attributes.TryGetValue(objectIdFieldName, out object? objectIdFromAttributes))
         {
-            filtered[objectIdFieldName] = objectIdFromAttributes;
+            filtered[objectIdFieldName] = GeoServicesValueNormalizer.Normalize(objectIdFromAttributes);
         }
         else
         {
@@ -320,8 +348,8 @@ internal sealed class QueryFormatter : IQueryFormatter
         }
         foreach (string field in outFields)
         {
-            if (attributes.TryGetValue(field, out object? fieldValue))
-                filtered[field] = fieldValue;
+            if (declaredAttributeFields.Contains(field) && attributes.TryGetValue(field, out object? fieldValue))
+                filtered[field] = GeoServicesValueNormalizer.Normalize(fieldValue);
         }
 
         return filtered;

--- a/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/QueryFormatters.cs
@@ -189,12 +189,12 @@ internal sealed class QueryFormatter : IQueryFormatter
             .ToArray();
         var queryFields = BuildQueryFields(layer, outFields, objectIdFieldName);
         var displayFieldName = ResolveDisplayFieldName(queryFields, objectIdFieldName);
-        bool? hasZ = null;
-        bool? hasM = null;
+        var hasZ = false;
+        var hasM = false;
         if (layer.HasGeometry && returnGeometry)
         {
-            hasZ = features.Any(feature => feature.Geometry?.HasZ == true) ? true : null;
-            hasM = features.Any(feature => feature.Geometry?.HasM == true) ? true : null;
+            hasZ = features.Any(feature => feature.Geometry?.HasZ == true);
+            hasM = features.Any(feature => feature.Geometry?.HasM == true);
         }
 
         var srid = outputSrid ?? layer.SpatialReference.Wkid;

--- a/src/Honua.Server/Features/GeometryService/GeometryServiceServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/GeometryService/GeometryServiceServiceCollectionExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Server.Features.GeometryService.Services;
+using Honua.Server.Features.Infrastructure.Services;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Honua.Server.Features.GeometryService;
 
@@ -15,6 +17,7 @@ internal static class GeometryServiceServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddGeometryService(this IServiceCollection services)
     {
+        services.TryAddScoped<SpatialReferenceResolver>();
         services.AddScoped<GeometryServiceHandler>();
         return services;
     }

--- a/src/Honua.Server/Features/GeometryService/Services/GeometryServiceHandler.cs
+++ b/src/Honua.Server/Features/GeometryService/Services/GeometryServiceHandler.cs
@@ -8,6 +8,7 @@ using Honua.Server.Features.GeometryService.Models;
 using Honua.Server.Features.Infrastructure.Services;
 using Honua.ServiceDefaults;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 
 namespace Honua.Server.Features.GeometryService.Services;
 
@@ -17,17 +18,22 @@ namespace Honua.Server.Features.GeometryService.Services;
 internal sealed class GeometryServiceHandler(
     IGeometryOperationService operationService,
     IGeometryConverter geometryConverter,
+    SpatialReferenceResolver spatialReferenceResolver,
     IOptions<LimitsOptions> limitsOptions,
     ILogger<GeometryServiceHandler> logger)
 {
     private const int MaxGeometriesPerRequestUpperBound = 1000;
     private const int MaxGeometryJsonLengthUpperBound = 10_000_000;
     private const string InvalidGeometryInputMessage = "Invalid geometry input.";
+    private const string InvalidSpatialReferenceMessage =
+        "must be a valid spatial reference WKID, EPSG code, CRS URI, WKT string, or spatial reference object.";
 
     private readonly IGeometryOperationService _operationService = operationService
         ?? throw new ArgumentNullException(nameof(operationService));
     private readonly IGeometryConverter _geometryConverter = geometryConverter
         ?? throw new ArgumentNullException(nameof(geometryConverter));
+    private readonly SpatialReferenceResolver _spatialReferenceResolver = spatialReferenceResolver
+        ?? throw new ArgumentNullException(nameof(spatialReferenceResolver));
     private readonly int _maxGeometriesPerRequest = Math.Clamp(
         limitsOptions?.Value.Query.MaxRecordCount ?? MaxGeometriesPerRequestUpperBound,
         1,
@@ -88,29 +94,20 @@ internal sealed class GeometryServiceHandler(
             }
 
             // Parse spatial references
-            var (inSr, inSrError) = GeometryServiceRequestParser.ParseSpatialReference(
-                GeometryServiceRequestParser.GetValue(values, "inSR"));
+            var (inSr, inSrError) = await ResolveRequiredSpatialReferenceAsync(values, "inSR", ct);
             if (inSrError is not null)
             {
                 GeometryServiceLog.InvalidGeometryInput(_logger, "buffer", inSrError);
                 return CreateError(400, inSrError);
             }
 
-            if (inSr <= 0)
-            {
-                GeometryServiceLog.InvalidGeometryInput(_logger, "buffer", "Invalid inSR");
-                return CreateError(400, "Parameter 'inSR' must be a valid spatial reference WKID.");
-            }
-
-            var (outSr, outSrError) = GeometryServiceRequestParser.ParseSpatialReference(
-                GeometryServiceRequestParser.GetValue(values, "outSR"));
+            var (outSr, outSrError) = await ResolveOptionalSpatialReferenceAsync(values, "outSR", ct);
             if (outSrError is not null)
             {
                 return CreateError(400, outSrError);
             }
 
-            var (bufferSr, bufferSrError) = GeometryServiceRequestParser.ParseSpatialReference(
-                GeometryServiceRequestParser.GetValue(values, "bufferSR"));
+            var (bufferSr, bufferSrError) = await ResolveOptionalSpatialReferenceAsync(values, "bufferSR", ct);
             if (bufferSrError is not null)
             {
                 return CreateError(400, bufferSrError);
@@ -142,9 +139,9 @@ internal sealed class GeometryServiceHandler(
             {
                 GeometryJsonStrings = geomStrings,
                 GeometryType = geomType,
-                InSR = inSr,
-                OutSR = outSr > 0 ? outSr : null,
-                BufferSR = bufferSr > 0 ? bufferSr : null,
+                InSR = inSr!.Value,
+                OutSR = outSr.HasValue && outSr.Value > 0 ? outSr.Value : null,
+                BufferSR = bufferSr.HasValue && bufferSr.Value > 0 ? bufferSr.Value : null,
                 Distances = distances,
                 Unit = unit,
                 UnionResults = unionResults,
@@ -212,25 +209,18 @@ internal sealed class GeometryServiceHandler(
             }
 
             // ArcGIS simplify uses "sr" not "inSR"
-            var (sr, srError) = GeometryServiceRequestParser.ParseSpatialReference(
-                GeometryServiceRequestParser.GetValue(values, "sr"));
+            var (sr, srError) = await ResolveRequiredSpatialReferenceAsync(values, "sr", ct);
             if (srError is not null)
             {
                 GeometryServiceLog.InvalidGeometryInput(_logger, "simplify", srError);
                 return CreateError(400, srError);
             }
 
-            if (sr <= 0)
-            {
-                GeometryServiceLog.InvalidGeometryInput(_logger, "simplify", "Invalid sr");
-                return CreateError(400, "Parameter 'sr' must be a valid spatial reference WKID.");
-            }
-
             var parameters = new SimplifyParameters
             {
                 GeometryJsonStrings = geomStrings,
                 GeometryType = geomType,
-                SR = sr
+                SR = sr!.Value
             };
 
             GeometryServiceLog.RequestParsed(_logger, "simplify", parameters.GeometryJsonStrings.Length, parameters.GeometryType);
@@ -294,40 +284,26 @@ internal sealed class GeometryServiceHandler(
             }
 
             // Parse spatial references
-            var (inSr, inSrError) = GeometryServiceRequestParser.ParseSpatialReference(
-                GeometryServiceRequestParser.GetValue(values, "inSR"));
+            var (inSr, inSrError) = await ResolveRequiredSpatialReferenceAsync(values, "inSR", ct);
             if (inSrError is not null)
             {
                 GeometryServiceLog.InvalidGeometryInput(_logger, "project", inSrError);
                 return CreateError(400, inSrError);
             }
 
-            if (inSr <= 0)
-            {
-                GeometryServiceLog.InvalidGeometryInput(_logger, "project", "Invalid inSR");
-                return CreateError(400, "Parameter 'inSR' must be a valid spatial reference WKID.");
-            }
-
-            var (outSr, outSrError) = GeometryServiceRequestParser.ParseSpatialReference(
-                GeometryServiceRequestParser.GetValue(values, "outSR"));
+            var (outSr, outSrError) = await ResolveRequiredSpatialReferenceAsync(values, "outSR", ct);
             if (outSrError is not null)
             {
                 GeometryServiceLog.InvalidGeometryInput(_logger, "project", outSrError);
                 return CreateError(400, outSrError);
             }
 
-            if (outSr <= 0)
-            {
-                GeometryServiceLog.InvalidGeometryInput(_logger, "project", "Invalid outSR");
-                return CreateError(400, "Parameter 'outSR' must be a valid spatial reference WKID.");
-            }
-
             var parameters = new ProjectParameters
             {
                 GeometryJsonStrings = geomStrings,
                 GeometryType = geomType,
-                InSR = inSr,
-                OutSR = outSr
+                InSR = inSr!.Value,
+                OutSR = outSr!.Value
             };
 
             GeometryServiceLog.RequestParsed(_logger, "project", parameters.GeometryJsonStrings.Length, parameters.GeometryType);
@@ -389,25 +365,18 @@ internal sealed class GeometryServiceHandler(
                 return CreateError(400, "Parameter 'geometries' must contain at least one geometry.");
             }
 
-            var (sr, srError) = GeometryServiceRequestParser.ParseSpatialReference(
-                GeometryServiceRequestParser.GetValue(values, "sr"));
+            var (sr, srError) = await ResolveRequiredSpatialReferenceAsync(values, "sr", ct);
             if (srError is not null)
             {
                 GeometryServiceLog.InvalidGeometryInput(_logger, "union", srError);
                 return CreateError(400, srError);
             }
 
-            if (sr <= 0)
-            {
-                GeometryServiceLog.InvalidGeometryInput(_logger, "union", "Invalid sr");
-                return CreateError(400, "Parameter 'sr' must be a valid spatial reference WKID.");
-            }
-
             var parameters = new UnionParameters
             {
                 GeometryJsonStrings = geomStrings,
                 GeometryType = geomType,
-                SR = sr
+                SR = sr!.Value
             };
 
             GeometryServiceLog.RequestParsed(_logger, "union", parameters.GeometryJsonStrings.Length, parameters.GeometryType);
@@ -495,24 +464,17 @@ internal sealed class GeometryServiceHandler(
                 return CreateError(400, "Parameter 'geometries' must contain at least one geometry.");
             }
 
-            var (sr, srError) = GeometryServiceRequestParser.ParseSpatialReference(
-                GeometryServiceRequestParser.GetValue(values, "sr"));
+            var (sr, srError) = await ResolveRequiredSpatialReferenceAsync(values, "sr", ct);
             if (srError is not null)
             {
                 GeometryServiceLog.InvalidGeometryInput(_logger, "area", srError);
                 return CreateError(400, srError);
             }
 
-            if (sr <= 0)
-            {
-                GeometryServiceLog.InvalidGeometryInput(_logger, "area", "Invalid sr");
-                return CreateError(400, "Parameter 'sr' must be a valid spatial reference WKID.");
-            }
-
             var parameters = new MeasurementParameters
             {
                 GeometryJsonStrings = geomStrings,
-                SR = sr,
+                SR = sr!.Value,
                 Unit = GeometryServiceRequestParser.GetValue(values, "areaUnit")
             };
 
@@ -573,24 +535,17 @@ internal sealed class GeometryServiceHandler(
                 return CreateError(400, "Parameter 'geometries' must contain at least one geometry.");
             }
 
-            var (sr, srError) = GeometryServiceRequestParser.ParseSpatialReference(
-                GeometryServiceRequestParser.GetValue(values, "sr"));
+            var (sr, srError) = await ResolveRequiredSpatialReferenceAsync(values, "sr", ct);
             if (srError is not null)
             {
                 GeometryServiceLog.InvalidGeometryInput(_logger, "length", srError);
                 return CreateError(400, srError);
             }
 
-            if (sr <= 0)
-            {
-                GeometryServiceLog.InvalidGeometryInput(_logger, "length", "Invalid sr");
-                return CreateError(400, "Parameter 'sr' must be a valid spatial reference WKID.");
-            }
-
             var parameters = new MeasurementParameters
             {
                 GeometryJsonStrings = geomStrings,
-                SR = sr,
+                SR = sr!.Value,
                 Unit = GeometryServiceRequestParser.GetValue(values, "lengthUnit")
             };
 
@@ -762,18 +717,11 @@ internal sealed class GeometryServiceHandler(
                 return CreateError(400, operatorError ?? "Parameter 'geometry' is required.");
             }
 
-            var (sr, srError) = GeometryServiceRequestParser.ParseSpatialReference(
-                GeometryServiceRequestParser.GetValue(values, "sr"));
+            var (sr, srError) = await ResolveRequiredSpatialReferenceAsync(values, "sr", ct);
             if (srError is not null)
             {
                 GeometryServiceLog.InvalidGeometryInput(_logger, operationName, srError);
                 return CreateError(400, srError);
-            }
-
-            if (sr <= 0)
-            {
-                GeometryServiceLog.InvalidGeometryInput(_logger, operationName, "Invalid sr");
-                return CreateError(400, "Parameter 'sr' must be a valid spatial reference WKID.");
             }
 
             var parameters = new BinaryGeometryOperationParameters
@@ -781,7 +729,7 @@ internal sealed class GeometryServiceHandler(
                 GeometryJsonStrings = geomStrings,
                 GeometryType = geomType,
                 OperatorGeometryJson = operatorGeometry,
-                SR = sr
+                SR = sr!.Value
             };
 
             GeometryServiceLog.RequestParsed(_logger, operationName, parameters.GeometryJsonStrings.Length, parameters.GeometryType);
@@ -873,6 +821,41 @@ internal sealed class GeometryServiceHandler(
 
         return _areaUnitDivisors.TryGetValue(unit, out var divisor) ? divisor : 1.0;
     }
+
+    private async Task<(int? Srid, string? Error)> ResolveSpatialReferenceAsync(
+        IReadOnlyDictionary<string, StringValues> values,
+        string parameterName,
+        bool required,
+        CancellationToken ct)
+    {
+        var raw = GeometryServiceRequestParser.GetValue(values, parameterName);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return required
+                ? (null, $"Parameter '{parameterName}' must be a valid spatial reference WKID, EPSG code, CRS URI, WKT string, or spatial reference object.")
+                : (null, null);
+        }
+
+        var srid = await _spatialReferenceResolver.ResolveSridAsync(raw, null, ct).ConfigureAwait(false);
+        if (!srid.HasValue || srid.Value <= 0)
+        {
+            return (null, $"Parameter '{parameterName}' must be a valid spatial reference WKID, EPSG code, CRS URI, WKT string, or spatial reference object.");
+        }
+
+        return (srid, null);
+    }
+
+    private Task<(int? Srid, string? Error)> ResolveRequiredSpatialReferenceAsync(
+        IReadOnlyDictionary<string, StringValues> values,
+        string parameterName,
+        CancellationToken ct)
+        => ResolveSpatialReferenceAsync(values, parameterName, required: true, ct);
+
+    private Task<(int? Srid, string? Error)> ResolveOptionalSpatialReferenceAsync(
+        IReadOnlyDictionary<string, StringValues> values,
+        string parameterName,
+        CancellationToken ct)
+        => ResolveSpatialReferenceAsync(values, parameterName, required: false, ct);
 
     private GeometryServiceResponse ConvertToResponse(List<byte[]> wkbs, int srid, string? geometryType)
     {

--- a/src/Honua.Server/Features/ImageServer/Handlers/ImageServerExportHandler.cs
+++ b/src/Honua.Server/Features/ImageServer/Handlers/ImageServerExportHandler.cs
@@ -73,16 +73,14 @@ internal sealed class ImageServerExportHandler
                 return StandardErrorHelpers.CreateNotFound(context, "Layer not found.");
             }
 
-            // Get raster data
-            var rasters = await _rasterStore.ListRastersAsync(layerId, cancellationToken);
-            if (rasters.Length == 0)
+            // Resolve the primary raster without scanning the entire layer.
+            var primaryRaster = await _rasterStore.GetPrimaryRasterInfoAsync(layerId, cancellationToken);
+            if (primaryRaster is null)
             {
                 ImageServerLog.NoRastersFound(_logger, layerId);
                 return StandardErrorHelpers.CreateNotFound(context, "No rasters found for layer.");
             }
-
-            // Use the first raster (could be enhanced for multi-raster scenarios)
-            var primaryRaster = rasters[0];
+            var primaryRasterInfo = primaryRaster.Value;
 
             // Parse export parameters
             var query = ParseExportParameters(request);
@@ -93,13 +91,13 @@ internal sealed class ImageServerExportHandler
             }
 
             // Determine output dimensions and propagate to query
-            var (width, height) = CalculateOutputDimensions(request, primaryRaster);
+            var (width, height) = CalculateOutputDimensions(request, primaryRasterInfo);
             var exportQuery = query.Value with { OutputWidth = width, OutputHeight = height };
             var formatName = exportQuery.OutputFormat.ToString();
             ImageServerLog.ExportImageStarted(_logger, layerId, width, height, formatName);
 
             // Export the image
-            var result = await _rasterStore.ExportImageAsync(layerId, primaryRaster.Id, exportQuery, cancellationToken);
+            var result = await _rasterStore.ExportImageAsync(layerId, primaryRasterInfo.Id, exportQuery, cancellationToken);
 
             // Store the image temporarily and get the public URL
             var imageUrl = await _temporaryFileService.StoreTemporaryFileAsync(
@@ -109,7 +107,7 @@ internal sealed class ImageServerExportHandler
                 cancellationToken);
 
             var extent = result.Extent;
-            extent ??= await _rasterStore.GetExtentAsync(layerId, primaryRaster.Id, cancellationToken);
+            extent ??= await _rasterStore.GetExtentAsync(layerId, primaryRasterInfo.Id, cancellationToken);
 
             var exportResponse = new ExportImageResponse
             {

--- a/src/Honua.Server/Features/ImageServer/Handlers/ImageServerIdentifyHandler.cs
+++ b/src/Honua.Server/Features/ImageServer/Handlers/ImageServerIdentifyHandler.cs
@@ -62,13 +62,14 @@ internal sealed class ImageServerIdentifyHandler
                 return StandardErrorHelpers.CreateNotFound(context, "Layer not found.");
             }
 
-            // Get raster data
-            var rasters = await _rasterStore.ListRastersAsync(layerId, cancellationToken);
-            if (rasters.Length == 0)
+            // Resolve the primary raster without scanning the entire layer.
+            var primaryRaster = await _rasterStore.GetPrimaryRasterInfoAsync(layerId, cancellationToken);
+            if (primaryRaster is null)
             {
                 ImageServerLog.NoRastersFound(_logger, layerId);
                 return StandardErrorHelpers.CreateNotFound(context, "No rasters found for layer.");
             }
+            var primaryRasterInfo = primaryRaster.Value;
 
             if (!string.IsNullOrWhiteSpace(request.GeometryType) &&
                 !string.Equals(request.GeometryType, SupportedGeometryType, StringComparison.OrdinalIgnoreCase))
@@ -89,13 +90,10 @@ internal sealed class ImageServerIdentifyHandler
 
             ImageServerLog.IdentifyStarted(_logger, layerId, x.Value, y.Value);
 
-            // Use the first raster (could be enhanced for multi-raster scenarios)
-            var primaryRaster = rasters[0];
-
             // Identify pixel values
             var pixelResult = await _rasterStore.IdentifyAsync(
                 layerId,
-                primaryRaster.Id,
+                primaryRasterInfo.Id,
                 x.Value,
                 y.Value,
                 srid,
@@ -104,8 +102,8 @@ internal sealed class ImageServerIdentifyHandler
             // Build identify response
             var response = new IdentifyResponse
             {
-                ObjectId = primaryRaster.Id,
-                Name = primaryRaster.Name,
+                ObjectId = primaryRasterInfo.Id,
+                Name = primaryRasterInfo.Name,
                 Value = FormatPixelValues(pixelResult.BandValues),
                 Location = new Point
                 {
@@ -114,7 +112,7 @@ internal sealed class ImageServerIdentifyHandler
                 },
                 Properties = CreateProperties(pixelResult),
                 CatalogItems = request.ReturnCatalogItems == true
-                    ? [new CatalogItem { Id = primaryRaster.Id, Name = primaryRaster.Name }]
+                    ? [new CatalogItem { Id = primaryRasterInfo.Id, Name = primaryRasterInfo.Name }]
                     : null
             };
 

--- a/src/Honua.Server/Features/ImageServer/Handlers/ImageServerTileHandler.cs
+++ b/src/Honua.Server/Features/ImageServer/Handlers/ImageServerTileHandler.cs
@@ -77,23 +77,21 @@ internal sealed class ImageServerTileHandler
                 return StandardErrorHelpers.CreateBadRequest(context, "Unsupported tile format. Supported formats: png, jpg, jpeg, tiff, tif.");
             }
 
-            // Get raster data
-            var rasters = await _rasterStore.ListRastersAsync(layerId, cancellationToken);
-            if (rasters.Length == 0)
+            // Resolve the primary raster without scanning the entire layer.
+            var primaryRaster = await _rasterStore.GetPrimaryRasterInfoAsync(layerId, cancellationToken);
+            if (primaryRaster is null)
             {
                 ImageServerLog.NoRastersFound(_logger, layerId);
                 return StandardErrorHelpers.CreateNotFound(context, "No rasters found for layer.");
             }
+            var primaryRasterInfo = primaryRaster.Value;
 
             ImageServerLog.ImageTileRequested(_logger, layerId, level, row, col);
-
-            // Use the first raster (could be enhanced for multi-raster scenarios)
-            var primaryRaster = rasters[0];
 
             // Get the image tile
             var tileResult = await _rasterStore.GetImageTileAsync(
                 layerId,
-                primaryRaster.Id,
+                primaryRasterInfo.Id,
                 level,
                 row,
                 col,

--- a/src/Honua.Server/Features/Import/ImportHttpClientHelper.cs
+++ b/src/Honua.Server/Features/Import/ImportHttpClientHelper.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Http;
+using Honua.Server.Features.Infrastructure.Events;
+
+namespace Honua.Server.Features.Import;
+
+/// <summary>
+/// Shared HTTP client wiring for import-related outbound requests.
+/// </summary>
+internal static class ImportHttpClientHelper
+{
+    internal static HttpMessageHandler CreatePinnedDnsHttpMessageHandler()
+        => WebhookDeliveryHelper.CreatePinnedDnsHttpMessageHandler();
+}

--- a/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheInvalidationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/OutputCacheInvalidationService.cs
@@ -54,6 +54,7 @@ internal sealed partial class OutputCacheInvalidationService
             tags.Add($"collection:{layerId.Value}");
             tags.Add("layer-metadata");
             tags.Add("layer-styles");
+            tags.Add("ogc-maps");
             responsePatterns.Add(ResponseCacheUtilities.BuildFeatureServerLayerPattern(layerId.Value));
             responsePatterns.Add(ResponseCacheUtilities.BuildODataLayerPattern(layerId.Value));
             responsePatterns.Add(ResponseCacheUtilities.BuildOgcCollectionPattern(
@@ -70,6 +71,7 @@ internal sealed partial class OutputCacheInvalidationService
 
         tags.Add("ogc-metadata");
         tags.Add("ogc-tiles");
+        tags.Add("ogc-maps");
         tags.Add("mvt-tiles");
 
         await Task.WhenAll(
@@ -84,6 +86,7 @@ internal sealed partial class OutputCacheInvalidationService
             $"collection:{collectionId.Trim().ToLowerInvariant()}",
             "ogc-metadata",
             "ogc-tiles",
+            "ogc-maps",
             "mvt-tiles"
         };
 
@@ -99,7 +102,7 @@ internal sealed partial class OutputCacheInvalidationService
 
     public Task InvalidateOgcMetadataAsync(CancellationToken cancellationToken)
     {
-        return EvictTagsAsync(["ogc-metadata", "ogc-tiles"], cancellationToken);
+        return EvictTagsAsync(["ogc-metadata", "ogc-tiles", "ogc-maps"], cancellationToken);
     }
 
     public Task InvalidateServiceCatalogAsync(
@@ -119,9 +122,12 @@ internal sealed partial class OutputCacheInvalidationService
             "service-directory",
             "service-metadata",
             "layer-metadata",
+            "layer-styles",
             "metadata",
             "ogc-metadata",
             "ogc-tiles",
+            "ogc-maps",
+            "stac-metadata",
             "mvt-tiles"
         };
 

--- a/src/Honua.Server/Features/Infrastructure/Middleware/CorrelationIdMiddleware.cs
+++ b/src/Honua.Server/Features/Infrastructure/Middleware/CorrelationIdMiddleware.cs
@@ -224,6 +224,26 @@ internal sealed class CorrelationIdMiddleware(RequestDelegate next, ILogger<Corr
                 return "query";
             }
 
+            if (path.Contains("/queryTopFeatures", StringComparison.OrdinalIgnoreCase))
+            {
+                return "queryTopFeatures";
+            }
+
+            if (path.Contains("/queryBins", StringComparison.OrdinalIgnoreCase))
+            {
+                return "queryBins";
+            }
+
+            if (path.Contains("/getEstimates", StringComparison.OrdinalIgnoreCase))
+            {
+                return "getEstimates";
+            }
+
+            if (path.Contains("/queryH3", StringComparison.OrdinalIgnoreCase))
+            {
+                return "queryH3";
+            }
+
             return "metadata";
         }
 

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/RecentErrorBuffer.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/RecentErrorBuffer.cs
@@ -30,16 +30,35 @@ internal sealed class RecentErrorBuffer
     /// Record a server error response into the buffer.
     /// </summary>
     public void Record(HttpContext context, StandardErrorResponse errorResponse)
+        => Record(context, errorResponse.StatusCode, errorResponse.Title, errorResponse.Detail);
+
+    /// <summary>
+    /// Record an error response into the buffer.
+    /// </summary>
+    /// <param name="context">Current request context.</param>
+    /// <param name="statusCode">HTTP status code.</param>
+    /// <param name="title">Short error title.</param>
+    /// <param name="detail">Detailed error text.</param>
+    /// <param name="includeClientErrors">Whether to include 4xx responses.</param>
+    public void Record(
+        HttpContext context,
+        int statusCode,
+        string title,
+        string detail,
+        bool includeClientErrors = false)
     {
-        if (_capacity <= 0 || errorResponse.StatusCode < StatusCodes.Status500InternalServerError)
+        var minimumStatusCode = includeClientErrors
+            ? StatusCodes.Status400BadRequest
+            : StatusCodes.Status500InternalServerError;
+        if (_capacity <= 0 || statusCode < minimumStatusCode)
         {
             return;
         }
 
-        var message = RecentErrorSanitizer.Sanitize(errorResponse.Detail);
+        var message = RecentErrorSanitizer.Sanitize(detail);
         if (string.IsNullOrWhiteSpace(message))
         {
-            message = RecentErrorSanitizer.Sanitize(errorResponse.Title);
+            message = RecentErrorSanitizer.Sanitize(title);
         }
 
         var entry = new RecentErrorEntry
@@ -47,7 +66,7 @@ internal sealed class RecentErrorBuffer
             Timestamp = DateTimeOffset.UtcNow,
             CorrelationId = string.IsNullOrWhiteSpace(context.TraceIdentifier) ? "unknown" : context.TraceIdentifier,
             Path = context.Request.Path.HasValue ? context.Request.Path.Value! : string.Empty,
-            StatusCode = errorResponse.StatusCode,
+            StatusCode = statusCode,
             Message = message
         };
 

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Find.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Find.cs
@@ -216,11 +216,11 @@ internal static partial class MapServerEndpoints
 
                 foreach (var feature in queryResult.Items)
                 {
-                        var attributes = new Dictionary<string, object?>();
-                        foreach (var kvp in feature.Attributes)
-                        {
-                            attributes[kvp.Key] = Honua.Server.Features.FeatureServer.Models.GeoServicesValueNormalizer.Normalize(kvp.Value);
-                        }
+                    var attributes = new Dictionary<string, object?>();
+                    foreach (var kvp in feature.Attributes)
+                    {
+                        attributes[kvp.Key] = Honua.Server.Features.FeatureServer.Models.GeoServicesValueNormalizer.Normalize(kvp.Value);
+                    }
 
                     object? geometryResult = null;
                     if (returnGeometry && feature.Geometry != null)

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Find.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Find.cs
@@ -177,9 +177,10 @@ internal static partial class MapServerEndpoints
                 var objectIdField = layer.PrimaryKeyField?.Name ?? FieldNames.ObjectId;
                 var displayField = ResolveDisplayField(layer, objectIdField);
 
+                var escapedSearchText = EscapeSqlStringLiteral(searchText);
+                var fieldSearchClauses = new List<string>(fieldsToSearch.Length);
                 foreach (var field in fieldsToSearch)
                 {
-                    var escapedSearchText = EscapeSqlStringLiteral(searchText);
                     var quotedFieldName = $"\"{field.Name}\"";
                     var whereClause = contains
                         ? $"{quotedFieldName} LIKE '%{EscapeLikeWildcards(escapedSearchText)}%' ESCAPE '\\'"
@@ -190,44 +191,57 @@ internal static partial class MapServerEndpoints
                         whereClause = $"({layerDef}) AND ({whereClause})";
                     }
 
-                    var translationResult = filterExpressionService.Translate(FilterLanguage.ArcGisSql, whereClause, layer);
-                    if (!translationResult.IsSuccess)
-                    {
-                        continue;
-                    }
+                    fieldSearchClauses.Add(whereClause);
+                }
 
-                    var featureQuery = new FeatureQuery
-                    {
-                        SpatialReferenceSrid = service.SpatialReference.Srid,
-                        OutputSrid = outputSrid,
-                        Limit = MaxFindResults - results.Count,
-                        SqlFilter = translationResult.SqlFilter
-                    };
+                var combinedWhereClause = fieldSearchClauses.Count == 1
+                    ? fieldSearchClauses[0]
+                    : $"({string.Join(" OR ", fieldSearchClauses.Select(clause => $"({clause})"))})";
 
-                    var queryResult = await featureReader.QueryAsync(layer.Id, featureQuery, context.RequestAborted);
+                var translationResult = filterExpressionService.Translate(FilterLanguage.ArcGisSql, combinedWhereClause, layer);
+                if (!translationResult.IsSuccess)
+                {
+                    continue;
+                }
 
-                    foreach (var feature in queryResult.Items)
-                    {
+                var featureQuery = new FeatureQuery
+                {
+                    SpatialReferenceSrid = service.SpatialReference.Srid,
+                    OutputSrid = outputSrid,
+                    Limit = MaxFindResults - results.Count,
+                    SqlFilter = translationResult.SqlFilter
+                };
+
+                var queryResult = await featureReader.QueryAsync(layer.Id, featureQuery, context.RequestAborted);
+
+                foreach (var feature in queryResult.Items)
+                {
                         var attributes = new Dictionary<string, object?>();
                         foreach (var kvp in feature.Attributes)
                         {
-                            attributes[kvp.Key] = kvp.Value;
+                            attributes[kvp.Key] = Honua.Server.Features.FeatureServer.Models.GeoServicesValueNormalizer.Normalize(kvp.Value);
                         }
 
-                        object? geometryResult = null;
-                        if (returnGeometry && feature.Geometry != null)
+                    object? geometryResult = null;
+                    if (returnGeometry && feature.Geometry != null)
+                    {
+                        try
                         {
-                            try
-                            {
-                                geometryResult = geometryConverter.ConvertWkbToGeoServicesGeometry(feature.Geometry, outputSrid);
-                            }
-                            catch (ArgumentException)
-                            {
-                                geometryResult = null;
-                            }
+                            geometryResult = geometryConverter.ConvertWkbToGeoServicesGeometry(feature.Geometry, outputSrid);
                         }
+                        catch (ArgumentException)
+                        {
+                            geometryResult = null;
+                        }
+                    }
 
-                        var displayValue = GetDisplayFieldValue(feature, displayField);
+                    var displayValue = GetDisplayFieldValue(feature, displayField);
+                    foreach (var field in fieldsToSearch)
+                    {
+                        if (!TryMatchSearchField(feature, field, searchText, contains))
+                        {
+                            continue;
+                        }
 
                         results.Add(new FindResult
                         {
@@ -240,6 +254,11 @@ internal static partial class MapServerEndpoints
                             GeometryType = layer.HasGeometry ? MapGeometryTypeToEsri(layer.GeometryType) : null,
                             Geometry = geometryResult
                         });
+
+                        if (results.Count >= MaxFindResults)
+                        {
+                            break;
+                        }
                     }
 
                     if (results.Count >= MaxFindResults)
@@ -396,4 +415,26 @@ internal static partial class MapServerEndpoints
     private static string EscapeLikeWildcards(string value)
         => value.Replace("%", "\\%", StringComparison.Ordinal)
             .Replace("_", "\\_", StringComparison.Ordinal);
+
+    private static bool TryMatchSearchField(
+        Feature feature,
+        FieldDefinition field,
+        string searchText,
+        bool contains)
+    {
+        if (!feature.Attributes.TryGetValue(field.Name, out var value) || value is null)
+        {
+            return false;
+        }
+
+        var actualText = value.ToString();
+        if (string.IsNullOrEmpty(actualText))
+        {
+            return false;
+        }
+
+        return contains
+            ? actualText.Contains(searchText, StringComparison.Ordinal)
+            : string.Equals(actualText, searchText, StringComparison.Ordinal);
+    }
 }

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Identify.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Identify.cs
@@ -300,7 +300,7 @@ internal static partial class MapServerEndpoints
                     var attributes = new Dictionary<string, object?>();
                     foreach (var kvp in feature.Attributes)
                     {
-                        attributes[kvp.Key] = kvp.Value;
+                        attributes[kvp.Key] = Honua.Server.Features.FeatureServer.Models.GeoServicesValueNormalizer.Normalize(kvp.Value);
                     }
 
                     object? geometryResult = null;

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Wms.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Wms.cs
@@ -13,11 +13,13 @@ using Honua.Core.Features.Styling.Abstractions;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Helpers;
+using Honua.Server.Features.Infrastructure.Monitoring;
 using Honua.Server.Features.Infrastructure.Models;
 using Honua.Server.Features.Infrastructure.Services;
 using Honua.Server.Features.Infrastructure.Rendering;
 using Honua.Server.Features.MapServer.Rendering;
 using Honua.ServiceDefaults;
+using Microsoft.Extensions.DependencyInjection;
 using SkiaSharp;
 
 namespace Honua.Server.Features.MapServer;
@@ -105,7 +107,7 @@ internal static partial class MapServerEndpoints
             if (!string.Equals(service, "WMS", StringComparison.OrdinalIgnoreCase) &&
                 !string.IsNullOrWhiteSpace(service))
             {
-                return CreateWmsServiceException("InvalidParameterValue", "SERVICE must be WMS.");
+                return CreateWmsServiceException(context, "InvalidParameterValue", "SERVICE must be WMS.");
             }
 
             var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
@@ -115,24 +117,24 @@ internal static partial class MapServerEndpoints
                 var errorMessage = serviceResult.ErrorMessage ?? "Service not found.";
                 if (serviceResult.ErrorCode == ResourceValidationError.InvalidIdentifier)
                 {
-                    return CreateWmsServiceException("InvalidParameterValue", errorMessage);
+                    return CreateWmsServiceException(context, "InvalidParameterValue", errorMessage);
                 }
 
-                return CreateWmsServiceException("LayerNotDefined", errorMessage, StatusCodes.Status404NotFound);
+                return CreateWmsServiceException(context, "LayerNotDefined", errorMessage, StatusCodes.Status404NotFound);
             }
 
             var svcDef = serviceResult.Resource!;
             var protocolError = ProtocolValidationHelpers.ValidateProtocolEnabled(context, svcDef, ServiceProtocols.MapServer);
             if (protocolError is not null)
             {
-                return CreateWmsServiceException("OperationNotSupported", "MapServer protocol is not enabled for this service.");
+                return CreateWmsServiceException(context, "OperationNotSupported", "MapServer protocol is not enabled for this service.");
             }
 
             var accessibleLayerCount = svcDef.Layers.Count(layer =>
                 layer.HasGeometry && AccessPolicyHelpers.IsLayerAccessible(context, layer, svcDef));
             if (accessibleLayerCount == 0)
             {
-                return CreateWmsServiceException("LayerNotDefined", "No accessible WMS layers are available for this service.");
+                return CreateWmsServiceException(context, "LayerNotDefined", "No accessible WMS layers are available for this service.");
             }
 
             if (string.IsNullOrWhiteSpace(requestType) ||
@@ -154,7 +156,7 @@ internal static partial class MapServerEndpoints
                 return await HandleWmsGetFeatureInfo(context, svcDef, serviceId, logger);
             }
 
-            return CreateWmsServiceException("OperationNotSupported", $"Unsupported WMS REQUEST '{requestType}'.");
+            return CreateWmsServiceException(context, "OperationNotSupported", $"Unsupported WMS REQUEST '{requestType}'.");
         }
         catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
         {
@@ -163,7 +165,7 @@ internal static partial class MapServerEndpoints
         catch (Exception ex)
         {
             MapServerLog.WmsFailed(logger, serviceId, ex.Message, ex);
-            return CreateWmsServiceException("NoApplicableCode", "WMS request failed.", StatusCodes.Status500InternalServerError);
+            return CreateWmsServiceException(context, "NoApplicableCode", "WMS request failed.", StatusCodes.Status500InternalServerError);
         }
     }
 
@@ -184,27 +186,27 @@ internal static partial class MapServerEndpoints
         var query = context.Request.Query;
         if (!TryGetRequiredQueryValue(query, "LAYERS", out var layersParam))
         {
-            return CreateWmsServiceException("MissingParameterValue", "LAYERS parameter is required.");
+            return CreateWmsServiceException(context, "MissingParameterValue", "LAYERS parameter is required.");
         }
 
         if (!TryGetRequiredQueryValue(query, "STYLES", out var stylesParam, allowEmpty: true))
         {
-            return CreateWmsServiceException("MissingParameterValue", "STYLES parameter is required.");
+            return CreateWmsServiceException(context, "MissingParameterValue", "STYLES parameter is required.");
         }
 
         if (!TryGetRequiredQueryValue(query, "BBOX", out var bboxValue))
         {
-            return CreateWmsServiceException("InvalidParameterValue", "Invalid BBOX parameter. Expected format: xmin,ymin,xmax,ymax.");
+            return CreateWmsServiceException(context, "InvalidParameterValue", "Invalid BBOX parameter. Expected format: xmin,ymin,xmax,ymax.");
         }
 
         if (!TryGetRequiredQueryValue(query, "VERSION", out var versionValue))
         {
-            return CreateWmsServiceException("MissingParameterValue", "VERSION parameter is required.");
+            return CreateWmsServiceException(context, "MissingParameterValue", "VERSION parameter is required.");
         }
 
         if (!IsSupportedWmsVersion(versionValue))
         {
-            return CreateWmsServiceException("InvalidParameterValue", "Unsupported VERSION value. Only 1.3.0 is supported.");
+            return CreateWmsServiceException(context, "InvalidParameterValue", "Unsupported VERSION value. Only 1.3.0 is supported.");
         }
 
         var crsValue = GetQueryValue(query, "CRS");
@@ -215,12 +217,12 @@ internal static partial class MapServerEndpoints
 
         if (!TryParseWmsCrs(crsValue, out var requestSrid, out var normalizedCrs))
         {
-            return CreateWmsServiceException("InvalidCRS", "Invalid or missing CRS/SRS parameter.");
+            return CreateWmsServiceException(context, "InvalidCRS", "Invalid or missing CRS/SRS parameter.");
         }
 
         if (!TryParseWmsBbox(bboxValue, normalizedCrs, out var requestedExtent))
         {
-            return CreateWmsServiceException("InvalidParameterValue", "Invalid BBOX parameter. Expected format: xmin,ymin,xmax,ymax.");
+            return CreateWmsServiceException(context, "InvalidParameterValue", "Invalid BBOX parameter. Expected format: xmin,ymin,xmax,ymax.");
         }
 
         var bboxOutsideCrsBounds = !IsExtentWithinCrsBounds(requestedExtent, normalizedCrs);
@@ -229,35 +231,35 @@ internal static partial class MapServerEndpoints
             !int.TryParse(widthValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var imageWidth) ||
             imageWidth <= 0 || imageWidth > WmsMaxImageDimension)
         {
-            return CreateWmsServiceException("InvalidDimensionValue", $"WIDTH must be an integer between 1 and {WmsMaxImageDimension.ToString(CultureInfo.InvariantCulture)}.");
+            return CreateWmsServiceException(context, "InvalidDimensionValue", $"WIDTH must be an integer between 1 and {WmsMaxImageDimension.ToString(CultureInfo.InvariantCulture)}.");
         }
 
         if (!TryGetRequiredQueryValue(query, "HEIGHT", out var heightValue) ||
             !int.TryParse(heightValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var imageHeight) ||
             imageHeight <= 0 || imageHeight > WmsMaxImageDimension)
         {
-            return CreateWmsServiceException("InvalidDimensionValue", $"HEIGHT must be an integer between 1 and {WmsMaxImageDimension.ToString(CultureInfo.InvariantCulture)}.");
+            return CreateWmsServiceException(context, "InvalidDimensionValue", $"HEIGHT must be an integer between 1 and {WmsMaxImageDimension.ToString(CultureInfo.InvariantCulture)}.");
         }
 
         if (!TryGetRequiredQueryValue(query, "FORMAT", out var formatValue))
         {
-            return CreateWmsServiceException("MissingParameterValue", "FORMAT parameter is required.");
+            return CreateWmsServiceException(context, "MissingParameterValue", "FORMAT parameter is required.");
         }
 
         if (!TryNormalizeWmsMapFormat(formatValue, out var imageFormat, out var contentType))
         {
-            return CreateWmsServiceException("InvalidFormat", "FORMAT must be image/png or image/jpeg.");
+            return CreateWmsServiceException(context, "InvalidFormat", "FORMAT must be image/png or image/jpeg.");
         }
 
         var exceptionsValue = GetQueryValue(query, "EXCEPTIONS");
         if (!IsSupportedWmsExceptionFormat(exceptionsValue))
         {
-            return CreateWmsServiceException("InvalidFormat", "Unsupported EXCEPTIONS format. Only XML exceptions are supported.");
+            return CreateWmsServiceException(context, "InvalidFormat", "Unsupported EXCEPTIONS format. Only XML exceptions are supported.");
         }
 
         if (!TryParseWmsTransparent(GetQueryValue(query, "TRANSPARENT"), out var transparent))
         {
-            return CreateWmsServiceException("InvalidParameterValue", "TRANSPARENT must be TRUE or FALSE.");
+            return CreateWmsServiceException(context, "InvalidParameterValue", "TRANSPARENT must be TRUE or FALSE.");
         }
 
         var backgroundColor = SKColors.White;
@@ -265,23 +267,23 @@ internal static partial class MapServerEndpoints
         if (!string.IsNullOrWhiteSpace(backgroundValue) &&
             !TryParseWmsBackgroundColor(backgroundValue, out backgroundColor))
         {
-            return CreateWmsServiceException("InvalidParameterValue", "BGCOLOR must be formatted as 0xRRGGBB or #RRGGBB.");
+            return CreateWmsServiceException(context, "InvalidParameterValue", "BGCOLOR must be formatted as 0xRRGGBB or #RRGGBB.");
         }
 
         if (!TryParseCsvTokens(layersParam, allowEmptyTokens: false, out var layerTokens))
         {
-            return CreateWmsServiceException("InvalidParameterValue", "LAYERS must contain at least one layer name.");
+            return CreateWmsServiceException(context, "InvalidParameterValue", "LAYERS must contain at least one layer name.");
         }
 
         if (!TryResolveWmsRequestedLayers(service, context, layerTokens, out var renderLayers, out var unresolvedLayer))
         {
             var layerLabel = string.IsNullOrWhiteSpace(unresolvedLayer) ? "requested layer" : unresolvedLayer;
-            return CreateWmsServiceException("LayerNotDefined", $"Layer '{layerLabel}' is not defined.");
+            return CreateWmsServiceException(context, "LayerNotDefined", $"Layer '{layerLabel}' is not defined.");
         }
 
         if (!ValidateWmsStyles(stylesParam, renderLayers.Length, out var styleError))
         {
-            return CreateWmsServiceException("StyleNotDefined", styleError);
+            return CreateWmsServiceException(context, "StyleNotDefined", styleError);
         }
 
         var effectiveTransparent = transparent && string.Equals(imageFormat, "png", StringComparison.OrdinalIgnoreCase);
@@ -291,7 +293,7 @@ internal static partial class MapServerEndpoints
             .ConfigureAwait(false);
         if (renderLease is null)
         {
-            return CreateWmsServiceException(
+            return CreateWmsServiceException(context,
                 "NoApplicableCode",
                 RasterRenderCapacityLimiter.CapacityExceededMessage,
                 StatusCodes.Status503ServiceUnavailable);
@@ -302,7 +304,7 @@ internal static partial class MapServerEndpoints
             using var outsideSurface = SKSurface.Create(new SKImageInfo(imageWidth, imageHeight, SKColorType.Rgba8888, SKAlphaType.Premul));
             if (outsideSurface is null)
             {
-                return CreateWmsServiceException("NoApplicableCode", "Failed to allocate render surface.", StatusCodes.Status500InternalServerError);
+                return CreateWmsServiceException(context, "NoApplicableCode", "Failed to allocate render surface.", StatusCodes.Status500InternalServerError);
             }
 
             outsideSurface.Canvas.Clear(effectiveTransparent ? SKColors.Transparent : backgroundColor);
@@ -338,7 +340,7 @@ internal static partial class MapServerEndpoints
                 context.RequestAborted);
             if (!extentTransformResult.IsSuccess)
             {
-                return CreateWmsServiceException("InvalidCRS", extentTransformResult.Error ?? "Invalid spatial reference.");
+                return CreateWmsServiceException(context, "InvalidCRS", extentTransformResult.Error ?? "Invalid spatial reference.");
             }
 
             queryExtent = extentTransformResult.Extent;
@@ -349,7 +351,7 @@ internal static partial class MapServerEndpoints
         using var surface = SKSurface.Create(new SKImageInfo(imageWidth, imageHeight, SKColorType.Rgba8888, SKAlphaType.Premul));
         if (surface is null)
         {
-            return CreateWmsServiceException("NoApplicableCode", "Failed to allocate render surface.", StatusCodes.Status500InternalServerError);
+            return CreateWmsServiceException(context, "NoApplicableCode", "Failed to allocate render surface.", StatusCodes.Status500InternalServerError);
         }
 
         var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
@@ -437,28 +439,28 @@ internal static partial class MapServerEndpoints
         if (!TryGetRequiredQueryValue(query, "LAYERS", out var layersParam) ||
             !TryParseCsvTokens(layersParam, allowEmptyTokens: false, out var mapLayerTokens))
         {
-            return CreateWmsServiceException("MissingParameterValue", "LAYERS parameter is required.");
+            return CreateWmsServiceException(context, "MissingParameterValue", "LAYERS parameter is required.");
         }
 
         if (!TryGetRequiredQueryValue(query, "QUERY_LAYERS", out var queryLayersParam) ||
             !TryParseCsvTokens(queryLayersParam, allowEmptyTokens: false, out var queryLayerTokens))
         {
-            return CreateWmsServiceException("MissingParameterValue", "QUERY_LAYERS parameter is required.");
+            return CreateWmsServiceException(context, "MissingParameterValue", "QUERY_LAYERS parameter is required.");
         }
 
         if (!TryGetRequiredQueryValue(query, "BBOX", out var bboxValue))
         {
-            return CreateWmsServiceException("InvalidParameterValue", "Invalid BBOX parameter. Expected format: xmin,ymin,xmax,ymax.");
+            return CreateWmsServiceException(context, "InvalidParameterValue", "Invalid BBOX parameter. Expected format: xmin,ymin,xmax,ymax.");
         }
 
         if (!TryGetRequiredQueryValue(query, "VERSION", out var versionValue))
         {
-            return CreateWmsServiceException("MissingParameterValue", "VERSION parameter is required.");
+            return CreateWmsServiceException(context, "MissingParameterValue", "VERSION parameter is required.");
         }
 
         if (!IsSupportedWmsVersion(versionValue))
         {
-            return CreateWmsServiceException("InvalidParameterValue", "Unsupported VERSION value. Only 1.3.0 is supported.");
+            return CreateWmsServiceException(context, "InvalidParameterValue", "Unsupported VERSION value. Only 1.3.0 is supported.");
         }
 
         var crsValue = GetQueryValue(query, "CRS");
@@ -469,48 +471,48 @@ internal static partial class MapServerEndpoints
 
         if (!TryParseWmsCrs(crsValue, out var requestSrid, out var normalizedCrs))
         {
-            return CreateWmsServiceException("InvalidCRS", "Invalid or missing CRS/SRS parameter.");
+            return CreateWmsServiceException(context, "InvalidCRS", "Invalid or missing CRS/SRS parameter.");
         }
 
         if (!TryParseWmsBbox(bboxValue, normalizedCrs, out var requestedExtent))
         {
-            return CreateWmsServiceException("InvalidParameterValue", "Invalid BBOX parameter. Expected format: xmin,ymin,xmax,ymax.");
+            return CreateWmsServiceException(context, "InvalidParameterValue", "Invalid BBOX parameter. Expected format: xmin,ymin,xmax,ymax.");
         }
 
         if (!IsExtentWithinCrsBounds(requestedExtent, normalizedCrs))
         {
-            return CreateWmsServiceException("InvalidParameterValue", "BBOX is outside the valid range for the requested CRS.");
+            return CreateWmsServiceException(context, "InvalidParameterValue", "BBOX is outside the valid range for the requested CRS.");
         }
 
         if (!TryGetRequiredQueryValue(query, "WIDTH", out var widthValue) ||
             !int.TryParse(widthValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var imageWidth) ||
             imageWidth <= 0 || imageWidth > WmsMaxImageDimension)
         {
-            return CreateWmsServiceException("InvalidDimensionValue", $"WIDTH must be an integer between 1 and {WmsMaxImageDimension.ToString(CultureInfo.InvariantCulture)}.");
+            return CreateWmsServiceException(context, "InvalidDimensionValue", $"WIDTH must be an integer between 1 and {WmsMaxImageDimension.ToString(CultureInfo.InvariantCulture)}.");
         }
 
         if (!TryGetRequiredQueryValue(query, "HEIGHT", out var heightValue) ||
             !int.TryParse(heightValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var imageHeight) ||
             imageHeight <= 0 || imageHeight > WmsMaxImageDimension)
         {
-            return CreateWmsServiceException("InvalidDimensionValue", $"HEIGHT must be an integer between 1 and {WmsMaxImageDimension.ToString(CultureInfo.InvariantCulture)}.");
+            return CreateWmsServiceException(context, "InvalidDimensionValue", $"HEIGHT must be an integer between 1 and {WmsMaxImageDimension.ToString(CultureInfo.InvariantCulture)}.");
         }
 
         if (!TryParseWmsFeatureInfoPixel(query, imageWidth, imageHeight, out var pixelX, out var pixelY))
         {
-            return CreateWmsServiceException("InvalidPoint", "I/J (or X/Y) must be within the request image dimensions.");
+            return CreateWmsServiceException(context, "InvalidPoint", "I/J (or X/Y) must be within the request image dimensions.");
         }
 
         if (!TryResolveWmsRequestedLayers(service, context, mapLayerTokens, out var mapLayers, out var unresolvedMapLayer))
         {
             var layerLabel = string.IsNullOrWhiteSpace(unresolvedMapLayer) ? "requested layer" : unresolvedMapLayer;
-            return CreateWmsServiceException("LayerNotDefined", $"Layer '{layerLabel}' is not defined.");
+            return CreateWmsServiceException(context, "LayerNotDefined", $"Layer '{layerLabel}' is not defined.");
         }
 
         if (!TryResolveWmsRequestedLayers(service, context, queryLayerTokens, out var queryLayers, out var unresolvedQueryLayer))
         {
             var layerLabel = string.IsNullOrWhiteSpace(unresolvedQueryLayer) ? "requested layer" : unresolvedQueryLayer;
-            return CreateWmsServiceException("LayerNotDefined", $"Layer '{layerLabel}' is not defined.");
+            return CreateWmsServiceException(context, "LayerNotDefined", $"Layer '{layerLabel}' is not defined.");
         }
 
         var mapLayerIds = new HashSet<int>(mapLayers.Select(layer => layer.Id));
@@ -518,13 +520,13 @@ internal static partial class MapServerEndpoints
         {
             if (!mapLayerIds.Contains(layer.Id))
             {
-                return CreateWmsServiceException("LayerNotDefined", "QUERY_LAYERS must be a subset of LAYERS.");
+                return CreateWmsServiceException(context, "LayerNotDefined", "QUERY_LAYERS must be a subset of LAYERS.");
             }
         }
 
         if (!TryNormalizeFeatureInfoFormat(GetQueryValue(query, "INFO_FORMAT"), out var infoFormat))
         {
-            return CreateWmsServiceException("InvalidFormat", "Unsupported INFO_FORMAT. Supported values are text/plain and application/json.");
+            return CreateWmsServiceException(context, "InvalidFormat", "Unsupported INFO_FORMAT. Supported values are text/plain and application/json.");
         }
 
         var featureCount = WmsDefaultFeatureInfoCount;
@@ -533,7 +535,7 @@ internal static partial class MapServerEndpoints
         {
             if (!int.TryParse(featureCountRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out featureCount) || featureCount <= 0)
             {
-                return CreateWmsServiceException("InvalidParameterValue", "FEATURE_COUNT must be a positive integer.");
+                return CreateWmsServiceException(context, "InvalidParameterValue", "FEATURE_COUNT must be a positive integer.");
             }
         }
 
@@ -548,7 +550,7 @@ internal static partial class MapServerEndpoints
                 context.RequestAborted);
             if (!extentTransformResult.IsSuccess)
             {
-                return CreateWmsServiceException("InvalidCRS", extentTransformResult.Error ?? "Invalid spatial reference.");
+                return CreateWmsServiceException(context, "InvalidCRS", extentTransformResult.Error ?? "Invalid spatial reference.");
             }
 
             queryExtent = extentTransformResult.Extent;
@@ -577,7 +579,7 @@ internal static partial class MapServerEndpoints
                 context.RequestAborted);
             if (!clickExtentTransform.IsSuccess)
             {
-                return CreateWmsServiceException("InvalidCRS", clickExtentTransform.Error ?? "Invalid spatial reference.");
+                return CreateWmsServiceException(context, "InvalidCRS", clickExtentTransform.Error ?? "Invalid spatial reference.");
             }
 
             clickExtent = clickExtentTransform.Extent;
@@ -1064,10 +1066,21 @@ internal static partial class MapServerEndpoints
     }
 
     private static IResult CreateWmsServiceException(
+        HttpContext? context,
         string code,
         string message,
         int statusCode = StatusCodes.Status400BadRequest)
     {
+        if (context is not null)
+        {
+            context.RequestServices.GetService<RecentErrorBuffer>()?.Record(
+                context,
+                statusCode,
+                code,
+                message,
+                includeClientErrors: true);
+        }
+
         var xml = BuildWmsServiceExceptionReport(code, message);
         return Results.Content(xml, WmsXmlExceptionMimeType, Encoding.UTF8, statusCode);
     }
@@ -1127,7 +1140,7 @@ internal static partial class MapServerEndpoints
                     out var warningHeader,
                     out var autosError))
             {
-                result = CreateWmsServiceException("InvalidDimensionValue", autosError ?? "Invalid TIME parameter.");
+                result = CreateWmsServiceException(context, "InvalidDimensionValue", autosError ?? "Invalid TIME parameter.");
                 return true;
             }
 
@@ -1150,7 +1163,7 @@ internal static partial class MapServerEndpoints
                     out var warningHeader,
                     out var terrainError))
             {
-                result = CreateWmsServiceException("InvalidDimensionValue", terrainError ?? "Invalid ELEVATION parameter.");
+                result = CreateWmsServiceException(context, "InvalidDimensionValue", terrainError ?? "Invalid ELEVATION parameter.");
                 return true;
             }
 
@@ -1173,7 +1186,7 @@ internal static partial class MapServerEndpoints
                     out var warningHeader,
                     out var lakesError))
             {
-                result = CreateWmsServiceException("InvalidDimensionValue", lakesError ?? "Invalid ELEVATION parameter.");
+                result = CreateWmsServiceException(context, "InvalidDimensionValue", lakesError ?? "Invalid ELEVATION parameter.");
                 return true;
             }
 

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Wmts.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Wmts.cs
@@ -13,11 +13,13 @@ using Honua.Core.Features.Tiles;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Helpers;
+using Honua.Server.Features.Infrastructure.Monitoring;
 using Honua.Server.Features.Infrastructure.Models;
 using Honua.Server.Features.OgcFeatures;
 using Honua.Server.Features.Infrastructure.Rendering;
 using Honua.ServiceDefaults;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Server.Features.MapServer;
@@ -92,7 +94,7 @@ internal static partial class MapServerEndpoints
             {
                 if (string.IsNullOrWhiteSpace(service))
                 {
-                    return CreateWmtsExceptionReport(
+                    return CreateWmtsExceptionReport(context,
                         "MissingParameterValue",
                         "service",
                         "SERVICE parameter is required.");
@@ -100,7 +102,7 @@ internal static partial class MapServerEndpoints
 
                 if (!string.Equals(service, "WMTS", StringComparison.OrdinalIgnoreCase))
                 {
-                    return CreateWmtsExceptionReport(
+                    return CreateWmtsExceptionReport(context,
                         "InvalidParameterValue",
                         "service",
                         "SERVICE must be WMTS.");
@@ -108,7 +110,7 @@ internal static partial class MapServerEndpoints
 
                 if (string.IsNullOrWhiteSpace(requestType))
                 {
-                    return CreateWmtsExceptionReport(
+                    return CreateWmtsExceptionReport(context,
                         "MissingParameterValue",
                         "request",
                         "REQUEST parameter is required.");
@@ -155,7 +157,7 @@ internal static partial class MapServerEndpoints
 
             if (!string.Equals(requestType, "GetCapabilities", StringComparison.OrdinalIgnoreCase))
             {
-                return CreateWmtsExceptionReport(
+                return CreateWmtsExceptionReport(context,
                     "InvalidParameterValue",
                     "request",
                     $"Unsupported REQUEST value '{requestType}'.");
@@ -167,7 +169,7 @@ internal static partial class MapServerEndpoints
                 var acceptFormats = GetQueryValue(request, "ACCEPTFORMATS");
                 if (string.IsNullOrWhiteSpace(acceptFormats))
                 {
-                    return CreateWmtsExceptionReport(
+                    return CreateWmtsExceptionReport(context,
                         "MissingParameterValue",
                         "acceptFormats",
                         "ACCEPTFORMATS parameter value is required.");
@@ -175,7 +177,7 @@ internal static partial class MapServerEndpoints
 
                 if (HasEmptyCommaSeparatedToken(acceptFormats))
                 {
-                    return CreateWmtsExceptionReport(
+                    return CreateWmtsExceptionReport(context,
                         "InvalidParameterValue",
                         "acceptFormats",
                         "ACCEPTFORMATS contains an empty format value.");
@@ -189,7 +191,7 @@ internal static partial class MapServerEndpoints
             {
                 if (HasEmptyCommaSeparatedToken(acceptVersions))
                 {
-                    return CreateWmtsExceptionReport(
+                    return CreateWmtsExceptionReport(context,
                         "InvalidParameterValue",
                         "acceptVersions",
                         "ACCEPTVERSIONS contains an empty version value.");
@@ -199,7 +201,7 @@ internal static partial class MapServerEndpoints
                     .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
                 if (!versions.Contains(WmtsVersion, StringComparer.OrdinalIgnoreCase))
                 {
-                    return CreateWmtsExceptionReport(
+                    return CreateWmtsExceptionReport(context,
                         "VersionNegotiationFailed",
                         null,
                         "Only WMTS version 1.0.0 is supported.");
@@ -210,7 +212,7 @@ internal static partial class MapServerEndpoints
             if (!string.IsNullOrWhiteSpace(version) &&
                 !string.Equals(version, WmtsVersion, StringComparison.OrdinalIgnoreCase))
             {
-                return CreateWmtsExceptionReport(
+                return CreateWmtsExceptionReport(context,
                     "InvalidParameterValue",
                     "version",
                     $"VERSION must be {WmtsVersion}.");
@@ -221,7 +223,7 @@ internal static partial class MapServerEndpoints
             {
                 if (string.IsNullOrWhiteSpace(updateSequence))
                 {
-                    return CreateWmtsExceptionReport(
+                    return CreateWmtsExceptionReport(context,
                         "MissingParameterValue",
                         "updateSequence",
                         "UPDATESEQUENCE parameter value is required.");
@@ -230,7 +232,7 @@ internal static partial class MapServerEndpoints
                 var updateComparison = CompareUpdateSequence(updateSequence, WmtsUpdateSequence);
                 if (updateComparison > 0)
                 {
-                    return CreateWmtsExceptionReport(
+                    return CreateWmtsExceptionReport(context,
                         "InvalidUpdateSequence",
                         null,
                         "UPDATESEQUENCE is greater than the current capabilities update sequence.");
@@ -247,7 +249,7 @@ internal static partial class MapServerEndpoints
             var sectionsParam = GetQueryValue(request, "SECTIONS");
             if (request.ContainsKey("SECTIONS") && string.IsNullOrWhiteSpace(sectionsParam))
             {
-                return CreateWmtsExceptionReport(
+                return CreateWmtsExceptionReport(context,
                     "MissingParameterValue",
                     "sections",
                     "SECTIONS parameter value is required.");
@@ -255,7 +257,7 @@ internal static partial class MapServerEndpoints
 
             if (HasEmptyCommaSeparatedToken(sectionsParam))
             {
-                return CreateWmtsExceptionReport(
+                return CreateWmtsExceptionReport(context,
                     "InvalidParameterValue",
                     "sections",
                     "SECTIONS contains an empty section value.");
@@ -263,7 +265,7 @@ internal static partial class MapServerEndpoints
 
             if (!TryParseWmtsSections(sectionsParam, out var sections, out var sectionsError))
             {
-                return CreateWmtsExceptionReport(
+                return CreateWmtsExceptionReport(context,
                     "InvalidParameterValue",
                     "sections",
                     sectionsError ?? "Invalid SECTIONS parameter.");
@@ -284,7 +286,7 @@ internal static partial class MapServerEndpoints
         catch (Exception ex)
         {
             MapServerLog.WmtsFailed(logger, serviceId, ex.Message, ex);
-            return CreateWmtsExceptionReport(
+            return CreateWmtsExceptionReport(context,
                 "NoApplicableCode",
                 "request",
                 "WMTS request failed.",
@@ -323,7 +325,7 @@ internal static partial class MapServerEndpoints
 
             if (!TryUnescapeWmtsValue(segments[0], out var capabilitiesVersion))
             {
-                return CreateWmtsExceptionReport(
+                return CreateWmtsExceptionReport(context,
                     "InvalidParameterValue",
                     "request",
                     "WMTS RESTful path contains malformed percent-encoding.");
@@ -356,7 +358,7 @@ internal static partial class MapServerEndpoints
                 out var tileColValue,
                 out var tileFormatMimeType))
         {
-            return CreateWmtsExceptionReport(
+            return CreateWmtsExceptionReport(context,
                 "InvalidParameterValue",
                 "request",
                 "WMTS RESTful path contains malformed percent-encoding.");
@@ -385,7 +387,7 @@ internal static partial class MapServerEndpoints
                     out var pixelI,
                     out var infoFormatMimeType))
             {
-                return CreateWmtsExceptionReport(
+                return CreateWmtsExceptionReport(context,
                     "InvalidParameterValue",
                     "request",
                     "WMTS RESTful path contains malformed percent-encoding.");
@@ -428,7 +430,7 @@ internal static partial class MapServerEndpoints
         var version = GetQueryValue(query, "VERSION");
         if (string.IsNullOrWhiteSpace(version))
         {
-            return CreateWmtsExceptionReport(
+            return CreateWmtsExceptionReport(context,
                 "MissingParameterValue",
                 "version",
                 "VERSION parameter is required.");
@@ -436,7 +438,7 @@ internal static partial class MapServerEndpoints
 
         if (!string.Equals(version, WmtsVersion, StringComparison.OrdinalIgnoreCase))
         {
-            return CreateWmtsExceptionReport(
+            return CreateWmtsExceptionReport(context,
                 "InvalidParameterValue",
                 "version",
                 $"VERSION must be {WmtsVersion}.");
@@ -444,12 +446,12 @@ internal static partial class MapServerEndpoints
 
         if (!TryGetRequiredQueryValue(query, "LAYER", out var layerValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "layer", "LAYER parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "layer", "LAYER parameter is required.");
         }
 
         if (!TryResolveWmtsLayer(service, layerValue, out var layer))
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "layer", "Invalid LAYER parameter.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "layer", "Invalid LAYER parameter.");
         }
 
         var layerAccessError = AccessPolicyHelpers.RequireLayerAccess(context, layer!, service);
@@ -460,91 +462,91 @@ internal static partial class MapServerEndpoints
 
         if (!TryGetRequiredQueryValue(query, "STYLE", out var styleValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "style", "STYLE parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "style", "STYLE parameter is required.");
         }
 
         if (!string.Equals(styleValue, "default", StringComparison.OrdinalIgnoreCase))
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "Style", "Only STYLE=default is supported.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "Style", "Only STYLE=default is supported.");
         }
 
-        if (!TryValidateWmtsDimensionParameters(query, layer!, includeFeatureInfoParameters: false, out var dimensionError))
+        if (!TryValidateWmtsDimensionParameters(context, query, layer!, includeFeatureInfoParameters: false, out var dimensionError))
         {
             return dimensionError;
         }
 
         if (!TryGetRequiredQueryValue(query, "FORMAT", out var formatValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "format", "FORMAT parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "format", "FORMAT parameter is required.");
         }
 
         if (!string.Equals(formatValue, "image/png", StringComparison.OrdinalIgnoreCase))
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "format", "Only FORMAT=image/png is supported.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "format", "Only FORMAT=image/png is supported.");
         }
 
         if (!TryGetRequiredQueryValue(query, "TILEMATRIXSET", out var tileMatrixSet))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "TileMatrixSet", "TILEMATRIXSET parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "TileMatrixSet", "TILEMATRIXSET parameter is required.");
         }
 
         if (!string.Equals(tileMatrixSet, "WebMercatorQuad", StringComparison.OrdinalIgnoreCase))
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "TileMatrixSet", "Only TILEMATRIXSET=WebMercatorQuad is supported.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "TileMatrixSet", "Only TILEMATRIXSET=WebMercatorQuad is supported.");
         }
 
         if (!TryGetRequiredQueryValue(query, "TILEMATRIX", out var tileMatrixValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "TileMatrix", "TILEMATRIX parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "TileMatrix", "TILEMATRIX parameter is required.");
         }
 
         if (!int.TryParse(tileMatrixValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var tileMatrix) ||
             tileMatrix < 0 ||
             tileMatrix > wmtsMaxZoom)
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "TileMatrix", "Invalid TILEMATRIX parameter.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "TileMatrix", "Invalid TILEMATRIX parameter.");
         }
 
         if (!TryGetRequiredQueryValue(query, "TILEROW", out var tileRowValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "TileRow", "TILEROW parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "TileRow", "TILEROW parameter is required.");
         }
 
         if (!int.TryParse(tileRowValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var tileRow) || tileRow < 0)
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "TileRow", "Invalid TILEROW parameter.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "TileRow", "Invalid TILEROW parameter.");
         }
 
         if (!TryGetRequiredQueryValue(query, "TILECOL", out var tileColValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "TileCol", "TILECOL parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "TileCol", "TILECOL parameter is required.");
         }
 
         if (!int.TryParse(tileColValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var tileCol) || tileCol < 0)
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "TileCol", "Invalid TILECOL parameter.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "TileCol", "Invalid TILECOL parameter.");
         }
 
         var maxTileIndex = (1L << tileMatrix) - 1;
         if (tileRow > maxTileIndex)
         {
-            return CreateWmtsExceptionReport("TileOutOfRange", "TileRow", "TILEROW is outside the valid range for TILEMATRIX.");
+            return CreateWmtsExceptionReport(context, "TileOutOfRange", "TileRow", "TILEROW is outside the valid range for TILEMATRIX.");
         }
 
         if (tileCol > maxTileIndex)
         {
-            return CreateWmtsExceptionReport("TileOutOfRange", "TileCol", "TILECOL is outside the valid range for TILEMATRIX.");
+            return CreateWmtsExceptionReport(context, "TileOutOfRange", "TileCol", "TILECOL is outside the valid range for TILEMATRIX.");
         }
 
         var tileMatrixLimitMax = GetWmtsTileMatrixLimitMax(tileMatrix);
         if (tileRow > tileMatrixLimitMax)
         {
-            return CreateWmtsExceptionReport("TileOutOfRange", "TileRow", "TILEROW is outside the TileMatrixSetLimits for TILEMATRIX.");
+            return CreateWmtsExceptionReport(context, "TileOutOfRange", "TileRow", "TILEROW is outside the TileMatrixSetLimits for TILEMATRIX.");
         }
 
         if (tileCol > tileMatrixLimitMax)
         {
-            return CreateWmtsExceptionReport("TileOutOfRange", "TileCol", "TILECOL is outside the TileMatrixSetLimits for TILEMATRIX.");
+            return CreateWmtsExceptionReport(context, "TileOutOfRange", "TileCol", "TILECOL is outside the TileMatrixSetLimits for TILEMATRIX.");
         }
 
         // Delegate to tile endpoint by setting route values.
@@ -574,7 +576,7 @@ internal static partial class MapServerEndpoints
         var version = GetQueryValue(query, "VERSION");
         if (string.IsNullOrWhiteSpace(version))
         {
-            return CreateWmtsExceptionReport(
+            return CreateWmtsExceptionReport(context,
                 "MissingParameterValue",
                 "version",
                 "VERSION parameter is required.");
@@ -582,7 +584,7 @@ internal static partial class MapServerEndpoints
 
         if (!string.Equals(version, WmtsVersion, StringComparison.OrdinalIgnoreCase))
         {
-            return CreateWmtsExceptionReport(
+            return CreateWmtsExceptionReport(context,
                 "InvalidParameterValue",
                 "version",
                 $"VERSION must be {WmtsVersion}.");
@@ -590,12 +592,12 @@ internal static partial class MapServerEndpoints
 
         if (!TryGetRequiredQueryValue(query, "LAYER", out var layerValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "layer", "LAYER parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "layer", "LAYER parameter is required.");
         }
 
         if (!TryResolveWmtsLayer(service, layerValue, out var layer))
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "layer", "Invalid LAYER parameter.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "layer", "Invalid LAYER parameter.");
         }
 
         var layerAccessError = AccessPolicyHelpers.RequireLayerAccess(context, layer!, service);
@@ -606,140 +608,140 @@ internal static partial class MapServerEndpoints
 
         if (!TryGetRequiredQueryValue(query, "STYLE", out var styleValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "style", "STYLE parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "style", "STYLE parameter is required.");
         }
 
         if (!string.Equals(styleValue, "default", StringComparison.OrdinalIgnoreCase))
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "style", "Only STYLE=default is supported.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "style", "Only STYLE=default is supported.");
         }
 
         if (!TryGetRequiredQueryValue(query, "FORMAT", out var formatValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "format", "FORMAT parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "format", "FORMAT parameter is required.");
         }
 
         if (!string.Equals(formatValue, "image/png", StringComparison.OrdinalIgnoreCase))
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "format", "Only FORMAT=image/png is supported.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "format", "Only FORMAT=image/png is supported.");
         }
 
         if (!IsWmtsLayerQueryable(service, layer!))
         {
-            return CreateWmtsExceptionReport(
+            return CreateWmtsExceptionReport(context,
                 "OperationNotSupported",
                 "GetFeatureInfo",
                 "GetFeatureInfo is not supported for this layer.",
                 StatusCodes.Status501NotImplemented);
         }
 
-        if (!TryValidateWmtsDimensionParameters(query, layer!, includeFeatureInfoParameters: true, out var dimensionError))
+        if (!TryValidateWmtsDimensionParameters(context, query, layer!, includeFeatureInfoParameters: true, out var dimensionError))
         {
             return dimensionError;
         }
 
         if (!TryGetRequiredQueryValue(query, "TILEMATRIXSET", out var tileMatrixSet))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "TileMatrixSet", "TILEMATRIXSET parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "TileMatrixSet", "TILEMATRIXSET parameter is required.");
         }
 
         if (!string.Equals(tileMatrixSet, "WebMercatorQuad", StringComparison.OrdinalIgnoreCase))
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "TileMatrixSet", "Only TILEMATRIXSET=WebMercatorQuad is supported.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "TileMatrixSet", "Only TILEMATRIXSET=WebMercatorQuad is supported.");
         }
 
         if (!TryGetRequiredQueryValue(query, "TILEMATRIX", out var tileMatrixValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "TileMatrix", "TILEMATRIX parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "TileMatrix", "TILEMATRIX parameter is required.");
         }
 
         if (!int.TryParse(tileMatrixValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var tileMatrix) ||
             tileMatrix < 0 ||
             tileMatrix > wmtsMaxZoom)
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "TileMatrix", "Invalid TILEMATRIX parameter.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "TileMatrix", "Invalid TILEMATRIX parameter.");
         }
 
         if (!TryGetRequiredQueryValue(query, "TILEROW", out var tileRowValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "TileRow", "TILEROW parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "TileRow", "TILEROW parameter is required.");
         }
 
         if (!int.TryParse(tileRowValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var tileRow) || tileRow < 0)
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "TileRow", "Invalid TILEROW parameter.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "TileRow", "Invalid TILEROW parameter.");
         }
 
         if (!TryGetRequiredQueryValue(query, "TILECOL", out var tileColValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "TileCol", "TILECOL parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "TileCol", "TILECOL parameter is required.");
         }
 
         if (!int.TryParse(tileColValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var tileCol) || tileCol < 0)
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "TileCol", "Invalid TILECOL parameter.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "TileCol", "Invalid TILECOL parameter.");
         }
 
         var maxTileIndex = (1L << tileMatrix) - 1;
         if (tileRow > maxTileIndex)
         {
-            return CreateWmtsExceptionReport("TileOutOfRange", "TileRow", "TILEROW is outside the valid range for TILEMATRIX.");
+            return CreateWmtsExceptionReport(context, "TileOutOfRange", "TileRow", "TILEROW is outside the valid range for TILEMATRIX.");
         }
 
         if (tileCol > maxTileIndex)
         {
-            return CreateWmtsExceptionReport("TileOutOfRange", "TileCol", "TILECOL is outside the valid range for TILEMATRIX.");
+            return CreateWmtsExceptionReport(context, "TileOutOfRange", "TileCol", "TILECOL is outside the valid range for TILEMATRIX.");
         }
 
         var tileMatrixLimitMax = GetWmtsTileMatrixLimitMax(tileMatrix);
         if (tileRow > tileMatrixLimitMax)
         {
-            return CreateWmtsExceptionReport("TileOutOfRange", "TileRow", "TILEROW is outside the TileMatrixSetLimits for TILEMATRIX.");
+            return CreateWmtsExceptionReport(context, "TileOutOfRange", "TileRow", "TILEROW is outside the TileMatrixSetLimits for TILEMATRIX.");
         }
 
         if (tileCol > tileMatrixLimitMax)
         {
-            return CreateWmtsExceptionReport("TileOutOfRange", "TileCol", "TILECOL is outside the TileMatrixSetLimits for TILEMATRIX.");
+            return CreateWmtsExceptionReport(context, "TileOutOfRange", "TileCol", "TILECOL is outside the TileMatrixSetLimits for TILEMATRIX.");
         }
 
         if (!TryGetRequiredQueryValue(query, "I", out var iValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "I", "I parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "I", "I parameter is required.");
         }
 
         if (!int.TryParse(iValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var pixelI) || pixelI < 0)
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "I", "I must be a non-negative integer.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "I", "I must be a non-negative integer.");
         }
 
         if (pixelI >= TileSize)
         {
-            return CreateWmtsExceptionReport("TileOutOfRange", "I", $"I must be less than {TileSize}.");
+            return CreateWmtsExceptionReport(context, "TileOutOfRange", "I", $"I must be less than {TileSize}.");
         }
 
         if (!TryGetRequiredQueryValue(query, "J", out var jValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "J", "J parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "J", "J parameter is required.");
         }
 
         if (!int.TryParse(jValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var pixelJ) || pixelJ < 0)
         {
-            return CreateWmtsExceptionReport("InvalidParameterValue", "J", "J must be a non-negative integer.");
+            return CreateWmtsExceptionReport(context, "InvalidParameterValue", "J", "J must be a non-negative integer.");
         }
 
         if (pixelJ >= TileSize)
         {
-            return CreateWmtsExceptionReport("TileOutOfRange", "J", $"J must be less than {TileSize}.");
+            return CreateWmtsExceptionReport(context, "TileOutOfRange", "J", $"J must be less than {TileSize}.");
         }
 
         if (!TryGetRequiredQueryValue(query, "INFOFORMAT", out var infoFormatValue))
         {
-            return CreateWmtsExceptionReport("MissingParameterValue", "InfoFormat", "INFOFORMAT parameter is required.");
+            return CreateWmtsExceptionReport(context, "MissingParameterValue", "InfoFormat", "INFOFORMAT parameter is required.");
         }
 
         if (!TryNormalizeFeatureInfoFormat(infoFormatValue, out var infoFormat))
         {
-            return CreateWmtsExceptionReport(
+            return CreateWmtsExceptionReport(context,
                 "InvalidParameterValue",
                 "InfoFormat",
                 $"Unsupported INFOFORMAT. Supported values are {WmsPlainTextMimeType} and {WmsJsonMimeType}.");
@@ -753,7 +755,7 @@ internal static partial class MapServerEndpoints
                 !int.TryParse(featureCountRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out featureCount) ||
                 featureCount <= 0)
             {
-                return CreateWmtsExceptionReport("InvalidParameterValue", "FEATURE_COUNT", "FEATURE_COUNT must be a positive integer.");
+                return CreateWmtsExceptionReport(context, "InvalidParameterValue", "FEATURE_COUNT", "FEATURE_COUNT must be a positive integer.");
             }
         }
 
@@ -782,7 +784,7 @@ internal static partial class MapServerEndpoints
                 context.RequestAborted);
             if (!clickExtentTransform.IsSuccess)
             {
-                return CreateWmtsExceptionReport(
+                return CreateWmtsExceptionReport(context,
                     "InvalidParameterValue",
                     "TileMatrixSet",
                     clickExtentTransform.Error ?? "Invalid spatial reference.");
@@ -969,11 +971,22 @@ internal static partial class MapServerEndpoints
     }
 
     private static IResult CreateWmtsExceptionReport(
+        HttpContext? context,
         string code,
         string? locator,
         string message,
         int statusCode = StatusCodes.Status400BadRequest)
     {
+        if (context is not null)
+        {
+            context.RequestServices.GetService<RecentErrorBuffer>()?.Record(
+                context,
+                statusCode,
+                code,
+                message,
+                includeClientErrors: true);
+        }
+
         var xml = BuildWmtsExceptionReport(code, locator, message);
         return Results.Content(xml, WmtsMimeType, Encoding.UTF8, statusCode);
     }
@@ -1442,6 +1455,7 @@ internal static partial class MapServerEndpoints
     }
 
     private static bool TryValidateWmtsDimensionParameters(
+        HttpContext context,
         IQueryCollection query,
         LayerDefinition layer,
         bool includeFeatureInfoParameters,
@@ -1465,7 +1479,7 @@ internal static partial class MapServerEndpoints
 
             if (!dimensionLookup.ContainsKey(key))
             {
-                errorResult = CreateWmtsExceptionReport(
+                errorResult = CreateWmtsExceptionReport(context,
                     "InvalidParameterValue",
                     key,
                     $"Unsupported parameter '{key}'.");
@@ -1479,7 +1493,7 @@ internal static partial class MapServerEndpoints
             {
                 if (string.IsNullOrWhiteSpace(dimension.DefaultValue))
                 {
-                    errorResult = CreateWmtsExceptionReport(
+                    errorResult = CreateWmtsExceptionReport(context,
                         "MissingParameterValue",
                         dimension.Identifier,
                         $"{dimension.Identifier} parameter is required.");
@@ -1492,7 +1506,7 @@ internal static partial class MapServerEndpoints
             var rawValue = GetQueryValue(query, dimension.Identifier);
             if (string.IsNullOrWhiteSpace(rawValue))
             {
-                errorResult = CreateWmtsExceptionReport(
+                errorResult = CreateWmtsExceptionReport(context,
                     "MissingParameterValue",
                     dimension.Identifier,
                     $"{dimension.Identifier} parameter value is required.");
@@ -1501,7 +1515,7 @@ internal static partial class MapServerEndpoints
 
             if (!TryResolveWmtsDimensionValue(dimension, rawValue, out _))
             {
-                errorResult = CreateWmtsExceptionReport(
+                errorResult = CreateWmtsExceptionReport(context,
                     "InvalidParameterValue",
                     dimension.Identifier,
                     $"Invalid value for {dimension.Identifier} parameter.");

--- a/src/Honua.Server/Features/OData/ODataEndpoints.cs
+++ b/src/Honua.Server/Features/OData/ODataEndpoints.cs
@@ -404,9 +404,8 @@ internal static partial class ODataEndpoints
         legacyDeleteFeature.RequireAuthorization();
 
         // POST - Batch operations
-        // Defense-in-depth: RequireAuthorization ensures unauthenticated users cannot reach
-        // the batch handler at all. The handler (ValidateBatchAccessAsync) performs additional
-        // per-operation authorization checks since a batch can contain both reads and writes.
+        // The handler (ValidateBatchAccessAsync) performs per-operation authorization checks
+        // so read-only requests to public layers can succeed while writes remain protected.
         var batch = endpoints.MapPost("/odata/$batch",
             (HttpContext context, [FromServices] ODataBatchOperationHandler handler, CancellationToken cancellationToken) =>
                 handler.HandleBatchRequestAsync(context, cancellationToken))
@@ -416,7 +415,7 @@ internal static partial class ODataEndpoints
             .WithTags("OData")
             .Produces<Models.ODataBatchResponse>(200, "application/json")
             .Produces(400);
-        batch.RequireAuthorization();
+        batch.AllowAnonymous();
 
         // GET - Aggregation with $apply (legacy)
         var apply = endpoints.MapGet("/odata/Features({layerId:int})/$apply",

--- a/src/Honua.Server/Features/OgcMaps/Handlers/OgcMapsRenderingHandler.cs
+++ b/src/Honua.Server/Features/OgcMaps/Handlers/OgcMapsRenderingHandler.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
@@ -11,6 +12,7 @@ using Honua.Core.Features.Shared.Models;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Models;
 using Honua.Server.Features.Infrastructure.Services;
+using Honua.Server.Features.Infrastructure.Validation;
 using Honua.Server.Features.OgcMaps;
 using Honua.Server.Features.OgcMaps.Models;
 using Honua.ServiceDefaults;
@@ -82,7 +84,8 @@ internal sealed class OgcMapsRenderingHandler
 
             if (context is not null)
             {
-                var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer);
+                var service = await ResolvePrimaryServiceAsync(layerId, cancellationToken);
+                var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer, service);
                 if (accessError != null)
                 {
                     return accessError;
@@ -149,6 +152,10 @@ internal sealed class OgcMapsRenderingHandler
         var resolvedLayerCount = layerIds.Length;
         try
         {
+            var primaryServices = context is not null
+                ? await GetPrimaryServicesAsync(cancellationToken)
+                : null;
+
             // Resolve dataset layers from explicit selection or all accessible layers.
             var layers = new List<Core.Features.Catalog.Domain.LayerDefinition>();
             int[] resolvedLayerIds;
@@ -165,7 +172,13 @@ internal sealed class OgcMapsRenderingHandler
                 {
                     foreach (var layer in allLayers)
                     {
-                        if (AccessPolicyHelpers.IsLayerAccessible(context, layer))
+                        var service = GetPrimaryService(layer.Id, primaryServices);
+                        var decision = AccessPolicyHelpers.EvaluateAccess(
+                            context,
+                            layer.Metadata?.AccessPolicy,
+                            service?.Metadata?.AccessPolicy);
+
+                        if (decision.IsAllowed)
                         {
                             layers.Add(layer);
                             if (layers.Count > OgcMapsLimits.MaxCollectionsPerDatasetMapRequest)
@@ -195,10 +208,30 @@ internal sealed class OgcMapsRenderingHandler
                 {
                     if (context is not null)
                     {
-                        var accessError = AccessPolicyHelpers.RequireAnyLayerAccess(context, allLayers);
-                        if (accessError != null)
+                        var requiresAuth = false;
+                        foreach (var layer in allLayers)
                         {
-                            return accessError;
+                            var service = GetPrimaryService(layer.Id, primaryServices);
+                            var decision = AccessPolicyHelpers.EvaluateAccess(
+                                context,
+                                layer.Metadata?.AccessPolicy,
+                                service?.Metadata?.AccessPolicy);
+                            if (decision.IsAllowed)
+                            {
+                                continue;
+                            }
+
+                            if (decision.RequiresAuthentication)
+                            {
+                                requiresAuth = true;
+                            }
+                        }
+
+                        if (requiresAuth || allLayers.Length > 0)
+                        {
+                            return requiresAuth
+                                ? StandardErrorHelpers.CreateUnauthorized(context, AccessPolicyHelpers.AuthRequiredMessage)
+                                : StandardErrorHelpers.CreateForbidden(context, AccessPolicyHelpers.AccessForbiddenMessage);
                         }
                     }
 
@@ -231,7 +264,8 @@ internal sealed class OgcMapsRenderingHandler
 
                     if (context is not null)
                     {
-                        var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer);
+                        var service = GetPrimaryService(layerId, primaryServices);
+                        var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer, service);
                         if (accessError != null)
                         {
                             return accessError;
@@ -288,6 +322,26 @@ internal sealed class OgcMapsRenderingHandler
         }
     }
 
+    private async Task<IReadOnlyDictionary<int, ServiceDefinition>> GetPrimaryServicesAsync(
+        CancellationToken cancellationToken)
+    {
+        var services = await _layerCatalog.ListServicesAsync(cancellationToken);
+        return LayerValidationHelpers.BuildPrimaryServiceMap(services);
+    }
+
+    private async Task<ServiceDefinition?> ResolvePrimaryServiceAsync(int layerId, CancellationToken cancellationToken)
+    {
+        var primaryServices = await GetPrimaryServicesAsync(cancellationToken);
+        return GetPrimaryService(layerId, primaryServices);
+    }
+
+    private static ServiceDefinition? GetPrimaryService(
+        int layerId,
+        IReadOnlyDictionary<int, ServiceDefinition>? primaryServices)
+        => primaryServices != null && primaryServices.TryGetValue(layerId, out var service)
+            ? service
+            : null;
+
     /// <summary>
     /// Renders a map with a specific style applied.
     /// </summary>
@@ -317,7 +371,8 @@ internal sealed class OgcMapsRenderingHandler
 
             if (context is not null)
             {
-                var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer);
+                var service = await ResolvePrimaryServiceAsync(layerId, cancellationToken);
+                var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer, service);
                 if (accessError != null)
                 {
                     return accessError;
@@ -482,6 +537,11 @@ internal sealed class OgcMapsRenderingHandler
         if (srid is null or <= 0)
         {
             return null;
+        }
+
+        if (srid == SpatialReference.WGS84.Wkid)
+        {
+            return "<https://www.opengis.net/def/crs/OGC/1.3/CRS84>";
         }
 
         return FormattableString.Invariant($"<https://www.opengis.net/def/crs/EPSG/0/{srid.Value}>");

--- a/src/Honua.Server/Features/OgcMaps/Handlers/OgcMapsTileSetHandler.cs
+++ b/src/Honua.Server/Features/OgcMaps/Handlers/OgcMapsTileSetHandler.cs
@@ -3,9 +3,11 @@
 
 using System.Globalization;
 using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.Catalog.Domain;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Validation;
 using Honua.Server.Features.OgcMaps.Models;
 using Honua.ServiceDefaults;
 using Microsoft.Extensions.Logging;
@@ -55,7 +57,8 @@ internal sealed class OgcMapsTileSetHandler
 
             if (context is not null)
             {
-                var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer);
+                var service = await ResolvePrimaryServiceAsync(layerId, cancellationToken);
+                var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer, service);
                 if (accessError != null)
                 {
                     return accessError;
@@ -153,4 +156,11 @@ internal sealed class OgcMapsTileSetHandler
         => context is not null
             ? StandardErrorHelpers.CreateInternalServerError(context, message)
             : Results.Problem(message, statusCode: 500);
+
+    private async Task<ServiceDefinition?> ResolvePrimaryServiceAsync(int layerId, CancellationToken cancellationToken)
+    {
+        var services = await _layerCatalog.ListServicesAsync(cancellationToken);
+        var primaryServices = LayerValidationHelpers.BuildPrimaryServiceMap(services);
+        return primaryServices.TryGetValue(layerId, out var service) ? service : null;
+    }
 }

--- a/src/Honua.Server/Features/OgcTiles/CollectionsEndpoints.cs
+++ b/src/Honua.Server/Features/OgcTiles/CollectionsEndpoints.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Validation;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.OgcFeatures;
 using Microsoft.AspNetCore.Mvc;
@@ -69,7 +70,50 @@ internal static class CollectionsEndpoints
 
             var cancellationToken = OgcTilesUtilities.GetTimeoutAwareCancellationToken(context);
             var layers = await layerCatalog.ListLayersAsync(cancellationToken);
-            var visibleLayers = layers.Where(layer => AccessPolicyHelpers.IsLayerAccessible(context, layer)).ToList();
+            var services = await layerCatalog.ListServicesAsync(cancellationToken);
+            var primaryServices = LayerValidationHelpers.BuildPrimaryServiceMap(services);
+            var visibleLayers = new List<LayerDefinition>(layers.Length);
+            var requiresAuth = false;
+            var hasDenied = false;
+
+            foreach (var layer in layers)
+            {
+                var service = GetPrimaryService(layer.Id, primaryServices);
+                var decision = AccessPolicyHelpers.EvaluateAccess(
+                    context,
+                    layer.Metadata?.AccessPolicy,
+                    service?.Metadata?.AccessPolicy);
+
+                if (decision.IsAllowed)
+                {
+                    visibleLayers.Add(layer);
+                    continue;
+                }
+
+                hasDenied = true;
+                if (decision.RequiresAuthentication)
+                {
+                    requiresAuth = true;
+                }
+            }
+
+            if (visibleLayers.Count == 0)
+            {
+                if (layers.Length == 0)
+                {
+                    return StandardErrorHelpers.CreateNotFound(context, "No collections are available.");
+                }
+
+                if (hasDenied)
+                {
+                    return requiresAuth
+                        ? StandardErrorHelpers.CreateUnauthorized(context, AccessPolicyHelpers.AuthRequiredMessage)
+                        : StandardErrorHelpers.CreateForbidden(context, AccessPolicyHelpers.AccessForbiddenMessage);
+                }
+
+                return StandardErrorHelpers.CreateNotFound(context, "No collections are available.");
+            }
+
             var collectionTasks = visibleLayers
                 .Select(layer => CreateCollectionAsync(layer, baseUrl, featureReader, crsRegistry, cancellationToken));
             var collections = (await Task.WhenAll(collectionTasks)).ToImmutableArray();
@@ -147,7 +191,9 @@ internal static class CollectionsEndpoints
                 return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
             }
 
-            var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer);
+            var services = await layerCatalog.ListServicesAsync(cancellationToken);
+            var primaryService = GetPrimaryService(layer.Id, LayerValidationHelpers.BuildPrimaryServiceMap(services));
+            var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer, primaryService);
             if (accessError != null)
             {
                 return accessError;
@@ -184,6 +230,11 @@ internal static class CollectionsEndpoints
                 "An error occurred while retrieving the collection.");
         }
     }
+
+    private static ServiceDefinition? GetPrimaryService(
+        int layerId,
+        IReadOnlyDictionary<int, ServiceDefinition> primaryServices)
+        => primaryServices.TryGetValue(layerId, out var service) ? service : null;
 
     private static async Task<CollectionInfo> CreateCollectionAsync(
         LayerDefinition layer,

--- a/src/Honua.Server/Features/OgcTiles/OgcTilesUtilities.cs
+++ b/src/Honua.Server/Features/OgcTiles/OgcTilesUtilities.cs
@@ -4,11 +4,13 @@
 using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Globalization;
+using Microsoft.AspNetCore.Http;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Shared.Models;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.OgcTiles.Models;
+using Microsoft.Net.Http.Headers;
 
 namespace Honua.Server.Features.OgcTiles;
 
@@ -297,16 +299,14 @@ internal static class OgcTilesUtilities
     /// </summary>
     public static bool AcceptsVectorTiles(HttpRequest request)
     {
-        var acceptHeader = request.Headers.Accept.ToString();
-        if (string.IsNullOrWhiteSpace(acceptHeader))
+        var accept = request.GetTypedHeaders().Accept;
+        if (accept is null || accept.Count == 0)
         {
             return true;
         }
 
-        return acceptHeader.Contains("*/*", StringComparison.OrdinalIgnoreCase) ||
-               acceptHeader.Contains(MediaTypes.Mvt, StringComparison.OrdinalIgnoreCase) ||
-               acceptHeader.Contains("application/x-protobuf", StringComparison.OrdinalIgnoreCase) ||
-               acceptHeader.Contains("application/octet-stream", StringComparison.OrdinalIgnoreCase);
+        var (_, vectorQuality) = GetTileAcceptQualities(accept);
+        return vectorQuality > 0;
     }
 
     /// <summary>
@@ -314,13 +314,14 @@ internal static class OgcTilesUtilities
     /// </summary>
     public static bool AcceptsPngTiles(HttpRequest request)
     {
-        var acceptHeader = request.Headers.Accept.ToString();
-        if (string.IsNullOrWhiteSpace(acceptHeader))
+        var accept = request.GetTypedHeaders().Accept;
+        if (accept is null || accept.Count == 0)
         {
             return false;
         }
 
-        return acceptHeader.Contains("image/png", StringComparison.OrdinalIgnoreCase);
+        var (pngQuality, _) = GetTileAcceptQualities(accept);
+        return pngQuality > 0;
     }
 
     /// <summary>
@@ -341,8 +342,59 @@ internal static class OgcTilesUtilities
             return false;
         }
 
-        // Fall back to Accept header: prefer PNG when explicitly requested
-        return AcceptsPngTiles(request) && !AcceptsVectorTiles(request);
+        var accept = request.GetTypedHeaders().Accept;
+        if (accept is null || accept.Count == 0)
+        {
+            return false;
+        }
+
+        var (pngQuality, vectorQuality) = GetTileAcceptQualities(accept);
+        return pngQuality > vectorQuality;
+    }
+
+    private static (double PngQuality, double VectorQuality) GetTileAcceptQualities(
+        IEnumerable<MediaTypeHeaderValue>? acceptHeaders)
+    {
+        var pngQuality = 0d;
+        var vectorQuality = 0d;
+
+        if (acceptHeaders is null)
+        {
+            return (pngQuality, vectorQuality);
+        }
+
+        foreach (var acceptHeader in acceptHeaders)
+        {
+            var quality = acceptHeader.Quality ?? 1d;
+            if (quality <= 0)
+            {
+                continue;
+            }
+
+            var mediaType = acceptHeader.MediaType.Value;
+            if (string.IsNullOrWhiteSpace(mediaType))
+            {
+                continue;
+            }
+
+            if (string.Equals(mediaType, "image/png", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(mediaType, "image/*", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(mediaType, "*/*", StringComparison.OrdinalIgnoreCase))
+            {
+                pngQuality = Math.Max(pngQuality, quality);
+            }
+
+            if (string.Equals(mediaType, MediaTypes.Mvt, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(mediaType, "application/*", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(mediaType, "*/*", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(mediaType, "application/x-protobuf", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(mediaType, "application/octet-stream", StringComparison.OrdinalIgnoreCase))
+            {
+                vectorQuality = Math.Max(vectorQuality, quality);
+            }
+        }
+
+        return (pngQuality, vectorQuality);
     }
 
     /// <summary>

--- a/src/Honua.Server/Features/OgcTiles/TilesEndpoints.cs
+++ b/src/Honua.Server/Features/OgcTiles/TilesEndpoints.cs
@@ -14,6 +14,7 @@ using Honua.Core.Features.Tiles;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Validation;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.OgcFeatures;
 using Honua.Server.Features.Tiles;
@@ -32,7 +33,7 @@ internal static class TilesEndpoints
             .WithDisplayName("OGC API Tiles Tilesets List")
             .WithName("OgcTilesTilesets")
             .WithSummary("Get available tilesets for the dataset")
-            .WithDescription("Lists vector tilesets for the dataset")
+            .WithDescription("Lists available tilesets for the dataset")
             .WithTags("OGC API Tiles")
             .CacheOutput("OgcTilesTilesets")
             .Produces<TileSetsList>(200, MediaTypes.Json)
@@ -51,8 +52,8 @@ internal static class TilesEndpoints
         var datasetTileItem = endpoints.MapGet("/ogc/tiles/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow:int}/{tileCol:int}", HandleGetDatasetTileItem)
             .WithDisplayName("OGC API Tiles Dataset Tile")
             .WithName("OgcTilesDatasetTile")
-            .WithSummary("Get a vector tile for the dataset")
-            .WithDescription("Returns a Mapbox Vector Tile for the dataset and tile coordinates")
+            .WithSummary("Get a tile for the dataset")
+            .WithDescription("Returns a Mapbox Vector Tile or PNG tile for the dataset and tile coordinates")
             .WithTags("OGC API Tiles")
             .CacheOutput("OgcTilesDatasetTile");
 
@@ -60,7 +61,7 @@ internal static class TilesEndpoints
             .WithDisplayName("OGC API Tiles Collection Tilesets List")
             .WithName("OgcTilesCollectionTilesets")
             .WithSummary("Get available tilesets for a collection")
-            .WithDescription("Lists vector tilesets for the specified collection")
+            .WithDescription("Lists available tilesets for the specified collection")
             .WithTags("OGC API Tiles")
             .CacheOutput("OgcTilesCollectionTilesets")
             .Produces<TileSetsList>(200, MediaTypes.Json)
@@ -79,8 +80,8 @@ internal static class TilesEndpoints
         var collectionTile = endpoints.MapGet("/ogc/tiles/collections/{collectionId}/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow:int}/{tileCol:int}", HandleGetCollectionTile)
             .WithDisplayName("OGC API Tiles Collection Tile")
             .WithName("OgcTilesCollectionTile")
-            .WithSummary("Get a vector tile for a collection")
-            .WithDescription("Returns a Mapbox Vector Tile for the specified collection and tile coordinates")
+            .WithSummary("Get a tile for a collection")
+            .WithDescription("Returns a Mapbox Vector Tile or PNG tile for the specified collection and tile coordinates")
             .WithTags("OGC API Tiles")
             .CacheOutput("OgcTilesTile");
 
@@ -263,7 +264,9 @@ internal static class TilesEndpoints
             return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
         }
 
-        var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer);
+        var services = await layerCatalog.ListServicesAsync(cancellationToken);
+        var primaryService = GetPrimaryService(layer.Id, LayerValidationHelpers.BuildPrimaryServiceMap(services));
+        var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer, primaryService);
         if (accessError != null)
         {
             return accessError;
@@ -389,7 +392,9 @@ internal static class TilesEndpoints
                     return (Array.Empty<LayerDefinition>(), StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found."));
                 }
 
-                var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer);
+                var services = await layerCatalog.ListServicesAsync(cancellationToken);
+                var primaryService = GetPrimaryService(layer.Id, LayerValidationHelpers.BuildPrimaryServiceMap(services));
+                var accessError = AccessPolicyHelpers.RequireLayerAccess(context, layer, primaryService);
                 if (accessError != null)
                 {
                     return (Array.Empty<LayerDefinition>(), accessError);
@@ -858,6 +863,14 @@ internal static class TilesEndpoints
                 Title = "Vector tiles",
                 Templated = true
             },
+            new Link
+            {
+                Href = tileTemplate,
+                Rel = "item",
+                Type = MediaTypes.Png,
+                Title = "Raster tiles",
+                Templated = true
+            },
             Link.Create(
                 href: tileMatrixSetHref,
                 rel: RelationTypes.TilingScheme,
@@ -867,7 +880,7 @@ internal static class TilesEndpoints
         return new TileSetItem
         {
             Title = title,
-            DataType = "vector",
+            DataType = "map",
             Crs = crs,
             TileMatrixSetId = tileMatrixSetId,
             TileMatrixSetUri = uri,
@@ -908,6 +921,14 @@ internal static class TilesEndpoints
                 Title = "Vector tiles",
                 Templated = true
             },
+            new Link
+            {
+                Href = tileTemplate,
+                Rel = "item",
+                Type = MediaTypes.Png,
+                Title = "Raster tiles",
+                Templated = true
+            },
             Link.Create(
                 href: tileMatrixSetHref,
                 rel: RelationTypes.TilingScheme,
@@ -924,7 +945,7 @@ internal static class TilesEndpoints
         {
             Title = $"{titleBase} ({tileMatrixSetId})",
             Description = description,
-            DataType = "vector",
+            DataType = "map",
             Crs = crs,
             TileMatrixSetId = tileMatrixSetId,
             TileMatrixSetUri = uri,
@@ -974,6 +995,9 @@ internal static class TilesEndpoints
         HttpContext context,
         CancellationToken cancellationToken)
     {
+        var services = await layerCatalog.ListServicesAsync(cancellationToken);
+        var primaryServices = LayerValidationHelpers.BuildPrimaryServiceMap(services);
+
         if (string.IsNullOrWhiteSpace(collections))
         {
             var layers = await layerCatalog.ListLayersAsync(cancellationToken);
@@ -982,17 +1006,48 @@ internal static class TilesEndpoints
                 return (Array.Empty<LayerDefinition>(), StandardErrorHelpers.CreateNotFound(context, "No collections are available."));
             }
 
-            var accessibleLayers = layers
-                .Where(layer => AccessPolicyHelpers.IsLayerAccessible(context, layer))
+            var accessibleLayers = new List<LayerDefinition>(layers.Length);
+            var requiresAuth = false;
+            var hasDenied = false;
+
+            foreach (var layer in layers)
+            {
+                var service = GetPrimaryService(layer.Id, primaryServices);
+                var decision = AccessPolicyHelpers.EvaluateAccess(
+                    context,
+                    layer.Metadata?.AccessPolicy,
+                    service?.Metadata?.AccessPolicy);
+
+                if (decision.IsAllowed)
+                {
+                    accessibleLayers.Add(layer);
+                    continue;
+                }
+
+                hasDenied = true;
+                if (decision.RequiresAuthentication)
+                {
+                    requiresAuth = true;
+                }
+            }
+
+            var accessibleLayersArray = accessibleLayers
                 .OrderBy(layer => layer.Id)
                 .ToArray();
 
-            if (accessibleLayers.Length == 0)
+            if (accessibleLayersArray.Length == 0)
             {
-                return (Array.Empty<LayerDefinition>(), AccessPolicyHelpers.RequireAnyLayerAccess(context, layers));
+                if (hasDenied)
+                {
+                    return (Array.Empty<LayerDefinition>(), requiresAuth
+                        ? StandardErrorHelpers.CreateUnauthorized(context, AccessPolicyHelpers.AuthRequiredMessage)
+                        : StandardErrorHelpers.CreateForbidden(context, AccessPolicyHelpers.AccessForbiddenMessage));
+                }
+
+                return (Array.Empty<LayerDefinition>(), StandardErrorHelpers.CreateNotFound(context, "No collections are available."));
             }
 
-            return (accessibleLayers, null);
+            return (accessibleLayersArray, null);
         }
 
         if (!TryParseCollectionIds(collections, out var collectionIds, out var parseError))
@@ -1009,7 +1064,8 @@ internal static class TilesEndpoints
                 return (Array.Empty<LayerDefinition>(), StandardErrorHelpers.CreateBadRequest(context, $"Collection '{collectionId}' not found."));
             }
 
-            var accessError = AccessPolicyHelpers.RequireLayerAccess(context, selectedLayer);
+            var primaryService = GetPrimaryService(selectedLayer.Id, primaryServices);
+            var accessError = AccessPolicyHelpers.RequireLayerAccess(context, selectedLayer, primaryService);
             if (accessError != null)
             {
                 return (Array.Empty<LayerDefinition>(), accessError);
@@ -1249,5 +1305,10 @@ internal static class TilesEndpoints
             await _inner.ExecuteAsync(httpContext);
         }
     }
+
+    private static ServiceDefinition? GetPrimaryService(
+        int layerId,
+        IReadOnlyDictionary<int, ServiceDefinition> primaryServices)
+        => primaryServices.TryGetValue(layerId, out var service) ? service : null;
 
 }

--- a/src/Honua.Server/Features/Stac/Models/StacConstants.cs
+++ b/src/Honua.Server/Features/Stac/Models/StacConstants.cs
@@ -71,7 +71,8 @@ internal static class StacConstants
 
         public static readonly HashSet<string> SearchGet = new(StringComparer.OrdinalIgnoreCase)
         {
-            "f", "limit", "offset", "bbox", "datetime", "collections", "ids"
+            "f", "limit", "offset", "bbox", "datetime", "collections", "ids",
+            "intersects", "fields", "sortby", "filter", "filter-lang", "filter-crs"
         };
     }
 }

--- a/src/Honua.Server/Features/Stac/Models/StacModels.cs
+++ b/src/Honua.Server/Features/Stac/Models/StacModels.cs
@@ -327,6 +327,12 @@ public sealed record StacSearchRequest
     public JsonElement? Filter { get; init; }
 
     /// <summary>
+    /// CRS for the filter geometry or filter expression.
+    /// </summary>
+    [JsonPropertyName("filter-crs")]
+    public string? FilterCrs { get; init; }
+
+    /// <summary>
     /// Filter language (defaults to cql2-json for POST).
     /// </summary>
     [JsonPropertyName("filter-lang")]
@@ -341,13 +347,13 @@ public sealed record StacFieldsExtension
     /// <summary>
     /// Properties to include.
     /// </summary>
-    [JsonPropertyName("includes")]
+    [JsonPropertyName("include")]
     public ImmutableArray<string>? Includes { get; init; }
 
     /// <summary>
     /// Properties to exclude.
     /// </summary>
-    [JsonPropertyName("excludes")]
+    [JsonPropertyName("exclude")]
     public ImmutableArray<string>? Excludes { get; init; }
 }
 

--- a/src/Honua.Server/Features/Stac/SearchEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/SearchEndpoints.cs
@@ -3,14 +3,17 @@
 
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Text.Json;
 using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Queries.Filters;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.Stac.Models;
 using Honua.Server.Features.Stac.Services;
+using Honua.Server.Features.OgcFeatures.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Honua.Server.Features.Stac;
@@ -20,6 +23,8 @@ namespace Honua.Server.Features.Stac;
 /// </summary>
 internal static class SearchEndpoints
 {
+    private delegate bool TryParseDelegate<TValue>(string input, out TValue value);
+
     /// <summary>
     /// Maps the STAC search endpoints.
     /// </summary>
@@ -55,8 +60,16 @@ internal static class SearchEndpoints
         [FromQuery] string? datetime,
         [FromQuery] string? collections,
         [FromQuery] string? ids,
+        [FromQuery] string? intersects,
+        [FromQuery] string? fields,
+        [FromQuery] string? sortby,
+        [FromQuery(Name = "filter")] string? filter,
+        [FromQuery(Name = "filter-lang")] string? filterLang,
+        [FromQuery(Name = "filter-crs")] string? filterCrs,
         [FromServices] ILayerCatalog layerCatalog,
         [FromServices] IFeatureReader featureReader,
+        [FromServices] IFilterExpressionService filterExpressionService,
+        [FromServices] OgcFeaturesGeometryServices geometryServices,
         [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
     {
         var validationError = OgcCommonUtilities.ValidateQueryParameters(
@@ -66,48 +79,37 @@ internal static class SearchEndpoints
             return StandardErrorHelpers.CreateBadRequest(context, validationError.Value ?? "Invalid query parameters.");
         }
 
-        // Convert GET parameters to a search request
-        var request = new StacSearchRequest
+        if (!TryBuildSearchRequestFromGet(
+                limit,
+                datetime,
+                bbox,
+                collections,
+                ids,
+                intersects,
+                fields,
+                sortby,
+                filter,
+                filterLang,
+                filterCrs,
+                true,
+                out var request,
+                out var requestError))
         {
-            Limit = limit,
-            Datetime = datetime
-        };
+            return StandardErrorHelpers.CreateBadRequest(context, requestError ?? "Invalid search parameters.");
+        }
+
         var effectiveOffset = Math.Max(offset ?? 0, 0);
 
-        if (!string.IsNullOrWhiteSpace(bbox))
-        {
-            var parts = bbox.Split(',');
-            if (parts.Length is 4 or 6)
-            {
-                var bboxValues = new double[parts.Length];
-                var allValid = true;
-                for (var i = 0; i < parts.Length; i++)
-                {
-                    if (!double.TryParse(parts[i], NumberStyles.Float, CultureInfo.InvariantCulture, out bboxValues[i]))
-                    {
-                        allValid = false;
-                        break;
-                    }
-                }
-
-                if (allValid)
-                {
-                    request = request with { Bbox = ImmutableArray.Create(bboxValues) };
-                }
-            }
-        }
-
-        if (!string.IsNullOrWhiteSpace(collections))
-        {
-            request = request with { Collections = collections.Split(',').ToImmutableArray() };
-        }
-
-        if (!string.IsNullOrWhiteSpace(ids))
-        {
-            request = request with { Ids = ids.Split(',').ToImmutableArray() };
-        }
-
-        return await ExecuteSearchAsync(request, effectiveOffset, context, layerCatalog, featureReader, logger);
+        return await ExecuteSearchAsync(
+            request,
+            effectiveOffset,
+            context,
+            layerCatalog,
+            featureReader,
+            filterExpressionService,
+            geometryServices,
+            defaultFilterLangIsText: true,
+            logger);
     }
 
     private static async Task<IResult> HandleSearchPost(
@@ -115,9 +117,20 @@ internal static class SearchEndpoints
         [FromBody] StacSearchRequest request,
         [FromServices] ILayerCatalog layerCatalog,
         [FromServices] IFeatureReader featureReader,
+        [FromServices] IFilterExpressionService filterExpressionService,
+        [FromServices] OgcFeaturesGeometryServices geometryServices,
         [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
     {
-        return await ExecuteSearchAsync(request, 0, context, layerCatalog, featureReader, logger);
+        return await ExecuteSearchAsync(
+            request,
+            0,
+            context,
+            layerCatalog,
+            featureReader,
+            filterExpressionService,
+            geometryServices,
+            defaultFilterLangIsText: false,
+            logger);
     }
 
     private static async Task<IResult> ExecuteSearchAsync(
@@ -126,6 +139,9 @@ internal static class SearchEndpoints
         HttpContext context,
         ILayerCatalog layerCatalog,
         IFeatureReader featureReader,
+        IFilterExpressionService filterExpressionService,
+        OgcFeaturesGeometryServices geometryServices,
+        bool defaultFilterLangIsText,
         ILogger logger)
     {
         var effectiveLimit = Math.Clamp(
@@ -147,132 +163,52 @@ internal static class SearchEndpoints
 
             IEnumerable<Core.Features.Catalog.Domain.LayerDefinition> targetLayers = visibleLayers;
 
-            // Filter by collection IDs if specified
             if (request.Collections is { IsDefault: false } requestedCollections && requestedCollections.Length > 0)
             {
-                var collectionIds = requestedCollections
-                    .Where(id => int.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
-                    .Select(id => int.Parse(id, CultureInfo.InvariantCulture))
-                    .ToHashSet();
+                if (!TryParseIntegerTokenSet(requestedCollections, out var collectionIds, out var collectionError))
+                {
+                    return StandardErrorHelpers.CreateBadRequest(context, collectionError ?? "Invalid collections parameter.");
+                }
+
                 targetLayers = targetLayers.Where(l => collectionIds.Contains(l.Id));
             }
 
-            // Pre-parse IDs filter; if provided but none are valid, return empty results
-            ImmutableArray<long>? parsedObjectIds = null;
             if (request.Ids is { IsDefault: false } requestedIds && requestedIds.Length > 0)
             {
-                var objectIds = requestedIds
-                    .Where(id => long.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
-                    .Select(id => long.Parse(id, CultureInfo.InvariantCulture))
-                    .ToImmutableArray();
-                if (objectIds.Length == 0)
+                if (!TryParseLongTokenSet(requestedIds, out var parsedObjectIds, out var idsError))
                 {
-                    // IDs were provided but none could be parsed — zero results
-                    parsedObjectIds = ImmutableArray<long>.Empty;
+                    return StandardErrorHelpers.CreateBadRequest(context, idsError ?? "Invalid ids parameter.");
                 }
-                else
-                {
-                    parsedObjectIds = objectIds;
-                }
+
+                var layerList = targetLayers.ToArray();
+                return await ExecuteSearchAcrossLayersAsync(
+                    request,
+                    offset,
+                    context,
+                    baseUrl,
+                    featureReader,
+                    filterExpressionService,
+                    geometryServices,
+                    defaultFilterLangIsText,
+                    logger,
+                    layerList,
+                    parsedObjectIds,
+                    effectiveLimit);
             }
 
-            var layerList = targetLayers.ToArray();
-            var allItems = ImmutableArray.CreateBuilder<StacItem>();
-            long totalMatched = 0;
-
-            // Short-circuit: if IDs filter resolved to empty, skip all queries
-            var hasEmptyIdFilter = parsedObjectIds is { Length: 0 };
-            var remainingSkip = offset;
-
-            // Query each target layer — continue for all layers to accumulate totalMatched
-            foreach (var layer in layerList)
-            {
-                if (hasEmptyIdFilter)
-                {
-                    break;
-                }
-
-                var query = BuildLayerQuery(request, layer, parsedObjectIds);
-
-                if (remainingSkip > 0)
-                {
-                    // Count this layer to decide how much to skip
-                    var layerCount = await featureReader.CountAsync(layer.Id, query, cancellationToken);
-                    totalMatched += layerCount;
-
-                    if (remainingSkip >= layerCount)
-                    {
-                        remainingSkip -= (int)Math.Min(layerCount, int.MaxValue);
-                        continue;
-                    }
-
-                    // Partial skip: fetch from offset within this layer
-                    var remaining = effectiveLimit - allItems.Count;
-                    query = query with { Offset = remainingSkip, Limit = remaining };
-                    remainingSkip = 0;
-
-                    var result = await featureReader.QueryAsync(layer.Id, query, cancellationToken);
-                    allItems.AddRange(result.Features
-                        .Select(f => StacMappingService.MapFeatureToItem(f, layer, baseUrl)));
-                }
-                else if (allItems.Count < effectiveLimit)
-                {
-                    var remaining = effectiveLimit - allItems.Count;
-                    query = query with { Limit = remaining };
-
-                    var result = await featureReader.QueryAsync(layer.Id, query, cancellationToken);
-                    totalMatched += result.TotalCount;
-
-                    allItems.AddRange(result.Features
-                        .Select(f => StacMappingService.MapFeatureToItem(f, layer, baseUrl)));
-                }
-                else
-                {
-                    // Page is full — count only to get accurate totalMatched
-                    totalMatched += await featureReader.CountAsync(layer.Id, query, cancellationToken);
-                }
-            }
-
-            var stacBase = $"{baseUrl}/stac";
-            var linksBuilder = ImmutableArray.CreateBuilder<Link>();
-            linksBuilder.Add(Link.Create(
-                href: $"{stacBase}/search?{BuildSearchQuery(effectiveLimit, offset, request)}",
-                rel: RelationTypes.Self,
-                type: MediaTypes.GeoJson,
-                title: "Search results"));
-            linksBuilder.Add(Link.Create(
-                href: stacBase,
-                rel: StacConstants.StacRelations.Root,
-                type: MediaTypes.Json,
-                title: "STAC Catalog"));
-
-            // Add next link when more items exist beyond the current page
-            var nextOffset = offset + allItems.Count;
-            if (totalMatched > nextOffset)
-            {
-                linksBuilder.Add(Link.Create(
-                    href: $"{stacBase}/search?{BuildSearchQuery(effectiveLimit, nextOffset, request)}",
-                    rel: "next",
-                    type: MediaTypes.GeoJson,
-                    title: "Next page"));
-            }
-
-            var response = new StacItemCollection
-            {
-                Features = allItems.ToImmutable(),
-                Links = linksBuilder.ToImmutable(),
-                NumberReturned = allItems.Count,
-                NumberMatched = totalMatched,
-                Context = new StacSearchContext
-                {
-                    Returned = allItems.Count,
-                    Matched = totalMatched,
-                    Limit = effectiveLimit
-                }
-            };
-
-            StacLog.SearchReturned(logger, allItems.Count);
-            return Results.Json(response, StacJsonContext.Default.StacItemCollection, MediaTypes.GeoJson);
+            return await ExecuteSearchAcrossLayersAsync(
+                request,
+                offset,
+                context,
+                baseUrl,
+                featureReader,
+                filterExpressionService,
+                geometryServices,
+                defaultFilterLangIsText,
+                logger,
+                targetLayers.ToArray(),
+                null,
+                effectiveLimit);
         }
         catch (OperationCanceledException)
             when (TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context).IsCancellationRequested)
@@ -287,68 +223,973 @@ internal static class SearchEndpoints
         }
     }
 
-    private static FeatureQuery BuildLayerQuery(
+    private static async Task<IResult> ExecuteSearchAcrossLayersAsync(
         StacSearchRequest request,
-        Core.Features.Catalog.Domain.LayerDefinition layer,
-        ImmutableArray<long>? parsedObjectIds)
+        int offset,
+        HttpContext context,
+        string baseUrl,
+        IFeatureReader featureReader,
+        IFilterExpressionService filterExpressionService,
+        OgcFeaturesGeometryServices geometryServices,
+        bool defaultFilterLangIsText,
+        ILogger logger,
+        Core.Features.Catalog.Domain.LayerDefinition[] layerList,
+        ImmutableArray<long>? parsedObjectIds,
+        int effectiveLimit)
     {
-        var query = new FeatureQuery();
+        var allItems = ImmutableArray.CreateBuilder<StacItem>();
+        long totalMatched = 0;
+        var remainingSkip = offset;
+        var hasEmptyIdFilter = parsedObjectIds is { Length: 0 };
+        var layerSelections = new Dictionary<int, IReadOnlySet<string>?>();
 
-        // Apply bbox filter
-        if (request.Bbox is { IsDefault: false } bboxArr && bboxArr.Length >= 4)
+        foreach (var layer in layerList)
         {
-            var spatialFilter = StacFilterHelpers.CreateBboxSpatialFilter(
-                west: bboxArr[0], south: bboxArr[1], east: bboxArr[2], north: bboxArr[3]);
-            query = query with { SpatialFilter = spatialFilter };
-        }
-
-        // Apply datetime filter
-        if (!string.IsNullOrWhiteSpace(request.Datetime))
-        {
-            var temporalFilter = StacFilterHelpers.ParseDatetime(request.Datetime, layer);
-            if (temporalFilter is not null)
+            if (hasEmptyIdFilter)
             {
-                query = query with { TemporalFilter = temporalFilter };
+                break;
+            }
+
+            if (!TryBuildLayerQuery(
+                    request,
+                    layer,
+                    parsedObjectIds,
+                    filterExpressionService,
+                    geometryServices,
+                    defaultFilterLangIsText,
+                    out var query,
+                    out var selectedProperties,
+                    out var queryError))
+            {
+                return StandardErrorHelpers.CreateBadRequest(context, queryError ?? "Invalid search parameters.");
+            }
+
+            layerSelections[layer.Id] = selectedProperties;
+
+            if (remainingSkip > 0)
+            {
+                var layerCount = await featureReader.CountAsync(layer.Id, query, context.RequestAborted);
+                totalMatched += layerCount;
+
+                if (remainingSkip >= layerCount)
+                {
+                    remainingSkip -= (int)Math.Min(layerCount, int.MaxValue);
+                    continue;
+                }
+
+                var remaining = effectiveLimit - allItems.Count;
+                query = query with { Offset = remainingSkip, Limit = remaining };
+                remainingSkip = 0;
+
+                var result = await featureReader.QueryAsync(layer.Id, query, context.RequestAborted);
+                allItems.AddRange(result.Features
+                    .Select(f => StacMappingService.MapFeatureToItem(f, layer, baseUrl, selectedProperties)));
+            }
+            else if (allItems.Count < effectiveLimit)
+            {
+                var remaining = effectiveLimit - allItems.Count;
+                query = query with { Limit = remaining };
+
+                var result = await featureReader.QueryAsync(layer.Id, query, context.RequestAborted);
+                totalMatched += result.TotalCount;
+
+                allItems.AddRange(result.Features
+                    .Select(f => StacMappingService.MapFeatureToItem(f, layer, baseUrl, selectedProperties)));
+            }
+            else
+            {
+                totalMatched += await featureReader.CountAsync(layer.Id, query, context.RequestAborted);
             }
         }
 
-        // Apply ID filter
+        var stacBase = $"{baseUrl}/stac";
+        var linksBuilder = ImmutableArray.CreateBuilder<Link>();
+        linksBuilder.Add(Link.Create(
+            href: $"{stacBase}/search?{BuildSearchQuery(effectiveLimit, offset, request, defaultFilterLangIsText)}",
+            rel: RelationTypes.Self,
+            type: MediaTypes.GeoJson,
+            title: "Search results"));
+        linksBuilder.Add(Link.Create(
+            href: stacBase,
+            rel: StacConstants.StacRelations.Root,
+            type: MediaTypes.Json,
+            title: "STAC Catalog"));
+
+        var nextOffset = offset + allItems.Count;
+        if (totalMatched > nextOffset)
+        {
+            linksBuilder.Add(Link.Create(
+                href: $"{stacBase}/search?{BuildSearchQuery(effectiveLimit, nextOffset, request, defaultFilterLangIsText)}",
+                rel: "next",
+                type: MediaTypes.GeoJson,
+                title: "Next page"));
+        }
+
+        var response = new StacItemCollection
+        {
+            Features = allItems.ToImmutable(),
+            Links = linksBuilder.ToImmutable(),
+            NumberReturned = allItems.Count,
+            NumberMatched = totalMatched,
+            Context = new StacSearchContext
+            {
+                Returned = allItems.Count,
+                Matched = totalMatched,
+                Limit = effectiveLimit
+            }
+        };
+
+        StacLog.SearchReturned(logger, allItems.Count);
+        return Results.Json(response, StacJsonContext.Default.StacItemCollection, MediaTypes.GeoJson);
+    }
+
+    private static bool TryBuildLayerQuery(
+        StacSearchRequest request,
+        Core.Features.Catalog.Domain.LayerDefinition layer,
+        ImmutableArray<long>? parsedObjectIds,
+        IFilterExpressionService filterExpressionService,
+        OgcFeaturesGeometryServices geometryServices,
+        bool defaultFilterLangIsText,
+        out FeatureQuery query,
+        out IReadOnlySet<string>? selectedProperties,
+        out string? error)
+    {
+        query = new FeatureQuery();
+        selectedProperties = null;
+        error = null;
+
+        if (request.Bbox is { IsDefault: false } bboxArr && bboxArr.Length >= 4)
+        {
+            if (request.Intersects.HasValue)
+            {
+                error = "bbox and intersects cannot be combined.";
+                return false;
+            }
+
+            query = query with
+            {
+                SpatialFilter = StacFilterHelpers.CreateBboxSpatialFilter(
+                    west: bboxArr[0], south: bboxArr[1], east: bboxArr[2], north: bboxArr[3])
+            };
+        }
+
+        if (request.Intersects.HasValue)
+        {
+            if (!StacFilterHelpers.TryCreateIntersectsSpatialFilter(
+                    request.Intersects.Value.GetRawText(),
+                    geometryServices,
+                    out var intersectsSpatialFilter,
+                    out var intersectsError))
+            {
+                error = intersectsError;
+                return false;
+            }
+
+            if (intersectsSpatialFilter.HasValue)
+            {
+                query = query with { SpatialFilter = intersectsSpatialFilter };
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Datetime))
+        {
+            var temporalFilter = StacFilterHelpers.ParseDatetime(request.Datetime, layer);
+            if (temporalFilter is null)
+            {
+                error = "Invalid datetime parameter.";
+                return false;
+            }
+
+            query = query with { TemporalFilter = temporalFilter };
+        }
+
         if (parsedObjectIds is { Length: > 0 } objectIds)
         {
             query = query with { ObjectIds = objectIds };
         }
 
-        // Apply sort
+        if (!TryResolveFilterQuery(request, layer, filterExpressionService, defaultFilterLangIsText, out var sqlFilter, out var filterError))
+        {
+            error = filterError;
+            return false;
+        }
+
+        if (sqlFilter is not null)
+        {
+            query = query with { SqlFilter = sqlFilter };
+        }
+
         if (request.Sortby is { IsDefault: false } sortby && sortby.Length > 0)
         {
-            var orderBy = sortby.Select(s =>
-                string.Equals(s.Direction, "desc", StringComparison.OrdinalIgnoreCase)
-                    ? OrderByClause.Desc(s.Field)
-                    : OrderByClause.Asc(s.Field))
-                .ToImmutableArray();
+            if (!TryBuildSortOrder(layer, sortby, out var orderBy, out var sortError))
+            {
+                error = sortError;
+                return false;
+            }
+
             query = query with { OrderBy = orderBy };
         }
 
-        // Apply field selection
-        if (request.Fields is { Includes: { IsDefault: false } includes } && includes.Length > 0)
+        if (request.Fields is not null)
         {
-            query = query with { OutFields = includes };
+            if (!TryBuildFieldSelection(layer, request.Fields, out var outFields, out selectedProperties, out var fieldError))
+            {
+                error = fieldError;
+                return false;
+            }
+
+            query = query with { OutFields = outFields };
         }
 
-        return query;
+        return true;
     }
 
-    private static string BuildSearchQuery(int limit, int offset, StacSearchRequest request)
+    private static bool TryResolveFilterQuery(
+        StacSearchRequest request,
+        Core.Features.Catalog.Domain.LayerDefinition layer,
+        IFilterExpressionService filterExpressionService,
+        bool defaultFilterLangIsText,
+        out SqlFragment? sqlFilter,
+        out string? error)
     {
-        var query = $"limit={limit}&offset={offset}";
+        sqlFilter = null;
+        error = null;
+
+        var hasFilter = request.Filter.HasValue;
+        var hasFilterLang = !string.IsNullOrWhiteSpace(request.FilterLang);
+        var hasFilterCrs = !string.IsNullOrWhiteSpace(request.FilterCrs);
+        if (!hasFilter && !hasFilterLang && !hasFilterCrs)
+        {
+            return true;
+        }
+
+        if (!hasFilter)
+        {
+            error = "filter requires a filter expression.";
+            return false;
+        }
+
+        if (hasFilterCrs && !IsCrs84(request.FilterCrs))
+        {
+            error = $"Unsupported filter-crs '{request.FilterCrs}'.";
+            return false;
+        }
+
+        var filterLanguage = ResolveFilterLanguage(request.FilterLang, request.Filter, defaultFilterLangIsText);
+        if (filterLanguage is null)
+        {
+            error = "Invalid filter-lang parameter.";
+            return false;
+        }
+
+        var filterElement = request.Filter!.Value;
+        var filterText = filterLanguage.Value == FilterLanguage.Cql2Json
+            ? filterElement.GetRawText()
+            : filterElement.ValueKind == JsonValueKind.String
+                ? filterElement.GetString()
+                : null;
+
+        if (filterLanguage.Value == FilterLanguage.Cql2Text && filterElement.ValueKind != JsonValueKind.String)
+        {
+            error = "filter must be a string when filter-lang is cql2-text.";
+            return false;
+        }
+
+        if (filterLanguage.Value == FilterLanguage.Cql2Json &&
+            filterElement.ValueKind is not JsonValueKind.Object and not JsonValueKind.Array)
+        {
+            error = "filter must be a JSON object when filter-lang is cql2-json.";
+            return false;
+        }
+
+        var parseResult = filterExpressionService.Parse(filterLanguage.Value, filterText);
+        if (!parseResult.IsSuccess)
+        {
+            error = parseResult.ErrorMessage ?? "Invalid filter expression.";
+            return false;
+        }
+
+        var translationResult = filterExpressionService.Translate(parseResult.Expression, layer);
+        if (!translationResult.IsSuccess)
+        {
+            error = translationResult.ErrorMessage ?? "Invalid filter expression.";
+            return false;
+        }
+
+        sqlFilter = translationResult.SqlFilter;
+        return true;
+    }
+
+    private static FilterLanguage? ResolveFilterLanguage(
+        string? filterLang,
+        JsonElement? filter,
+        bool defaultFilterLangIsText)
+    {
+        if (!string.IsNullOrWhiteSpace(filterLang))
+        {
+            return filterLang.Trim().ToLowerInvariant() switch
+            {
+                "cql2-text" => FilterLanguage.Cql2Text,
+                "cql2-json" => FilterLanguage.Cql2Json,
+                _ => null
+            };
+        }
+
+        if (!filter.HasValue)
+        {
+            return null;
+        }
+
+        return defaultFilterLangIsText || filter.Value.ValueKind == JsonValueKind.String
+            ? FilterLanguage.Cql2Text
+            : FilterLanguage.Cql2Json;
+    }
+
+    private static bool TryBuildSortOrder(
+        Core.Features.Catalog.Domain.LayerDefinition layer,
+        ImmutableArray<StacSortDefinition> sortby,
+        out ImmutableArray<OrderByClause> orderBy,
+        out string? error)
+    {
+        var availableFields = layer.AttributeFields.ToDictionary(field => field.Name, StringComparer.OrdinalIgnoreCase);
+        var orderByBuilder = ImmutableArray.CreateBuilder<OrderByClause>(sortby.Length);
+
+        foreach (var sort in sortby)
+        {
+            if (string.IsNullOrWhiteSpace(sort.Field))
+            {
+                error = "sortby contains an empty field name.";
+                orderBy = default;
+                return false;
+            }
+
+            if (!availableFields.ContainsKey(sort.Field))
+            {
+                error = $"Unknown sort field '{sort.Field}'.";
+                orderBy = default;
+                return false;
+            }
+
+            orderByBuilder.Add(
+                string.Equals(sort.Direction, "desc", StringComparison.OrdinalIgnoreCase)
+                    ? OrderByClause.Desc(sort.Field)
+                    : string.Equals(sort.Direction, "asc", StringComparison.OrdinalIgnoreCase)
+                        ? OrderByClause.Asc(sort.Field)
+                        : throw new ArgumentException($"Invalid sort direction '{sort.Direction}'."));
+        }
+
+        error = null;
+        orderBy = orderByBuilder.ToImmutable();
+        return true;
+    }
+
+    private static bool TryBuildFieldSelection(
+        Core.Features.Catalog.Domain.LayerDefinition layer,
+        StacFieldsExtension fields,
+        out ImmutableArray<string> outFields,
+        out IReadOnlySet<string>? selectedProperties,
+        out string? error)
+    {
+        var availableFields = layer.AttributeFields
+            .Where(field => !field.IsGeometry)
+            .ToDictionary(field => field.Name, StringComparer.OrdinalIgnoreCase);
+
+        var includeAll = false;
+        var requestedIncludes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var requestedExcludes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (fields.Includes is { IsDefault: false } includes && includes.Length > 0)
+        {
+            foreach (var include in includes)
+            {
+                if (!TryNormalizePropertyName(include, out var normalized))
+                {
+                    error = $"Invalid fields include value '{include}'.";
+                    outFields = default;
+                    selectedProperties = null;
+                    return false;
+                }
+
+                if (IsPropertiesSentinel(normalized))
+                {
+                    includeAll = true;
+                    continue;
+                }
+
+                if (!availableFields.ContainsKey(normalized))
+                {
+                    error = $"Unknown fields include '{include}'.";
+                    outFields = default;
+                    selectedProperties = null;
+                    return false;
+                }
+
+                requestedIncludes.Add(normalized);
+            }
+        }
+        else
+        {
+            includeAll = true;
+        }
+
+        if (fields.Excludes is { IsDefault: false } excludes && excludes.Length > 0)
+        {
+            foreach (var exclude in excludes)
+            {
+                if (!TryNormalizePropertyName(exclude, out var normalized))
+                {
+                    error = $"Invalid fields exclude value '{exclude}'.";
+                    outFields = default;
+                    selectedProperties = null;
+                    return false;
+                }
+
+                if (IsPropertiesSentinel(normalized))
+                {
+                    continue;
+                }
+
+                if (!availableFields.ContainsKey(normalized))
+                {
+                    error = $"Unknown fields exclude '{exclude}'.";
+                    outFields = default;
+                    selectedProperties = null;
+                    return false;
+                }
+
+                requestedExcludes.Add(normalized);
+            }
+        }
+
+        var resolvedSelection = includeAll
+            ? availableFields.Keys.Where(field => !requestedExcludes.Contains(field))
+            : requestedIncludes.Where(field => !requestedExcludes.Contains(field));
+
+        var selected = resolvedSelection
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (selected.Length == 0 && !includeAll)
+        {
+            error = null;
+            outFields = ImmutableArray<string>.Empty;
+            selectedProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            return true;
+        }
+
+        var timeField = layer.Metadata?.TimeInfo?.StartTimeField;
+        var queryFields = selected.Length == 0
+            ? ImmutableArray<string>.Empty
+            : layer.AttributeFields
+                .Where(field => selected.Contains(field.Name))
+                .Select(field => field.Name)
+                .ToImmutableArray();
+
+        if (!string.IsNullOrWhiteSpace(timeField) && !queryFields.Contains(timeField, StringComparer.OrdinalIgnoreCase))
+        {
+            queryFields = queryFields.Add(timeField!);
+        }
+
+        outFields = queryFields;
+        selectedProperties = selected.Length == 0
+            ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(selected, StringComparer.OrdinalIgnoreCase);
+        error = null;
+        return true;
+    }
+
+    private static bool TryBuildSearchRequestFromGet(
+        int? limit,
+        string? datetime,
+        string? bbox,
+        string? collections,
+        string? ids,
+        string? intersects,
+        string? fields,
+        string? sortby,
+        string? filter,
+        string? filterLang,
+        string? filterCrs,
+        bool defaultFilterLangIsText,
+        out StacSearchRequest request,
+        out string? error)
+    {
+        request = new StacSearchRequest
+        {
+            Limit = limit,
+            Datetime = datetime
+        };
+        error = null;
+
+        if (!string.IsNullOrWhiteSpace(bbox))
+        {
+            if (!TryParseBbox(bbox, out var bboxValues, out error))
+            {
+                return false;
+            }
+
+            request = request with { Bbox = bboxValues };
+        }
+
+        if (!string.IsNullOrWhiteSpace(collections))
+        {
+            if (!TryParseIntegerTokenSet(collections, out var collectionValues, out error))
+            {
+                return false;
+            }
+
+            request = request with
+            {
+                Collections = collectionValues.Select(v => v.ToString(CultureInfo.InvariantCulture)).ToImmutableArray()
+            };
+        }
+
+        if (!string.IsNullOrWhiteSpace(ids))
+        {
+            if (!TryParseLongTokens(ids, out var idValues, out error))
+            {
+                return false;
+            }
+
+            request = request with { Ids = idValues };
+        }
+
+        if (!string.IsNullOrWhiteSpace(intersects))
+        {
+            if (!TryParseJsonElement(intersects, out var intersectsElement, out error))
+            {
+                return false;
+            }
+
+            request = request with { Intersects = intersectsElement };
+        }
+
+        if (!string.IsNullOrWhiteSpace(fields))
+        {
+            if (!TryParseFieldsParameter(fields, out var fieldsExtension, out error))
+            {
+                return false;
+            }
+
+            request = request with { Fields = fieldsExtension };
+        }
+
+        if (!string.IsNullOrWhiteSpace(sortby))
+        {
+            if (!TryParseSortByParameter(sortby, out var sortDefinitions, out error))
+            {
+                return false;
+            }
+
+            request = request with { Sortby = sortDefinitions };
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter))
+        {
+            var resolvedFilterLang = ResolveFilterLanguage(filterLang, null, defaultFilterLangIsText);
+            if (resolvedFilterLang is null)
+            {
+                error = $"Invalid filter-lang '{filterLang}'.";
+                return false;
+            }
+
+            if (resolvedFilterLang.Value == FilterLanguage.Cql2Json)
+            {
+                if (!TryParseJsonElement(filter, out var filterElement, out error))
+                {
+                    return false;
+                }
+
+                request = request with { Filter = filterElement, FilterLang = NormalizeFilterLang(filterLang), FilterCrs = filterCrs };
+            }
+            else
+            {
+                request = request with
+                {
+                    Filter = CreateJsonStringElement(filter),
+                    FilterLang = NormalizeFilterLang(filterLang),
+                    FilterCrs = filterCrs
+                };
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(filterLang) || !string.IsNullOrWhiteSpace(filterCrs))
+        {
+            error = "filter-lang and filter-crs require a filter parameter.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryParseBbox(string bbox, out ImmutableArray<double> values, out string? error)
+    {
+        var parts = bbox.Split(',', StringSplitOptions.None | StringSplitOptions.TrimEntries);
+        if (parts.Length is not 4 and not 6)
+        {
+            values = default;
+            error = "bbox must contain four or six numeric values.";
+            return false;
+        }
+
+        var parsed = new double[parts.Length];
+        for (var i = 0; i < parts.Length; i++)
+        {
+            if (!double.TryParse(parts[i], NumberStyles.Float, CultureInfo.InvariantCulture, out parsed[i]))
+            {
+                values = default;
+                error = "bbox contains an invalid numeric value.";
+                return false;
+            }
+        }
+
+        values = ImmutableArray.Create(parsed);
+        error = null;
+        return true;
+    }
+
+    private static bool TryParseCsvValues<T>(
+        string value,
+        TryParseDelegate<T> tryParse,
+        out ImmutableArray<string> results,
+        out string? error)
+    {
+        var builder = ImmutableArray.CreateBuilder<string>();
+        foreach (var token in value.Split(',', StringSplitOptions.None))
+        {
+            var trimmed = token.Trim();
+            if (trimmed.Length == 0)
+            {
+                results = default;
+                error = "Parameter contains an empty value.";
+                return false;
+            }
+
+            if (!tryParse(trimmed, out _))
+            {
+                results = default;
+                error = $"Invalid value '{trimmed}'.";
+                return false;
+            }
+
+            builder.Add(trimmed);
+        }
+
+        results = builder.ToImmutable();
+        error = null;
+        return true;
+    }
+
+    private static bool TryParseJsonElement(string value, out JsonElement element, out string? error)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(value);
+            element = document.RootElement.Clone();
+            error = null;
+            return true;
+        }
+        catch (JsonException)
+        {
+            element = default;
+            error = "Invalid JSON value.";
+            return false;
+        }
+    }
+
+    private static JsonElement CreateJsonStringElement(string value)
+    {
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(value));
+        return document.RootElement.Clone();
+    }
+
+    private static string? NormalizeFilterLang(string? filterLang)
+    {
+        if (string.IsNullOrWhiteSpace(filterLang))
+        {
+            return null;
+        }
+
+        return filterLang.Trim().ToLowerInvariant() switch
+        {
+            "cql2-text" => "cql2-text",
+            "cql2-json" => "cql2-json",
+            _ => null
+        };
+    }
+
+    private static bool TryParseFieldsParameter(string fields, out StacFieldsExtension? result, out string? error)
+    {
+        var includeAll = false;
+        var includes = ImmutableArray.CreateBuilder<string>();
+        var excludes = ImmutableArray.CreateBuilder<string>();
+
+        foreach (var token in fields.Split(',', StringSplitOptions.None))
+        {
+            var trimmed = token.Trim();
+            if (trimmed.Length == 0)
+            {
+                result = null;
+                error = "fields contains an empty value.";
+                return false;
+            }
+
+            var isExclude = trimmed[0] == '-';
+            var normalized = isExclude ? trimmed[1..] : trimmed;
+            if (!TryNormalizePropertyName(normalized, out normalized))
+            {
+                result = null;
+                error = $"Invalid fields value '{trimmed}'.";
+                return false;
+            }
+
+            if (IsPropertiesSentinel(normalized))
+            {
+                includeAll = true;
+                continue;
+            }
+
+            if (isExclude)
+            {
+                excludes.Add(normalized);
+            }
+            else
+            {
+                includes.Add(normalized);
+            }
+        }
+
+        if (includeAll && includes.Count == 0 && excludes.Count == 0)
+        {
+            result = null;
+            error = null;
+            return true;
+        }
+
+        result = new StacFieldsExtension
+        {
+            Includes = includes.Count > 0 ? includes.ToImmutable() : null,
+            Excludes = excludes.Count > 0 ? excludes.ToImmutable() : null
+        };
+        error = null;
+        return true;
+    }
+
+    private static bool TryParseSortByParameter(string sortby, out ImmutableArray<StacSortDefinition>? result, out string? error)
+    {
+        var builder = ImmutableArray.CreateBuilder<StacSortDefinition>();
+        foreach (var token in sortby.Split(',', StringSplitOptions.None))
+        {
+            var trimmed = token.Trim();
+            if (trimmed.Length == 0)
+            {
+                result = null;
+                error = "sortby contains an empty value.";
+                return false;
+            }
+
+            var direction = "asc";
+            var field = trimmed;
+            if (trimmed[0] == '-')
+            {
+                direction = "desc";
+                field = trimmed[1..];
+            }
+            else if (trimmed[0] == '+')
+            {
+                field = trimmed[1..];
+            }
+
+            if (string.IsNullOrWhiteSpace(field))
+            {
+                result = null;
+                error = "sortby contains an empty field name.";
+                return false;
+            }
+
+            builder.Add(new StacSortDefinition
+            {
+                Field = field,
+                Direction = direction
+            });
+        }
+
+        result = builder.ToImmutable();
+        error = null;
+        return true;
+    }
+
+    private static bool TryParseIntegerTokenSet(
+        string value,
+        out ImmutableArray<string> parsedValues,
+        out string? error)
+        => TryParseCsvValues(
+            value,
+            static (string input, out int parsed) => int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed),
+            out parsedValues,
+            out error);
+
+    private static bool TryParseLongTokens(
+        string value,
+        out ImmutableArray<string> parsedValues,
+        out string? error)
+        => TryParseCsvValues(
+            value,
+            static (string input, out long parsed) => long.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed),
+            out parsedValues,
+            out error);
+
+    private static bool TryParseIntegerTokenSet(
+        ImmutableArray<string> values,
+        out HashSet<int> parsedValues,
+        out string? error)
+    {
+        parsedValues = new HashSet<int>();
+        foreach (var value in values)
+        {
+            if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                error = $"Invalid integer value '{value}'.";
+                parsedValues = new HashSet<int>();
+                return false;
+            }
+
+            parsedValues.Add(parsed);
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static bool TryParseLongTokenSet(
+        ImmutableArray<string> values,
+        out ImmutableArray<long> parsedValues,
+        out string? error)
+    {
+        var builder = ImmutableArray.CreateBuilder<long>();
+        foreach (var value in values)
+        {
+            if (!long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                error = $"Invalid integer value '{value}'.";
+                parsedValues = default;
+                return false;
+            }
+
+            builder.Add(parsed);
+        }
+
+        parsedValues = builder.ToImmutable();
+        error = null;
+        return true;
+    }
+
+    private static bool TryNormalizePropertyName(string name, out string normalized)
+    {
+        normalized = name.Trim();
+        if (normalized.Length == 0)
+        {
+            return false;
+        }
+
+        if (normalized.StartsWith("properties.", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized["properties.".Length..];
+        }
+
+        return normalized.Length > 0;
+    }
+
+    private static bool IsPropertiesSentinel(string name)
+        => name.Equals("properties", StringComparison.OrdinalIgnoreCase) ||
+           name.Equals("*", StringComparison.Ordinal);
+
+    private static bool IsCrs84(string? crs)
+        => string.IsNullOrWhiteSpace(crs) ||
+           crs.Equals(Honua.Server.Features.OgcFeatures.OgcFeaturesUtilities.Crs84Uri, StringComparison.OrdinalIgnoreCase) ||
+           crs.Equals("CRS84", StringComparison.OrdinalIgnoreCase) ||
+           crs.Equals("OGC:CRS84", StringComparison.OrdinalIgnoreCase);
+
+    private static string BuildSearchQuery(int limit, int offset, StacSearchRequest request, bool defaultFilterLangIsText)
+    {
+        var query = new List<string>
+        {
+            $"limit={limit}",
+            $"offset={offset}"
+        };
+
         if (request.Bbox is { IsDefault: false } bboxArr && bboxArr.Length >= 4)
-            query += "&bbox=" + string.Join(",", bboxArr.Select(v => v.ToString(CultureInfo.InvariantCulture)));
+        {
+            query.Add("bbox=" + string.Join(",", bboxArr.Select(v => v.ToString(CultureInfo.InvariantCulture))));
+        }
+
         if (!string.IsNullOrWhiteSpace(request.Datetime))
-            query += $"&datetime={request.Datetime}";
+        {
+            query.Add($"datetime={Uri.EscapeDataString(request.Datetime)}");
+        }
+
         if (request.Collections is { IsDefault: false } cols && cols.Length > 0)
-            query += $"&collections={string.Join(",", cols)}";
+        {
+            query.Add($"collections={Uri.EscapeDataString(string.Join(",", cols))}");
+        }
+
         if (request.Ids is { IsDefault: false } ids && ids.Length > 0)
-            query += $"&ids={string.Join(",", ids)}";
-        return query;
+        {
+            query.Add($"ids={Uri.EscapeDataString(string.Join(",", ids))}");
+        }
+
+        if (request.Intersects.HasValue)
+        {
+            query.Add($"intersects={Uri.EscapeDataString(request.Intersects.Value.GetRawText())}");
+        }
+
+        if (request.Fields is not null)
+        {
+            var fieldTokens = new List<string>();
+            if (request.Fields.Includes is { IsDefault: false } includes && includes.Length > 0)
+            {
+                fieldTokens.AddRange(includes);
+            }
+
+            if (request.Fields.Excludes is { IsDefault: false } excludes && excludes.Length > 0)
+            {
+                fieldTokens.AddRange(excludes.Select(field => "-" + field));
+            }
+
+            if (fieldTokens.Count > 0)
+            {
+                query.Add($"fields={Uri.EscapeDataString(string.Join(",", fieldTokens))}");
+            }
+        }
+
+        if (request.Sortby is { IsDefault: false } sortby && sortby.Length > 0)
+        {
+            var sortTokens = sortby.Select(sort => string.Equals(sort.Direction, "desc", StringComparison.OrdinalIgnoreCase)
+                ? "-" + sort.Field
+                : sort.Field);
+            query.Add($"sortby={Uri.EscapeDataString(string.Join(",", sortTokens))}");
+        }
+
+        if (request.Filter.HasValue)
+        {
+            query.Add($"filter={Uri.EscapeDataString(
+                request.Filter.Value.ValueKind == JsonValueKind.String
+                    ? request.Filter.Value.GetString() ?? string.Empty
+                    : request.Filter.Value.GetRawText())}");
+
+            var filterLang = NormalizeFilterLang(request.FilterLang)
+                ?? (defaultFilterLangIsText
+                    ? "cql2-text"
+                    : request.Filter.Value.ValueKind == JsonValueKind.String
+                        ? "cql2-text"
+                        : "cql2-json");
+            query.Add($"filter-lang={filterLang}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.FilterCrs))
+        {
+            query.Add($"filter-crs={Uri.EscapeDataString(request.FilterCrs)}");
+        }
+
+        return string.Join("&", query);
     }
 }

--- a/src/Honua.Server/Features/Stac/Services/StacFilterHelpers.cs
+++ b/src/Honua.Server/Features/Stac/Services/StacFilterHelpers.cs
@@ -5,7 +5,10 @@ using System.Globalization;
 using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Shared.Models;
 using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.OgcFeatures.Models;
+using Honua.Server.Features.OgcFeatures.Services;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 
@@ -90,6 +93,41 @@ internal static class StacFilterHelpers
         var wkb = GetWkbWriter().Write(geometry);
 
         return SpatialFilter.Create(wkb, SpatialRelationship.Intersects, srid: 4326);
+    }
+
+    /// <summary>
+    /// Parses a GeoJSON geometry from a STAC intersects parameter into a spatial filter.
+    /// </summary>
+    public static bool TryCreateIntersectsSpatialFilter(
+        string? intersectsGeoJson,
+        OgcFeaturesGeometryServices geometryServices,
+        out SpatialFilter? spatialFilter,
+        out string? error)
+    {
+        spatialFilter = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(intersectsGeoJson))
+        {
+            return true;
+        }
+
+        var simpleGeometry = geometryServices.ConvertGeoJsonToSimpleGeometry(intersectsGeoJson, AxisOrder.EastNorth);
+        if (simpleGeometry is null)
+        {
+            error = "Invalid intersects geometry.";
+            return false;
+        }
+
+        var wkbResult = geometryServices.TryCreateWkbFromGeoJson(simpleGeometry, 4326, AxisOrder.EastNorth);
+        if (!wkbResult.IsSuccess || wkbResult.Wkb is null)
+        {
+            error = wkbResult.ErrorMessage ?? "Invalid intersects geometry.";
+            return false;
+        }
+
+        spatialFilter = SpatialFilter.Create(wkbResult.Wkb, SpatialRelationship.Intersects, srid: 4326);
+        return true;
     }
 
     /// <summary>

--- a/src/Honua.Server/Features/Stac/Services/StacMappingService.cs
+++ b/src/Honua.Server/Features/Stac/Services/StacMappingService.cs
@@ -92,11 +92,15 @@ internal sealed class StacMappingService
     public static StacItem MapFeatureToItem(
         Feature feature,
         LayerDefinition layer,
-        string baseUrl)
+        string baseUrl,
+        IReadOnlySet<string>? selectedProperties = null)
     {
         var collectionId = layer.Id.ToString(CultureInfo.InvariantCulture);
         var itemId = feature.ObjectId?.ToString(CultureInfo.InvariantCulture) ?? "0";
         var stacBase = $"{baseUrl}/stac";
+        var selectedPropertiesLookup = selectedProperties is null
+            ? null
+            : new HashSet<string>(selectedProperties, StringComparer.OrdinalIgnoreCase);
 
         var properties = new Dictionary<string, object?>();
 
@@ -122,6 +126,12 @@ internal sealed class StacMappingService
         {
             if (!string.Equals(kvp.Key, "objectid", StringComparison.OrdinalIgnoreCase))
             {
+                if (selectedPropertiesLookup is not null &&
+                    !selectedPropertiesLookup.Contains(kvp.Key))
+                {
+                    continue;
+                }
+
                 properties[kvp.Key] = kvp.Value;
             }
         }

--- a/src/Honua.Server/Features/Streaming/FeatureStreamEndpoints.cs
+++ b/src/Honua.Server/Features/Streaming/FeatureStreamEndpoints.cs
@@ -24,11 +24,12 @@ internal static class FeatureStreamEndpoints
 
     public static void MapFeatureStreamEndpoints(this IEndpointRouteBuilder endpoints)
     {
-        // Streaming data endpoint (public — callers authenticate via normal request pipeline)
+        // Feature-change events are global and include replay, so only admins can subscribe.
         var streamGroup = endpoints.MapGroup("/api/v{version:apiVersion}/streaming")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
-            .WithTags("Streaming");
+            .WithTags("Streaming")
+            .RequireAdminAuthorization();
 
         streamGroup.MapGet("/features", HandleFeatureStream)
             .WithDisplayName("Stream Feature Changes")

--- a/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
+++ b/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
@@ -18,6 +18,7 @@ using Honua.Core.Queries.Filters;
 using Honua.Core.Queries.Filters.Fes20;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Services;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.OgcFeatures;
 using Honua.Server.Features.OgcFeatures.Models;
@@ -788,19 +789,29 @@ internal sealed class Wfs20Handler
             throw new ArgumentException("BBOX must contain 4 coordinates and an optional CRS identifier.");
         }
 
-        if (!double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var minX) ||
-            !double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var minY) ||
-            !double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var maxX) ||
-            !double.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var maxY))
+        var crsDefinition = parts.Length == 5
+            ? SpatialReferenceHelpers.TryParseCrsDefinition(parts[4], out var bboxCrs)
+                ? bboxCrs
+                : throw new ArgumentException($"Unsupported BBOX CRS '{parts[4]}'.")
+            : SpatialReferenceHelpers.TryParseCrsDefinition(
+                layer.SpatialReference.ToSrid().ToString(CultureInfo.InvariantCulture),
+                out var layerCrs)
+                ? layerCrs
+                : throw new ArgumentException($"Unsupported layer spatial reference '{layer.SpatialReference.ToSrid()}'.");
+
+        if (!RasterParsingHelpers.TryParseBoundingBox(
+                bbox,
+                crsDefinition.AxisOrder,
+                crsDefinition.IsGeographic,
+                out var minX,
+                out var minY,
+                out var maxX,
+                out var maxY))
         {
-            throw new ArgumentException("BBOX contains invalid numeric coordinates.");
+            throw new ArgumentException("BBOX contains invalid numeric coordinates or is outside supported CRS bounds.");
         }
 
-        var srid = parts.Length == 5
-            ? ParseSrid(parts[4]) ?? throw new ArgumentException($"Unsupported BBOX CRS '{parts[4]}'.")
-            : layer.SpatialReference.ToSrid();
-
-        var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(srid);
+        var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(crsDefinition.Srid);
         var polygon = geometryFactory.CreatePolygon(
         [
             new Coordinate(minX, minY),
@@ -813,7 +824,7 @@ internal sealed class Wfs20Handler
         return new SpatialFilter
         {
             Geometry = BboxWkbWriter.Write(polygon),
-            Srid = srid,
+            Srid = crsDefinition.Srid,
             SpatialRelationship = SpatialRelationship.Intersects
         };
     }

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -214,10 +214,7 @@ builder.Services.AddOptions<ControlPlaneOptions>()
     .Bind(builder.Configuration.GetSection(ControlPlaneOptions.SectionName))
     .ValidateOnStart();
 builder.Services.AddHttpClient("import-source")
-    .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
-    {
-        AllowAutoRedirect = false
-    });
+    .ConfigurePrimaryHttpMessageHandler(static () => Honua.Server.Features.Import.ImportHttpClientHelper.CreatePinnedDnsHttpMessageHandler());
 builder.Services.AddHttpClient("control-plane-telemetry");
 builder.Services.AddHttpClient("control-plane-azure");
 builder.Services.AddSingleton<IAwsLambdaAliasClient, AwsSdkLambdaAliasClient>();

--- a/tests/Honua.Server.Tests/Features/Caching/OutputCacheInvalidationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Caching/OutputCacheInvalidationServiceTests.cs
@@ -37,6 +37,9 @@ public sealed class OutputCacheInvalidationServiceTests
         await outputCacheStore.Received().EvictByTagAsync("service:testservice", Arg.Any<CancellationToken>());
         await outputCacheStore.Received().EvictByTagAsync("layer:1", Arg.Any<CancellationToken>());
         await outputCacheStore.Received().EvictByTagAsync("layer:2", Arg.Any<CancellationToken>());
+        await outputCacheStore.Received().EvictByTagAsync("layer-styles", Arg.Any<CancellationToken>());
+        await outputCacheStore.Received().EvictByTagAsync("ogc-maps", Arg.Any<CancellationToken>());
+        await outputCacheStore.Received().EvictByTagAsync("stac-metadata", Arg.Any<CancellationToken>());
 
         await metadataCache.Received().RemoveAsync("services:all", Arg.Any<CancellationToken>());
         await metadataCache.Received().RemoveAsync("layers:all", Arg.Any<CancellationToken>());
@@ -116,6 +119,7 @@ public sealed class OutputCacheInvalidationServiceTests
 
         await outputCacheStore.Received().EvictByTagAsync("service:alpha", Arg.Any<CancellationToken>());
         await outputCacheStore.Received().EvictByTagAsync("service:beta", Arg.Any<CancellationToken>());
+        await outputCacheStore.Received().EvictByTagAsync("ogc-maps", Arg.Any<CancellationToken>());
         await responseCache.Received().RemoveByPatternAsync("response:query:featureserver:service:alpha:layer:7:*", Arg.Any<CancellationToken>());
         await responseCache.Received().RemoveByPatternAsync("response:query:featureserver:service:beta:layer:7:*", Arg.Any<CancellationToken>());
     }

--- a/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerQueryParameterTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/FeatureServerQueryParameterTests.cs
@@ -45,14 +45,14 @@ public sealed class FeatureServerQueryParameterTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
-    public async Task Query_WithDatumTransformation_ReturnsOk()
+    public async Task Query_WithDatumTransformation_ReturnsBadRequest()
     {
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?f=json&datumTransformation=4326");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var content = await response.Content.ReadAsStringAsync();
-        content.Should().Contain("\"features\"");
+        content.Should().Contain("Unsupported query parameters").And.Contain("datumTransformation");
     }
 
     [IntegrationTest]

--- a/tests/Honua.Server.Tests/Features/GeometryService/GeometryServiceBufferTests.cs
+++ b/tests/Honua.Server.Tests/Features/GeometryService/GeometryServiceBufferTests.cs
@@ -33,7 +33,7 @@ public sealed class GeometryServiceBufferTests : IAsyncLifetime
                 "geometryType": "esriGeometryPoint",
                 "geometries": [{"x": -122.4194, "y": 37.7749, "spatialReference": {"wkid": 4326}}]
             },
-            "inSR": "4326",
+            "inSR": {"latestWkid": 4326},
             "distances": "1000",
             "unit": "esriMeters",
             "geodesic": "true"

--- a/tests/Honua.Server.Tests/Features/GeometryService/GeometryServiceProjectTests.cs
+++ b/tests/Honua.Server.Tests/Features/GeometryService/GeometryServiceProjectTests.cs
@@ -179,7 +179,7 @@ public sealed class GeometryServiceProjectTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Project)]
     [Endpoint("POST /rest/services/geometry/project")]
-    public async Task Project_JsonSpatialReference_ParsesCorrectly()
+    public async Task Project_JsonSpatialReference_WithLatestWkid_ParsesCorrectly()
     {
         var body = """
         {
@@ -187,8 +187,37 @@ public sealed class GeometryServiceProjectTests : IAsyncLifetime
                 "geometryType": "esriGeometryPoint",
                 "geometries": [{"x": 0, "y": 0}]
             },
-            "inSR": {"wkid": 4326},
-            "outSR": {"wkid": 3857}
+            "inSR": {"latestWkid": 4326},
+            "outSR": {"latestWkid": 3857}
+        }
+        """;
+        var content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        var response = await _fixture.Client.PostAsync("/rest/services/geometry/project", content);
+
+        response.Be200Ok();
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<GeometryServiceResponse>(
+            responseContent, GeometryServiceJsonContext.Default.GeometryServiceResponse);
+
+        result.Should().NotBeNull();
+        result!.Geometries.Should().HaveCount(1);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Project)]
+    [Endpoint("POST /rest/services/geometry/project")]
+    public async Task Project_JsonSpatialReference_WithName_ParsesCorrectly()
+    {
+        var body = """
+        {
+            "geometries": {
+                "geometryType": "esriGeometryPoint",
+                "geometries": [{"x": 0, "y": 0}]
+            },
+            "inSR": {"name": "EPSG:4326"},
+            "outSR": {"name": "EPSG:3857"}
         }
         """;
         var content = new StringContent(body, Encoding.UTF8, "application/json");

--- a/tests/Honua.Server.Tests/Features/ImageServer/ImageServerExportHandlerTests.cs
+++ b/tests/Honua.Server.Tests/Features/ImageServer/ImageServerExportHandlerTests.cs
@@ -61,8 +61,8 @@ public class ImageServerExportHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(Array.Empty<RasterInfo>());
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns((RasterInfo?)null);
 
         var context = CreateImageServerContext();
         var request = CreateRequest();
@@ -164,8 +164,8 @@ public class ImageServerExportHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns([CreateTestRasterInfo() with { Width = 100, Height = 20000 }]);
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestRasterInfo() with { Width = 100, Height = 20000 });
 
         RasterQuery? capturedQuery = null;
         _rasterStore.ExportImageAsync(1, 100, Arg.Any<RasterQuery>(), Arg.Any<CancellationToken>())
@@ -396,8 +396,8 @@ public class ImageServerExportHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(new[] { CreateTestRasterInfo() });
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestRasterInfo());
     }
 
     private void SetupSuccessfulExport()

--- a/tests/Honua.Server.Tests/Features/ImageServer/ImageServerIdentifyHandlerTests.cs
+++ b/tests/Honua.Server.Tests/Features/ImageServer/ImageServerIdentifyHandlerTests.cs
@@ -58,8 +58,8 @@ public class ImageServerIdentifyHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(Array.Empty<RasterInfo>());
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns((RasterInfo?)null);
 
         var context = CreateImageServerContext();
         var request = CreateRequest("10,20");
@@ -75,8 +75,8 @@ public class ImageServerIdentifyHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(new[] { CreateTestRasterInfo() });
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestRasterInfo());
 
         var context = CreateImageServerContext();
         var request = CreateRequest("invalid-geometry");
@@ -92,8 +92,8 @@ public class ImageServerIdentifyHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(new[] { CreateTestRasterInfo() });
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestRasterInfo());
 
         var context = CreateImageServerContext();
         var request = CreateRequest("10,20,30");
@@ -111,8 +111,8 @@ public class ImageServerIdentifyHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(new[] { CreateTestRasterInfo() });
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestRasterInfo());
 
         var oversizedGeometry = $"10,20,{new string('x', 1200)}";
         var context = CreateImageServerContext();
@@ -131,8 +131,8 @@ public class ImageServerIdentifyHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(new[] { CreateTestRasterInfo() });
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestRasterInfo());
 
         var context = CreateImageServerContext();
         var request = CreateRequest("10,20", sr: "invalid-srid");
@@ -148,8 +148,8 @@ public class ImageServerIdentifyHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(new[] { CreateTestRasterInfo() });
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestRasterInfo());
 
         var context = CreateImageServerContext();
         var request = CreateRequest("10,20", geometryType: "esriGeometryPolygon");
@@ -191,8 +191,8 @@ public class ImageServerIdentifyHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(new[] { CreateTestRasterInfo() });
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestRasterInfo());
 
         // JSON geometry exceeding 1000 char limit
         var padding = new string(' ', 1001);
@@ -210,8 +210,8 @@ public class ImageServerIdentifyHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(new[] { CreateTestRasterInfo() });
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestRasterInfo());
 
         var context = CreateImageServerContext();
         var request = CreateRequest("{invalid-json}");
@@ -277,8 +277,8 @@ public class ImageServerIdentifyHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(new[] { CreateTestRasterInfo() });
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestRasterInfo());
         _rasterStore.IdentifyAsync(1, 100, Arg.Any<double>(), Arg.Any<double>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(new PixelValueResult
             {

--- a/tests/Honua.Server.Tests/Features/ImageServer/ImageServerTileHandlerTests.cs
+++ b/tests/Honua.Server.Tests/Features/ImageServer/ImageServerTileHandlerTests.cs
@@ -121,7 +121,7 @@ public class ImageServerTileHandlerTests
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
         await _rasterStore.DidNotReceive()
-            .ListRastersAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+            .GetPrimaryRasterInfoAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
     [UnitTest]
@@ -130,8 +130,8 @@ public class ImageServerTileHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(Array.Empty<RasterInfo>());
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns((RasterInfo?)null);
 
         var context = CreateImageServerContext();
         var result = await _handler.GetImageTileAsync(context, 1, 0, 0, 0, "png");
@@ -146,8 +146,8 @@ public class ImageServerTileHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(new[] { CreateTestRasterInfo() });
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestRasterInfo());
         _rasterStore.GetImageTileAsync(1, 100, 0, 0, 0, RasterFormat.PNG, Arg.Any<CancellationToken>())
             .Returns((RasterResult?)null);
 
@@ -165,8 +165,8 @@ public class ImageServerTileHandlerTests
         var tileData = new byte[] { 0x89, 0x50, 0x4E, 0x47 }; // PNG header
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(new[] { CreateTestRasterInfo() });
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestRasterInfo());
         _rasterStore.GetImageTileAsync(1, 100, 0, 0, 0, RasterFormat.PNG, Arg.Any<CancellationToken>())
             .Returns(new RasterResult
             {
@@ -194,8 +194,8 @@ public class ImageServerTileHandlerTests
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
             .Returns(CreateTestLayer());
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(new[] { CreateTestRasterInfo() });
+        _rasterStore.GetPrimaryRasterInfoAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestRasterInfo());
         _rasterStore.GetImageTileAsync(1, 100, level, row, col, RasterFormat.PNG, Arg.Any<CancellationToken>())
             .Returns(new RasterResult
             {

--- a/tests/Honua.Server.Tests/Features/Infrastructure/Services/SpatialReferenceResolverTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/Services/SpatialReferenceResolverTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Shared.Models;
+using Honua.Server.Features.Infrastructure.Services;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Services;
+
+public sealed class SpatialReferenceResolverTests
+{
+    private readonly FakeCrsDetectionService _crsDetectionService = new();
+    private readonly FakeCrsRegistry _crsRegistry = new();
+    private readonly SpatialReferenceResolver _resolver;
+
+    public SpatialReferenceResolverTests()
+    {
+        _resolver = new SpatialReferenceResolver(_crsDetectionService, _crsRegistry);
+    }
+
+    [Fact]
+    public async Task ResolveSridAsync_JsonLatestWkid_ReturnsLatestWkid()
+    {
+        var srid = await _resolver.ResolveSridAsync("""{"latestWkid":3857}""", null);
+
+        srid.Should().Be(3857);
+    }
+
+    [Fact]
+    public async Task ResolveSridAsync_JsonName_ReturnsEpsgCode()
+    {
+        _crsDetectionService.EpsgLookup["EPSG:4326"] = 4326;
+
+        var srid = await _resolver.ResolveSridAsync("""{"name":"EPSG:4326"}""", null);
+
+        srid.Should().Be(4326);
+    }
+
+    [Fact]
+    public async Task ResolveSridAsync_JsonWkt_ReturnsDetectedSrid()
+    {
+        _crsDetectionService.WktResult = 3857;
+
+        var srid = await _resolver.ResolveSridAsync("""{"wkt":"GEOGCRS[\"WGS 84\"]"}""", null);
+
+        srid.Should().Be(3857);
+    }
+
+    private sealed class FakeCrsRegistry : ICrsRegistry
+    {
+        public ValueTask<CrsDefinition?> ResolveAsync(string? crsIdentifier, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<CrsDefinition?>(null);
+
+        public ValueTask<CrsDefinition?> ResolveBySridAsync(int srid, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<CrsDefinition?>(null);
+
+        public ValueTask<bool> IsSridSupportedAsync(int srid, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(true);
+    }
+
+    private sealed class FakeCrsDetectionService : ICrsDetectionService
+    {
+        public Dictionary<string, int?> EpsgLookup { get; } = new(StringComparer.Ordinal);
+
+        public int? WktResult { get; set; }
+
+        public Task<int?> DetectFromPrjAsync(string prjContent)
+            => Task.FromResult<int?>(null);
+
+        public Task<int?> DetectFromWktAsync(string wktContent)
+            => Task.FromResult(WktResult);
+
+        public int? DetectFromEpsgCode(string epsgCode)
+            => EpsgLookup.TryGetValue(epsgCode, out var srid) ? srid : null;
+
+        public Task<int?> DetectFromGeoJsonCrsAsync(string crsObject)
+            => Task.FromResult<int?>(null);
+
+        public Task<int?> DetectFromShapefilePrjAsync(string shapefilePath)
+            => Task.FromResult<int?>(null);
+
+        public Task<bool> ValidateSridAsync(int srid)
+            => Task.FromResult(true);
+    }
+}

--- a/tests/Honua.Server.Tests/Features/OgcMaps/OgcMapsRenderingHandlerTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcMaps/OgcMapsRenderingHandlerTests.cs
@@ -7,6 +7,7 @@ using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Shared.Models;
 using Honua.Core.Features.Security;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Server.Features.OgcMaps.Handlers;
@@ -309,6 +310,29 @@ public class OgcMapsRenderingHandlerTests
 
     [UnitTest]
     [Operation(Operations.Render)]
+    public async Task RenderCollectionMapAsync_ServiceRestrictionOverridesPublicLayerAccess()
+    {
+        var layer = CreatePublicLayerWithExtent();
+        var service = CreateRestrictedService(layer);
+        _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
+            .Returns(layer);
+        _layerCatalog.ListServicesAsync(Arg.Any<CancellationToken>())
+            .Returns([service]);
+
+        var context = CreateAnonymousOgcMapsContext();
+        var result = await _handler.RenderCollectionMapAsync(1, CreateDefaultRequest(), context: context);
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>();
+        var statusCodeResult = (IStatusCodeHttpResult)result;
+        statusCodeResult.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        await _mapRenderer.DidNotReceive().RenderCollectionMapAsync(
+            Arg.Any<int>(),
+            Arg.Any<MapRenderRequest>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Render)]
     public async Task RenderCollectionMapAsync_LayerWithoutExplicitPolicy_ReturnsUnauthorized()
     {
         _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
@@ -578,6 +602,40 @@ public class OgcMapsRenderingHandlerTests
 
     [UnitTest]
     [Operation(Operations.Render)]
+    public async Task RenderCollectionMapAsync_WithGeographicExtent_UsesCrs84ContentCrs()
+    {
+        var context = CreateAuthenticatedOgcMapsContext();
+        _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
+            .Returns(CreateTestLayerWithExtent());
+        _mapRenderer.RenderCollectionMapAsync(1, Arg.Any<MapRenderRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new RasterResult
+            {
+                Data = new byte[] { 0x89, 0x50, 0x4E, 0x47 },
+                ContentType = "image/png",
+                Width = 256,
+                Height = 256,
+                Srid = 4326,
+                Extent = new RasterExtent
+                {
+                    XMin = -122.5,
+                    YMin = 37.7,
+                    XMax = -122.3,
+                    YMax = 37.8,
+                    Srid = 4326
+                }
+            });
+
+        var result = await _handler.RenderCollectionMapAsync(1, CreateDefaultRequest(), context);
+
+        result.Should().BeOfType<FileContentHttpResult>();
+        context.Response.Headers["Content-Crs"].ToString()
+            .Should().Be("<https://www.opengis.net/def/crs/OGC/1.3/CRS84>");
+        context.Response.Headers["Content-Bbox"].ToString()
+            .Should().Be("-122.5,37.7,-122.3,37.8");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Render)]
     public async Task RenderDatasetMapAsync_WithoutLayerIds_UsesAllCatalogLayers()
     {
         _layerCatalog.ListLayersAsync(Arg.Any<CancellationToken>())
@@ -657,6 +715,33 @@ public class OgcMapsRenderingHandlerTests
                 AccessPolicy = new AccessPolicy
                 {
                     AllowAnonymous = false
+                }
+            }
+        };
+
+    private static LayerDefinition CreatePublicLayerWithExtent(int id = 1)
+        => CreateTestLayerWithExtent(id) with
+        {
+            Metadata = new CatalogMetadata
+            {
+                AccessPolicy = new AccessPolicy
+                {
+                    AllowAnonymous = true
+                }
+            }
+        };
+
+    private static ServiceDefinition CreateRestrictedService(LayerDefinition layer)
+        => ServiceDefinition.CreateSingle(
+            "restricted-service",
+            layer,
+            SpatialReference.Create(layer.SpatialReference.Wkid)) with
+        {
+            Metadata = new CatalogMetadata
+            {
+                AccessPolicy = new AccessPolicy
+                {
+                    AllowedRoles = ["service-reader"]
                 }
             }
         };

--- a/tests/Honua.Server.Tests/Features/OgcMaps/OgcMapsTileSetHandlerTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcMaps/OgcMapsTileSetHandlerTests.cs
@@ -4,6 +4,7 @@
 using FluentAssertions;
 using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Shared.Models;
 using Honua.Core.Features.Security;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Server.Features.OgcMaps.Handlers;
@@ -171,6 +172,25 @@ public class OgcMapsTileSetHandlerTests
         statusCodeResult.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
     }
 
+    [UnitTest]
+    [Operation(Operations.GetTileMetadata)]
+    public async Task GetMapTileSetsAsync_ServiceRestrictionOverridesPublicLayerAccess()
+    {
+        var layer = CreatePublicLayer();
+        var service = CreateRestrictedService(layer);
+        _layerCatalog.GetLayerAsync(1, Arg.Any<CancellationToken>())
+            .Returns(layer);
+        _layerCatalog.ListServicesAsync(Arg.Any<CancellationToken>())
+            .Returns([service]);
+
+        var context = CreateAnonymousOgcMapsContext();
+        var result = await _handler.GetMapTileSetsAsync(1, context: context);
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>();
+        var statusCodeResult = (IStatusCodeHttpResult)result;
+        statusCodeResult.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
     private static LayerDefinition CreateTestLayer()
         => LayerDefinition.CreateBasic(1, "test-layer", GeometryType.Point);
 
@@ -182,6 +202,33 @@ public class OgcMapsTileSetHandlerTests
                 AccessPolicy = new AccessPolicy
                 {
                     AllowAnonymous = false
+                }
+            }
+        };
+
+    private static LayerDefinition CreatePublicLayer()
+        => CreateTestLayer() with
+        {
+            Metadata = new CatalogMetadata
+            {
+                AccessPolicy = new AccessPolicy
+                {
+                    AllowAnonymous = true
+                }
+            }
+        };
+
+    private static ServiceDefinition CreateRestrictedService(LayerDefinition layer)
+        => ServiceDefinition.CreateSingle(
+            "restricted-service",
+            layer,
+            SpatialReference.Create(layer.SpatialReference.Wkid)) with
+        {
+            Metadata = new CatalogMetadata
+            {
+                AccessPolicy = new AccessPolicy
+                {
+                    AllowedRoles = ["service-reader"]
                 }
             }
         };

--- a/tests/Honua.Server.Tests/Features/OgcTiles/OgcTilesCrsTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcTiles/OgcTilesCrsTests.cs
@@ -117,6 +117,7 @@ public sealed class OgcTilesCrsTests : IAsyncLifetime
         tileset.MediaTypes.Should().NotBeNull();
         tileset.MediaTypes!.Value.Should().Contain(MediaTypes.Mvt);
         tileset.MediaTypes!.Value.Should().Contain(MediaTypes.Png);
+        tileset.Links.Should().Contain(link => link.Rel == "item" && link.Type == MediaTypes.Png);
     }
 
     [IntegrationTest]

--- a/tests/Honua.Server.Tests/Features/OgcTiles/OgcTilesEndpointTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcTiles/OgcTilesEndpointTests.cs
@@ -178,6 +178,7 @@ public sealed class OgcTilesEndpointTests : IAsyncLifetime
         tileset.Should().NotBeNull();
         tileset!.Links.Should().Contain(l => l.Rel == RelationTypes.TilingScheme);
         tileset.Links.Should().Contain(l => l.Rel == "item");
+        tileset.Links.Should().Contain(l => l.Rel == "item" && l.Type == MediaTypes.Png);
     }
 
     [IntegrationTest]
@@ -204,6 +205,7 @@ public sealed class OgcTilesEndpointTests : IAsyncLifetime
         tileset.Should().NotBeNull();
         tileset!.Links.Should().Contain(l => l.Rel == RelationTypes.TilingScheme);
         tileset.Links.Should().Contain(l => l.Rel == "item");
+        tileset.Links.Should().Contain(l => l.Rel == "item" && l.Type == MediaTypes.Png);
     }
 
     [IntegrationTest]

--- a/tests/Honua.Server.Tests/Features/OgcTiles/OgcTilesRasterTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcTiles/OgcTilesRasterTests.cs
@@ -82,6 +82,26 @@ public sealed class OgcTilesRasterTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.GetTile)]
     [Endpoint("GET /ogc/tiles/collections/{collectionId}/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}")]
+    public async Task GetCollectionTile_WithPngPreferredOverVector_ReturnsRasterImage()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get,
+            "/ogc/tiles/collections/0/tiles/WebMercatorQuad/0/0/0");
+        request.Headers.Accept.Clear();
+        request.Headers.Accept.ParseAdd("image/png;q=1.0, application/vnd.mapbox-vector-tile;q=0.1");
+
+        var response = await _fixture.Client.SendAsync(request);
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NoContent);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            response.Content.Headers.ContentType?.MediaType.Should().Be(MediaTypes.Png);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /ogc/tiles/collections/{collectionId}/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}")]
     public async Task GetCollectionTile_AfterCachedPngRequest_InvalidAcceptStillReturnsNotAcceptable()
     {
         using var pngRequest = new HttpRequestMessage(HttpMethod.Get,

--- a/tests/Honua.Server.Tests/Features/Security/AccessPolicyEvaluatorTests.cs
+++ b/tests/Honua.Server.Tests/Features/Security/AccessPolicyEvaluatorTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Security;
+
+namespace Honua.Server.Tests.Features.Security;
+
+public sealed class AccessPolicyEvaluatorTests
+{
+    private readonly AccessPolicyEvaluator _evaluator = new();
+
+    [Fact]
+    public void Evaluate_WithPermissiveLayerAndRestrictedService_DeniesAnonymousRead()
+    {
+        var decision = _evaluator.Evaluate(
+            new ClaimsPrincipal(new ClaimsIdentity()),
+            new AccessPolicy { AllowAnonymous = true },
+            new AccessPolicy { AllowedRoles = ["service-reader"] });
+
+        decision.IsAllowed.Should().BeFalse();
+        decision.RequiresAuthentication.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_WithConflictingRoles_RequiresBothPolicies()
+    {
+        var principal = new ClaimsPrincipal(
+            new ClaimsIdentity(
+                [new Claim(ClaimTypes.Name, "test-user"), new Claim(ClaimTypes.Role, "layer-reader")],
+                authenticationType: "Test"));
+
+        var decision = _evaluator.Evaluate(
+            principal,
+            new AccessPolicy { AllowedRoles = ["layer-reader"] },
+            new AccessPolicy { AllowedRoles = ["service-reader"] });
+
+        decision.IsAllowed.Should().BeFalse();
+        decision.RequiresAuthentication.Should().BeFalse();
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Security/ServiceRbacAuthorizationTests.cs
+++ b/tests/Honua.Server.Tests/Features/Security/ServiceRbacAuthorizationTests.cs
@@ -342,6 +342,29 @@ public sealed class OgcServiceAccessPolicyTests
 
         await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
     }
+
+    [IntegrationTest]
+    [Protocol(Protocols.OgcApiTiles)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /ogc/tiles/collections/{collectionId}")]
+    public async Task GetCollection_WithAnonymousClient_RespectsServiceReadPolicy()
+    {
+        using var factory = ServiceRbacTestFixture.CreateFactory(static () =>
+            new RbacTestLayerCatalog(
+                alphaServiceMetadata: ServiceRbacTestFixture.CreateServiceMetadata(readRoles: ["alpha-reader"]),
+                alphaLayerMetadata: new CatalogMetadata
+                {
+                    AccessPolicy = new AccessPolicy
+                    {
+                        AllowAnonymous = true
+                    }
+                }));
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync($"/ogc/tiles/collections/{ServiceRbacTestFixture.AlphaLayerId}");
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Unauthorized);
+    }
 }
 
 public sealed class ODataServiceRbacTests
@@ -426,6 +449,46 @@ public sealed class ODataServiceRbacTests
             new StringContent(json, Encoding.UTF8, "application/json"));
 
         await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+    }
+
+    [IntegrationTest]
+    [Protocol(Protocols.ODataV4)]
+    [Operation(Operations.ODataBatch)]
+    [Endpoint("POST /odata/$batch")]
+    public async Task Batch_WithAnonymousClient_AllowsPublicLayerReads()
+    {
+        using var factory = ServiceRbacTestFixture.CreateFactory(static () =>
+            new RbacTestLayerCatalog(
+                alphaLayerMetadata: new CatalogMetadata
+                {
+                    AccessPolicy = new AccessPolicy
+                    {
+                        AllowAnonymous = true
+                    }
+                }));
+        using var client = factory.CreateClient();
+
+        var batchRequest = new ODataBatchRequest
+        {
+            Requests = ImmutableArray.Create(new ODataBatchRequestItem
+            {
+                Id = "read-alpha",
+                Method = "GET",
+                Url = $"Layers({ServiceRbacTestFixture.AlphaLayerId})"
+            })
+        };
+
+        var json = JsonSerializer.Serialize(batchRequest, ODataJsonContext.Default.ODataBatchRequest);
+        var response = await client.PostAsync(
+            "/odata/$batch",
+            new StringContent(json, Encoding.UTF8, "application/json"));
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
+
+        var responseDocument = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var responses = ServiceRbacTestFixture.GetPropertyCaseInsensitive(responseDocument.RootElement, "responses");
+        responses.GetArrayLength().Should().Be(1);
+        ServiceRbacTestFixture.GetPropertyCaseInsensitive(responses[0], "status").GetInt32().Should().Be(200);
     }
 
     [IntegrationTest]

--- a/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamEndpointsTests.cs
@@ -68,6 +68,34 @@ public sealed class FeatureStreamEndpointsTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/streaming/features")]
+    public async Task Stream_WithoutAuth_ReturnsUnauthorized()
+    {
+        var fixture = new WebAppFixture()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", "test-stream-admin-key");
+            });
+
+        await fixture.InitializeAsync();
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/api/v1/streaming/features?cursor=1");
+            request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+            using var response = await fixture.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
     // ─── AC: Client can open an SSE connection ──────────────────────────
 
     [IntegrationTest]

--- a/tests/Honua.Server.Tests/Import/ImportHttpClientHelperTests.cs
+++ b/tests/Honua.Server.Tests/Import/ImportHttpClientHelperTests.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Server.Features.Import;
+using System.Net.Http;
+using Xunit;
+
+namespace Honua.Server.Tests.Import;
+
+public sealed class ImportHttpClientHelperTests
+{
+    [Fact]
+    public void CreatePinnedDnsHttpMessageHandler_UsesSocketsHandlerWithPinnedConnectCallback()
+    {
+        var handler = ImportHttpClientHelper.CreatePinnedDnsHttpMessageHandler();
+
+        var socketsHandler = handler.Should().BeOfType<SocketsHttpHandler>().Subject;
+        socketsHandler.AllowAutoRedirect.Should().BeFalse();
+        socketsHandler.ConnectCallback.Should().NotBeNull();
+    }
+}

--- a/tests/Honua.Server.Tests/Infrastructure/Monitoring/RecentErrorsEndpointTests.cs
+++ b/tests/Honua.Server.Tests/Infrastructure/Monitoring/RecentErrorsEndpointTests.cs
@@ -62,6 +62,36 @@ public sealed class RecentErrorsEndpointTests
 
     [IntegrationTest]
     [Endpoint("GET /api/v1/admin/observability/errors")]
+    public async Task RecentErrorsEndpoint_RecordsClientErrorsWhenExplicitlyRequested()
+    {
+        using var factory = CreateFactory(capacity: 5);
+        using var scope = factory.Services.CreateScope();
+        var buffer = scope.ServiceProvider.GetRequiredService<RecentErrorBuffer>();
+
+        var context = CreateContext("/rest/services/test/MapServer/WMS", "trace-client-error");
+        buffer.Record(
+            context,
+            StatusCodes.Status400BadRequest,
+            "Bad Request",
+            "WMS invalid BBOX",
+            includeClientErrors: true);
+
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/admin/observability/errors");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<RecentErrorsResponse>(payload, _jsonOptions);
+
+        result.Should().NotBeNull();
+        result!.Errors.Should().ContainSingle();
+        result.Errors[0].StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        result.Errors[0].Path.Should().Be("/rest/services/test/MapServer/WMS");
+        result.Errors[0].Message.Should().Contain("WMS invalid BBOX");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/observability/errors")]
     public async Task RecentErrorsEndpoint_CapsBuffer()
     {
         using var factory = CreateFactory(capacity: 2);


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #620

## Summary
This hardening pass closes the cross-cutting audit findings across authorization, protocol conformance, geodesy, caching, telemetry, logging, and a few hot-path performance paths.

## Changes Made
- compose service and layer access policies correctly; require authorization on previously exposed streaming and service-scoped OGC routes; and pin outbound import fetch resolution
- reject or correctly honor previously ignored request parameters across FeatureServer, Geometry Service, WFS, STAC, OGC Maps, OGC Tiles, and GeoServices payload paths
- expand cache invalidation and recent-error capture, redact raw `where` clauses from logs, normalize GeoServices boolean payloads, and remove avoidable raster/map query inefficiencies

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review