### PR TITLE
feat: Real-time streaming: spatial and attribute subscription filters (#503)

### DIFF
--- a/src/Honua.Core/Queries/Filters/InMemoryFilterEvaluator.cs
+++ b/src/Honua.Core/Queries/Filters/InMemoryFilterEvaluator.cs
@@ -1,0 +1,272 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Honua.Core.Queries.Filters;
+
+/// <summary>
+/// Evaluates a <see cref="FilterExpression"/> AST against an in-memory property dictionary.
+/// Used for subscription-time filtering of CDC events. Static, allocation-free on comparison
+/// paths, no reflection — safe for AOT and hot-path broadcast evaluation.
+/// </summary>
+public static class InMemoryFilterEvaluator
+{
+    /// <summary>
+    /// Maximum expression depth allowed for streaming filters (DoS protection).
+    /// </summary>
+    public const int MaxStreamingDepth = 10;
+
+    /// <summary>
+    /// Evaluates a filter expression against a JSON-element property dictionary.
+    /// Returns true if the properties satisfy the filter.
+    /// </summary>
+    public static bool Evaluate(FilterExpression expression, IReadOnlyDictionary<string, JsonElement> properties)
+    {
+        return EvaluateBool(expression, properties, depth: 0);
+    }
+
+    private static bool EvaluateBool(FilterExpression expr, IReadOnlyDictionary<string, JsonElement> props, int depth)
+    {
+        if (depth > MaxStreamingDepth)
+        {
+            return true; // Safety: pass through overly complex filters.
+        }
+
+        return expr switch
+        {
+            BinaryExpression bin => EvaluateBinary(bin, props, depth),
+            UnaryExpression un => EvaluateUnary(un, props, depth),
+            Literal lit => lit.Type == LiteralType.Boolean && lit.Value is true,
+            _ => true // Unsupported node types pass through.
+        };
+    }
+
+    private static bool EvaluateBinary(BinaryExpression bin, IReadOnlyDictionary<string, JsonElement> props, int depth)
+    {
+        // Short-circuit logical operators.
+        if (bin.Operator == BinaryOperator.And)
+        {
+            return EvaluateBool(bin.Left, props, depth + 1) && EvaluateBool(bin.Right, props, depth + 1);
+        }
+
+        if (bin.Operator == BinaryOperator.Or)
+        {
+            return EvaluateBool(bin.Left, props, depth + 1) || EvaluateBool(bin.Right, props, depth + 1);
+        }
+
+        // IN / NOT IN: left is property, right is ValueList.
+        if (bin.Operator is BinaryOperator.In or BinaryOperator.NotIn)
+        {
+            return EvaluateIn(bin, props, depth);
+        }
+
+        // Comparison operators: resolve both sides to comparable values.
+        var left = ResolveValue(bin.Left, props);
+        var right = ResolveValue(bin.Right, props);
+
+        // Null comparisons: only Equal/NotEqual are meaningful.
+        if (left is null || right is null)
+        {
+            return bin.Operator switch
+            {
+                BinaryOperator.Equal => left is null && right is null,
+                BinaryOperator.NotEqual => !(left is null && right is null),
+                _ => false
+            };
+        }
+
+        return bin.Operator switch
+        {
+            BinaryOperator.Equal => CompareValues(left, right) == 0,
+            BinaryOperator.NotEqual => CompareValues(left, right) != 0,
+            BinaryOperator.LessThan => CompareValues(left, right) < 0,
+            BinaryOperator.LessThanOrEqual => CompareValues(left, right) <= 0,
+            BinaryOperator.GreaterThan => CompareValues(left, right) > 0,
+            BinaryOperator.GreaterThanOrEqual => CompareValues(left, right) >= 0,
+            BinaryOperator.Like => EvaluateLike(left, right),
+            BinaryOperator.NotLike => !EvaluateLike(left, right),
+            _ => true // Unsupported operator — pass through.
+        };
+    }
+
+    private static bool EvaluateUnary(UnaryExpression un, IReadOnlyDictionary<string, JsonElement> props, int depth)
+    {
+        return un.Operator switch
+        {
+            UnaryOperator.Not => !EvaluateBool(un.Operand, props, depth + 1),
+            UnaryOperator.IsNull => ResolveValue(un.Operand, props) is null,
+            UnaryOperator.IsNotNull => ResolveValue(un.Operand, props) is not null,
+            _ => true
+        };
+    }
+
+    private static bool EvaluateIn(BinaryExpression bin, IReadOnlyDictionary<string, JsonElement> props, int depth)
+    {
+        var left = ResolveValue(bin.Left, props);
+        if (left is null)
+        {
+            return bin.Operator == BinaryOperator.NotIn;
+        }
+
+        if (bin.Right is not ValueList valueList)
+        {
+            return bin.Operator == BinaryOperator.NotIn;
+        }
+
+        foreach (var item in valueList.Values)
+        {
+            var itemValue = ResolveValue(item, props);
+            if (itemValue is not null && CompareValues(left, itemValue) == 0)
+            {
+                return bin.Operator == BinaryOperator.In;
+            }
+        }
+
+        return bin.Operator == BinaryOperator.NotIn;
+    }
+
+    private static object? ResolveValue(FilterExpression expr, IReadOnlyDictionary<string, JsonElement> props)
+    {
+        return expr switch
+        {
+            PropertyReference prop => ResolveProperty(prop.PropertyName, props),
+            Literal lit => ResolveLiteral(lit),
+            _ => null
+        };
+    }
+
+    private static object? ResolveProperty(string name, IReadOnlyDictionary<string, JsonElement> props)
+    {
+        if (!props.TryGetValue(name, out var element))
+        {
+            return null;
+        }
+
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null or JsonValueKind.Undefined => null,
+            _ => element.GetRawText()
+        };
+    }
+
+    private static object? ResolveLiteral(Literal lit)
+    {
+        return lit.Type switch
+        {
+            LiteralType.Null => null,
+            LiteralType.Text => lit.Value as string,
+            LiteralType.Number => lit.Value switch
+            {
+                double d => d,
+                int i => (double)i,
+                long l => (double)l,
+                float f => (double)f,
+                decimal m => (double)m,
+                _ => Convert.ToDouble(lit.Value, CultureInfo.InvariantCulture)
+            },
+            LiteralType.Boolean => lit.Value is true,
+            LiteralType.Date or LiteralType.DateTime => lit.Value switch
+            {
+                DateTimeOffset dto => dto,
+                DateTime dt => new DateTimeOffset(dt, TimeSpan.Zero),
+                string s => DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed)
+                    ? parsed
+                    : (object?)s,
+                _ => lit.Value
+            },
+            _ => lit.Value
+        };
+    }
+
+    private static int CompareValues(object left, object right)
+    {
+        // Numeric comparison.
+        if (TryGetDouble(left, out var ld) && TryGetDouble(right, out var rd))
+        {
+            return ld.CompareTo(rd);
+        }
+
+        // DateTimeOffset comparison.
+        if (left is DateTimeOffset ldt && right is DateTimeOffset rdt)
+        {
+            return ldt.CompareTo(rdt);
+        }
+
+        // Boolean comparison.
+        if (left is bool lb && right is bool rb)
+        {
+            return lb.CompareTo(rb);
+        }
+
+        // String comparison (case-insensitive for filter evaluation).
+        var ls = left.ToString() ?? string.Empty;
+        var rs = right.ToString() ?? string.Empty;
+        return string.Compare(ls, rs, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryGetDouble(object value, out double result)
+    {
+        if (value is double d) { result = d; return true; }
+        if (value is int i) { result = i; return true; }
+        if (value is long l) { result = l; return true; }
+        if (value is float f) { result = f; return true; }
+        if (value is decimal m) { result = (double)m; return true; }
+        result = 0;
+        return false;
+    }
+
+    // Unbounded by design: entries are created per unique LIKE pattern at subscription time
+    // (not per event), so growth is bounded by the number of distinct streaming filter patterns.
+    private static readonly ConcurrentDictionary<string, Regex> LikePatternCache = new();
+
+    private static bool EvaluateLike(object left, object right)
+    {
+        var input = left.ToString() ?? string.Empty;
+        var pattern = right.ToString() ?? string.Empty;
+
+        // Cache compiled regex per LIKE pattern to avoid per-event allocation on the broadcast hot path.
+        var regex = LikePatternCache.GetOrAdd(pattern, static p =>
+        {
+            // Convert SQL LIKE pattern to regex: % → .*, _ → ., escape others.
+            var regexPattern = "^" + Regex.Escape(p)
+                .Replace("%", ".*", StringComparison.Ordinal)
+                .Replace("_", ".", StringComparison.Ordinal) + "$";
+            return new Regex(regexPattern, RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+        });
+
+        return regex.IsMatch(input);
+    }
+
+    /// <summary>
+    /// Validates that the expression depth does not exceed the streaming limit.
+    /// </summary>
+    public static bool ExceedsMaxDepth(FilterExpression expression)
+    {
+        return MeasureDepth(expression, 0) > MaxStreamingDepth;
+    }
+
+    private static int MeasureDepth(FilterExpression expr, int current)
+    {
+        if (current > MaxStreamingDepth)
+        {
+            return current;
+        }
+
+        return expr switch
+        {
+            BinaryExpression bin => Math.Max(
+                MeasureDepth(bin.Left, current + 1),
+                MeasureDepth(bin.Right, current + 1)),
+            UnaryExpression un => MeasureDepth(un.Operand, current + 1),
+            _ => current
+        };
+    }
+}

--- a/src/Honua.Core/Queries/Filters/InMemoryFilterEvaluator.cs
+++ b/src/Honua.Core/Queries/Filters/InMemoryFilterEvaluator.cs
@@ -29,11 +29,23 @@ public static class InMemoryFilterEvaluator
         return EvaluateBool(expression, properties, depth: 0);
     }
 
+    /// <summary>
+    /// Validates that a filter expression only uses the subset of nodes and operators
+    /// supported by streaming subscriptions.
+    /// </summary>
+    /// <param name="expression">Expression to validate.</param>
+    /// <param name="error">Validation error when the expression is not stream-evaluable.</param>
+    /// <returns><see langword="true"/> when the expression can be evaluated in-memory for streaming.</returns>
+    public static bool TryValidateStreamingExpression(FilterExpression expression, out string? error)
+    {
+        return TryValidateBooleanExpression(expression, out error);
+    }
+
     private static bool EvaluateBool(FilterExpression expr, IReadOnlyDictionary<string, JsonElement> props, int depth)
     {
         if (depth > MaxStreamingDepth)
         {
-            return true; // Safety: pass through overly complex filters.
+            return false; // Fail closed for expressions that exceed streaming limits.
         }
 
         return expr switch
@@ -41,7 +53,7 @@ public static class InMemoryFilterEvaluator
             BinaryExpression bin => EvaluateBinary(bin, props, depth),
             UnaryExpression un => EvaluateUnary(un, props, depth),
             Literal lit => lit.Type == LiteralType.Boolean && lit.Value is true,
-            _ => true // Unsupported node types pass through.
+            _ => false
         };
     }
 
@@ -89,7 +101,7 @@ public static class InMemoryFilterEvaluator
             BinaryOperator.GreaterThanOrEqual => CompareValues(left, right) >= 0,
             BinaryOperator.Like => EvaluateLike(left, right),
             BinaryOperator.NotLike => !EvaluateLike(left, right),
-            _ => true // Unsupported operator — pass through.
+            _ => false
         };
     }
 
@@ -100,7 +112,7 @@ public static class InMemoryFilterEvaluator
             UnaryOperator.Not => !EvaluateBool(un.Operand, props, depth + 1),
             UnaryOperator.IsNull => ResolveValue(un.Operand, props) is null,
             UnaryOperator.IsNotNull => ResolveValue(un.Operand, props) is not null,
-            _ => true
+            _ => false
         };
     }
 
@@ -109,12 +121,12 @@ public static class InMemoryFilterEvaluator
         var left = ResolveValue(bin.Left, props);
         if (left is null)
         {
-            return bin.Operator == BinaryOperator.NotIn;
+            return false;
         }
 
         if (bin.Right is not ValueList valueList)
         {
-            return bin.Operator == BinaryOperator.NotIn;
+            return false;
         }
 
         foreach (var item in valueList.Values)
@@ -149,7 +161,7 @@ public static class InMemoryFilterEvaluator
         return element.ValueKind switch
         {
             JsonValueKind.String => element.GetString(),
-            JsonValueKind.Number => element.GetDouble(),
+            JsonValueKind.Number => ResolveNumericElement(element),
             JsonValueKind.True => true,
             JsonValueKind.False => false,
             JsonValueKind.Null or JsonValueKind.Undefined => null,
@@ -165,11 +177,16 @@ public static class InMemoryFilterEvaluator
             LiteralType.Text => lit.Value as string,
             LiteralType.Number => lit.Value switch
             {
-                double d => d,
-                int i => (double)i,
-                long l => (double)l,
+                byte b => (long)b,
+                sbyte sb => (long)sb,
+                short s => (long)s,
+                ushort us => (long)us,
+                int i => (long)i,
+                uint ui => (long)ui,
+                long l => l,
+                decimal m => m,
                 float f => (double)f,
-                decimal m => (double)m,
+                double d => d,
                 _ => Convert.ToDouble(lit.Value, CultureInfo.InvariantCulture)
             },
             LiteralType.Boolean => lit.Value is true,
@@ -188,6 +205,16 @@ public static class InMemoryFilterEvaluator
 
     private static int CompareValues(object left, object right)
     {
+        if (TryGetInt64(left, out var li) && TryGetInt64(right, out var ri))
+        {
+            return li.CompareTo(ri);
+        }
+
+        if (TryGetDecimal(left, out var ldec) && TryGetDecimal(right, out var rdec))
+        {
+            return ldec.CompareTo(rdec);
+        }
+
         // Numeric comparison.
         if (TryGetDouble(left, out var ld) && TryGetDouble(right, out var rd))
         {
@@ -220,6 +247,203 @@ public static class InMemoryFilterEvaluator
         if (value is float f) { result = f; return true; }
         if (value is decimal m) { result = (double)m; return true; }
         result = 0;
+        return false;
+    }
+
+    private static bool TryGetInt64(object value, out long result)
+    {
+        switch (value)
+        {
+            case byte b:
+                result = b;
+                return true;
+            case sbyte sb:
+                result = sb;
+                return true;
+            case short s:
+                result = s;
+                return true;
+            case ushort us:
+                result = us;
+                return true;
+            case int i:
+                result = i;
+                return true;
+            case uint ui:
+                result = (long)ui;
+                return true;
+            case long l:
+                result = l;
+                return true;
+            default:
+                result = 0;
+                return false;
+        }
+    }
+
+    private static bool TryGetDecimal(object value, out decimal result)
+    {
+        switch (value)
+        {
+            case byte b:
+                result = b;
+                return true;
+            case sbyte sb:
+                result = sb;
+                return true;
+            case short s:
+                result = s;
+                return true;
+            case ushort us:
+                result = us;
+                return true;
+            case int i:
+                result = i;
+                return true;
+            case uint ui:
+                result = ui;
+                return true;
+            case long l:
+                result = l;
+                return true;
+            case decimal m:
+                result = m;
+                return true;
+            default:
+                result = 0;
+                return false;
+        }
+    }
+
+    private static object ResolveNumericElement(JsonElement element)
+    {
+        if (element.TryGetInt64(out var integer))
+        {
+            return integer;
+        }
+
+        if (element.TryGetDecimal(out var preciseDecimal))
+        {
+            return preciseDecimal;
+        }
+
+        return element.GetDouble();
+    }
+
+    private static bool TryValidateBooleanExpression(FilterExpression expression, out string? error)
+    {
+        switch (expression)
+        {
+            case BinaryExpression binary:
+                return TryValidateBinaryExpression(binary, out error);
+            case UnaryExpression unary:
+                return TryValidateUnaryExpression(unary, out error);
+            case Literal literal when literal.Type == LiteralType.Boolean:
+                error = null;
+                return true;
+            default:
+                return FailUnsupportedBooleanExpression(expression, out error);
+        }
+    }
+
+    private static bool TryValidateBinaryExpression(BinaryExpression binary, out string? error)
+    {
+        switch (binary.Operator)
+        {
+            case BinaryOperator.And:
+            case BinaryOperator.Or:
+                return TryValidateBooleanExpression(binary.Left, out error) &&
+                       TryValidateBooleanExpression(binary.Right, out error);
+            case BinaryOperator.Equal:
+            case BinaryOperator.NotEqual:
+            case BinaryOperator.LessThan:
+            case BinaryOperator.LessThanOrEqual:
+            case BinaryOperator.GreaterThan:
+            case BinaryOperator.GreaterThanOrEqual:
+            case BinaryOperator.Like:
+            case BinaryOperator.NotLike:
+                return TryValidateScalarExpression(binary.Left, out error) &&
+                       TryValidateScalarExpression(binary.Right, out error);
+            case BinaryOperator.In:
+            case BinaryOperator.NotIn:
+                return TryValidateScalarExpression(binary.Left, out error) &&
+                       TryValidateValueList(binary.Right, out error);
+            default:
+                error = $"Streaming subscriptions do not support the '{binary.Operator}' operator in filter expressions.";
+                return false;
+        }
+    }
+
+    private static bool TryValidateUnaryExpression(UnaryExpression unary, out string? error)
+    {
+        switch (unary.Operator)
+        {
+            case UnaryOperator.Not:
+                return TryValidateBooleanExpression(unary.Operand, out error);
+            case UnaryOperator.IsNull:
+            case UnaryOperator.IsNotNull:
+                return TryValidateScalarExpression(unary.Operand, out error);
+            default:
+                error = $"Streaming subscriptions do not support the '{unary.Operator}' operator in filter expressions.";
+                return false;
+        }
+    }
+
+    private static bool TryValidateScalarExpression(FilterExpression expression, out string? error)
+    {
+        switch (expression)
+        {
+            case PropertyReference:
+            case Literal:
+                error = null;
+                return true;
+            case FunctionCall:
+                error = "Streaming subscriptions do not support function calls in filter expressions.";
+                return false;
+            case SpatialPredicate or SpatialDistancePredicate:
+                error = "Streaming subscriptions do not support spatial predicates inside filter expressions. Use the bbox parameter instead.";
+                return false;
+            case TemporalPredicate:
+                error = "Streaming subscriptions do not support temporal predicates in filter expressions.";
+                return false;
+            case ValueList:
+                error = "Streaming subscriptions do not support nested value lists in filter expressions.";
+                return false;
+            default:
+                error = $"Streaming subscriptions do not support {expression.GetType().Name} expressions.";
+                return false;
+        }
+    }
+
+    private static bool TryValidateValueList(FilterExpression expression, out string? error)
+    {
+        if (expression is not ValueList valueList)
+        {
+            error = "Streaming subscriptions require a literal value list for IN/NOT IN filters.";
+            return false;
+        }
+
+        foreach (var value in valueList.Values)
+        {
+            if (!TryValidateScalarExpression(value, out error))
+            {
+                return false;
+            }
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static bool FailUnsupportedBooleanExpression(FilterExpression expression, out string? error)
+    {
+        error = expression switch
+        {
+            FunctionCall => "Streaming subscriptions do not support function calls in filter expressions.",
+            SpatialPredicate or SpatialDistancePredicate => "Streaming subscriptions do not support spatial predicates inside filter expressions. Use the bbox parameter instead.",
+            TemporalPredicate => "Streaming subscriptions do not support temporal predicates in filter expressions.",
+            _ => $"Streaming subscriptions do not support {expression.GetType().Name} expressions."
+        };
         return false;
     }
 
@@ -266,7 +490,38 @@ public static class InMemoryFilterEvaluator
                 MeasureDepth(bin.Left, current + 1),
                 MeasureDepth(bin.Right, current + 1)),
             UnaryExpression un => MeasureDepth(un.Operand, current + 1),
+            SpatialPredicate spatial => Math.Max(
+                MeasureDepth(spatial.Left, current + 1),
+                MeasureDepth(spatial.Right, current + 1)),
+            SpatialDistancePredicate spatialDistance => Math.Max(
+                MeasureDepth(spatialDistance.Left, current + 1),
+                Math.Max(
+                    MeasureDepth(spatialDistance.Right, current + 1),
+                    MeasureDepth(spatialDistance.Distance, current + 1))),
+            TemporalPredicate temporal => Math.Max(
+                MeasureDepth(temporal.Left, current + 1),
+                MeasureDepth(temporal.Right, current + 1)),
+            ArrayPredicate array => Math.Max(
+                MeasureDepth(array.Left, current + 1),
+                MeasureDepth(array.Right, current + 1)),
+            FunctionCall function => MeasureDepth(function.Arguments, current + 1),
+            ArrayLiteral arrayLiteral => MeasureDepth(arrayLiteral.Elements, current + 1),
+            ValueList valueList => MeasureDepth(valueList.Values, current + 1),
+            IntervalLiteral interval => Math.Max(
+                interval.Start is null ? current : MeasureDepth(interval.Start, current + 1),
+                interval.End is null ? current : MeasureDepth(interval.End, current + 1)),
             _ => current
         };
+    }
+
+    private static int MeasureDepth(IReadOnlyList<FilterExpression> expressions, int current)
+    {
+        var max = current;
+        foreach (var expression in expressions)
+        {
+            max = Math.Max(max, MeasureDepth(expression, current));
+        }
+
+        return max;
     }
 }

--- a/src/Honua.Core/Queries/Filters/InMemoryFilterEvaluator.cs
+++ b/src/Honua.Core/Queries/Filters/InMemoryFilterEvaluator.cs
@@ -233,10 +233,10 @@ public static class InMemoryFilterEvaluator
             return lb.CompareTo(rb);
         }
 
-        // String comparison (case-insensitive for filter evaluation).
+        // Match the default SQL/CQL semantics used by the main query path.
         var ls = left.ToString() ?? string.Empty;
         var rs = right.ToString() ?? string.Empty;
-        return string.Compare(ls, rs, StringComparison.OrdinalIgnoreCase);
+        return string.Compare(ls, rs, StringComparison.Ordinal);
     }
 
     private static bool TryGetDouble(object value, out double result)
@@ -463,7 +463,7 @@ public static class InMemoryFilterEvaluator
             var regexPattern = "^" + Regex.Escape(p)
                 .Replace("%", ".*", StringComparison.Ordinal)
                 .Replace("_", ".", StringComparison.Ordinal) + "$";
-            return new Regex(regexPattern, RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+            return new Regex(regexPattern, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
         });
 
         return regex.IsMatch(input);

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerEditsDependencies.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerEditsDependencies.cs
@@ -14,6 +14,7 @@ internal sealed class FeatureServerEditsDependencies
     public FeatureServerEditsDependencies(
         IResourceValidator resourceValidator,
         IFeatureWriter featureWriter,
+        IFeatureReader featureReader,
         IFeatureServerGeometryServices geometryServices,
         FeatureMutationValidator mutationValidator,
         IHttpContextAccessor httpContextAccessor,
@@ -21,6 +22,7 @@ internal sealed class FeatureServerEditsDependencies
     {
         ResourceValidator = resourceValidator ?? throw new ArgumentNullException(nameof(resourceValidator));
         FeatureWriter = featureWriter ?? throw new ArgumentNullException(nameof(featureWriter));
+        FeatureReader = featureReader ?? throw new ArgumentNullException(nameof(featureReader));
         GeometryServices = geometryServices ?? throw new ArgumentNullException(nameof(geometryServices));
         MutationValidator = mutationValidator ?? throw new ArgumentNullException(nameof(mutationValidator));
         HttpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
@@ -29,6 +31,7 @@ internal sealed class FeatureServerEditsDependencies
 
     public IResourceValidator ResourceValidator { get; }
     public IFeatureWriter FeatureWriter { get; }
+    public IFeatureReader FeatureReader { get; }
     public IFeatureServerGeometryServices GeometryServices { get; }
     public FeatureMutationValidator MutationValidator { get; }
     public IHttpContextAccessor HttpContextAccessor { get; }

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerEditsHandler.cs
@@ -32,6 +32,7 @@ internal sealed class FeatureServerEditsHandler(
 
     private readonly IResourceValidator _resourceValidator = dependencies?.ResourceValidator
         ?? throw new ArgumentNullException(nameof(dependencies));
+    private readonly IFeatureReader _featureReader = dependencies.FeatureReader;
     private readonly IFeatureWriter _featureWriter = dependencies.FeatureWriter;
     private readonly IFeatureServerGeometryServices _geometryServices = dependencies.GeometryServices;
     private readonly FeatureMutationValidator _mutationValidator = dependencies.MutationValidator;
@@ -191,7 +192,7 @@ internal sealed class FeatureServerEditsHandler(
 
         await ProcessAddOperationsAsync(request, context, layer, cancellationToken);
         await ProcessUpdateOperationsAsync(request, context, layer, cancellationToken);
-        ProcessDeleteOperations(request, context);
+        await ProcessDeleteOperationsAsync(request, layer.Id, context, cancellationToken);
 
         return context;
     }
@@ -288,7 +289,11 @@ internal sealed class FeatureServerEditsHandler(
     /// <summary>
     /// Processes delete operations and tracks features to delete
     /// </summary>
-    private static void ProcessDeleteOperations(ApplyEditsRequest request, EditOperationContext context)
+    private async Task ProcessDeleteOperationsAsync(
+        ApplyEditsRequest request,
+        int layerId,
+        EditOperationContext context,
+        CancellationToken cancellationToken)
     {
         if (request.Deletes == null)
             return;
@@ -306,6 +311,22 @@ internal sealed class FeatureServerEditsHandler(
 
             context.DeleteIds.Add(objectId);
             context.DeleteIndexes.Add(i);
+            context.DeleteFeatures.Add(await ReadDeleteFeatureSnapshotAsync(layerId, objectId, cancellationToken));
+        }
+    }
+
+    private async Task<Feature?> ReadDeleteFeatureSnapshotAsync(
+        int layerId,
+        long objectId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _featureReader.GetAsync(layerId, objectId, cancellationToken);
+        }
+        catch
+        {
+            return null;
         }
     }
 
@@ -467,18 +488,28 @@ internal sealed class FeatureServerEditsHandler(
                 cancellationToken).ConfigureAwait(false);
         }
 
-        var deleteResults = FinalizeResults(context.DeleteResults) ?? [];
-        foreach (var result in deleteResults.Where(static r => r.Success && r.ObjectId.HasValue))
+        for (var i = 0; i < context.DeleteIndexes.Count; i++)
         {
+            var resultIndex = context.DeleteIndexes[i];
+            var result = context.DeleteResults?[resultIndex];
+            if (result is not { Success: true, ObjectId: { } objectId })
+            {
+                continue;
+            }
+
+            var deleteFeature = context.DeleteFeatures.Count > i ? context.DeleteFeatures[i] : null;
+            var (deleteEnv, deleteProps) = FeatureChangeEventEnrichment.FromFeature(deleteFeature);
             await _featureChangeEventPublisher.PublishAsync(
                 new FeatureChangeEventRequest
                 {
                     ServiceId = serviceId,
                     LayerId = layerId,
-                    ObjectId = result.ObjectId!.Value,
+                    ObjectId = objectId,
                     Operation = "delete",
                     Protocol = HonuaTelemetry.Protocols.FeatureServer,
-                    RequestId = requestId
+                    RequestId = requestId,
+                    GeometryEnvelope = deleteEnv,
+                    PropertiesJson = deleteProps
                 },
                 cancellationToken).ConfigureAwait(false);
         }
@@ -498,6 +529,7 @@ internal sealed class FeatureServerEditsHandler(
         public List<int> UpdateIndexes { get; } = new();
         public List<long> UpdateObjectIds { get; } = new();
         public List<long> DeleteIds { get; } = new();
+        public List<Feature?> DeleteFeatures { get; } = new();
         public List<int> DeleteIndexes { get; } = new();
         public bool HasValidationErrors { get; set; }
     }

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerEditsHandler.cs
@@ -417,34 +417,52 @@ internal sealed class FeatureServerEditsHandler(
     {
         var requestId = _httpContextAccessor.HttpContext?.TraceIdentifier ?? "unknown";
 
-        var addResults = FinalizeResults(context.AddResults) ?? [];
-        foreach (var result in addResults.Where(static r => r.Success && r.ObjectId.HasValue))
+        for (var i = 0; i < context.CreateFeatures.Count; i++)
         {
+            var resultIndex = context.CreateIndexes[i];
+            var result = context.AddResults?[resultIndex];
+            if (result is not { Success: true, ObjectId: { } objectId })
+            {
+                continue;
+            }
+
+            var (createEnv, createProps) = FeatureChangeEventEnrichment.FromFeature(context.CreateFeatures[i]);
             await _featureChangeEventPublisher.PublishAsync(
                 new FeatureChangeEventRequest
                 {
                     ServiceId = serviceId,
                     LayerId = layerId,
-                    ObjectId = result.ObjectId!.Value,
+                    ObjectId = objectId,
                     Operation = "create",
                     Protocol = HonuaTelemetry.Protocols.FeatureServer,
-                    RequestId = requestId
+                    RequestId = requestId,
+                    GeometryEnvelope = createEnv,
+                    PropertiesJson = createProps
                 },
                 cancellationToken).ConfigureAwait(false);
         }
 
-        var updateResults = FinalizeResults(context.UpdateResults) ?? [];
-        foreach (var result in updateResults.Where(static r => r.Success && r.ObjectId.HasValue))
+        for (var i = 0; i < context.UpdateFeatures.Count; i++)
         {
+            var resultIndex = context.UpdateIndexes[i];
+            var result = context.UpdateResults?[resultIndex];
+            if (result is not { Success: true, ObjectId: { } objectId })
+            {
+                continue;
+            }
+
+            var (updateEnv, updateProps) = FeatureChangeEventEnrichment.FromFeature(context.UpdateFeatures[i]);
             await _featureChangeEventPublisher.PublishAsync(
                 new FeatureChangeEventRequest
                 {
                     ServiceId = serviceId,
                     LayerId = layerId,
-                    ObjectId = result.ObjectId!.Value,
+                    ObjectId = objectId,
                     Operation = "update",
                     Protocol = HonuaTelemetry.Protocols.FeatureServer,
-                    RequestId = requestId
+                    RequestId = requestId,
+                    GeometryEnvelope = updateEnv,
+                    PropertiesJson = updateProps
                 },
                 cancellationToken).ConfigureAwait(false);
         }

--- a/src/Honua.Server/Features/Infrastructure/Events/FeatureChangeEventEnrichment.cs
+++ b/src/Honua.Server/Features/Infrastructure/Events/FeatureChangeEventEnrichment.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Server.Features.Infrastructure.Services;
+
+namespace Honua.Server.Features.Infrastructure.Events;
+
+/// <summary>
+/// Extracts geometry envelope and attribute snapshot from a feature for CDC event enrichment.
+/// Called at publish sites so filter evaluation during broadcast requires no I/O.
+/// </summary>
+internal static class FeatureChangeEventEnrichment
+{
+    /// <summary>
+    /// Extracts enrichment data from a feature. Returns null envelope and properties for null features (deletes).
+    /// </summary>
+    public static (double[]? GeometryEnvelope, string? PropertiesJson) FromFeature(Feature? feature)
+    {
+        if (feature is null)
+        {
+            return (null, null);
+        }
+
+        var envelope = ExtractEnvelope(feature.Value.Geometry);
+        var propertiesJson = SerializeAttributes(feature.Value.Attributes);
+        return (envelope, propertiesJson);
+    }
+
+    private static double[]? ExtractEnvelope(byte[]? wkb)
+    {
+        if (wkb is null || wkb.Length == 0)
+        {
+            return null;
+        }
+
+        try
+        {
+            var reader = WkbReaderCache.Get();
+            var geometry = reader.Read(wkb);
+            if (geometry is null || geometry.IsEmpty)
+            {
+                return null;
+            }
+
+            var env = geometry.EnvelopeInternal;
+            return [env.MinX, env.MinY, env.MaxX, env.MaxY];
+        }
+        catch
+        {
+            // Invalid WKB — skip enrichment rather than failing the write.
+            return null;
+        }
+    }
+
+    private static string? SerializeAttributes(ImmutableDictionary<string, object?>? attributes)
+    {
+        if (attributes is null || attributes.Count == 0)
+        {
+            return null;
+        }
+
+        return JsonSerializer.Serialize(attributes, FeatureChangeEventEnrichmentJsonContext.Default.ImmutableDictionaryStringObject);
+    }
+}
+
+/// <summary>
+/// Source-generated JSON context for attribute snapshot serialization (AOT compatible).
+/// Registers all primitive types that <c>object?</c> values resolve to at runtime,
+/// following the same pattern as <c>FeatureAttributesJsonContext</c>.
+/// </summary>
+[System.Text.Json.Serialization.JsonSourceGenerationOptions(
+    PropertyNamingPolicy = System.Text.Json.Serialization.JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+[System.Text.Json.Serialization.JsonSerializable(typeof(ImmutableDictionary<string, object?>))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(Dictionary<string, object?>))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(object))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(string))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(int))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(long))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(double))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(float))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(decimal))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(bool))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(DateTime))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(DateTimeOffset))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(JsonElement))]
+internal sealed partial class FeatureChangeEventEnrichmentJsonContext : System.Text.Json.Serialization.JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Infrastructure/Events/FeatureChangeEventEnrichment.cs
+++ b/src/Honua.Server/Features/Infrastructure/Events/FeatureChangeEventEnrichment.cs
@@ -62,7 +62,15 @@ internal static class FeatureChangeEventEnrichment
             return null;
         }
 
-        return JsonSerializer.Serialize(attributes, FeatureChangeEventEnrichmentJsonContext.Default.ImmutableDictionaryStringObject);
+        try
+        {
+            return JsonSerializer.Serialize(attributes, FeatureChangeEventEnrichmentJsonContext.Default.ImmutableDictionaryStringObject);
+        }
+        catch
+        {
+            // Unsupported runtime attribute value — skip enrichment rather than failing the write.
+            return null;
+        }
     }
 }
 
@@ -76,6 +84,8 @@ internal static class FeatureChangeEventEnrichment
     DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
 [System.Text.Json.Serialization.JsonSerializable(typeof(ImmutableDictionary<string, object?>))]
 [System.Text.Json.Serialization.JsonSerializable(typeof(Dictionary<string, object?>))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(List<object?>))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(object[]))]
 [System.Text.Json.Serialization.JsonSerializable(typeof(object))]
 [System.Text.Json.Serialization.JsonSerializable(typeof(string))]
 [System.Text.Json.Serialization.JsonSerializable(typeof(int))]
@@ -84,8 +94,13 @@ internal static class FeatureChangeEventEnrichment
 [System.Text.Json.Serialization.JsonSerializable(typeof(float))]
 [System.Text.Json.Serialization.JsonSerializable(typeof(decimal))]
 [System.Text.Json.Serialization.JsonSerializable(typeof(bool))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(byte[]))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(Guid))]
 [System.Text.Json.Serialization.JsonSerializable(typeof(DateTime))]
 [System.Text.Json.Serialization.JsonSerializable(typeof(DateTimeOffset))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(DateOnly))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(TimeOnly))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(TimeSpan))]
 [System.Text.Json.Serialization.JsonSerializable(typeof(JsonElement))]
 internal sealed partial class FeatureChangeEventEnrichmentJsonContext : System.Text.Json.Serialization.JsonSerializerContext
 {

--- a/src/Honua.Server/Features/Infrastructure/Events/FeatureChangeEventModels.cs
+++ b/src/Honua.Server/Features/Infrastructure/Events/FeatureChangeEventModels.cs
@@ -33,6 +33,18 @@ internal sealed record FeatureChangeEvent
     /// Best-effort: may default to false when the originating protocol cannot determine this.
     /// </summary>
     public bool GeometryChanged { get; init; }
+
+    /// <summary>
+    /// Geometry bounding box (MinX, MinY, MaxX, MaxY) captured at mutation time.
+    /// Null for deletes or non-spatial features.
+    /// </summary>
+    public double[]? GeometryEnvelope { get; init; }
+
+    /// <summary>
+    /// Pre-serialized JSON of feature attributes at mutation time.
+    /// Null for deletes.
+    /// </summary>
+    public string? PropertiesJson { get; init; }
 }
 
 /// <summary>
@@ -59,6 +71,18 @@ internal sealed record FeatureChangeEventRequest
     /// Best-effort: may default to false when the originating protocol cannot determine this.
     /// </summary>
     public bool GeometryChanged { get; init; }
+
+    /// <summary>
+    /// Geometry bounding box (MinX, MinY, MaxX, MaxY) captured at mutation time.
+    /// Null for deletes or non-spatial features.
+    /// </summary>
+    public double[]? GeometryEnvelope { get; init; }
+
+    /// <summary>
+    /// Pre-serialized JSON of feature attributes at mutation time.
+    /// Null for deletes.
+    /// </summary>
+    public string? PropertiesJson { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Server/Features/Infrastructure/Events/FeatureChangeEventsJsonContext.cs
+++ b/src/Honua.Server/Features/Infrastructure/Events/FeatureChangeEventsJsonContext.cs
@@ -15,7 +15,13 @@ namespace Honua.Server.Features.Infrastructure.Events;
 [JsonSerializable(typeof(int))]
 [JsonSerializable(typeof(long))]
 [JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(float))]
+[JsonSerializable(typeof(decimal))]
 [JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(DateTime))]
+[JsonSerializable(typeof(DateTimeOffset))]
+[JsonSerializable(typeof(JsonElement))]
+[JsonSerializable(typeof(double[]))]
 internal sealed partial class FeatureChangeEventsJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Server/Features/Infrastructure/Events/InMemoryFeatureChangeEventStore.cs
+++ b/src/Honua.Server/Features/Infrastructure/Events/InMemoryFeatureChangeEventStore.cs
@@ -58,6 +58,8 @@ internal sealed class InMemoryFeatureChangeEventStore(
                     request.Timestamp,
                     request.ChangedAttributes,
                     request.GeometryChanged,
+                    request.GeometryEnvelope,
+                    request.PropertiesJson,
                     cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -74,6 +76,8 @@ internal sealed class InMemoryFeatureChangeEventStore(
                     request.Timestamp,
                     request.ChangedAttributes,
                     request.GeometryChanged,
+                    request.GeometryEnvelope,
+                    request.PropertiesJson,
                     cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -91,7 +95,9 @@ internal sealed class InMemoryFeatureChangeEventStore(
                 normalizedRequestId,
                 request.Timestamp,
                 request.ChangedAttributes,
-                request.GeometryChanged);
+                request.GeometryChanged,
+                request.GeometryEnvelope,
+                request.PropertiesJson);
 
             _events.Add(created);
             TrimIfNeeded();
@@ -145,10 +151,24 @@ internal sealed class InMemoryFeatureChangeEventStore(
         DateTimeOffset? timestamp,
         Dictionary<string, object?>? changedAttributes,
         bool geometryChanged,
+        double[]? geometryEnvelope,
+        string? propertiesJson,
         CancellationToken cancellationToken)
     {
         var cursor = (long)await _redisDb!.StringIncrementAsync(CursorKey).ConfigureAwait(false);
-        var created = CreateEvent(cursor, serviceId, layerId, objectId, operation, protocol, requestId, timestamp, changedAttributes, geometryChanged);
+        var created = CreateEvent(
+            cursor,
+            serviceId,
+            layerId,
+            objectId,
+            operation,
+            protocol,
+            requestId,
+            timestamp,
+            changedAttributes,
+            geometryChanged,
+            geometryEnvelope,
+            propertiesJson);
         var eventKey = GetEventKey(cursor);
         var eventJson = JsonSerializer.Serialize(created, FeatureChangeEventsJsonContext.Default.FeatureChangeEvent);
 
@@ -168,6 +188,8 @@ internal sealed class InMemoryFeatureChangeEventStore(
         DateTimeOffset? timestamp,
         Dictionary<string, object?>? changedAttributes,
         bool geometryChanged,
+        double[]? geometryEnvelope,
+        string? propertiesJson,
         CancellationToken cancellationToken)
     {
         await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -175,7 +197,19 @@ internal sealed class InMemoryFeatureChangeEventStore(
         {
             var cursors = await ReadCachedIndexAsync(cancellationToken).ConfigureAwait(false);
             var cursor = await ReadCachedCursorAsync(cancellationToken).ConfigureAwait(false) + 1;
-            var created = CreateEvent(cursor, serviceId, layerId, objectId, operation, protocol, requestId, timestamp, changedAttributes, geometryChanged);
+            var created = CreateEvent(
+                cursor,
+                serviceId,
+                layerId,
+                objectId,
+                operation,
+                protocol,
+                requestId,
+                timestamp,
+                changedAttributes,
+                geometryChanged,
+                geometryEnvelope,
+                propertiesJson);
             cursors.Add(cursor);
 
             while (cursors.Count > _maxRetained)
@@ -362,7 +396,9 @@ internal sealed class InMemoryFeatureChangeEventStore(
         string requestId,
         DateTimeOffset? timestamp,
         Dictionary<string, object?>? changedAttributes = null,
-        bool geometryChanged = false)
+        bool geometryChanged = false,
+        double[]? geometryEnvelope = null,
+        string? propertiesJson = null)
         => new()
         {
             EventId = Guid.NewGuid().ToString("N"),
@@ -375,7 +411,9 @@ internal sealed class InMemoryFeatureChangeEventStore(
             Protocol = protocol,
             RequestId = requestId,
             ChangedAttributes = changedAttributes,
-            GeometryChanged = geometryChanged
+            GeometryChanged = geometryChanged,
+            GeometryEnvelope = geometryEnvelope,
+            PropertiesJson = propertiesJson
         };
 
     private void TrimIfNeeded()

--- a/src/Honua.Server/Features/OData/Models/ODataBatchModels.cs
+++ b/src/Honua.Server/Features/OData/Models/ODataBatchModels.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using System.Text.Json.Serialization;
+using Honua.Core.Features.FeatureStore.Domain;
 
 namespace Honua.Server.Features.OData.Models;
 
@@ -107,6 +108,8 @@ public sealed class ODataBatchResponseItem
     /// </summary>
     [JsonPropertyName("body")]
     public object? Body { get; init; }
+
+    internal Feature? MutationFeature { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Server/Features/OData/ODataBatchOperationHandler.cs
+++ b/src/Honua.Server/Features/OData/ODataBatchOperationHandler.cs
@@ -674,6 +674,7 @@ internal sealed partial class ODataBatchOperationHandler(
                 _ => "update"
             };
             var serviceId = await ResolveServiceIdAsync(context, layerId, cancellationToken);
+            var (geometryEnvelope, propertiesJson) = FeatureChangeEventEnrichment.FromFeature(responseItem.MutationFeature);
 
             await _batchDependencies.FeatureChangeEventPublisher.PublishAsync(
                 new FeatureChangeEventRequest
@@ -683,7 +684,9 @@ internal sealed partial class ODataBatchOperationHandler(
                     ObjectId = objectId,
                     Operation = eventOperation,
                     Protocol = Honua.ServiceDefaults.HonuaTelemetry.Protocols.OData,
-                    RequestId = $"{context.TraceIdentifier}:{responseItem.Id}"
+                    RequestId = $"{context.TraceIdentifier}:{responseItem.Id}",
+                    GeometryEnvelope = geometryEnvelope,
+                    PropertiesJson = propertiesJson
                 },
                 cancellationToken).ConfigureAwait(false);
         }

--- a/src/Honua.Server/Features/OData/ODataCrudHandler.cs
+++ b/src/Honua.Server/Features/OData/ODataCrudHandler.cs
@@ -316,6 +316,7 @@ internal sealed class ODataCrudHandler(
             if (TryExtractObjectId(result.Data, out var createdObjectId))
             {
                 var serviceId = await ResolveServiceIdAsync(context, resolvedLayerId.Value, effectiveToken);
+                var (createEnv, createProps) = FeatureChangeEventEnrichment.FromFeature(result.MutationFeature);
                 await _featureChangeEventPublisher.PublishAsync(
                     new FeatureChangeEventRequest
                     {
@@ -324,7 +325,9 @@ internal sealed class ODataCrudHandler(
                         ObjectId = createdObjectId,
                         Operation = "create",
                         Protocol = HonuaTelemetry.Protocols.OData,
-                        RequestId = context.TraceIdentifier
+                        RequestId = context.TraceIdentifier,
+                        GeometryEnvelope = createEnv,
+                        PropertiesJson = createProps
                     },
                     effectiveToken).ConfigureAwait(false);
             }
@@ -429,6 +432,7 @@ internal sealed class ODataCrudHandler(
 
             await InvalidateCacheAsync(context, layerId, effectiveToken);
             var serviceId = await ResolveServiceIdAsync(context, layerId, effectiveToken);
+            var (updateEnv, updateProps) = FeatureChangeEventEnrichment.FromFeature(result.MutationFeature);
             await _featureChangeEventPublisher.PublishAsync(
                 new FeatureChangeEventRequest
                 {
@@ -437,7 +441,9 @@ internal sealed class ODataCrudHandler(
                     ObjectId = objectId,
                     Operation = "update",
                     Protocol = HonuaTelemetry.Protocols.OData,
-                    RequestId = context.TraceIdentifier
+                    RequestId = context.TraceIdentifier,
+                    GeometryEnvelope = updateEnv,
+                    PropertiesJson = updateProps
                 },
                 effectiveToken).ConfigureAwait(false);
             HonuaTelemetry.SetSuccess(activity);

--- a/src/Honua.Server/Features/OData/ODataCrudHandler.cs
+++ b/src/Honua.Server/Features/OData/ODataCrudHandler.cs
@@ -492,6 +492,7 @@ internal sealed class ODataCrudHandler(
         {
             await InvalidateCacheAsync(context, layerId, effectiveToken);
             var serviceId = await ResolveServiceIdAsync(context, layerId, effectiveToken);
+            var (deleteEnv, deleteProps) = FeatureChangeEventEnrichment.FromFeature(result.MutationFeature);
             await _featureChangeEventPublisher.PublishAsync(
                 new FeatureChangeEventRequest
                 {
@@ -500,7 +501,9 @@ internal sealed class ODataCrudHandler(
                     ObjectId = objectId,
                     Operation = "delete",
                     Protocol = HonuaTelemetry.Protocols.OData,
-                    RequestId = context.TraceIdentifier
+                    RequestId = context.TraceIdentifier,
+                    GeometryEnvelope = deleteEnv,
+                    PropertiesJson = deleteProps
                 },
                 effectiveToken).ConfigureAwait(false);
             HonuaTelemetry.SetSuccess(activity);

--- a/src/Honua.Server/Features/OData/Services/ODataBatchHandler.cs
+++ b/src/Honua.Server/Features/OData/Services/ODataBatchHandler.cs
@@ -354,7 +354,7 @@ internal sealed partial class ODataBatchHandler
         // Collect all operations for atomic execution
         var createRequests = new Dictionary<int, List<(string requestId, Feature feature)>>();
         var updateRequests = new Dictionary<int, List<(string requestId, long objectId, Feature feature)>>();
-        var deleteRequests = new Dictionary<int, List<(string requestId, long objectId)>>();
+        var deleteRequests = new Dictionary<int, List<(string requestId, long objectId, Feature existingFeature)>>();
         var reads = new List<(string requestId, int layerId, long? objectId)>();
         var writeLayerIds = new HashSet<int>();
         var layerCache = new Dictionary<int, LayerDefinition>();
@@ -571,11 +571,11 @@ internal sealed partial class ODataBatchHandler
 
                             if (!deleteRequests.TryGetValue(layerId.Value, out var deleteList))
                             {
-                                deleteList = new List<(string requestId, long objectId)>();
+                                deleteList = new List<(string requestId, long objectId, Feature existingFeature)>();
                                 deleteRequests[layerId.Value] = deleteList;
                             }
 
-                            deleteList.Add((request.Id, objectId.Value));
+                            deleteList.Add((request.Id, objectId.Value, existing.Value));
                             writeLayerIds.Add(layerId.Value);
                             break;
                         }
@@ -838,11 +838,15 @@ internal sealed partial class ODataBatchHandler
                     for (var i = 0; i < result.DeleteResults.Length && i < layerDeletes.Count; i++)
                     {
                         var deleteResult = result.DeleteResults[i];
-                        var (requestId, _) = layerDeletes[i];
+                        var (requestId, _, existingFeature) = layerDeletes[i];
 
                         if (deleteResult.IsSuccess)
                         {
-                            responses.Add(CreateSuccessResponse(requestId, 204, null));
+                            responses.Add(CreateSuccessResponse(
+                                requestId,
+                                204,
+                                null,
+                                mutationFeature: existingFeature));
                         }
                         else
                         {
@@ -875,7 +879,7 @@ internal sealed partial class ODataBatchHandler
 
             foreach (var deleteList in deleteRequests.Values)
             {
-                foreach (var (requestId, _) in deleteList.Where(d => !responses.Any(r => r.Id == d.requestId)))
+                foreach (var (requestId, _, _) in deleteList.Where(d => !responses.Any(r => r.Id == d.requestId)))
                 {
                     responses.Add(CreateErrorResponse(requestId, 500, "TransactionFailed", "Atomic group transaction failed."));
                 }

--- a/src/Honua.Server/Features/OData/Services/ODataBatchHandler.cs
+++ b/src/Honua.Server/Features/OData/Services/ODataBatchHandler.cs
@@ -1105,7 +1105,8 @@ internal sealed partial class ODataBatchHandler
                 ["Location"] = $"{baseUrl}/odata/Features(LayerId={layer.Id},ObjectId={created.Id})",
                 ["OData-EntityId"] = $"{baseUrl}/odata/Features(LayerId={layer.Id},ObjectId={created.Id})",
                 ["ETag"] = etag
-            });
+            },
+            created);
     }
 
     private async Task<ODataBatchResponseItem> HandlePatchAsync(
@@ -1159,7 +1160,8 @@ internal sealed partial class ODataBatchHandler
             requestId,
             200,
             updatedPayload,
-            new Dictionary<string, string> { ["ETag"] = etag });
+            new Dictionary<string, string> { ["ETag"] = etag },
+            result);
     }
 
     private async Task<ODataBatchResponseItem> HandleDeleteAsync(
@@ -1450,14 +1452,16 @@ internal sealed partial class ODataBatchHandler
         string id,
         int status,
         object? body,
-        Dictionary<string, string>? headers = null)
+        Dictionary<string, string>? headers = null,
+        Feature? mutationFeature = null)
     {
         return new ODataBatchResponseItem
         {
             Id = id,
             Status = status,
             Headers = headers,
-            Body = body
+            Body = body,
+            MutationFeature = mutationFeature
         };
     }
 

--- a/src/Honua.Server/Features/OData/Services/ODataCrudService.cs
+++ b/src/Honua.Server/Features/OData/Services/ODataCrudService.cs
@@ -377,7 +377,7 @@ internal sealed partial class ODataCrudService
                 return ODataCrudResult<object>.NotFound($"Feature {objectId} not found in layer {layerId}");
             }
 
-            return ODataCrudResult<object>.NoContent();
+            return ODataCrudResult<object>.NoContent(existingFeature.Value);
         }
         catch (Exception ex)
         {
@@ -517,8 +517,8 @@ internal sealed record ODataCrudResult<T>
             MutationFeature = mutationFeature
         };
 
-    public static ODataCrudResult<T> NoContent()
-        => new() { IsSuccess = true, StatusCode = 204 };
+    public static ODataCrudResult<T> NoContent(Feature? mutationFeature = null)
+        => new() { IsSuccess = true, StatusCode = 204, MutationFeature = mutationFeature };
 
     public static ODataCrudResult<T> BadRequest(string message)
         => new() { IsSuccess = false, StatusCode = 400, ErrorMessage = message };

--- a/src/Honua.Server/Features/OData/Services/ODataCrudService.cs
+++ b/src/Honua.Server/Features/OData/Services/ODataCrudService.cs
@@ -171,7 +171,7 @@ internal sealed partial class ODataCrudService
             var etag = ComputeFeatureEtag(layerId, createdFeature, responseGeometry, serializedAttributes);
 
             var locationHeader = $"{baseUrl}/odata/Features(LayerId={layerId},ObjectId={createdFeature.Id})";
-            return ODataCrudResult<Dictionary<string, object?>>.Created(response, etag, locationHeader);
+            return ODataCrudResult<Dictionary<string, object?>>.Created(response, etag, locationHeader, createdFeature);
         }
         catch (ResourceConflictException ex)
         {
@@ -297,7 +297,7 @@ internal sealed partial class ODataCrudService
             var response = ODataUtilityService.BuildFeaturePayload(layerId, result, responseGeometry, serializedAttributes);
             var etag = ComputeFeatureEtag(layerId, result, responseGeometry, serializedAttributes);
 
-            return ODataCrudResult<Dictionary<string, object?>>.Success(response, etag);
+            return ODataCrudResult<Dictionary<string, object?>>.Success(response, etag, result);
         }
         catch (ResourceNotFoundException ex)
         {
@@ -499,14 +499,23 @@ internal sealed record ODataCrudResult<T>
     public string? ErrorMessage { get; init; }
     public string? ETag { get; init; }
     public string? LocationHeader { get; init; }
+    internal Feature? MutationFeature { get; init; }
 
     private ODataCrudResult() { }
 
-    public static ODataCrudResult<T> Success(T data, string? etag = null)
-        => new() { IsSuccess = true, StatusCode = 200, Data = data, ETag = etag };
+    public static ODataCrudResult<T> Success(T data, string? etag = null, Feature? mutationFeature = null)
+        => new() { IsSuccess = true, StatusCode = 200, Data = data, ETag = etag, MutationFeature = mutationFeature };
 
-    public static ODataCrudResult<T> Created(T data, string? etag = null, string? locationHeader = null)
-        => new() { IsSuccess = true, StatusCode = 201, Data = data, ETag = etag, LocationHeader = locationHeader };
+    public static ODataCrudResult<T> Created(T data, string? etag = null, string? locationHeader = null, Feature? mutationFeature = null)
+        => new()
+        {
+            IsSuccess = true,
+            StatusCode = 201,
+            Data = data,
+            ETag = etag,
+            LocationHeader = locationHeader,
+            MutationFeature = mutationFeature
+        };
 
     public static ODataCrudResult<T> NoContent()
         => new() { IsSuccess = true, StatusCode = 204 };

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesCrudHandler.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesCrudHandler.cs
@@ -88,6 +88,7 @@ internal sealed partial class OgcFeaturesCrudHandler(
             var created = await _featureWriter.CreateAsync(layerId, feature, cancellationToken);
             await OgcFeaturesUtilities.InvalidateLayerCacheAsync(context, layerId, cancellationToken);
             var serviceId = await ResolveServiceIdAsync(context, layerId, cancellationToken);
+            var (createEnv, createProps) = FeatureChangeEventEnrichment.FromFeature(created);
             await _featureChangeEventPublisher.PublishAsync(
                 new FeatureChangeEventRequest
                 {
@@ -96,7 +97,9 @@ internal sealed partial class OgcFeaturesCrudHandler(
                     ObjectId = created.Id,
                     Operation = "create",
                     Protocol = HonuaTelemetry.Protocols.OgcFeatures,
-                    RequestId = context.TraceIdentifier
+                    RequestId = context.TraceIdentifier,
+                    GeometryEnvelope = createEnv,
+                    PropertiesJson = createProps
                 },
                 cancellationToken).ConfigureAwait(false);
             var createLinks = OgcFeaturesUtilities.BuildFeatureLinks(

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesTransactionHandler.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesTransactionHandler.cs
@@ -119,6 +119,16 @@ internal sealed partial class OgcFeaturesTransactionHandler(
 
             if (!hasErrors)
             {
+                PreparedBatchOperation?[]? preparedOperationsByIndex = null;
+                if (!preparedBatch.PreparedOperations.IsDefaultOrEmpty)
+                {
+                    preparedOperationsByIndex = new PreparedBatchOperation?[batchRequest.Operations.Count];
+                    foreach (var preparedOperation in preparedBatch.PreparedOperations)
+                    {
+                        preparedOperationsByIndex[preparedOperation.Index] = preparedOperation;
+                    }
+                }
+
                 var serviceId = await ResolveServiceIdAsync(context, layerId, cancellationToken);
                 for (var index = 0; index < results.Count && index < batchRequest.Operations.Count; index++)
                 {
@@ -129,6 +139,7 @@ internal sealed partial class OgcFeaturesTransactionHandler(
                         continue;
                     }
 
+                    var (geometryEnvelope, propertiesJson) = GetBatchEventEnrichment(preparedOperationsByIndex?[index]);
                     await _featureChangeEventPublisher.PublishAsync(
                         new FeatureChangeEventRequest
                         {
@@ -137,7 +148,9 @@ internal sealed partial class OgcFeaturesTransactionHandler(
                             ObjectId = objectId,
                             Operation = eventOperation,
                             Protocol = HonuaTelemetry.Protocols.OgcFeatures,
-                            RequestId = $"{context.TraceIdentifier}:{operation.Id ?? "batch"}"
+                            RequestId = $"{context.TraceIdentifier}:{operation.Id ?? "batch"}",
+                            GeometryEnvelope = geometryEnvelope,
+                            PropertiesJson = propertiesJson
                         },
                         cancellationToken).ConfigureAwait(false);
                 }
@@ -265,6 +278,7 @@ internal sealed partial class OgcFeaturesTransactionHandler(
 
                 await OgcFeaturesUtilities.InvalidateLayerCacheAsync(context, layerId, cancellationToken);
                 var serviceId = await ResolveServiceIdAsync(context, layerId, cancellationToken);
+                var (replaceEnv, replaceProps) = FeatureChangeEventEnrichment.FromFeature(updated);
                 await _featureChangeEventPublisher.PublishAsync(
                     new FeatureChangeEventRequest
                     {
@@ -273,7 +287,9 @@ internal sealed partial class OgcFeaturesTransactionHandler(
                         ObjectId = updated.Id,
                         Operation = "update",
                         Protocol = HonuaTelemetry.Protocols.OgcFeatures,
-                        RequestId = context.TraceIdentifier
+                        RequestId = context.TraceIdentifier,
+                        GeometryEnvelope = replaceEnv,
+                        PropertiesJson = replaceProps
                     },
                     cancellationToken).ConfigureAwait(false);
                 HonuaTelemetry.SetSuccess(activity);
@@ -477,6 +493,7 @@ internal sealed partial class OgcFeaturesTransactionHandler(
 
                 await OgcFeaturesUtilities.InvalidateLayerCacheAsync(context, layerId, cancellationToken);
                 var serviceId = await ResolveServiceIdAsync(context, layerId, cancellationToken);
+                var (patchEnv, patchProps) = FeatureChangeEventEnrichment.FromFeature(updated);
                 await _featureChangeEventPublisher.PublishAsync(
                     new FeatureChangeEventRequest
                     {
@@ -485,7 +502,9 @@ internal sealed partial class OgcFeaturesTransactionHandler(
                         ObjectId = updated.Id,
                         Operation = "update",
                         Protocol = HonuaTelemetry.Protocols.OgcFeatures,
-                        RequestId = context.TraceIdentifier
+                        RequestId = context.TraceIdentifier,
+                        GeometryEnvelope = patchEnv,
+                        PropertiesJson = patchProps
                     },
                     cancellationToken).ConfigureAwait(false);
                 HonuaTelemetry.SetSuccess(activity);
@@ -935,6 +954,16 @@ internal sealed partial class OgcFeaturesTransactionHandler(
         {
             state.DeletedObjectIds.Add(operation.ObjectId.Value);
         }
+    }
+
+    private static (double[]? GeometryEnvelope, string? PropertiesJson) GetBatchEventEnrichment(PreparedBatchOperation? operation)
+    {
+        if (operation is null || operation.OperationKind == BatchOperationKind.Delete)
+        {
+            return (null, null);
+        }
+
+        return FeatureChangeEventEnrichment.FromFeature(operation.Feature);
     }
 
     private static async Task<(BatchRequest? Request, string? Error)> ReadBatchRequestAsync(

--- a/src/Honua.Server/Features/Stac/SearchEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/SearchEndpoints.cs
@@ -10,12 +10,12 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Queries.Filters;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Services;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.Stac.Models;
-using Honua.Core.Features.Geometry.Abstractions;
 using Honua.Server.Features.Stac.Services;
+using Honua.Core.Features.Geometry.Abstractions;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Server.Features.Stac;
 
@@ -67,11 +67,7 @@ internal static class SearchEndpoints
         [FromQuery(Name = "filter")] string? filter,
         [FromQuery(Name = "filter-lang")] string? filterLang,
         [FromQuery(Name = "filter-crs")] string? filterCrs,
-        [FromServices] ILayerCatalog layerCatalog,
-        [FromServices] IFeatureReader featureReader,
-        [FromServices] IFilterExpressionService filterExpressionService,
-        [FromServices] IGeometryService geometryService,
-        [FromServices] ILogger<StacEndpoints.StacEndpointsLog> logger)
+        [FromServices] StacSearchDependencies deps)
     {
         var validationError = OgcCommonUtilities.ValidateQueryParameters(
             context.Request, StacConstants.AllowedQueryParameters.SearchGet);
@@ -105,34 +101,29 @@ internal static class SearchEndpoints
             request,
             effectiveOffset,
             context,
-            layerCatalog,
-            featureReader,
-            filterExpressionService,
-            geometryService,
+            deps.LayerCatalog,
+            deps.FeatureReader,
+            deps.FilterExpressionService,
+            deps.GeometryService,
             defaultFilterLangIsText: true,
-            logger);
+            deps.Logger);
     }
 
     private static async Task<IResult> HandleSearchPost(
         HttpContext context,
         [FromBody] StacSearchRequest request,
-        [FromServices] ILayerCatalog layerCatalog,
-        [FromServices] IFeatureReader featureReader,
-        [FromServices] IFilterExpressionService filterExpressionService,
-        [FromServices] IGeometryService geometryService)
+        [FromServices] StacSearchDependencies deps)
     {
-        var logger = context.RequestServices.GetRequiredService<ILogger<StacEndpoints.StacEndpointsLog>>();
-
         return await ExecuteSearchAsync(
             request,
             0,
             context,
-            layerCatalog,
-            featureReader,
-            filterExpressionService,
-            geometryService,
+            deps.LayerCatalog,
+            deps.FeatureReader,
+            deps.FilterExpressionService,
+            deps.GeometryService,
             defaultFilterLangIsText: false,
-            logger);
+            deps.Logger);
     }
 
     private static async Task<IResult> ExecuteSearchAsync(
@@ -1108,7 +1099,7 @@ internal static class SearchEndpoints
 
     private static bool IsCrs84(string? crs)
         => string.IsNullOrWhiteSpace(crs) ||
-           crs.Equals(Honua.Server.Features.OgcFeatures.OgcFeaturesUtilities.Crs84Uri, StringComparison.OrdinalIgnoreCase) ||
+           crs.Equals(SpatialReferenceHelpers.Crs84Uri, StringComparison.OrdinalIgnoreCase) ||
            crs.Equals("CRS84", StringComparison.OrdinalIgnoreCase) ||
            crs.Equals("OGC:CRS84", StringComparison.OrdinalIgnoreCase);
 

--- a/src/Honua.Server/Features/Stac/Services/StacFilterHelpers.cs
+++ b/src/Honua.Server/Features/Stac/Services/StacFilterHelpers.cs
@@ -6,7 +6,6 @@ using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Geometry.Abstractions;
-using Honua.Core.Features.Shared.Models;
 using Honua.Server.Features.Infrastructure.Authentication;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;

--- a/src/Honua.Server/Features/Stac/StacSearchDependencies.cs
+++ b/src/Honua.Server/Features/Stac/StacSearchDependencies.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.Geometry.Abstractions;
+using Honua.Core.Queries.Filters;
+
+namespace Honua.Server.Features.Stac;
+
+internal sealed class StacSearchDependencies
+{
+    public StacSearchDependencies(
+        ILayerCatalog layerCatalog,
+        IFeatureReader featureReader,
+        IFilterExpressionService filterExpressionService,
+        IGeometryService geometryService,
+        ILogger<StacEndpoints.StacEndpointsLog> logger)
+    {
+        LayerCatalog = layerCatalog ?? throw new ArgumentNullException(nameof(layerCatalog));
+        FeatureReader = featureReader ?? throw new ArgumentNullException(nameof(featureReader));
+        FilterExpressionService = filterExpressionService ?? throw new ArgumentNullException(nameof(filterExpressionService));
+        GeometryService = geometryService ?? throw new ArgumentNullException(nameof(geometryService));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public ILayerCatalog LayerCatalog { get; }
+    public IFeatureReader FeatureReader { get; }
+    public IFilterExpressionService FilterExpressionService { get; }
+    public IGeometryService GeometryService { get; }
+    public ILogger<StacEndpoints.StacEndpointsLog> Logger { get; }
+}

--- a/src/Honua.Server/Features/Stac/StacServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Stac/StacServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ internal static class StacServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        // All STAC mapping/filter helpers are static — no scoped registrations needed currently.
+        services.AddScoped<StacSearchDependencies>();
 
         return services;
     }

--- a/src/Honua.Server/Features/Streaming/FeatureStreamDependencies.cs
+++ b/src/Honua.Server/Features/Streaming/FeatureStreamDependencies.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Queries.Filters;
+using Honua.Server.Features.Infrastructure.Events;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Streaming;
+
+/// <summary>
+/// Dependency bundle for feature stream endpoints. Keeps the endpoint method
+/// signature within the 5-dependency limit (follows <c>FeatureServerEditsDependencies</c> pattern).
+/// </summary>
+internal sealed class FeatureStreamDependencies
+{
+    public FeatureStreamDependencies(
+        FeatureStreamSessionManager sessionManager,
+        IFeatureChangeEventStore eventStore,
+        IOptions<FeatureStreamOptions> options,
+        IFilterExpressionService filterExpressionService,
+        ILayerCatalog layerCatalog)
+    {
+        SessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
+        EventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+        Options = options ?? throw new ArgumentNullException(nameof(options));
+        FilterExpressionService = filterExpressionService ?? throw new ArgumentNullException(nameof(filterExpressionService));
+        LayerCatalog = layerCatalog ?? throw new ArgumentNullException(nameof(layerCatalog));
+    }
+
+    public FeatureStreamSessionManager SessionManager { get; }
+    public IFeatureChangeEventStore EventStore { get; }
+    public IOptions<FeatureStreamOptions> Options { get; }
+    public IFilterExpressionService FilterExpressionService { get; }
+    public ILayerCatalog LayerCatalog { get; }
+}

--- a/src/Honua.Server/Features/Streaming/FeatureStreamDependencies.cs
+++ b/src/Honua.Server/Features/Streaming/FeatureStreamDependencies.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.GeometryService.Abstractions;
 using Honua.Core.Queries.Filters;
 using Honua.Server.Features.Infrastructure.Events;
 using Microsoft.Extensions.Options;
@@ -19,13 +20,15 @@ internal sealed class FeatureStreamDependencies
         IFeatureChangeEventStore eventStore,
         IOptions<FeatureStreamOptions> options,
         IFilterExpressionService filterExpressionService,
-        ILayerCatalog layerCatalog)
+        ILayerCatalog layerCatalog,
+        IGeometryOperationService geometryOperationService)
     {
         SessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
         EventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         Options = options ?? throw new ArgumentNullException(nameof(options));
         FilterExpressionService = filterExpressionService ?? throw new ArgumentNullException(nameof(filterExpressionService));
         LayerCatalog = layerCatalog ?? throw new ArgumentNullException(nameof(layerCatalog));
+        GeometryOperationService = geometryOperationService ?? throw new ArgumentNullException(nameof(geometryOperationService));
     }
 
     public FeatureStreamSessionManager SessionManager { get; }
@@ -33,4 +36,5 @@ internal sealed class FeatureStreamDependencies
     public IOptions<FeatureStreamOptions> Options { get; }
     public IFilterExpressionService FilterExpressionService { get; }
     public ILayerCatalog LayerCatalog { get; }
+    public IGeometryOperationService GeometryOperationService { get; }
 }

--- a/src/Honua.Server/Features/Streaming/FeatureStreamEndpoints.cs
+++ b/src/Honua.Server/Features/Streaming/FeatureStreamEndpoints.cs
@@ -222,11 +222,11 @@ internal static class FeatureStreamEndpoints
         if (!string.IsNullOrWhiteSpace(filterParam))
         {
             var filterLang = query["filter-lang"].ToString();
-            var language = string.IsNullOrWhiteSpace(filterLang) || filterLang.Equals("cql2-text", StringComparison.OrdinalIgnoreCase)
-                ? FilterLanguage.Cql2Text
-                : filterLang.Equals("cql2-json", StringComparison.OrdinalIgnoreCase)
-                    ? FilterLanguage.Cql2Json
-                    : FilterLanguage.Cql2Text;
+            if (!TryResolveFilterLanguage(filterLang, out var language, out var filterLangError))
+            {
+                FeatureStreamLog.FilterValidationFailed(logger, filterLangError);
+                return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, filterLangError));
+            }
 
             var parseResult = deps.FilterExpressionService.Parse(language, filterParam);
             if (!parseResult.IsSuccess)
@@ -269,6 +269,27 @@ internal static class FeatureStreamEndpoints
             bbox: bbox,
             attributeFilter: attributeFilter);
         return (filter, null);
+    }
+
+    private static bool TryResolveFilterLanguage(string? filterLang, out FilterLanguage language, out string error)
+    {
+        language = FilterLanguage.Cql2Text;
+        error = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(filterLang) ||
+            filterLang.Equals("cql2-text", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (filterLang.Equals("cql2-json", StringComparison.OrdinalIgnoreCase))
+        {
+            language = FilterLanguage.Cql2Json;
+            return true;
+        }
+
+        error = $"Unsupported filter language '{filterLang}'.";
+        return false;
     }
 
     private static async Task<(double[] Bbox, string? Error)> TryProjectSubscriptionBboxAsync(

--- a/src/Honua.Server/Features/Streaming/FeatureStreamEndpoints.cs
+++ b/src/Honua.Server/Features/Streaming/FeatureStreamEndpoints.cs
@@ -5,11 +5,11 @@ using System.Globalization;
 using System.IO;
 using System.Net.WebSockets;
 using System.Text.Json;
+using Honua.Core.Queries.Filters;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Events;
 using Honua.Server.Features.Infrastructure.Models;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 
 namespace Honua.Server.Features.Streaming;
 
@@ -36,8 +36,8 @@ internal static class FeatureStreamEndpoints
             .WithMetadata(new HttpMethodMetadata([HttpMethods.Get]))
             .WithDescription("Opens a WebSocket or SSE stream of real-time feature-change events. " +
                              "WebSocket: send Upgrade header. SSE: send Accept: text/event-stream. " +
-                             "Query params: cursor (resume from cursor), clientLabel, " +
-                             "serviceId (filter by service), layerIds (comma-separated layer ID filter).")
+                             "Query params: cursor (resume from cursor), clientLabel, serviceId, " +
+                             "layerIds/layers (comma-separated layer filter), bbox, filter, filter-lang.")
             .ProducesProblem(StatusCodes.Status400BadRequest);
 
         // Admin endpoints for session visibility
@@ -60,23 +60,28 @@ internal static class FeatureStreamEndpoints
     }
 
     private static async Task<IResult> HandleFeatureStream(
-        [FromServices] FeatureStreamSessionManager sessionManager,
-        [FromServices] IFeatureChangeEventStore eventStore,
-        [FromServices] IOptions<FeatureStreamOptions> options,
+        [FromServices] FeatureStreamDependencies deps,
         ILogger<FeatureStreamEndpointsLog> logger,
         HttpContext context)
     {
+        // Parse and validate subscription filters before accepting the connection.
+        var filterResult = await ParseSubscriptionFilterAsync(deps, logger, context).ConfigureAwait(false);
+        if (filterResult.Error is not null)
+        {
+            return filterResult.Error;
+        }
+
         // Determine transport from request headers.
         if (context.WebSockets.IsWebSocketRequest)
         {
-            await HandleWebSocketStream(sessionManager, eventStore, options.Value, logger, context).ConfigureAwait(false);
+            await HandleWebSocketStream(deps.SessionManager, deps.EventStore, deps.Options.Value, logger, context, filterResult.Filter).ConfigureAwait(false);
             return Results.Empty;
         }
 
         var accept = context.Request.Headers.Accept.ToString();
         if (accept.Contains("text/event-stream", StringComparison.OrdinalIgnoreCase))
         {
-            await HandleSseStream(sessionManager, eventStore, options.Value, logger, context).ConfigureAwait(false);
+            await HandleSseStream(deps.SessionManager, deps.EventStore, deps.Options.Value, logger, context, filterResult.Filter).ConfigureAwait(false);
             return Results.Empty;
         }
 
@@ -86,33 +91,146 @@ internal static class FeatureStreamEndpoints
             "WebSocket upgrade or Accept: text/event-stream header required.");
     }
 
-    private static FeatureStreamFilter? ParseFilter(HttpContext context)
+    private static async Task<(IStreamSubscriptionFilter? Filter, IResult? Error)> ParseSubscriptionFilterAsync(
+        FeatureStreamDependencies deps,
+        ILogger logger,
+        HttpContext context)
     {
-        var serviceId = NullIfEmpty(context.Request.Query["serviceId"].ToString());
-        var layerIdsParam = NullIfEmpty(context.Request.Query["layerIds"].ToString());
+        var query = context.Request.Query;
+        var serviceId = NullIfEmpty(query["serviceId"].ToString());
+        var layersParam = NullIfEmpty(query["layers"].ToString());
+        var legacyLayerIdsParam = NullIfEmpty(query["layerIds"].ToString());
+        var bboxParam = NullIfEmpty(query["bbox"].ToString());
+        var filterParam = NullIfEmpty(query["filter"].ToString());
 
-        if (serviceId == null && layerIdsParam == null)
-        {
-            return null;
-        }
+        int[]? layerIds = null;
+        double[]? bbox = null;
+        FilterExpression? attributeFilter = null;
+        bool hasAnyFilter = serviceId is not null;
 
-        HashSet<int>? layerIds = null;
-        if (layerIdsParam != null)
+        // Parse the new strict layer filter first.
+        if (!string.IsNullOrWhiteSpace(layersParam))
         {
-            layerIds = [];
-            foreach (var part in layerIdsParam.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            var parts = layersParam.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var ids = new List<int>(parts.Length);
+            foreach (var part in parts)
             {
-                if (int.TryParse(part, CultureInfo.InvariantCulture, out var id))
+                if (!int.TryParse(part, CultureInfo.InvariantCulture, out var id))
                 {
-                    layerIds.Add(id);
+                    var msg = $"Invalid layer ID '{part}'. Must be an integer.";
+                    FeatureStreamLog.FilterValidationFailed(logger, msg);
+                    return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, msg));
+                }
+
+                ids.Add(id);
+            }
+
+            // Validate layers exist.
+            foreach (var id in ids)
+            {
+                var layer = await deps.LayerCatalog.GetLayerAsync(id, context.RequestAborted).ConfigureAwait(false);
+                if (layer is null)
+                {
+                    var msg = $"Layer {id} not found.";
+                    FeatureStreamLog.FilterValidationFailed(logger, msg);
+                    return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, msg));
                 }
             }
 
-            // An empty set (all values were non-numeric) means "no valid layers
-            // requested" and will match nothing, preventing accidental stream widening.
+            layerIds = ids.ToArray();
+            hasAnyFilter = true;
+        }
+        else if (!string.IsNullOrWhiteSpace(legacyLayerIdsParam))
+        {
+            var ids = new HashSet<int>();
+            foreach (var part in legacyLayerIdsParam.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (int.TryParse(part, CultureInfo.InvariantCulture, out var id))
+                {
+                    ids.Add(id);
+                }
+            }
+
+            layerIds = ids.ToArray();
+            hasAnyFilter = true;
         }
 
-        return new FeatureStreamFilter { ServiceId = serviceId, LayerIds = layerIds };
+        // Parse bbox (minX,minY,maxX,maxY).
+        if (!string.IsNullOrWhiteSpace(bboxParam))
+        {
+            var parts = bboxParam.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length != 4)
+            {
+                var msg = "Invalid bbox: expected 4 comma-separated values (minX,minY,maxX,maxY).";
+                FeatureStreamLog.FilterValidationFailed(logger, msg);
+                return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, msg));
+            }
+
+            bbox = new double[4];
+            for (int i = 0; i < 4; i++)
+            {
+                if (!double.TryParse(parts[i], CultureInfo.InvariantCulture, out bbox[i]) || !double.IsFinite(bbox[i]))
+                {
+                    var msg = $"Invalid bbox value '{parts[i]}' at position {i}. Must be a finite number.";
+                    FeatureStreamLog.FilterValidationFailed(logger, msg);
+                    return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, msg));
+                }
+            }
+
+            if (bbox[0] > bbox[2] || bbox[1] > bbox[3])
+            {
+                var msg = "Invalid bbox: minX must be <= maxX and minY must be <= maxY.";
+                FeatureStreamLog.FilterValidationFailed(logger, msg);
+                return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, msg));
+            }
+
+            hasAnyFilter = true;
+        }
+
+        // Parse attribute filter (CQL2-text).
+        if (!string.IsNullOrWhiteSpace(filterParam))
+        {
+            var filterLang = query["filter-lang"].ToString();
+            var language = string.IsNullOrWhiteSpace(filterLang) || filterLang.Equals("cql2-text", StringComparison.OrdinalIgnoreCase)
+                ? FilterLanguage.Cql2Text
+                : filterLang.Equals("cql2-json", StringComparison.OrdinalIgnoreCase)
+                    ? FilterLanguage.Cql2Json
+                    : FilterLanguage.Cql2Text;
+
+            var parseResult = deps.FilterExpressionService.Parse(language, filterParam);
+            if (!parseResult.IsSuccess)
+            {
+                var msg = $"Invalid filter expression: {parseResult.ErrorMessage}";
+                FeatureStreamLog.FilterValidationFailed(logger, msg);
+                return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, msg));
+            }
+
+            if (parseResult.Expression is not null)
+            {
+                // Enforce streaming depth limit.
+                if (InMemoryFilterEvaluator.ExceedsMaxDepth(parseResult.Expression))
+                {
+                    var msg = $"Filter expression exceeds maximum depth ({InMemoryFilterEvaluator.MaxStreamingDepth}) for streaming subscriptions.";
+                    FeatureStreamLog.FilterValidationFailed(logger, msg);
+                    return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, msg));
+                }
+
+                attributeFilter = parseResult.Expression;
+                hasAnyFilter = true;
+            }
+        }
+
+        if (!hasAnyFilter)
+        {
+            return (null, null);
+        }
+
+        var filter = new StreamSubscriptionFilter(
+            serviceId: serviceId,
+            layerIds: layerIds,
+            bbox: bbox,
+            attributeFilter: attributeFilter);
+        return (filter, null);
     }
 
     private static async Task HandleWebSocketStream(
@@ -120,16 +238,20 @@ internal static class FeatureStreamEndpoints
         IFeatureChangeEventStore eventStore,
         FeatureStreamOptions options,
         ILogger logger,
-        HttpContext context)
+        HttpContext context,
+        IStreamSubscriptionFilter? subscriptionFilter)
     {
         using var webSocket = await context.WebSockets.AcceptWebSocketAsync().ConfigureAwait(false);
 
         var clientLabel = context.Request.Query["clientLabel"].ToString();
         var cursorParam = context.Request.Query["cursor"].ToString();
         long? cursor = long.TryParse(cursorParam, CultureInfo.InvariantCulture, out var c) ? c : null;
-        var filter = ParseFilter(context);
+        using var session = sessionManager.CreateSession(WebSocketTransport, NullIfEmpty(clientLabel), subscriptionFilter);
 
-        using var session = sessionManager.CreateSession(WebSocketTransport, NullIfEmpty(clientLabel), filter);
+        if (subscriptionFilter is not null)
+        {
+            FeatureStreamLog.SessionCreatedWithFilter(logger, session.SessionId, subscriptionFilter.Summary);
+        }
 
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
             context.RequestAborted, session.DisconnectToken);
@@ -144,11 +266,11 @@ internal static class FeatureStreamEndpoints
         {
             try
             {
-                replayCursor = await ReplayToWebSocketAsync(webSocket, eventStore, cursor!.Value, options.ReplayBatchSize, logger, session.SessionId, filter, linkedCts.Token).ConfigureAwait(false);
+                replayCursor = await ReplayToWebSocketAsync(webSocket, eventStore, cursor!.Value, options.ReplayBatchSize, logger, session.SessionId, linkedCts.Token, subscriptionFilter).ConfigureAwait(false);
 
                 // Catch-up: replay events published during the main replay window that
                 // were silently dropped from the bounded channel pre-drain.
-                replayCursor = await ReplayToWebSocketAsync(webSocket, eventStore, replayCursor, options.ReplayBatchSize, logger, session.SessionId, filter, linkedCts.Token).ConfigureAwait(false);
+                replayCursor = await ReplayToWebSocketAsync(webSocket, eventStore, replayCursor, options.ReplayBatchSize, logger, session.SessionId, linkedCts.Token, subscriptionFilter).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (linkedCts.Token.IsCancellationRequested)
             {
@@ -188,7 +310,7 @@ internal static class FeatureStreamEndpoints
                     while (session.Reader.TryRead(out _)) { }
 
                     previousCursor = replayCursor;
-                    replayCursor = await ReplayToWebSocketAsync(webSocket, eventStore, replayCursor, options.ReplayBatchSize, logger, session.SessionId, filter, linkedCts.Token).ConfigureAwait(false);
+                    replayCursor = await ReplayToWebSocketAsync(webSocket, eventStore, replayCursor, options.ReplayBatchSize, logger, session.SessionId, linkedCts.Token, subscriptionFilter).ConfigureAwait(false);
                 } while (replayCursor > previousCursor || session.Reader.TryPeek(out _));
             }
         }
@@ -221,7 +343,7 @@ internal static class FeatureStreamEndpoints
                         while (session.Reader.TryRead(out _)) { }
 
                         long prev = cursor;
-                        cursor = await ReplayToWebSocketAsync(webSocket, eventStore, cursor, options.ReplayBatchSize, logger, session.SessionId, filter, ct).ConfigureAwait(false);
+                        cursor = await ReplayToWebSocketAsync(webSocket, eventStore, cursor, options.ReplayBatchSize, logger, session.SessionId, ct, subscriptionFilter).ConfigureAwait(false);
                         if (cursor > prev)
                         {
                             progress = true;
@@ -334,7 +456,8 @@ internal static class FeatureStreamEndpoints
         IFeatureChangeEventStore eventStore,
         FeatureStreamOptions options,
         ILogger logger,
-        HttpContext context)
+        HttpContext context,
+        IStreamSubscriptionFilter? subscriptionFilter)
     {
         context.Response.ContentType = "text/event-stream";
         context.Response.Headers.CacheControl = "no-cache";
@@ -370,8 +493,12 @@ internal static class FeatureStreamEndpoints
             }
         }
 
-        var filter = ParseFilter(context);
-        using var session = sessionManager.CreateSession(SseTransport, NullIfEmpty(clientLabel), filter);
+        using var session = sessionManager.CreateSession(SseTransport, NullIfEmpty(clientLabel), subscriptionFilter);
+
+        if (subscriptionFilter is not null)
+        {
+            FeatureStreamLog.SessionCreatedWithFilter(logger, session.SessionId, subscriptionFilter.Summary);
+        }
 
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
             context.RequestAborted, session.DisconnectToken);
@@ -386,11 +513,11 @@ internal static class FeatureStreamEndpoints
         {
             try
             {
-                replayCursor = await ReplayToSseAsync(context.Response, eventStore, cursor!.Value, options.ReplayBatchSize, logger, session.SessionId, filter, linkedCts.Token).ConfigureAwait(false);
+                replayCursor = await ReplayToSseAsync(context.Response, eventStore, cursor!.Value, options.ReplayBatchSize, logger, session.SessionId, linkedCts.Token, subscriptionFilter).ConfigureAwait(false);
 
                 // Catch-up: replay events published during the main replay window that
                 // were silently dropped from the bounded channel pre-drain.
-                replayCursor = await ReplayToSseAsync(context.Response, eventStore, replayCursor, options.ReplayBatchSize, logger, session.SessionId, filter, linkedCts.Token).ConfigureAwait(false);
+                replayCursor = await ReplayToSseAsync(context.Response, eventStore, replayCursor, options.ReplayBatchSize, logger, session.SessionId, linkedCts.Token, subscriptionFilter).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (linkedCts.Token.IsCancellationRequested)
             {
@@ -433,7 +560,7 @@ internal static class FeatureStreamEndpoints
                     while (session.Reader.TryRead(out _)) { }
 
                     previousCursor = replayCursor;
-                    replayCursor = await ReplayToSseAsync(context.Response, eventStore, replayCursor, options.ReplayBatchSize, logger, session.SessionId, filter, linkedCts.Token).ConfigureAwait(false);
+                    replayCursor = await ReplayToSseAsync(context.Response, eventStore, replayCursor, options.ReplayBatchSize, logger, session.SessionId, linkedCts.Token, subscriptionFilter).ConfigureAwait(false);
                 } while (replayCursor > previousCursor || session.Reader.TryPeek(out _));
             }
 
@@ -459,7 +586,7 @@ internal static class FeatureStreamEndpoints
                         while (session.Reader.TryRead(out _)) { }
 
                         long prev = replayCursor;
-                        replayCursor = await ReplayToSseAsync(context.Response, eventStore, replayCursor, options.ReplayBatchSize, logger, session.SessionId, filter, linkedCts.Token).ConfigureAwait(false);
+                        replayCursor = await ReplayToSseAsync(context.Response, eventStore, replayCursor, options.ReplayBatchSize, logger, session.SessionId, linkedCts.Token, subscriptionFilter).ConfigureAwait(false);
                         if (replayCursor > prev)
                         {
                             progress = true;
@@ -522,8 +649,8 @@ internal static class FeatureStreamEndpoints
         int batchSize,
         ILogger logger,
         Guid sessionId,
-        FeatureStreamFilter? filter,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IStreamSubscriptionFilter? subscriptionFilter = null)
     {
         var cursor = fromCursor;
         while (!cancellationToken.IsCancellationRequested)
@@ -541,7 +668,9 @@ internal static class FeatureStreamEndpoints
                 var envelope = FeatureStreamPublisher.ToEnvelope(evt);
                 cursor = evt.Cursor;
 
-                if (filter != null && !filter.Matches(envelope))
+                // Apply subscription filter during replay — advance cursor past filtered events.
+                if (subscriptionFilter is not null
+                    && !subscriptionFilter.Matches(envelope, evt.GeometryEnvelope, evt.PropertiesJson))
                 {
                     continue;
                 }
@@ -566,8 +695,8 @@ internal static class FeatureStreamEndpoints
         int batchSize,
         ILogger logger,
         Guid sessionId,
-        FeatureStreamFilter? filter,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IStreamSubscriptionFilter? subscriptionFilter = null)
     {
         var cursor = fromCursor;
         while (!cancellationToken.IsCancellationRequested)
@@ -585,7 +714,9 @@ internal static class FeatureStreamEndpoints
                 var envelope = FeatureStreamPublisher.ToEnvelope(evt);
                 cursor = evt.Cursor;
 
-                if (filter != null && !filter.Matches(envelope))
+                // Apply subscription filter during replay — advance cursor past filtered events.
+                if (subscriptionFilter is not null
+                    && !subscriptionFilter.Matches(envelope, evt.GeometryEnvelope, evt.PropertiesJson))
                 {
                     continue;
                 }
@@ -624,8 +755,10 @@ internal static class FeatureStreamEndpoints
             Transport = s.Transport,
             LastQueuedCursor = s.LastQueuedCursor,
             DurationSeconds = (now - s.ConnectedAt).TotalSeconds,
-            ServiceIdFilter = s.Filter?.ServiceId,
-            LayerIdFilter = s.Filter?.LayerIds?.ToArray()
+            HasFilter = s.HasFilter,
+            FilterSummary = s.FilterSummary,
+            ServiceIdFilter = s.ServiceIdFilter,
+            LayerIdFilter = s.LayerIdFilter
         }).ToArray();
 
         var wsSessions = sessionResponses.Count(s => s.Transport == WebSocketTransport);

--- a/src/Honua.Server/Features/Streaming/FeatureStreamEndpoints.cs
+++ b/src/Honua.Server/Features/Streaming/FeatureStreamEndpoints.cs
@@ -5,10 +5,13 @@ using System.Globalization;
 using System.IO;
 using System.Net.WebSockets;
 using System.Text.Json;
+using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Queries.Filters;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Events;
+using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Honua.Server.Features.Streaming;
@@ -19,6 +22,7 @@ namespace Honua.Server.Features.Streaming;
 /// </summary>
 internal static class FeatureStreamEndpoints
 {
+    private const int SubscriptionBboxSrid = 4326;
     private const string WebSocketTransport = "WebSocket";
     private const string SseTransport = "SSE";
 
@@ -37,7 +41,7 @@ internal static class FeatureStreamEndpoints
             .WithDescription("Opens a WebSocket or SSE stream of real-time feature-change events. " +
                              "WebSocket: send Upgrade header. SSE: send Accept: text/event-stream. " +
                              "Query params: cursor (resume from cursor), clientLabel, serviceId, " +
-                             "layerIds/layers (comma-separated layer filter), bbox, filter, filter-lang.")
+                             "layerIds/layers (comma-separated layer filter), bbox (WGS84; requires exactly one layer), filter, filter-lang.")
             .ProducesProblem(StatusCodes.Status400BadRequest);
 
         // Admin endpoints for session visibility
@@ -184,6 +188,33 @@ internal static class FeatureStreamEndpoints
                 return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, msg));
             }
 
+            if (layerIds is null || layerIds.Length != 1)
+            {
+                const string msg = "bbox filters require exactly one layer specified via the layers or layerIds parameter.";
+                FeatureStreamLog.FilterValidationFailed(logger, msg);
+                return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, msg));
+            }
+
+            var bboxLayer = await deps.LayerCatalog.GetLayerAsync(layerIds[0], context.RequestAborted).ConfigureAwait(false);
+            if (bboxLayer is null)
+            {
+                var msg = $"Layer {layerIds[0]} not found.";
+                FeatureStreamLog.FilterValidationFailed(logger, msg);
+                return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, msg));
+            }
+
+            var (projectedBbox, bboxError) = await TryProjectSubscriptionBboxAsync(
+                deps,
+                bbox,
+                bboxLayer,
+                context.RequestAborted).ConfigureAwait(false);
+            if (bboxError is not null)
+            {
+                FeatureStreamLog.FilterValidationFailed(logger, bboxError);
+                return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, bboxError));
+            }
+
+            bbox = projectedBbox;
             hasAnyFilter = true;
         }
 
@@ -215,6 +246,13 @@ internal static class FeatureStreamEndpoints
                     return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, msg));
                 }
 
+                if (!InMemoryFilterEvaluator.TryValidateStreamingExpression(parseResult.Expression, out var validationError))
+                {
+                    var msg = validationError ?? "Streaming subscriptions do not support the requested filter expression.";
+                    FeatureStreamLog.FilterValidationFailed(logger, msg);
+                    return (null, ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, msg));
+                }
+
                 attributeFilter = parseResult.Expression;
                 hasAnyFilter = true;
             }
@@ -231,6 +269,59 @@ internal static class FeatureStreamEndpoints
             bbox: bbox,
             attributeFilter: attributeFilter);
         return (filter, null);
+    }
+
+    private static async Task<(double[] Bbox, string? Error)> TryProjectSubscriptionBboxAsync(
+        FeatureStreamDependencies deps,
+        double[] bbox,
+        LayerDefinition layer,
+        CancellationToken cancellationToken)
+    {
+        if (!layer.HasGeometry)
+        {
+            return (bbox, $"bbox filters are not supported for non-spatial layer {layer.Id}.");
+        }
+
+        var layerSrid = layer.SpatialReference.Wkid;
+        if (layerSrid <= 0)
+        {
+            return (bbox, $"Layer {layer.Id} does not define a valid spatial reference.");
+        }
+
+        if (layerSrid == SubscriptionBboxSrid)
+        {
+            return (bbox, null);
+        }
+
+        try
+        {
+            var projectedWkb = await deps.GeometryOperationService.ProjectAsync(
+                SpatialFilterHelpers.CreateEnvelopeWkb(bbox[0], bbox[1], bbox[2], bbox[3]),
+                SubscriptionBboxSrid,
+                layerSrid,
+                cancellationToken).ConfigureAwait(false);
+
+            var geometry = WkbReaderCache.Get().Read(projectedWkb);
+            if (geometry is null || geometry.IsEmpty)
+            {
+                return (bbox, $"Unable to project bbox to layer {layer.Id} spatial reference.");
+            }
+
+            var env = geometry.EnvelopeInternal;
+            return ([env.MinX, env.MinY, env.MaxX, env.MaxY], null);
+        }
+        catch (ArgumentException ex)
+        {
+            return (bbox, $"Invalid bbox projection for layer {layer.Id}: {ex.Message}");
+        }
+        catch (NotSupportedException ex)
+        {
+            return (bbox, $"bbox filters do not support projecting layer {layer.Id} to SRID {layerSrid}: {ex.Message}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return (bbox, $"bbox filters could not be projected for layer {layer.Id}: {ex.Message}");
+        }
     }
 
     private static async Task HandleWebSocketStream(

--- a/src/Honua.Server/Features/Streaming/FeatureStreamJsonContext.cs
+++ b/src/Honua.Server/Features/Streaming/FeatureStreamJsonContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Honua.Server.Features.Infrastructure.Models;
 
@@ -26,7 +27,12 @@ namespace Honua.Server.Features.Streaming;
 [JsonSerializable(typeof(int))]
 [JsonSerializable(typeof(long))]
 [JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(float))]
+[JsonSerializable(typeof(decimal))]
 [JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(DateTime))]
+[JsonSerializable(typeof(DateTimeOffset))]
+[JsonSerializable(typeof(Dictionary<string, JsonElement>))]
 internal sealed partial class FeatureStreamJsonContext : JsonSerializerContext
 {
 }
@@ -122,6 +128,16 @@ internal sealed class FeatureStreamSessionResponse
     /// Connection duration in seconds.
     /// </summary>
     public double DurationSeconds { get; init; }
+
+    /// <summary>
+    /// Whether this session has an active subscription filter.
+    /// </summary>
+    public bool HasFilter { get; init; }
+
+    /// <summary>
+    /// Human-readable summary of the subscription filter, if any.
+    /// </summary>
+    public string? FilterSummary { get; init; }
 
     /// <summary>
     /// Service ID filter applied to this session, if any.

--- a/src/Honua.Server/Features/Streaming/FeatureStreamLog.cs
+++ b/src/Honua.Server/Features/Streaming/FeatureStreamLog.cs
@@ -43,4 +43,12 @@ internal static partial class FeatureStreamLog
     [LoggerMessage(EventId = 5009, Level = LogLevel.Information,
         Message = "Feature stream heartbeat service stopped")]
     public static partial void HeartbeatServiceStopped(ILogger logger);
+
+    [LoggerMessage(EventId = 5010, Level = LogLevel.Information,
+        Message = "Feature stream session {SessionId} created with filter: {FilterSummary}")]
+    public static partial void SessionCreatedWithFilter(ILogger logger, Guid sessionId, string filterSummary);
+
+    [LoggerMessage(EventId = 5011, Level = LogLevel.Warning,
+        Message = "Feature stream filter validation failed: {Error}")]
+    public static partial void FilterValidationFailed(ILogger logger, string error);
 }

--- a/src/Honua.Server/Features/Streaming/FeatureStreamModels.cs
+++ b/src/Honua.Server/Features/Streaming/FeatureStreamModels.cs
@@ -68,41 +68,6 @@ internal sealed record FeatureStreamEnvelope
 }
 
 /// <summary>
-/// Subscription filter applied to a streaming session.
-/// When set, only events matching the criteria are delivered.
-/// </summary>
-internal sealed class FeatureStreamFilter
-{
-    /// <summary>
-    /// If set, only events for this service are delivered.
-    /// </summary>
-    public string? ServiceId { get; init; }
-
-    /// <summary>
-    /// If set, only events for these layer IDs are delivered.
-    /// </summary>
-    public HashSet<int>? LayerIds { get; init; }
-
-    /// <summary>
-    /// Returns true if the given envelope matches this filter.
-    /// </summary>
-    public bool Matches(FeatureStreamEnvelope envelope)
-    {
-        if (ServiceId != null && !string.Equals(envelope.ServiceId, ServiceId, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        if (LayerIds != null && !LayerIds.Contains(envelope.LayerId))
-        {
-            return false;
-        }
-
-        return true;
-    }
-}
-
-/// <summary>
 /// Metadata about an active feature-stream session for admin visibility.
 /// </summary>
 internal sealed record FeatureStreamSessionInfo(
@@ -111,7 +76,10 @@ internal sealed record FeatureStreamSessionInfo(
     string? ClientLabel,
     string Transport,
     long LastQueuedCursor,
-    FeatureStreamFilter? Filter = null);
+    bool HasFilter,
+    string? FilterSummary = null,
+    string? ServiceIdFilter = null,
+    int[]? LayerIdFilter = null);
 
 /// <summary>
 /// Disconnect reason for feature-stream sessions.

--- a/src/Honua.Server/Features/Streaming/FeatureStreamPublisher.cs
+++ b/src/Honua.Server/Features/Streaming/FeatureStreamPublisher.cs
@@ -37,8 +37,11 @@ internal sealed partial class FeatureStreamPublisher(
         }
 
         // Fan out to live streaming sessions after durable append.
+        // Enrichment data (geometry envelope + properties) is carried on the message
+        // for subscription filter evaluation during broadcast — no I/O in the hot path.
         var envelope = ToEnvelope(persisted);
-        var delivered = _sessionManager.Broadcast(FeatureStreamMessage.Data(envelope));
+        var delivered = _sessionManager.Broadcast(
+            FeatureStreamMessage.Data(envelope, persisted.GeometryEnvelope, persisted.PropertiesJson));
 
         FeatureStreamLog.EventBroadcast(_logger, delivered, persisted.Cursor);
     }

--- a/src/Honua.Server/Features/Streaming/FeatureStreamSessionManager.cs
+++ b/src/Honua.Server/Features/Streaming/FeatureStreamSessionManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;
+using System.Text.Json;
 using System.Threading.Channels;
 using Microsoft.Extensions.Options;
 
@@ -51,11 +52,7 @@ internal sealed class FeatureStreamSessionManager : IDisposable
     public FeatureStreamSession CreateSession(string transport, string? clientLabel)
         => CreateSession(transport, clientLabel, filter: null);
 
-    /// <summary>
-    /// Creates a new session with an optional subscription filter.
-    /// When a filter is specified, only events matching the filter criteria are delivered.
-    /// </summary>
-    public FeatureStreamSession CreateSession(string transport, string? clientLabel, FeatureStreamFilter? filter)
+    public FeatureStreamSession CreateSession(string transport, string? clientLabel, IStreamSubscriptionFilter? filter = null)
     {
         var opts = _options.Value;
         var id = Guid.NewGuid();
@@ -125,6 +122,8 @@ internal sealed class FeatureStreamSessionManager : IDisposable
     public int Broadcast(FeatureStreamMessage message)
     {
         var delivered = 0;
+        IReadOnlyDictionary<string, JsonElement>? parsedProperties = null;
+        bool propertiesParsed = false;
         foreach (var (id, entry) in _sessions)
         {
             if (entry.Cts.IsCancellationRequested)
@@ -132,8 +131,21 @@ internal sealed class FeatureStreamSessionManager : IDisposable
                 continue;
             }
 
-            // Skip sessions whose filter does not match this event.
-            if (!message.IsHeartbeat && entry.Filter != null && !entry.Filter.Matches(message.Envelope))
+            // Apply subscription filter before queueing. Filtered events never
+            // enter the channel, reducing buffer pressure for selective subscribers.
+            if (entry.SubscriptionFilter is not null
+                && !message.IsHeartbeat
+                && !(entry.SubscriptionFilter is StreamSubscriptionFilter streamFilter
+                    ? streamFilter.Matches(
+                        message.Envelope,
+                        message.GeometryEnvelope,
+                        message.PropertiesJson,
+                        ref parsedProperties,
+                        ref propertiesParsed)
+                    : entry.SubscriptionFilter.Matches(
+                        message.Envelope,
+                        message.GeometryEnvelope,
+                        message.PropertiesJson)))
             {
                 continue;
             }
@@ -244,13 +256,20 @@ internal sealed class FeatureStreamSessionManager : IDisposable
     /// </summary>
     public IReadOnlyList<FeatureStreamSessionInfo> GetSessions()
     {
-        return _sessions.Select(kvp => new FeatureStreamSessionInfo(
-            kvp.Key,
-            kvp.Value.ConnectedAt,
-            kvp.Value.ClientLabel,
-            kvp.Value.Transport,
-            kvp.Value.LastQueuedCursor,
-            kvp.Value.Filter)).ToArray();
+        return _sessions.Select(kvp =>
+        {
+            var streamFilter = kvp.Value.SubscriptionFilter as StreamSubscriptionFilter;
+            return new FeatureStreamSessionInfo(
+                kvp.Key,
+                kvp.Value.ConnectedAt,
+                kvp.Value.ClientLabel,
+                kvp.Value.Transport,
+                kvp.Value.LastQueuedCursor,
+                kvp.Value.SubscriptionFilter is not null,
+                kvp.Value.SubscriptionFilter?.Summary,
+                streamFilter?.ServiceId,
+                streamFilter?.LayerIds?.ToArray());
+        }).ToArray();
     }
 
     public void Dispose()
@@ -276,7 +295,7 @@ internal sealed class FeatureStreamSessionManager : IDisposable
             DateTimeOffset connectedAt,
             string? clientLabel,
             string transport,
-            FeatureStreamFilter? filter = null)
+            IStreamSubscriptionFilter? subscriptionFilter = null)
         {
             Id = id;
             Channel = channel;
@@ -284,7 +303,7 @@ internal sealed class FeatureStreamSessionManager : IDisposable
             ConnectedAt = connectedAt;
             ClientLabel = clientLabel;
             Transport = transport;
-            Filter = filter;
+            SubscriptionFilter = subscriptionFilter;
         }
 
         public Guid Id { get; }
@@ -293,7 +312,7 @@ internal sealed class FeatureStreamSessionManager : IDisposable
         public DateTimeOffset ConnectedAt { get; }
         public string? ClientLabel { get; }
         public string Transport { get; }
-        public FeatureStreamFilter? Filter { get; }
+        public IStreamSubscriptionFilter? SubscriptionFilter { get; }
         public volatile bool DrainStarted;
         public long LastQueuedCursor => Interlocked.Read(ref _lastQueuedCursor);
 
@@ -378,10 +397,29 @@ internal readonly record struct FeatureStreamMessage
     public FeatureStreamEnvelope Envelope { get; private init; }
 
     /// <summary>
-    /// Creates a data message.
+    /// Geometry bounding box from the enriched event (internal only, never serialized to clients).
     /// </summary>
-    public static FeatureStreamMessage Data(FeatureStreamEnvelope envelope) =>
-        new() { IsHeartbeat = false, Envelope = envelope };
+    public double[]? GeometryEnvelope { get; private init; }
+
+    /// <summary>
+    /// Pre-serialized attribute JSON from the enriched event (internal only, never serialized to clients).
+    /// </summary>
+    public string? PropertiesJson { get; private init; }
+
+    /// <summary>
+    /// Creates a data message with optional enrichment for subscription filtering.
+    /// </summary>
+    public static FeatureStreamMessage Data(
+        FeatureStreamEnvelope envelope,
+        double[]? geometryEnvelope = null,
+        string? propertiesJson = null) =>
+        new()
+        {
+            IsHeartbeat = false,
+            Envelope = envelope,
+            GeometryEnvelope = geometryEnvelope,
+            PropertiesJson = propertiesJson
+        };
 
     /// <summary>
     /// Creates a heartbeat message.

--- a/src/Honua.Server/Features/Streaming/IStreamSubscriptionFilter.cs
+++ b/src/Honua.Server/Features/Streaming/IStreamSubscriptionFilter.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Streaming;
+
+/// <summary>
+/// Evaluates whether a streaming event matches a subscription filter.
+/// Implementations must be synchronous and allocation-free on the comparison path
+/// to avoid blocking the broadcast hot path.
+/// </summary>
+internal interface IStreamSubscriptionFilter
+{
+    /// <summary>
+    /// Returns true if the event matches this subscription's filter criteria.
+    /// </summary>
+    /// <param name="envelope">Event metadata envelope.</param>
+    /// <param name="geometryEnvelope">Geometry bounding box (MinX, MinY, MaxX, MaxY), null for deletes.</param>
+    /// <param name="propertiesJson">Pre-serialized JSON of feature attributes, null for deletes.</param>
+    bool Matches(FeatureStreamEnvelope envelope, double[]? geometryEnvelope, string? propertiesJson);
+
+    /// <summary>
+    /// Human-readable summary for admin visibility.
+    /// </summary>
+    string Summary { get; }
+}

--- a/src/Honua.Server/Features/Streaming/StreamSubscriptionFilter.cs
+++ b/src/Honua.Server/Features/Streaming/StreamSubscriptionFilter.cs
@@ -135,8 +135,8 @@ internal sealed class StreamSubscriptionFilter : IStreamSubscriptionFilter
         {
             if (geometryEnvelope is null || geometryEnvelope.Length < 4)
             {
-                // No geometry — pass through (non-spatial feature).
-                // This is safe: the feature has no geometry to exclude.
+                // Non-delete events without geometry cannot intersect a bbox.
+                return false;
             }
             else if (!EnvelopesIntersect(_bbox, geometryEnvelope))
             {

--- a/src/Honua.Server/Features/Streaming/StreamSubscriptionFilter.cs
+++ b/src/Honua.Server/Features/Streaming/StreamSubscriptionFilter.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Queries.Filters;
+
+namespace Honua.Server.Features.Streaming;
+
+/// <summary>
+/// Composite subscription filter that evaluates in cheapest-first order:
+/// layer filter, bbox filter, then attribute filter. Delete events pass
+/// all non-layer filters (subscribers should always be notified of deletes
+/// in their subscribed layers).
+/// </summary>
+internal sealed class StreamSubscriptionFilter : IStreamSubscriptionFilter
+{
+    private readonly string? _serviceId;
+    private readonly int[]? _layerIds;
+    private readonly double[]? _bbox;
+    private readonly FilterExpression? _attributeFilter;
+
+    /// <summary>
+    /// Creates a composite subscription filter.
+    /// </summary>
+    /// <param name="serviceId">Allowed service ID (null = all services).</param>
+    /// <param name="layerIds">Allowed layer IDs (null = all layers).</param>
+    /// <param name="bbox">Bounding box [MinX, MinY, MaxX, MaxY] (null = no spatial filter).</param>
+    /// <param name="attributeFilter">Parsed filter expression (null = no attribute filter).</param>
+    public StreamSubscriptionFilter(
+        string? serviceId = null,
+        int[]? layerIds = null,
+        double[]? bbox = null,
+        FilterExpression? attributeFilter = null)
+    {
+        _serviceId = serviceId;
+        _layerIds = layerIds;
+        _bbox = bbox;
+        _attributeFilter = attributeFilter;
+    }
+
+    /// <summary>
+    /// Service ID restriction, if any.
+    /// </summary>
+    public string? ServiceId => _serviceId;
+
+    /// <summary>
+    /// Layer restrictions, if any.
+    /// </summary>
+    public int[]? LayerIds => _layerIds;
+
+    /// <inheritdoc />
+    public string Summary
+    {
+        get
+        {
+            var parts = new List<string>(4);
+            if (_serviceId is not null)
+            {
+                parts.Add($"serviceId={_serviceId}");
+            }
+
+            if (_layerIds is not null)
+            {
+                parts.Add($"layers=[{string.Join(",", _layerIds)}]");
+            }
+
+            if (_bbox is not null)
+            {
+                parts.Add($"bbox=[{_bbox[0]},{_bbox[1]},{_bbox[2]},{_bbox[3]}]");
+            }
+
+            if (_attributeFilter is not null)
+            {
+                parts.Add("where=<expression>");
+            }
+
+            return string.Join("; ", parts);
+        }
+    }
+
+    /// <inheritdoc />
+    public bool Matches(FeatureStreamEnvelope envelope, double[]? geometryEnvelope, string? propertiesJson)
+    {
+        IReadOnlyDictionary<string, JsonElement>? parsedProperties = null;
+        bool propertiesParsed = false;
+        return Matches(envelope, geometryEnvelope, propertiesJson, ref parsedProperties, ref propertiesParsed);
+    }
+
+    internal bool Matches(
+        FeatureStreamEnvelope envelope,
+        double[]? geometryEnvelope,
+        string? propertiesJson,
+        ref IReadOnlyDictionary<string, JsonElement>? parsedProperties,
+        ref bool propertiesParsed)
+    {
+        // 1. Service filter — cheapest, short-circuits first.
+        if (_serviceId is not null &&
+            !string.Equals(envelope.ServiceId, _serviceId, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // 2. Layer filter.
+        if (_layerIds is not null)
+        {
+            bool found = false;
+            for (int i = 0; i < _layerIds.Length; i++)
+            {
+                if (_layerIds[i] == envelope.LayerId)
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                return false;
+            }
+        }
+
+        // Delete events pass all non-layer filters. Subscribers should always
+        // be notified when a feature in their layer is removed.
+        bool isDelete = string.Equals(envelope.Operation, "delete", StringComparison.OrdinalIgnoreCase);
+        if (isDelete)
+        {
+            return true;
+        }
+
+        // 3. Bbox filter — 4 double comparisons for envelope intersection.
+        if (_bbox is not null)
+        {
+            if (geometryEnvelope is null || geometryEnvelope.Length < 4)
+            {
+                // No geometry — pass through (non-spatial feature).
+                // This is safe: the feature has no geometry to exclude.
+            }
+            else if (!EnvelopesIntersect(_bbox, geometryEnvelope))
+            {
+                return false;
+            }
+        }
+
+        // 4. Attribute filter — parse propertiesJson and evaluate AST.
+        if (_attributeFilter is not null)
+        {
+            if (propertiesJson is null)
+            {
+                return true; // No properties — pass through.
+            }
+
+            if (!propertiesParsed)
+            {
+                propertiesParsed = true;
+                try
+                {
+                    parsedProperties = JsonSerializer.Deserialize(
+                        propertiesJson,
+                        FeatureStreamJsonContext.Default.DictionaryStringJsonElement);
+                }
+                catch
+                {
+                    parsedProperties = null;
+                }
+            }
+
+            return parsedProperties is null
+                || InMemoryFilterEvaluator.Evaluate(_attributeFilter, parsedProperties);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Tests whether two axis-aligned bounding boxes intersect.
+    /// Both arrays are [MinX, MinY, MaxX, MaxY].
+    /// </summary>
+    private static bool EnvelopesIntersect(double[] a, double[] b)
+    {
+        // Two AABBs do NOT intersect when one is entirely to the left/right/above/below the other.
+        return a[0] <= b[2] && a[2] >= b[0] && a[1] <= b[3] && a[3] >= b[1];
+    }
+}

--- a/src/Honua.Server/Features/Streaming/StreamSubscriptionFilter.cs
+++ b/src/Honua.Server/Features/Streaming/StreamSubscriptionFilter.cs
@@ -14,6 +14,9 @@ namespace Honua.Server.Features.Streaming;
 /// </summary>
 internal sealed class StreamSubscriptionFilter : IStreamSubscriptionFilter
 {
+    private static readonly IReadOnlyDictionary<string, JsonElement> EmptyProperties =
+        new Dictionary<string, JsonElement>(0, StringComparer.Ordinal);
+
     private readonly string? _serviceId;
     private readonly int[]? _layerIds;
     private readonly double[]? _bbox;
@@ -144,28 +147,30 @@ internal sealed class StreamSubscriptionFilter : IStreamSubscriptionFilter
         // 4. Attribute filter — parse propertiesJson and evaluate AST.
         if (_attributeFilter is not null)
         {
-            if (propertiesJson is null)
-            {
-                return true; // No properties — pass through.
-            }
-
             if (!propertiesParsed)
             {
                 propertiesParsed = true;
-                try
+                if (propertiesJson is null)
                 {
-                    parsedProperties = JsonSerializer.Deserialize(
-                        propertiesJson,
-                        FeatureStreamJsonContext.Default.DictionaryStringJsonElement);
+                    parsedProperties = EmptyProperties;
                 }
-                catch
+                else
                 {
-                    parsedProperties = null;
+                    try
+                    {
+                        parsedProperties = JsonSerializer.Deserialize(
+                            propertiesJson,
+                            FeatureStreamJsonContext.Default.DictionaryStringJsonElement) ?? EmptyProperties;
+                    }
+                    catch
+                    {
+                        parsedProperties = null;
+                    }
                 }
             }
 
-            return parsedProperties is null
-                || InMemoryFilterEvaluator.Evaluate(_attributeFilter, parsedProperties);
+            return parsedProperties is not null &&
+                   InMemoryFilterEvaluator.Evaluate(_attributeFilter, parsedProperties);
         }
 
         return true;

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -425,6 +425,7 @@ builder.Services.AddSingleton<Honua.Server.Features.Infrastructure.Events.IFeatu
         sp.GetRequiredService<Honua.Server.Features.Infrastructure.Events.IFeatureChangeEventStore>(),
         sp.GetRequiredService<Honua.Server.Features.Streaming.FeatureStreamSessionManager>(),
         sp.GetRequiredService<ILogger<Honua.Server.Features.Streaming.FeatureStreamPublisher>>()));
+builder.Services.AddScoped<Honua.Server.Features.Streaming.FeatureStreamDependencies>();
 builder.Services.AddHostedService<Honua.Server.Features.Streaming.FeatureStreamHeartbeatService>();
 builder.Services.AddHttpClient("feature-change-webhook")
     .ConfigurePrimaryHttpMessageHandler(static () => Honua.Server.Features.Infrastructure.Events.WebhookDeliveryHelper.CreatePinnedDnsHttpMessageHandler());

--- a/tests/Honua.Core.Tests/Queries/Filters/InMemoryFilterEvaluatorTests.cs
+++ b/tests/Honua.Core.Tests/Queries/Filters/InMemoryFilterEvaluatorTests.cs
@@ -49,6 +49,28 @@ public sealed class InMemoryFilterEvaluatorTests
     }
 
     [UnitTest]
+    public void Evaluate_StringEquality_IsCaseSensitive()
+    {
+        var expression = new BinaryExpression(
+            new PropertyReference("name"),
+            BinaryOperator.Equal,
+            new Literal("ALPHA", LiteralType.Text));
+
+        InMemoryFilterEvaluator.Evaluate(expression, CreateProperties("""{"name":"alpha"}""")).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void Evaluate_Like_IsCaseSensitive()
+    {
+        var expression = new BinaryExpression(
+            new PropertyReference("name"),
+            BinaryOperator.Like,
+            new Literal("ALP%", LiteralType.Text));
+
+        InMemoryFilterEvaluator.Evaluate(expression, CreateProperties("""{"name":"alpha"}""")).Should().BeFalse();
+    }
+
+    [UnitTest]
     public void Evaluate_BigIntegerEquality_PreservesPrecision()
     {
         const long objectId = 9_007_199_254_740_993L;

--- a/tests/Honua.Core.Tests/Queries/Filters/InMemoryFilterEvaluatorTests.cs
+++ b/tests/Honua.Core.Tests/Queries/Filters/InMemoryFilterEvaluatorTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Queries.Filters;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Queries.Filters;
+
+public sealed class InMemoryFilterEvaluatorTests
+{
+    [UnitTest]
+    public void TryValidateStreamingExpression_FunctionCall_ReturnsFalse()
+    {
+        var expression = new BinaryExpression(
+            new FunctionCall("UPPER", [new PropertyReference("name")]),
+            BinaryOperator.Equal,
+            new Literal("ALICE", LiteralType.Text));
+
+        var result = InMemoryFilterEvaluator.TryValidateStreamingExpression(expression, out var error);
+
+        result.Should().BeFalse();
+        error.Should().Contain("function calls");
+    }
+
+    [UnitTest]
+    public void Evaluate_UnsupportedExpression_ReturnsFalse()
+    {
+        var expression = new BinaryExpression(
+            new FunctionCall("UPPER", [new PropertyReference("name")]),
+            BinaryOperator.Equal,
+            new Literal("ALICE", LiteralType.Text));
+
+        var properties = CreateProperties("""{"name":"alice"}""");
+
+        InMemoryFilterEvaluator.Evaluate(expression, properties).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void Evaluate_NotInWithMissingProperty_ReturnsFalse()
+    {
+        var expression = new BinaryExpression(
+            new PropertyReference("status"),
+            BinaryOperator.NotIn,
+            new ValueList([new Literal("active", LiteralType.Text)]));
+
+        InMemoryFilterEvaluator.Evaluate(expression, CreateProperties("{}")).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void Evaluate_BigIntegerEquality_PreservesPrecision()
+    {
+        const long objectId = 9_007_199_254_740_993L;
+        var expression = new BinaryExpression(
+            new PropertyReference("objectid"),
+            BinaryOperator.Equal,
+            new Literal(objectId, LiteralType.Number));
+
+        var properties = CreateProperties($$"""{"objectid":{{objectId}}}""");
+
+        InMemoryFilterEvaluator.Evaluate(expression, properties).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Evaluate_BigIntegerMismatch_DoesNotCollapseToDoublePrecision()
+    {
+        const long propertyValue = 9_007_199_254_740_993L;
+        const long literalValue = 9_007_199_254_740_992L;
+        var expression = new BinaryExpression(
+            new PropertyReference("objectid"),
+            BinaryOperator.Equal,
+            new Literal(literalValue, LiteralType.Number));
+
+        var properties = CreateProperties($$"""{"objectid":{{propertyValue}}}""");
+
+        InMemoryFilterEvaluator.Evaluate(expression, properties).Should().BeFalse();
+    }
+
+    private static Dictionary<string, JsonElement> CreateProperties(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement
+            .EnumerateObject()
+            .ToDictionary(
+                static property => property.Name,
+                static property => property.Value.Clone(),
+                StringComparer.Ordinal);
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Infrastructure/Events/FeatureChangeEventEnrichmentTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/Events/FeatureChangeEventEnrichmentTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Server.Features.Infrastructure.Events;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Events;
+
+public sealed class FeatureChangeEventEnrichmentTests
+{
+    [UnitTest]
+    public void FromFeature_WithNestedJsonAttributes_SerializesPropertiesJson()
+    {
+        var attributes = ImmutableDictionary<string, object?>.Empty
+            .Add(
+                "metadata",
+                new Dictionary<string, object?>
+                {
+                    ["priority"] = 2L,
+                    ["tags"] = new object?[] { "alpha", 7L }
+                });
+
+        var feature = Feature.Create(42, geometry: null, attributes);
+
+        var (_, propertiesJson) = FeatureChangeEventEnrichment.FromFeature(feature);
+
+        Assert.NotNull(propertiesJson);
+
+        using var document = JsonDocument.Parse(propertiesJson!);
+        var metadata = document.RootElement.GetProperty("metadata");
+        Assert.Equal(2L, metadata.GetProperty("priority").GetInt64());
+        Assert.Equal("alpha", metadata.GetProperty("tags")[0].GetString());
+        Assert.Equal(7L, metadata.GetProperty("tags")[1].GetInt64());
+    }
+
+    [UnitTest]
+    public void FromFeature_WithSupportedRuntimeAttributeTypes_SerializesPropertiesJson()
+    {
+        var identifier = Guid.Parse("5f9a6f86-89af-4f5a-8a09-5216265fc056");
+        var payload = new byte[] { 1, 2, 3, 4 };
+        var attributes = ImmutableDictionary<string, object?>.Empty
+            .Add("featureId", identifier)
+            .Add("effectiveDate", new DateOnly(2026, 3, 31))
+            .Add("windowStart", new TimeOnly(9, 30, 0))
+            .Add("duration", TimeSpan.FromMinutes(15))
+            .Add("payload", payload);
+
+        var feature = Feature.Create(99, geometry: null, attributes);
+
+        var (_, propertiesJson) = FeatureChangeEventEnrichment.FromFeature(feature);
+
+        Assert.NotNull(propertiesJson);
+
+        using var document = JsonDocument.Parse(propertiesJson!);
+        var root = document.RootElement;
+
+        Assert.Equal(identifier.ToString(), root.GetProperty("featureId").GetString());
+        Assert.Equal("2026-03-31", root.GetProperty("effectiveDate").GetString());
+        Assert.Equal(JsonValueKind.String, root.GetProperty("windowStart").ValueKind);
+        Assert.Equal(JsonValueKind.String, root.GetProperty("duration").ValueKind);
+        Assert.Equal(Convert.ToBase64String(payload), root.GetProperty("payload").GetString());
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamCdcScaleTests.cs
+++ b/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamCdcScaleTests.cs
@@ -184,8 +184,8 @@ public sealed class FeatureStreamCdcScaleTests : IDisposable
     public async Task CdcFanOut_FilteredSubscribers_ReceiveOnlyMatchingLayerDeltas()
     {
         // Arrange: create subscribers with different layer filters.
-        var layer0Filter = new FeatureStreamFilter { LayerIds = [0] };
-        var layer1Filter = new FeatureStreamFilter { LayerIds = [1] };
+        var layer0Filter = new StreamSubscriptionFilter(layerIds: [0]);
+        var layer1Filter = new StreamSubscriptionFilter(layerIds: [1]);
 
         using var session0 = _sessionManager.CreateSession("WebSocket", "layer-0", layer0Filter);
         _sessionManager.MarkDrainStarted(session0.SessionId);

--- a/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamEndpointsTests.cs
@@ -117,6 +117,23 @@ public sealed class FeatureStreamEndpointsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("GET /api/v1/streaming/features")]
+    public async Task Stream_WithUnsupportedFilterLanguage_ReturnsBadRequest()
+    {
+        var encodedFilter = Uri.EscapeDataString("name = 'alpha'");
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/api/v1/streaming/features?layers=0&filter={encodedFilter}&filter-lang=unsupported");
+        request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        using var response = await _client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().Contain("Unsupported filter language");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/streaming/features")]
     public async Task Stream_WithBboxWithoutSingleLayer_ReturnsBadRequest()
     {
         using var request = new HttpRequestMessage(

--- a/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamEndpointsTests.cs
@@ -6,11 +6,13 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Server.Features.Infrastructure.Events;
 using Honua.Server.Features.Streaming;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.TestKit.Infrastructure;
 
 namespace Honua.Server.Tests.Features.Streaming;
 
@@ -89,6 +91,68 @@ public sealed class FeatureStreamEndpointsTests : IAsyncLifetime
             using var response = await fixture.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
             response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/streaming/features")]
+    public async Task Stream_WithUnsupportedFunctionFilter_ReturnsBadRequest()
+    {
+        var encodedFilter = Uri.EscapeDataString("UPPER(name) = 'ALICE'");
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/api/v1/streaming/features?layers=0&filter={encodedFilter}");
+        request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        using var response = await _client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().Contain("function calls");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/streaming/features")]
+    public async Task Stream_WithBboxWithoutSingleLayer_ReturnsBadRequest()
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            "/api/v1/streaming/features?bbox=-122.5,37.5,-122.0,38.0");
+        request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        using var response = await _client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().Contain("exactly one layer");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/streaming/features")]
+    public async Task Stream_WithProjectedBboxLayer_AllowsSseHandshake()
+    {
+        var fixture = new WebAppFixture()
+            .ReplaceService<ILayerCatalog>(new SpatialReferenceTestLayerCatalog());
+
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var client = fixture.CreateAdminClient();
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"/api/v1/streaming/features?layers={SpatialReferenceTestLayerCatalog.PointLayerId}&bbox=-122.5,37.5,-122.0,38.0");
+            request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Content.Headers.ContentType?.MediaType.Should().Be("text/event-stream");
         }
         finally
         {

--- a/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamEndpointsTests.cs
@@ -471,11 +471,7 @@ public sealed class FeatureStreamEndpointsTests : IAsyncLifetime
     public async Task ListSessions_WithFilter_ReturnsSessionFilterInfo()
     {
         var sessionManager = _fixture.GetService<FeatureStreamSessionManager>();
-        var filter = new FeatureStreamFilter
-        {
-            ServiceId = "svc-admin-filter",
-            LayerIds = [1, 3]
-        };
+        var filter = new StreamSubscriptionFilter(serviceId: "svc-admin-filter", layerIds: [1, 3]);
         using var session = sessionManager.CreateSession("SSE", "filtered-admin-vis-test", filter);
 
         var response = await _client.GetAsync("/api/v1/admin/streaming/features/sessions");
@@ -489,6 +485,8 @@ public sealed class FeatureStreamEndpointsTests : IAsyncLifetime
             .EnumerateArray()
             .First(s => s.GetProperty("clientLabel").GetString() == "filtered-admin-vis-test");
 
+        sessionData.GetProperty("hasFilter").GetBoolean().Should().BeTrue();
+        sessionData.GetProperty("filterSummary").GetString().Should().Contain("serviceId=svc-admin-filter");
         sessionData.GetProperty("serviceIdFilter").GetString().Should().Be("svc-admin-filter");
         sessionData.GetProperty("layerIdFilter")
             .EnumerateArray()

--- a/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamSessionManagerTests.cs
+++ b/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamSessionManagerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Server.Features.Streaming;
+using Honua.Core.Queries.Filters.Cql2;
 using Honua.TestKit.Attributes;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -361,6 +362,74 @@ public sealed class FeatureStreamSessionManagerTests : IDisposable
     }
 
     [UnitTest]
+    public void Broadcast_WithBboxFilter_OnlyDeliversIntersectingEvents()
+    {
+        var filter = new StreamSubscriptionFilter(bbox: [0d, 0d, 10d, 10d]);
+        using var filtered = _manager.CreateSession("WebSocket", "bbox-filtered", filter);
+
+        _manager.Broadcast(FeatureStreamMessage.Data(
+            CreateEnvelope(cursor: 1),
+            geometryEnvelope: [20d, 20d, 30d, 30d]));
+        _manager.Broadcast(FeatureStreamMessage.Data(
+            CreateEnvelope(cursor: 2),
+            geometryEnvelope: [5d, 5d, 15d, 15d]));
+
+        Assert.True(filtered.Reader.TryRead(out var msg));
+        Assert.Equal(2L, msg.Envelope.Cursor);
+        Assert.False(filtered.Reader.TryRead(out _));
+    }
+
+    [UnitTest]
+    public void Broadcast_WithAttributeFilter_OnlyDeliversMatchingEvents()
+    {
+        var filter = new StreamSubscriptionFilter(attributeFilter: new Cql2Parser().Parse("status = 'active'"));
+        using var filtered = _manager.CreateSession("WebSocket", "attribute-filtered", filter);
+
+        _manager.Broadcast(FeatureStreamMessage.Data(
+            CreateEnvelope(cursor: 1),
+            propertiesJson: """{"status":"inactive"}"""));
+        _manager.Broadcast(FeatureStreamMessage.Data(
+            CreateEnvelope(cursor: 2),
+            propertiesJson: """{"status":"active"}"""));
+
+        Assert.True(filtered.Reader.TryRead(out var msg));
+        Assert.Equal(2L, msg.Envelope.Cursor);
+        Assert.False(filtered.Reader.TryRead(out _));
+    }
+
+    [UnitTest]
+    public void Broadcast_WithCombinedFilters_OnlyDeliversEventsMatchingAllCriteria()
+    {
+        var filter = new StreamSubscriptionFilter(
+            serviceId: "target-svc",
+            layerIds: [2],
+            bbox: [0d, 0d, 10d, 10d],
+            attributeFilter: new Cql2Parser().Parse("status = 'active'"));
+        using var filtered = _manager.CreateSession("WebSocket", "combined-filtered", filter);
+
+        _manager.Broadcast(FeatureStreamMessage.Data(
+            CreateEnvelope(cursor: 1, layerId: 2, serviceId: "other-svc"),
+            geometryEnvelope: [5d, 5d, 6d, 6d],
+            propertiesJson: """{"status":"active"}"""));
+        _manager.Broadcast(FeatureStreamMessage.Data(
+            CreateEnvelope(cursor: 2, layerId: 2, serviceId: "target-svc"),
+            geometryEnvelope: [20d, 20d, 30d, 30d],
+            propertiesJson: """{"status":"active"}"""));
+        _manager.Broadcast(FeatureStreamMessage.Data(
+            CreateEnvelope(cursor: 3, layerId: 2, serviceId: "target-svc"),
+            geometryEnvelope: [5d, 5d, 6d, 6d],
+            propertiesJson: """{"status":"inactive"}"""));
+        _manager.Broadcast(FeatureStreamMessage.Data(
+            CreateEnvelope(cursor: 4, layerId: 2, serviceId: "target-svc"),
+            geometryEnvelope: [5d, 5d, 6d, 6d],
+            propertiesJson: """{"status":"active"}"""));
+
+        Assert.True(filtered.Reader.TryRead(out var msg));
+        Assert.Equal(4L, msg.Envelope.Cursor);
+        Assert.False(filtered.Reader.TryRead(out _));
+    }
+
+    [UnitTest]
     public void Broadcast_WithEmptyLayerFilter_MatchesNothing()
     {
         // Simulates malformed layerIds (e.g. ?layerIds=abc) where no valid IDs were parsed.
@@ -386,14 +455,16 @@ public sealed class FeatureStreamSessionManagerTests : IDisposable
         Assert.True(msg.IsHeartbeat);
     }
 
-    private static FeatureStreamEnvelope CreateEnvelope(long cursor) => CreateEnvelope(cursor, layerId: 0);
+    private static FeatureStreamEnvelope CreateEnvelope(long cursor) => CreateEnvelope(cursor, layerId: 0, serviceId: "test-svc");
 
-    private static FeatureStreamEnvelope CreateEnvelope(long cursor, int layerId) => new()
+    private static FeatureStreamEnvelope CreateEnvelope(long cursor, int layerId) => CreateEnvelope(cursor, layerId, serviceId: "test-svc");
+
+    private static FeatureStreamEnvelope CreateEnvelope(long cursor, int layerId, string serviceId) => new()
     {
         EventId = Guid.NewGuid().ToString(),
         Cursor = cursor,
         Timestamp = DateTimeOffset.UtcNow,
-        ServiceId = "test-svc",
+        ServiceId = serviceId,
         LayerId = layerId,
         ObjectId = 1,
         Operation = "create",
@@ -401,16 +472,5 @@ public sealed class FeatureStreamSessionManagerTests : IDisposable
         RequestId = "req-1"
     };
 
-    private static FeatureStreamEnvelope CreateEnvelopeForService(long cursor, string serviceId) => new()
-    {
-        EventId = Guid.NewGuid().ToString(),
-        Cursor = cursor,
-        Timestamp = DateTimeOffset.UtcNow,
-        ServiceId = serviceId,
-        LayerId = 0,
-        ObjectId = 1,
-        Operation = "create",
-        Protocol = "rest",
-        RequestId = "req-1"
-    };
+    private static FeatureStreamEnvelope CreateEnvelopeForService(long cursor, string serviceId) => CreateEnvelope(cursor, layerId: 0, serviceId: serviceId);
 }

--- a/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamSessionManagerTests.cs
+++ b/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamSessionManagerTests.cs
@@ -310,7 +310,7 @@ public sealed class FeatureStreamSessionManagerTests : IDisposable
     [UnitTest]
     public void Broadcast_WithLayerFilter_OnlyDeliversMatchingEvents()
     {
-        var filter = new FeatureStreamFilter { LayerIds = [1, 2] };
+        var filter = new StreamSubscriptionFilter(layerIds: [1, 2]);
         using var filtered = _manager.CreateSession("WebSocket", "filtered", filter);
         using var unfiltered = _manager.CreateSession("WebSocket", "unfiltered");
 
@@ -343,7 +343,7 @@ public sealed class FeatureStreamSessionManagerTests : IDisposable
     [UnitTest]
     public void Broadcast_WithServiceFilter_OnlyDeliversMatchingEvents()
     {
-        var filter = new FeatureStreamFilter { ServiceId = "target-svc" };
+        var filter = new StreamSubscriptionFilter(serviceId: "target-svc");
         using var filtered = _manager.CreateSession("WebSocket", "svc-filtered", filter);
 
         _manager.Broadcast(FeatureStreamMessage.Data(CreateEnvelopeForService(cursor: 1, serviceId: "other-svc")));
@@ -364,7 +364,7 @@ public sealed class FeatureStreamSessionManagerTests : IDisposable
     public void Broadcast_WithEmptyLayerFilter_MatchesNothing()
     {
         // Simulates malformed layerIds (e.g. ?layerIds=abc) where no valid IDs were parsed.
-        var filter = new FeatureStreamFilter { LayerIds = [] };
+        var filter = new StreamSubscriptionFilter(layerIds: []);
         using var filtered = _manager.CreateSession("WebSocket", "empty-filter", filter);
 
         _manager.Broadcast(FeatureStreamMessage.Data(CreateEnvelope(cursor: 1, layerId: 0)));
@@ -376,7 +376,7 @@ public sealed class FeatureStreamSessionManagerTests : IDisposable
     [UnitTest]
     public void Broadcast_HeartbeatBypassesFilter()
     {
-        var filter = new FeatureStreamFilter { LayerIds = [99] };
+        var filter = new StreamSubscriptionFilter(layerIds: [99]);
         using var filtered = _manager.CreateSession("WebSocket", "hb-filter", filter);
 
         // Heartbeats should always be delivered regardless of filter.

--- a/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamSessionManagerTests.cs
+++ b/tests/Honua.Server.Tests/Features/Streaming/FeatureStreamSessionManagerTests.cs
@@ -380,6 +380,36 @@ public sealed class FeatureStreamSessionManagerTests : IDisposable
     }
 
     [UnitTest]
+    public void Broadcast_WithBboxFilter_DropsNonDeleteEventsWithoutGeometry()
+    {
+        var filter = new StreamSubscriptionFilter(bbox: [0d, 0d, 10d, 10d]);
+        using var filtered = _manager.CreateSession("WebSocket", "bbox-null-geometry", filter);
+
+        _manager.Broadcast(FeatureStreamMessage.Data(CreateEnvelope(cursor: 1), geometryEnvelope: null));
+        _manager.Broadcast(FeatureStreamMessage.Data(CreateEnvelope(cursor: 2), geometryEnvelope: [5d, 5d, 6d, 6d]));
+
+        Assert.True(filtered.Reader.TryRead(out var msg));
+        Assert.Equal(2L, msg.Envelope.Cursor);
+        Assert.False(filtered.Reader.TryRead(out _));
+    }
+
+    [UnitTest]
+    public void Broadcast_WithBboxFilter_DeleteEventsWithoutGeometryStillPass()
+    {
+        var filter = new StreamSubscriptionFilter(bbox: [0d, 0d, 10d, 10d]);
+        using var filtered = _manager.CreateSession("WebSocket", "bbox-delete-no-geometry", filter);
+
+        _manager.Broadcast(FeatureStreamMessage.Data(
+            CreateEnvelope(cursor: 1) with { Operation = "delete" },
+            geometryEnvelope: null));
+
+        Assert.True(filtered.Reader.TryRead(out var msg));
+        Assert.Equal(1L, msg.Envelope.Cursor);
+        Assert.Equal("delete", msg.Envelope.Operation);
+        Assert.False(filtered.Reader.TryRead(out _));
+    }
+
+    [UnitTest]
     public void Broadcast_WithAttributeFilter_OnlyDeliversMatchingEvents()
     {
         var filter = new StreamSubscriptionFilter(attributeFilter: new Cql2Parser().Parse("status = 'active'"));


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #503
## Summary

Format check also confirmed clean. All validations passed — nothing remaining for this fix pass.
## Changes Made

- Format check also confirmed clean. All validations passed — nothing remaining for this fix pass.
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally

## Additional Context

Decisions:
No new decisions. Human override on trunk baseline FluentAssertions failure already recorded.

Follow-ons:
- FeatureServer + OData enrichment parity (separate ticket)
- Trunk architecture test fixes (separate ticket)

Code kaizen:
Auto-deferred by kaizen policy.
