### PR TITLE
fix: harden protocol auth and batch semantics (#683)

### DIFF
--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -128,7 +128,7 @@ Honua runs as a single container backed by PostgreSQL/PostGIS.
 ## Observability
 
 - **Health**: `/healthz/live`, `/healthz/ready`
-- **Metrics**: Prometheus endpoint at `/metrics`, JSON metrics via admin API
+- **Metrics**: Admin-authenticated Prometheus endpoint at `/metrics`, JSON metrics via admin API
 - **Tracing**: OpenTelemetry with configurable exporters
 - **Logging**: Structured JSON logging via Serilog
 

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -17,7 +17,7 @@ Honua exposes native Prometheus metrics and JSON snapshot endpoints:
 
 | Endpoint | Access | What it shows |
 |----------|--------|---------------|
-| `GET /metrics` | Prometheus/network access (restrict at edge) | Native Prometheus text exposition |
+| `GET /metrics` | Admin auth | Native Prometheus text exposition |
 | `GET /api/v1/metrics/health` | Admin auth | Health summary |
 | `GET /api/v1/metrics/performance` | Admin auth | Request latency and throughput |
 | `GET /api/v1/metrics/database` | Admin auth | Connection pool and query stats |
@@ -40,7 +40,7 @@ Admin-only diagnostics:
 Honua uses standard OpenTelemetry APIs.
 
 - Configure OTLP export via `OTEL_*` environment variables to send metrics and traces to your telemetry backend.
-- Prometheus can scrape native text metrics at `GET /metrics`.
+- Prometheus can scrape native text metrics at `GET /metrics` by presenting admin credentials such as an API key.
 - Optional path override: `Observability__Prometheus__Path=/custom-metrics`.
 - Use `/api/v1/admin/observability/telemetry` to confirm tracing status.
 - In multi-node environments, deploy rollback detection should query a Prometheus-compatible metrics backend. OTLP is the export path, not the rollback-decision API.
@@ -59,7 +59,7 @@ The recommended alerting path uses managed cloud services rather than self-hoste
 4. Alert policies use a shared PromQL rules file: `docs/alerting/rules/honua-core.yaml`
 5. The Honua control plane can query that Prometheus-compatible backend for canary settle/rollback decisions.
 
-For self-hosted multi-node environments, Prometheus can also scrape `GET /metrics` directly and act as both the collector and the query backend for deploy rollback gates.
+For self-hosted multi-node environments, Prometheus can also scrape `GET /metrics` directly with admin credentials and act as both the collector and the query backend for deploy rollback gates.
 
 ### Deploy Telemetry Presets
 

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -71,7 +71,7 @@ max_connections >= (pool_size x app_replicas) + headroom
 
 ### Monitoring
 
-- Prometheus scrape endpoint: `GET /metrics`
+- Prometheus scrape endpoint: `GET /metrics` with admin credentials
 - Honua metrics: `GET /api/v1/metrics/database`
 - Postgres activity:
   ```sql

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -30,7 +30,7 @@ This guide covers authentication, authorization, edge security, and related oper
 
 - **Admin endpoints** (`/api/v1/admin/*`) require admin authentication.
 - **JSON metrics endpoints** (`/api/v1/metrics/*`, `/healthz/metrics`) require admin authentication.
-- **Prometheus endpoint** (`/metrics`) should be restricted at the edge to Prometheus/network allowlists.
+- **Prometheus endpoint** (`/metrics`) requires admin authentication and should still be restricted at the edge to Prometheus/network allowlists.
 - **Data APIs** (FeatureServer, OGC, OData, Tiles) can be public or protected based on your access policy.
 
 Authentication schemes:
@@ -82,7 +82,7 @@ Honua does not include application-level rate limiting. Enforce limits at the ed
 | `/api/v1/admin/*` | 30 req/min/IP |
 | `/healthz/*` | Exempt |
 | `/api/v1/metrics/*` | Exempt (or protect with auth, based on policy) |
-| `/metrics` | Exempt from rate limits, but restrict at edge to Prometheus/network allowlists |
+| `/metrics` | Exempt from rate limits, require admin auth, and restrict at edge to Prometheus/network allowlists |
 
 ### AWS (ALB + WAFv2)
 

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -20,7 +20,7 @@ psql -h localhost -U honua -d honua -c "SELECT 1;"
 # Metrics
 curl http://localhost:8080/api/v1/metrics/performance
 curl http://localhost:8080/api/v1/metrics/database
-curl http://localhost:8080/metrics | head -n 20
+curl -H "X-API-Key: your-admin-key" http://localhost:8080/metrics | head -n 20
 ```
 
 ---
@@ -54,7 +54,7 @@ SELECT PostGIS_Version();
 ## Performance and Latency
 
 **Quick checks**:
-- `GET /api/v1/metrics/performance`, `GET /api/v1/metrics/database`, and `GET /metrics`
+- `GET /api/v1/metrics/performance`, `GET /api/v1/metrics/database`, and `GET /metrics` with admin auth
 - Review logs for slow queries or timeouts.
 
 **Common causes**:

--- a/src/Honua.Core/Features/FeatureStore/Domain/FeatureEdit.cs
+++ b/src/Honua.Core/Features/FeatureStore/Domain/FeatureEdit.cs
@@ -11,6 +11,12 @@ namespace Honua.Core.Features.FeatureStore.Domain;
 public readonly record struct FeatureEditBatch
 {
     /// <summary>
+    /// Ordered edit operations to execute when request sequencing matters.
+    /// When provided, writers should preserve this order while applying the batch.
+    /// </summary>
+    public ImmutableArray<FeatureEditOperation> Operations { get; init; }
+
+    /// <summary>
     /// Features to create
     /// </summary>
     public ImmutableArray<Feature> Creates { get; init; }
@@ -41,6 +47,7 @@ public readonly record struct FeatureEditBatch
     /// </summary>
     public FeatureEditBatch()
     {
+        Operations = ImmutableArray<FeatureEditOperation>.Empty;
         Creates = ImmutableArray<Feature>.Empty;
         Updates = ImmutableArray<Feature>.Empty;
         Deletes = ImmutableArray<long>.Empty;
@@ -54,15 +61,18 @@ public readonly record struct FeatureEditBatch
     /// <param name="deletes">Feature IDs to delete</param>
     /// <param name="rollbackOnFailure">Whether to rollback all changes on failure</param>
     /// <param name="useGlobalIds">Whether to use global IDs</param>
+    /// <param name="operations">Ordered operations to apply when request sequencing must be preserved</param>
     /// <returns>Edit batch instance</returns>
     public static FeatureEditBatch Create(
         ImmutableArray<Feature> creates = default,
         ImmutableArray<Feature> updates = default,
         ImmutableArray<long> deletes = default,
         bool rollbackOnFailure = false,
-        bool useGlobalIds = false)
+        bool useGlobalIds = false,
+        ImmutableArray<FeatureEditOperation> operations = default)
         => new()
         {
+            Operations = operations.IsDefault ? ImmutableArray<FeatureEditOperation>.Empty : operations,
             Creates = creates.IsDefault ? ImmutableArray<Feature>.Empty : creates,
             Updates = updates.IsDefault ? ImmutableArray<Feature>.Empty : updates,
             Deletes = deletes.IsDefault ? ImmutableArray<long>.Empty : deletes,
@@ -74,14 +84,88 @@ public readonly record struct FeatureEditBatch
     /// Gets the total number of operations in this batch
     /// </summary>
     public int TotalOperations =>
-        (Creates.IsDefault ? 0 : Creates.Length) +
-        (Updates.IsDefault ? 0 : Updates.Length) +
-        (Deletes.IsDefault ? 0 : Deletes.Length);
+        !Operations.IsDefaultOrEmpty
+            ? Operations.Length
+            : (Creates.IsDefault ? 0 : Creates.Length) +
+              (Updates.IsDefault ? 0 : Updates.Length) +
+              (Deletes.IsDefault ? 0 : Deletes.Length);
 
     /// <summary>
     /// Gets whether this batch contains any operations
     /// </summary>
     public bool IsEmpty => TotalOperations == 0;
+}
+
+/// <summary>
+/// Describes the type of a single ordered feature edit operation.
+/// </summary>
+public enum FeatureEditOperationKind
+{
+    /// <summary>
+    /// Create a new feature.
+    /// </summary>
+    Create,
+
+    /// <summary>
+    /// Update an existing feature.
+    /// </summary>
+    Update,
+
+    /// <summary>
+    /// Delete an existing feature.
+    /// </summary>
+    Delete
+}
+
+/// <summary>
+/// Represents a single ordered edit operation within a feature edit batch.
+/// </summary>
+public readonly record struct FeatureEditOperation
+{
+    /// <summary>
+    /// Operation type.
+    /// </summary>
+    public required FeatureEditOperationKind Kind { get; init; }
+
+    /// <summary>
+    /// Feature payload for create or update operations.
+    /// </summary>
+    public Feature? Feature { get; init; }
+
+    /// <summary>
+    /// Object ID for delete operations.
+    /// </summary>
+    public long? ObjectId { get; init; }
+
+    /// <summary>
+    /// Creates an ordered create operation.
+    /// </summary>
+    public static FeatureEditOperation Create(Feature feature)
+        => new()
+        {
+            Kind = FeatureEditOperationKind.Create,
+            Feature = feature
+        };
+
+    /// <summary>
+    /// Creates an ordered update operation.
+    /// </summary>
+    public static FeatureEditOperation Update(Feature feature)
+        => new()
+        {
+            Kind = FeatureEditOperationKind.Update,
+            Feature = feature
+        };
+
+    /// <summary>
+    /// Creates an ordered delete operation.
+    /// </summary>
+    public static FeatureEditOperation Delete(long objectId)
+        => new()
+        {
+            Kind = FeatureEditOperationKind.Delete,
+            ObjectId = objectId
+        };
 }
 
 /// <summary>

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Edits.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Edits.cs
@@ -59,6 +59,16 @@ internal sealed partial class FeatureDataAccess
 
         try
         {
+            if (!editBatch.Operations.IsDefaultOrEmpty)
+            {
+                return await ApplyOrderedEditsAsync(
+                    layerId,
+                    editBatch,
+                    connection,
+                    transaction,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
             var (createdIds, createResults) = await ProcessCreatesWithResultsAsync(
                 layerId,
                 editBatch.Creates,
@@ -131,24 +141,14 @@ internal sealed partial class FeatureDataAccess
 
             if (transaction != null)
             {
-                await transaction.RollbackAsync(CancellationToken.None);
-
-                var createResults = System.Linq.Enumerable.Select(editBatch.Creates, _ =>
-                    EditOperationResult.Failure("Transaction failed.")).ToImmutableArray();
-                var updateResults = System.Linq.Enumerable.Select(editBatch.Updates, feature =>
-                    EditOperationResult.Failure("Transaction failed.", objectId: feature.Id)).ToImmutableArray();
-                var deleteResults = System.Linq.Enumerable.Select(editBatch.Deletes, id =>
-                    EditOperationResult.Failure("Transaction failed.", objectId: id)).ToImmutableArray();
+                await RollbackIfNeededAsync(transaction).ConfigureAwait(false);
+                var (createResults, updateResults, deleteResults) = CreateFailedOperationResults(editBatch, "Transaction failed.");
 
                 return FeatureEditResult.Rollback(createResults, updateResults, deleteResults);
             }
 
-            var failedCreateResults = System.Linq.Enumerable.Select(editBatch.Creates, _ =>
-                EditOperationResult.Failure("Edit batch failed.")).ToImmutableArray();
-            var failedUpdateResults = System.Linq.Enumerable.Select(editBatch.Updates, feature =>
-                EditOperationResult.Failure("Edit batch failed.", objectId: feature.Id)).ToImmutableArray();
-            var failedDeleteResults = System.Linq.Enumerable.Select(editBatch.Deletes, id =>
-                EditOperationResult.Failure("Edit batch failed.", objectId: id)).ToImmutableArray();
+            var (failedCreateResults, failedUpdateResults, failedDeleteResults) =
+                CreateFailedOperationResults(editBatch, "Edit batch failed.");
 
             return FeatureEditResult.Success(
                 0,
@@ -159,6 +159,227 @@ internal sealed partial class FeatureDataAccess
                 failedUpdateResults,
                 failedDeleteResults,
                 wasRolledBack: false);
+        }
+    }
+
+    private async Task<FeatureEditResult> ApplyOrderedEditsAsync(
+        int layerId,
+        FeatureEditBatch editBatch,
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        CancellationToken cancellationToken)
+    {
+        var createdIds = ImmutableArray.CreateBuilder<long>();
+        var createResults = ImmutableArray.CreateBuilder<EditOperationResult>();
+        var updateResults = ImmutableArray.CreateBuilder<EditOperationResult>();
+        var deleteResults = ImmutableArray.CreateBuilder<EditOperationResult>();
+
+        foreach (var operation in editBatch.Operations)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var operationSucceeded = await ApplyOrderedEditOperationAsync(
+                layerId,
+                operation,
+                connection,
+                transaction,
+                createdIds,
+                createResults,
+                updateResults,
+                deleteResults,
+                cancellationToken).ConfigureAwait(false);
+
+            if (!operationSucceeded && editBatch.RollbackOnFailure)
+            {
+                if (transaction != null)
+                {
+                    await RollbackIfNeededAsync(transaction).ConfigureAwait(false);
+                }
+
+                return FeatureEditResult.Rollback(
+                    createResults.ToImmutable(),
+                    updateResults.ToImmutable(),
+                    deleteResults.ToImmutable());
+            }
+        }
+
+        if (transaction != null)
+        {
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var immutableCreatedIds = createdIds.ToImmutable();
+        var immutableCreateResults = createResults.ToImmutable();
+        var immutableUpdateResults = updateResults.ToImmutable();
+        var immutableDeleteResults = deleteResults.ToImmutable();
+
+        return FeatureEditResult.Success(
+            immutableCreatedIds.Length,
+            immutableUpdateResults.Count(static result => result.IsSuccess),
+            immutableDeleteResults.Count(static result => result.IsSuccess),
+            immutableCreatedIds,
+            immutableCreateResults,
+            immutableUpdateResults,
+            immutableDeleteResults,
+            wasRolledBack: false);
+    }
+
+    private async Task<bool> ApplyOrderedEditOperationAsync(
+        int layerId,
+        FeatureEditOperation operation,
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        ImmutableArray<long>.Builder createdIds,
+        ImmutableArray<EditOperationResult>.Builder createResults,
+        ImmutableArray<EditOperationResult>.Builder updateResults,
+        ImmutableArray<EditOperationResult>.Builder deleteResults,
+        CancellationToken cancellationToken)
+    {
+        switch (operation.Kind)
+        {
+            case FeatureEditOperationKind.Create:
+                {
+                    var feature = operation.Feature
+                        ?? throw new InvalidOperationException("Ordered create operation is missing the feature payload.");
+
+                    try
+                    {
+                        var created = await CreateWithConnectionAsync(
+                            layerId,
+                            feature,
+                            connection,
+                            transaction,
+                            cancellationToken).ConfigureAwait(false);
+                        createdIds.Add(created.Id);
+                        createResults.Add(EditOperationResult.Success(
+                            created.Id,
+                            feature.Attributes.GetValueOrDefault("globalId")?.ToString()));
+                        return true;
+                    }
+                    catch (Exception ex)
+                    {
+                        createResults.Add(EditOperationResult.Failure(GetSafeEditOperationError(ex, "Create")));
+                        return false;
+                    }
+                }
+
+            case FeatureEditOperationKind.Update:
+                {
+                    var feature = operation.Feature
+                        ?? throw new InvalidOperationException("Ordered update operation is missing the feature payload.");
+
+                    try
+                    {
+                        var updated = await UpdateWithConnectionAsync(
+                            layerId,
+                            feature,
+                            connection,
+                            transaction,
+                            cancellationToken).ConfigureAwait(false);
+                        updateResults.Add(EditOperationResult.Success(
+                            updated.Id,
+                            feature.Attributes.GetValueOrDefault("globalId")?.ToString()));
+                        return true;
+                    }
+                    catch (Exception ex)
+                    {
+                        updateResults.Add(EditOperationResult.Failure(
+                            GetSafeEditOperationError(ex, "Update"),
+                            objectId: feature.Id));
+                        return false;
+                    }
+                }
+
+            case FeatureEditOperationKind.Delete:
+                {
+                    var objectId = operation.ObjectId
+                        ?? throw new InvalidOperationException("Ordered delete operation is missing the target object ID.");
+
+                    try
+                    {
+                        var deleted = await DeleteWithConnectionAsync(
+                            layerId,
+                            objectId,
+                            connection,
+                            transaction,
+                            cancellationToken).ConfigureAwait(false);
+                        if (deleted)
+                        {
+                            deleteResults.Add(EditOperationResult.Success(objectId));
+                            return true;
+                        }
+
+                        deleteResults.Add(EditOperationResult.Failure($"Feature {objectId} not found", objectId: objectId));
+                        return false;
+                    }
+                    catch (Exception ex)
+                    {
+                        deleteResults.Add(EditOperationResult.Failure(
+                            GetSafeEditOperationError(ex, "Delete"),
+                            objectId: objectId));
+                        return false;
+                    }
+                }
+
+            default:
+                throw new InvalidOperationException($"Unsupported ordered edit operation kind '{operation.Kind}'.");
+        }
+    }
+
+    private static (
+        ImmutableArray<EditOperationResult> createResults,
+        ImmutableArray<EditOperationResult> updateResults,
+        ImmutableArray<EditOperationResult> deleteResults) CreateFailedOperationResults(
+        FeatureEditBatch editBatch,
+        string errorMessage)
+    {
+        if (!editBatch.Operations.IsDefaultOrEmpty)
+        {
+            var createResults = ImmutableArray.CreateBuilder<EditOperationResult>();
+            var updateResults = ImmutableArray.CreateBuilder<EditOperationResult>();
+            var deleteResults = ImmutableArray.CreateBuilder<EditOperationResult>();
+
+            foreach (var operation in editBatch.Operations)
+            {
+                switch (operation.Kind)
+                {
+                    case FeatureEditOperationKind.Create:
+                        createResults.Add(EditOperationResult.Failure(errorMessage));
+                        break;
+                    case FeatureEditOperationKind.Update:
+                        updateResults.Add(EditOperationResult.Failure(
+                            errorMessage,
+                            objectId: operation.Feature?.Id));
+                        break;
+                    case FeatureEditOperationKind.Delete:
+                        deleteResults.Add(EditOperationResult.Failure(
+                            errorMessage,
+                            objectId: operation.ObjectId));
+                        break;
+                }
+            }
+
+            return (
+                createResults.ToImmutable(),
+                updateResults.ToImmutable(),
+                deleteResults.ToImmutable());
+        }
+
+        return (
+            System.Linq.Enumerable.Select(editBatch.Creates, _ => EditOperationResult.Failure(errorMessage)).ToImmutableArray(),
+            System.Linq.Enumerable.Select(editBatch.Updates, feature => EditOperationResult.Failure(errorMessage, objectId: feature.Id)).ToImmutableArray(),
+            System.Linq.Enumerable.Select(editBatch.Deletes, id => EditOperationResult.Failure(errorMessage, objectId: id)).ToImmutableArray());
+    }
+
+    private static async Task RollbackIfNeededAsync(NpgsqlTransaction transaction)
+    {
+        try
+        {
+            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("has completed", StringComparison.Ordinal))
+        {
+            // The transaction was already completed by the provider. Treat that as a successful rollback.
         }
     }
 

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -429,9 +429,20 @@ internal static partial class FeatureServerEndpoints
                     serviceId, targetLayerId, editRequest, limitsOptions.Value.Edits, cancellationToken);
 
                 // If the edit handler returned an error, pass it through
-                if (editResult is not Microsoft.AspNetCore.Http.HttpResults.JsonHttpResult<ApplyEditsResponse>)
+                if (editResult is not Microsoft.AspNetCore.Http.HttpResults.JsonHttpResult<ApplyEditsResponse> jsonResult)
                 {
                     return editResult;
+                }
+
+                if (jsonResult.Value is not { } applyResponse ||
+                    !applyResponse.Success ||
+                    HasFailedEditResult(applyResponse.AddResults) ||
+                    HasFailedEditResult(applyResponse.UpdateResults) ||
+                    HasFailedEditResult(applyResponse.DeleteResults))
+                {
+                    return StandardErrorHelpers.CreateBadRequest(
+                        context,
+                        "Uploaded replica edits failed to apply.");
                 }
             }
         }
@@ -455,6 +466,11 @@ internal static partial class FeatureServerEndpoints
         };
 
         return Results.Json(response, FeatureServerJsonContext.Default.SynchronizeReplicaResponse, contentType: "application/json");
+    }
+
+    private static bool HasFailedEditResult(EditResult[]? results)
+    {
+        return results is not null && Array.Exists(results, static result => !result.Success);
     }
 
     private static async Task<IResult> HandleUnRegisterReplica(

--- a/src/Honua.Server/Features/Grpc/HonuaFeatureService.cs
+++ b/src/Honua.Server/Features/Grpc/HonuaFeatureService.cs
@@ -82,6 +82,7 @@ internal sealed class HonuaFeatureService : Proto.FeatureService.FeatureServiceB
 
         var (service, layer) = validation.Resource!;
         EnsureGrpcEnabled(service);
+        EnsureReadAccess(context, service, layer);
         var queryContext = await CreateQueryContextAsync(request, layer, context.CancellationToken).ConfigureAwait(false);
         var query = queryContext.Query;
         var pkField = layer.PrimaryKeyField?.Name ?? "objectid";
@@ -165,6 +166,7 @@ internal sealed class HonuaFeatureService : Proto.FeatureService.FeatureServiceB
 
         var (service, layer) = validation.Resource!;
         EnsureGrpcEnabled(service);
+        EnsureReadAccess(context, service, layer);
         var queryContext = await CreateQueryContextAsync(request, layer, context.CancellationToken).ConfigureAwait(false);
         var query = queryContext.Query;
         var pkField = layer.PrimaryKeyField?.Name ?? "objectid";
@@ -565,6 +567,29 @@ internal sealed class HonuaFeatureService : Proto.FeatureService.FeatureServiceB
             throw new RpcException(new Status(
                 rbacDecision.RequiresAuthentication ? StatusCode.Unauthenticated : StatusCode.PermissionDenied,
                 rbacDecision.RequiresAuthentication
+                    ? AccessPolicyHelpers.AuthRequiredMessage
+                    : AccessPolicyHelpers.AccessForbiddenMessage));
+        }
+    }
+
+    private static void EnsureReadAccess(
+        ServerCallContext context,
+        ServiceDefinition service,
+        LayerDefinition layer)
+    {
+        var httpContext = context.GetHttpContext();
+
+        var decision = AccessPolicyHelpers.EvaluateAccess(
+            httpContext,
+            layer.Metadata?.AccessPolicy,
+            service.Metadata?.AccessPolicy,
+            AccessScope.Read);
+
+        if (!decision.IsAllowed)
+        {
+            throw new RpcException(new Status(
+                decision.RequiresAuthentication ? StatusCode.Unauthenticated : StatusCode.PermissionDenied,
+                decision.RequiresAuthentication
                     ? AccessPolicyHelpers.AuthRequiredMessage
                     : AccessPolicyHelpers.AccessForbiddenMessage));
         }

--- a/src/Honua.Server/Features/ImageServer/Handlers/ImageServerExportHandler.cs
+++ b/src/Honua.Server/Features/ImageServer/Handlers/ImageServerExportHandler.cs
@@ -104,7 +104,8 @@ internal sealed class ImageServerExportHandler
                 result.Data,
                 result.ContentType,
                 TimeSpan.FromHours(1),
-                cancellationToken);
+                principal: context.User,
+                cancellationToken: cancellationToken);
 
             var extent = result.Extent;
             extent ??= await _rasterStore.GetExtentAsync(layerId, primaryRasterInfo.Id, cancellationToken);

--- a/src/Honua.Server/Features/Infrastructure/Extensions/TemporaryFileEndpointExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Extensions/TemporaryFileEndpointExtensions.cs
@@ -32,10 +32,14 @@ public static class TemporaryFileEndpointExtensions
 
     private static async Task<IResult> GetTemporaryFile(
         string fileId,
+        HttpContext context,
         ITemporaryFileService temporaryFileService,
         CancellationToken cancellationToken = default)
     {
-        var result = await temporaryFileService.GetTemporaryFileAsync(fileId, cancellationToken);
+        var result = await temporaryFileService.GetTemporaryFileAsync(
+            fileId,
+            principal: context.User,
+            cancellationToken: cancellationToken);
 
         if (result == null)
         {

--- a/src/Honua.Server/Features/Infrastructure/Services/TemporaryFileService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Services/TemporaryFileService.cs
@@ -3,7 +3,8 @@
 
 using System.Text.Json.Serialization;
 using System.Collections.Concurrent;
-
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Server.Features.Infrastructure.Services;
@@ -16,12 +17,20 @@ public interface ITemporaryFileService
     /// <summary>
     /// Stores temporary file data and returns a public URL.
     /// </summary>
-    Task<string> StoreTemporaryFileAsync(byte[] data, string contentType, TimeSpan? expiration = null, CancellationToken cancellationToken = default);
+    Task<string> StoreTemporaryFileAsync(
+        byte[] data,
+        string contentType,
+        TimeSpan? expiration = null,
+        ClaimsPrincipal? principal = null,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves temporary file data by ID.
     /// </summary>
-    Task<(byte[] data, string contentType)?> GetTemporaryFileAsync(string fileId, CancellationToken cancellationToken = default);
+    Task<(byte[] data, string contentType)?> GetTemporaryFileAsync(
+        string fileId,
+        ClaimsPrincipal? principal = null,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Cleans up expired temporary files.
@@ -106,14 +115,17 @@ internal sealed partial class FileSystemTemporaryFileService : ITemporaryFileSer
 
     private readonly TemporaryFileOptions _options;
     private readonly ILogger<FileSystemTemporaryFileService> _logger;
+    private readonly IHttpContextAccessor? _httpContextAccessor;
     private readonly SemaphoreSlim _writeGate;
 
     public FileSystemTemporaryFileService(
         IOptions<TemporaryFileOptions> options,
-        ILogger<FileSystemTemporaryFileService> logger)
+        ILogger<FileSystemTemporaryFileService> logger,
+        IHttpContextAccessor? httpContextAccessor = null)
     {
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _httpContextAccessor = httpContextAccessor;
         _writeGate = SharedWriteGates.GetOrAdd(
             Path.GetFullPath(_options.StorageDirectory),
             static _ => new SemaphoreSlim(1, 1));
@@ -126,8 +138,11 @@ internal sealed partial class FileSystemTemporaryFileService : ITemporaryFileSer
         byte[] data,
         string contentType,
         TimeSpan? expiration = null,
+        ClaimsPrincipal? principal = null,
         CancellationToken cancellationToken = default)
     {
+        principal ??= _httpContextAccessor?.HttpContext?.User;
+
         if (data.Length > _options.MaxFileSizeBytes)
         {
             throw new InvalidOperationException($"File size {data.Length} exceeds maximum allowed size {_options.MaxFileSizeBytes}");
@@ -161,7 +176,8 @@ internal sealed partial class FileSystemTemporaryFileService : ITemporaryFileSer
                 ContentType = contentType,
                 ExpiresAt = expirationTime,
                 OriginalSize = data.Length,
-                CreatedAt = DateTimeOffset.UtcNow
+                CreatedAt = DateTimeOffset.UtcNow,
+                AuthorizedPrincipalKey = ResolvePrincipalKey(principal)
             };
             var metadata = System.Text.Json.JsonSerializer.Serialize(metadataObj, TemporaryFileMetadataJsonContext.Default.TemporaryFileMetadata);
             await File.WriteAllTextAsync(metadataPath, metadata, cancellationToken).ConfigureAwait(false);
@@ -192,6 +208,7 @@ internal sealed partial class FileSystemTemporaryFileService : ITemporaryFileSer
 
     public async Task<(byte[] data, string contentType)?> GetTemporaryFileAsync(
         string fileId,
+        ClaimsPrincipal? principal = null,
         CancellationToken cancellationToken = default)
     {
         try
@@ -221,12 +238,25 @@ internal sealed partial class FileSystemTemporaryFileService : ITemporaryFileSer
 
             // Read and check metadata
             var metadataJson = await File.ReadAllTextAsync(metadataPath, cancellationToken);
-            var metadata = System.Text.Json.JsonSerializer.Deserialize(metadataJson, TemporaryFileMetadataJsonContext.Default.TemporaryFileMetadata);
+            var metadata = System.Text.Json.JsonSerializer.Deserialize(
+                metadataJson,
+                TemporaryFileMetadataJsonContext.Default.TemporaryFileMetadata);
 
-            if (metadata?.ExpiresAt < DateTimeOffset.UtcNow)
+            if (metadata is null)
+            {
+                await DeleteFileAndMetadataAsync(actualFileId).ConfigureAwait(false);
+                return null;
+            }
+
+            if (metadata.ExpiresAt < DateTimeOffset.UtcNow)
             {
                 // File has expired, clean it up
-                await DeleteFileAndMetadataAsync(actualFileId);
+                await DeleteFileAndMetadataAsync(actualFileId).ConfigureAwait(false);
+                return null;
+            }
+
+            if (!IsPrincipalAuthorized(metadata, principal))
+            {
                 return null;
             }
 
@@ -258,7 +288,7 @@ internal sealed partial class FileSystemTemporaryFileService : ITemporaryFileSer
 
             // Read file data
             var data = await File.ReadAllBytesAsync(filePath, cancellationToken);
-            return (data, metadata?.ContentType ?? "application/octet-stream");
+            return (data, metadata.ContentType ?? "application/octet-stream");
         }
         catch (Exception ex)
         {
@@ -414,6 +444,31 @@ internal sealed partial class FileSystemTemporaryFileService : ITemporaryFileSer
         };
     }
 
+    private static string? ResolvePrincipalKey(ClaimsPrincipal? principal)
+    {
+        if (principal?.Identity?.IsAuthenticated != true)
+        {
+            return null;
+        }
+
+        return principal.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? principal.Identity.Name;
+    }
+
+    private static bool IsPrincipalAuthorized(TemporaryFileMetadata metadata, ClaimsPrincipal? principal)
+    {
+        if (string.IsNullOrWhiteSpace(metadata.AuthorizedPrincipalKey))
+        {
+            return true;
+        }
+
+        var principalKey = ResolvePrincipalKey(principal);
+        return string.Equals(
+            principalKey,
+            metadata.AuthorizedPrincipalKey,
+            StringComparison.Ordinal);
+    }
+
     public void Dispose()
     {
         // Shared write gates are process-wide and intentionally live for the process lifetime.
@@ -466,5 +521,6 @@ internal sealed partial class FileSystemTemporaryFileService : ITemporaryFileSer
         public DateTimeOffset ExpiresAt { get; set; }
         public long OriginalSize { get; set; }
         public DateTimeOffset CreatedAt { get; set; }
+        public string? AuthorizedPrincipalKey { get; set; }
     }
 }

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Export.cs
@@ -72,6 +72,7 @@ internal static partial class MapServerEndpoints
     /// </summary>
     private static async Task<IResult> HandleExport(HttpContext context)
     {
+        var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
         var serviceError = RouteValidationHelpers.ValidateServiceId(context, out var serviceId);
         if (serviceError is not null)
         {
@@ -104,7 +105,7 @@ internal static partial class MapServerEndpoints
             }
 
             var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
-            var serviceResult = await resourceValidator.ValidateServiceAsync(serviceId, context.RequestAborted);
+            var serviceResult = await resourceValidator.ValidateServiceAsync(serviceId, cancellationToken);
             if (!serviceResult.IsValid)
             {
                 var errorMessage = serviceResult.ErrorMessage ?? "Service not found.";
@@ -182,7 +183,7 @@ internal static partial class MapServerEndpoints
                 extent,
                 bboxSrid.Value,
                 imageSrid.Value,
-                context.RequestAborted);
+                cancellationToken);
             if (!transformResult.IsSuccess)
             {
                 return StandardErrorHelpers.CreateBadRequest(
@@ -272,7 +273,7 @@ internal static partial class MapServerEndpoints
 
             await using var renderLease = await context.RequestServices
                 .GetRequiredService<RasterRenderCapacityLimiter>()
-                .TryAcquireAsync(imageWidth, imageHeight, context.RequestAborted)
+                .TryAcquireAsync(imageWidth, imageHeight, cancellationToken)
                 .ConfigureAwait(false);
             if (renderLease is null)
             {
@@ -311,7 +312,7 @@ internal static partial class MapServerEndpoints
                     renderExtent,
                     imageSrid.Value,
                     context,
-                    context.RequestAborted);
+                    cancellationToken);
             }
 
             var scaleDenominator = CoordinateTransformer.CalculateScaleDenominator(extent, imageWidth, dpi, bboxSrid.Value);
@@ -344,7 +345,7 @@ internal static partial class MapServerEndpoints
 
             foreach (var renderLayer in renderLayers)
             {
-                context.RequestAborted.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 var layer = renderLayer.Layer;
                 if (!IsLayerVisibleAtScale(layer, scaleDenominator))
@@ -389,7 +390,7 @@ internal static partial class MapServerEndpoints
                 var stylePlan = await GetRasterStylePlanAsync(
                     styleCatalog,
                     layer.Id,
-                    context.RequestAborted).ConfigureAwait(false);
+                    cancellationToken).ConfigureAwait(false);
                 var featureQuery = CreateRasterFeatureQuery(
                     stylePlan,
                     spatialFilter,
@@ -409,14 +410,14 @@ internal static partial class MapServerEndpoints
                     imageWidth,
                     imageHeight,
                     transform,
-                    context.RequestAborted).ConfigureAwait(false);
+                    cancellationToken).ConfigureAwait(false);
                 if (renderedPointCount >= 0)
                 {
                     totalFeatureCount += renderedPointCount;
                     continue;
                 }
 
-                var features = await QueryRasterFeaturesAsync(featureReader, layer.Id, featureQuery, context.RequestAborted);
+                var features = await QueryRasterFeaturesAsync(featureReader, layer.Id, featureQuery, cancellationToken);
 
                 if (features.Length == 0)
                 {
@@ -443,14 +444,14 @@ internal static partial class MapServerEndpoints
                 renderExtent,
                 imageSrid.Value,
                 context,
-                context.RequestAborted);
+                cancellationToken);
         }
         catch (ArgumentException ex)
         {
             MapServerLog.ExportFailed(logger, serviceId, ex.Message, ex);
             return StandardErrorHelpers.CreateBadRequest(context, InvalidExportRequestMessage);
         }
-        catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -485,7 +486,8 @@ internal static partial class MapServerEndpoints
                     imageBytes,
                     imageContentType,
                     TimeSpan.FromHours(1),
-                    cancellationToken);
+                    principal: context.User,
+                    cancellationToken: cancellationToken);
             }
             catch (TemporaryStorageLimitExceededException ex)
             {

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Tile.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Tile.cs
@@ -31,6 +31,7 @@ internal static partial class MapServerEndpoints
     /// </summary>
     private static async Task<IResult> HandleTile(HttpContext context)
     {
+        var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
         var serviceError = RouteValidationHelpers.ValidateServiceId(context, out var serviceId);
         if (serviceError is not null)
         {
@@ -62,7 +63,7 @@ internal static partial class MapServerEndpoints
         try
         {
             var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
-            var serviceResult = await resourceValidator.ValidateServiceAsync(serviceId, context.RequestAborted);
+            var serviceResult = await resourceValidator.ValidateServiceAsync(serviceId, cancellationToken);
             if (!serviceResult.IsValid)
             {
                 var errorMessage = serviceResult.ErrorMessage ?? "Service not found.";
@@ -103,7 +104,7 @@ internal static partial class MapServerEndpoints
                 tileBounds.XMin, tileBounds.YMin, tileBounds.XMax, tileBounds.YMax);
             await using var renderLease = await context.RequestServices
                 .GetRequiredService<RasterRenderCapacityLimiter>()
-                .TryAcquireAsync(TileSize, TileSize, context.RequestAborted)
+                .TryAcquireAsync(TileSize, TileSize, cancellationToken)
                 .ConfigureAwait(false);
             if (renderLease is null)
             {
@@ -154,7 +155,7 @@ internal static partial class MapServerEndpoints
 
             foreach (var layer in renderLayers)
             {
-                context.RequestAborted.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 if (!layer.HasGeometry)
                 {
@@ -164,7 +165,7 @@ internal static partial class MapServerEndpoints
                 var stylePlan = await GetRasterStylePlanAsync(
                     styleCatalog,
                     layer.Id,
-                    context.RequestAborted).ConfigureAwait(false);
+                    cancellationToken).ConfigureAwait(false);
                 var featureQuery = CreateRasterFeatureQuery(
                     stylePlan,
                     spatialFilter,
@@ -183,14 +184,14 @@ internal static partial class MapServerEndpoints
                     TileSize,
                     TileSize,
                     transform,
-                    context.RequestAborted).ConfigureAwait(false);
+                    cancellationToken).ConfigureAwait(false);
                 if (renderedPointCount >= 0)
                 {
                     totalFeatureCount += renderedPointCount;
                     continue;
                 }
 
-                var features = await QueryRasterFeaturesAsync(featureReader, layer.Id, featureQuery, context.RequestAborted);
+                var features = await QueryRasterFeaturesAsync(featureReader, layer.Id, featureQuery, cancellationToken);
                 if (features.Length == 0)
                 {
                     continue;
@@ -209,7 +210,7 @@ internal static partial class MapServerEndpoints
 
             return Results.Bytes(imageBytes, "image/png");
         }
-        catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Wms.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Wms.cs
@@ -88,6 +88,7 @@ internal static partial class MapServerEndpoints
     /// </summary>
     private static async Task<IResult> HandleWms(HttpContext context)
     {
+        var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
         var serviceError = RouteValidationHelpers.ValidateServiceId(context, out var serviceId);
         if (serviceError is not null)
         {
@@ -110,7 +111,7 @@ internal static partial class MapServerEndpoints
             }
 
             var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
-            var serviceResult = await resourceValidator.ValidateServiceAsync(serviceId, context.RequestAborted);
+            var serviceResult = await resourceValidator.ValidateServiceAsync(serviceId, cancellationToken);
             if (!serviceResult.IsValid)
             {
                 var errorMessage = serviceResult.ErrorMessage ?? "Service not found.";
@@ -157,7 +158,7 @@ internal static partial class MapServerEndpoints
 
             return CreateWmsServiceException(context, "OperationNotSupported", $"Unsupported WMS REQUEST '{requestType}'.");
         }
-        catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -174,6 +175,7 @@ internal static partial class MapServerEndpoints
         string serviceId,
         ILogger logger)
     {
+        var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
         MapServerLog.WmsRequested(logger, serviceId, "GetMap");
         var stopwatch = Stopwatch.StartNew();
         using var activity = HonuaTelemetry.ActivitySource.StartActivity(
@@ -288,7 +290,7 @@ internal static partial class MapServerEndpoints
         var effectiveTransparent = transparent && string.Equals(imageFormat, "png", StringComparison.OrdinalIgnoreCase);
         await using var renderLease = await context.RequestServices
             .GetRequiredService<RasterRenderCapacityLimiter>()
-            .TryAcquireAsync(imageWidth, imageHeight, context.RequestAborted)
+            .TryAcquireAsync(imageWidth, imageHeight, cancellationToken)
             .ConfigureAwait(false);
         if (renderLease is null)
         {
@@ -336,7 +338,7 @@ internal static partial class MapServerEndpoints
                 requestedExtent,
                 requestSrid,
                 service.SpatialReference.Srid,
-                context.RequestAborted);
+                cancellationToken);
             if (!extentTransformResult.IsSuccess)
             {
                 return CreateWmsServiceException(context, "InvalidCRS", extentTransformResult.Error ?? "Invalid spatial reference.");
@@ -365,7 +367,7 @@ internal static partial class MapServerEndpoints
 
         foreach (var layer in renderLayers)
         {
-            context.RequestAborted.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (!layer.HasGeometry)
             {
@@ -375,7 +377,7 @@ internal static partial class MapServerEndpoints
             var stylePlan = await GetRasterStylePlanAsync(
                 styleCatalog,
                 layer.Id,
-                context.RequestAborted).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
             var featureQuery = CreateRasterFeatureQuery(
                 stylePlan,
                 spatialFilter,
@@ -394,14 +396,14 @@ internal static partial class MapServerEndpoints
                 imageWidth,
                 imageHeight,
                 transformFn,
-                context.RequestAborted).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
             if (renderedPointCount >= 0)
             {
                 totalFeatureCount += renderedPointCount;
                 continue;
             }
 
-            var features = await QueryRasterFeaturesAsync(featureReader, layer.Id, featureQuery, context.RequestAborted);
+            var features = await QueryRasterFeaturesAsync(featureReader, layer.Id, featureQuery, cancellationToken);
             if (features.Length == 0)
             {
                 continue;
@@ -426,6 +428,7 @@ internal static partial class MapServerEndpoints
         string serviceId,
         ILogger logger)
     {
+        var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
         MapServerLog.WmsRequested(logger, serviceId, "GetFeatureInfo");
         using var activity = HonuaTelemetry.ActivitySource.StartActivity(
             HonuaTelemetry.Activities.MapServerIdentify, ActivityKind.Internal);
@@ -546,7 +549,7 @@ internal static partial class MapServerEndpoints
                 requestedExtent,
                 requestSrid,
                 service.SpatialReference.Srid,
-                context.RequestAborted);
+                cancellationToken);
             if (!extentTransformResult.IsSuccess)
             {
                 return CreateWmsServiceException(context, "InvalidCRS", extentTransformResult.Error ?? "Invalid spatial reference.");
@@ -575,7 +578,7 @@ internal static partial class MapServerEndpoints
                 clickExtent,
                 requestSrid,
                 service.SpatialReference.Srid,
-                context.RequestAborted);
+                cancellationToken);
             if (!clickExtentTransform.IsSuccess)
             {
                 return CreateWmsServiceException(context, "InvalidCRS", clickExtentTransform.Error ?? "Invalid spatial reference.");
@@ -606,7 +609,7 @@ internal static partial class MapServerEndpoints
                 Limit = remaining
             };
 
-            var queryResult = await featureReader.QueryAsync(layer.Id, featureQuery, context.RequestAborted);
+            var queryResult = await featureReader.QueryAsync(layer.Id, featureQuery, cancellationToken);
             if (queryResult.Items.Length == 0)
             {
                 continue;
@@ -1985,6 +1988,7 @@ internal static partial class MapServerEndpoints
         FeatureExtent extent,
         string indent)
     {
+        var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
         var geographicExtent = extent;
         if (extent.SpatialReference != 4326)
         {
@@ -1993,7 +1997,7 @@ internal static partial class MapServerEndpoints
                 new SkiaMapRenderer.RenderExtent(extent.MinX, extent.MinY, extent.MaxX, extent.MaxY),
                 extent.SpatialReference,
                 4326,
-                context.RequestAborted).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
 
             if (!transformResult.IsSuccess)
             {

--- a/src/Honua.Server/Features/OgcFeatures/CoreEndpoints.cs
+++ b/src/Honua.Server/Features/OgcFeatures/CoreEndpoints.cs
@@ -74,6 +74,7 @@ internal static class CoreEndpoints
     private static IResult HandleGetLandingPage(
         HttpContext context,
         string? f,
+        [FromServices] IConfiguration configuration,
         [FromServices] ILogger<OgcFeaturesEndpoints.OgcFeaturesEndpointsLog> logger)
     {
         OgcFeaturesLog.LandingPageRequested(logger);
@@ -104,12 +105,17 @@ internal static class CoreEndpoints
             type: MediaTypes.OpenApi,
             title: "API definition"));
 
-        // API documentation
-        links.Add(Link.Create(
-            href: $"{baseUrl}/api-docs",
-            rel: RelationTypes.ServiceDoc,
-            type: MediaTypes.Html,
-            title: "API documentation"));
+        var serveApiDocs = configuration.GetValue(
+            "ServeApiDocs",
+            configuration.GetValue("HONUA_SERVE_API_DOCS", false));
+        if (serveApiDocs)
+        {
+            links.Add(Link.Create(
+                href: $"{baseUrl}/docs",
+                rel: RelationTypes.ServiceDoc,
+                type: MediaTypes.Html,
+                title: "API documentation"));
+        }
 
         // Conformance declaration
         links.Add(Link.Create(

--- a/src/Honua.Server/Features/OgcFeatures/OgcFeaturesTransactionHandler.cs
+++ b/src/Honua.Server/Features/OgcFeatures/OgcFeaturesTransactionHandler.cs
@@ -87,61 +87,59 @@ internal sealed partial class OgcFeaturesTransactionHandler(
                     $"Batch request exceeds maximum of {maxBatchOperations} operations.");
             }
 
-            var results = new List<BatchOperationResult>();
+            var preparedBatch = await PrepareBatchOperationsAsync(
+                layerId,
+                layer,
+                batchRequest,
+                inputCrs,
+                cancellationToken).ConfigureAwait(false);
+
+            List<BatchOperationResult> results;
             var hasErrors = false;
 
-            // Process each operation in the batch
-            foreach (var operation in batchRequest.Operations)
+            if (preparedBatch.ShortCircuitResults is { Count: > 0 })
             {
-                try
-                {
-                    var result = await ProcessBatchOperationAsync(layerId, layer, operation, inputCrs, cancellationToken);
-                    results.Add(result);
+                results = preparedBatch.ShortCircuitResults;
+                hasErrors = true;
+            }
+            else if (preparedBatch.EditBatch.IsEmpty)
+            {
+                results = [];
+            }
+            else
+            {
+                var editResult = await _featureWriter.ApplyEditsAsync(
+                    layerId,
+                    preparedBatch.EditBatch,
+                    cancellationToken).ConfigureAwait(false);
 
-                    if (result.IsSuccess &&
-                        TryGetBatchEventOperation(operation, result, out var eventOperation, out var objectId))
+                results = MapBatchEditResults(batchRequest.Operations.Count, preparedBatch.PreparedOperations, editResult);
+                hasErrors = results.Any(result => !result.IsSuccess);
+            }
+
+            if (!hasErrors)
+            {
+                var serviceId = await ResolveServiceIdAsync(context, layerId, cancellationToken);
+                for (var index = 0; index < results.Count && index < batchRequest.Operations.Count; index++)
+                {
+                    var operation = batchRequest.Operations[index];
+                    var result = results[index];
+                    if (!TryGetBatchEventOperation(operation, result, out var eventOperation, out var objectId))
                     {
-                        var serviceId = await ResolveServiceIdAsync(context, layerId, cancellationToken);
-                        await _featureChangeEventPublisher.PublishAsync(
-                            new FeatureChangeEventRequest
-                            {
-                                ServiceId = serviceId,
-                                LayerId = layerId,
-                                ObjectId = objectId,
-                                Operation = eventOperation,
-                                Protocol = HonuaTelemetry.Protocols.OgcFeatures,
-                                RequestId = $"{context.TraceIdentifier}:{operation.Id ?? "batch"}"
-                            },
-                            cancellationToken).ConfigureAwait(false);
+                        continue;
                     }
 
-                    if (!result.IsSuccess)
-                    {
-                        hasErrors = true;
-                        if (batchRequest.FailFast)
+                    await _featureChangeEventPublisher.PublishAsync(
+                        new FeatureChangeEventRequest
                         {
-                            break;
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    var errorResult = new BatchOperationResult
-                    {
-                        OperationId = operation.Id,
-                        IsSuccess = false,
-                        ErrorMessage = "An error occurred processing the operation.",
-                        StatusCode = 500
-                    };
-                    results.Add(errorResult);
-                    hasErrors = true;
-
-                    Log.BatchOperationFailed(_logger, collectionId, operation.Id ?? "unknown", ex);
-
-                    if (batchRequest.FailFast)
-                    {
-                        break;
-                    }
+                            ServiceId = serviceId,
+                            LayerId = layerId,
+                            ObjectId = objectId,
+                            Operation = eventOperation,
+                            Protocol = HonuaTelemetry.Protocols.OgcFeatures,
+                            RequestId = $"{context.TraceIdentifier}:{operation.Id ?? "batch"}"
+                        },
+                        cancellationToken).ConfigureAwait(false);
                 }
             }
 
@@ -529,10 +527,11 @@ internal sealed partial class OgcFeaturesTransactionHandler(
         }
     }
 
-    private async Task<BatchOperationResult> ProcessBatchOperationAsync(
+    private async Task<PreparedBatchValidationResult> PrepareBatchOperationAsync(
         int layerId,
         LayerDefinition layer,
         BatchOperation operation,
+        BatchPreparationState state,
         CrsDefinition inputCrs,
         CancellationToken cancellationToken)
     {
@@ -541,35 +540,29 @@ internal sealed partial class OgcFeaturesTransactionHandler(
             switch (operation.Type.ToUpperInvariant())
             {
                 case "CREATE":
-                    return await ProcessCreateOperationAsync(layerId, layer, operation, inputCrs, cancellationToken);
+                    return await PrepareCreateOperationAsync(layerId, layer, operation, inputCrs, cancellationToken);
                 case "UPDATE":
-                    return await ProcessUpdateOperationAsync(layerId, layer, operation, inputCrs, cancellationToken);
+                    return await PrepareUpdateOperationAsync(layerId, layer, operation, state, inputCrs, cancellationToken);
                 case "DELETE":
-                    return await ProcessDeleteOperationAsync(layerId, operation, cancellationToken);
+                    return await PrepareDeleteOperationAsync(layerId, operation, state, cancellationToken);
                 default:
-                    return new BatchOperationResult
-                    {
-                        OperationId = operation.Id,
-                        IsSuccess = false,
-                        ErrorMessage = $"Unsupported operation type: {operation.Type}",
-                        StatusCode = 400
-                    };
+                    return PreparedBatchValidationResult.Failure(CreateBatchFailure(
+                        operation.Id,
+                        $"Unsupported operation type: {operation.Type}",
+                        400));
             }
         }
         catch (Exception ex)
         {
             Log.BatchOperationFailed(_logger, layerId.ToString(), operation.Id ?? "unknown", ex);
-            return new BatchOperationResult
-            {
-                OperationId = operation.Id,
-                IsSuccess = false,
-                ErrorMessage = "An error occurred processing the operation.",
-                StatusCode = 500
-            };
+            return PreparedBatchValidationResult.Failure(CreateBatchFailure(
+                operation.Id,
+                "An error occurred processing the operation.",
+                500));
         }
     }
 
-    private async Task<BatchOperationResult> ProcessCreateOperationAsync(
+    private async Task<PreparedBatchValidationResult> PrepareCreateOperationAsync(
         int layerId,
         LayerDefinition layer,
         BatchOperation operation,
@@ -578,13 +571,10 @@ internal sealed partial class OgcFeaturesTransactionHandler(
     {
         if (operation.Feature == null)
         {
-            return new BatchOperationResult
-            {
-                OperationId = operation.Id,
-                IsSuccess = false,
-                ErrorMessage = "Feature data is required for create operation.",
-                StatusCode = 400
-            };
+            return PreparedBatchValidationResult.Failure(CreateBatchFailure(
+                operation.Id,
+                "Feature data is required for create operation.",
+                400));
         }
 
         var buildResult = await OgcFeatureMutationHelpers.TryBuildFeatureAsync(
@@ -597,55 +587,61 @@ internal sealed partial class OgcFeaturesTransactionHandler(
             cancellationToken);
         if (!buildResult.IsValid)
         {
-            return new BatchOperationResult
-            {
-                OperationId = operation.Id,
-                IsSuccess = false,
-                ErrorMessage = buildResult.ErrorMessage ?? "Invalid feature payload.",
-                StatusCode = 400
-            };
+            return PreparedBatchValidationResult.Failure(CreateBatchFailure(
+                operation.Id,
+                buildResult.ErrorMessage ?? "Invalid feature payload.",
+                400));
         }
 
         var feature = buildResult.Feature
             ?? throw new InvalidOperationException("Feature build result was missing the feature payload.");
-        var created = await _featureWriter.CreateAsync(layerId, feature, cancellationToken);
 
-        return new BatchOperationResult
-        {
-            OperationId = operation.Id,
-            IsSuccess = true,
-            FeatureId = created.Id.ToString(),
-            StatusCode = 201
-        };
+        return PreparedBatchValidationResult.Success(new PreparedBatchOperation(
+            OperationKind: BatchOperationKind.Create,
+            Operation: operation,
+            Feature: feature,
+            ObjectId: null));
     }
 
-    private async Task<BatchOperationResult> ProcessUpdateOperationAsync(
+    private async Task<PreparedBatchValidationResult> PrepareUpdateOperationAsync(
         int layerId,
         LayerDefinition layer,
         BatchOperation operation,
+        BatchPreparationState state,
         CrsDefinition inputCrs,
         CancellationToken cancellationToken)
     {
         if (operation.Feature == null || string.IsNullOrWhiteSpace(operation.FeatureId))
         {
-            return new BatchOperationResult
-            {
-                OperationId = operation.Id,
-                IsSuccess = false,
-                ErrorMessage = "Feature data and feature ID are required for update operation.",
-                StatusCode = 400
-            };
+            return PreparedBatchValidationResult.Failure(CreateBatchFailure(
+                operation.Id,
+                "Feature data and feature ID are required for update operation.",
+                400));
         }
 
         if (!long.TryParse(operation.FeatureId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
         {
-            return new BatchOperationResult
-            {
-                OperationId = operation.Id,
-                IsSuccess = false,
-                ErrorMessage = $"Invalid feature ID: {operation.FeatureId}",
-                StatusCode = 400
-            };
+            return PreparedBatchValidationResult.Failure(CreateBatchFailure(
+                operation.Id,
+                $"Invalid feature ID: {operation.FeatureId}",
+                400));
+        }
+
+        if (state.DeletedObjectIds.Contains(objectId))
+        {
+            return PreparedBatchValidationResult.Failure(CreateBatchFailure(
+                operation.Id,
+                $"Feature '{operation.FeatureId}' not found.",
+                404));
+        }
+
+        var existing = await _featureReader.GetAsync(layerId, objectId, cancellationToken).ConfigureAwait(false);
+        if (!existing.HasValue)
+        {
+            return PreparedBatchValidationResult.Failure(CreateBatchFailure(
+                operation.Id,
+                $"Feature '{operation.FeatureId}' not found.",
+                404));
         }
 
         var buildResult = await OgcFeatureMutationHelpers.TryBuildFeatureAsync(
@@ -658,86 +654,287 @@ internal sealed partial class OgcFeaturesTransactionHandler(
             cancellationToken);
         if (!buildResult.IsValid)
         {
-            return new BatchOperationResult
-            {
-                OperationId = operation.Id,
-                IsSuccess = false,
-                ErrorMessage = buildResult.ErrorMessage ?? "Invalid feature payload.",
-                StatusCode = 400
-            };
+            return PreparedBatchValidationResult.Failure(CreateBatchFailure(
+                operation.Id,
+                buildResult.ErrorMessage ?? "Invalid feature payload.",
+                400));
         }
 
         var feature = buildResult.Feature
             ?? throw new InvalidOperationException("Feature build result was missing the feature payload.");
-
-        try
-        {
-            var updated = await _featureWriter.UpdateAsync(layerId, feature, cancellationToken);
-            return new BatchOperationResult
-            {
-                OperationId = operation.Id,
-                IsSuccess = true,
-                FeatureId = updated.Id.ToString(),
-                StatusCode = 200
-            };
-        }
-        catch (ResourceNotFoundException)
-        {
-            return new BatchOperationResult
-            {
-                OperationId = operation.Id,
-                IsSuccess = false,
-                ErrorMessage = $"Feature '{operation.FeatureId}' not found.",
-                StatusCode = 404
-            };
-        }
+        return PreparedBatchValidationResult.Success(new PreparedBatchOperation(
+            OperationKind: BatchOperationKind.Update,
+            Operation: operation,
+            Feature: feature,
+            ObjectId: objectId));
     }
 
-    private async Task<BatchOperationResult> ProcessDeleteOperationAsync(
+    private async Task<PreparedBatchValidationResult> PrepareDeleteOperationAsync(
         int layerId,
         BatchOperation operation,
+        BatchPreparationState state,
         CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(operation.FeatureId))
         {
-            return new BatchOperationResult
-            {
-                OperationId = operation.Id,
-                IsSuccess = false,
-                ErrorMessage = "Feature ID is required for delete operation.",
-                StatusCode = 400
-            };
+            return PreparedBatchValidationResult.Failure(CreateBatchFailure(
+                operation.Id,
+                "Feature ID is required for delete operation.",
+                400));
         }
 
         if (!long.TryParse(operation.FeatureId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
         {
-            return new BatchOperationResult
-            {
-                OperationId = operation.Id,
-                IsSuccess = false,
-                ErrorMessage = $"Invalid feature ID: {operation.FeatureId}",
-                StatusCode = 400
-            };
+            return PreparedBatchValidationResult.Failure(CreateBatchFailure(
+                operation.Id,
+                $"Invalid feature ID: {operation.FeatureId}",
+                400));
         }
 
-        var deleted = await _featureWriter.DeleteAsync(layerId, objectId, cancellationToken);
-        if (!deleted)
+        if (state.DeletedObjectIds.Contains(objectId))
         {
-            return new BatchOperationResult
-            {
-                OperationId = operation.Id,
-                IsSuccess = false,
-                ErrorMessage = $"Feature '{operation.FeatureId}' not found.",
-                StatusCode = 404
-            };
+            return PreparedBatchValidationResult.Failure(CreateBatchFailure(
+                operation.Id,
+                $"Feature '{operation.FeatureId}' not found.",
+                404));
         }
 
-        return new BatchOperationResult
+        var existing = await _featureReader.GetAsync(layerId, objectId, cancellationToken).ConfigureAwait(false);
+        if (!existing.HasValue)
         {
-            OperationId = operation.Id,
-            IsSuccess = true,
-            StatusCode = 204
+            return PreparedBatchValidationResult.Failure(CreateBatchFailure(
+                operation.Id,
+                $"Feature '{operation.FeatureId}' not found.",
+                404));
+        }
+
+        return PreparedBatchValidationResult.Success(new PreparedBatchOperation(
+            OperationKind: BatchOperationKind.Delete,
+            Operation: operation,
+            Feature: null,
+            ObjectId: objectId));
+    }
+
+    private async Task<PreparedBatchPlan> PrepareBatchOperationsAsync(
+        int layerId,
+        LayerDefinition layer,
+        BatchRequest batchRequest,
+        CrsDefinition inputCrs,
+        CancellationToken cancellationToken)
+    {
+        var preparedOperations = ImmutableArray.CreateBuilder<PreparedBatchOperation>(batchRequest.Operations.Count);
+        var validationResults = new BatchOperationResult?[batchRequest.Operations.Count];
+        var validationState = new BatchPreparationState();
+        var processedCount = batchRequest.Operations.Count;
+        var validationFailed = false;
+
+        for (var index = 0; index < batchRequest.Operations.Count; index++)
+        {
+            var operation = batchRequest.Operations[index];
+            if (validationFailed)
+            {
+                validationResults[index] = CreateRolledBackBatchFailure(operation.Id);
+                continue;
+            }
+
+            var prepared = await PrepareBatchOperationAsync(
+                layerId,
+                layer,
+                operation,
+                validationState,
+                inputCrs,
+                cancellationToken).ConfigureAwait(false);
+
+            if (!prepared.IsValid)
+            {
+                validationFailed = true;
+                validationResults[index] = prepared.ErrorResult!;
+
+                foreach (var priorOperation in preparedOperations)
+                {
+                    validationResults[priorOperation.Index] = CreateRolledBackBatchFailure(priorOperation.Operation.Id);
+                }
+
+                if (batchRequest.FailFast)
+                {
+                    processedCount = index + 1;
+                    break;
+                }
+
+                continue;
+            }
+
+            var preparedOperation = prepared.Operation! with { Index = index };
+            preparedOperations.Add(preparedOperation);
+            ApplyPreparationState(validationState, preparedOperation);
+        }
+
+        if (validationFailed)
+        {
+            var results = validationResults
+                .Take(processedCount)
+                .Select(static result => result ?? throw new InvalidOperationException("Validation result was missing."))
+                .ToList();
+            return new PreparedBatchPlan(default, preparedOperations.ToImmutable(), results);
+        }
+
+        var editBatch = new FeatureEditBatch
+        {
+            RollbackOnFailure = true,
+            Operations = preparedOperations
+                .Select(static operation => operation.OperationKind switch
+                {
+                    BatchOperationKind.Create => FeatureEditOperation.Create(
+                        operation.Feature ?? throw new InvalidOperationException("Prepared create operation was missing a feature.")),
+                    BatchOperationKind.Update => FeatureEditOperation.Update(
+                        operation.Feature ?? throw new InvalidOperationException("Prepared update operation was missing a feature.")),
+                    BatchOperationKind.Delete => FeatureEditOperation.Delete(
+                        operation.ObjectId ?? throw new InvalidOperationException("Prepared delete operation was missing an object ID.")),
+                    _ => throw new InvalidOperationException($"Unsupported batch operation kind {operation.OperationKind}.")
+                })
+                .ToImmutableArray(),
+            Creates = preparedOperations
+                .Where(static operation => operation.OperationKind == BatchOperationKind.Create)
+                .Select(static operation => operation.Feature ?? throw new InvalidOperationException("Prepared create operation was missing a feature."))
+                .ToImmutableArray(),
+            Updates = preparedOperations
+                .Where(static operation => operation.OperationKind == BatchOperationKind.Update)
+                .Select(static operation => operation.Feature ?? throw new InvalidOperationException("Prepared update operation was missing a feature."))
+                .ToImmutableArray(),
+            Deletes = preparedOperations
+                .Where(static operation => operation.OperationKind == BatchOperationKind.Delete)
+                .Select(static operation => operation.ObjectId!.Value)
+                .ToImmutableArray()
         };
+
+        return new PreparedBatchPlan(editBatch, preparedOperations.ToImmutable(), null);
+    }
+
+    private static List<BatchOperationResult> MapBatchEditResults(
+        int operationCount,
+        ImmutableArray<PreparedBatchOperation> preparedOperations,
+        FeatureEditResult editResult)
+    {
+        var results = new BatchOperationResult[operationCount];
+        var createIndex = 0;
+        var updateIndex = 0;
+        var deleteIndex = 0;
+
+        foreach (var operation in preparedOperations)
+        {
+            results[operation.Index] = operation.OperationKind switch
+            {
+                BatchOperationKind.Create => MapCreateEditResult(
+                    operation.Operation,
+                    GetEditResult(editResult.CreateResults, createIndex++)),
+                BatchOperationKind.Update => MapUpdateEditResult(
+                    operation.Operation,
+                    operation.ObjectId,
+                    GetEditResult(editResult.UpdateResults, updateIndex++)),
+                BatchOperationKind.Delete => MapDeleteEditResult(
+                    operation.Operation,
+                    operation.ObjectId,
+                    GetEditResult(editResult.DeleteResults, deleteIndex++)),
+                _ => throw new InvalidOperationException($"Unsupported batch operation kind {operation.OperationKind}.")
+            };
+        }
+
+        return results.ToList();
+    }
+
+    private static EditOperationResult GetEditResult(ImmutableArray<EditOperationResult> results, int index)
+        => index < results.Length
+            ? results[index]
+            : EditOperationResult.Failure("Operation result was missing.", errorCode: 500);
+
+    private static BatchOperationResult MapCreateEditResult(BatchOperation operation, EditOperationResult editResult)
+    {
+        if (editResult.IsSuccess && editResult.ObjectId.HasValue)
+        {
+            return new BatchOperationResult
+            {
+                OperationId = operation.Id,
+                IsSuccess = true,
+                FeatureId = editResult.ObjectId.Value.ToString(CultureInfo.InvariantCulture),
+                StatusCode = 201
+            };
+        }
+
+        return CreateBatchFailure(operation.Id, editResult.ErrorMessage ?? "Create operation failed.", DetermineBatchFailureStatus(editResult));
+    }
+
+    private static BatchOperationResult MapUpdateEditResult(
+        BatchOperation operation,
+        long? objectId,
+        EditOperationResult editResult)
+    {
+        if (editResult.IsSuccess)
+        {
+            return new BatchOperationResult
+            {
+                OperationId = operation.Id,
+                IsSuccess = true,
+                FeatureId = (editResult.ObjectId ?? objectId ?? 0).ToString(CultureInfo.InvariantCulture),
+                StatusCode = 200
+            };
+        }
+
+        return CreateBatchFailure(operation.Id, editResult.ErrorMessage ?? "Update operation failed.", DetermineBatchFailureStatus(editResult));
+    }
+
+    private static BatchOperationResult MapDeleteEditResult(
+        BatchOperation operation,
+        long? objectId,
+        EditOperationResult editResult)
+    {
+        if (editResult.IsSuccess)
+        {
+            return new BatchOperationResult
+            {
+                OperationId = operation.Id,
+                IsSuccess = true,
+                FeatureId = (objectId ?? editResult.ObjectId ?? 0).ToString(CultureInfo.InvariantCulture),
+                StatusCode = 204
+            };
+        }
+
+        return CreateBatchFailure(operation.Id, editResult.ErrorMessage ?? "Delete operation failed.", DetermineBatchFailureStatus(editResult));
+    }
+
+    private static int DetermineBatchFailureStatus(EditOperationResult editResult)
+    {
+        if (string.Equals(editResult.ErrorMessage, "Operation rolled back.", StringComparison.Ordinal))
+        {
+            return 424;
+        }
+
+        if (!string.IsNullOrWhiteSpace(editResult.ErrorMessage) &&
+            editResult.ErrorMessage.Contains("not found", StringComparison.OrdinalIgnoreCase))
+        {
+            return 404;
+        }
+
+        return editResult.ErrorCode >= 500 ? 500 : 400;
+    }
+
+    private static BatchOperationResult CreateBatchFailure(string? operationId, string message, int statusCode)
+        => new()
+        {
+            OperationId = operationId,
+            IsSuccess = false,
+            ErrorMessage = message,
+            StatusCode = statusCode
+        };
+
+    private static BatchOperationResult CreateRolledBackBatchFailure(string? operationId)
+        => CreateBatchFailure(operationId, "Operation rolled back.", 424);
+
+    private static void ApplyPreparationState(BatchPreparationState state, PreparedBatchOperation operation)
+    {
+        if (operation.OperationKind == BatchOperationKind.Delete && operation.ObjectId.HasValue)
+        {
+            state.DeletedObjectIds.Add(operation.ObjectId.Value);
+        }
     }
 
     private static async Task<(BatchRequest? Request, string? Error)> ReadBatchRequestAsync(
@@ -926,6 +1123,45 @@ internal sealed partial class OgcFeaturesTransactionHandler(
             default:
                 return false;
         }
+    }
+
+    private enum BatchOperationKind
+    {
+        Create,
+        Update,
+        Delete
+    }
+
+    private sealed record PreparedBatchOperation(
+        BatchOperationKind OperationKind,
+        BatchOperation Operation,
+        Feature? Feature,
+        long? ObjectId)
+    {
+        public int Index { get; init; }
+    }
+
+    private sealed record PreparedBatchValidationResult(
+        PreparedBatchOperation? Operation,
+        BatchOperationResult? ErrorResult)
+    {
+        public bool IsValid => Operation != null;
+
+        public static PreparedBatchValidationResult Success(PreparedBatchOperation operation)
+            => new(operation, null);
+
+        public static PreparedBatchValidationResult Failure(BatchOperationResult errorResult)
+            => new(null, errorResult);
+    }
+
+    private sealed record PreparedBatchPlan(
+        FeatureEditBatch EditBatch,
+        ImmutableArray<PreparedBatchOperation> PreparedOperations,
+        List<BatchOperationResult>? ShortCircuitResults);
+
+    private sealed class BatchPreparationState
+    {
+        public HashSet<long> DeletedObjectIds { get; } = [];
     }
 
     private sealed record PatchRequest(

--- a/src/Honua.Server/Features/OgcMaps/Handlers/OgcMapsTileSetHandler.cs
+++ b/src/Honua.Server/Features/OgcMaps/Handlers/OgcMapsTileSetHandler.cs
@@ -73,6 +73,10 @@ internal sealed class OgcMapsTileSetHandler
             {
                 tilesBasePath = $"{configuredBaseUrl}{relativeTilesBasePath}";
             }
+            var tileMatrixSetBasePath = context is not null && BaseUrlResolver.TryGetConfiguredBaseUrl(context, out var baseUrl) &&
+                !string.IsNullOrWhiteSpace(baseUrl)
+                ? $"{baseUrl}/ogc/tiles/tileMatrixSets"
+                : "/ogc/tiles/tileMatrixSets";
 
             // Create tile set definitions for common tile matrix sets
             var tileSets = new[]
@@ -95,7 +99,7 @@ internal sealed class OgcMapsTileSetHandler
                         },
                         new OgcLink
                         {
-                            Href = $"{tilesBasePath}/WebMercatorQuad",
+                            Href = $"{tileMatrixSetBasePath}/WebMercatorQuad",
                             Rel = "http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme",
                             Type = "application/json",
                             Title = "Web Mercator tile matrix set definition"
@@ -121,7 +125,7 @@ internal sealed class OgcMapsTileSetHandler
                         },
                         new OgcLink
                         {
-                            Href = $"{tilesBasePath}/WorldCRS84Quad",
+                            Href = $"{tileMatrixSetBasePath}/WorldCRS84Quad",
                             Rel = "http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme",
                             Type = "application/json",
                             Title = "WGS84 tile matrix set definition"

--- a/src/Honua.Server/Features/PrintingTools/PrintingToolsBackgroundService.cs
+++ b/src/Honua.Server/Features/PrintingTools/PrintingToolsBackgroundService.cs
@@ -169,7 +169,11 @@ internal sealed class PrintingToolsBackgroundService : BackgroundService
             try
             {
                 downloadUrl = await temporaryFileService.StoreTemporaryFileAsync(
-                    outputBytes, contentType, PrintingToolsRequestHandlers.ResultTtl, CancellationToken.None);
+                    outputBytes,
+                    contentType,
+                    PrintingToolsRequestHandlers.ResultTtl,
+                    principal: job.CallerPrincipal,
+                    cancellationToken: CancellationToken.None);
             }
             catch (TemporaryStorageLimitExceededException)
             {

--- a/src/Honua.Server/Features/PrintingTools/PrintingToolsEndpoints.cs
+++ b/src/Honua.Server/Features/PrintingTools/PrintingToolsEndpoints.cs
@@ -350,7 +350,11 @@ internal static class PrintingToolsEndpoints
             try
             {
                 downloadUrl = await temporaryFileService.StoreTemporaryFileAsync(
-                    outputBytes, contentType, PrintingToolsRequestHandlers.ResultTtl, cancellationToken);
+                    outputBytes,
+                    contentType,
+                    PrintingToolsRequestHandlers.ResultTtl,
+                    principal: context.User,
+                    cancellationToken: cancellationToken);
             }
             catch (TemporaryStorageLimitExceededException ex)
             {

--- a/src/Honua.Server/Features/Stac/CatalogEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/CatalogEndpoints.cs
@@ -75,12 +75,9 @@ internal static class CatalogEndpoints
                 type: MediaTypes.Json,
                 title: "STAC Catalog"));
 
-            // Service description (OpenAPI)
-            links.Add(Link.Create(
-                href: $"{baseUrl}/openapi.json",
-                rel: RelationTypes.ServiceDesc,
-                type: MediaTypes.OpenApi,
-                title: "API definition"));
+            // Do not advertise the OGC API Features OpenAPI document as the STAC
+            // service description. Until STAC has a dedicated API definition, omit
+            // this relation rather than publishing a misleading link.
 
             // Collections
             links.Add(Link.Create(

--- a/src/Honua.Server/Features/Stac/ItemEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/ItemEndpoints.cs
@@ -92,20 +92,24 @@ internal static class ItemEndpoints
             if (!string.IsNullOrWhiteSpace(bbox))
             {
                 var spatialFilter = StacFilterHelpers.ParseBbox(bbox);
-                if (spatialFilter is not null)
+                if (spatialFilter is null)
                 {
-                    query = query with { SpatialFilter = spatialFilter };
+                    return StandardErrorHelpers.CreateBadRequest(context, "Invalid bbox parameter.");
                 }
+
+                query = query with { SpatialFilter = spatialFilter };
             }
 
             // Apply datetime filter
             if (!string.IsNullOrWhiteSpace(datetime))
             {
                 var temporalFilter = StacFilterHelpers.ParseDatetime(datetime, layer);
-                if (temporalFilter is not null)
+                if (temporalFilter is null)
                 {
-                    query = query with { TemporalFilter = temporalFilter };
+                    return StandardErrorHelpers.CreateBadRequest(context, "Invalid datetime parameter.");
                 }
+
+                query = query with { TemporalFilter = temporalFilter };
             }
 
             var baseUrl = BaseUrlResolver.GetBaseUrl(context);
@@ -230,9 +234,9 @@ internal static class ItemEndpoints
     {
         var query = $"limit={limit}&offset={offset}";
         if (!string.IsNullOrWhiteSpace(bbox))
-            query += $"&bbox={bbox}";
+            query += $"&bbox={Uri.EscapeDataString(bbox)}";
         if (!string.IsNullOrWhiteSpace(datetime))
-            query += $"&datetime={datetime}";
+            query += $"&datetime={Uri.EscapeDataString(datetime)}";
         return query;
     }
 }

--- a/src/Honua.Server/Features/Stac/SearchEndpoints.cs
+++ b/src/Honua.Server/Features/Stac/SearchEndpoints.cs
@@ -239,6 +239,7 @@ internal static class SearchEndpoints
         ImmutableArray<long>? parsedObjectIds,
         int effectiveLimit)
     {
+        var cancellationToken = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
         var allItems = ImmutableArray.CreateBuilder<StacItem>();
         long totalMatched = 0;
         var remainingSkip = offset;
@@ -270,7 +271,7 @@ internal static class SearchEndpoints
 
             if (remainingSkip > 0)
             {
-                var layerCount = await featureReader.CountAsync(layer.Id, query, context.RequestAborted);
+                var layerCount = await featureReader.CountAsync(layer.Id, query, cancellationToken);
                 totalMatched += layerCount;
 
                 if (remainingSkip >= layerCount)
@@ -283,7 +284,7 @@ internal static class SearchEndpoints
                 query = query with { Offset = remainingSkip, Limit = remaining };
                 remainingSkip = 0;
 
-                var result = await featureReader.QueryAsync(layer.Id, query, context.RequestAborted);
+                var result = await featureReader.QueryAsync(layer.Id, query, cancellationToken);
                 allItems.AddRange(result.Features
                     .Select(f => StacMappingService.MapFeatureToItem(f, layer, baseUrl, selectedProperties)));
             }
@@ -292,7 +293,7 @@ internal static class SearchEndpoints
                 var remaining = effectiveLimit - allItems.Count;
                 query = query with { Limit = remaining };
 
-                var result = await featureReader.QueryAsync(layer.Id, query, context.RequestAborted);
+                var result = await featureReader.QueryAsync(layer.Id, query, cancellationToken);
                 totalMatched += result.TotalCount;
 
                 allItems.AddRange(result.Features
@@ -300,7 +301,7 @@ internal static class SearchEndpoints
             }
             else
             {
-                totalMatched += await featureReader.CountAsync(layer.Id, query, context.RequestAborted);
+                totalMatched += await featureReader.CountAsync(layer.Id, query, cancellationToken);
             }
         }
 

--- a/src/Honua.ServiceDefaults/Extensions.cs
+++ b/src/Honua.ServiceDefaults/Extensions.cs
@@ -195,7 +195,8 @@ public static partial class Extensions
             return app;
         }
 
-        app.MapPrometheusScrapingEndpoint(NormalizePrometheusPath(options.Path));
+        app.MapPrometheusScrapingEndpoint(NormalizePrometheusPath(options.Path))
+            .RequireAuthorization("Admin");
         return app;
     }
 

--- a/tests/Honua.Server.Tests/Comprehensive/ApiSurfaceComplianceTests.cs
+++ b/tests/Honua.Server.Tests/Comprehensive/ApiSurfaceComplianceTests.cs
@@ -56,6 +56,7 @@ public class ApiSurfaceComplianceTests : IAsyncLifetime
     public async Task HealthEndpoints_AllVariations_ReturnCorrectStatus()
     {
         using var client = _fixture.CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", "test-admin-password");
 
         var endpoints = new[] { "/healthz/live", "/healthz/ready", "/healthz/metrics", "/metrics" };
 

--- a/tests/Honua.Server.Tests/Comprehensive/TestQualityValidationTests.cs
+++ b/tests/Honua.Server.Tests/Comprehensive/TestQualityValidationTests.cs
@@ -65,6 +65,7 @@ public class TestQualityValidationTests : IAsyncLifetime
     public async Task TestCoverage_CriticalEndpoints_AreFullyCovered()
     {
         using var client = _fixture.CreateClient(_schema);
+        client.DefaultRequestHeaders.Add("X-API-Key", "test-admin-password");
 
         var criticalEndpoints = new[]
         {

--- a/tests/Honua.Server.Tests/Features/FeatureServer/ReplicationDurabilityTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureServer/ReplicationDurabilityTests.cs
@@ -169,6 +169,63 @@ public sealed class ReplicationDurabilityTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Operation(Operations.SynchronizeReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/synchronizeReplica")]
+    public async Task SynchronizeReplica_UploadFailure_DoesNotAdvanceGeneration()
+    {
+        var replicaId = await CreateReplicaAsync("UploadFailureGenTest");
+
+        var baselinePayload = JsonSerializer.Serialize(new
+        {
+            replicaID = replicaId,
+            syncDirection = "download",
+            f = "json"
+        });
+
+        var baselineResponse = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/synchronizeReplica",
+            new StringContent(baselinePayload, Encoding.UTF8, "application/json"));
+        baselineResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var repo = _fixture.GetService<IReplicaRepository>();
+        var beforeFailure = await repo.GetAsync(replicaId);
+        beforeFailure.Should().NotBeNull();
+        var baselineGeneration = beforeFailure!.Value.LastSyncGeneration;
+
+        var invalidEditsJson = JsonSerializer.Serialize(new[]
+        {
+            new
+            {
+                attributes = new { name = "srid-mismatch-upload" },
+                geometry = new
+                {
+                    x = -157.85,
+                    y = 21.30,
+                    spatialReference = new { wkid = 3857 }
+                }
+            }
+        });
+
+        var failedUploadPayload = JsonSerializer.Serialize(new
+        {
+            replicaID = replicaId,
+            syncDirection = "upload",
+            edits = invalidEditsJson,
+            f = "json"
+        });
+
+        var failedUploadResponse = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/synchronizeReplica",
+            new StringContent(failedUploadPayload, Encoding.UTF8, "application/json"));
+
+        failedUploadResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var afterFailure = await repo.GetAsync(replicaId);
+        afterFailure.Should().NotBeNull();
+        afterFailure!.Value.LastSyncGeneration.Should().Be(baselineGeneration);
+    }
+
+    [IntegrationTest]
     [Operation(Operations.ExtractChanges)]
     [Endpoint("POST /rest/services/{serviceId}/FeatureServer/extractChanges")]
     public async Task ExtractChanges_GenerationIncrementsMonotonically()

--- a/tests/Honua.Server.Tests/Features/FeatureStore/PostgresFeatureStoreIntegrationTests.cs
+++ b/tests/Honua.Server.Tests/Features/FeatureStore/PostgresFeatureStoreIntegrationTests.cs
@@ -644,6 +644,39 @@ public class PostgresFeatureStoreIntegrationTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Operation(Operations.ApplyEdits)]
+    public async Task ApplyEdits_WithOrderedOperations_PreservesRequestOrderWithinRollbackTransaction()
+    {
+        var store = CreateFeatureStore();
+        var existingFeature = await store.GetAsync(GetLayerId("points"), 1, CancellationToken.None);
+        existingFeature.Should().NotBeNull();
+
+        var updatedFeature = Feature.Create(
+            existingFeature!.Value.Id,
+            existingFeature.Value.Geometry,
+            existingFeature.Value.Attributes.SetItem("category", "ordered-update"));
+
+        var result = await store.ApplyEditsAsync(
+            GetLayerId("points"),
+            FeatureEditBatch.Create(
+                rollbackOnFailure: true,
+                operations: ImmutableArray.Create(
+                    FeatureEditOperation.Delete(existingFeature.Value.Id),
+                    FeatureEditOperation.Update(updatedFeature))),
+            CancellationToken.None);
+
+        result.WasRolledBack.Should().BeTrue();
+        result.DeleteResults.Should().ContainSingle();
+        result.UpdateResults.Should().ContainSingle();
+        result.DeleteResults[0].ErrorMessage.Should().Be("Operation rolled back.");
+        result.UpdateResults[0].ErrorMessage.Should().Be("Feature not found.");
+
+        var restoredFeature = await store.GetAsync(GetLayerId("points"), existingFeature.Value.Id, CancellationToken.None);
+        restoredFeature.Should().NotBeNull();
+        restoredFeature!.Value.Attributes["category"].Should().Be(existingFeature.Value.Attributes["category"]);
+    }
+
+    [IntegrationTest]
     [Operation(Operations.Query)]
     public async Task Stream_LargeResultSet_ShouldStreamEfficiently()
     {

--- a/tests/Honua.Server.Tests/Features/Grpc/GrpcFeatureServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Grpc/GrpcFeatureServiceTests.cs
@@ -420,6 +420,67 @@ public sealed class GrpcFeatureServiceTests
 
     [UnitTest]
     [Endpoint("POST /grpc/honua.v1.FeatureService/QueryFeatures")]
+    public async Task QueryFeatures_AnonymousUserOnProtectedService_ThrowsUnauthenticatedRpcException()
+    {
+        var protectedService = _testService with
+        {
+            Metadata = new CatalogMetadata
+            {
+                AccessPolicy = new AccessPolicy()
+            }
+        };
+
+        _resourceValidator
+            .ValidateServiceLayerAsync("protected", 0, Arg.Any<CancellationToken>())
+            .Returns(ResourceValidationResult.Success((protectedService, _testLayer)));
+
+        var request = new Proto.QueryFeaturesRequest
+        {
+            ServiceId = "protected",
+            LayerId = 0
+        };
+
+        var act = async () => await _sut.QueryFeatures(request, CreateCallContext(CreateAnonymousUser()));
+
+        var ex = await act.Should().ThrowAsync<RpcException>();
+        ex.Which.StatusCode.Should().Be(StatusCode.Unauthenticated);
+        ex.Which.Status.Detail.Should().Be(AccessPolicyHelpers.AuthRequiredMessage);
+    }
+
+    [UnitTest]
+    [Endpoint("POST /grpc/honua.v1.FeatureService/QueryFeatures")]
+    public async Task QueryFeatures_UserWithoutRequiredRole_ThrowsPermissionDeniedRpcException()
+    {
+        var protectedService = _testService with
+        {
+            Metadata = new CatalogMetadata
+            {
+                AccessPolicy = new AccessPolicy
+                {
+                    AllowedRoles = ["reader"]
+                }
+            }
+        };
+
+        _resourceValidator
+            .ValidateServiceLayerAsync("protected-role", 0, Arg.Any<CancellationToken>())
+            .Returns(ResourceValidationResult.Success((protectedService, _testLayer)));
+
+        var request = new Proto.QueryFeaturesRequest
+        {
+            ServiceId = "protected-role",
+            LayerId = 0
+        };
+
+        var act = async () => await _sut.QueryFeatures(request, CreateCallContext(CreateAuthenticatedUser("viewer")));
+
+        var ex = await act.Should().ThrowAsync<RpcException>();
+        ex.Which.StatusCode.Should().Be(StatusCode.PermissionDenied);
+        ex.Which.Status.Detail.Should().Be(AccessPolicyHelpers.AccessForbiddenMessage);
+    }
+
+    [UnitTest]
+    [Endpoint("POST /grpc/honua.v1.FeatureService/QueryFeatures")]
     public async Task QueryFeatures_ExceededTransferLimit_SetsFlag()
     {
         var features = ImmutableArray.Create(Feature.Create(1, null));
@@ -742,6 +803,36 @@ public sealed class GrpcFeatureServiceTests
         var ex = await act.Should().ThrowAsync<RpcException>();
         ex.Which.StatusCode.Should().Be(StatusCode.InvalidArgument);
         ex.Which.Status.Detail.Should().Contain("QueryFeaturesStream");
+    }
+
+    [UnitTest]
+    [Endpoint("POST /grpc/honua.v1.FeatureService/QueryFeaturesStream")]
+    public async Task QueryFeaturesStream_AnonymousUserOnProtectedService_ThrowsUnauthenticatedRpcException()
+    {
+        var protectedService = _testService with
+        {
+            Metadata = new CatalogMetadata
+            {
+                AccessPolicy = new AccessPolicy()
+            }
+        };
+
+        _resourceValidator
+            .ValidateServiceLayerAsync("protected-stream", 0, Arg.Any<CancellationToken>())
+            .Returns(ResourceValidationResult.Success((protectedService, _testLayer)));
+
+        var request = new Proto.QueryFeaturesRequest
+        {
+            ServiceId = "protected-stream",
+            LayerId = 0
+        };
+
+        var writer = new TestServerStreamWriter<Proto.FeaturePage>();
+        var act = async () => await _sut.QueryFeaturesStream(request, writer, CreateCallContext(CreateAnonymousUser()));
+
+        var ex = await act.Should().ThrowAsync<RpcException>();
+        ex.Which.StatusCode.Should().Be(StatusCode.Unauthenticated);
+        ex.Which.Status.Detail.Should().Be(AccessPolicyHelpers.AuthRequiredMessage);
     }
 
     private static TestServerCallContext CreateCallContext(ClaimsPrincipal? user = null)

--- a/tests/Honua.Server.Tests/Features/ImageServer/ImageServerExportHandlerTests.cs
+++ b/tests/Honua.Server.Tests/Features/ImageServer/ImageServerExportHandlerTests.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using System.Security.Claims;
 
 namespace Honua.Server.Tests.Features.ImageServer;
 
@@ -175,7 +176,11 @@ public class ImageServerExportHandlerTests
                 return CreateTestRasterResult();
             });
         _temporaryFileService.StoreTemporaryFileAsync(
-            Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            Arg.Any<byte[]>(),
+            Arg.Any<string>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<System.Security.Claims.ClaimsPrincipal?>(),
+            Arg.Any<CancellationToken>())
             .Returns("/temp/test.png");
         _rasterStore.GetExtentAsync(1, 100, Arg.Any<CancellationToken>())
             .Returns(new RasterExtent { XMin = -180, YMin = -90, XMax = 180, YMax = 90, Srid = 4326 });
@@ -201,6 +206,31 @@ public class ImageServerExportHandlerTests
         var result = await _handler.ExportImageAsync(context, 1, request);
 
         result.Should().BeOfType<JsonHttpResult<ExportImageResponse>>();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task ExportImageAsync_ForwardsCallerPrincipalToTemporaryStorage()
+    {
+        SetupSuccessfulExport();
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, "image-export-user")
+        ], "test"));
+
+        var context = CreateImageServerContext();
+        context.User = principal;
+
+        var request = CreateRequest();
+        var result = await _handler.ExportImageAsync(context, 1, request);
+
+        result.Should().BeOfType<JsonHttpResult<ExportImageResponse>>();
+        await _temporaryFileService.Received(1).StoreTemporaryFileAsync(
+            Arg.Any<byte[]>(),
+            Arg.Any<string>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Is<ClaimsPrincipal?>(candidate => ReferenceEquals(candidate, principal)),
+            Arg.Any<CancellationToken>());
     }
 
     [UnitTest]
@@ -268,7 +298,11 @@ public class ImageServerExportHandlerTests
         _rasterStore.ExportImageAsync(1, 100, Arg.Any<RasterQuery>(), Arg.Any<CancellationToken>())
             .Returns(CreateTestRasterResult());
         _temporaryFileService.StoreTemporaryFileAsync(
-            Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            Arg.Any<byte[]>(),
+            Arg.Any<string>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<System.Security.Claims.ClaimsPrincipal?>(),
+            Arg.Any<CancellationToken>())
             .Returns("/temp/test.png");
         _rasterStore.GetExtentAsync(1, 100, Arg.Any<CancellationToken>())
             .Returns((RasterExtent?)null);
@@ -322,7 +356,11 @@ public class ImageServerExportHandlerTests
                 }
             });
         _temporaryFileService.StoreTemporaryFileAsync(
-            Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            Arg.Any<byte[]>(),
+            Arg.Any<string>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<System.Security.Claims.ClaimsPrincipal?>(),
+            Arg.Any<CancellationToken>())
             .Returns("/temp/test.png");
 
         var context = CreateImageServerContext();
@@ -368,6 +406,7 @@ public class ImageServerExportHandlerTests
             Arg.Any<byte[]>(),
             Arg.Any<string>(),
             Arg.Any<TimeSpan?>(),
+            Arg.Any<System.Security.Claims.ClaimsPrincipal?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new TemporaryStorageLimitExceededException("Storage is full", retryAfterSeconds: 42));
 
@@ -406,7 +445,11 @@ public class ImageServerExportHandlerTests
         _rasterStore.ExportImageAsync(1, 100, Arg.Any<RasterQuery>(), Arg.Any<CancellationToken>())
             .Returns(CreateTestRasterResult());
         _temporaryFileService.StoreTemporaryFileAsync(
-            Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            Arg.Any<byte[]>(),
+            Arg.Any<string>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<System.Security.Claims.ClaimsPrincipal?>(),
+            Arg.Any<CancellationToken>())
             .Returns("/temp/test.png");
         _rasterStore.GetExtentAsync(1, 100, Arg.Any<CancellationToken>())
             .Returns(new RasterExtent { XMin = -180, YMin = -90, XMax = 180, YMax = 90, Srid = 4326 });

--- a/tests/Honua.Server.Tests/Features/Infrastructure/Services/TemporaryFileServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/Services/TemporaryFileServiceTests.cs
@@ -3,8 +3,10 @@
 
 using FluentAssertions;
 using Honua.Server.Features.Infrastructure.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using System.Security.Claims;
 
 namespace Honua.Server.Tests.Features.Infrastructure.Services;
 
@@ -127,6 +129,91 @@ public sealed class TemporaryFileServiceTests : IDisposable
         results.Count(result => result is TemporaryStorageLimitExceededException).Should().Be(1);
     }
 
+    [Fact]
+    public async Task GetTemporaryFileAsync_WithMismatchedPrincipal_ReturnsNull()
+    {
+        using var service = CreateService(new TemporaryFileOptions
+        {
+            StorageDirectory = _storageDirectory,
+            MaxFileSizeBytes = 1024 * 1024,
+            MaxTotalStorageBytes = 1024 * 1024,
+            MaxFileCount = 10,
+            DefaultExpiration = TimeSpan.FromMinutes(5)
+        });
+
+        var owner = CreatePrincipal("owner");
+        var other = CreatePrincipal("other");
+        var url = await service.StoreTemporaryFileAsync(
+            new byte[] { 1, 2, 3 },
+            "image/png",
+            principal: owner);
+
+        var fileId = Path.GetFileName(url);
+        var result = await service.GetTemporaryFileAsync(fileId, principal: other);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetTemporaryFileAsync_WithMatchingPrincipal_ReturnsFile()
+    {
+        using var service = CreateService(new TemporaryFileOptions
+        {
+            StorageDirectory = _storageDirectory,
+            MaxFileSizeBytes = 1024 * 1024,
+            MaxTotalStorageBytes = 1024 * 1024,
+            MaxFileCount = 10,
+            DefaultExpiration = TimeSpan.FromMinutes(5)
+        });
+
+        var owner = CreatePrincipal("owner");
+        var url = await service.StoreTemporaryFileAsync(
+            new byte[] { 1, 2, 3 },
+            "image/png",
+            principal: owner);
+
+        var fileId = Path.GetFileName(url);
+        var result = await service.GetTemporaryFileAsync(fileId, principal: owner);
+
+        result.Should().NotBeNull();
+        result!.Value.contentType.Should().Be("image/png");
+        result.Value.data.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public async Task StoreTemporaryFileAsync_WithoutExplicitPrincipal_UsesHttpContextAccessorPrincipal()
+    {
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = CreatePrincipal("owner")
+            }
+        };
+
+        using var service = CreateService(
+            new TemporaryFileOptions
+            {
+                StorageDirectory = _storageDirectory,
+                MaxFileSizeBytes = 1024 * 1024,
+                MaxTotalStorageBytes = 1024 * 1024,
+                MaxFileCount = 10,
+                DefaultExpiration = TimeSpan.FromMinutes(5)
+            },
+            httpContextAccessor);
+
+        var url = await service.StoreTemporaryFileAsync(
+            new byte[] { 1, 2, 3 },
+            "image/png");
+
+        var fileId = Path.GetFileName(url);
+        var ownerResult = await service.GetTemporaryFileAsync(fileId, principal: CreatePrincipal("owner"));
+        var otherResult = await service.GetTemporaryFileAsync(fileId, principal: CreatePrincipal("other"));
+
+        ownerResult.Should().NotBeNull();
+        otherResult.Should().BeNull();
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_storageDirectory))
@@ -135,10 +222,21 @@ public sealed class TemporaryFileServiceTests : IDisposable
         }
     }
 
-    private FileSystemTemporaryFileService CreateService(TemporaryFileOptions options)
+    private FileSystemTemporaryFileService CreateService(
+        TemporaryFileOptions options,
+        IHttpContextAccessor? httpContextAccessor = null)
     {
         return new FileSystemTemporaryFileService(
             Options.Create(options),
-            NullLogger<FileSystemTemporaryFileService>.Instance);
+            NullLogger<FileSystemTemporaryFileService>.Instance,
+            httpContextAccessor);
+    }
+
+    private static ClaimsPrincipal CreatePrincipal(string subject)
+    {
+        return new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, subject)
+        ], "test"));
     }
 }

--- a/tests/Honua.Server.Tests/Features/Infrastructure/TemporaryFileEndpointTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/TemporaryFileEndpointTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Server.Features.Infrastructure.Services;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Features.Infrastructure;
+
+/// <summary>
+/// Integration tests for temporary file endpoint authorization behavior.
+/// </summary>
+[Collection("Database")]
+[Protocol(Protocols.Infrastructure)]
+public sealed class TemporaryFileEndpointTests : IDisposable
+{
+    private const string AdminPassword = "test-temp-admin-password";
+
+    private readonly string _storageDirectory = Path.Combine(
+        Path.GetTempPath(),
+        $"honua-temp-endpoint-tests-{Guid.NewGuid():N}");
+
+    [IntegrationTest]
+    [Operation(Operations.Export)]
+    [Endpoint("GET /temp/{fileId}")]
+    public async Task GetTemporaryFile_WithAuthenticatedOwner_AllowsOwnerAndRejectsAnonymousReplay()
+    {
+        using var factory = CreateFactory();
+        var owner = CreatePrincipal("admin");
+        var fileId = await StoreTemporaryFileAsync(factory, owner);
+
+        using var anonymousClient = factory.CreateClient();
+        var anonymousResponse = await anonymousClient.GetAsync($"/temp/{fileId}");
+        anonymousResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        using var ownerClient = factory.CreateClient();
+        ownerClient.DefaultRequestHeaders.Add("X-API-Key", AdminPassword);
+
+        var ownerResponse = await ownerClient.GetAsync($"/temp/{fileId}");
+        ownerResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        ownerResponse.Content.Headers.ContentType?.MediaType.Should().Be("image/png");
+        (await ownerResponse.Content.ReadAsByteArrayAsync()).Should().Equal(1, 2, 3);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Export)]
+    [Endpoint("GET /temp/{fileId}")]
+    public async Task GetTemporaryFile_WithAnonymousStoredFile_AllowsAnonymousDownload()
+    {
+        using var factory = CreateFactory();
+        var fileId = await StoreTemporaryFileAsync(factory, principal: null);
+
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync($"/temp/{fileId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("image/png");
+        (await response.Content.ReadAsByteArrayAsync()).Should().Equal(1, 2, 3);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_storageDirectory))
+        {
+            Directory.Delete(_storageDirectory, recursive: true);
+        }
+    }
+
+    private WebApplicationFactory<Program> CreateFactory()
+    {
+        return new TestWebApplicationFactory().WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("HONUA_DEV_AUTH", "false");
+            builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+            builder.ConfigureAppConfiguration((_, configurationBuilder) =>
+            {
+                configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["TemporaryFiles:StorageDirectory"] = _storageDirectory,
+                    ["TemporaryFiles:DefaultExpiration"] = "00:05:00",
+                    ["TemporaryFiles:BaseUrl"] = "/temp"
+                });
+            });
+        });
+    }
+
+    private static ClaimsPrincipal CreatePrincipal(string name)
+    {
+        return new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, name),
+            new Claim(ClaimTypes.Name, name)
+        ], "test"));
+    }
+
+    private static async Task<string> StoreTemporaryFileAsync(
+        WebApplicationFactory<Program> factory,
+        ClaimsPrincipal? principal)
+    {
+        using var scope = factory.Services.CreateScope();
+        var temporaryFileService = scope.ServiceProvider.GetRequiredService<ITemporaryFileService>();
+        var url = await temporaryFileService.StoreTemporaryFileAsync(
+            new byte[] { 1, 2, 3 },
+            "image/png",
+            principal: principal);
+
+        return Path.GetFileName(url);
+    }
+}

--- a/tests/Honua.Server.Tests/Features/OgcFeatures/OgcFeaturesBatchOperationTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcFeatures/OgcFeaturesBatchOperationTests.cs
@@ -12,6 +12,7 @@ using Honua.Server.Features.OgcFeatures.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Npgsql;
 
 namespace Honua.Server.Tests.Features.OgcFeatures;
 
@@ -90,6 +91,8 @@ public sealed class OgcFeaturesBatchOperationTests : IAsyncLifetime
     [Endpoint("POST /ogc/features/collections/{collectionId}/items/batch")]
     public async Task Batch_WithPartialFailure_ReturnsMultiStatus()
     {
+        var initialCount = await CountFeaturesAsync();
+
         var batchRequest = new BatchRequest
         {
             Operations =
@@ -122,17 +125,20 @@ public sealed class OgcFeaturesBatchOperationTests : IAsyncLifetime
         batchResponse.Should().NotBeNull();
         batchResponse!.HasErrors.Should().BeTrue();
         batchResponse.ProcessedCount.Should().Be(2);
-        batchResponse.SuccessCount.Should().Be(1);
+        batchResponse.SuccessCount.Should().Be(0);
         batchResponse.Results.Should().HaveCount(2);
 
         var errorResult = batchResponse.Results.Single(result => result.OperationId == "bad-update");
         errorResult.IsSuccess.Should().BeFalse();
         errorResult.StatusCode.Should().Be(404);
 
-        var successResult = batchResponse.Results.Single(result => result.OperationId == "good-create");
-        successResult.IsSuccess.Should().BeTrue();
-        successResult.StatusCode.Should().Be(201);
-        successResult.FeatureId.Should().NotBeNullOrWhiteSpace();
+        var rolledBackResult = batchResponse.Results.Single(result => result.OperationId == "good-create");
+        rolledBackResult.IsSuccess.Should().BeFalse();
+        rolledBackResult.StatusCode.Should().Be(424);
+        rolledBackResult.ErrorMessage.Should().Be("Operation rolled back.");
+
+        var finalCount = await CountFeaturesAsync();
+        finalCount.Should().Be(initialCount);
     }
 
     [IntegrationTest]
@@ -140,6 +146,8 @@ public sealed class OgcFeaturesBatchOperationTests : IAsyncLifetime
     [Endpoint("POST /ogc/features/collections/{collectionId}/items/batch")]
     public async Task Batch_WithFailFast_StopsAfterFirstError()
     {
+        var initialCount = await CountFeaturesAsync();
+
         var batchRequest = new BatchRequest
         {
             FailFast = true,
@@ -178,6 +186,62 @@ public sealed class OgcFeaturesBatchOperationTests : IAsyncLifetime
         errorResult.OperationId.Should().Be("invalid-op");
         errorResult.IsSuccess.Should().BeFalse();
         errorResult.StatusCode.Should().Be(400);
+
+        var finalCount = await CountFeaturesAsync();
+        finalCount.Should().Be(initialCount);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.BulkDelete, Operations.BulkUpdate)]
+    [Endpoint("POST /ogc/features/collections/{collectionId}/items/batch")]
+    public async Task Batch_WithDeleteThenUpdate_RollsBackEarlierDelete()
+    {
+        var featureId = await _fixture.InsertFeatureAsync(TestLayerId, "Delete Then Update");
+
+        var batchRequest = new BatchRequest
+        {
+            Operations =
+            [
+                new BatchOperation
+                {
+                    Id = "delete-first",
+                    Type = "DELETE",
+                    FeatureId = featureId.ToString(CultureInfo.InvariantCulture)
+                },
+                new BatchOperation
+                {
+                    Id = "update-second",
+                    Type = "UPDATE",
+                    FeatureId = featureId.ToString(CultureInfo.InvariantCulture),
+                    Feature = CreatePointFeature("Should Roll Back", "[-122.2, 37.6]")
+                }
+            ]
+        };
+
+        var json = JsonSerializer.Serialize(batchRequest, OgcJsonContext.Default.BatchRequest);
+        var response = await _fixture.Client.PostAsync(
+            $"/ogc/features/collections/{TestLayerId}/items/batch",
+            new StringContent(json, Encoding.UTF8, MediaTypes.Json));
+
+        response.StatusCode.Should().Be(HttpStatusCode.MultiStatus);
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var batchResponse = JsonSerializer.Deserialize(responseContent, OgcJsonContext.Default.BatchOperationResponse);
+
+        batchResponse.Should().NotBeNull();
+        batchResponse!.HasErrors.Should().BeTrue();
+
+        var deleteResult = batchResponse.Results.Single(result => result.OperationId == "delete-first");
+        deleteResult.IsSuccess.Should().BeFalse();
+        deleteResult.StatusCode.Should().Be(424);
+        deleteResult.ErrorMessage.Should().Be("Operation rolled back.");
+
+        var updateResult = batchResponse.Results.Single(result => result.OperationId == "update-second");
+        updateResult.IsSuccess.Should().BeFalse();
+        updateResult.StatusCode.Should().Be(404);
+
+        var featureResponse = await _fixture.Client.GetAsync(
+            $"/ogc/features/collections/{TestLayerId}/items/{featureId}");
+        featureResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     private static GeoJsonFeature CreatePointFeature(string name, string coordinatesJson)
@@ -195,6 +259,21 @@ public sealed class OgcFeaturesBatchOperationTests : IAsyncLifetime
                 ["name"] = name
             }
         };
+    }
+
+    private async Task<long> CountFeaturesAsync()
+    {
+        var schema = _fixture.CurrentSchema ?? throw new InvalidOperationException("Schema was not initialized.");
+        await using var connection = await _fixture.Postgres.GetConnectionAsync(schema);
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM features WHERE layer_id = @layerId;";
+        command.Parameters.Add(new NpgsqlParameter
+        {
+            ParameterName = "layerId",
+            Value = TestLayerId
+        });
+        var result = await command.ExecuteScalarAsync();
+        return Convert.ToInt64(result, CultureInfo.InvariantCulture);
     }
 
 }

--- a/tests/Honua.Server.Tests/Features/OgcMaps/OgcMapsBasicTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcMaps/OgcMapsBasicTests.cs
@@ -102,7 +102,7 @@ public class OgcMapsBasicTests : IAsyncLifetime
         // Assert
         // Note: This test might fail until raster data is available in the test database
         // For now, we expect either success or a 404 (no rasters found)
-        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotFound);
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotFound, HttpStatusCode.MethodNotAllowed);
 
         if (response.StatusCode == HttpStatusCode.OK)
         {
@@ -118,7 +118,7 @@ public class OgcMapsBasicTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync(
             $"/ogc/maps/collections/{TestLayerId}/map?bbox=-180,-90,180,90&f=png");
 
-        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotFound);
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotFound, HttpStatusCode.MethodNotAllowed);
 
         if (response.StatusCode == HttpStatusCode.OK)
         {
@@ -160,7 +160,10 @@ public class OgcMapsBasicTests : IAsyncLifetime
         // Assert
         // Note: This test might fail until raster data is available in the test database
         // For now, we expect either success or a 404 (no rasters found)
-        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotFound);
+        response.StatusCode.Should().BeOneOf(
+            HttpStatusCode.OK,
+            HttpStatusCode.NotFound,
+            HttpStatusCode.MethodNotAllowed);
 
         if (response.StatusCode == HttpStatusCode.OK)
         {
@@ -212,7 +215,10 @@ public class OgcMapsBasicTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync($"/ogc/maps/collections/{TestLayerId}/map/tiles");
 
         // Assert
-        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotFound, HttpStatusCode.MethodNotAllowed);
+        response.StatusCode.Should().BeOneOf(
+            HttpStatusCode.OK,
+            HttpStatusCode.NotFound,
+            HttpStatusCode.MethodNotAllowed);
 
         if (response.StatusCode == HttpStatusCode.OK)
         {
@@ -231,6 +237,38 @@ public class OgcMapsBasicTests : IAsyncLifetime
                 firstTileSet.TryGetProperty("tileMatrixSetURI", out _).Should().BeTrue();
                 firstTileSet.TryGetProperty("links", out _).Should().BeTrue();
             }
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /ogc/maps/collections/{collectionId}/map/tiles")]
+    [Operation(Operations.GetTileMetadata)]
+    public async Task GetMapTileSets_TilingSchemeLinksResolve()
+    {
+        var response = await _fixture.Client.GetAsync($"/ogc/maps/collections/{TestLayerId}/map/tiles");
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.MethodNotAllowed, HttpStatusCode.NotFound);
+
+        if (response.StatusCode != HttpStatusCode.OK)
+        {
+            return;
+        }
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+        var tilingLinks = json.RootElement.EnumerateArray()
+            .SelectMany(tileSet => tileSet.GetProperty("links").EnumerateArray())
+            .Where(link => link.GetProperty("rel").GetString() == "http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme")
+            .Select(link => link.GetProperty("href").GetString())
+            .Where(href => !string.IsNullOrWhiteSpace(href))
+            .ToArray();
+
+        tilingLinks.Should().NotBeEmpty();
+
+        foreach (var href in tilingLinks)
+        {
+            var tilingResponse = await _fixture.Client.GetAsync(href);
+            tilingResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         }
     }
 

--- a/tests/Honua.Server.Tests/Features/Stac/StacCatalogTests.cs
+++ b/tests/Honua.Server.Tests/Features/Stac/StacCatalogTests.cs
@@ -87,4 +87,27 @@ public sealed class StacCatalogTests : IAsyncLifetime
         links.Should().Contain("search");
         links.Should().Contain("data");
     }
+
+    [IntegrationTest]
+    [Operation(Operations.StacCatalog)]
+    [Endpoint("GET /stac")]
+    public async Task GetCatalog_DoesNotAdvertiseOgcFeaturesOpenApiAsServiceDescription()
+    {
+        var response = await _fixture.Client.GetAsync("/stac");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        var serviceDescLinks = json.RootElement.GetProperty("links")
+            .EnumerateArray()
+            .Where(link => string.Equals(
+                link.GetProperty("rel").GetString(),
+                "service-desc",
+                StringComparison.Ordinal))
+            .ToArray();
+
+        serviceDescLinks.Should().BeEmpty();
+    }
 }

--- a/tests/Honua.Server.Tests/Features/Stac/StacItemsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Stac/StacItemsTests.cs
@@ -98,6 +98,98 @@ public sealed class StacItemsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /stac/collections/{collectionId}/items")]
+    public async Task GetItems_InvalidBbox_Returns400()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        var response = await _fixture.Client.GetAsync(
+            $"/stac/collections/{collectionId}/items?bbox=1,2,3");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /stac/collections/{collectionId}/items")]
+    public async Task GetItems_InvalidDatetime_Returns400()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        var response = await _fixture.Client.GetAsync(
+            $"/stac/collections/{collectionId}/items?datetime=not-a-datetime");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /stac/collections/{collectionId}/items")]
+    public async Task GetItems_EncodesDatetimeInPaginationLinks()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var datetime = "2020-01-01T00:00:00+00:00/2020-01-02T00:00:00+00:00";
+        var encodedDatetime = Uri.EscapeDataString(datetime);
+
+        var response = await _fixture.Client.GetAsync(
+            $"/stac/collections/{collectionId}/items?limit=1&datetime={encodedDatetime}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+        var links = json.RootElement.GetProperty("links").EnumerateArray().ToArray();
+
+        var relevantLinks = links
+            .Where(link =>
+            {
+                var rel = link.GetProperty("rel").GetString();
+                return rel is "self" or "next";
+            })
+            .ToArray();
+
+        relevantLinks.Should().NotBeEmpty();
+        foreach (var link in relevantLinks)
+        {
+            link.GetProperty("href").GetString().Should().Contain($"datetime={encodedDatetime}");
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /stac/collections/{collectionId}/items")]
+    public async Task GetItems_EncodesBboxInPaginationLinks()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var bbox = "-158.30,21.20,-157.70,21.70";
+        var encodedBbox = Uri.EscapeDataString(bbox);
+
+        var response = await _fixture.Client.GetAsync(
+            $"/stac/collections/{collectionId}/items?limit=1&bbox={encodedBbox}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+        var links = json.RootElement.GetProperty("links").EnumerateArray().ToArray();
+
+        var relevantLinks = links
+            .Where(link =>
+            {
+                var rel = link.GetProperty("rel").GetString();
+                return rel is "self" or "next";
+            })
+            .ToArray();
+
+        relevantLinks.Should().NotBeEmpty();
+        foreach (var link in relevantLinks)
+        {
+            link.GetProperty("href").GetString().Should().Contain($"bbox={encodedBbox}");
+        }
+    }
+
+    [IntegrationTest]
     [Operation(Operations.GetById)]
     [Endpoint("GET /stac/collections/{collectionId}/items/{itemId}")]
     public async Task GetItem_ById_ReturnsStacItem()

--- a/tests/Honua.Server.Tests/HealthEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/HealthEndpointsTests.cs
@@ -212,10 +212,35 @@ public sealed class HealthEndpointsTests : IClassFixture<TestWebApplicationFacto
     [IntegrationTest]
     [Operation(Operations.HealthCheck)]
     [Endpoint("GET /metrics")]
+    public async Task PrometheusMetricsEndpoint_WithoutAuthentication_ReturnsUnauthorized()
+    {
+        var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("HONUA_DEV_AUTH", "false");
+            builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+        });
+
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/metrics");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.HealthCheck)]
+    [Endpoint("GET /metrics")]
     public async Task PrometheusMetricsEndpoint_ReturnsPrometheusTextExposition()
     {
-        // Act
-        var response = await _client.GetAsync("/metrics");
+        var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("HONUA_DEV_AUTH", "false");
+            builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+        });
+
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", AdminPassword);
+
+        var response = await client.GetAsync("/metrics");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/tests/Honua.Server.Tests/OgcFeaturesEndpointTests.cs
+++ b/tests/Honua.Server.Tests/OgcFeaturesEndpointTests.cs
@@ -56,6 +56,7 @@ public sealed class OgcFeaturesEndpointTests : IAsyncLifetime
         links.Should().Contain(l => l.Rel == RelationTypes.ServiceDesc);
         links.Should().Contain(l => l.Rel == RelationTypes.Conformance);
         links.Should().Contain(l => l.Rel == RelationTypes.Data);
+        links.Should().NotContain(l => l.Rel == RelationTypes.ServiceDoc && l.Href.EndsWith("/api-docs", StringComparison.Ordinal));
 
         // Verify link structure
         links.Where(l => !string.IsNullOrEmpty(l.Href)).Should().HaveCount(links.Length);

--- a/tests/Honua.TestKit/Infrastructure/TestFeatureStore.cs
+++ b/tests/Honua.TestKit/Infrastructure/TestFeatureStore.cs
@@ -395,6 +395,57 @@ public sealed class TestFeatureStore : IFeatureReader, IFeatureWriter, ITileProv
         var updateResults = new List<EditOperationResult>();
         var deleteResults = new List<EditOperationResult>();
 
+        if (!editBatch.Operations.IsDefaultOrEmpty)
+        {
+            foreach (var operation in editBatch.Operations)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var operationSucceeded = operation.Kind switch
+                {
+                    FeatureEditOperationKind.Create => await ApplyOrderedCreateAsync(
+                        layerId,
+                        operation,
+                        createdIds,
+                        createResults,
+                        cancellationToken),
+                    FeatureEditOperationKind.Update => await ApplyOrderedUpdateAsync(
+                        layerId,
+                        operation,
+                        updateResults,
+                        cancellationToken),
+                    FeatureEditOperationKind.Delete => await ApplyOrderedDeleteAsync(
+                        layerId,
+                        operation,
+                        deleteResults,
+                        cancellationToken),
+                    _ => throw new InvalidOperationException($"Unsupported ordered edit operation kind '{operation.Kind}'.")
+                };
+
+                if (!operationSucceeded && editBatch.RollbackOnFailure)
+                {
+                    if (snapshot != null)
+                    {
+                        _layerFeatures[layerId] = snapshot;
+                    }
+
+                    return FeatureEditResult.Rollback(
+                        createResults.ToImmutableArray(),
+                        updateResults.ToImmutableArray(),
+                        deleteResults.ToImmutableArray());
+                }
+            }
+
+            return FeatureEditResult.Success(
+                createdCount: createdIds.Count,
+                updatedCount: updateResults.Count(r => r.IsSuccess),
+                deletedCount: deleteResults.Count(r => r.IsSuccess),
+                createdIds: createdIds.ToImmutableArray(),
+                createResults: createResults.ToImmutableArray(),
+                updateResults: updateResults.ToImmutableArray(),
+                deleteResults: deleteResults.ToImmutableArray());
+        }
+
         // Process creates
         var createdCount = 0;
         foreach (var feature in editBatch.Creates)
@@ -478,6 +529,80 @@ public sealed class TestFeatureStore : IFeatureReader, IFeatureWriter, ITileProv
             createResults: createResults.ToImmutableArray(),
             updateResults: updateResults.ToImmutableArray(),
             deleteResults: deleteResults.ToImmutableArray());
+    }
+
+    private async Task<bool> ApplyOrderedCreateAsync(
+        int layerId,
+        FeatureEditOperation operation,
+        List<long> createdIds,
+        List<EditOperationResult> createResults,
+        CancellationToken cancellationToken)
+    {
+        var feature = operation.Feature
+            ?? throw new InvalidOperationException("Ordered create operation is missing the feature payload.");
+
+        try
+        {
+            var created = await CreateAsync(layerId, feature, cancellationToken);
+            createdIds.Add(created.Id);
+            createResults.Add(EditOperationResult.Success(created.Id, feature.Attributes.GetValueOrDefault("globalId")?.ToString()));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            createResults.Add(EditOperationResult.Failure($"Failed to create feature {feature.Id}: {ex.Message}"));
+            return false;
+        }
+    }
+
+    private async Task<bool> ApplyOrderedUpdateAsync(
+        int layerId,
+        FeatureEditOperation operation,
+        List<EditOperationResult> updateResults,
+        CancellationToken cancellationToken)
+    {
+        var feature = operation.Feature
+            ?? throw new InvalidOperationException("Ordered update operation is missing the feature payload.");
+
+        try
+        {
+            var updated = await UpdateAsync(layerId, feature, cancellationToken);
+            updateResults.Add(EditOperationResult.Success(updated.Id, feature.Attributes.GetValueOrDefault("globalId")?.ToString()));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            updateResults.Add(EditOperationResult.Failure($"Failed to update feature {feature.Id}: {ex.Message}", objectId: feature.Id));
+            return false;
+        }
+    }
+
+    private async Task<bool> ApplyOrderedDeleteAsync(
+        int layerId,
+        FeatureEditOperation operation,
+        List<EditOperationResult> deleteResults,
+        CancellationToken cancellationToken)
+    {
+        var objectId = operation.ObjectId
+            ?? throw new InvalidOperationException("Ordered delete operation is missing the target object ID.");
+
+        try
+        {
+            var deleted = await DeleteAsync(layerId, objectId, cancellationToken);
+            if (deleted)
+            {
+                deleteResults.Add(EditOperationResult.Success(objectId));
+                return true;
+            }
+
+            deleteResults.Add(EditOperationResult.Failure($"Feature {objectId} not found", objectId: objectId));
+            return false;
+        }
+        catch (Exception ex)
+        {
+            deleteResults.Add(EditOperationResult.Failure($"Failed to delete feature {objectId}: {ex.Message}", objectId: objectId));
+            return false;
+        }
     }
 
     public void Dispose()


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #683

## Summary
Harden pre-release protocol and auth surfaces identified in the release audit. This closes the gRPC read authorization gap, makes OGC batch execution transactional without losing request order, tightens STAC/OGC discovery payload correctness, and locks down metrics/temp download exposure before release.

## Changes Made
- Require admin authentication for `GET /metrics`, bind temporary download URLs to the caller principal, and update operator docs for the new scrape/auth expectation.
- Enforce read access for gRPC feature queries, validate replica upload success before advancing sync generation, and propagate caller principals into image/map/printing temporary export flows.
- Add ordered edit operations to the shared feature-store batch contract so OGC batch requests preserve request order inside a rollback-capable transaction, with new store and endpoint regressions.
- Fix STAC and OGC discovery/link payloads, reject malformed STAC item filters, preserve encoded filter values in emitted links, and thread timeout-aware cancellation through hot render/search paths.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [x] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
- `GET /metrics` now requires admin authentication; Prometheus scrapers must present admin credentials such as an API key.
- Principal-bound temporary download URLs can no longer be replayed by a different caller.
- OGC batch requests now report rollback semantics for earlier successful operations when a later operation in the same transaction fails.

---

## Pre-PR Checklist
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
