### PR TITLE
feat: implement WFS 2.0 transactions

### DIFF
--- a/docker/cite-scripts/execute-cite-tests.sh
+++ b/docker/cite-scripts/execute-cite-tests.sh
@@ -75,6 +75,7 @@ curl -sS --fail --retry 5 --retry-delay 2 --retry-all-errors -L \
     -o /tmp/teamengine-console-bin.zip \
     "$TEAMENGINE_CONSOLE_URL"
 unzip -q /tmp/teamengine-console-bin.zip -d /tmp/te-console
+unzip -qo /root/teamengine-web-6.0.0-RC2-common-libs.zip -d "$TE_BASE_DIR/resources/lib" || true
 unzip -qo -j /root/ets-wfs20-1.43-deps.zip -d "$TE_BASE_DIR/resources/lib" || true
 unzip -qo /root/ets-wfs20-1.43-ctl.zip -d "$TE_BASE_DIR/scripts" || true
 
@@ -93,6 +94,67 @@ cat > "$RESULTS_DIR/test-params.xml" << EOF
 </values>
 EOF
 
+generate_transactional_suite() {
+    suite_path="$1"
+
+    cat > "$suite_path" << EOF_SUITE
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="wfs20-1.43-transactional" verbose="0" configfailurepolicy="skip">
+  <parameter name="wfs" value="$ESCAPED_WFS_CAPABILITIES_URL"/>
+  <listeners>
+    <listener class-name="org.opengis.cite.iso19142.SuiteFixtureListener" />
+  </listeners>
+  <test name="Preconditions">
+    <classes>
+      <class name="org.opengis.cite.iso19142.SuitePreconditions"/>
+    </classes>
+  </test>
+  <test name="All GML application schemas">
+    <classes>
+      <class name="org.opengis.cite.iso19136.general.XMLSchemaTests" />
+      <class name="org.opengis.cite.iso19136.general.GeneralSchemaTests" />
+      <class name="org.opengis.cite.iso19136.general.ModelAndSyntaxTests" />
+      <class name="org.opengis.cite.iso19136.general.ComplexPropertyTests" />
+    </classes>
+  </test>
+  <test name="GML application schemas defining features">
+    <classes>
+      <class name="org.opengis.cite.iso19136.components.FeatureComponentTests" />
+    </classes>
+  </test>
+  <test name="Transactional WFS">
+    <classes>
+      <class name="org.opengis.cite.iso19142.transaction.TransactionCapabilitiesTests" />
+      <class name="org.opengis.cite.iso19142.transaction.Update" />
+      <class name="org.opengis.cite.iso19142.transaction.InsertTests" />
+      <class name="org.opengis.cite.iso19142.transaction.ReplaceTests" />
+      <class name="org.opengis.cite.iso19142.transaction.DeleteTests" />
+    </classes>
+  </test>
+</suite>
+EOF_SUITE
+}
+
+run_transactional_suite() {
+    suite_path="$RESULTS_DIR/testng-transactional.xml"
+    output_dir="$RESULTS_DIR/test-output"
+    generate_transactional_suite "$suite_path"
+    rm -rf "$output_dir"
+    mkdir -p "$output_dir"
+
+    classpath="/tmp/te-console/lib/*:$TE_BASE_DIR/resources/lib/*"
+
+    set +e
+    java -cp "$classpath" org.testng.TestNG -d "$output_dir" "$suite_path" > "$CONSOLE_LOG" 2>&1
+    TEST_EXIT_CODE=$?
+    set -e
+
+    if [ -d "$output_dir" ]; then
+        mkdir -p "$RESULTS_DIR/html-report"
+        cp -R "$output_dir/." "$RESULTS_DIR/html-report/" 2>/dev/null || true
+    fi
+}
+
 echo -e "${YELLOW}Executing WFS 2.0 conformance tests...${NC}"
 echo "Session: $SESSION_NAME"
 echo "This may take 10-30 minutes depending on the advertised WFS capabilities..."
@@ -101,15 +163,20 @@ TEST_EXECUTION_START=$(date +%s)
 TEST_EXIT_CODE=0
 CONSOLE_LOG="$RESULTS_DIR/cite-console.log"
 
-set +e
-/tmp/te-console/bin/unix/test.sh \
-    -source="$TE_BASE_DIR/scripts/wfs/2.0.0/ctl/wfs-suite.ctl" \
-    -form="$RESULTS_DIR/test-params.xml" \
-    -logdir=users/cite/logs \
-    -session="$SESSION_NAME" \
-    > "$CONSOLE_LOG" 2>&1
-TEST_EXIT_CODE=$?
-set -e
+if [ "$TEST_PROFILE" = "transactional" ]; then
+    echo "Running the transactional WFS TestNG suite only."
+    run_transactional_suite
+else
+    set +e
+    /tmp/te-console/bin/unix/test.sh \
+        -source="$TE_BASE_DIR/scripts/wfs/2.0.0/ctl/wfs-suite.ctl" \
+        -form="$RESULTS_DIR/test-params.xml" \
+        -logdir=users/cite/logs \
+        -session="$SESSION_NAME" \
+        > "$CONSOLE_LOG" 2>&1
+    TEST_EXIT_CODE=$?
+    set -e
+fi
 
 cat "$CONSOLE_LOG"
 
@@ -118,14 +185,19 @@ EXECUTION_TIME=$((TEST_EXECUTION_END - TEST_EXECUTION_START))
 
 echo -e "${GREEN}✅ CITE test execution completed${NC}"
 echo "Execution time: ${EXECUTION_TIME}s"
-echo "test.sh exit code: ${TEST_EXIT_CODE}"
+echo "Runner exit code: ${TEST_EXIT_CODE}"
 
 echo -e "${YELLOW}Collecting CITE test results...${NC}"
 mkdir -p "$RESULTS_DIR/te-logs"
 cp -R "$TE_BASE_DIR/users/cite/logs/." "$RESULTS_DIR/te-logs/" 2>/dev/null || true
 
-TESTNG_RESULTS=$(find "$TE_BASE_DIR/users/cite/logs" -name 'testng-results.xml' | sort | tail -n 1)
-HTML_REPORT=$(find "$TE_BASE_DIR/users/cite/logs" -path '*/html/index.html' | sort | tail -n 1)
+if [ "$TEST_PROFILE" = "transactional" ]; then
+    TESTNG_RESULTS="$RESULTS_DIR/test-output/testng-results.xml"
+    HTML_REPORT="$RESULTS_DIR/test-output/index.html"
+else
+    TESTNG_RESULTS=$(find "$TE_BASE_DIR/users/cite/logs" -name 'testng-results.xml' | sort | tail -n 1)
+    HTML_REPORT=$(find "$TE_BASE_DIR/users/cite/logs" -path '*/html/index.html' | sort | tail -n 1)
+fi
 
 if [ -n "$TESTNG_RESULTS" ] && [ -f "$TESTNG_RESULTS" ]; then
     cp "$TESTNG_RESULTS" "$RESULTS_DIR/testng-results.xml"
@@ -151,7 +223,7 @@ if [ -n "$TESTNG_RESULTS" ] && [ -f "$TESTNG_RESULTS" ]; then
     PASSED=$(extract_count "passed" "$TESTNG_RESULTS")
     FAILED=$(extract_count "failed" "$TESTNG_RESULTS")
     SKIPPED=$(extract_count "skipped" "$TESTNG_RESULTS")
-    TOTAL=$((PASSED + FAILED))
+    TOTAL=$((PASSED + FAILED + SKIPPED))
 else
     PASSED=0
     FAILED=0
@@ -170,7 +242,7 @@ if [ "$TOTAL" -le 0 ]; then
     exit 1
 fi
 
-if [ "$FAILED" -eq 0 ]; then
+if [ "$FAILED" -eq 0 ] && [ "$SKIPPED" -eq 0 ]; then
     COMPLIANCE_STATUS="COMPLIANT"
 elif [ "$PASSED" -gt 0 ]; then
     COMPLIANCE_STATUS="PARTIAL"
@@ -192,14 +264,20 @@ cat > "$RESULTS_DIR/cite-compliance-report.xml" << EOF_REPORT
 </testReport>
 EOF_REPORT
 
-if [ "$FAILED" -eq 0 ]; then
+HOST_UID=${HOST_UID:-}
+HOST_GID=${HOST_GID:-}
+if [ -n "$HOST_UID" ] && [ -n "$HOST_GID" ]; then
+    chown -R "$HOST_UID:$HOST_GID" "$RESULTS_DIR" 2>/dev/null || true
+fi
+
+if [ "$FAILED" -eq 0 ] && [ "$SKIPPED" -eq 0 ]; then
     echo -e "${GREEN}🎉 FULL WFS 2.0 CITE COMPLIANCE ACHIEVED!${NC}"
     exit 0
 fi
 
 if [ "$PASSED" -gt 0 ]; then
     echo -e "${YELLOW}⚠️ Partial WFS 2.0 CITE compliance${NC}"
-    echo "Some tests failed - see detailed results for specific issues"
+    echo "Some tests failed or were skipped - see detailed results for specific issues"
     exit 0
 fi
 

--- a/docker/cite-test-data/01-init-cite-test-data.sql
+++ b/docker/cite-test-data/01-init-cite-test-data.sql
@@ -1,130 +1,327 @@
 -- OGC CITE WFS 2.0 Test Data Initialization
--- Creates basic test datasets for WFS 2.0 conformance testing
+-- Seeds the actual Honua catalog tables so WFS can advertise and transact on the data.
 
--- Enable PostGIS if not already enabled
 CREATE EXTENSION IF NOT EXISTS postgis;
-CREATE EXTENSION IF NOT EXISTS postgis_topology;
 
--- Create CITE test schema
-CREATE SCHEMA IF NOT EXISTS cite_test;
-SET search_path = cite_test, public;
+CREATE SCHEMA IF NOT EXISTS honua;
 
--- Test feature type 1: Simple points of interest
-CREATE TABLE IF NOT EXISTS cite_test.poi (
-    id SERIAL PRIMARY KEY,
-    fid VARCHAR(50) UNIQUE NOT NULL,
-    name VARCHAR(100) NOT NULL,
-    category VARCHAR(50),
+CREATE TABLE IF NOT EXISTS honua.services (
+    service_name VARCHAR(64) PRIMARY KEY,
+    description TEXT NOT NULL DEFAULT '',
+    srid INT NOT NULL DEFAULT 4326,
+    max_record_count INT NOT NULL DEFAULT 1000,
+    supported_formats TEXT[] NOT NULL DEFAULT '{JSON,GeoJSON}',
+    capabilities TEXT[] NOT NULL DEFAULT '{Query,Extract}',
+    service_extent GEOMETRY,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    metadata JSONB,
+    connection_id UUID
+);
+
+CREATE TABLE IF NOT EXISTS honua.layers (
+    layer_id SERIAL PRIMARY KEY,
+    layer_name TEXT NOT NULL,
     description TEXT,
-    geom GEOMETRY(POINT, 4326),
-    created_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    table_schema TEXT NOT NULL DEFAULT current_schema(),
+    table_name TEXT NOT NULL,
+    geometry_type TEXT NOT NULL,
+    srid INT NOT NULL DEFAULT 4326,
+    extent GEOMETRY(POLYGON, 4326),
+    min_scale DOUBLE PRECISION,
+    max_scale DOUBLE PRECISION,
+    default_visibility BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    metadata JSONB,
+    maplibre_style JSONB,
+    geoservices_drawing_info JSONB,
+    style_version INT DEFAULT 1,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE
 );
 
--- Test feature type 2: Administrative boundaries
-CREATE TABLE IF NOT EXISTS cite_test.admin_boundaries (
-    id SERIAL PRIMARY KEY,
-    fid VARCHAR(50) UNIQUE NOT NULL,
-    name VARCHAR(100) NOT NULL,
-    admin_level INTEGER,
-    area_km2 NUMERIC(10,2),
-    population INTEGER,
-    geom GEOMETRY(POLYGON, 4326),
-    created_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE IF NOT EXISTS honua.service_layers (
+    service_name VARCHAR(64) NOT NULL REFERENCES honua.services(service_name) ON DELETE CASCADE,
+    layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,
+    layer_order INT NOT NULL,
+    PRIMARY KEY (service_name, layer_id),
+    UNIQUE (service_name, layer_order)
 );
 
--- Test feature type 3: Transportation lines
-CREATE TABLE IF NOT EXISTS cite_test.transport_lines (
-    id SERIAL PRIMARY KEY,
-    fid VARCHAR(50) UNIQUE NOT NULL,
-    name VARCHAR(100),
-    transport_type VARCHAR(50),
-    length_km NUMERIC(8,2),
-    geom GEOMETRY(LINESTRING, 4326),
-    created_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE IF NOT EXISTS honua.layer_fields (
+    layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,
+    field_name VARCHAR(64) NOT NULL,
+    field_type VARCHAR(32) NOT NULL,
+    field_order INT NOT NULL,
+    max_length INT,
+    nullable BOOLEAN NOT NULL DEFAULT TRUE,
+    default_value TEXT,
+    description TEXT,
+    PRIMARY KEY (layer_id, field_name)
 );
 
--- Insert sample POI data
-INSERT INTO cite_test.poi (fid, name, category, description, geom) VALUES
-    ('poi.1', 'City Hall', 'government', 'Municipal government building', ST_GeomFromText('POINT(-122.4194 37.7749)', 4326)),
-    ('poi.2', 'Central Library', 'public', 'Main public library branch', ST_GeomFromText('POINT(-122.4158 37.7803)', 4326)),
-    ('poi.3', 'Fire Station 1', 'emergency', 'Primary fire station downtown', ST_GeomFromText('POINT(-122.4089 37.7849)', 4326)),
-    ('poi.4', 'Hospital', 'medical', 'General hospital with emergency services', ST_GeomFromText('POINT(-122.4064 37.7749)', 4326)),
-    ('poi.5', 'School', 'education', 'Elementary school', ST_GeomFromText('POINT(-122.4194 37.7699)', 4326))
-ON CONFLICT (fid) DO NOTHING;
+CREATE TABLE IF NOT EXISTS honua.relationships (
+    layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,
+    relationship_id INT NOT NULL,
+    name TEXT NOT NULL,
+    related_layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,
+    relationship_type TEXT NOT NULL,
+    origin_foreign_key TEXT NOT NULL,
+    destination_foreign_key TEXT NOT NULL,
+    description TEXT,
+    PRIMARY KEY (layer_id, relationship_id)
+);
 
--- Insert sample administrative boundary data
-INSERT INTO cite_test.admin_boundaries (fid, name, admin_level, area_km2, population, geom) VALUES
-    ('admin.1', 'Downtown District', 1, 5.2, 15000,
-     ST_GeomFromText('POLYGON((-122.43 37.77, -122.41 37.77, -122.41 37.79, -122.43 37.79, -122.43 37.77))', 4326)),
-    ('admin.2', 'Residential Zone A', 2, 12.8, 45000,
-     ST_GeomFromText('POLYGON((-122.45 37.75, -122.42 37.75, -122.42 37.78, -122.45 37.78, -122.45 37.75))', 4326))
-ON CONFLICT (fid) DO NOTHING;
+CREATE TABLE IF NOT EXISTS features (
+    objectid BIGSERIAL PRIMARY KEY,
+    layer_id INT NOT NULL,
+    geometry GEOMETRY,
+    attributes JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
 
--- Insert sample transportation data
-INSERT INTO cite_test.transport_lines (fid, name, transport_type, length_km, geom) VALUES
-    ('transport.1', 'Main Street', 'road', 2.5,
-     ST_GeomFromText('LINESTRING(-122.43 37.77, -122.42 37.775, -122.41 37.78)', 4326)),
-    ('transport.2', 'Metro Line Blue', 'rail', 8.2,
-     ST_GeomFromText('LINESTRING(-122.44 37.76, -122.43 37.77, -122.42 37.78, -122.41 37.79)', 4326))
-ON CONFLICT (fid) DO NOTHING;
+CREATE INDEX IF NOT EXISTS idx_service_layers_service_name ON honua.service_layers(service_name);
+CREATE INDEX IF NOT EXISTS idx_service_layers_layer_id ON honua.service_layers(layer_id);
+CREATE INDEX IF NOT EXISTS idx_layer_fields_layer_id ON honua.layer_fields(layer_id);
+CREATE INDEX IF NOT EXISTS idx_relationships_layer_id ON honua.relationships(layer_id);
+CREATE INDEX IF NOT EXISTS idx_features_layer_id ON features(layer_id);
+CREATE INDEX IF NOT EXISTS idx_features_geometry ON features USING GIST(geometry);
+CREATE INDEX IF NOT EXISTS idx_features_attributes ON features USING GIN(attributes);
 
--- Create spatial indexes for performance
-CREATE INDEX IF NOT EXISTS poi_geom_idx ON cite_test.poi USING GIST (geom);
-CREATE INDEX IF NOT EXISTS admin_boundaries_geom_idx ON cite_test.admin_boundaries USING GIST (geom);
-CREATE INDEX IF NOT EXISTS transport_lines_geom_idx ON cite_test.transport_lines USING GIST (geom);
+BEGIN;
 
--- Create regular indexes on commonly queried fields
-CREATE INDEX IF NOT EXISTS poi_category_idx ON cite_test.poi (category);
-CREATE INDEX IF NOT EXISTS admin_boundaries_admin_level_idx ON cite_test.admin_boundaries (admin_level);
-CREATE INDEX IF NOT EXISTS transport_lines_type_idx ON cite_test.transport_lines (transport_type);
+TRUNCATE honua.service_layers RESTART IDENTITY CASCADE;
+TRUNCATE honua.layer_fields RESTART IDENTITY CASCADE;
+TRUNCATE honua.relationships RESTART IDENTITY CASCADE;
+TRUNCATE honua.layers RESTART IDENTITY CASCADE;
+TRUNCATE honua.services RESTART IDENTITY CASCADE;
+TRUNCATE features RESTART IDENTITY;
 
--- Grant permissions for the application user
-GRANT USAGE ON SCHEMA cite_test TO postgres;
-GRANT SELECT ON ALL TABLES IN SCHEMA cite_test TO postgres;
-GRANT USAGE ON ALL SEQUENCES IN SCHEMA cite_test TO postgres;
+INSERT INTO honua.services (
+    service_name,
+    description,
+    srid,
+    max_record_count,
+    supported_formats,
+    capabilities,
+    service_extent,
+    metadata
+)
+VALUES (
+    'cite',
+    'Seeded WFS 2.0 service for OGC CITE conformance tests',
+    4326,
+    1000,
+    ARRAY['JSON', 'GeoJSON'],
+    ARRAY['Query', 'Extract', 'Create', 'Update', 'Delete'],
+    ST_MakeEnvelope(-123.0, 37.1, -122.2, 37.9, 4326),
+    '{"accessPolicy":{"allowAnonymous":true},"enabledProtocols":["Wfs20","OgcFeatures","FeatureServer"]}'::jsonb
+)
+ON CONFLICT (service_name) DO UPDATE SET
+    description = EXCLUDED.description,
+    srid = EXCLUDED.srid,
+    max_record_count = EXCLUDED.max_record_count,
+    supported_formats = EXCLUDED.supported_formats,
+    capabilities = EXCLUDED.capabilities,
+    service_extent = EXCLUDED.service_extent,
+    metadata = EXCLUDED.metadata,
+    updated_at = NOW();
 
--- Set default privileges for future tables
-ALTER DEFAULT PRIVILEGES IN SCHEMA cite_test GRANT SELECT ON TABLES TO postgres;
+INSERT INTO honua.layers (
+    layer_id,
+    layer_name,
+    description,
+    table_schema,
+    table_name,
+    geometry_type,
+    srid,
+    extent,
+    default_visibility,
+    metadata,
+    enabled
+)
+VALUES
+    (1, 'poi', 'Points of interest for WFS CITE testing', 'public', 'features', 'Point', 4326,
+        ST_MakeEnvelope(-122.42, 37.76, -122.40, 37.79, 4326), TRUE,
+        '{"accessPolicy":{"allowAnonymous":true}}'::jsonb, TRUE),
+    (2, 'admin_boundaries', 'Administrative boundaries for WFS CITE testing', 'public', 'features', 'Polygon', 4326,
+        ST_MakeEnvelope(-122.45, 37.75, -122.41, 37.79, 4326), TRUE,
+        '{"accessPolicy":{"allowAnonymous":true}}'::jsonb, TRUE),
+    (3, 'transport_lines', 'Transportation lines for WFS CITE testing', 'public', 'features', 'LineString', 4326,
+        ST_MakeEnvelope(-122.44, 37.76, -122.41, 37.79, 4326), TRUE,
+        '{"accessPolicy":{"allowAnonymous":true}}'::jsonb, TRUE)
+ON CONFLICT (layer_id) DO UPDATE SET
+    layer_name = EXCLUDED.layer_name,
+    description = EXCLUDED.description,
+    table_schema = EXCLUDED.table_schema,
+    table_name = EXCLUDED.table_name,
+    geometry_type = EXCLUDED.geometry_type,
+    srid = EXCLUDED.srid,
+    extent = EXCLUDED.extent,
+    default_visibility = EXCLUDED.default_visibility,
+    metadata = EXCLUDED.metadata,
+    enabled = EXCLUDED.enabled;
 
--- Add some summary info for debugging
+INSERT INTO honua.service_layers (service_name, layer_id, layer_order)
+VALUES
+    ('cite', 1, 0),
+    ('cite', 2, 1),
+    ('cite', 3, 2)
+ON CONFLICT (service_name, layer_id) DO UPDATE SET
+    layer_order = EXCLUDED.layer_order;
+
+INSERT INTO honua.layer_fields (
+    layer_id,
+    field_name,
+    field_type,
+    field_order,
+    max_length,
+    nullable,
+    default_value,
+    description
+)
+VALUES
+    (1, 'objectid', 'Integer', 0, NULL, FALSE, NULL, 'Primary key'),
+    (1, 'fid', 'String', 1, 50, FALSE, NULL, 'Stable feature identifier'),
+    (1, 'name', 'String', 2, 100, FALSE, NULL, 'Display name'),
+    (1, 'category', 'String', 3, 50, TRUE, NULL, 'POI category'),
+    (1, 'description', 'String', 4, 500, TRUE, NULL, 'Narrative description'),
+    (1, 'rating', 'Double', 5, NULL, TRUE, NULL, 'Numeric comparison property'),
+    (1, 'is_public', 'Boolean', 6, NULL, TRUE, NULL, 'Boolean property'),
+    (1, 'created_date', 'DateTime', 7, NULL, TRUE, NULL, 'Timestamp property'),
+    (1, 'event_date', 'Date', 8, NULL, TRUE, NULL, 'Date property'),
+    (1, 'shape', 'Geometry', 9, NULL, TRUE, NULL, 'Point geometry'),
+    (2, 'objectid', 'Integer', 0, NULL, FALSE, NULL, 'Primary key'),
+    (2, 'fid', 'String', 1, 50, FALSE, NULL, 'Stable feature identifier'),
+    (2, 'name', 'String', 2, 100, FALSE, NULL, 'Display name'),
+    (2, 'admin_level', 'Integer', 3, NULL, TRUE, NULL, 'Administrative level'),
+    (2, 'area_km2', 'Double', 4, NULL, TRUE, NULL, 'Area in square kilometres'),
+    (2, 'population', 'Integer', 5, NULL, TRUE, NULL, 'Population count'),
+    (2, 'status', 'String', 6, 32, TRUE, NULL, 'Enumerated-style string'),
+    (2, 'created_date', 'DateTime', 7, NULL, TRUE, NULL, 'Timestamp property'),
+    (2, 'shape', 'Geometry', 8, NULL, TRUE, NULL, 'Polygon geometry'),
+    (3, 'objectid', 'Integer', 0, NULL, FALSE, NULL, 'Primary key'),
+    (3, 'fid', 'String', 1, 50, FALSE, NULL, 'Stable feature identifier'),
+    (3, 'name', 'String', 2, 100, TRUE, NULL, 'Display name'),
+    (3, 'transport_type', 'String', 3, 50, TRUE, NULL, 'Transport category'),
+    (3, 'length_km', 'Double', 4, NULL, TRUE, NULL, 'Length in kilometres'),
+    (3, 'is_active', 'Boolean', 5, NULL, TRUE, NULL, 'Boolean property'),
+    (3, 'created_date', 'DateTime', 6, NULL, TRUE, NULL, 'Timestamp property'),
+    (3, 'shape', 'Geometry', 7, NULL, TRUE, NULL, 'Line geometry')
+ON CONFLICT (layer_id, field_name) DO UPDATE SET
+    field_type = EXCLUDED.field_type,
+    field_order = EXCLUDED.field_order,
+    max_length = EXCLUDED.max_length,
+    nullable = EXCLUDED.nullable,
+    default_value = EXCLUDED.default_value,
+    description = EXCLUDED.description;
+
+INSERT INTO features (objectid, layer_id, geometry, attributes)
+VALUES
+    (
+        1,
+        1,
+        ST_GeomFromText('POINT(-122.4194 37.7749)', 4326),
+        jsonb_build_object(
+            'fid', 'poi.1',
+            'name', 'City Hall',
+            'category', 'government',
+            'description', 'Municipal government building',
+            'rating', 4.5,
+            'is_public', true,
+            'created_date', '2024-01-01T09:00:00Z',
+            'event_date', '2024-01-01')
+    ),
+    (
+        2,
+        1,
+        ST_GeomFromText('POINT(-122.4158 37.7803)', 4326),
+        jsonb_build_object(
+            'fid', 'poi.2',
+            'name', 'Central Library',
+            'category', 'public',
+            'description', NULL,
+            'rating', 4.9,
+            'is_public', true,
+            'created_date', '2024-01-02T10:15:00Z',
+            'event_date', '2024-01-02')
+    ),
+    (
+        3,
+        1,
+        ST_GeomFromText('POINT(-122.4064 37.7749)', 4326),
+        jsonb_build_object(
+            'fid', 'poi.3',
+            'name', 'Hospital',
+            'category', 'medical',
+            'description', 'Regional hospital',
+            'rating', 4.2,
+            'is_public', false,
+            'created_date', '2024-01-03T12:30:00Z',
+            'event_date', NULL)
+    ),
+    (
+        101,
+        2,
+        ST_GeomFromText('POLYGON((-122.43 37.77, -122.41 37.77, -122.41 37.79, -122.43 37.79, -122.43 37.77))', 4326),
+        jsonb_build_object(
+            'fid', 'admin.1',
+            'name', 'Downtown District',
+            'admin_level', 1,
+            'area_km2', 5.2,
+            'population', 15000,
+            'status', 'active',
+            'created_date', '2024-02-01T08:00:00Z')
+    ),
+    (
+        102,
+        2,
+        ST_GeomFromText('POLYGON((-122.45 37.75, -122.42 37.75, -122.42 37.78, -122.45 37.78, -122.45 37.75))', 4326),
+        jsonb_build_object(
+            'fid', 'admin.2',
+            'name', 'Residential Zone A',
+            'admin_level', 2,
+            'area_km2', 12.8,
+            'population', 45000,
+            'status', 'planned',
+            'created_date', '2024-02-02T08:00:00Z')
+    ),
+    (
+        201,
+        3,
+        ST_GeomFromText('LINESTRING(-122.43 37.77, -122.42 37.775, -122.41 37.78)', 4326),
+        jsonb_build_object(
+            'fid', 'transport.1',
+            'name', 'Main Street',
+            'transport_type', 'road',
+            'length_km', 2.5,
+            'is_active', true,
+            'created_date', '2024-03-01T07:00:00Z')
+    ),
+    (
+        202,
+        3,
+        ST_GeomFromText('LINESTRING(-122.44 37.76, -122.43 37.77, -122.42 37.78, -122.41 37.79)', 4326),
+        jsonb_build_object(
+            'fid', 'transport.2',
+            'name', NULL,
+            'transport_type', 'rail',
+            'length_km', 8.2,
+            'is_active', false,
+            'created_date', '2024-03-02T07:00:00Z')
+    );
+
+SELECT setval(
+    pg_get_serial_sequence('features', 'objectid'),
+    COALESCE((SELECT MAX(objectid) FROM features), 1),
+    true);
+
+COMMIT;
+
 DO $$
 BEGIN
-    RAISE NOTICE 'CITE test data initialization completed';
-    RAISE NOTICE 'POI records: %', (SELECT COUNT(*) FROM cite_test.poi);
-    RAISE NOTICE 'Admin boundary records: %', (SELECT COUNT(*) FROM cite_test.admin_boundaries);
-    RAISE NOTICE 'Transport line records: %', (SELECT COUNT(*) FROM cite_test.transport_lines);
+    RAISE NOTICE 'CITE WFS test data initialization completed';
+    RAISE NOTICE 'Services: %', (SELECT COUNT(*) FROM honua.services);
+    RAISE NOTICE 'Layers: %', (SELECT COUNT(*) FROM honua.layers);
+    RAISE NOTICE 'Features: %', (SELECT COUNT(*) FROM features);
 END $$;
-
--- Create view for all feature types (useful for generic queries)
-CREATE OR REPLACE VIEW cite_test.all_features AS
-SELECT
-    'poi' as feature_type,
-    fid,
-    name,
-    category as type_detail,
-    description,
-    geom,
-    created_date
-FROM cite_test.poi
-UNION ALL
-SELECT
-    'admin_boundary' as feature_type,
-    fid,
-    name,
-    admin_level::text as type_detail,
-    CONCAT('Area: ', area_km2, ' km², Population: ', population) as description,
-    geom,
-    created_date
-FROM cite_test.admin_boundaries
-UNION ALL
-SELECT
-    'transport_line' as feature_type,
-    fid,
-    COALESCE(name, 'Unnamed') as name,
-    transport_type as type_detail,
-    CONCAT('Length: ', length_km, ' km') as description,
-    geom,
-    created_date
-FROM cite_test.transport_lines;
-
-GRANT SELECT ON cite_test.all_features TO postgres;

--- a/docker/cite-wfs20-compose.yml
+++ b/docker/cite-wfs20-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # Honua Server under test
   honua-server:
@@ -7,8 +5,11 @@ services:
     ports:
       - "8090:8080"
     environment:
-      - ASPNETCORE_ENVIRONMENT=Testing
+      - ASPNETCORE_ENVIRONMENT=Test
       - ASPNETCORE_URLS=http://+:8080
+      - HONUA_DEV_AUTH=true
+      - HONUA_REGISTER_TEST_INFRASTRUCTURE=true
+      - HONUA_SKIP_MIGRATIONS=true
       - ConnectionStrings__DefaultConnection=Host=postgres;Database=honua_cite;Username=postgres;Password=postgres;Include Error Detail=true
       - HONUA_ADMIN_PASSWORD=cite_testing_admin_password_123!
       - Security__ConnectionEncryption__MasterKey=cite_testing_master_key_for_testing_only_not_secure
@@ -82,6 +83,8 @@ services:
       - WFS_ENDPOINT=http://honua-server:8080/wfs
       - CITE_ENGINE=http://cite-teamengine:8080/teamengine
       - TEST_PROFILE=${CITE_PROFILE:-basic}
+      - HOST_UID=${HOST_UID:-1000}
+      - HOST_GID=${HOST_GID:-1000}
     volumes:
       - ../cite-wfs20-results:/results
       - ./cite-scripts:/scripts:ro

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "updatedUtc": "2026-04-03T00:00:00Z",
+  "updatedUtc": "2026-04-09T00:00:00Z",
   "surfaces": [
     {
       "surfaceId": "platform-http",
@@ -949,7 +949,10 @@
         "WFS-2.0::GetCapabilities",
         "WFS-2.0::DescribeFeatureType",
         "WFS-2.0::GetFeature",
-        "WFS-2.0::GetPropertyValue"
+        "WFS-2.0::GetPropertyValue",
+        "WFS-2.0::Transaction",
+        "WFS-2.0::ListStoredQueries",
+        "WFS-2.0::DescribeStoredQueries"
       ],
       "proofs": [
         {

--- a/scripts/run-cite-wfs20-tests.sh
+++ b/scripts/run-cite-wfs20-tests.sh
@@ -123,9 +123,18 @@ cleanup() {
 # Set trap for cleanup
 trap cleanup EXIT
 
+# Reset results directory even if a previous run left root-owned artifacts behind.
+reset_results_dir() {
+    mkdir -p "$CITE_RESULTS_DIR"
+
+    docker run --rm \
+        -v "$(pwd)/$CITE_RESULTS_DIR:/results" \
+        alpine:3.22 \
+        sh -c "rm -rf /results/* /results/.[!.]* /results/..?* 2>/dev/null || true; chown -R $(id -u):$(id -g) /results"
+}
+
 # Create results directory
-mkdir -p "$CITE_RESULTS_DIR"
-rm -rf "$CITE_RESULTS_DIR"/*
+reset_results_dir
 
 # Start the CITE test environment
 echo -e "${YELLOW}Starting WFS 2.0 CITE test environment...${NC}"
@@ -133,6 +142,8 @@ $COMPOSE_CMD -f "$CITE_COMPOSE_FILE" down --remove-orphans --volumes 2>/dev/null
 
 # Export profile for docker-compose
 export CITE_PROFILE="$PROFILE"
+export HOST_UID="$(id -u)"
+export HOST_GID="$(id -g)"
 
 # Start all services
 if [[ "$VERBOSE" == "true" ]]; then

--- a/src/Honua.Core/Queries/Filters/Fes20/Fes20Parser.cs
+++ b/src/Honua.Core/Queries/Filters/Fes20/Fes20Parser.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
+using Honua.Core.Features.Shared.Models;
 using NetTopologySuite;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
@@ -89,6 +90,7 @@ public static class Fes20Parser
             "PropertyIsLessThanOrEqualTo" => ParseComparison(element, BinaryOperator.LessThanOrEqual),
             "PropertyIsGreaterThanOrEqualTo" => ParseComparison(element, BinaryOperator.GreaterThanOrEqual),
             "PropertyIsLike" => ParseLike(element),
+            "PropertyIsNil" => ParseIsNull(element),
             "PropertyIsNull" => ParseIsNull(element),
             "PropertyIsBetween" => ParseBetween(element),
 
@@ -285,20 +287,31 @@ public static class Fes20Parser
     private static SpatialPredicate ParseBBox(XElement element)
     {
         var children = element.Elements().ToArray();
-        if (children.Length != 2)
+        if (children.Length is not 1 and not 2)
         {
-            throw new Fes20ParseException("BBOX element must contain exactly 2 child elements");
+            throw new Fes20ParseException("BBOX element must contain an Envelope and an optional ValueReference.");
         }
 
-        var propertyRef = children[0];
-        var envelope = children[1];
-
-        if (propertyRef.Name.LocalName != "ValueReference")
+        XElement envelope;
+        FilterExpression property;
+        if (children.Length == 1)
         {
-            throw new Fes20ParseException("First child of BBOX must be ValueReference");
+            property = new PropertyReference("geometry");
+            envelope = children[0];
+        }
+        else
+        {
+            var propertyRef = children[0];
+            envelope = children[1];
+
+            if (propertyRef.Name.LocalName != "ValueReference")
+            {
+                throw new Fes20ParseException("First child of BBOX must be ValueReference when specified.");
+            }
+
+            property = new PropertyReference(propertyRef.Value.Trim());
         }
 
-        var property = new PropertyReference(propertyRef.Value.Trim());
         var geometry = ParseGeometry(envelope);
 
         return new SpatialPredicate(SpatialOperator.Intersects, property, geometry);
@@ -402,11 +415,31 @@ public static class Fes20Parser
     /// <summary>
     /// Parses temporal operations (basic support)
     /// </summary>
-    private static FilterExpression ParseTemporal(XElement element)
+    private static TemporalPredicate ParseTemporal(XElement element)
     {
-        // TODO: Implement temporal filter parsing
-        // For now, throw exception as temporal filters are not yet supported
-        throw new Fes20ParseException($"Temporal operator {element.Name.LocalName} is not yet supported");
+        var children = element.Elements().ToArray();
+        if (children.Length != 2)
+        {
+            throw new Fes20ParseException($"{element.Name.LocalName} element must contain exactly 2 child elements");
+        }
+
+        if (children[0].Name.LocalName != "ValueReference")
+        {
+            throw new Fes20ParseException($"First child of {element.Name.LocalName} must be ValueReference");
+        }
+
+        var property = new PropertyReference(children[0].Value.Trim());
+        var temporalOperand = ParseTemporalOperand(children[1]);
+
+        var op = element.Name.LocalName switch
+        {
+            "After" => TemporalOperator.After,
+            "Before" => TemporalOperator.Before,
+            "During" => TemporalOperator.During,
+            _ => throw new Fes20ParseException($"Unsupported temporal operator {element.Name.LocalName}")
+        };
+
+        return new TemporalPredicate(op, property, temporalOperand);
     }
 
     /// <summary>
@@ -463,6 +496,8 @@ public static class Fes20Parser
     private static GeometryLiteral ParseEnvelope(XElement element)
     {
         var srsName = element.Attribute("srsName")?.Value ?? "EPSG:4326";
+        var srid = ParseSrid(srsName);
+        var axisOrder = ResolveAxisOrder(srsName, srid);
         var lowerCorner = element.Elements().FirstOrDefault(e => e.Name.LocalName == "lowerCorner")?.Value;
         var upperCorner = element.Elements().FirstOrDefault(e => e.Name.LocalName == "upperCorner")?.Value;
 
@@ -487,15 +522,19 @@ public static class Fes20Parser
             throw new Fes20ParseException("Invalid envelope coordinates");
         }
 
-        // Convert to WKB polygon
-        // TODO: Implement proper envelope to WKB conversion
-        // For now, create a simple polygon representation
-        var wkbGeometry = CreateEnvelopeWkb(minX, minY, maxX, maxY);
+        var lower = CreateCoordinate(minX, minY, axisOrder);
+        var upper = CreateCoordinate(maxX, maxY, axisOrder);
+        var wkbGeometry = CreateEnvelopeWkb(
+            Math.Min(lower.X, upper.X),
+            Math.Min(lower.Y, upper.Y),
+            Math.Max(lower.X, upper.X),
+            Math.Max(lower.Y, upper.Y),
+            srid);
 
         return new GeometryLiteral(
             wkbGeometry,
-            ParseSrid(srsName),
-            "FES:Envelope");
+            srid,
+            element.ToString(SaveOptions.DisableFormatting));
     }
 
     /// <summary>
@@ -503,9 +542,211 @@ public static class Fes20Parser
     /// </summary>
     private static GeometryLiteral ParseGmlGeometry(XElement element)
     {
-        // TODO: Implement GML geometry parsing
-        // For now, throw exception as full GML parsing is complex
-        throw new Fes20ParseException($"GML geometry parsing is not yet implemented for {element.Name.LocalName}");
+        var srsName = element.Attribute("srsName")?.Value ?? "EPSG:4326";
+        var srid = ParseSrid(srsName);
+        var axisOrder = ResolveAxisOrder(srsName, srid);
+        var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(srid);
+
+        Geometry geometry = element.Name.LocalName switch
+        {
+            "Point" => geometryFactory.CreatePoint(ParseSingleCoordinate(element, axisOrder)),
+            "LineString" or "Curve" => geometryFactory.CreateLineString(ParseCoordinateSequence(element, axisOrder)),
+            "Polygon" or "Surface" => ParsePolygonGeometry(element, geometryFactory, axisOrder),
+            _ => throw new Fes20ParseException($"GML geometry parsing is not yet implemented for {element.Name.LocalName}")
+        };
+
+        return new GeometryLiteral(
+            new WKBWriter(ByteOrder.LittleEndian, handleSRID: false).Write(geometry),
+            srid,
+            element.ToString(SaveOptions.DisableFormatting));
+    }
+
+    private static FilterExpression ParseTemporalOperand(XElement element)
+    {
+        if (element.Name.NamespaceName != GmlNamespace)
+        {
+            throw new Fes20ParseException($"Unsupported temporal operand namespace: {element.Name.NamespaceName}");
+        }
+
+        return element.Name.LocalName switch
+        {
+            "TimeInstant" => ParseTimeInstant(element),
+            "TimePeriod" => ParseTimePeriod(element),
+            _ => throw new Fes20ParseException($"Unsupported temporal operand: {element.Name.LocalName}")
+        };
+    }
+
+    private static Literal ParseTimeInstant(XElement element)
+    {
+        var timePosition = element.Descendants()
+            .FirstOrDefault(candidate => candidate.Name.NamespaceName == GmlNamespace &&
+                                         candidate.Name.LocalName == "timePosition")
+            ?.Value;
+        if (string.IsNullOrWhiteSpace(timePosition))
+        {
+            throw new Fes20ParseException("TimeInstant must contain a gml:timePosition element.");
+        }
+
+        return ParseTemporalPosition(timePosition);
+    }
+
+    private static IntervalLiteral ParseTimePeriod(XElement element)
+    {
+        var beginPosition = element.Descendants()
+            .FirstOrDefault(candidate => candidate.Name.NamespaceName == GmlNamespace &&
+                                         candidate.Name.LocalName is "beginPosition" or "timePosition" &&
+                                         candidate.Parent?.Name.LocalName is "TimePeriod" or "begin" or "TimeInstant")
+            ?.Value;
+        var endPosition = element.Descendants()
+            .FirstOrDefault(candidate => candidate.Name.NamespaceName == GmlNamespace &&
+                                         candidate.Name.LocalName is "endPosition" or "timePosition" &&
+                                         candidate.Parent?.Name.LocalName is "TimePeriod" or "end" or "TimeInstant")
+            ?.Value;
+
+        if (string.IsNullOrWhiteSpace(beginPosition) || string.IsNullOrWhiteSpace(endPosition))
+        {
+            throw new Fes20ParseException("TimePeriod must contain both begin and end positions.");
+        }
+
+        return new IntervalLiteral(
+            ParseTemporalPosition(beginPosition),
+            ParseTemporalPosition(endPosition));
+    }
+
+    private static Literal ParseTemporalPosition(string value)
+    {
+        if (DateOnly.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateOnly))
+        {
+            return new Literal(dateOnly, LiteralType.Date);
+        }
+
+        if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var timestamp))
+        {
+            return new Literal(timestamp, LiteralType.DateTime);
+        }
+
+        throw new Fes20ParseException($"Invalid temporal position '{value}'.");
+    }
+
+    private static Polygon ParsePolygonGeometry(
+        XElement element,
+        GeometryFactory geometryFactory,
+        AxisOrder axisOrder)
+    {
+        var exterior = element.Descendants()
+            .FirstOrDefault(candidate => candidate.Name.NamespaceName == GmlNamespace &&
+                                         candidate.Name.LocalName == "exterior")
+            ?? throw new Fes20ParseException($"{element.Name.LocalName} must contain an exterior ring.");
+        var shell = geometryFactory.CreateLinearRing(ParseRingCoordinates(exterior, axisOrder));
+        var holes = element.Descendants()
+            .Where(candidate => candidate.Name.NamespaceName == GmlNamespace &&
+                                candidate.Name.LocalName == "interior")
+            .Select(candidate => geometryFactory.CreateLinearRing(ParseRingCoordinates(candidate, axisOrder)))
+            .ToArray();
+
+        return geometryFactory.CreatePolygon(shell, holes);
+    }
+
+    private static Coordinate[] ParseRingCoordinates(XElement ringContainer, AxisOrder axisOrder)
+    {
+        var ring = ringContainer.Descendants()
+            .FirstOrDefault(candidate => candidate.Name.NamespaceName == GmlNamespace &&
+                                         candidate.Name.LocalName == "LinearRing")
+            ?? ringContainer;
+        return ParseCoordinateSequence(ring, axisOrder);
+    }
+
+    private static Coordinate ParseSingleCoordinate(XElement element, AxisOrder axisOrder)
+    {
+        var pos = element.Descendants()
+            .FirstOrDefault(candidate => candidate.Name.NamespaceName == GmlNamespace &&
+                                         candidate.Name.LocalName == "pos")
+            ?.Value;
+        if (string.IsNullOrWhiteSpace(pos))
+        {
+            throw new Fes20ParseException($"{element.Name.LocalName} must contain a gml:pos element.");
+        }
+
+        return ParseCoordinate(pos, axisOrder);
+    }
+
+    private static Coordinate[] ParseCoordinateSequence(XElement element, AxisOrder axisOrder)
+    {
+        var posList = element.Descendants()
+            .FirstOrDefault(candidate => candidate.Name.NamespaceName == GmlNamespace &&
+                                         candidate.Name.LocalName == "posList")
+            ?.Value;
+        if (!string.IsNullOrWhiteSpace(posList))
+        {
+            return ParsePosList(posList, axisOrder);
+        }
+
+        var positions = element.Descendants()
+            .Where(candidate => candidate.Name.NamespaceName == GmlNamespace &&
+                                candidate.Name.LocalName == "pos")
+            .Select(candidate => ParseCoordinate(candidate.Value, axisOrder))
+            .ToArray();
+        if (positions.Length == 0)
+        {
+            throw new Fes20ParseException($"{element.Name.LocalName} must contain coordinate positions.");
+        }
+
+        return positions;
+    }
+
+    private static Coordinate[] ParsePosList(string rawPosList, AxisOrder axisOrder)
+    {
+        var ordinates = rawPosList
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(value => double.Parse(value, CultureInfo.InvariantCulture))
+            .ToArray();
+        if (ordinates.Length < 2 || ordinates.Length % 2 != 0)
+        {
+            throw new Fes20ParseException("gml:posList must contain an even number of ordinates.");
+        }
+
+        var coordinates = new Coordinate[ordinates.Length / 2];
+        for (var i = 0; i < ordinates.Length; i += 2)
+        {
+            coordinates[i / 2] = CreateCoordinate(ordinates[i], ordinates[i + 1], axisOrder);
+        }
+
+        return coordinates;
+    }
+
+    private static Coordinate ParseCoordinate(string rawPosition, AxisOrder axisOrder)
+    {
+        var ordinates = rawPosition
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (ordinates.Length < 2)
+        {
+            throw new Fes20ParseException("Coordinate position must contain at least two ordinates.");
+        }
+
+        if (!double.TryParse(ordinates[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var first) ||
+            !double.TryParse(ordinates[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var second))
+        {
+            throw new Fes20ParseException("Coordinate position contains invalid numeric ordinates.");
+        }
+
+        return CreateCoordinate(first, second, axisOrder);
+    }
+
+    private static Coordinate CreateCoordinate(double first, double second, AxisOrder axisOrder)
+        => axisOrder == AxisOrder.NorthEast
+            ? new Coordinate(second, first)
+            : new Coordinate(first, second);
+
+    private static AxisOrder ResolveAxisOrder(string srsName, int srid)
+    {
+        if (srsName.Contains("CRS84", StringComparison.OrdinalIgnoreCase))
+        {
+            return AxisOrder.EastNorth;
+        }
+
+        return SpatialReference.Create(srid).IsGeographic
+            ? AxisOrder.NorthEast
+            : AxisOrder.EastNorth;
     }
 
     /// <summary>
@@ -688,9 +929,9 @@ public static class Fes20Parser
     /// <summary>
     /// Creates WKB representation for an envelope/bbox
     /// </summary>
-    private static byte[] CreateEnvelopeWkb(double minX, double minY, double maxX, double maxY)
+    private static byte[] CreateEnvelopeWkb(double minX, double minY, double maxX, double maxY, int srid)
     {
-        var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
+        var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(srid);
         var polygon = geometryFactory.CreatePolygon(
         [
             new Coordinate(minX, minY),

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Parameters.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Parameters.cs
@@ -92,7 +92,7 @@ internal sealed partial class FeatureDataAccess
 
     private static void AddParameterValue(NpgsqlCommand command, ref int parameterIndex, object? value)
     {
-        var parameterValue = value ?? DBNull.Value;
+        var parameterValue = NormalizeParameterValue(value);
 
         if (command.Parameters.Count > parameterIndex)
         {
@@ -104,5 +104,15 @@ internal sealed partial class FeatureDataAccess
         }
 
         parameterIndex++;
+    }
+
+    private static object NormalizeParameterValue(object? value)
+    {
+        return value switch
+        {
+            null => DBNull.Value,
+            DateTimeOffset dateTimeOffset => dateTimeOffset.ToUniversalTime(),
+            _ => value
+        };
     }
 }

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -684,7 +684,9 @@ internal static partial class FeatureServerEndpoints
     {
         return new GeoServicesFeature
         {
-            Attributes = new Dictionary<string, object?>(feature.Attributes),
+            Attributes = feature.Attributes
+                .Where(kvp => !FeatureAttributeVisibility.IsInternalAttribute(kvp.Key))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
             Geometry = GeoServicesGeometryConverter.ConvertWkbToGeoServicesGeometry(
                 feature.Geometry, null, null, false, false)
         };

--- a/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.TopFeatures.cs
+++ b/src/Honua.Server/Features/FeatureServer/FeatureServerRequestHandlers.TopFeatures.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Validation.Abstractions;
 using Honua.Server.Features.FeatureServer.Models;
 using Honua.Server.Features.FeatureServer.Services;
 using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
 using Honua.ServiceDefaults;
 using Microsoft.Extensions.Primitives;
@@ -121,7 +122,9 @@ internal static partial class FeatureServerEndpoints
         var objectIdField = layer.PrimaryKeyField?.Name ?? "objectid";
         var responseFeatures = result.Items.Select(feature => new GeoServicesFeature
         {
-            Attributes = new Dictionary<string, object?>(feature.Attributes),
+            Attributes = feature.Attributes
+                .Where(kvp => !FeatureAttributeVisibility.IsInternalAttribute(kvp.Key))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
             Geometry = GeoServicesGeometryConverter.ConvertWkbToGeoServicesGeometry(
                 feature.Geometry, null, null, false, false)
         }).ToArray();

--- a/src/Honua.Server/Features/FeatureServer/Services/RelatedRecordsService.cs
+++ b/src/Honua.Server/Features/FeatureServer/Services/RelatedRecordsService.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Shared.Models;
 using Honua.Core.Queries.Filters;
 using Honua.Server.Features.FeatureServer;
 using Honua.Server.Features.FeatureServer.Models;
+using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Services;
 using Microsoft.Extensions.Options;
 using Npgsql;
@@ -247,9 +248,12 @@ internal sealed class RelatedRecordsService : IRelatedRecordsService
         GeometryLimits geometryLimits)
     {
         var attributes = outFields == null
-            ? feature.Attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
+            ? feature.Attributes
+                .Where(kvp => !FeatureAttributeVisibility.IsInternalAttribute(kvp.Key))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
             : feature.Attributes
-                .Where(kvp => outFields.Contains(kvp.Key))
+                .Where(kvp => outFields.Contains(kvp.Key) &&
+                              !FeatureAttributeVisibility.IsInternalAttribute(kvp.Key))
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
         return new GeoServicesFeature

--- a/src/Honua.Server/Features/Grpc/GrpcConversionHelpers.cs
+++ b/src/Honua.Server/Features/Grpc/GrpcConversionHelpers.cs
@@ -7,6 +7,7 @@ using Honua.Core.Configuration;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Shared.Models;
+using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Services;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
@@ -188,6 +189,11 @@ internal static class GrpcConversionHelpers
 
         foreach (var (key, value) in feature.Attributes)
         {
+            if (FeatureAttributeVisibility.IsInternalAttribute(key))
+            {
+                continue;
+            }
+
             proto.Attributes[key] = ToAttributeValue(value);
         }
 

--- a/src/Honua.Server/Features/Infrastructure/Helpers/FeatureAttributeVisibility.cs
+++ b/src/Honua.Server/Features/Infrastructure/Helpers/FeatureAttributeVisibility.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Infrastructure.Helpers;
+
+internal static class FeatureAttributeVisibility
+{
+    internal static bool IsInternalAttribute(string? attributeName)
+        => !string.IsNullOrWhiteSpace(attributeName) &&
+           attributeName.StartsWith("__", StringComparison.Ordinal);
+}

--- a/src/Honua.Server/Features/Infrastructure/Models/StandardErrorResponseFormatter.cs
+++ b/src/Honua.Server/Features/Infrastructure/Models/StandardErrorResponseFormatter.cs
@@ -135,7 +135,7 @@ internal static class StandardErrorResponseFormatter
 
         var xmlContent = $$"""
             <?xml version="1.0" encoding="UTF-8"?>
-            <ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" version="1.1.0">
+            <ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" version="2.0.0">
               <ows:Exception exceptionCode="{{EscapeForXml(exceptionCode!)}}"{{locatorAttribute}}>
                 <ows:ExceptionText>{{EscapeForXml(BuildDetailWithExtras(errorResponse, options))}}</ows:ExceptionText>
               </ows:Exception>

--- a/src/Honua.Server/Features/Infrastructure/Models/XmlResultSerializer.cs
+++ b/src/Honua.Server/Features/Infrastructure/Models/XmlResultSerializer.cs
@@ -8,6 +8,11 @@ using System.Xml.Serialization;
 
 namespace Honua.Server.Features.Infrastructure.Models;
 
+internal interface IXmlNamespaceProvider
+{
+    XmlSerializerNamespaces Namespaces { get; }
+}
+
 internal static class XmlResultSerializer
 {
     // XML serialization is isolated here so protocol endpoints keep their reflection-aware
@@ -28,7 +33,15 @@ internal static class XmlResultSerializer
 
         using var stringWriter = new Utf8StringWriter();
         using var xmlWriter = XmlWriter.Create(stringWriter, settings);
-        serializer.Serialize(xmlWriter, value);
+        if (value is IXmlNamespaceProvider namespaceProvider)
+        {
+            serializer.Serialize(xmlWriter, value, namespaceProvider.Namespaces);
+        }
+        else
+        {
+            serializer.Serialize(xmlWriter, value);
+        }
+
         return stringWriter.ToString();
     }
 

--- a/src/Honua.Server/Features/Infrastructure/Validation/ValidationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Validation/ValidationExtensions.cs
@@ -17,6 +17,10 @@ namespace Honua.Server.Features.Infrastructure.Validation;
 /// </summary>
 public static class ValidationExtensions
 {
+    internal const string WfsGmlIdentifierAttributeName = "__honua_wfs_gml_identifier";
+    internal const string WfsGmlNameAttributeName = "__honua_wfs_gml_name";
+    internal const string WfsGmlDescriptionAttributeName = "__honua_wfs_gml_description";
+
     /// <summary>
     /// Attribute validation behavior by protocol.
     /// </summary>
@@ -186,6 +190,12 @@ public static class ValidationExtensions
 
         foreach (var (key, rawValue) in attributes)
         {
+            if (IsReservedMutationAttribute(key))
+            {
+                builder[key] = NormalizeAttributeValue(rawValue);
+                continue;
+            }
+
             if (!fieldsByName.TryGetValue(key, out var field))
             {
                 if (mode == AttributeValidationMode.GeoServices)
@@ -217,6 +227,13 @@ public static class ValidationExtensions
         }
 
         return ValidationResult<ImmutableDictionary<string, object?>>.Success(builder.ToImmutable());
+    }
+
+    internal static bool IsReservedMutationAttribute(string attributeName)
+    {
+        return attributeName.Equals(WfsGmlIdentifierAttributeName, StringComparison.Ordinal) ||
+               attributeName.Equals(WfsGmlNameAttributeName, StringComparison.Ordinal) ||
+               attributeName.Equals(WfsGmlDescriptionAttributeName, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Find.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Find.cs
@@ -219,6 +219,11 @@ internal static partial class MapServerEndpoints
                     var attributes = new Dictionary<string, object?>();
                     foreach (var kvp in feature.Attributes)
                     {
+                        if (FeatureAttributeVisibility.IsInternalAttribute(kvp.Key))
+                        {
+                            continue;
+                        }
+
                         attributes[kvp.Key] = Honua.Server.Features.FeatureServer.Models.GeoServicesValueNormalizer.Normalize(kvp.Value);
                     }
 

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.GenerateKml.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.GenerateKml.cs
@@ -386,6 +386,11 @@ internal static partial class MapServerEndpoints
                 continue;
             }
 
+            if (FeatureAttributeVisibility.IsInternalAttribute(key))
+            {
+                continue;
+            }
+
             writer.WriteStartElement("Data");
             writer.WriteAttributeString("name", key);
             writer.WriteElementString("value", ConvertToAttributeString(value));

--- a/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Identify.cs
+++ b/src/Honua.Server/Features/MapServer/MapServerRequestHandlers.Identify.cs
@@ -300,6 +300,11 @@ internal static partial class MapServerEndpoints
                     var attributes = new Dictionary<string, object?>();
                     foreach (var kvp in feature.Attributes)
                     {
+                        if (FeatureAttributeVisibility.IsInternalAttribute(kvp.Key))
+                        {
+                            continue;
+                        }
+
                         attributes[kvp.Key] = Honua.Server.Features.FeatureServer.Models.GeoServicesValueNormalizer.Normalize(kvp.Value);
                     }
 

--- a/src/Honua.Server/Features/OData/Services/ODataAggregationHandler.cs
+++ b/src/Honua.Server/Features/OData/Services/ODataAggregationHandler.cs
@@ -11,6 +11,7 @@ using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Shared.Models;
 using Honua.Core.Queries.Filters;
+using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.OData.Models;
 
 namespace Honua.Server.Features.OData.Services;
@@ -708,6 +709,11 @@ internal sealed class ODataAggregationHandler
 
         foreach (var kvp in feature.Attributes)
         {
+            if (FeatureAttributeVisibility.IsInternalAttribute(kvp.Key))
+            {
+                continue;
+            }
+
             dict[kvp.Key] = kvp.Value;
         }
 

--- a/src/Honua.Server/Features/OData/Services/ODataUtilityService.cs
+++ b/src/Honua.Server/Features/OData/Services/ODataUtilityService.cs
@@ -560,6 +560,11 @@ internal static class ODataUtilityService
             return true;
         }
 
+        if (FeatureAttributeVisibility.IsInternalAttribute(propertyName))
+        {
+            return true;
+        }
+
         return _reservedFeatureProperties.Contains(propertyName);
     }
 

--- a/src/Honua.Server/Features/OgcFeatures/Services/OgcResponseFormatter.cs
+++ b/src/Honua.Server/Features/OgcFeatures/Services/OgcResponseFormatter.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.OgcFeatures.Models;
 
@@ -613,6 +614,11 @@ internal static class OgcResponseFormatter
         foreach (var (key, value) in properties)
         {
             if (value == null)
+            {
+                continue;
+            }
+
+            if (FeatureAttributeVisibility.IsInternalAttribute(key))
             {
                 continue;
             }

--- a/src/Honua.Server/Features/Stac/Services/StacMappingService.cs
+++ b/src/Honua.Server/Features/Stac/Services/StacMappingService.cs
@@ -114,7 +114,8 @@ internal sealed class StacMappingService
             if (!string.Equals(kvp.Key, "objectid", StringComparison.OrdinalIgnoreCase) &&
                 !string.Equals(kvp.Key, "datetime", StringComparison.OrdinalIgnoreCase) &&
                 !string.Equals(kvp.Key, "start_datetime", StringComparison.OrdinalIgnoreCase) &&
-                !string.Equals(kvp.Key, "end_datetime", StringComparison.OrdinalIgnoreCase))
+                !string.Equals(kvp.Key, "end_datetime", StringComparison.OrdinalIgnoreCase) &&
+                !FeatureAttributeVisibility.IsInternalAttribute(kvp.Key))
             {
                 if (selectedPropertiesLookup is not null &&
                     !selectedPropertiesLookup.Contains(kvp.Key))

--- a/src/Honua.Server/Features/Wfs20/Models/Wfs20Models.cs
+++ b/src/Honua.Server/Features/Wfs20/Models/Wfs20Models.cs
@@ -2,7 +2,9 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Xml;
 using System.Xml.Serialization;
+using Honua.Server.Features.Infrastructure.Models;
 
 namespace Honua.Server.Features.Wfs20.Models;
 
@@ -13,13 +15,30 @@ namespace Honua.Server.Features.Wfs20.Models;
 /// WFS 2.0 GetCapabilities response
 /// </summary>
 [XmlRoot("WFS_Capabilities", Namespace = Wfs20Utilities.WfsNamespace)]
-public sealed class WfsCapabilities
+public sealed class WfsCapabilities : IXmlNamespaceProvider
 {
+    [XmlNamespaceDeclarations]
+    public XmlSerializerNamespaces Namespaces { get; } = new(
+        new[]
+        {
+            new XmlQualifiedName(string.Empty, Wfs20Utilities.WfsNamespace),
+            new XmlQualifiedName("ows", Wfs20Utilities.OwsNamespace),
+            new XmlQualifiedName("fes", Wfs20Utilities.FesNamespace),
+            new XmlQualifiedName("gml", Wfs20Utilities.GmlNamespace),
+            new XmlQualifiedName("honua", "http://honua.io/wfs"),
+            new XmlQualifiedName("xlink", Wfs20Utilities.XLinkNamespace),
+            new XmlQualifiedName("xsi", Wfs20Utilities.XsiNamespace),
+        });
+
     [XmlAttribute("version")]
     public string Version { get; set; } = Wfs20Utilities.Version;
 
     [XmlAttribute("updateSequence")]
     public string? UpdateSequence { get; set; }
+
+    [XmlAttribute("schemaLocation", Namespace = Wfs20Utilities.XsiNamespace)]
+    public string SchemaLocation { get; set; } =
+        $"{Wfs20Utilities.WfsNamespace} http://schemas.opengis.net/wfs/2.0/wfs.xsd";
 
     [XmlElement("ServiceIdentification", Namespace = Wfs20Utilities.OwsNamespace)]
     public ServiceIdentification? ServiceIdentification { get; set; }
@@ -55,9 +74,8 @@ public sealed class ServiceIdentification
     [XmlElement("ServiceType", Namespace = Wfs20Utilities.OwsNamespace)]
     public string ServiceType { get; set; } = Wfs20Utilities.ServiceType;
 
-    [XmlArray("ServiceTypeVersion", Namespace = Wfs20Utilities.OwsNamespace)]
-    [XmlArrayItem("ServiceTypeVersion", Namespace = Wfs20Utilities.OwsNamespace)]
-    public string[] ServiceTypeVersion { get; set; } = { Wfs20Utilities.Version };
+    [XmlElement("ServiceTypeVersion", Namespace = Wfs20Utilities.OwsNamespace)]
+    public string[] ServiceTypeVersion { get; set; } = [Wfs20Utilities.Version];
 
     [XmlElement("Fees", Namespace = Wfs20Utilities.OwsNamespace)]
     public string Fees { get; set; } = "NONE";
@@ -98,8 +116,8 @@ public sealed class ServiceContact
     [XmlElement("IndividualName", Namespace = Wfs20Utilities.OwsNamespace)]
     public string? IndividualName { get; set; }
 
-    [XmlElement("OrganisationName", Namespace = Wfs20Utilities.OwsNamespace)]
-    public string OrganisationName { get; set; } = "Honua";
+    [XmlElement("PositionName", Namespace = Wfs20Utilities.OwsNamespace)]
+    public string? PositionName { get; set; }
 
     [XmlElement("ContactInfo", Namespace = Wfs20Utilities.OwsNamespace)]
     public ContactInfo? ContactInfo { get; set; }
@@ -212,11 +230,11 @@ public sealed class Parameter
     [XmlElement("AllowedValues", Namespace = Wfs20Utilities.OwsNamespace)]
     public AllowedValues? AllowedValues { get; set; }
 
-    [XmlElement("NoValues", Namespace = Wfs20Utilities.OwsNamespace)]
-    public object? NoValues { get; set; }
-
     [XmlElement("AnyValue", Namespace = Wfs20Utilities.OwsNamespace)]
     public object? AnyValue { get; set; }
+
+    [XmlElement("NoValues", Namespace = Wfs20Utilities.OwsNamespace)]
+    public object? NoValues { get; set; }
 }
 
 /// <summary>
@@ -236,17 +254,17 @@ public sealed class Constraint
     [XmlAttribute("name")]
     public required string Name { get; set; }
 
-    [XmlElement("DefaultValue", Namespace = Wfs20Utilities.OwsNamespace)]
-    public string? DefaultValue { get; set; }
-
     [XmlElement("AllowedValues", Namespace = Wfs20Utilities.OwsNamespace)]
     public AllowedValues? AllowedValues { get; set; }
+
+    [XmlElement("AnyValue", Namespace = Wfs20Utilities.OwsNamespace)]
+    public object? AnyValue { get; set; }
 
     [XmlElement("NoValues", Namespace = Wfs20Utilities.OwsNamespace)]
     public object? NoValues { get; set; }
 
-    [XmlElement("AnyValue", Namespace = Wfs20Utilities.OwsNamespace)]
-    public object? AnyValue { get; set; }
+    [XmlElement("DefaultValue", Namespace = Wfs20Utilities.OwsNamespace)]
+    public string? DefaultValue { get; set; }
 }
 
 /// <summary>
@@ -369,6 +387,12 @@ public sealed class FesConstraint
     [XmlAttribute("name")]
     public required string Name { get; set; }
 
+    [XmlElement("AllowedValues", Namespace = Wfs20Utilities.OwsNamespace)]
+    public AllowedValues? AllowedValues { get; set; }
+
+    [XmlElement("AnyValue", Namespace = Wfs20Utilities.OwsNamespace)]
+    public object? AnyValue { get; set; }
+
     [XmlElement("NoValues", Namespace = Wfs20Utilities.OwsNamespace)]
     public object? NoValues { get; set; }
 
@@ -451,7 +475,7 @@ public sealed class GeometryOperands
 public sealed class GeometryOperand
 {
     [XmlAttribute("name")]
-    public required string Name { get; set; }
+    public required XmlQualifiedName Name { get; set; }
 }
 
 /// <summary>
@@ -499,7 +523,7 @@ public sealed class TemporalOperands
 public sealed class TemporalOperand
 {
     [XmlAttribute("name")]
-    public required string Name { get; set; }
+    public required XmlQualifiedName Name { get; set; }
 }
 
 /// <summary>
@@ -527,7 +551,7 @@ public sealed class TemporalOperator
 public sealed class ExceptionReport
 {
     [XmlAttribute("version")]
-    public string Version { get; set; } = "1.1.0";
+    public string Version { get; set; } = Wfs20Utilities.Version;
 
     [XmlElement("Exception", Namespace = Wfs20Utilities.OwsNamespace)]
     public required ExceptionType[] Exceptions { get; set; }

--- a/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
+++ b/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
@@ -4118,7 +4118,10 @@ internal sealed class Wfs20Handler
 
         writer.WriteAttributeString("gml", "id", Wfs20Utilities.GmlNamespace, BuildFeatureId(plan.Descriptor, feature.Id));
 
-        if (TryGetGmlDescriptionValue(plan.Descriptor.Layer, feature.Attributes, out var gmlDescription))
+        // Keep collection members aligned to the application schema; duplicating gml:name/description
+        // alongside matching feature properties causes GDAL/OGR to surface list-valued fields.
+        if (!includeMemberWrapper &&
+            TryGetGmlDescriptionValue(plan.Descriptor.Layer, feature.Attributes, out var gmlDescription))
         {
             writer.WriteElementString("gml", "description", Wfs20Utilities.GmlNamespace, gmlDescription);
         }
@@ -4128,7 +4131,8 @@ internal sealed class Wfs20Handler
             writer.WriteElementString("gml", "identifier", Wfs20Utilities.GmlNamespace, gmlIdentifier);
         }
 
-        if (TryGetGmlNameValue(plan.Descriptor.Layer, feature.Attributes, out var gmlName))
+        if (!includeMemberWrapper &&
+            TryGetGmlNameValue(plan.Descriptor.Layer, feature.Attributes, out var gmlName))
         {
             writer.WriteElementString("gml", "name", Wfs20Utilities.GmlNamespace, gmlName);
         }

--- a/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
+++ b/src/Honua.Server/Features/Wfs20/Services/Wfs20Handler.cs
@@ -9,18 +9,23 @@ using System.Security;
 using System.Text;
 using System.Text.Json;
 using System.Xml;
+using System.Xml.Linq;
+using Honua.Core.Configuration;
 using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Shared.Models;
 using Honua.Core.Queries.Filters;
 using Honua.Core.Queries.Filters.Fes20;
 using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Events;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
 using Honua.Server.Features.Infrastructure.Services;
+using Honua.Server.Features.Infrastructure.Validation;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.OgcFeatures;
 using Honua.Server.Features.OgcFeatures.Models;
@@ -40,16 +45,24 @@ internal sealed class Wfs20Handler
 {
     private const string FeatureNamespacePrefix = "honua";
     private const string FeatureNamespaceUri = "http://honua.io/wfs";
+    private const string GetFeatureByIdStoredQueryId = "urn:ogc:def:query:OGC-WFS::GetFeatureById";
+    private const string GetFeatureByIdStoredQueryUri = "http://www.opengis.net/def/query/OGC-WFS/0/GetFeatureById";
     private static readonly WKBWriter BboxWkbWriter = new();
+    private static readonly WKBWriter GeometryWkbWriter = new();
+    private static readonly SqlFragment FalseSqlFilter = new("FALSE", Array.Empty<object?>());
 
     private readonly ILogger<Wfs20Handler> _logger;
     private readonly ILayerCatalog _layerCatalog;
     private readonly IFeatureReader _featureReader;
+    private readonly IFeatureWriter _featureWriter;
     private readonly IGmlFeatureStore _gmlFeatureStore;
     private readonly IFilterExpressionService _filterExpressionService;
     private readonly OgcFeaturesGeometryServices _geometryServices;
     private readonly Wfs20Options _wfs20Options;
     private readonly ICrsRegistry _crsRegistry;
+    private readonly FeatureMutationValidator _mutationValidator;
+    private readonly FeatureMutationEventService _mutationEventService;
+    private readonly EditLimits _editLimits;
 
     public Wfs20Handler(
         ILogger<Wfs20Handler> logger,
@@ -58,11 +71,15 @@ internal sealed class Wfs20Handler
         _logger = logger;
         _layerCatalog = queryServices.LayerCatalog;
         _featureReader = queryServices.FeatureReader;
+        _featureWriter = queryServices.FeatureWriter;
         _gmlFeatureStore = queryServices.GmlFeatureStore;
         _filterExpressionService = queryServices.FilterExpressionService;
         _geometryServices = queryServices.GeometryServices;
         _crsRegistry = queryServices.CrsRegistry;
         _wfs20Options = queryServices.Wfs20Options;
+        _mutationValidator = queryServices.MutationValidator;
+        _mutationEventService = queryServices.MutationEventService;
+        _editLimits = queryServices.EditLimits;
     }
 
     public async Task<WfsCapabilities> HandleGetCapabilitiesAsync(
@@ -137,10 +154,12 @@ internal sealed class Wfs20Handler
             var requestedTypes = Wfs20Utilities.ParseTypeNames(typeNames);
             var publishedTypes = await GetPublishedFeatureTypesAsync(context, cancellationToken);
             var selectedTypes = ResolveRequestedFeatureTypes(publishedTypes, requestedTypes);
+            if (selectedTypes.Length == 0 && requestedTypes.Length > 0)
+            {
+                throw new ArgumentException($"Requested feature type(s) not found: {string.Join(", ", requestedTypes)}.");
+            }
 
-            var schema = selectedTypes.Length == 0 && requestedTypes.Length > 0
-                ? GenerateEmptySchemaForTypes(requestedTypes)
-                : GenerateSchemaForTypes(selectedTypes);
+            var schema = GenerateSchemaForTypes(selectedTypes);
 
             Wfs20Log.DescribeFeatureTypeReturned(_logger, selectedTypes.Length == 0 ? requestedTypes.Length : selectedTypes.Length);
             return schema;
@@ -151,6 +170,130 @@ internal sealed class Wfs20Handler
             activity?.SetTag(HonuaTelemetry.Tags.ErrorMessage, ex.Message);
             throw;
         }
+    }
+
+    public async Task<IResult> HandleListStoredQueriesAsync(
+        HttpContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var descriptors = await GetPublishedFeatureTypesAsync(context, cancellationToken).ConfigureAwait(false);
+        var xml = BuildListStoredQueriesXml(descriptors);
+        return Results.Content(xml, "application/xml", Encoding.UTF8);
+    }
+
+    public async Task<IResult> HandleDescribeStoredQueriesAsync(
+        HttpContext context,
+        string? storedQueryIds,
+        CancellationToken cancellationToken = default)
+    {
+        var requestedIds = ParseQualifiedList(storedQueryIds);
+        foreach (var requestedId in requestedIds)
+        {
+            if (!IsGetFeatureByIdStoredQuery(requestedId))
+            {
+                return Wfs20ErrorResults.CreateBadRequest(
+                    context,
+                    "InvalidParameterValue",
+                    $"Stored query '{requestedId}' is not supported.",
+                    "storedquery_id");
+            }
+        }
+
+        var descriptors = await GetPublishedFeatureTypesAsync(context, cancellationToken).ConfigureAwait(false);
+        var xml = BuildDescribeStoredQueriesXml(descriptors);
+        return Results.Content(xml, "application/xml", Encoding.UTF8);
+    }
+
+    public async Task<IResult> HandleStoredQueryGetFeatureAsync(
+        HttpContext context,
+        string storedQueryId,
+        string? featureId,
+        string? outputFormat,
+        string? count,
+        CancellationToken cancellationToken = default)
+    {
+        if (!IsGetFeatureByIdStoredQuery(storedQueryId))
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "OperationParsingFailed",
+                $"Stored query '{storedQueryId}' is not supported.",
+                "storedquery_id");
+        }
+
+        if (string.IsNullOrWhiteSpace(featureId))
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "MissingParameterValue",
+                "Stored query 'GetFeatureById' requires an 'id' parameter.",
+                "id");
+        }
+
+        var normalizedFormat = Wfs20Utilities.OutputFormats.NormalizeOutputFormat(outputFormat);
+        if (!string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.Gml32, StringComparison.OrdinalIgnoreCase))
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "InvalidParameterValue",
+                $"Stored query 'GetFeatureById' supports only '{Wfs20Utilities.OutputFormats.Gml32}'.",
+                "outputFormat");
+        }
+
+        if (!Wfs20Utilities.TryParseCount(count, out _))
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "InvalidParameterValue",
+                $"Invalid COUNT parameter '{count}'. COUNT must be a non-negative integer.",
+                "count");
+        }
+
+        var descriptors = await GetPublishedFeatureTypesAsync(context, cancellationToken).ConfigureAwait(false);
+        var descriptor = ResolveStoredQueryFeatureTypeDescriptor(descriptors, featureId);
+        if (descriptor is null)
+        {
+            return CreateStoredQueryFeatureNotFoundResult(context, featureId);
+        }
+
+        var query = await BuildFeatureQueryAsync(
+            descriptor.Layer,
+            propertyName: null,
+            sortBy: null,
+            bbox: null,
+            filter: null,
+            resourceId: featureId,
+            srsName: null,
+            enforceResourceIdTypeMatch: true,
+            cancellationToken).ConfigureAwait(false);
+
+        var result = await _gmlFeatureStore.QueryGmlAsync(
+            descriptor.Layer.Id,
+            query with { Limit = 1 },
+            cancellationToken).ConfigureAwait(false);
+        if (result.Items.IsDefaultOrEmpty)
+        {
+            return CreateStoredQueryFeatureNotFoundResult(context, featureId);
+        }
+
+        var plan = new LayerQueryPlan(descriptor, query with { Limit = 1 }, 1);
+        var xml = WriteXmlDocument(writer =>
+        {
+            writer.WriteStartDocument();
+            WriteFeature(writer, plan, result.Items[0], includeMemberWrapper: false);
+            writer.WriteEndDocument();
+        });
+
+        return Results.Content(xml, MediaTypes.Gml, Encoding.UTF8);
+    }
+
+    private static IResult CreateStoredQueryFeatureNotFoundResult(HttpContext context, string featureId)
+    {
+        return Wfs20ErrorResults.CreateNotFound(
+            context,
+            "NotFound",
+            $"Feature '{featureId}' was not found.",
+            "id");
     }
 
     public async Task<IResult> HandleGetFeatureAsync(
@@ -222,6 +365,7 @@ internal sealed class Wfs20Handler
 
             var publishedTypes = await GetPublishedFeatureTypesAsync(context, cancellationToken);
             var selectedTypes = ResolveRequestedFeatureTypes(publishedTypes, requestedTypes);
+            var wfsUrl = $"{BaseUrlResolver.GetBaseUrl(context)}/wfs";
             if (selectedTypes.Length == 0)
             {
                 return isHitsRequest
@@ -240,6 +384,7 @@ internal sealed class Wfs20Handler
                     filter,
                     resourceId,
                     srsName,
+                    selectedTypes.Length == 1,
                     cancellationToken).ConfigureAwait(false)) with
                 {
                     Offset = offset,
@@ -274,26 +419,85 @@ internal sealed class Wfs20Handler
 
             if (planSet.TotalMatched == 0)
             {
+                var emptyMetadata = BuildFeatureCollectionResponseMetadata(
+                    wfsUrl,
+                    selectedTypes,
+                    outputFormat,
+                    count,
+                    sortBy,
+                    bbox,
+                    filter,
+                    resourceId,
+                    propertyName,
+                    srsName,
+                    normalizedResultType,
+                    offset,
+                    maxFeatures,
+                    0,
+                    0);
                 return isHitsRequest
-                    ? CreateHitsFeatureCollectionResult(0)
-                    : CreateEmptyFeatureCollectionResult(normalizedFormat);
+                    ? CreateHitsFeatureCollectionResult(0, emptyMetadata.SchemaLocation, emptyMetadata.PagingLinks.Next, emptyMetadata.PagingLinks.Previous)
+                    : CreateEmptyFeatureCollectionResult(normalizedFormat, emptyMetadata.SchemaLocation, emptyMetadata.PagingLinks.Next, emptyMetadata.PagingLinks.Previous);
             }
 
             if (isHitsRequest)
             {
+                var hitsMetadata = BuildFeatureCollectionResponseMetadata(
+                    wfsUrl,
+                    selectedTypes,
+                    outputFormat,
+                    count,
+                    sortBy,
+                    bbox,
+                    filter,
+                    resourceId,
+                    propertyName,
+                    srsName,
+                    normalizedResultType,
+                    offset,
+                    maxFeatures,
+                    planSet.TotalMatched,
+                    0);
                 if (_logger.IsEnabled(LogLevel.Information))
                 {
                     var matchedSummary = planSet.TotalMatched.ToString(CultureInfo.InvariantCulture);
                     Wfs20Log.GetFeatureReturned(_logger, 0, matchedSummary);
                 }
-                return CreateHitsFeatureCollectionResult(planSet.TotalMatched);
+                return CreateHitsFeatureCollectionResult(
+                    planSet.TotalMatched,
+                    hitsMetadata.SchemaLocation,
+                    hitsMetadata.PagingLinks.Next,
+                    hitsMetadata.PagingLinks.Previous);
             }
+
+            var expectedReturnedCount = planSet.Plans.Sum(plan => plan.Query.Limit ?? 0);
+            var responseMetadata = BuildFeatureCollectionResponseMetadata(
+                wfsUrl,
+                selectedTypes,
+                outputFormat,
+                count,
+                sortBy,
+                bbox,
+                filter,
+                resourceId,
+                propertyName,
+                srsName,
+                normalizedResultType,
+                offset,
+                maxFeatures,
+                planSet.TotalMatched,
+                expectedReturnedCount);
 
             var (result, returnedCount) = normalizedFormat switch
             {
                 Wfs20Utilities.OutputFormats.Csv => await BuildCsvResultAsync(planSet, cancellationToken),
                 Wfs20Utilities.OutputFormats.GeoJson or Wfs20Utilities.OutputFormats.Json => await BuildJsonResultAsync(planSet, normalizedFormat, cancellationToken),
-                _ => await BuildGmlResultAsync(planSet, cancellationToken)
+                _ => await BuildGmlResultAsync(
+                    planSet,
+                    responseMetadata.SchemaLocation,
+                    responseMetadata.PagingLinks.Next,
+                    responseMetadata.PagingLinks.Previous,
+                    cancellationToken)
             };
 
             if (_logger.IsEnabled(LogLevel.Information))
@@ -307,12 +511,24 @@ internal sealed class Wfs20Handler
 
             return result;
         }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or Fes20ParseException)
+        catch (WfsQueryException ex)
         {
             Wfs20Log.ParameterValidationFailed(_logger, ex.Message);
             return Wfs20ErrorResults.CreateBadRequest(
                 context,
-                "InvalidParameterValue",
+                ex.ExceptionCode,
+                ex.Message,
+                ex.Locator);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or Fes20ParseException)
+        {
+            Wfs20Log.ParameterValidationFailed(_logger, ex.Message);
+            var exceptionCode = ex.Message.Contains("boundedBy", StringComparison.OrdinalIgnoreCase)
+                ? "OperationProcessingFailed"
+                : "InvalidParameterValue";
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                exceptionCode,
                 "Invalid WFS parameter value; see logs for details.");
         }
         catch (Exception ex)
@@ -326,6 +542,7 @@ internal sealed class Wfs20Handler
         HttpContext context,
         string? typeNames,
         string? valueReference,
+        bool valueReferenceSpecified,
         string? outputFormat,
         string? count,
         string? startIndex,
@@ -342,12 +559,21 @@ internal sealed class Wfs20Handler
         activity?.SetTag("wfs.type_names", typeNames ?? "ALL");
         activity?.SetTag("wfs.value_reference", valueReference ?? "unknown");
 
-        if (string.IsNullOrWhiteSpace(valueReference))
+        if (!valueReferenceSpecified)
         {
             return Wfs20ErrorResults.CreateBadRequest(
                 context,
                 "MissingParameterValue",
                 "Missing required 'valueReference' parameter for GetPropertyValue.",
+                "valueReference");
+        }
+
+        if (string.IsNullOrWhiteSpace(valueReference))
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "InvalidParameterValue",
+                "The 'valueReference' parameter must not be empty for GetPropertyValue.",
                 "valueReference");
         }
 
@@ -413,6 +639,15 @@ internal sealed class Wfs20Handler
             Wfs20Log.GetPropertyValueReturned(_logger, returnedCount);
             return result;
         }
+        catch (WfsQueryException ex)
+        {
+            Wfs20Log.ParameterValidationFailed(_logger, ex.Message);
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                ex.ExceptionCode,
+                ex.Message,
+                ex.Locator);
+        }
         catch (Exception ex) when (ex is ArgumentException or NotSupportedException or Fes20ParseException)
         {
             Wfs20Log.ParameterValidationFailed(_logger, ex.Message);
@@ -426,6 +661,1761 @@ internal sealed class Wfs20Handler
             Wfs20Log.DatabaseQueryFailed(_logger, Wfs20Utilities.Operations.GetPropertyValue, ex.Message);
             return StandardErrorHelpers.CreateInternalServerError(context, "Failed to process GetPropertyValue request.");
         }
+    }
+
+    /// <summary>
+    /// Processes WFS 2.0 Transaction requests by translating XML actions into the shared edit pipeline.
+    /// Behavior reference: ../Honua.Server/src/domain/ogc/wfs/WfsTransactionHandlers.cs
+    /// Preserves request order and carries insert handles into InsertResults.
+    /// </summary>
+    public async Task<IResult> HandleTransactionAsync(
+        HttpContext context,
+        CancellationToken cancellationToken = default)
+    {
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity(
+            "wfs20.transaction", ActivityKind.Internal);
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.Wfs20);
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, Wfs20Utilities.Operations.Transaction);
+
+        try
+        {
+            var document = await ReadTransactionDocumentAsync(context.Request, cancellationToken).ConfigureAwait(false);
+            var root = document.Root;
+            if (root == null || !string.Equals(root.Name.LocalName, Wfs20Utilities.Operations.Transaction, StringComparison.OrdinalIgnoreCase))
+            {
+                return Wfs20ErrorResults.CreateBadRequest(
+                    context,
+                    "OperationParsingFailed",
+                    "Transaction payload must contain a wfs:Transaction root element.",
+                    "request");
+            }
+
+            var rollbackOnFailure = ResolveRollbackOnFailure(context.Request, root);
+            var prepared = await PrepareTransactionAsync(
+                context,
+                root,
+                rollbackOnFailure,
+                cancellationToken).ConfigureAwait(false);
+
+            if (!prepared.IsValid)
+            {
+                return prepared.ErrorResult!;
+            }
+
+            if (prepared.Operations.IsDefaultOrEmpty)
+            {
+                return Wfs20ErrorResults.CreateBadRequest(
+                    context,
+                    "MissingParameterValue",
+                    "Transaction request did not contain any supported operations.",
+                    "request");
+            }
+
+            if (prepared.LayerIdCount > 1)
+            {
+                return Wfs20ErrorResults.CreateNotImplemented(
+                    context,
+                    "OperationNotSupported",
+                    "Transactions spanning multiple feature types are not yet supported.",
+                    "typeName");
+            }
+
+            Wfs20Log.TransactionRequested(_logger, prepared.InsertCount, prepared.UpdateCount, prepared.DeleteCount);
+
+            var editBatch = FeatureEditBatch.Create(
+                rollbackOnFailure: rollbackOnFailure,
+                operations: prepared.Operations
+                    .Select(static operation => operation.EditOperation)
+                    .ToImmutableArray());
+
+            var editResult = await _featureWriter.ApplyEditsAsync(
+                prepared.LayerId,
+                editBatch,
+                cancellationToken).ConfigureAwait(false);
+
+            if (editResult.HasErrors)
+            {
+                var firstError = GetFirstTransactionError(editResult);
+                if (editResult.WasRolledBack)
+                {
+                    Wfs20Log.TransactionRolledBack(_logger, firstError);
+                }
+
+                return Wfs20ErrorResults.CreateBadRequest(
+                    context,
+                    "OperationProcessingFailed",
+                    firstError,
+                    "Transaction");
+            }
+
+            var serviceId = await FeatureMutationEventService.ResolveServiceIdAsync(
+                context,
+                prepared.LayerId,
+                ServiceProtocols.Wfs20,
+                cancellationToken).ConfigureAwait(false);
+
+            if ((editResult.CreatedCount + editResult.UpdatedCount + editResult.DeletedCount) > 0)
+            {
+                await _mutationEventService.InvalidateLayerAsync(serviceId, prepared.LayerId, CancellationToken.None).ConfigureAwait(false);
+                await PublishTransactionEventsAsync(
+                    context,
+                    serviceId,
+                    prepared,
+                    editResult,
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+
+            Wfs20Log.TransactionReturned(_logger, editResult.CreatedCount, editResult.UpdatedCount, editResult.DeletedCount);
+
+            var responseXml = BuildTransactionResponseXml(prepared, editResult);
+            return Results.Content(responseXml, "application/xml", Encoding.UTF8);
+        }
+        catch (InvalidDataException ex)
+        {
+            Wfs20Log.ParameterValidationFailed(_logger, ex.Message);
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "OperationParsingFailed",
+                ex.Message,
+                "request");
+        }
+        catch (WfsTransactionException ex)
+        {
+            Wfs20Log.ParameterValidationFailed(_logger, ex.Message);
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                ex.ExceptionCode,
+                ex.Message,
+                ex.Locator);
+        }
+        catch (ArgumentException ex)
+        {
+            Wfs20Log.ParameterValidationFailed(_logger, ex.Message);
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "InvalidParameterValue",
+                ex.Message,
+                "request");
+        }
+        catch (NotSupportedException ex)
+        {
+            Wfs20Log.UnsupportedOperationRequested(_logger, ex.Message);
+            return Wfs20ErrorResults.CreateNotImplemented(
+                context,
+                "OperationNotSupported",
+                ex.Message,
+                "request");
+        }
+        catch (Exception ex)
+        {
+            Wfs20Log.DatabaseQueryFailed(_logger, Wfs20Utilities.Operations.Transaction, ex.Message);
+            return StandardErrorHelpers.CreateInternalServerError(context, "Failed to process Transaction request.");
+        }
+    }
+
+    private async Task<TransactionPreparationResult> PrepareTransactionAsync(
+        HttpContext context,
+        XElement root,
+        bool rollbackOnFailure,
+        CancellationToken cancellationToken)
+    {
+        var descriptors = await GetPublishedFeatureTypesAsync(context, cancellationToken).ConfigureAwait(false);
+        var operations = ImmutableArray.CreateBuilder<PreparedTransactionOperation>();
+        var distinctLayerIds = new HashSet<int>();
+        var validatedLayerIds = new HashSet<int>();
+
+        foreach (var actionElement in root.Elements())
+        {
+            IResult? errorResult = actionElement.Name.LocalName switch
+            {
+                "Insert" => await PrepareInsertOperationsAsync(
+                    context,
+                    actionElement,
+                    descriptors,
+                    operations,
+                    distinctLayerIds,
+                    validatedLayerIds,
+                    cancellationToken).ConfigureAwait(false),
+                "Update" => await PrepareUpdateOperationsAsync(
+                    context,
+                    actionElement,
+                    descriptors,
+                    operations,
+                    distinctLayerIds,
+                    validatedLayerIds,
+                    cancellationToken).ConfigureAwait(false),
+                "Delete" => await PrepareDeleteOperationsAsync(
+                    context,
+                    actionElement,
+                    descriptors,
+                    operations,
+                    distinctLayerIds,
+                    validatedLayerIds,
+                    cancellationToken).ConfigureAwait(false),
+                "Replace" => await PrepareReplaceOperationsAsync(
+                    context,
+                    actionElement,
+                    descriptors,
+                    operations,
+                    distinctLayerIds,
+                    validatedLayerIds,
+                    cancellationToken).ConfigureAwait(false),
+                "Native" => Wfs20ErrorResults.CreateNotImplemented(
+                    context,
+                    "OperationNotSupported",
+                    "Native transaction actions are not supported.",
+                    "request"),
+                _ => Wfs20ErrorResults.CreateBadRequest(
+                    context,
+                    "InvalidParameterValue",
+                    $"Unsupported transaction action '{actionElement.Name.LocalName}'.",
+                    "request")
+            };
+
+            if (errorResult != null)
+            {
+                return TransactionPreparationResult.Failure(errorResult);
+            }
+        }
+
+        if (operations.Count > _editLimits.MaxEditsPerTransaction)
+        {
+            return TransactionPreparationResult.Failure(Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "InvalidParameterValue",
+                $"Transaction contains {operations.Count.ToString(CultureInfo.InvariantCulture)} operations, exceeding the maximum of {_editLimits.MaxEditsPerTransaction.ToString(CultureInfo.InvariantCulture)}.",
+                "request"));
+        }
+
+        if (rollbackOnFailure && distinctLayerIds.Count > 1)
+        {
+            return TransactionPreparationResult.Failure(Wfs20ErrorResults.CreateNotImplemented(
+                context,
+                "OperationNotSupported",
+                "Atomic transactions spanning multiple feature types are not supported.",
+                "typeName"));
+        }
+
+        var layerId = operations.Count == 0
+            ? 0
+            : operations[0].Descriptor.Layer.Id;
+
+        return TransactionPreparationResult.Success(
+            operations.ToImmutable(),
+            layerId,
+            distinctLayerIds.Count);
+    }
+
+    private async Task<IResult?> PrepareInsertOperationsAsync(
+        HttpContext context,
+        XElement insertElement,
+        IReadOnlyList<WfsFeatureTypeDescriptor> descriptors,
+        ImmutableArray<PreparedTransactionOperation>.Builder operations,
+        HashSet<int> distinctLayerIds,
+        HashSet<int> validatedLayerIds,
+        CancellationToken cancellationToken)
+    {
+        var handle = insertElement.Attributes()
+            .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, "handle", StringComparison.OrdinalIgnoreCase))
+            ?.Value;
+
+        var featureElements = insertElement.Elements().ToArray();
+        if (featureElements.Length == 0)
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "MissingParameterValue",
+                "Insert action must contain at least one feature element.",
+                "Insert");
+        }
+
+        if (featureElements.Length > _editLimits.MaxFeaturesPerEdit)
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "InvalidParameterValue",
+                $"Insert action exceeds the maximum of {_editLimits.MaxFeaturesPerEdit.ToString(CultureInfo.InvariantCulture)} features.",
+                "Insert");
+        }
+
+        foreach (var featureElement in featureElements)
+        {
+            var descriptor = ResolveTransactionFeatureTypeDescriptor(descriptors, featureElement.Name.LocalName);
+            var validationError = await ValidateTransactionLayerWriteAccessAsync(
+                context,
+                descriptor.Layer.Id,
+                validatedLayerIds,
+                cancellationToken).ConfigureAwait(false);
+            if (validationError != null)
+            {
+                return validationError;
+            }
+
+            distinctLayerIds.Add(descriptor.Layer.Id);
+            var feature = await BuildTransactionInsertFeatureAsync(
+                descriptor.Layer,
+                featureElement,
+                cancellationToken).ConfigureAwait(false);
+            operations.Add(new PreparedTransactionOperation(
+                descriptor,
+                TransactionActionKind.Insert,
+                FeatureEditOperation.Create(feature),
+                handle,
+                feature,
+                null));
+        }
+
+        return null;
+    }
+
+    private async Task<IResult?> PrepareUpdateOperationsAsync(
+        HttpContext context,
+        XElement updateElement,
+        IReadOnlyList<WfsFeatureTypeDescriptor> descriptors,
+        ImmutableArray<PreparedTransactionOperation>.Builder operations,
+        HashSet<int> distinctLayerIds,
+        HashSet<int> validatedLayerIds,
+        CancellationToken cancellationToken)
+    {
+        var handle = updateElement.Attributes()
+            .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, "handle", StringComparison.OrdinalIgnoreCase))
+            ?.Value;
+        var typeName = updateElement.Attributes()
+            .FirstOrDefault(attribute =>
+                string.Equals(attribute.Name.LocalName, "typeName", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(attribute.Name.LocalName, "typeNames", StringComparison.OrdinalIgnoreCase))
+            ?.Value;
+        if (string.IsNullOrWhiteSpace(typeName))
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "MissingParameterValue",
+                "Update action requires a typeName attribute.",
+                "typeName");
+        }
+
+        var descriptor = ResolveTransactionFeatureTypeDescriptor(descriptors, typeName);
+        var validationError = await ValidateTransactionLayerWriteAccessAsync(
+            context,
+            descriptor.Layer.Id,
+            validatedLayerIds,
+            cancellationToken).ConfigureAwait(false);
+        if (validationError != null)
+        {
+            return validationError;
+        }
+
+        distinctLayerIds.Add(descriptor.Layer.Id);
+
+        var changes = ParseTransactionUpdateChanges(descriptor.Layer, updateElement);
+        var targetIds = await ResolveTransactionTargetObjectIdsAsync(
+            descriptor.Layer,
+            updateElement,
+            cancellationToken).ConfigureAwait(false);
+
+        if (targetIds.Length > _editLimits.MaxFeaturesPerEdit)
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "InvalidParameterValue",
+                $"Update action exceeds the maximum of {_editLimits.MaxFeaturesPerEdit.ToString(CultureInfo.InvariantCulture)} matched features.",
+                "Filter");
+        }
+
+        foreach (var objectId in targetIds)
+        {
+            var existing = await _featureReader.GetAsync(
+                descriptor.Layer.Id,
+                objectId,
+                cancellationToken).ConfigureAwait(false);
+            if (!existing.HasValue)
+            {
+                return Wfs20ErrorResults.CreateBadRequest(
+                    context,
+                    "InvalidParameterValue",
+                    $"Feature '{BuildFeatureId(descriptor, objectId)}' not found.",
+                    "Filter");
+            }
+
+            var updatedFeature = await BuildTransactionUpdatedFeatureAsync(
+                existing.Value,
+                descriptor.Layer,
+                changes,
+                cancellationToken).ConfigureAwait(false);
+            operations.Add(new PreparedTransactionOperation(
+                descriptor,
+                TransactionActionKind.Update,
+                FeatureEditOperation.Update(updatedFeature),
+                handle,
+                updatedFeature,
+                null));
+        }
+
+        return null;
+    }
+
+    private async Task<IResult?> PrepareDeleteOperationsAsync(
+        HttpContext context,
+        XElement deleteElement,
+        IReadOnlyList<WfsFeatureTypeDescriptor> descriptors,
+        ImmutableArray<PreparedTransactionOperation>.Builder operations,
+        HashSet<int> distinctLayerIds,
+        HashSet<int> validatedLayerIds,
+        CancellationToken cancellationToken)
+    {
+        var handle = deleteElement.Attributes()
+            .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, "handle", StringComparison.OrdinalIgnoreCase))
+            ?.Value;
+        var typeName = deleteElement.Attributes()
+            .FirstOrDefault(attribute =>
+                string.Equals(attribute.Name.LocalName, "typeName", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(attribute.Name.LocalName, "typeNames", StringComparison.OrdinalIgnoreCase))
+            ?.Value;
+        if (string.IsNullOrWhiteSpace(typeName))
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "MissingParameterValue",
+                "Delete action requires a typeName attribute.",
+                "typeName");
+        }
+
+        var descriptor = ResolveTransactionFeatureTypeDescriptor(descriptors, typeName);
+        var validationError = await ValidateTransactionLayerWriteAccessAsync(
+            context,
+            descriptor.Layer.Id,
+            validatedLayerIds,
+            cancellationToken).ConfigureAwait(false);
+        if (validationError != null)
+        {
+            return validationError;
+        }
+
+        distinctLayerIds.Add(descriptor.Layer.Id);
+
+        var targetIds = await ResolveTransactionTargetObjectIdsAsync(
+            descriptor.Layer,
+            deleteElement,
+            cancellationToken).ConfigureAwait(false);
+
+        if (targetIds.Length > _editLimits.MaxFeaturesPerEdit)
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "InvalidParameterValue",
+                $"Delete action exceeds the maximum of {_editLimits.MaxFeaturesPerEdit.ToString(CultureInfo.InvariantCulture)} matched features.",
+                "Filter");
+        }
+
+        foreach (var objectId in targetIds)
+        {
+            var existing = await _featureReader.GetAsync(
+                descriptor.Layer.Id,
+                objectId,
+                cancellationToken).ConfigureAwait(false);
+            if (!existing.HasValue)
+            {
+                return Wfs20ErrorResults.CreateBadRequest(
+                    context,
+                    "InvalidParameterValue",
+                    $"Feature '{BuildFeatureId(descriptor, objectId)}' not found.",
+                    "Filter");
+            }
+
+            operations.Add(new PreparedTransactionOperation(
+                descriptor,
+                TransactionActionKind.Delete,
+                FeatureEditOperation.Delete(objectId),
+                handle,
+                null,
+                existing.Value));
+        }
+
+        return null;
+    }
+
+    private async Task<IResult?> PrepareReplaceOperationsAsync(
+        HttpContext context,
+        XElement replaceElement,
+        IReadOnlyList<WfsFeatureTypeDescriptor> descriptors,
+        ImmutableArray<PreparedTransactionOperation>.Builder operations,
+        HashSet<int> distinctLayerIds,
+        HashSet<int> validatedLayerIds,
+        CancellationToken cancellationToken)
+    {
+        var handle = replaceElement.Attributes()
+            .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, "handle", StringComparison.OrdinalIgnoreCase))
+            ?.Value;
+
+        var featureElement = replaceElement.Elements()
+            .FirstOrDefault(element => !string.Equals(element.Name.LocalName, "Filter", StringComparison.OrdinalIgnoreCase));
+        if (featureElement == null)
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "MissingParameterValue",
+                "Replace action must contain a replacement feature element.",
+                "Replace");
+        }
+
+        var descriptor = ResolveTransactionFeatureTypeDescriptor(descriptors, featureElement.Name.LocalName);
+        var validationError = await ValidateTransactionLayerWriteAccessAsync(
+            context,
+            descriptor.Layer.Id,
+            validatedLayerIds,
+            cancellationToken).ConfigureAwait(false);
+        if (validationError != null)
+        {
+            return validationError;
+        }
+
+        distinctLayerIds.Add(descriptor.Layer.Id);
+
+        var targetIds = await ResolveTransactionTargetObjectIdsAsync(
+            descriptor.Layer,
+            replaceElement,
+            cancellationToken).ConfigureAwait(false);
+        if (targetIds.Length != 1)
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "InvalidParameterValue",
+                "Replace action must identify exactly one target feature.",
+                "Filter");
+        }
+
+        var existing = await _featureReader.GetAsync(
+            descriptor.Layer.Id,
+            targetIds[0],
+            cancellationToken).ConfigureAwait(false);
+        if (!existing.HasValue)
+        {
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "InvalidParameterValue",
+                $"Feature '{BuildFeatureId(descriptor, targetIds[0])}' not found.",
+                "Filter");
+        }
+
+        var replacement = await BuildTransactionReplaceFeatureAsync(
+            descriptor.Layer,
+            targetIds[0],
+            featureElement,
+            cancellationToken).ConfigureAwait(false);
+        operations.Add(new PreparedTransactionOperation(
+            descriptor,
+            TransactionActionKind.Replace,
+            FeatureEditOperation.Update(replacement),
+            handle,
+            replacement,
+            null));
+
+        return null;
+    }
+
+    private async Task<Feature> BuildTransactionInsertFeatureAsync(
+        LayerDefinition layer,
+        XElement featureElement,
+        CancellationToken cancellationToken)
+    {
+        var payload = ReadTransactionFeaturePayload(layer, featureElement);
+
+        return await CreateTransactionFeatureAsync(
+            layer,
+            objectId: 0,
+            payload.Geometry,
+            payload.Attributes,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<Feature> BuildTransactionReplaceFeatureAsync(
+        LayerDefinition layer,
+        long objectId,
+        XElement featureElement,
+        CancellationToken cancellationToken)
+    {
+        var payload = ReadTransactionFeaturePayload(layer, featureElement);
+
+        return await CreateTransactionFeatureAsync(
+            layer,
+            objectId,
+            payload.Geometry,
+            payload.Attributes,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<Feature> BuildTransactionUpdatedFeatureAsync(
+        Feature existing,
+        LayerDefinition layer,
+        TransactionFeatureChanges changes,
+        CancellationToken cancellationToken)
+    {
+        var attributes = existing.Attributes.ToBuilder();
+        foreach (var (key, value) in changes.Attributes)
+        {
+            attributes[key] = value;
+        }
+
+        var geometry = changes.GeometrySpecified
+            ? changes.Geometry
+            : existing.Geometry;
+
+        return await CreateTransactionFeatureAsync(
+            layer,
+            existing.Id,
+            geometry,
+            attributes.ToImmutable(),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<Feature> CreateTransactionFeatureAsync(
+        LayerDefinition layer,
+        long objectId,
+        byte[]? geometry,
+        ImmutableDictionary<string, object?> attributes,
+        CancellationToken cancellationToken)
+    {
+        var geometryValidation = await _mutationValidator.ValidateGeometryAsync(
+            geometry,
+            cancellationToken).ConfigureAwait(false);
+        if (!geometryValidation.IsValid)
+        {
+            throw new ArgumentException($"Geometry validation failed: {geometryValidation.ErrorMessage}");
+        }
+
+        var attributesResult = _mutationValidator.ValidateAttributes(
+            layer,
+            attributes,
+            ValidationExtensions.AttributeValidationMode.Strict);
+        if (!attributesResult.IsValid)
+        {
+            throw new ArgumentException(attributesResult.ErrorMessage ?? "Invalid attributes.");
+        }
+
+        return Feature.Create(objectId, geometryValidation.Geometry, attributesResult.Value!);
+    }
+
+    private TransactionFeaturePayload ReadTransactionFeaturePayload(
+        LayerDefinition layer,
+        XElement featureElement)
+    {
+        var attributes = ImmutableDictionary.CreateBuilder<string, object?>(StringComparer.OrdinalIgnoreCase);
+        var gmlAssignedFields = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        byte[]? geometry = null;
+
+        foreach (var propertyElement in featureElement.Elements())
+        {
+            if (TryResolveReservedGmlTransactionAttributeName(
+                layer,
+                propertyElement.Name.LocalName,
+                propertyElement.Name.NamespaceName,
+                out var reservedAttributeName))
+            {
+                attributes[reservedAttributeName] = ParseTransactionReservedAttributeValue(propertyElement);
+                continue;
+            }
+
+            var resolution = ResolveTransactionField(
+                layer,
+                propertyElement.Name.LocalName,
+                propertyElement.Name.NamespaceName);
+            if (!resolution.HasValue)
+            {
+                continue;
+            }
+
+            var resolvedField = resolution.Value;
+
+            if (layer.GeometryField != null &&
+                resolvedField.Field.Name.Equals(layer.GeometryField.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                geometry = ParseTransactionGeometryProperty(propertyElement, layer);
+                continue;
+            }
+
+            if (resolvedField.IsGmlProperty)
+            {
+                gmlAssignedFields.Add(resolvedField.Field.Name);
+                attributes[resolvedField.Field.Name] = ParseTransactionFieldValue(resolvedField.Field, propertyElement);
+                continue;
+            }
+
+            if (gmlAssignedFields.Contains(resolvedField.Field.Name))
+            {
+                continue;
+            }
+
+            attributes[resolvedField.Field.Name] = ParseTransactionFieldValue(resolvedField.Field, propertyElement);
+        }
+
+        return new TransactionFeaturePayload(geometry, attributes.ToImmutable());
+    }
+
+    private TransactionFeatureChanges ParseTransactionUpdateChanges(
+        LayerDefinition layer,
+        XElement updateElement)
+    {
+        var attributes = ImmutableDictionary.CreateBuilder<string, object?>(StringComparer.OrdinalIgnoreCase);
+        var propertyElements = updateElement.Elements()
+            .Where(element => string.Equals(element.Name.LocalName, "Property", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (propertyElements.Length == 0)
+        {
+            throw new ArgumentException("Update action must include at least one Property element.");
+        }
+
+        byte[]? geometry = null;
+        var geometrySpecified = false;
+        var gmlAssignedFields = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var propertyElement in propertyElements)
+        {
+            var nameElement = propertyElement.Elements()
+                .FirstOrDefault(element =>
+                    string.Equals(element.Name.LocalName, "ValueReference", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(element.Name.LocalName, "Name", StringComparison.OrdinalIgnoreCase));
+            if (nameElement == null)
+            {
+                continue;
+            }
+
+            var normalizedPropertyName = NormalizeTransactionPropertyReference(nameElement.Value);
+            if (normalizedPropertyName.Equals("boundedBy", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new WfsTransactionException(
+                    "InvalidValue",
+                    "Property 'gml:boundedBy' cannot be updated with the supplied value.",
+                    "ValueReference");
+            }
+
+            var valueElement = propertyElement.Elements()
+                .FirstOrDefault(element => string.Equals(element.Name.LocalName, "Value", StringComparison.OrdinalIgnoreCase));
+
+            if (TryResolveReservedGmlTransactionAttributeName(
+                layer,
+                nameElement.Value.Trim(),
+                namespaceName: null,
+                out var reservedAttributeName))
+            {
+                attributes[reservedAttributeName] = valueElement == null
+                    ? null
+                    : ParseTransactionReservedAttributeValue(valueElement);
+                continue;
+            }
+
+            var fieldResolution = ResolveTransactionField(layer, nameElement.Value.Trim());
+            if (!fieldResolution.HasValue)
+            {
+                continue;
+            }
+
+            var resolvedField = fieldResolution.Value;
+
+            if (layer.GeometryField != null &&
+                resolvedField.Field.Name.Equals(layer.GeometryField.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                geometrySpecified = true;
+                geometry = valueElement == null
+                    ? null
+                    : ParseTransactionGeometryProperty(valueElement, layer);
+                continue;
+            }
+
+            if (resolvedField.IsGmlProperty)
+            {
+                gmlAssignedFields.Add(resolvedField.Field.Name);
+            }
+            else if (gmlAssignedFields.Contains(resolvedField.Field.Name))
+            {
+                continue;
+            }
+
+            attributes[resolvedField.Field.Name] = valueElement == null
+                ? null
+                : ParseTransactionFieldValue(resolvedField.Field, valueElement);
+        }
+
+        if (attributes.Count == 0 && !geometrySpecified)
+        {
+            throw new ArgumentException("Update action must include at least one mutable property.");
+        }
+
+        return new TransactionFeatureChanges(geometrySpecified, geometry, attributes.ToImmutable());
+    }
+
+    private async Task<ImmutableArray<long>> ResolveTransactionTargetObjectIdsAsync(
+        LayerDefinition layer,
+        XElement actionElement,
+        CancellationToken cancellationToken)
+    {
+        var filterElement = actionElement.Elements()
+            .FirstOrDefault(element => string.Equals(element.Name.LocalName, "Filter", StringComparison.OrdinalIgnoreCase));
+        var filterChildren = filterElement?.Elements().ToArray() ?? [];
+        var resourceIdValues = filterElement == null
+            ? []
+            : filterElement
+                .Descendants()
+                .Where(element => string.Equals(element.Name.LocalName, "ResourceId", StringComparison.OrdinalIgnoreCase))
+                .Select(element => element.Attributes()
+                    .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, "rid", StringComparison.OrdinalIgnoreCase))
+                    ?.Value)
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Cast<string>()
+                .ToArray();
+        var resourceIds = resourceIdValues.Length == 0
+            ? null
+            : string.Join(',', resourceIdValues);
+        var hasOnlyResourceIdPredicates = filterChildren.Length > 0 &&
+            filterChildren.All(element => string.Equals(element.Name.LocalName, "ResourceId", StringComparison.OrdinalIgnoreCase));
+        var filterXml = hasOnlyResourceIdPredicates
+            ? null
+            : filterElement?.ToString(SaveOptions.DisableFormatting);
+
+        if (string.IsNullOrWhiteSpace(filterXml) && string.IsNullOrWhiteSpace(resourceIds))
+        {
+            throw new ArgumentException("Update and Delete actions must include a Filter or ResourceId.");
+        }
+
+        if (!hasOnlyResourceIdPredicates &&
+            resourceIdValues.Length > 0)
+        {
+            throw new NotSupportedException("Transaction filters that combine ResourceId with other predicates are not yet supported.");
+        }
+
+        var query = await BuildFeatureQueryAsync(
+            layer,
+            propertyName: null,
+            sortBy: null,
+            bbox: null,
+            filter: filterXml,
+            resourceId: resourceIds,
+            srsName: null,
+            enforceResourceIdTypeMatch: true,
+            cancellationToken).ConfigureAwait(false);
+
+        var objectIds = await _featureReader.QueryObjectIdsAsync(
+            layer.Id,
+            query,
+            cancellationToken).ConfigureAwait(false);
+
+        if (objectIds.IsDefaultOrEmpty)
+        {
+            throw new ArgumentException("Transaction filter did not match any features.");
+        }
+
+        return objectIds;
+    }
+
+    private async Task<IResult?> ValidateTransactionLayerWriteAccessAsync(
+        HttpContext context,
+        int layerId,
+        HashSet<int> validatedLayerIds,
+        CancellationToken cancellationToken)
+    {
+        if (!validatedLayerIds.Add(layerId))
+        {
+            return null;
+        }
+
+        var layerValidation = await LayerValidationHelpers.ValidateLayerWithAccessAsync(
+            context,
+            layerId,
+            scope: AccessScope.Write,
+            requiredProtocol: ServiceProtocols.Wfs20,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!layerValidation.IsValid)
+        {
+            return layerValidation.ErrorResult;
+        }
+
+        return await ServiceDataEditorAuthorization.RequireLayerDataEditorAsync(
+            context,
+            layerId,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static WfsFeatureTypeDescriptor ResolveTransactionFeatureTypeDescriptor(
+        IReadOnlyList<WfsFeatureTypeDescriptor> descriptors,
+        string rawTypeName)
+    {
+        if (string.IsNullOrWhiteSpace(rawTypeName))
+        {
+            throw new WfsTransactionException("MissingParameterValue", "Transaction action is missing a feature type name.", "typeName");
+        }
+
+        var trimmedTypeName = rawTypeName.Trim();
+        var localName = trimmedTypeName.Contains(':', StringComparison.Ordinal)
+            ? trimmedTypeName[(trimmedTypeName.LastIndexOf(':') + 1)..]
+            : trimmedTypeName;
+
+        foreach (var descriptor in descriptors)
+        {
+            if (descriptor.QualifiedName.Equals(trimmedTypeName, StringComparison.OrdinalIgnoreCase) ||
+                descriptor.LocalName.Equals(trimmedTypeName, StringComparison.OrdinalIgnoreCase) ||
+                descriptor.LocalName.Equals(localName, StringComparison.OrdinalIgnoreCase))
+            {
+                return descriptor;
+            }
+        }
+
+        throw new WfsTransactionException("InvalidValue", $"Unknown feature type '{rawTypeName}'.", "typeName");
+    }
+
+    private static TransactionFieldResolution? ResolveTransactionField(
+        LayerDefinition layer,
+        string rawName,
+        string? namespaceName = null)
+    {
+        var normalizedName = NormalizeTransactionPropertyReference(rawName);
+        if (TryResolveGmlTransactionField(layer, normalizedName, rawName, namespaceName, out var gmlField))
+        {
+            return gmlField == null
+                ? null
+                : new TransactionFieldResolution(gmlField, IsGmlProperty: true);
+        }
+
+        var resolvedName = FilterExpressionHelpers.ResolveFieldName(
+            layer,
+            normalizedName,
+            allowGeometryAlias: true);
+        if (resolvedName == null)
+        {
+            throw new ArgumentException($"Unknown property '{rawName}' for feature type '{layer.Name}'.");
+        }
+
+        if (layer.PrimaryKeyField != null &&
+            resolvedName.Equals(layer.PrimaryKeyField.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var resolvedField = layer.Fields.FirstOrDefault(field =>
+            field.Name.Equals(resolvedName, StringComparison.OrdinalIgnoreCase))
+            ?? throw new ArgumentException($"Unknown property '{rawName}' for feature type '{layer.Name}'.");
+
+        return new TransactionFieldResolution(resolvedField, IsGmlProperty: false);
+    }
+
+    private static string NormalizeTransactionPropertyReference(string rawName)
+    {
+        var normalized = rawName.Trim();
+        var lastSlash = normalized.LastIndexOf('/');
+        if (lastSlash >= 0 && lastSlash < normalized.Length - 1)
+        {
+            normalized = normalized[(lastSlash + 1)..];
+        }
+
+        if (normalized.StartsWith('@'))
+        {
+            normalized = normalized[1..];
+        }
+
+        var predicateIndex = normalized.IndexOf('[');
+        if (predicateIndex > 0)
+        {
+            normalized = normalized[..predicateIndex];
+        }
+
+        var colonIndex = normalized.LastIndexOf(':');
+        if (colonIndex >= 0 && colonIndex < normalized.Length - 1)
+        {
+            normalized = normalized[(colonIndex + 1)..];
+        }
+
+        return normalized.Trim();
+    }
+
+    private static bool TryResolveReservedGmlTransactionAttributeName(
+        LayerDefinition layer,
+        string rawName,
+        string? namespaceName,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? attributeName)
+    {
+        attributeName = null;
+
+        var isGmlProperty = string.Equals(namespaceName, Wfs20Utilities.GmlNamespace, StringComparison.Ordinal) ||
+            rawName.StartsWith("gml:", StringComparison.OrdinalIgnoreCase);
+        if (!isGmlProperty)
+        {
+            return false;
+        }
+
+        var normalizedName = NormalizeTransactionPropertyReference(rawName);
+        var localName = normalizedName.Contains(':', StringComparison.Ordinal)
+            ? normalizedName[(normalizedName.LastIndexOf(':') + 1)..]
+            : normalizedName;
+
+        attributeName = localName.ToLowerInvariant() switch
+        {
+            "identifier" => ValidationExtensions.WfsGmlIdentifierAttributeName,
+            "name" when !HasTransactionAttributeField(layer, "name") => ValidationExtensions.WfsGmlNameAttributeName,
+            "description" when !HasTransactionAttributeField(layer, "description") => ValidationExtensions.WfsGmlDescriptionAttributeName,
+            _ => null
+        };
+
+        return attributeName != null;
+    }
+
+    private static bool HasTransactionAttributeField(LayerDefinition layer, string fieldName)
+    {
+        return layer.AttributeFields.Any(candidate =>
+            candidate.Name.Equals(fieldName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool TryResolveGmlTransactionField(
+        LayerDefinition layer,
+        string normalizedName,
+        string rawName,
+        string? namespaceName,
+        out FieldDefinition? field)
+    {
+        field = null;
+
+        var isGmlProperty = string.Equals(namespaceName, Wfs20Utilities.GmlNamespace, StringComparison.Ordinal) ||
+            rawName.StartsWith("gml:", StringComparison.OrdinalIgnoreCase);
+        if (!isGmlProperty)
+        {
+            return false;
+        }
+
+        var localName = normalizedName.Contains(':', StringComparison.Ordinal)
+            ? normalizedName[(normalizedName.LastIndexOf(':') + 1)..]
+            : normalizedName;
+
+        var mappedFieldName = localName.ToLowerInvariant() switch
+        {
+            "name" => "name",
+            "description" => "description",
+            "identifier" => null,
+            _ => null
+        };
+        if (mappedFieldName == null)
+        {
+            return true;
+        }
+
+        field = layer.Fields.FirstOrDefault(candidate =>
+            candidate.Name.Equals(mappedFieldName, StringComparison.OrdinalIgnoreCase));
+        if (field != null &&
+            layer.PrimaryKeyField != null &&
+            field.Name.Equals(layer.PrimaryKeyField.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            field = null;
+        }
+
+        return true;
+    }
+
+    private static object? ParseTransactionFieldValue(FieldDefinition field, XElement valueElement)
+    {
+        if (HasNilAttribute(valueElement))
+        {
+            return null;
+        }
+
+        var rawValue = valueElement.Value.Trim();
+        return field.Type switch
+        {
+            FieldType.Integer or FieldType.BigInteger
+                => long.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var integerValue)
+                    ? integerValue
+                    : rawValue,
+            FieldType.Double or FieldType.Float
+                => double.TryParse(rawValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var numericValue)
+                    ? numericValue
+                    : rawValue,
+            FieldType.Boolean
+                => bool.TryParse(rawValue, out var booleanValue)
+                    ? booleanValue
+                    : rawValue,
+            _ => rawValue
+        };
+    }
+
+    private static string? ParseTransactionReservedAttributeValue(XElement valueElement)
+    {
+        if (HasNilAttribute(valueElement))
+        {
+            return null;
+        }
+
+        return valueElement.Value.Trim();
+    }
+
+    private static byte[]? ParseTransactionGeometryProperty(
+        XElement propertyElement,
+        LayerDefinition layer)
+    {
+        if (HasNilAttribute(propertyElement))
+        {
+            return null;
+        }
+
+        var geometryElement = propertyElement.Name.NamespaceName == Wfs20Utilities.GmlNamespace
+            ? propertyElement
+            : propertyElement.Elements()
+                .FirstOrDefault(element => string.Equals(element.Name.NamespaceName, Wfs20Utilities.GmlNamespace, StringComparison.Ordinal));
+
+        if (geometryElement == null)
+        {
+            if (propertyElement.IsEmpty)
+            {
+                return null;
+            }
+
+            throw new ArgumentException($"Geometry property '{propertyElement.Name.LocalName}' must contain a GML geometry.");
+        }
+
+        var defaultSrid = layer.SpatialReference.ToSrid();
+        var geometry = ParseTransactionGeometry(geometryElement, defaultSrid);
+        return GeometryWkbWriter.Write(geometry);
+    }
+
+    private static Geometry ParseTransactionGeometry(XElement geometryElement, int defaultSrid)
+    {
+        var crsDefinition = geometryElement.Attributes()
+            .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, "srsName", StringComparison.OrdinalIgnoreCase))
+            ?.Value is { Length: > 0 } srsName &&
+            SpatialReferenceHelpers.TryParseCrsDefinition(srsName, out var parsedDefinition)
+            ? parsedDefinition
+            : SpatialReferenceHelpers.TryParseCrsDefinition(defaultSrid.ToString(CultureInfo.InvariantCulture), out var defaultDefinition)
+                ? defaultDefinition
+                : new CrsDefinition(
+                    FormattableString.Invariant($"http://www.opengis.net/def/crs/EPSG/0/{defaultSrid}"),
+                    defaultSrid,
+                    AxisOrder.EastNorth,
+                    IsGeographic: false);
+
+        var geometryFactory = NtsGeometryServices.Instance.CreateGeometryFactory(crsDefinition.Srid);
+
+        return geometryElement.Name.LocalName switch
+        {
+            "Point" => ParseTransactionPointGeometry(geometryElement, geometryFactory, crsDefinition.AxisOrder),
+            "MultiPoint" => ParseTransactionMultiPointGeometry(geometryElement, geometryFactory, crsDefinition.AxisOrder),
+            "LineString" or "Curve" => ParseTransactionLineStringGeometry(geometryElement, geometryFactory, crsDefinition.AxisOrder),
+            "MultiLineString" or "MultiCurve" => ParseTransactionMultiLineStringGeometry(geometryElement, geometryFactory, crsDefinition.AxisOrder),
+            "Polygon" or "Surface" => ParseTransactionPolygonGeometry(geometryElement, geometryFactory, crsDefinition.AxisOrder),
+            "MultiPolygon" or "MultiSurface" => ParseTransactionMultiPolygonGeometry(geometryElement, geometryFactory, crsDefinition.AxisOrder),
+            _ => throw new NotSupportedException($"Unsupported GML geometry type '{geometryElement.Name.LocalName}'.")
+        };
+    }
+
+    private static Point ParseTransactionPointGeometry(
+        XElement geometryElement,
+        GeometryFactory geometryFactory,
+        AxisOrder axisOrder)
+    {
+        var positionElement = geometryElement.Descendants()
+            .FirstOrDefault(element => string.Equals(element.Name.LocalName, "pos", StringComparison.OrdinalIgnoreCase))
+            ?? throw new ArgumentException("Point geometry must contain a gml:pos element.");
+
+        return geometryFactory.CreatePoint(ParseTransactionCoordinate(positionElement.Value, axisOrder));
+    }
+
+    private static MultiPoint ParseTransactionMultiPointGeometry(
+        XElement geometryElement,
+        GeometryFactory geometryFactory,
+        AxisOrder axisOrder)
+    {
+        var points = geometryElement
+            .Descendants()
+            .Where(element => string.Equals(element.Name.LocalName, "Point", StringComparison.OrdinalIgnoreCase))
+            .Select(pointElement => ParseTransactionPointGeometry(pointElement, geometryFactory, axisOrder))
+            .ToArray();
+
+        if (points.Length == 0)
+        {
+            throw new ArgumentException("MultiPoint geometry must contain at least one gml:Point element.");
+        }
+
+        return geometryFactory.CreateMultiPoint(points);
+    }
+
+    private static LineString ParseTransactionLineStringGeometry(
+        XElement geometryElement,
+        GeometryFactory geometryFactory,
+        AxisOrder axisOrder)
+    {
+        var coordinates = ParseTransactionCoordinateSequence(geometryElement, axisOrder);
+        if (coordinates.Length < 2)
+        {
+            throw new ArgumentException("LineString geometry must contain at least two positions.");
+        }
+
+        return geometryFactory.CreateLineString(coordinates);
+    }
+
+    private static MultiLineString ParseTransactionMultiLineStringGeometry(
+        XElement geometryElement,
+        GeometryFactory geometryFactory,
+        AxisOrder axisOrder)
+    {
+        var lineStrings = geometryElement
+            .Descendants()
+            .Where(element =>
+                string.Equals(element.Name.LocalName, "LineString", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(element.Name.LocalName, "Curve", StringComparison.OrdinalIgnoreCase))
+            .Select(lineElement => ParseTransactionLineStringGeometry(lineElement, geometryFactory, axisOrder))
+            .ToArray();
+
+        if (lineStrings.Length == 0)
+        {
+            throw new ArgumentException("MultiLineString geometry must contain at least one line geometry.");
+        }
+
+        return geometryFactory.CreateMultiLineString(lineStrings);
+    }
+
+    private static Polygon ParseTransactionPolygonGeometry(
+        XElement geometryElement,
+        GeometryFactory geometryFactory,
+        AxisOrder axisOrder)
+    {
+        XElement? polygonSource = geometryElement;
+        if (string.Equals(geometryElement.Name.LocalName, "Surface", StringComparison.OrdinalIgnoreCase))
+        {
+            polygonSource = geometryElement
+                .Descendants()
+                .FirstOrDefault(element => string.Equals(element.Name.LocalName, "PolygonPatch", StringComparison.OrdinalIgnoreCase))
+                ?? throw new ArgumentException("Surface geometry must contain a PolygonPatch element.");
+        }
+
+        var exteriorElement = polygonSource
+            .Descendants()
+            .FirstOrDefault(element => string.Equals(element.Name.LocalName, "exterior", StringComparison.OrdinalIgnoreCase))
+            ?? throw new ArgumentException("Polygon geometry must contain an exterior ring.");
+
+        var shell = geometryFactory.CreateLinearRing(ParseTransactionLinearRingCoordinates(exteriorElement, axisOrder));
+        var holes = polygonSource
+            .Descendants()
+            .Where(element => string.Equals(element.Name.LocalName, "interior", StringComparison.OrdinalIgnoreCase))
+            .Select(interiorElement => geometryFactory.CreateLinearRing(ParseTransactionLinearRingCoordinates(interiorElement, axisOrder)))
+            .ToArray();
+
+        return geometryFactory.CreatePolygon(shell, holes);
+    }
+
+    private static MultiPolygon ParseTransactionMultiPolygonGeometry(
+        XElement geometryElement,
+        GeometryFactory geometryFactory,
+        AxisOrder axisOrder)
+    {
+        var polygons = geometryElement
+            .Descendants()
+            .Where(element =>
+                string.Equals(element.Name.LocalName, "Polygon", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(element.Name.LocalName, "Surface", StringComparison.OrdinalIgnoreCase))
+            .Select(polygonElement => ParseTransactionPolygonGeometry(polygonElement, geometryFactory, axisOrder))
+            .ToArray();
+
+        if (polygons.Length == 0)
+        {
+            throw new ArgumentException("MultiPolygon geometry must contain at least one polygon geometry.");
+        }
+
+        return geometryFactory.CreateMultiPolygon(polygons);
+    }
+
+    private static Coordinate[] ParseTransactionLinearRingCoordinates(XElement ringContainer, AxisOrder axisOrder)
+    {
+        var linearRingElement = ringContainer.Descendants()
+            .FirstOrDefault(element => string.Equals(element.Name.LocalName, "LinearRing", StringComparison.OrdinalIgnoreCase))
+            ?? throw new ArgumentException("Polygon ring must contain a LinearRing element.");
+        var coordinates = ParseTransactionCoordinateSequence(linearRingElement, axisOrder);
+        if (coordinates.Length < 4)
+        {
+            throw new ArgumentException("Polygon rings must contain at least four positions.");
+        }
+
+        return coordinates;
+    }
+
+    private static Coordinate[] ParseTransactionCoordinateSequence(XElement geometryElement, AxisOrder axisOrder)
+    {
+        var posListElement = geometryElement.Descendants()
+            .FirstOrDefault(element => string.Equals(element.Name.LocalName, "posList", StringComparison.OrdinalIgnoreCase));
+        if (posListElement != null)
+        {
+            return ParseTransactionPosList(posListElement.Value, axisOrder);
+        }
+
+        var positions = geometryElement.Descendants()
+            .Where(element => string.Equals(element.Name.LocalName, "pos", StringComparison.OrdinalIgnoreCase))
+            .Select(element => ParseTransactionCoordinate(element.Value, axisOrder))
+            .ToArray();
+        if (positions.Length > 0)
+        {
+            return positions;
+        }
+
+        throw new ArgumentException($"Geometry '{geometryElement.Name.LocalName}' must contain gml:pos or gml:posList coordinates.");
+    }
+
+    private static Coordinate[] ParseTransactionPosList(string rawPosList, AxisOrder axisOrder)
+    {
+        var ordinates = rawPosList
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(value => double.Parse(value, CultureInfo.InvariantCulture))
+            .ToArray();
+
+        if (ordinates.Length < 2 || ordinates.Length % 2 != 0)
+        {
+            throw new ArgumentException("GML posList must contain an even number of ordinates.");
+        }
+
+        var coordinates = new Coordinate[ordinates.Length / 2];
+        for (var index = 0; index < ordinates.Length; index += 2)
+        {
+            coordinates[index / 2] = CreateTransactionCoordinate(ordinates[index], ordinates[index + 1], axisOrder);
+        }
+
+        return coordinates;
+    }
+
+    private static Coordinate ParseTransactionCoordinate(string rawPosition, AxisOrder axisOrder)
+    {
+        var ordinates = rawPosition
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(value => double.Parse(value, CultureInfo.InvariantCulture))
+            .ToArray();
+        if (ordinates.Length < 2)
+        {
+            throw new ArgumentException("GML position must contain at least two ordinates.");
+        }
+
+        return CreateTransactionCoordinate(ordinates[0], ordinates[1], axisOrder);
+    }
+
+    private static Coordinate CreateTransactionCoordinate(double first, double second, AxisOrder axisOrder)
+    {
+        return axisOrder == AxisOrder.NorthEast
+            ? new Coordinate(second, first)
+            : new Coordinate(first, second);
+    }
+
+    private static bool HasNilAttribute(XElement element)
+    {
+        return element.Attributes().Any(attribute =>
+            string.Equals(attribute.Name.LocalName, "nil", StringComparison.OrdinalIgnoreCase) &&
+            bool.TryParse(attribute.Value, out var isNil) &&
+            isNil);
+    }
+
+    private static async Task<XDocument> ReadTransactionDocumentAsync(
+        HttpRequest request,
+        CancellationToken cancellationToken)
+    {
+        request.EnableBuffering();
+        request.Body.Position = 0;
+
+        using var reader = new StreamReader(
+            request.Body,
+            Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: true,
+            bufferSize: 1024,
+            leaveOpen: true);
+        var body = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+        request.Body.Position = 0;
+
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            throw new InvalidDataException("Transaction requests require an XML request body.");
+        }
+
+        try
+        {
+            return XDocument.Parse(body, LoadOptions.PreserveWhitespace);
+        }
+        catch (XmlException ex)
+        {
+            throw new InvalidDataException("Invalid WFS Transaction XML request body.", ex);
+        }
+    }
+
+    private static bool ResolveRollbackOnFailure(HttpRequest request, XElement root)
+    {
+        var rawValue = request.Query["rollbackOnFailure"].FirstOrDefault()
+            ?? request.Query["ROLLBACKONFAILURE"].FirstOrDefault()
+            ?? root.Attributes()
+                .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, "rollbackOnFailure", StringComparison.OrdinalIgnoreCase))
+                ?.Value;
+
+        if (string.IsNullOrWhiteSpace(rawValue))
+        {
+            return true;
+        }
+
+        return bool.TryParse(rawValue, out var parsed)
+            ? parsed
+            : throw new ArgumentException("rollbackOnFailure must be a boolean value.");
+    }
+
+    private static string GetFirstTransactionError(FeatureEditResult editResult)
+    {
+        return editResult.CreateResults.Concat(editResult.UpdateResults).Concat(editResult.DeleteResults)
+            .FirstOrDefault(result => !result.IsSuccess)
+            .ErrorMessage
+            ?? "Transaction failed.";
+    }
+
+    private async Task PublishTransactionEventsAsync(
+        HttpContext context,
+        string serviceId,
+        TransactionPreparationResult prepared,
+        FeatureEditResult editResult,
+        CancellationToken cancellationToken)
+    {
+        var createIndex = 0;
+        var updateIndex = 0;
+        var deleteIndex = 0;
+
+        foreach (var operation in prepared.Operations)
+        {
+            switch (operation.EditOperation.Kind)
+            {
+                case FeatureEditOperationKind.Create:
+                    {
+                        var result = createIndex < editResult.CreateResults.Length
+                            ? editResult.CreateResults[createIndex]
+                            : default;
+                        createIndex++;
+
+                        if (!result.IsSuccess || !result.ObjectId.HasValue || operation.MutationFeature == null)
+                        {
+                            break;
+                        }
+
+                        var createdFeature = operation.MutationFeature.Value with { Id = result.ObjectId.Value };
+                        await _mutationEventService.PublishAsync(
+                            context,
+                            prepared.LayerId,
+                            result.ObjectId.Value,
+                            "create",
+                            HonuaTelemetry.Protocols.Wfs20,
+                            cancellationToken,
+                            mutationFeature: createdFeature,
+                            serviceId: serviceId,
+                            serviceProtocol: ServiceProtocols.Wfs20).ConfigureAwait(false);
+                        break;
+                    }
+
+                case FeatureEditOperationKind.Update:
+                    {
+                        var result = updateIndex < editResult.UpdateResults.Length
+                            ? editResult.UpdateResults[updateIndex]
+                            : default;
+                        updateIndex++;
+
+                        if (!result.IsSuccess || !result.ObjectId.HasValue || operation.MutationFeature == null)
+                        {
+                            break;
+                        }
+
+                        await _mutationEventService.PublishAsync(
+                            context,
+                            prepared.LayerId,
+                            result.ObjectId.Value,
+                            "update",
+                            HonuaTelemetry.Protocols.Wfs20,
+                            cancellationToken,
+                            mutationFeature: operation.MutationFeature.Value,
+                            serviceId: serviceId,
+                            serviceProtocol: ServiceProtocols.Wfs20).ConfigureAwait(false);
+                        break;
+                    }
+
+                case FeatureEditOperationKind.Delete:
+                    {
+                        var result = deleteIndex < editResult.DeleteResults.Length
+                            ? editResult.DeleteResults[deleteIndex]
+                            : default;
+                        deleteIndex++;
+
+                        if (!result.IsSuccess || !result.ObjectId.HasValue)
+                        {
+                            break;
+                        }
+
+                        await _mutationEventService.PublishAsync(
+                            context,
+                            prepared.LayerId,
+                            result.ObjectId.Value,
+                            "delete",
+                            HonuaTelemetry.Protocols.Wfs20,
+                            cancellationToken,
+                            mutationFeature: operation.DeleteSnapshot,
+                            serviceId: serviceId,
+                            serviceProtocol: ServiceProtocols.Wfs20).ConfigureAwait(false);
+                        break;
+                    }
+            }
+        }
+    }
+
+    private static string BuildTransactionResponseXml(
+        TransactionPreparationResult prepared,
+        FeatureEditResult editResult)
+    {
+        var inserted = new List<(PreparedTransactionOperation Operation, EditOperationResult Result)>();
+        var replaced = new List<(PreparedTransactionOperation Operation, EditOperationResult Result)>();
+        var updatedCount = 0;
+        var deletedCount = 0;
+        var createResultIndex = 0;
+        var updateResultIndex = 0;
+        var deleteResultIndex = 0;
+
+        foreach (var operation in prepared.Operations)
+        {
+            switch (operation.EditOperation.Kind)
+            {
+                case FeatureEditOperationKind.Create:
+                    {
+                        var result = createResultIndex < editResult.CreateResults.Length
+                            ? editResult.CreateResults[createResultIndex]
+                            : default;
+                        createResultIndex++;
+
+                        if (result.IsSuccess && result.ObjectId.HasValue)
+                        {
+                            inserted.Add((operation, result));
+                        }
+
+                        break;
+                    }
+
+                case FeatureEditOperationKind.Update:
+                    {
+                        var result = updateResultIndex < editResult.UpdateResults.Length
+                            ? editResult.UpdateResults[updateResultIndex]
+                            : default;
+                        updateResultIndex++;
+
+                        if (!result.IsSuccess || !result.ObjectId.HasValue)
+                        {
+                            break;
+                        }
+
+                        if (operation.ActionKind == TransactionActionKind.Replace)
+                        {
+                            replaced.Add((operation, result));
+                        }
+                        else
+                        {
+                            updatedCount++;
+                        }
+
+                        break;
+                    }
+
+                case FeatureEditOperationKind.Delete:
+                    {
+                        var result = deleteResultIndex < editResult.DeleteResults.Length
+                            ? editResult.DeleteResults[deleteResultIndex]
+                            : default;
+                        deleteResultIndex++;
+
+                        if (result.IsSuccess)
+                        {
+                            deletedCount++;
+                        }
+
+                        break;
+                    }
+            }
+        }
+
+        return WriteXmlDocument(writer =>
+        {
+            writer.WriteStartDocument();
+            writer.WriteStartElement("wfs", "TransactionResponse", Wfs20Utilities.WfsNamespace);
+            writer.WriteAttributeString("xmlns", "fes", null, Wfs20Utilities.FesNamespace);
+            writer.WriteAttributeString("version", Wfs20Utilities.Version);
+            writer.WriteAttributeString("timeStamp", DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture));
+
+            writer.WriteStartElement("wfs", "TransactionSummary", Wfs20Utilities.WfsNamespace);
+            if (prepared.InsertCount > 0)
+            {
+                writer.WriteElementString("wfs", "totalInserted", Wfs20Utilities.WfsNamespace, inserted.Count.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (prepared.UpdateCount > 0)
+            {
+                writer.WriteElementString("wfs", "totalUpdated", Wfs20Utilities.WfsNamespace, updatedCount.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (prepared.ReplaceCount > 0)
+            {
+                writer.WriteElementString("wfs", "totalReplaced", Wfs20Utilities.WfsNamespace, replaced.Count.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (prepared.DeleteCount > 0)
+            {
+                writer.WriteElementString("wfs", "totalDeleted", Wfs20Utilities.WfsNamespace, deletedCount.ToString(CultureInfo.InvariantCulture));
+            }
+
+            writer.WriteEndElement();
+
+            if (inserted.Count > 0)
+            {
+                writer.WriteStartElement("wfs", "InsertResults", Wfs20Utilities.WfsNamespace);
+                foreach (var (operation, result) in inserted)
+                {
+                    var objectId = result.ObjectId ?? 0;
+                    writer.WriteStartElement("wfs", "Feature", Wfs20Utilities.WfsNamespace);
+                    if (!string.IsNullOrWhiteSpace(operation.Handle))
+                    {
+                        writer.WriteAttributeString("handle", operation.Handle);
+                    }
+
+                    WriteTransactionResourceId(writer, operation.Descriptor, objectId);
+                    writer.WriteEndElement();
+                }
+
+                writer.WriteEndElement();
+            }
+
+            if (replaced.Count > 0)
+            {
+                writer.WriteStartElement("wfs", "ReplaceResults", Wfs20Utilities.WfsNamespace);
+                foreach (var (operation, result) in replaced)
+                {
+                    var objectId = result.ObjectId ?? 0;
+                    writer.WriteStartElement("wfs", "Feature", Wfs20Utilities.WfsNamespace);
+                    if (!string.IsNullOrWhiteSpace(operation.Handle))
+                    {
+                        writer.WriteAttributeString("handle", operation.Handle);
+                    }
+
+                    WriteTransactionResourceId(writer, operation.Descriptor, objectId);
+                    writer.WriteEndElement();
+                }
+
+                writer.WriteEndElement();
+            }
+
+            writer.WriteEndElement();
+            writer.WriteEndDocument();
+        });
+    }
+
+    private static void WriteTransactionResourceId(
+        XmlWriter writer,
+        WfsFeatureTypeDescriptor descriptor,
+        long objectId)
+    {
+        writer.WriteStartElement("fes", "ResourceId", Wfs20Utilities.FesNamespace);
+        writer.WriteAttributeString("rid", BuildFeatureId(descriptor, objectId));
+        writer.WriteEndElement();
+    }
+
+    private static string BuildListStoredQueriesXml(IReadOnlyList<WfsFeatureTypeDescriptor> descriptors)
+    {
+        return WriteXmlDocument(writer =>
+        {
+            writer.WriteStartDocument();
+            writer.WriteStartElement("wfs", "ListStoredQueriesResponse", Wfs20Utilities.WfsNamespace);
+            writer.WriteAttributeString("xmlns", FeatureNamespacePrefix, null, FeatureNamespaceUri);
+
+            writer.WriteStartElement("wfs", "StoredQuery", Wfs20Utilities.WfsNamespace);
+            writer.WriteAttributeString("id", GetFeatureByIdStoredQueryId);
+            WriteStoredQueryTitle(writer, "Get feature by identifier");
+
+            foreach (var descriptor in descriptors)
+            {
+                writer.WriteElementString("wfs", "ReturnFeatureType", Wfs20Utilities.WfsNamespace, descriptor.QualifiedName);
+            }
+
+            writer.WriteEndElement();
+            writer.WriteEndElement();
+            writer.WriteEndDocument();
+        });
+    }
+
+    private static string BuildDescribeStoredQueriesXml(IReadOnlyList<WfsFeatureTypeDescriptor> descriptors)
+    {
+        return WriteXmlDocument(writer =>
+        {
+            writer.WriteStartDocument();
+            writer.WriteStartElement("wfs", "DescribeStoredQueriesResponse", Wfs20Utilities.WfsNamespace);
+            writer.WriteAttributeString("xmlns", "fes", null, Wfs20Utilities.FesNamespace);
+            writer.WriteAttributeString("xmlns", "xsd", null, "http://www.w3.org/2001/XMLSchema");
+            writer.WriteAttributeString("xmlns", FeatureNamespacePrefix, null, FeatureNamespaceUri);
+
+            writer.WriteStartElement("wfs", "StoredQueryDescription", Wfs20Utilities.WfsNamespace);
+            writer.WriteAttributeString("id", GetFeatureByIdStoredQueryId);
+            WriteStoredQueryTitle(writer, "Get feature by identifier");
+            WriteStoredQueryAbstract(writer, "Returns a single feature that matches the supplied identifier.");
+            writer.WriteStartElement("wfs", "Parameter", Wfs20Utilities.WfsNamespace);
+            writer.WriteAttributeString("name", "id");
+            writer.WriteAttributeString("type", "xsd:string");
+            writer.WriteEndElement();
+
+            foreach (var descriptor in descriptors)
+            {
+                writer.WriteStartElement("wfs", "QueryExpressionText", Wfs20Utilities.WfsNamespace);
+                writer.WriteAttributeString("returnFeatureTypes", descriptor.QualifiedName);
+                writer.WriteAttributeString("language", "urn:ogc:def:queryLanguage:OGC-WFS::WFS_QueryExpression");
+                writer.WriteAttributeString("isPrivate", XmlConvert.ToString(false));
+
+                writer.WriteStartElement("wfs", "Query", Wfs20Utilities.WfsNamespace);
+                writer.WriteAttributeString("typeNames", descriptor.QualifiedName);
+                writer.WriteStartElement("fes", "Filter", Wfs20Utilities.FesNamespace);
+                writer.WriteStartElement("fes", "ResourceId", Wfs20Utilities.FesNamespace);
+                writer.WriteAttributeString("rid", "${id}");
+                writer.WriteEndElement();
+                writer.WriteEndElement();
+                writer.WriteEndElement();
+                writer.WriteEndElement();
+            }
+
+            writer.WriteEndElement();
+            writer.WriteEndElement();
+            writer.WriteEndDocument();
+        });
+    }
+
+    private static void WriteStoredQueryTitle(XmlWriter writer, string value)
+    {
+        writer.WriteStartElement("wfs", "Title", Wfs20Utilities.WfsNamespace);
+        writer.WriteAttributeString("xml", "lang", "http://www.w3.org/XML/1998/namespace", "en");
+        writer.WriteString(value);
+        writer.WriteEndElement();
+    }
+
+    private static void WriteStoredQueryAbstract(XmlWriter writer, string value)
+    {
+        writer.WriteStartElement("wfs", "Abstract", Wfs20Utilities.WfsNamespace);
+        writer.WriteAttributeString("xml", "lang", "http://www.w3.org/XML/1998/namespace", "en");
+        writer.WriteString(value);
+        writer.WriteEndElement();
+    }
+
+    private static bool IsGetFeatureByIdStoredQuery(string storedQueryId)
+        => string.Equals(storedQueryId, GetFeatureByIdStoredQueryId, StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(storedQueryId, GetFeatureByIdStoredQueryUri, StringComparison.OrdinalIgnoreCase);
+
+    private static WfsFeatureTypeDescriptor? ResolveStoredQueryFeatureTypeDescriptor(
+        IReadOnlyList<WfsFeatureTypeDescriptor> descriptors,
+        string featureId)
+    {
+        var trimmedFeatureId = featureId.Trim();
+        var lastDot = trimmedFeatureId.LastIndexOf('.');
+        if (lastDot > 0)
+        {
+            var typeName = trimmedFeatureId[..lastDot];
+            var localName = typeName.Contains(':', StringComparison.Ordinal)
+                ? typeName[(typeName.LastIndexOf(':') + 1)..]
+                : typeName;
+
+            return descriptors.FirstOrDefault(descriptor =>
+                descriptor.QualifiedName.Equals(typeName, StringComparison.OrdinalIgnoreCase) ||
+                descriptor.LocalName.Equals(typeName, StringComparison.OrdinalIgnoreCase) ||
+                descriptor.LocalName.Equals(localName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return descriptors.Count == 1
+            ? descriptors[0]
+            : null;
     }
 
     private async Task<ImmutableArray<WfsFeatureTypeDescriptor>> GetPublishedFeatureTypesAsync(
@@ -488,6 +2478,7 @@ internal sealed class Wfs20Handler
                 filter,
                 resourceId,
                 srsName,
+                featureTypes.Count == 1,
                 cancellationToken);
 
             var layerMatched = await _featureReader.CountAsync(featureType.Layer.Id, query, cancellationToken);
@@ -556,6 +2547,7 @@ internal sealed class Wfs20Handler
                 filter,
                 resourceId,
                 srsName,
+                featureTypes.Count == 1,
                 cancellationToken);
 
             var layerMatched = await _featureReader.CountAsync(featureType.Layer.Id, query, cancellationToken);
@@ -607,20 +2599,25 @@ internal sealed class Wfs20Handler
         string? filter,
         string? resourceId,
         string? srsName,
+        bool enforceResourceIdTypeMatch,
         CancellationToken cancellationToken)
     {
         var projectedFields = ResolveProjectedFields(layer, propertyName);
-        var sqlFilter = TranslateFesFilter(layer, filter);
+        var (normalizedFilter, normalizedResourceId) = NormalizeFilterInputs(filter, resourceId);
+        var sqlFilter = TranslateFesFilter(layer, normalizedFilter);
         var spatialFilter = ParseBboxFilter(bbox, layer);
-        var objectIds = ParseResourceIds(resourceId);
+        var resourceIds = ParseResourceIds(normalizedResourceId, layer, enforceResourceIdTypeMatch);
+        sqlFilter = resourceIds.MatchesNothing
+            ? CombineSqlFilters(sqlFilter, FalseSqlFilter)
+            : sqlFilter;
         var orderBy = ParseSortBy(layer, sortBy);
-        var outputSrid = ParseSrid(srsName) ?? layer.SpatialReference.ToSrid();
+        var outputSrid = await ResolveRequestedOutputSridAsync(layer, srsName, cancellationToken).ConfigureAwait(false);
         var outputAxisOrder = await ResolveOutputAxisOrderAsync(srsName, outputSrid, cancellationToken).ConfigureAwait(false);
 
         return new FeatureQuery
         {
             SqlFilter = sqlFilter,
-            ObjectIds = objectIds,
+            ObjectIds = resourceIds.ObjectIds,
             OutFields = projectedFields,
             SpatialFilter = spatialFilter,
             SpatialReferenceSrid = layer.SpatialReference.ToSrid(),
@@ -637,22 +2634,27 @@ internal sealed class Wfs20Handler
         string? filter,
         string? resourceId,
         string? srsName,
+        bool enforceResourceIdTypeMatch,
         CancellationToken cancellationToken)
     {
         ImmutableArray<string>? outFields = valueReference.IsGeometry || valueReference.IsFeatureId
             ? ImmutableArray<string>.Empty
             : ImmutableArray.Create(valueReference.CanonicalName);
 
-        var sqlFilter = TranslateFesFilter(layer, filter);
+        var (normalizedFilter, normalizedResourceId) = NormalizeFilterInputs(filter, resourceId);
+        var sqlFilter = TranslateFesFilter(layer, normalizedFilter);
         var spatialFilter = ParseBboxFilter(bbox, layer);
-        var objectIds = ParseResourceIds(resourceId);
-        var outputSrid = ParseSrid(srsName) ?? layer.SpatialReference.ToSrid();
+        var resourceIds = ParseResourceIds(normalizedResourceId, layer, enforceResourceIdTypeMatch);
+        sqlFilter = resourceIds.MatchesNothing
+            ? CombineSqlFilters(sqlFilter, FalseSqlFilter)
+            : sqlFilter;
+        var outputSrid = await ResolveRequestedOutputSridAsync(layer, srsName, cancellationToken).ConfigureAwait(false);
         var outputAxisOrder = await ResolveOutputAxisOrderAsync(srsName, outputSrid, cancellationToken).ConfigureAwait(false);
 
         return new FeatureQuery
         {
             SqlFilter = sqlFilter,
-            ObjectIds = objectIds,
+            ObjectIds = resourceIds.ObjectIds,
             OutFields = outFields,
             SpatialFilter = spatialFilter,
             SpatialReferenceSrid = layer.SpatialReference.ToSrid(),
@@ -683,6 +2685,101 @@ internal sealed class Wfs20Handler
         }
 
         return translation.SqlFilter;
+    }
+
+    private static (string? Filter, string? ResourceId) NormalizeFilterInputs(
+        string? filter,
+        string? resourceId)
+    {
+        if (!TryExtractStandaloneResourceIds(filter, out var normalizedFilter, out var filterResourceIds))
+        {
+            return (filter, resourceId);
+        }
+
+        var combinedResourceIds = string.IsNullOrWhiteSpace(resourceId)
+            ? filterResourceIds
+            : string.IsNullOrWhiteSpace(filterResourceIds)
+                ? resourceId
+                : $"{resourceId},{filterResourceIds}";
+
+        return (normalizedFilter, combinedResourceIds);
+    }
+
+    private static bool TryExtractStandaloneResourceIds(
+        string? filter,
+        out string? normalizedFilter,
+        out string? resourceIds)
+    {
+        normalizedFilter = filter;
+        resourceIds = null;
+
+        if (string.IsNullOrWhiteSpace(filter))
+        {
+            return false;
+        }
+
+        XDocument document;
+        try
+        {
+            document = XDocument.Parse(filter, LoadOptions.PreserveWhitespace);
+        }
+        catch (XmlException)
+        {
+            return false;
+        }
+
+        var root = document.Root;
+        if (root == null || !string.Equals(root.Name.LocalName, "Filter", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var filterChildren = root.Elements().ToArray();
+        if (filterChildren.Length == 0)
+        {
+            return false;
+        }
+
+        var hasOnlyResourceIdPredicates = filterChildren.All(element =>
+            string.Equals(element.Name.LocalName, "ResourceId", StringComparison.OrdinalIgnoreCase));
+        if (!hasOnlyResourceIdPredicates)
+        {
+            if (root.Descendants().Any(element =>
+                    string.Equals(element.Name.LocalName, "ResourceId", StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new NotSupportedException("Filters that combine ResourceId with other predicates are not yet supported.");
+            }
+
+            return false;
+        }
+
+        var values = filterChildren
+            .Select(element => element.Attributes()
+                .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, "rid", StringComparison.OrdinalIgnoreCase))
+                ?.Value)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Cast<string>()
+            .ToArray();
+        if (values.Length == 0)
+        {
+            return false;
+        }
+
+        normalizedFilter = null;
+        resourceIds = string.Join(',', values);
+        return true;
+    }
+
+    private static SqlFragment CombineSqlFilters(SqlFragment? left, SqlFragment right)
+    {
+        if (left is null)
+        {
+            return right;
+        }
+
+        return new SqlFragment(
+            $"({left.Sql}) AND ({right.Sql})",
+            left.Parameters.Concat(right.Parameters).ToArray());
     }
 
     private static ImmutableArray<string>? ResolveProjectedFields(LayerDefinition layer, string? propertyName)
@@ -776,10 +2873,13 @@ internal sealed class Wfs20Handler
                 out var layerCrs)
                 ? layerCrs
                 : throw new ArgumentException($"Unsupported layer spatial reference '{layer.SpatialReference.ToSrid()}'.");
+        var axisOrder = parts.Length == 5
+            ? crsDefinition.AxisOrder
+            : AxisOrder.EastNorth;
 
         if (!RasterParsingHelpers.TryParseBoundingBox(
                 bbox,
-                crsDefinition.AxisOrder,
+                axisOrder,
                 crsDefinition.IsGeographic,
                 out var minX,
                 out var minY,
@@ -807,32 +2907,60 @@ internal sealed class Wfs20Handler
         };
     }
 
-    private static ImmutableArray<long>? ParseResourceIds(string? resourceId)
+    private static ResourceIdResolution ParseResourceIds(
+        string? resourceId,
+        LayerDefinition layer,
+        bool enforceTypeMatch)
     {
         if (string.IsNullOrWhiteSpace(resourceId))
         {
-            return null;
+            return new ResourceIdResolution(null, false);
         }
 
         var ids = ImmutableArray.CreateBuilder<long>();
+        var sawCandidate = false;
+        var localTypeName = BuildTypeLocalName(layer);
         foreach (var rawResourceId in resourceId.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
+            sawCandidate = true;
             var candidate = rawResourceId;
+            var prefix = string.Empty;
             var lastDot = candidate.LastIndexOf('.');
             if (lastDot >= 0 && lastDot < candidate.Length - 1)
             {
+                prefix = candidate[..lastDot];
                 candidate = candidate[(lastDot + 1)..];
+            }
+
+            if (prefix.Length > 0 &&
+                !FilterExpressionHelpers.NormalizeIdentifier(prefix).Equals(localTypeName, StringComparison.OrdinalIgnoreCase) &&
+                !FilterExpressionHelpers.NormalizeIdentifier(prefix).Equals(layer.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                if (enforceTypeMatch)
+                {
+                    throw new WfsQueryException(
+                        "InvalidParameterValue",
+                        $"resourceId '{rawResourceId}' does not match queried feature type '{localTypeName}'.",
+                        Wfs20Utilities.ParameterNames.ResourceId);
+                }
+
+                continue;
             }
 
             if (!long.TryParse(candidate, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
             {
-                throw new ArgumentException($"Invalid resourceId '{rawResourceId}'. Expected numeric feature identifiers or qualified ids like 'type.123'.");
+                continue;
             }
 
             ids.Add(parsed);
         }
 
-        return ids.ToImmutable();
+        if (ids.Count > 0)
+        {
+            return new ResourceIdResolution(ids.ToImmutable(), false);
+        }
+
+        return new ResourceIdResolution(null, sawCandidate);
     }
 
     private static int? ParseSrid(string? srsName)
@@ -840,6 +2968,11 @@ internal sealed class Wfs20Handler
         if (string.IsNullOrWhiteSpace(srsName))
         {
             return null;
+        }
+
+        if (srsName.Contains("CRS84", StringComparison.OrdinalIgnoreCase))
+        {
+            return SpatialReference.WGS84.Wkid;
         }
 
         if (srsName.StartsWith("EPSG:", StringComparison.OrdinalIgnoreCase) &&
@@ -862,6 +2995,46 @@ internal sealed class Wfs20Handler
         }
 
         return null;
+    }
+
+    private async ValueTask<int> ResolveRequestedOutputSridAsync(
+        LayerDefinition layer,
+        string? srsName,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(srsName))
+        {
+            return layer.SpatialReference.ToSrid();
+        }
+
+        if (srsName.Contains("CRS84", StringComparison.OrdinalIgnoreCase))
+        {
+            return SpatialReference.WGS84.Wkid;
+        }
+
+        if (!SpatialReferenceHelpers.TryParseCrsDefinition(srsName, out var parsedDefinition))
+        {
+            throw new WfsQueryException(
+                "InvalidParameterValue",
+                $"Unsupported srsName '{srsName}'.",
+                Wfs20Utilities.ParameterNames.SrsName);
+        }
+
+        var resolvedDefinition = await _crsRegistry.ResolveAsync(srsName, cancellationToken).ConfigureAwait(false);
+        if (resolvedDefinition.HasValue)
+        {
+            return resolvedDefinition.Value.Srid;
+        }
+
+        if (parsedDefinition.Srid == SpatialReference.WGS84.Wkid || parsedDefinition.Srid == 3857)
+        {
+            return parsedDefinition.Srid;
+        }
+
+        throw new WfsQueryException(
+            "InvalidParameterValue",
+            $"Unsupported srsName '{srsName}'.",
+            Wfs20Utilities.ParameterNames.SrsName);
     }
 
     private async ValueTask<AxisOrder> ResolveOutputAxisOrderAsync(
@@ -948,6 +3121,9 @@ internal sealed class Wfs20Handler
     private static FeatureType BuildFeatureType(WfsFeatureTypeDescriptor featureType)
     {
         var layer = featureType.Layer;
+        string[]? otherCrs = layer.SpatialReference.ToSrid() == 3857
+            ? null
+            : [FormatCrs(3857)];
 
         return new FeatureType
         {
@@ -956,6 +3132,7 @@ internal sealed class Wfs20Handler
             Abstract = layer.Description,
             Keywords = BuildKeywords(layer),
             DefaultCRS = FormatCrs(layer.SpatialReference.ToSrid()),
+            OtherCRS = otherCrs,
             OutputFormats = new OutputFormats
             {
                 Formats = Wfs20Utilities.OutputFormats.All.ToArray()
@@ -1042,7 +3219,8 @@ internal sealed class Wfs20Handler
                     CreateParameter("bbox", allowAnyValue: true),
                     CreateParameter("resourceId", allowAnyValue: true),
                     CreateParameter("propertyName", allowAnyValue: true),
-                    CreateParameter("srsName", allowAnyValue: true)
+                    CreateParameter("srsName", allowAnyValue: true),
+                    CreateParameter("resolve", "none", "local", "remote", "all")
                 ]),
                 CreateOperation(Wfs20Utilities.Operations.GetPropertyValue, wfsUrl,
                 [
@@ -1058,7 +3236,18 @@ internal sealed class Wfs20Handler
                     CreateParameter("filter", allowAnyValue: true),
                     CreateParameter("bbox", allowAnyValue: true),
                     CreateParameter("resourceId", allowAnyValue: true),
-                    CreateParameter("srsName", allowAnyValue: true)
+                    CreateParameter("srsName", allowAnyValue: true),
+                    CreateParameter("resolve", "none", "local", "remote", "all")
+                ]),
+                CreateOperation(Wfs20Utilities.Operations.Transaction, wfsUrl,
+                [
+                    CreateParameter("typeName", allowAnyValue: true),
+                    CreateParameter("typeNames", allowAnyValue: true)
+                ]),
+                CreateOperation(Wfs20Utilities.Operations.ListStoredQueries, wfsUrl),
+                CreateOperation(Wfs20Utilities.Operations.DescribeStoredQueries, wfsUrl,
+                [
+                    CreateParameter("storedquery_id", allowAnyValue: true)
                 ])
             ],
             Parameters =
@@ -1068,51 +3257,22 @@ internal sealed class Wfs20Handler
             ],
             Constraints =
             [
-                new Constraint
-                {
-                    Name = "ImplementsBasicWFS",
-                    DefaultValue = "TRUE"
-                },
-                new Constraint
-                {
-                    Name = "ImplementsTransactionalWFS",
-                    DefaultValue = "FALSE"
-                },
-                new Constraint
-                {
-                    Name = "ImplementsLockingWFS",
-                    DefaultValue = "FALSE"
-                },
-                new Constraint
-                {
-                    Name = "KVPEncoding",
-                    DefaultValue = "TRUE"
-                },
-                new Constraint
-                {
-                    Name = "XMLEncoding",
-                    DefaultValue = "TRUE"
-                },
-                new Constraint
-                {
-                    Name = "SOAPEncoding",
-                    DefaultValue = "FALSE"
-                },
-                new Constraint
-                {
-                    Name = "ImplementsResultPaging",
-                    DefaultValue = "TRUE"
-                },
-                new Constraint
-                {
-                    Name = "DefaultMaxFeatures",
-                    DefaultValue = Wfs20Utilities.DefaultMaxFeatures.ToString(CultureInfo.InvariantCulture)
-                },
-                new Constraint
-                {
-                    Name = "CountDefault",
-                    DefaultValue = Wfs20Utilities.DefaultMaxFeatures.ToString(CultureInfo.InvariantCulture)
-                }
+                CreateBooleanConstraint("ImplementsBasicWFS", true),
+                CreateBooleanConstraint("ImplementsTransactionalWFS", true),
+                CreateBooleanConstraint("ImplementsLockingWFS", false),
+                CreateBooleanConstraint("ImplementsInheritance", false),
+                CreateBooleanConstraint("ImplementsRemoteResolve", false),
+                CreateBooleanConstraint("ImplementsResultPaging", true),
+                CreateBooleanConstraint("ImplementsStandardJoins", false),
+                CreateBooleanConstraint("ImplementsSpatialJoins", false),
+                CreateBooleanConstraint("ImplementsTemporalJoins", false),
+                CreateBooleanConstraint("ImplementsFeatureVersioning", false),
+                CreateBooleanConstraint("ManageStoredQueries", false),
+                CreateBooleanConstraint("KVPEncoding", true),
+                CreateBooleanConstraint("XMLEncoding", true),
+                CreateBooleanConstraint("SOAPEncoding", false),
+                CreateOpenConstraint("DefaultMaxFeatures", Wfs20Utilities.DefaultMaxFeatures.ToString(CultureInfo.InvariantCulture)),
+                CreateOpenConstraint("CountDefault", Wfs20Utilities.DefaultMaxFeatures.ToString(CultureInfo.InvariantCulture))
             ]
         };
     }
@@ -1156,6 +3316,26 @@ internal sealed class Wfs20Handler
         };
     }
 
+    private static Constraint CreateBooleanConstraint(string name, bool defaultValue)
+    {
+        return new Constraint
+        {
+            Name = name,
+            AllowedValues = new AllowedValues { Values = ["TRUE", "FALSE"] },
+            DefaultValue = defaultValue ? "TRUE" : "FALSE"
+        };
+    }
+
+    private static Constraint CreateOpenConstraint(string name, string defaultValue)
+    {
+        return new Constraint
+        {
+            Name = name,
+            AnyValue = new object(),
+            DefaultValue = defaultValue
+        };
+    }
+
     private static FilterCapabilities BuildFilterCapabilities()
     {
         return new FilterCapabilities
@@ -1164,18 +3344,19 @@ internal sealed class Wfs20Handler
             {
                 Constraints =
                 [
-                    new FesConstraint { Name = "ImplementsQuery", DefaultValue = "TRUE" },
-                    new FesConstraint { Name = "ImplementsAdHocQuery", DefaultValue = "TRUE" },
-                    new FesConstraint { Name = "ImplementsResourceId", DefaultValue = "TRUE" },
-                    new FesConstraint { Name = "ImplementsMinStandardFilter", DefaultValue = "TRUE" },
-                    new FesConstraint { Name = "ImplementsStandardFilter", DefaultValue = "TRUE" },
-                    new FesConstraint { Name = "ImplementsMinSpatialFilter", DefaultValue = "TRUE" },
-                    new FesConstraint { Name = "ImplementsSpatialFilter", DefaultValue = "TRUE" },
-                    new FesConstraint { Name = "ImplementsMinTemporalFilter", DefaultValue = "FALSE" },
-                    new FesConstraint { Name = "ImplementsTemporalFilter", DefaultValue = "FALSE" },
-                    new FesConstraint { Name = "ImplementsVersionNav", DefaultValue = "FALSE" },
-                    new FesConstraint { Name = "ImplementsSorting", DefaultValue = "TRUE" },
-                    new FesConstraint { Name = "ImplementsExtendedOperators", DefaultValue = "FALSE" }
+                    CreateBooleanFesConstraint("ImplementsQuery", true),
+                    CreateBooleanFesConstraint("ImplementsAdHocQuery", true),
+                    CreateBooleanFesConstraint("ImplementsResourceId", true),
+                    CreateBooleanFesConstraint("ImplementsMinStandardFilter", true),
+                    CreateBooleanFesConstraint("ImplementsStandardFilter", true),
+                    CreateBooleanFesConstraint("ImplementsMinimumXPath", true),
+                    CreateBooleanFesConstraint("ImplementsMinSpatialFilter", true),
+                    CreateBooleanFesConstraint("ImplementsSpatialFilter", true),
+                    CreateBooleanFesConstraint("ImplementsMinTemporalFilter", true),
+                    CreateBooleanFesConstraint("ImplementsTemporalFilter", true),
+                    CreateBooleanFesConstraint("ImplementsVersionNav", false),
+                    CreateBooleanFesConstraint("ImplementsSorting", true),
+                    CreateBooleanFesConstraint("ImplementsExtendedOperators", false)
                 ]
             },
             IdCapabilities = new IdCapabilities
@@ -1201,6 +3382,7 @@ internal sealed class Wfs20Handler
                         new ComparisonOperator { Name = "PropertyIsLessThanOrEqualTo" },
                         new ComparisonOperator { Name = "PropertyIsGreaterThanOrEqualTo" },
                         new ComparisonOperator { Name = "PropertyIsLike" },
+                        new ComparisonOperator { Name = "PropertyIsNil" },
                         new ComparisonOperator { Name = "PropertyIsNull" },
                         new ComparisonOperator { Name = "PropertyIsBetween" }
                     ]
@@ -1212,7 +3394,12 @@ internal sealed class Wfs20Handler
                 {
                     Operands =
                     [
-                        new GeometryOperand { Name = $"{Wfs20Utilities.GmlNamespace}:Envelope" }
+                        new GeometryOperand { Name = new XmlQualifiedName("Envelope", Wfs20Utilities.GmlNamespace) },
+                        new GeometryOperand { Name = new XmlQualifiedName("Point", Wfs20Utilities.GmlNamespace) },
+                        new GeometryOperand { Name = new XmlQualifiedName("LineString", Wfs20Utilities.GmlNamespace) },
+                        new GeometryOperand { Name = new XmlQualifiedName("Curve", Wfs20Utilities.GmlNamespace) },
+                        new GeometryOperand { Name = new XmlQualifiedName("Polygon", Wfs20Utilities.GmlNamespace) },
+                        new GeometryOperand { Name = new XmlQualifiedName("Surface", Wfs20Utilities.GmlNamespace) }
                     ]
                 },
                 SpatialOperators = new SpatialOperators
@@ -1232,7 +3419,37 @@ internal sealed class Wfs20Handler
                         new Models.SpatialOperator { Name = "Beyond" }
                     ]
                 }
+            },
+            TemporalCapabilities = new TemporalCapabilities
+            {
+                TemporalOperands = new TemporalOperands
+                {
+                    Operands =
+                    [
+                        new TemporalOperand { Name = new XmlQualifiedName("TimeInstant", Wfs20Utilities.GmlNamespace) },
+                        new TemporalOperand { Name = new XmlQualifiedName("TimePeriod", Wfs20Utilities.GmlNamespace) }
+                    ]
+                },
+                TemporalOperators = new TemporalOperators
+                {
+                    Operators =
+                    [
+                        new Models.TemporalOperator { Name = "After" },
+                        new Models.TemporalOperator { Name = "Before" },
+                        new Models.TemporalOperator { Name = "During" }
+                    ]
+                }
             }
+        };
+    }
+
+    private static FesConstraint CreateBooleanFesConstraint(string name, bool defaultValue)
+    {
+        return new FesConstraint
+        {
+            Name = name,
+            AllowedValues = new AllowedValues { Values = ["TRUE", "FALSE"] },
+            DefaultValue = defaultValue ? "TRUE" : "FALSE"
         };
     }
 
@@ -1243,6 +3460,172 @@ internal sealed class Wfs20Handler
         return requestedSections is null ||
                requestedSections.Count == 0 ||
                requestedSections.Contains(sectionName);
+    }
+
+    private static FeatureCollectionResponseMetadata BuildFeatureCollectionResponseMetadata(
+        string wfsUrl,
+        IReadOnlyList<WfsFeatureTypeDescriptor> selectedTypes,
+        string? outputFormat,
+        string? count,
+        string? sortBy,
+        string? bbox,
+        string? filter,
+        string? resourceId,
+        string? propertyName,
+        string? srsName,
+        string? resultType,
+        int offset,
+        int pageSize,
+        long totalMatched,
+        int returnedCount)
+    {
+        var pagingResultType = string.Equals(resultType, "hits", StringComparison.OrdinalIgnoreCase)
+            ? null
+            : resultType;
+
+        return new FeatureCollectionResponseMetadata(
+            BuildFeatureCollectionSchemaLocation(wfsUrl, selectedTypes),
+            BuildPagingLinks(
+                wfsUrl,
+                selectedTypes,
+                outputFormat,
+                sortBy,
+                bbox,
+                filter,
+                resourceId,
+                propertyName,
+                srsName,
+                pagingResultType,
+                offset,
+                pageSize,
+                totalMatched,
+                returnedCount));
+    }
+
+    private static string BuildFeatureCollectionSchemaLocation(
+        string wfsUrl,
+        IReadOnlyList<WfsFeatureTypeDescriptor> selectedTypes)
+    {
+        var values = new List<string>
+        {
+            Wfs20Utilities.WfsNamespace,
+            "http://schemas.opengis.net/wfs/2.0/wfs.xsd"
+        };
+
+        if (selectedTypes.Count > 0)
+        {
+            var typeNames = string.Join(
+                ",",
+                selectedTypes.Select(descriptor => descriptor.LocalName));
+            values.Add(FeatureNamespaceUri);
+            values.Add(
+                $"{wfsUrl}?SERVICE=WFS&VERSION={Wfs20Utilities.Version}&REQUEST=DescribeFeatureType&TYPENAMES={Uri.EscapeDataString(typeNames)}");
+        }
+
+        return string.Join(" ", values);
+    }
+
+    private static PagingLinks BuildPagingLinks(
+        string wfsUrl,
+        IReadOnlyList<WfsFeatureTypeDescriptor> selectedTypes,
+        string? outputFormat,
+        string? sortBy,
+        string? bbox,
+        string? filter,
+        string? resourceId,
+        string? propertyName,
+        string? srsName,
+        string? resultType,
+        int offset,
+        int pageSize,
+        long totalMatched,
+        int returnedCount)
+    {
+        if (pageSize <= 0 || selectedTypes.Count == 0)
+        {
+            return new PagingLinks(null, null);
+        }
+
+        var next = offset + pageSize < totalMatched
+            ? BuildGetFeaturePagingLink(
+                wfsUrl,
+                selectedTypes,
+                outputFormat,
+                sortBy,
+                bbox,
+                filter,
+                resourceId,
+                propertyName,
+                srsName,
+                resultType,
+                offset + pageSize,
+                pageSize)
+            : null;
+        var previous = offset > 0
+            ? BuildGetFeaturePagingLink(
+                wfsUrl,
+                selectedTypes,
+                outputFormat,
+                sortBy,
+                bbox,
+                filter,
+                resourceId,
+                propertyName,
+                srsName,
+                resultType,
+                Math.Max(offset - pageSize, 0),
+                pageSize)
+            : null;
+
+        return new PagingLinks(next, previous);
+    }
+
+    private static string BuildGetFeaturePagingLink(
+        string wfsUrl,
+        IReadOnlyList<WfsFeatureTypeDescriptor> selectedTypes,
+        string? outputFormat,
+        string? sortBy,
+        string? bbox,
+        string? filter,
+        string? resourceId,
+        string? propertyName,
+        string? srsName,
+        string? resultType,
+        int offset,
+        int count)
+    {
+        var queryParts = new List<string>
+        {
+            $"SERVICE={Uri.EscapeDataString(Wfs20Utilities.ServiceType)}",
+            $"VERSION={Uri.EscapeDataString(Wfs20Utilities.Version)}",
+            $"REQUEST={Uri.EscapeDataString(Wfs20Utilities.Operations.GetFeature)}",
+            $"TYPENAMES={Uri.EscapeDataString(string.Join(',', selectedTypes.Select(descriptor => descriptor.LocalName)))}",
+            $"COUNT={count.ToString(CultureInfo.InvariantCulture)}",
+            $"STARTINDEX={offset.ToString(CultureInfo.InvariantCulture)}"
+        };
+
+        AppendQueryPart(queryParts, "OUTPUTFORMAT", outputFormat);
+        AppendQueryPart(queryParts, "SORTBY", sortBy);
+        AppendQueryPart(queryParts, "BBOX", bbox);
+        AppendQueryPart(queryParts, "FILTER", filter);
+        AppendQueryPart(queryParts, "RESOURCEID", resourceId);
+        AppendQueryPart(queryParts, "PROPERTYNAME", propertyName);
+        AppendQueryPart(queryParts, "SRSNAME", srsName);
+        if (!string.IsNullOrWhiteSpace(resultType) &&
+            !string.Equals(resultType, "results", StringComparison.OrdinalIgnoreCase))
+        {
+            AppendQueryPart(queryParts, "RESULTTYPE", resultType);
+        }
+
+        return $"{wfsUrl}?{string.Join("&", queryParts)}";
+    }
+
+    private static void AppendQueryPart(List<string> queryParts, string name, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            queryParts.Add($"{name}={Uri.EscapeDataString(value)}");
+        }
     }
 
     private static string GenerateSchemaForTypes(IReadOnlyList<WfsFeatureTypeDescriptor> featureTypes)
@@ -1330,6 +3713,9 @@ internal sealed class Wfs20Handler
 
     private async Task<(IResult Result, int ReturnedCount)> BuildGmlResultAsync(
         LayerQueryPlanSet planSet,
+        string? schemaLocation,
+        string? next,
+        string? previous,
         CancellationToken cancellationToken)
     {
         var queryResults = new List<(LayerQueryPlan Plan, ImmutableArray<GmlFeature> Features)>(planSet.Plans.Length);
@@ -1347,15 +3733,22 @@ internal sealed class Wfs20Handler
             writer.WriteStartElement("wfs", "FeatureCollection", Wfs20Utilities.WfsNamespace);
             writer.WriteAttributeString("xmlns", "gml", null, Wfs20Utilities.GmlNamespace);
             writer.WriteAttributeString("xmlns", FeatureNamespacePrefix, null, FeatureNamespaceUri);
+            writer.WriteAttributeString("xmlns", "xsi", null, Wfs20Utilities.XsiNamespace);
             writer.WriteAttributeString("timeStamp", DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture));
             writer.WriteAttributeString("numberMatched", planSet.TotalMatched.ToString(CultureInfo.InvariantCulture));
             writer.WriteAttributeString("numberReturned", returnedCount.ToString(CultureInfo.InvariantCulture));
+            if (!string.IsNullOrWhiteSpace(schemaLocation))
+            {
+                writer.WriteAttributeString("xsi", "schemaLocation", Wfs20Utilities.XsiNamespace, schemaLocation);
+            }
+
+            WritePagingAttributes(writer, next, previous);
 
             foreach (var queryResult in queryResults)
             {
                 foreach (var feature in queryResult.Features)
                 {
-                    WriteFeatureMember(writer, queryResult.Plan, feature);
+                    WriteFeature(writer, queryResult.Plan, feature, includeMemberWrapper: true);
                 }
             }
             writer.WriteEndElement();
@@ -1708,11 +4101,37 @@ internal sealed class Wfs20Handler
         return (Results.Json(payload, OgcJsonContext.Default.FeatureCollection, contentType: contentType), features.Count);
     }
 
-    private static void WriteFeatureMember(XmlWriter writer, LayerQueryPlan plan, GmlFeature feature)
+    private static void WriteFeature(XmlWriter writer, LayerQueryPlan plan, GmlFeature feature, bool includeMemberWrapper)
     {
-        writer.WriteStartElement("wfs", "member", Wfs20Utilities.WfsNamespace);
+        if (includeMemberWrapper)
+        {
+            writer.WriteStartElement("wfs", "member", Wfs20Utilities.WfsNamespace);
+        }
+
         writer.WriteStartElement(FeatureNamespacePrefix, plan.Descriptor.LocalName, FeatureNamespaceUri);
+        if (!includeMemberWrapper)
+        {
+            writer.WriteAttributeString("xmlns", "gml", null, Wfs20Utilities.GmlNamespace);
+            writer.WriteAttributeString("xmlns", FeatureNamespacePrefix, null, FeatureNamespaceUri);
+            writer.WriteAttributeString("xmlns", "xsi", null, Wfs20Utilities.XsiNamespace);
+        }
+
         writer.WriteAttributeString("gml", "id", Wfs20Utilities.GmlNamespace, BuildFeatureId(plan.Descriptor, feature.Id));
+
+        if (TryGetGmlDescriptionValue(plan.Descriptor.Layer, feature.Attributes, out var gmlDescription))
+        {
+            writer.WriteElementString("gml", "description", Wfs20Utilities.GmlNamespace, gmlDescription);
+        }
+
+        if (TryGetGmlIdentifierValue(feature.Attributes, out var gmlIdentifier))
+        {
+            writer.WriteElementString("gml", "identifier", Wfs20Utilities.GmlNamespace, gmlIdentifier);
+        }
+
+        if (TryGetGmlNameValue(plan.Descriptor.Layer, feature.Attributes, out var gmlName))
+        {
+            writer.WriteElementString("gml", "name", Wfs20Utilities.GmlNamespace, gmlName);
+        }
 
         if (plan.Descriptor.Layer.GeometryField is not null &&
             !string.IsNullOrWhiteSpace(feature.GeometryGml))
@@ -1729,6 +4148,16 @@ internal sealed class Wfs20Handler
         {
             if (!feature.Attributes.TryGetValue(field.Name, out var value) || value is null)
             {
+                if (field.Nullable)
+                {
+                    writer.WriteStartElement(
+                        FeatureNamespacePrefix,
+                        XmlConvert.EncodeLocalName(field.Name),
+                        FeatureNamespaceUri);
+                    writer.WriteAttributeString("xsi", "nil", Wfs20Utilities.XsiNamespace, XmlConvert.ToString(true));
+                    writer.WriteEndElement();
+                }
+
                 continue;
             }
 
@@ -1741,7 +4170,86 @@ internal sealed class Wfs20Handler
         }
 
         writer.WriteEndElement();
-        writer.WriteEndElement();
+        if (includeMemberWrapper)
+        {
+            writer.WriteEndElement();
+        }
+    }
+
+    private static bool TryGetGmlNameValue(
+        LayerDefinition layer,
+        ImmutableDictionary<string, object?> attributes,
+        out string? gmlName)
+    {
+        return TryGetTransactionMappedValue(
+            layer,
+            attributes,
+            "name",
+            ValidationExtensions.WfsGmlNameAttributeName,
+            out gmlName);
+    }
+
+    private static bool TryGetGmlDescriptionValue(
+        LayerDefinition layer,
+        ImmutableDictionary<string, object?> attributes,
+        out string? gmlDescription)
+    {
+        return TryGetTransactionMappedValue(
+            layer,
+            attributes,
+            "description",
+            ValidationExtensions.WfsGmlDescriptionAttributeName,
+            out gmlDescription);
+    }
+
+    private static bool TryGetGmlIdentifierValue(
+        ImmutableDictionary<string, object?> attributes,
+        out string? gmlIdentifier)
+    {
+        return TryGetReservedTransactionValue(
+            attributes,
+            ValidationExtensions.WfsGmlIdentifierAttributeName,
+            out gmlIdentifier);
+    }
+
+    private static bool TryGetTransactionMappedValue(
+        LayerDefinition layer,
+        ImmutableDictionary<string, object?> attributes,
+        string fieldName,
+        string reservedAttributeName,
+        out string? valueText)
+    {
+        var field = layer.AttributeFields.FirstOrDefault(candidate =>
+            candidate.Name.Equals(fieldName, StringComparison.OrdinalIgnoreCase));
+
+        if (field != null &&
+            attributes.TryGetValue(field.Name, out var value) &&
+            value is not null)
+        {
+            valueText = ConvertToInvariantString(value);
+            if (!string.IsNullOrWhiteSpace(valueText))
+            {
+                return true;
+            }
+        }
+
+        return TryGetReservedTransactionValue(attributes, reservedAttributeName, out valueText);
+    }
+
+    private static bool TryGetReservedTransactionValue(
+        ImmutableDictionary<string, object?> attributes,
+        string reservedAttributeName,
+        out string? valueText)
+    {
+        if (attributes.TryGetValue(reservedAttributeName, out var value) &&
+            value is not null)
+        {
+            valueText = ConvertToInvariantString(value);
+            return !string.IsNullOrWhiteSpace(valueText);
+        }
+
+        valueText = null;
+        return false;
     }
 
     private static string BuildFeatureId(WfsFeatureTypeDescriptor descriptor, long featureId)
@@ -1824,7 +4332,11 @@ internal sealed class Wfs20Handler
                string.Equals(format, Wfs20Utilities.OutputFormats.Json, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static IResult CreateEmptyFeatureCollectionResult(string normalizedFormat)
+    private static IResult CreateEmptyFeatureCollectionResult(
+        string normalizedFormat,
+        string? schemaLocation = null,
+        string? next = null,
+        string? previous = null)
     {
         if (string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.GeoJson, StringComparison.OrdinalIgnoreCase) ||
             string.Equals(normalizedFormat, Wfs20Utilities.OutputFormats.Json, StringComparison.OrdinalIgnoreCase))
@@ -1843,20 +4355,54 @@ internal sealed class Wfs20Handler
             return Results.Content("typeName,id\n", MediaTypes.Csv, Encoding.UTF8);
         }
 
-        var xml = $$"""
-            <?xml version="1.0" encoding="UTF-8"?>
-            <wfs:FeatureCollection xmlns:wfs="{{Wfs20Utilities.WfsNamespace}}" xmlns:gml="{{Wfs20Utilities.GmlNamespace}}" xmlns:{{FeatureNamespacePrefix}}="{{FeatureNamespaceUri}}" timeStamp="{{DateTimeOffset.UtcNow:O}}" numberMatched="0" numberReturned="0" />
-            """;
+        var xml = WriteXmlDocument(writer =>
+        {
+            writer.WriteStartDocument();
+            writer.WriteStartElement("wfs", "FeatureCollection", Wfs20Utilities.WfsNamespace);
+            writer.WriteAttributeString("xmlns", "gml", null, Wfs20Utilities.GmlNamespace);
+            writer.WriteAttributeString("xmlns", FeatureNamespacePrefix, null, FeatureNamespaceUri);
+            writer.WriteAttributeString("xmlns", "xsi", null, Wfs20Utilities.XsiNamespace);
+            writer.WriteAttributeString("timeStamp", DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture));
+            writer.WriteAttributeString("numberMatched", "0");
+            writer.WriteAttributeString("numberReturned", "0");
+            if (!string.IsNullOrWhiteSpace(schemaLocation))
+            {
+                writer.WriteAttributeString("xsi", "schemaLocation", Wfs20Utilities.XsiNamespace, schemaLocation);
+            }
+
+            WritePagingAttributes(writer, next, previous);
+            writer.WriteEndElement();
+            writer.WriteEndDocument();
+        });
 
         return Results.Content(xml, MediaTypes.Gml, Encoding.UTF8);
     }
 
-    private static IResult CreateHitsFeatureCollectionResult(long totalMatched)
+    private static IResult CreateHitsFeatureCollectionResult(
+        long totalMatched,
+        string? schemaLocation = null,
+        string? next = null,
+        string? previous = null)
     {
-        var xml = $$"""
-            <?xml version="1.0" encoding="UTF-8"?>
-            <wfs:FeatureCollection xmlns:wfs="{{Wfs20Utilities.WfsNamespace}}" xmlns:gml="{{Wfs20Utilities.GmlNamespace}}" xmlns:{{FeatureNamespacePrefix}}="{{FeatureNamespaceUri}}" timeStamp="{{DateTimeOffset.UtcNow:O}}" numberMatched="{{totalMatched.ToString(CultureInfo.InvariantCulture)}}" numberReturned="0" />
-            """;
+        var xml = WriteXmlDocument(writer =>
+        {
+            writer.WriteStartDocument();
+            writer.WriteStartElement("wfs", "FeatureCollection", Wfs20Utilities.WfsNamespace);
+            writer.WriteAttributeString("xmlns", "gml", null, Wfs20Utilities.GmlNamespace);
+            writer.WriteAttributeString("xmlns", FeatureNamespacePrefix, null, FeatureNamespaceUri);
+            writer.WriteAttributeString("xmlns", "xsi", null, Wfs20Utilities.XsiNamespace);
+            writer.WriteAttributeString("timeStamp", DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture));
+            writer.WriteAttributeString("numberMatched", totalMatched.ToString(CultureInfo.InvariantCulture));
+            writer.WriteAttributeString("numberReturned", "0");
+            if (!string.IsNullOrWhiteSpace(schemaLocation))
+            {
+                writer.WriteAttributeString("xsi", "schemaLocation", Wfs20Utilities.XsiNamespace, schemaLocation);
+            }
+
+            WritePagingAttributes(writer, next, previous);
+            writer.WriteEndElement();
+            writer.WriteEndDocument();
+        });
 
         return Results.Content(xml, MediaTypes.Gml, Encoding.UTF8);
     }
@@ -1895,7 +4441,7 @@ internal sealed class Wfs20Handler
             Indent = true,
             IndentChars = "  ",
             NewLineChars = "\n",
-            Encoding = Encoding.UTF8,
+            Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
             OmitXmlDeclaration = false
         };
 
@@ -1904,6 +4450,19 @@ internal sealed class Wfs20Handler
         writeAction(writer);
         writer.Flush();
         return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static void WritePagingAttributes(XmlWriter writer, string? next, string? previous)
+    {
+        if (!string.IsNullOrWhiteSpace(next))
+        {
+            writer.WriteAttributeString("next", next);
+        }
+
+        if (!string.IsNullOrWhiteSpace(previous))
+        {
+            writer.WriteAttributeString("previous", previous);
+        }
     }
 
     private static string BuildTypeLocalName(LayerDefinition layer)
@@ -1995,14 +4554,33 @@ internal sealed class Wfs20Handler
             null => string.Empty,
             string text => text,
             bool boolean => XmlConvert.ToString(boolean),
-            DateTimeOffset dateTimeOffset => XmlConvert.ToString(dateTimeOffset),
-            DateTime dateTime => XmlConvert.ToString(dateTime, XmlDateTimeSerializationMode.RoundtripKind),
+            DateTimeOffset dateTimeOffset => FormatXmlDateTimeOffset(dateTimeOffset),
+            DateTime dateTime => FormatXmlDateTime(dateTime),
             DateOnly dateOnly => dateOnly.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
             TimeOnly timeOnly => timeOnly.ToString("HH:mm:ss.fffffff", CultureInfo.InvariantCulture),
             Guid guid => guid.ToString("D", CultureInfo.InvariantCulture),
             IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
             _ => ConvertStructuredValueToJson(value)
         };
+    }
+
+    private static string FormatXmlDateTime(DateTime value)
+    {
+        if (value.Kind == DateTimeKind.Unspecified)
+        {
+            return value.ToString("yyyy-MM-dd'T'HH:mm:ss", CultureInfo.InvariantCulture);
+        }
+
+        return FormatXmlDateTimeOffset(new DateTimeOffset(value.ToUniversalTime(), TimeSpan.Zero));
+    }
+
+    private static string FormatXmlDateTimeOffset(DateTimeOffset value)
+    {
+        var normalized = value.ToUniversalTime();
+        var format = normalized.Millisecond == 0
+            ? "yyyy-MM-dd'T'HH:mm:sszzz"
+            : "yyyy-MM-dd'T'HH:mm:ss.fffzzz";
+        return normalized.ToString(format, CultureInfo.InvariantCulture);
     }
 
     private static string ConvertStructuredValueToJson(object value)
@@ -2190,6 +4768,18 @@ internal sealed class Wfs20Handler
         ImmutableArray<LayerValuePlan> Plans,
         long TotalMatched);
 
+    private readonly record struct ResourceIdResolution(
+        ImmutableArray<long>? ObjectIds,
+        bool MatchesNothing);
+
+    private readonly record struct PagingLinks(
+        string? Next,
+        string? Previous);
+
+    private readonly record struct FeatureCollectionResponseMetadata(
+        string SchemaLocation,
+        PagingLinks PagingLinks);
+
     private readonly record struct PagedGetFeatureResult(
         IResult Result,
         int ReturnedCount,
@@ -2200,4 +4790,117 @@ internal sealed class Wfs20Handler
         string CanonicalName,
         bool IsGeometry,
         bool IsFeatureId);
+
+    private sealed class WfsTransactionException(
+        string exceptionCode,
+        string message,
+        string? locator = null) : Exception(message)
+    {
+        public string ExceptionCode { get; } = exceptionCode;
+
+        public string? Locator { get; } = locator;
+    }
+
+    private sealed class WfsQueryException(
+        string exceptionCode,
+        string message,
+        string? locator = null) : Exception(message)
+    {
+        public string ExceptionCode { get; } = exceptionCode;
+
+        public string? Locator { get; } = locator;
+    }
+
+    private enum TransactionActionKind
+    {
+        Insert,
+        Update,
+        Replace,
+        Delete
+    }
+
+    private sealed record PreparedTransactionOperation(
+        WfsFeatureTypeDescriptor Descriptor,
+        TransactionActionKind ActionKind,
+        FeatureEditOperation EditOperation,
+        string? Handle,
+        Feature? MutationFeature,
+        Feature? DeleteSnapshot);
+
+    private readonly record struct TransactionFieldResolution(
+        FieldDefinition Field,
+        bool IsGmlProperty);
+
+    private readonly record struct TransactionFeaturePayload(
+        byte[]? Geometry,
+        ImmutableDictionary<string, object?> Attributes);
+
+    private readonly record struct TransactionFeatureChanges(
+        bool GeometrySpecified,
+        byte[]? Geometry,
+        ImmutableDictionary<string, object?> Attributes);
+
+    private readonly record struct TransactionPreparationResult(
+        ImmutableArray<PreparedTransactionOperation> Operations,
+        int LayerId,
+        int LayerIdCount,
+        IResult? ErrorResult,
+        int InsertCount,
+        int UpdateCount,
+        int ReplaceCount,
+        int DeleteCount)
+    {
+        public bool IsValid => ErrorResult is null;
+
+        public static TransactionPreparationResult Success(
+            ImmutableArray<PreparedTransactionOperation> operations,
+            int layerId,
+            int layerIdCount)
+        {
+            var insertCount = 0;
+            var updateCount = 0;
+            var replaceCount = 0;
+            var deleteCount = 0;
+
+            foreach (var operation in operations)
+            {
+                switch (operation.ActionKind)
+                {
+                    case TransactionActionKind.Insert:
+                        insertCount++;
+                        break;
+                    case TransactionActionKind.Update:
+                        updateCount++;
+                        break;
+                    case TransactionActionKind.Replace:
+                        replaceCount++;
+                        break;
+                    case TransactionActionKind.Delete:
+                        deleteCount++;
+                        break;
+                }
+            }
+
+            return new TransactionPreparationResult(
+                operations,
+                layerId,
+                layerIdCount,
+                null,
+                insertCount,
+                updateCount,
+                replaceCount,
+                deleteCount);
+        }
+
+        public static TransactionPreparationResult Failure(IResult errorResult)
+            => new(
+                ImmutableArray<PreparedTransactionOperation>.Empty,
+                0,
+                0,
+                errorResult,
+                0,
+                0,
+                0,
+                0);
+    }
 }

--- a/src/Honua.Server/Features/Wfs20/Services/Wfs20QueryServices.cs
+++ b/src/Honua.Server/Features/Wfs20/Services/Wfs20QueryServices.cs
@@ -1,10 +1,13 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Configuration;
 using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Queries.Filters;
+using Honua.Server.Features.Infrastructure.Events;
+using Honua.Server.Features.Infrastructure.Validation;
 using Honua.Server.Features.OgcFeatures;
 using Honua.Server.Features.OgcFeatures.Services;
 using Microsoft.Extensions.Options;
@@ -18,15 +21,21 @@ namespace Honua.Server.Features.Wfs20.Services;
 internal sealed class Wfs20QueryServices(
     ILayerCatalog layerCatalog,
     IFeatureReader featureReader,
+    IFeatureWriter featureWriter,
     IGmlFeatureStore gmlFeatureStore,
     IFilterExpressionService filterExpressionService,
     OgcFeaturesGeometryServices geometryServices,
+    FeatureMutationValidator mutationValidator,
+    FeatureMutationEventService mutationEventService,
     ICrsRegistry crsRegistry,
-    IOptions<Wfs20Options> wfs20Options)
+    IOptions<Wfs20Options> wfs20Options,
+    IOptions<LimitsOptions> limitsOptions)
 {
     internal ILayerCatalog LayerCatalog { get; } = layerCatalog;
 
     internal IFeatureReader FeatureReader { get; } = featureReader;
+
+    internal IFeatureWriter FeatureWriter { get; } = featureWriter;
 
     internal IGmlFeatureStore GmlFeatureStore { get; } = gmlFeatureStore;
 
@@ -34,7 +43,13 @@ internal sealed class Wfs20QueryServices(
 
     internal OgcFeaturesGeometryServices GeometryServices { get; } = geometryServices;
 
+    internal FeatureMutationValidator MutationValidator { get; } = mutationValidator;
+
+    internal FeatureMutationEventService MutationEventService { get; } = mutationEventService;
+
     internal ICrsRegistry CrsRegistry { get; } = crsRegistry;
 
     internal Wfs20Options Wfs20Options { get; } = wfs20Options?.Value ?? throw new ArgumentNullException(nameof(wfs20Options));
+
+    internal EditLimits EditLimits { get; } = limitsOptions?.Value?.Edits ?? throw new ArgumentNullException(nameof(limitsOptions));
 }

--- a/src/Honua.Server/Features/Wfs20/Wfs20DispatcherEndpoint.cs
+++ b/src/Honua.Server/Features/Wfs20/Wfs20DispatcherEndpoint.cs
@@ -36,6 +36,16 @@ internal static class Wfs20DispatcherEndpoint
 
         public bool HasMultipleXmlQueries => XmlQueryCount > 1;
 
+        public bool Contains(string primaryName, params string[] aliases)
+        {
+            if (_values.ContainsKey(primaryName))
+            {
+                return true;
+            }
+
+            return aliases.Any(alias => _values.ContainsKey(alias));
+        }
+
         public string? Get(string primaryName, params string[] aliases)
         {
             if (_values.TryGetValue(primaryName, out var primaryValue) &&
@@ -70,6 +80,9 @@ internal static class Wfs20DispatcherEndpoint
             ["DescribeFeatureType"] = HandleDescribeFeatureType,
             ["GetFeature"] = HandleGetFeature,
             ["GetPropertyValue"] = HandleGetPropertyValue,
+            ["Transaction"] = HandleTransaction,
+            ["ListStoredQueries"] = HandleListStoredQueries,
+            ["DescribeStoredQueries"] = HandleDescribeStoredQueries,
         };
 
     /// <summary>
@@ -91,7 +104,7 @@ internal static class Wfs20DispatcherEndpoint
             .WithDisplayName("WFS 2.0 Service")
             .WithName("Wfs20Service")
             .WithSummary("OGC Web Feature Service 2.0")
-            .WithDescription("Handles all WFS 2.0 operations: GetCapabilities, DescribeFeatureType, GetFeature, GetPropertyValue, Transaction")
+            .WithDescription("Handles all WFS 2.0 operations: GetCapabilities, DescribeFeatureType, GetFeature, GetPropertyValue, Transaction, ListStoredQueries, DescribeStoredQueries")
             .WithTags("WFS 2.0", "OGC")
             .Produces<object>(200, "application/xml")
             .Produces<ExceptionReport>(400, "application/xml")
@@ -119,7 +132,7 @@ internal static class Wfs20DispatcherEndpoint
                 return Wfs20ErrorResults.CreateBadRequest(
                     context,
                     "MissingParameterValue",
-                    "Missing required 'request' parameter. Supported operations: GetCapabilities, DescribeFeatureType, GetFeature, GetPropertyValue, Transaction",
+                    "Missing required 'request' parameter. Supported operations: GetCapabilities, DescribeFeatureType, GetFeature, GetPropertyValue, Transaction, ListStoredQueries, DescribeStoredQueries",
                     "request");
             }
 
@@ -129,17 +142,10 @@ internal static class Wfs20DispatcherEndpoint
                 return await operationHandler(context, parameters, handler, logger);
             }
 
-            // Transaction is a known but unimplemented stub — kept out of _operationHandlers
-            // so it does not appear in ImplementedOperations or trigger coverage requirements.
-            if (string.Equals(requestParam, "TRANSACTION", StringComparison.OrdinalIgnoreCase))
-            {
-                return await HandleTransaction(context, parameters, handler, logger);
-            }
-
             return Wfs20ErrorResults.CreateNotImplemented(
                 context,
                 "OperationNotSupported",
-                $"Unsupported operation '{requestParam}'. Supported operations: GetCapabilities, DescribeFeatureType, GetFeature, GetPropertyValue, Transaction",
+                $"Unsupported operation '{requestParam}'. Supported operations: GetCapabilities, DescribeFeatureType, GetFeature, GetPropertyValue, Transaction, ListStoredQueries, DescribeStoredQueries",
                 "request");
         }
         catch (InvalidDataException ex)
@@ -264,6 +270,15 @@ internal static class Wfs20DispatcherEndpoint
 
             return Results.Content(schema, "application/xml", System.Text.Encoding.UTF8);
         }
+        catch (ArgumentException ex)
+        {
+            logger.LogWarning(ex, "DescribeFeatureType validation failed");
+            return Wfs20ErrorResults.CreateBadRequest(
+                context,
+                "InvalidParameterValue",
+                ex.Message,
+                "typeNames");
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to process DescribeFeatureType request");
@@ -316,11 +331,24 @@ internal static class Wfs20DispatcherEndpoint
             var resourceId = parameters.Get(
                 Wfs20Utilities.ParameterNames.ResourceId,
                 Wfs20Utilities.ParameterNames.FeatureId);
+            var storedQueryId = parameters.Get(Wfs20Utilities.ParameterNames.StoredQueryId);
+            var storedQueryFeatureId = parameters.Get(Wfs20Utilities.ParameterNames.Id, "id");
             var propertyName = parameters.Get(Wfs20Utilities.ParameterNames.PropertyName);
             var srsName = parameters.Get(
                 Wfs20Utilities.ParameterNames.SrsName,
                 Wfs20Utilities.ParameterNames.Srs);
             var resultType = parameters.Get(Wfs20Utilities.ParameterNames.ResultType);
+
+            if (!string.IsNullOrWhiteSpace(storedQueryId))
+            {
+                return await handler.HandleStoredQueryGetFeatureAsync(
+                    context,
+                    storedQueryId,
+                    storedQueryFeatureId,
+                    outputFormat,
+                    count,
+                    context.RequestAborted);
+            }
 
             // Handle the request
             return await handler.HandleGetFeatureAsync(
@@ -372,6 +400,9 @@ internal static class Wfs20DispatcherEndpoint
             var valueReference = parameters.Get(
                 Wfs20Utilities.ParameterNames.ValueReference,
                 Wfs20Utilities.ParameterNames.PropertyName);
+            var valueReferenceSpecified = parameters.Contains(
+                Wfs20Utilities.ParameterNames.ValueReference,
+                Wfs20Utilities.ParameterNames.PropertyName);
             var count = parameters.Get(
                 Wfs20Utilities.ParameterNames.Count,
                 Wfs20Utilities.ParameterNames.MaxFeatures);
@@ -387,7 +418,7 @@ internal static class Wfs20DispatcherEndpoint
 
             // Handle the request
             return await handler.HandleGetPropertyValueAsync(
-                context, typeNames, valueReference, outputFormat, count, startIndex, bbox, filter, resourceId, srsName,
+                context, typeNames, valueReference, valueReferenceSpecified, outputFormat, count, startIndex, bbox, filter, resourceId, srsName,
                 context.RequestAborted);
         }
         catch (Exception ex)
@@ -400,19 +431,89 @@ internal static class Wfs20DispatcherEndpoint
     /// <summary>
     /// Handles Transaction operation
     /// </summary>
-    private static Task<IResult> HandleTransaction(
+    private static async Task<IResult> HandleTransaction(
         HttpContext context,
         WfsRequestParameters parameters,
         Wfs20Handler handler,
         ILogger logger)
     {
-        // TODO: Implement Transaction operation
-        logger.LogWarning("Transaction operation not yet implemented");
-        return Task.FromResult(Wfs20ErrorResults.CreateNotImplemented(
-            context,
-            "OperationNotSupported",
-            "Transaction operation not yet implemented",
-            "request"));
+        try
+        {
+            var validationError = ValidateOperationRequestParameters(parameters);
+
+            if (validationError is not null)
+            {
+                return Wfs20ErrorResults.CreateBadRequest(
+                    context,
+                    validationError.ExceptionCode,
+                    validationError.Detail,
+                    validationError.Locator);
+            }
+
+            return await handler.HandleTransactionAsync(context, context.RequestAborted);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to process Transaction request");
+            return StandardErrorHelpers.CreateInternalServerError(context, "Failed to process Transaction request");
+        }
+    }
+
+    private static async Task<IResult> HandleListStoredQueries(
+        HttpContext context,
+        WfsRequestParameters parameters,
+        Wfs20Handler handler,
+        ILogger logger)
+    {
+        try
+        {
+            var validationError = ValidateOperationRequestParameters(parameters);
+
+            if (validationError is not null)
+            {
+                return Wfs20ErrorResults.CreateBadRequest(
+                    context,
+                    validationError.ExceptionCode,
+                    validationError.Detail,
+                    validationError.Locator);
+            }
+
+            return await handler.HandleListStoredQueriesAsync(context, context.RequestAborted);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to process ListStoredQueries request");
+            return StandardErrorHelpers.CreateInternalServerError(context, "Failed to process ListStoredQueries request");
+        }
+    }
+
+    private static async Task<IResult> HandleDescribeStoredQueries(
+        HttpContext context,
+        WfsRequestParameters parameters,
+        Wfs20Handler handler,
+        ILogger logger)
+    {
+        try
+        {
+            var validationError = ValidateOperationRequestParameters(parameters);
+
+            if (validationError is not null)
+            {
+                return Wfs20ErrorResults.CreateBadRequest(
+                    context,
+                    validationError.ExceptionCode,
+                    validationError.Detail,
+                    validationError.Locator);
+            }
+
+            var storedQueryIds = parameters.Get(Wfs20Utilities.ParameterNames.StoredQueryId);
+            return await handler.HandleDescribeStoredQueriesAsync(context, storedQueryIds, context.RequestAborted);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to process DescribeStoredQueries request");
+            return StandardErrorHelpers.CreateInternalServerError(context, "Failed to process DescribeStoredQueries request");
+        }
     }
 
     private static WfsValidationError? ValidateCapabilitiesRequestParameters(WfsRequestParameters parameters)
@@ -496,10 +597,7 @@ internal static class Wfs20DispatcherEndpoint
         foreach (var key in context.Request.Query.Keys)
         {
             var value = context.Request.Query[key].FirstOrDefault();
-            if (!string.IsNullOrWhiteSpace(value))
-            {
-                values[key] = value;
-            }
+            values[key] = value?.Trim() ?? string.Empty;
         }
 
         if (!HttpMethods.IsPost(context.Request.Method))
@@ -553,6 +651,7 @@ internal static class Wfs20DispatcherEndpoint
         CopyAttribute(root, values, Wfs20Utilities.ParameterNames.UpdateSequence, "updateSequence");
         CopyAttribute(root, values, Wfs20Utilities.ParameterNames.TypeNames, "typeNames");
         CopyAttribute(root, values, Wfs20Utilities.ParameterNames.TypeName, "typeName");
+        CopyAttribute(root, values, Wfs20Utilities.ParameterNames.StoredQueryId, "storedQueryId");
 
         var typeNames = root
             .Elements()
@@ -569,54 +668,84 @@ internal static class Wfs20DispatcherEndpoint
             .Elements()
             .Where(element => string.Equals(element.Name.LocalName, "Query", StringComparison.OrdinalIgnoreCase))
             .ToArray();
-        if (queries.Length == 0)
+        if (queries.Length > 0)
         {
-            CopyElementValue(root, values, Wfs20Utilities.ParameterNames.ValueReference, "ValueReference");
-            return 0;
+            var queryTypeNames = queries
+                .SelectMany(query => query.Attributes()
+                    .Where(attribute => string.Equals(attribute.Name.LocalName, "typeNames", StringComparison.OrdinalIgnoreCase))
+                    .Select(attribute => attribute.Value.Trim()))
+                .Where(value => value.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (queryTypeNames.Length > 0)
+            {
+                SetValue(values, Wfs20Utilities.ParameterNames.TypeNames, string.Join(",", queryTypeNames));
+            }
+
+            var propertyNames = queries
+                .SelectMany(query => query.Elements()
+                    .Where(element => string.Equals(element.Name.LocalName, "PropertyName", StringComparison.OrdinalIgnoreCase))
+                    .Select(element => element.Value.Trim()))
+                .Where(value => value.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (propertyNames.Length > 0)
+            {
+                SetValue(values, Wfs20Utilities.ParameterNames.PropertyName, string.Join(",", propertyNames));
+            }
+
+            var srsName = queries
+                .SelectMany(query => query.Attributes()
+                    .Where(attribute => string.Equals(attribute.Name.LocalName, "srsName", StringComparison.OrdinalIgnoreCase))
+                    .Select(attribute => attribute.Value.Trim()))
+                .FirstOrDefault(value => value.Length > 0);
+            if (!string.IsNullOrWhiteSpace(srsName))
+            {
+                SetValue(values, Wfs20Utilities.ParameterNames.SrsName, srsName);
+            }
+
+            var filter = queries
+                .SelectMany(query => query.Elements()
+                    .Where(element => string.Equals(element.Name.LocalName, "Filter", StringComparison.OrdinalIgnoreCase))
+                    .Select(element => element.ToString(SaveOptions.DisableFormatting)))
+                .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+            if (!string.IsNullOrWhiteSpace(filter))
+            {
+                SetValue(values, Wfs20Utilities.ParameterNames.Filter, filter);
+            }
         }
 
-        var queryTypeNames = queries
-            .SelectMany(query => query.Attributes()
-                .Where(attribute => string.Equals(attribute.Name.LocalName, "typeNames", StringComparison.OrdinalIgnoreCase))
-                .Select(attribute => attribute.Value.Trim()))
+        var storedQuery = root.Elements()
+            .FirstOrDefault(element => string.Equals(element.Name.LocalName, "StoredQuery", StringComparison.OrdinalIgnoreCase));
+        if (storedQuery != null)
+        {
+            CopyAttribute(storedQuery, values, Wfs20Utilities.ParameterNames.StoredQueryId, "id");
+
+            var storedQueryFeatureId = storedQuery.Elements()
+                .FirstOrDefault(element =>
+                    string.Equals(element.Name.LocalName, "Parameter", StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(
+                        element.Attributes()
+                            .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, "name", StringComparison.OrdinalIgnoreCase))
+                            ?.Value,
+                        "id",
+                        StringComparison.OrdinalIgnoreCase))
+                ?.Value;
+            if (!string.IsNullOrWhiteSpace(storedQueryFeatureId))
+            {
+                SetValue(values, Wfs20Utilities.ParameterNames.Id, storedQueryFeatureId);
+            }
+        }
+
+        var storedQueryIds = root
+            .Elements()
+            .Where(element => string.Equals(element.Name.LocalName, "StoredQueryId", StringComparison.OrdinalIgnoreCase))
+            .Select(element => element.Value.Trim())
             .Where(value => value.Length > 0)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
-        if (queryTypeNames.Length > 0)
+        if (storedQueryIds.Length > 0)
         {
-            SetValue(values, Wfs20Utilities.ParameterNames.TypeNames, string.Join(",", queryTypeNames));
-        }
-
-        var propertyNames = queries
-            .SelectMany(query => query.Elements()
-                .Where(element => string.Equals(element.Name.LocalName, "PropertyName", StringComparison.OrdinalIgnoreCase))
-                .Select(element => element.Value.Trim()))
-            .Where(value => value.Length > 0)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        if (propertyNames.Length > 0)
-        {
-            SetValue(values, Wfs20Utilities.ParameterNames.PropertyName, string.Join(",", propertyNames));
-        }
-
-        var srsName = queries
-            .SelectMany(query => query.Attributes()
-                .Where(attribute => string.Equals(attribute.Name.LocalName, "srsName", StringComparison.OrdinalIgnoreCase))
-                .Select(attribute => attribute.Value.Trim()))
-            .FirstOrDefault(value => value.Length > 0);
-        if (!string.IsNullOrWhiteSpace(srsName))
-        {
-            SetValue(values, Wfs20Utilities.ParameterNames.SrsName, srsName);
-        }
-
-        var filter = queries
-            .SelectMany(query => query.Elements()
-                .Where(element => string.Equals(element.Name.LocalName, "Filter", StringComparison.OrdinalIgnoreCase))
-                .Select(element => element.ToString(SaveOptions.DisableFormatting)))
-            .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
-        if (!string.IsNullOrWhiteSpace(filter))
-        {
-            SetValue(values, Wfs20Utilities.ParameterNames.Filter, filter);
+            SetValue(values, Wfs20Utilities.ParameterNames.StoredQueryId, string.Join(",", storedQueryIds));
         }
 
         CopyElementValue(root, values, Wfs20Utilities.ParameterNames.ValueReference, "ValueReference");
@@ -634,9 +763,9 @@ internal static class Wfs20DispatcherEndpoint
             var value = element.Attributes()
                 .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, attributeName, StringComparison.OrdinalIgnoreCase))
                 ?.Value;
-            if (!string.IsNullOrWhiteSpace(value))
+            if (value is not null)
             {
-                SetValue(values, targetName, value);
+                SetRawValue(values, targetName, value);
                 return;
             }
         }
@@ -651,9 +780,9 @@ internal static class Wfs20DispatcherEndpoint
         var value = root.Elements()
             .FirstOrDefault(element => string.Equals(element.Name.LocalName, elementName, StringComparison.OrdinalIgnoreCase))
             ?.Value;
-        if (!string.IsNullOrWhiteSpace(value))
+        if (value is not null)
         {
-            SetValue(values, targetName, value);
+            SetRawValue(values, targetName, value);
         }
     }
 
@@ -664,6 +793,9 @@ internal static class Wfs20DispatcherEndpoint
             values[key] = value.Trim();
         }
     }
+
+    private static void SetRawValue(Dictionary<string, string> values, string key, string value)
+        => values[key] = value.Trim();
 
     /// <summary>
     /// Serializes an object to XML and returns as IResult

--- a/src/Honua.Server/Features/Wfs20/Wfs20ErrorResults.cs
+++ b/src/Honua.Server/Features/Wfs20/Wfs20ErrorResults.cs
@@ -39,6 +39,20 @@ internal static class Wfs20ErrorResults
             locator);
     }
 
+    internal static IResult CreateNotFound(
+        HttpContext context,
+        string exceptionCode,
+        string detail,
+        string? locator = null,
+        IReadOnlyList<string>? additionalDetails = null)
+    {
+        return Create(
+            context,
+            StandardErrorResponse.NotFound(detail, additionalDetails),
+            exceptionCode,
+            locator);
+    }
+
     private static IResult Create(
         HttpContext context,
         StandardErrorResponse errorResponse,

--- a/src/Honua.Server/Features/Wfs20/Wfs20Utilities.cs
+++ b/src/Honua.Server/Features/Wfs20/Wfs20Utilities.cs
@@ -67,6 +67,8 @@ internal static class Wfs20Utilities
         public const string GetFeature = "GetFeature";
         public const string GetPropertyValue = "GetPropertyValue";
         public const string Transaction = "Transaction";
+        public const string ListStoredQueries = "ListStoredQueries";
+        public const string DescribeStoredQueries = "DescribeStoredQueries";
         public const string LockFeature = "LockFeature";
         public const string GetFeatureWithLock = "GetFeatureWithLock";
     }
@@ -153,6 +155,7 @@ internal static class Wfs20Utilities
         public const string FeatureId = "FEATUREID";
         public const string ResultType = "RESULTTYPE";
         public const string StoredQueryId = "STOREDQUERY_ID";
+        public const string Id = "ID";
         public const string PropertyName = "PROPERTYNAME";
         public const string ValueReference = "VALUEREFERENCE";
         public const string Srs = "SRS";
@@ -207,6 +210,7 @@ internal static class Wfs20Utilities
             ParameterNames.FeatureId,
             ParameterNames.ResultType,
             ParameterNames.StoredQueryId,
+            ParameterNames.Id,
             ParameterNames.PropertyName,
             ParameterNames.Srs,
             ParameterNames.SrsName);

--- a/src/Honua.Server/OperationRegistry.cs
+++ b/src/Honua.Server/OperationRegistry.cs
@@ -14,8 +14,8 @@ namespace Honua.Server;
 /// (WFS 2.0) and non-HTTP protocol surfaces (gRPC).
 /// </para>
 /// <para>
-/// Unimplemented operations (e.g. WFS Transaction) are intentionally excluded.
-/// Add them here only when the implementation ships.
+/// Add new dispatched operations here when the implementation ships so the
+/// architecture tests can enforce integration coverage.
 /// </para>
 /// </remarks>
 public static class OperationRegistry
@@ -37,6 +37,9 @@ public static class OperationRegistry
         new(Wfs20, "DescribeFeatureType"),
         new(Wfs20, "GetFeature"),
         new(Wfs20, "GetPropertyValue"),
+        new(Wfs20, "Transaction"),
+        new(Wfs20, "ListStoredQueries"),
+        new(Wfs20, "DescribeStoredQueries"),
 
         // gRPC FeatureService methods (geospatial.v1.FeatureService)
         new(Grpc, "geospatial.v1.FeatureService/QueryFeatures"),

--- a/tests/Honua.Server.Tests/Features/Wfs20/Wfs20EndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Wfs20/Wfs20EndpointsTests.cs
@@ -509,14 +509,15 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
     [Operation(Operations.Query)]
     [Endpoint("GET /wfs")]
     [InterfaceOperation(Protocols.Wfs20, "GetFeature")]
-    public async Task Wfs_GetFeature_WithNamedFeature_IncludesGmlName()
+    public async Task Wfs_GetFeature_WithNamedFeature_UsesApplicationNameWithoutDuplicateGmlName()
     {
         var response = await _fixture.Client.GetAsync(
             "/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=test_layer&COUNT=1");
 
         var content = await response.Content.ReadAsStringAsync();
         response.StatusCode.Should().Be(HttpStatusCode.OK, content);
-        content.Should().Contain("<gml:name>Test Feature</gml:name>");
+        content.Should().Contain("<honua:name>Test Feature</honua:name>");
+        content.Should().NotContain("<gml:name>Test Feature</gml:name>");
     }
 
     [IntegrationTest]

--- a/tests/Honua.Server.Tests/Features/Wfs20/Wfs20EndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Wfs20/Wfs20EndpointsTests.cs
@@ -16,6 +16,7 @@ namespace Honua.Server.Tests.Features.Wfs20;
 [Protocol(Protocols.Wfs20)]
 public sealed class Wfs20EndpointsTests : IAsyncLifetime
 {
+    private const string GetFeatureByIdStoredQueryId = "urn:ogc:def:query:OGC-WFS::GetFeatureById";
     private readonly WebAppFixture _fixture = new();
 
     public async Task InitializeAsync() => await _fixture.InitializeAsync();
@@ -26,7 +27,7 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
     [Operation(Operations.Metadata)]
     [Endpoint("GET /wfs")]
     [InterfaceOperation(Protocols.Wfs20, "GetCapabilities")]
-    public async Task Wfs_GetCapabilities_ReturnsXmlWithoutTransactionOperation()
+    public async Task Wfs_GetCapabilities_ReturnsXmlWithTransactionOperation()
     {
         var response = await _fixture.Client.GetAsync(
             "/wfs?SERVICE=WFS&REQUEST=GetCapabilities&VERSION=2.0.0");
@@ -36,13 +37,21 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
         content.Should().Contain("WFS_Capabilities");
         content.Should().Contain("updateSequence=\"20260325\"");
-        content.Should().Contain("<Operation name=\"GetFeature\">");
-        content.Should().Contain("<Operation name=\"GetPropertyValue\">");
-        content.Should().NotContain("<Operation name=\"Transaction\">");
+        content.Should().Contain("xmlns:honua=\"http://honua.io/wfs\"");
+        content.Should().Contain("Operation name=\"GetFeature\"");
+        content.Should().Contain("Operation name=\"GetPropertyValue\"");
+        content.Should().Contain("Operation name=\"Transaction\"");
+        content.Should().Contain("Operation name=\"ListStoredQueries\"");
+        content.Should().Contain("Operation name=\"DescribeStoredQueries\"");
         content.Should().Contain("name=\"ImplementsBasicWFS\"");
+        content.Should().Contain("name=\"ImplementsTransactionalWFS\"");
         content.Should().Contain("name=\"KVPEncoding\"");
         content.Should().Contain("name=\"XMLEncoding\"");
         content.Should().Contain("ImplementsSpatialFilter");
+        Regex.IsMatch(
+            content,
+            "name=\"ImplementsTransactionalWFS\"[\\s\\S]*?<[^>]*DefaultValue>TRUE</",
+            RegexOptions.CultureInvariant).Should().BeTrue(content);
         content.Should().Contain(">TRUE<");
         content.Should().Contain("SpatialOperator name=\"Intersects\"");
         content.Should().Contain("SpatialOperator name=\"DWithin\"");
@@ -325,13 +334,49 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
     public async Task Wfs_UnsupportedOperation_ReturnsExceptionReport()
     {
         var response = await _fixture.Client.GetAsync(
-            "/wfs?SERVICE=WFS&REQUEST=ListStoredQueries&VERSION=2.0.0");
+            "/wfs?SERVICE=WFS&REQUEST=LockFeature&VERSION=2.0.0");
 
         var content = await response.Content.ReadAsStringAsync();
         response.StatusCode.Should().Be(HttpStatusCode.NotImplemented, content);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
         content.Should().Contain("ExceptionReport");
         content.Should().Contain("exceptionCode=\"OperationNotSupported\"");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /wfs")]
+    [InterfaceOperation(Protocols.Wfs20, "ListStoredQueries")]
+    public async Task Wfs_ListStoredQueries_ReturnsGetFeatureByIdDefinition()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/wfs?SERVICE=WFS&REQUEST=ListStoredQueries&VERSION=2.0.0");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+        content.Should().Contain("ListStoredQueriesResponse");
+        content.Should().Contain($"id=\"{GetFeatureByIdStoredQueryId}\"");
+        content.Should().Contain("<wfs:ReturnFeatureType>honua:test_layer</wfs:ReturnFeatureType>");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /wfs")]
+    [InterfaceOperation(Protocols.Wfs20, "DescribeStoredQueries")]
+    public async Task Wfs_DescribeStoredQueries_ReturnsGetFeatureByIdDefinition()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/wfs?SERVICE=WFS&REQUEST=DescribeStoredQueries&VERSION=2.0.0&STOREDQUERY_ID={Uri.EscapeDataString(GetFeatureByIdStoredQueryId)}");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+        content.Should().Contain("DescribeStoredQueriesResponse");
+        content.Should().Contain($"StoredQueryDescription id=\"{GetFeatureByIdStoredQueryId}\"");
+        content.Should().Contain("Parameter name=\"id\" type=\"xsd:string\"");
+        content.Should().Contain("QueryExpressionText");
+        content.Should().Contain("rid=\"${id}\"");
     }
 
     [IntegrationTest]
@@ -352,15 +397,370 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.ErrorHandling)]
     [Endpoint("GET /wfs")]
-    public async Task Wfs_Transaction_ReturnsNotImplementedExceptionReport()
+    [InterfaceOperation(Protocols.Wfs20, "Transaction")]
+    public async Task Wfs_Transaction_Insert_ReturnsTransactionResponseAndCreatesFeature()
     {
-        var response = await _fixture.Client.GetAsync(
-            "/wfs?SERVICE=WFS&REQUEST=Transaction&VERSION=2.0.0");
+        const string requestBody = """
+            <wfs:Transaction service="WFS" version="2.0.0"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:honua="http://honua.io/wfs">
+              <wfs:Insert handle="insert-feature">
+                <honua:test_layer>
+                  <honua:name>WFS Transaction Insert</honua:name>
+                  <honua:shape>
+                    <gml:Point srsName="urn:ogc:def:crs:EPSG::4326">
+                      <gml:pos>37.123 -122.456</gml:pos>
+                    </gml:Point>
+                  </honua:shape>
+                </honua:test_layer>
+              </wfs:Insert>
+            </wfs:Transaction>
+            """;
+
+        using var requestContent = new StringContent(requestBody, Encoding.UTF8, "application/xml");
+        var response = await _fixture.Client.PostAsync("/wfs", requestContent);
 
         var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+        content.Should().Contain("TransactionResponse");
+        content.Should().Contain("<wfs:totalInserted>1</wfs:totalInserted>");
+        content.Should().Contain("handle=\"insert-feature\"");
+
+        var resourceIdMatch = Regex.Match(content, "rid=\"(?<rid>test_layer\\.\\d+)\"", RegexOptions.CultureInvariant);
+        resourceIdMatch.Success.Should().BeTrue(content);
+        var resourceId = resourceIdMatch.Groups["rid"].Value;
+
+        var queryResponse = await _fixture.Client.GetAsync(
+            $"/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=test_layer&RESOURCEID={resourceId}");
+        var queryContent = await queryResponse.Content.ReadAsStringAsync();
+
+        queryResponse.StatusCode.Should().Be(HttpStatusCode.OK, queryContent);
+        queryContent.Should().Contain("WFS Transaction Insert");
+        queryContent.Should().Contain(resourceId);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /wfs")]
+    public async Task Wfs_Transaction_WithInsertUpdateAndDelete_ReturnsTransactionSummary()
+    {
+        var updateId = await _fixture.InsertFeatureAsync(WebAppFixture.TestLayerId, "WFS Transaction Update Target");
+        var deleteId = await _fixture.InsertFeatureAsync(WebAppFixture.TestLayerId, "WFS Transaction Delete Target");
+
+        var requestBody = $$"""
+            <wfs:Transaction service="WFS" version="2.0.0"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:fes="http://www.opengis.net/fes/2.0"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:honua="http://honua.io/wfs">
+              <wfs:Insert>
+                <honua:test_layer>
+                  <honua:name>WFS Transaction Mixed Insert</honua:name>
+                  <honua:shape>
+                    <gml:Point srsName="urn:ogc:def:crs:EPSG::4326">
+                      <gml:pos>37.124 -122.457</gml:pos>
+                    </gml:Point>
+                  </honua:shape>
+                </honua:test_layer>
+              </wfs:Insert>
+              <wfs:Update typeName="test_layer">
+                <wfs:Property>
+                  <wfs:ValueReference>name</wfs:ValueReference>
+                  <wfs:Value>WFS Transaction Updated</wfs:Value>
+                </wfs:Property>
+                <fes:Filter>
+                  <fes:ResourceId rid="test_layer.{{updateId}}" />
+                </fes:Filter>
+              </wfs:Update>
+              <wfs:Delete typeName="test_layer">
+                <fes:Filter>
+                  <fes:ResourceId rid="test_layer.{{deleteId}}" />
+                </fes:Filter>
+              </wfs:Delete>
+            </wfs:Transaction>
+            """;
+
+        using var requestContent = new StringContent(requestBody, Encoding.UTF8, "application/xml");
+        var response = await _fixture.Client.PostAsync("/wfs", requestContent);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, responseBody);
+        responseBody.Should().Contain("TransactionResponse");
+        responseBody.Should().Contain("<wfs:totalInserted>1</wfs:totalInserted>");
+        responseBody.Should().Contain("<wfs:totalUpdated>1</wfs:totalUpdated>");
+        responseBody.Should().Contain("<wfs:totalDeleted>1</wfs:totalDeleted>");
+
+        var updatedFeatureResponse = await _fixture.Client.GetAsync(
+            $"/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=test_layer&RESOURCEID=test_layer.{updateId}");
+        var updatedFeatureBody = await updatedFeatureResponse.Content.ReadAsStringAsync();
+        updatedFeatureResponse.StatusCode.Should().Be(HttpStatusCode.OK, updatedFeatureBody);
+        updatedFeatureBody.Should().Contain("WFS Transaction Updated");
+
+        var deletedFeatureResponse = await _fixture.Client.GetAsync(
+            $"/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=test_layer&RESOURCEID=test_layer.{deleteId}");
+        var deletedFeatureBody = await deletedFeatureResponse.Content.ReadAsStringAsync();
+        deletedFeatureResponse.StatusCode.Should().Be(HttpStatusCode.OK, deletedFeatureBody);
+        deletedFeatureBody.Should().Contain("numberMatched=\"0\"");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /wfs")]
+    [InterfaceOperation(Protocols.Wfs20, "GetFeature")]
+    public async Task Wfs_GetFeature_WithNamedFeature_IncludesGmlName()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=test_layer&COUNT=1");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        content.Should().Contain("<gml:name>Test Feature</gml:name>");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /wfs")]
+    [InterfaceOperation(Protocols.Wfs20, "GetFeature")]
+    public async Task Wfs_GetFeature_GetFeatureByIdStoredQuery_Kvp_ReturnsSingleFeatureElement()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&STOREDQUERY_ID={Uri.EscapeDataString(GetFeatureByIdStoredQueryId)}&ID=test_layer.1");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/gml+xml");
+        content.Should().Contain("<honua:test_layer");
+        content.Should().Contain("gml:id=\"test_layer.1\"");
+        content.Should().Contain("<gml:name>Test Feature</gml:name>");
+        content.Should().NotContain("FeatureCollection");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(Protocols.Wfs20, "GetFeature")]
+    public async Task Wfs_Post_GetFeature_GetFeatureByIdStoredQuery_ReturnsSingleFeatureElement()
+    {
+        var requestBody = $$"""
+            <wfs:GetFeature service="WFS" version="2.0.0" count="1"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0">
+              <wfs:StoredQuery id="{{GetFeatureByIdStoredQueryId}}">
+                <wfs:Parameter name="id">test_layer.1</wfs:Parameter>
+              </wfs:StoredQuery>
+            </wfs:GetFeature>
+            """;
+
+        using var content = new StringContent(requestBody, Encoding.UTF8, "application/xml");
+        var response = await _fixture.Client.PostAsync("/wfs", content);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, responseBody);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/gml+xml");
+        responseBody.Should().Contain("<honua:test_layer");
+        responseBody.Should().Contain("gml:id=\"test_layer.1\"");
+        responseBody.Should().NotContain("FeatureCollection");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("GET /wfs")]
+    [InterfaceOperation(Protocols.Wfs20, "GetFeature")]
+    public async Task Wfs_GetFeature_GetFeatureByIdStoredQuery_UnknownId_Returns404ExceptionReport()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&STOREDQUERY_ID={Uri.EscapeDataString(GetFeatureByIdStoredQueryId)}&ID=test_layer.999999");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound, content);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
         content.Should().Contain("ExceptionReport");
-        content.Should().Contain("exceptionCode=\"OperationNotSupported\"");
+        content.Should().Contain("exceptionCode=\"NotFound\"");
+        content.Should().Contain("locator=\"id\"");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("GET /wfs")]
+    public async Task Wfs_GetFeature_UnknownStoredQuery_ReturnsOperationParsingFailedException()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&STOREDQUERY_ID=urn:ogc:def:query:OGC-WFS::UnknownQuery&ID=test_layer.1");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, content);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+        content.Should().Contain("ExceptionReport");
+        content.Should().Contain("exceptionCode=\"OperationParsingFailed\"");
+        content.Should().Contain("locator=\"storedquery_id\"");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(Protocols.Wfs20, "Transaction")]
+    public async Task Wfs_Transaction_UpdateGmlNameXPathReference_UpdatesStoredQueryResult()
+    {
+        var featureId = await _fixture.InsertFeatureAsync(WebAppFixture.TestLayerId, "WFS XPath Name Original");
+
+        var requestBody = $$"""
+            <wfs:Transaction service="WFS" version="2.0.0"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:fes="http://www.opengis.net/fes/2.0">
+              <wfs:Update typeName="test_layer">
+                <wfs:Property>
+                  <wfs:ValueReference>gml:name[1]</wfs:ValueReference>
+                  <wfs:Value>WFS XPath Name Updated</wfs:Value>
+                </wfs:Property>
+                <fes:Filter>
+                  <fes:ResourceId rid="test_layer.{{featureId}}" />
+                </fes:Filter>
+              </wfs:Update>
+            </wfs:Transaction>
+            """;
+
+        using var requestContent = new StringContent(requestBody, Encoding.UTF8, "application/xml");
+        var response = await _fixture.Client.PostAsync("/wfs", requestContent);
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        content.Should().Contain("<wfs:totalUpdated>1</wfs:totalUpdated>");
+
+        var queryResponse = await _fixture.Client.GetAsync(
+            $"/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&STOREDQUERY_ID={Uri.EscapeDataString(GetFeatureByIdStoredQueryId)}&ID=test_layer.{featureId}");
+        var queryContent = await queryResponse.Content.ReadAsStringAsync();
+
+        queryResponse.StatusCode.Should().Be(HttpStatusCode.OK, queryContent);
+        queryContent.Should().Contain("<honua:test_layer");
+        queryContent.Should().Contain("<gml:name>WFS XPath Name Updated</gml:name>");
+        queryContent.Should().NotContain("FeatureCollection");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(Protocols.Wfs20, "Transaction")]
+    public async Task Wfs_Transaction_Replace_ReturnsReplaceSummaryAndUpdatesFeature()
+    {
+        var featureId = await _fixture.InsertFeatureAsync(WebAppFixture.TestLayerId, "WFS Replace Original");
+        var replacementIdentifier = Guid.NewGuid().ToString();
+
+        var requestBody = $$"""
+            <wfs:Transaction service="WFS" version="2.0.0"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:fes="http://www.opengis.net/fes/2.0"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:honua="http://honua.io/wfs">
+              <wfs:Replace>
+                <honua:test_layer gml:id="test_layer.{{featureId}}">
+                  <gml:description>WFS Replace Description</gml:description>
+                  <gml:identifier>{{replacementIdentifier}}</gml:identifier>
+                  <gml:name>WFS Replace Name</gml:name>
+                  <honua:name>WFS Replace Name</honua:name>
+                </honua:test_layer>
+                <fes:Filter>
+                  <fes:ResourceId rid="test_layer.{{featureId}}" />
+                </fes:Filter>
+              </wfs:Replace>
+            </wfs:Transaction>
+            """;
+
+        using var requestContent = new StringContent(requestBody, Encoding.UTF8, "application/xml");
+        var response = await _fixture.Client.PostAsync("/wfs", requestContent);
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        content.Should().Contain("<wfs:totalReplaced>1</wfs:totalReplaced>");
+        content.Should().Contain("<wfs:ReplaceResults>");
+        content.Should().Contain($"rid=\"test_layer.{featureId}\"");
+
+        var queryResponse = await _fixture.Client.GetAsync(
+            $"/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&STOREDQUERY_ID={Uri.EscapeDataString(GetFeatureByIdStoredQueryId)}&ID=test_layer.{featureId}");
+        var queryContent = await queryResponse.Content.ReadAsStringAsync();
+
+        queryResponse.StatusCode.Should().Be(HttpStatusCode.OK, queryContent);
+        queryContent.Should().Contain("<honua:test_layer");
+        queryContent.Should().Contain("WFS Replace Name");
+        queryContent.Should().Contain("WFS Replace Description");
+        queryContent.Should().Contain($"<gml:identifier>{replacementIdentifier}</gml:identifier>");
+        queryContent.Should().NotContain("FeatureCollection");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(Protocols.Wfs20, "Transaction")]
+    public async Task Wfs_Transaction_Delete_DeletedFeatureStoredQueryReturns404ExceptionReport()
+    {
+        var featureId = await _fixture.InsertFeatureAsync(WebAppFixture.TestLayerId, "WFS Delete Target");
+
+        var requestBody = $$"""
+            <wfs:Transaction service="WFS" version="2.0.0"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:fes="http://www.opengis.net/fes/2.0">
+              <wfs:Delete typeName="test_layer">
+                <fes:Filter>
+                  <fes:ResourceId rid="test_layer.{{featureId}}" />
+                </fes:Filter>
+              </wfs:Delete>
+            </wfs:Transaction>
+            """;
+
+        using var requestContent = new StringContent(requestBody, Encoding.UTF8, "application/xml");
+        var response = await _fixture.Client.PostAsync("/wfs", requestContent);
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        content.Should().Contain("<wfs:totalDeleted>1</wfs:totalDeleted>");
+
+        var queryResponse = await _fixture.Client.GetAsync(
+            $"/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&STOREDQUERY_ID={Uri.EscapeDataString(GetFeatureByIdStoredQueryId)}&ID=test_layer.{featureId}");
+        var queryContent = await queryResponse.Content.ReadAsStringAsync();
+
+        queryResponse.StatusCode.Should().Be(HttpStatusCode.NotFound, queryContent);
+        queryResponse.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+        queryContent.Should().Contain("ExceptionReport");
+        queryContent.Should().Contain("exceptionCode=\"NotFound\"");
+        queryContent.Should().Contain("locator=\"id\"");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(Protocols.Wfs20, "Transaction")]
+    public async Task Wfs_Transaction_UpdateBoundedBy_WithInvalidValue_ReturnsInvalidValueException()
+    {
+        var updateId = await _fixture.InsertFeatureAsync(WebAppFixture.TestLayerId, "WFS BoundedBy Target");
+
+        var requestBody = $$"""
+            <wfs:Transaction service="WFS" version="2.0.0"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:fes="http://www.opengis.net/fes/2.0"
+                xmlns:kml="http://www.opengis.net/kml/2.2">
+              <wfs:Update typeName="test_layer">
+                <wfs:Property>
+                  <wfs:ValueReference>gml:boundedBy</wfs:ValueReference>
+                  <wfs:Value>
+                    <kml:Point>
+                      <kml:coordinates>-122.456,37.123</kml:coordinates>
+                    </kml:Point>
+                  </wfs:Value>
+                </wfs:Property>
+                <fes:Filter>
+                  <fes:ResourceId rid="test_layer.{{updateId}}" />
+                </fes:Filter>
+              </wfs:Update>
+            </wfs:Transaction>
+            """;
+
+        using var requestContent = new StringContent(requestBody, Encoding.UTF8, "application/xml");
+        var response = await _fixture.Client.PostAsync("/wfs", requestContent);
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, content);
+        content.Should().Contain("ExceptionReport");
+        content.Should().Contain("exceptionCode=\"InvalidValue\"");
     }
 
     [IntegrationTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #714

## Summary
Implements WFS 2.0 transactional operations and the supporting CITE coverage needed for transactional conformance.

## Changes Made
- Add WFS 2.0 `Transaction` support for insert, update, delete, and replace on `/wfs`, with compliant transaction and exception responses.
- Advertise transactional WFS capabilities, preserve WFS-specific GML metadata needed by stored queries and replace flows, and keep those internal attributes hidden from non-WFS protocols.
- Add WFS transaction integration coverage and update the transactional CITE runner and seed data so the transactional profile passes with zero skips.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

