### PR TITLE
fix: normalize operations progress identity fields after #721

### DIFF
--- a/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
@@ -125,10 +125,30 @@ internal static class OperationsProgressEndpoints
 
         // List payloads need stable cross-operation keys for generic admin clients
         // while still preserving the type-specific fields from each concrete progress DTO.
-        operation.TryAdd("operationId", progress.OperationId);
-        operation.TryAdd("type", (int)progress.Type);
+        NormalizeCanonicalProperty(operation, "operationId", JsonValue.Create(progress.OperationId));
+        NormalizeCanonicalProperty(operation, "type", JsonValue.Create((int)progress.Type));
 
         return JsonSerializer.SerializeToElement(operation);
+    }
+
+    private static void NormalizeCanonicalProperty(JsonObject operation, string propertyName, JsonNode? value)
+    {
+        var duplicateKeys = new List<string>();
+
+        foreach (var property in operation)
+        {
+            if (string.Equals(property.Key, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                duplicateKeys.Add(property.Key);
+            }
+        }
+
+        foreach (var duplicateKey in duplicateKeys)
+        {
+            operation.Remove(duplicateKey);
+        }
+
+        operation[propertyName] = value;
     }
 
     /// <summary>

--- a/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
@@ -158,6 +158,7 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
             GetPropertyCaseInsensitive(op, "operationId").GetString() == geoprocessingId &&
             GetPropertyCaseInsensitive(op, "type").GetInt32() == (int)OperationType.Geoprocessing &&
             GetPropertyCaseInsensitive(op, "currentStage").ValueKind != JsonValueKind.Undefined);
+        operations.Should().OnlyContain(op => CountPropertiesIgnoringCase(op, "operationId") == 1);
     }
 
     [IntegrationTest]
@@ -257,6 +258,7 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
         GetPropertyCaseInsensitive(op, "currentStage").ValueKind.Should().NotBe(JsonValueKind.Undefined);
         GetPropertyCaseInsensitive(op, "currentStageStatus").ValueKind.Should().NotBe(JsonValueKind.Undefined);
         GetPropertyCaseInsensitive(op, "stepsCompleted").GetInt32().Should().Be(0);
+        CountPropertiesIgnoringCase(op, "operationId").Should().Be(1);
     }
 
     [IntegrationTest]
@@ -301,5 +303,24 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
         }
 
         throw new KeyNotFoundException($"Property '{propertyName}' not found in JSON payload.");
+    }
+
+    private static int CountPropertiesIgnoringCase(JsonElement element, string propertyName)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidOperationException($"Expected JSON object for property '{propertyName}'.");
+        }
+
+        var count = 0;
+        foreach (var property in element.EnumerateObject())
+        {
+            if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                count++;
+            }
+        }
+
+        return count;
     }
 }


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #721

## Summary
Recover the missed admin operations payload fix after the original #721 merge.

## Changes Made
- normalize mixed-case `operationId` and `type` keys before writing canonical admin payload fields
- preserve one canonical `operationId` and one canonical `type` field for mixed operation list responses
- add endpoint assertions that fail if a payload item emits duplicate operation-id keys ignoring case

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

## Context
This PR recovers a post-merge fix for the admin operations list payload after the original #721 implementation landed. The targeted review found that geoprocessing list items could emit both `OperationId` and `operationId` in the same payload object.
