### PR TITLE
fix(#681): finish durable cancellation handling

### DIFF
--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -116,15 +116,16 @@ REST API and GitOps-ready management:
 
 ## Deployment
 
-Honua runs as a single container. The default PostgreSQL provider requires an external PostGIS database; the DuckDB provider is fully embedded and needs no external infrastructure.
+Honua runs as a single container in combined mode. The job orchestration substrate ([ADR-0031](contributor/adr/0031-durable-job-orchestration-substrate.md)) is designed to support separate API and worker hosts for enterprise scale-out, but separate worker-mode hosting is not yet wired — it will land with the per-kind executor tickets. See [Operations — Job Orchestration](operator/operations.md#job-orchestration) and [Deployment Scenarios](operator/DEPLOYMENT_SCENARIOS.md#apiworker-host-separation) for details.
 
 ```
   PostgreSQL (default):         DuckDB (embedded):
   ---------------------         ------------------
   1x Honua container            1x Honua container
   1x PostgreSQL/PostGIS         .duckdb file (bundled or mounted)
-  Redis (optional)
-  Reverse proxy (TLS)           Reverse proxy (TLS)
+  Redis (optional; required     Reverse proxy (TLS)
+    for job orchestration)
+  Reverse proxy (TLS)
 ```
 
 **Deployment options:**

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -53,6 +53,8 @@
 - [MCP Server](developer/MCP_SERVER.md)
 - [AI Operator Contract](developer/AI_OPERATOR_CONTRACT.md)
 - [Deterministic Operator Workflow Results](developer/DETERMINISTIC_OPERATOR_WORKFLOW_RESULTS.md)
+- [Redis Fallback Patterns](developer/REDIS_FALLBACK_PATTERNS.md)
+- [Service Registration Consolidation](developer/SERVICE_REGISTRATION_CONSOLIDATION.md)
 - [Versioning Policy](developer/CONTROL_PLANE_VERSIONING_POLICY.md)
 - [Migration Guide](developer/CONTROL_PLANE_MIGRATION_GUIDE.md)
 

--- a/docs/contributor/ARCHITECTURE.md
+++ b/docs/contributor/ARCHITECTURE.md
@@ -39,6 +39,7 @@ The server is organized by vertical slices under `src/Honua.Server/Features/`.
 - **OData**: CRUD + query options ($filter, $select, $orderby, $top, $skip, $count, $search, $apply, $batch).
 - **Tiles**: MVT + TileJSON.
 - **Geoprocessing**: gRPC `ProcessService` — plan validation, dry-run estimation, async job lifecycle. Workspace lifecycle management — artifact storage, retention policies, quota evaluation, promotion from temporary to durable workspaces, and background cleanup. Protocol adapters: GeoServices REST GPServer — job status polling and cancellation over the canonical process runtime, with service info (stub), task info, submitJob, execute, and per-parameter result routes registered; and OGC API Processes — REST process discovery, async execution, and job/result endpoints over the same canonical runtime.
+- **Control Plane**: Durable job orchestration substrate — queue, claim/heartbeat, retry, reconciliation, structured execution logs, and artifact references ([ADR-0031](adr/0031-durable-job-orchestration-substrate.md)). `AddJobOrchestration()` is safe for lean API images; `AddJobWorker()` adds the execution host and reconciliation service for worker or combined-mode hosts only.
 - **Admin**: connections, publishing, metadata, styles, imports, operations, observability.
 - **Import**: file import pipeline + Esri service import.
 

--- a/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
+++ b/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
@@ -56,6 +56,33 @@ The existing `ExecutionJobStatus` enum is retained unchanged:
   `LastHeartbeatAt` exceeds the heartbeat timeout (default: 90 seconds), the
   job is considered abandoned.
 
+### Job Kinds
+
+`ExecutionJobKind` categorises workloads so workers can filter what they claim:
+
+| Kind | Description |
+|------|-------------|
+| Geoprocessing | Analytical compute (buffer, spatial join, etc.) |
+| ExtractTransformLoad | Data movement and transformation |
+| TileCache | Tile cache generation or refresh |
+
+`IJobQueue.TryClaimAsync` accepts an optional `acceptedKinds` filter; when
+omitted the worker accepts all kinds.
+
+### Priority Queue
+
+Jobs are dequeued in priority order. Within a priority band, FIFO ordering
+applies.
+
+| Priority | Score Band | Use case |
+|----------|-----------|----------|
+| Critical | 0 | Operator-initiated urgent work |
+| High | 1 × 10¹² | Time-sensitive processing |
+| Normal | 2 × 10¹² | Default for most workloads |
+| Low | 3 × 10¹² | Background or deferrable work |
+
+Millisecond timestamps break ties within a band.
+
 ### Retry Policy
 
 - `JobRetryPolicy` specifies `MaxAttempts`, `BackoffStrategy` (Fixed, Linear,
@@ -65,6 +92,15 @@ The existing `ExecutionJobStatus` enum is retained unchanged:
 - When a heartbeat expires and retries remain, the reconciler requeues the job
   with a computed backoff delay. `AttemptCount` on the record tracks attempts.
 - When retries are exhausted, the job transitions to Failed.
+
+### Timeout Policy
+
+- `JobTimeoutPolicy` specifies `MaxDuration`.
+- Default: 1 hour. A `LongRunning` preset provides a 24-hour ceiling.
+- Enforcement is dual-layered: `JobExecutionService` sets a
+  `CancellationTokenSource` timeout for in-process detection, while
+  `JobReconciliationService` catches workers that crash without cancelling.
+- Jobs that exceed their timeout are marked Failed and are **not** retried.
 
 ### Cancellation
 
@@ -77,9 +113,13 @@ The existing `ExecutionJobStatus` enum is retained unchanged:
 ### Progress Reporting
 
 - Workers report progress through `IJobExecutionContext.ReportProgressAsync`,
-  which updates `PercentComplete`, `CurrentPhase`, and refreshes the heartbeat.
+  which updates `PercentComplete`, `CurrentPhase`, and refreshes the heartbeat
+  on the `ExecutionJobRecord` in `IExecutionJobStore`.
 - The existing `IUniversalProgressStore` remains the canonical progress surface
-  for API consumers and admin dashboards.
+  for API consumers and admin dashboards. A substrate-level projection from
+  `IExecutionJobStore` to `IUniversalProgressStore` is a follow-on integration
+  point; until that projection exists, execution job progress is available
+  through the execution job store directly.
 
 ### Structured Execution Logs
 
@@ -104,6 +144,16 @@ The existing `ExecutionJobStatus` enum is retained unchanged:
   Only worker or combined-mode hosts call this method.
 - `IJobExecutor` implementations are registered per `ExecutionJobKind` and
   only resolved in worker hosts.
+
+### Graceful Shutdown
+
+When a worker host shuts down (e.g. rolling deployment, scale-down), in-flight
+jobs are abandoned rather than marked as terminal failures. The worker itself
+transitions the job back to Queued, clears the claim fields (`ClaimedBy`,
+`ClaimedAt`, `LastHeartbeatAt`), and re-enqueues it with the applicable retry
+backoff delay. If the worker crashes without clean abandonment,
+`JobReconciliationService` detects the stale heartbeat and performs the same
+recovery.
 
 ### Integration with Canonical Process Model
 

--- a/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
+++ b/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
@@ -104,12 +104,22 @@ Millisecond timestamps break ties within a band.
 
 ### Cancellation
 
-- API-side cancellation uses the existing `IJobCancellationNotifier` to signal
-  in-flight workers. The worker registers its per-job cancellation token source
-  before the `Provisioning → Running` transition so that operator cancellation
-  arriving during that window is delivered through the token rather than as a
-  direct store write. If no worker token is registered, the API marks the job
-  as Cancelled directly and removes it from the queue.
+- API-side cancellation first attempts to signal in-flight workers via the
+  process-local `IJobCancellationNotifier`. The worker registers its per-job
+  cancellation token source before the `Provisioning → Running` transition so
+  that operator cancellation arriving during that window is delivered through
+  the token rather than as a direct store write.
+- When the local notifier confirms the signal was delivered, the worker owns
+  the terminal state transition and the API returns immediately.
+- When no local notifier can reach the worker (the common case in split
+  API/worker deployments), the API checks the job's claim state:
+  - **Unclaimed** (`ClaimedBy` is null): the API marks the job as Cancelled
+    directly and removes it from the queue.
+  - **Actively claimed**: the API persists `CancellationRequestedAt` on the
+    `ExecutionJobRecord` as a durable cancellation signal. The worker observes
+    this signal during its next heartbeat read and cancels locally. If the
+    worker's heartbeat expires before it processes the signal, the reconciler
+    honours the request with a terminal Cancelled state instead of retrying.
 - Worker-side cancellation flows through `CancellationToken` passed to
   `IJobExecutor.ExecuteAsync`.
 - When the reconciler requeues or terminally fails a job (heartbeat or timeout

--- a/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
+++ b/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
@@ -151,9 +151,21 @@ When a worker host shuts down (e.g. rolling deployment, scale-down), in-flight
 jobs are abandoned rather than marked as terminal failures. The worker itself
 transitions the job back to Queued, clears the claim fields (`ClaimedBy`,
 `ClaimedAt`, `LastHeartbeatAt`), and re-enqueues it with the applicable retry
-backoff delay. If the worker crashes without clean abandonment,
-`JobReconciliationService` detects the stale heartbeat and performs the same
-recovery.
+backoff delay.
+
+Both the worker and the reconciler re-read the current job record before writing
+any state transition. If the record is already terminal or the claim owner has
+changed, the writer skips its update. This bidirectional guard prevents two race
+windows:
+
+- The reconciler snapshots active jobs, then a worker finalizes before the
+  reconciler handler runs — the reconciler would otherwise overwrite the
+  terminal state.
+- The reconciler requeues or fails a job, then the worker's post-execution
+  handler runs — the worker would otherwise overwrite the reconciler's update.
+
+If a worker crashes without clean abandonment, `JobReconciliationService`
+detects the stale heartbeat and performs the same recovery.
 
 ### Integration with Canonical Process Model
 

--- a/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
+++ b/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
@@ -1,0 +1,139 @@
+# ADR-0031: Durable Job Orchestration Substrate
+
+## Status
+Accepted
+
+## Context
+
+The canonical geoprocess framework (ADR-0026, ADR-0029, ticket #360) defines an
+analysis plan lifecycle: intent capture, plan validation, execution, and result
+packaging. The multi-provider operation architecture (ADR-0025) established the
+`ExecutionJobRecord` model and `IExecutionJobStore` for durable job state. What
+was missing is the execution substrate that connects these pieces: how jobs move
+from submission to execution, how workers claim and report liveness, how failures
+trigger retries, and how the API serving path stays lean.
+
+Key constraints:
+
+1. The API server must remain lightweight. Heavyweight execution dependencies
+   (executor implementations, reconciliation loops) must not be loaded in the
+   default request-serving image.
+2. Workers must be horizontally scalable. Any worker instance must be able to
+   claim any eligible job without coordination beyond the shared store.
+3. Job execution must be durable across worker restarts. A worker crash must not
+   silently lose a job; heartbeat expiry and retry policies must recover it.
+4. The substrate must be provider-agnostic. Downstream tickets will implement
+   executors for Kubernetes Jobs, AWS Batch, and in-process workloads. The
+   substrate cannot bind to any one backend.
+5. Structured execution logs and artifact references must be first-class outputs,
+   not afterthoughts bolted onto progress reporting.
+
+## Decision
+
+Honua defines a durable job orchestration substrate with these components:
+
+### Job Lifecycle States
+
+The existing `ExecutionJobStatus` enum is retained unchanged:
+
+| State | Meaning |
+|-------|---------|
+| Queued | Job is in the queue, not yet claimed |
+| Provisioning | Worker has claimed the job, preparing to execute |
+| Running | Execution is in progress |
+| Succeeded | Terminal: execution completed successfully |
+| Failed | Terminal: execution failed (may be retried) |
+| Cancelled | Terminal: cancelled by user or system |
+
+### Claim and Heartbeat
+
+- `IJobQueue.TryClaimAsync` atomically removes a job from the pending set and
+  associates it with a worker ID. The claim sets `ClaimedBy`, `ClaimedAt`, and
+  `LastHeartbeatAt` on the `ExecutionJobRecord`.
+- Workers pump heartbeats at the interval specified by `JobHeartbeatPolicy`
+  (default: 30 seconds). Each heartbeat updates `LastHeartbeatAt`.
+- `JobReconciliationService` sweeps active jobs every 30 seconds. If
+  `LastHeartbeatAt` exceeds the heartbeat timeout (default: 90 seconds), the
+  job is considered abandoned.
+
+### Retry Policy
+
+- `JobRetryPolicy` specifies `MaxAttempts`, `BackoffStrategy` (Fixed, Linear,
+  Exponential), `BaseDelay`, and `MaxDelay`.
+- Default: 3 attempts with exponential backoff starting at 30 seconds, capped
+  at 10 minutes.
+- When a heartbeat expires and retries remain, the reconciler requeues the job
+  with a computed backoff delay. `AttemptCount` on the record tracks attempts.
+- When retries are exhausted, the job transitions to Failed.
+
+### Cancellation
+
+- API-side cancellation uses the existing `IJobCancellationNotifier` to signal
+  in-flight workers. If the worker owns the terminal state transition, the API
+  defers; otherwise it marks the job as Cancelled directly.
+- Worker-side cancellation flows through `CancellationToken` passed to
+  `IJobExecutor.ExecuteAsync`.
+
+### Progress Reporting
+
+- Workers report progress through `IJobExecutionContext.ReportProgressAsync`,
+  which updates `PercentComplete`, `CurrentPhase`, and refreshes the heartbeat.
+- The existing `IUniversalProgressStore` remains the canonical progress surface
+  for API consumers and admin dashboards.
+
+### Structured Execution Logs
+
+- `ExecutionLogEntry` captures timestamp, level, message, phase, and optional
+  metadata as an opaque string dictionary (AOT-safe).
+- `IExecutionLogStore` provides append-only writes during execution and read
+  access for diagnostics. Redis list-backed implementation with configurable
+  retention.
+
+### Artifact References
+
+- Workers publish artifact references through
+  `IJobExecutionContext.PublishArtifactAsync`.
+- References accumulate in `ExecutionJobRecord.ArtifactReferences` and are
+  available for result packaging after terminal state.
+
+### API/Worker Boundary
+
+- `AddJobOrchestration()` registers shared infrastructure (queue, log store)
+  and is safe for the lean API-serving image.
+- `AddJobWorker()` registers the execution host and reconciliation service.
+  Only worker or combined-mode hosts call this method.
+- `IJobExecutor` implementations are registered per `ExecutionJobKind` and
+  only resolved in worker hosts.
+
+### Integration with Canonical Process Model
+
+The substrate supports the ADR-0029 canonical model as follows:
+
+| Canonical Noun | Substrate Mapping |
+|----------------|-------------------|
+| AnalysisPlan | Serialized into `ExecutionJobSpec.Parameters` or a referenced artifact |
+| ExecutionJob | `ExecutionJobRecord` with policies, claim, and heartbeat fields |
+| Result Package | Assembled from `ArtifactReferences` after terminal state |
+| Workspace/Artifact | Managed by `IWorkspaceLifecycleService`; references tracked via context |
+| Provenance | Captured through `OperationAuditInfo` and structured execution logs |
+
+## Consequences
+
+- Follow-on tickets (#721, #724, #727) can implement `IJobExecutor` for their
+  respective backends without modifying the substrate contracts.
+- The API server image size and startup time are unaffected by executor
+  dependencies.
+- Redis remains the coordination layer for job state, consistent with ADR-0021
+  and ADR-0025.
+- The heartbeat/retry mechanism adds a background sweep but runs only in worker
+  hosts, not in lean API deployments.
+- The `ExecutionJobRecord` grows by ~7 fields; the existing Redis serialization
+  via source-generated JSON handles this without runtime reflection.
+
+## References
+
+- ADR-0025: Multi-Provider Operation Architecture
+- ADR-0026: AI-First Operator Contract
+- ADR-0029: Geoprocess Canonical Model Mappings
+- Ticket #360: Geoprocess framework comparative research and target model
+- Ticket #681: Durable worker and job orchestration substrate

--- a/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
+++ b/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
@@ -109,7 +109,7 @@ Millisecond timestamps break ties within a band.
   before the `Provisioning → Running` transition so that operator cancellation
   arriving during that window is delivered through the token rather than as a
   direct store write. If no worker token is registered, the API marks the job
-  as Cancelled directly.
+  as Cancelled directly and removes it from the queue.
 - Worker-side cancellation flows through `CancellationToken` passed to
   `IJobExecutor.ExecuteAsync`.
 - When the reconciler requeues or terminally fails a job (heartbeat or timeout
@@ -161,9 +161,11 @@ Millisecond timestamps break ties within a band.
 When a worker host shuts down (e.g. rolling deployment, scale-down), in-flight
 jobs are abandoned rather than marked as terminal failures. The worker itself
 transitions the job back to Queued, clears the claim fields (`ClaimedBy`,
-`ClaimedAt`, `LastHeartbeatAt`), and re-enqueues it immediately. Shutdown
-requeue always succeeds regardless of the job's retry budget because a host
-shutdown is an infrastructure event, not an execution failure.
+`ClaimedAt`, `LastHeartbeatAt`), and re-enqueues it immediately. This applies
+both during active execution and during the pre-execution window between claim
+and Running. Shutdown requeue always succeeds regardless of the job's retry
+budget because a host shutdown is an infrastructure event, not an execution
+failure.
 
 Both the worker and the reconciler re-read the current job record before writing
 any state transition. If the record is already terminal or the claim owner has

--- a/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
+++ b/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
@@ -105,8 +105,11 @@ Millisecond timestamps break ties within a band.
 ### Cancellation
 
 - API-side cancellation uses the existing `IJobCancellationNotifier` to signal
-  in-flight workers. If the worker owns the terminal state transition, the API
-  defers; otherwise it marks the job as Cancelled directly.
+  in-flight workers. The worker registers its per-job cancellation token source
+  before the `Provisioning → Running` transition so that operator cancellation
+  arriving during that window is delivered through the token rather than as a
+  direct store write. If no worker token is registered, the API marks the job
+  as Cancelled directly.
 - Worker-side cancellation flows through `CancellationToken` passed to
   `IJobExecutor.ExecuteAsync`.
 
@@ -155,14 +158,19 @@ backoff delay.
 
 Both the worker and the reconciler re-read the current job record before writing
 any state transition. If the record is already terminal or the claim owner has
-changed, the writer skips its update. This bidirectional guard prevents two race
-windows:
+changed, the writer skips its update. Additionally, the reconciler re-validates
+the heartbeat expiry predicate against the fresh record — a heartbeat that
+landed between the sweep snapshot and the handler invocation means the worker is
+still alive and the transition is skipped. This bidirectional guard prevents
+three race windows:
 
 - The reconciler snapshots active jobs, then a worker finalizes before the
   reconciler handler runs — the reconciler would otherwise overwrite the
   terminal state.
 - The reconciler requeues or fails a job, then the worker's post-execution
   handler runs — the worker would otherwise overwrite the reconciler's update.
+- A heartbeat arrives between the sweep snapshot and the reconciler handler —
+  the reconciler would otherwise requeue or fail a healthy running job.
 
 If a worker crashes without clean abandonment, `JobReconciliationService`
 detects the stale heartbeat and performs the same recovery.

--- a/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
+++ b/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
@@ -112,6 +112,10 @@ Millisecond timestamps break ties within a band.
   as Cancelled directly.
 - Worker-side cancellation flows through `CancellationToken` passed to
   `IJobExecutor.ExecuteAsync`.
+- When the reconciler requeues or terminally fails a job (heartbeat or timeout
+  expiry), it revokes the stale worker's cancellation token source. This
+  prevents a subsequent `Cancel()` call from returning a false positive for a
+  token that no longer corresponds to an active execution.
 
 ### Progress Reporting
 
@@ -131,6 +135,10 @@ Millisecond timestamps break ties within a band.
 - `IExecutionLogStore` provides append-only writes during execution and read
   access for diagnostics. Redis list-backed implementation with configurable
   retention.
+- When a job is abandoned and requeued for retry, the substrate persists any
+  executor-reported warnings to the structured log before clearing them from
+  the requeued record. On terminal failure (retries exhausted), warnings are
+  retained on the `ExecutionJobRecord` for post-mortem inspection.
 
 ### Artifact References
 

--- a/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
+++ b/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
@@ -159,10 +159,11 @@ backoff delay.
 Both the worker and the reconciler re-read the current job record before writing
 any state transition. If the record is already terminal or the claim owner has
 changed, the writer skips its update. Additionally, the reconciler re-validates
-the heartbeat expiry predicate against the fresh record — a heartbeat that
-landed between the sweep snapshot and the handler invocation means the worker is
-still alive and the transition is skipped. This bidirectional guard prevents
-three race windows:
+the expiry predicate (heartbeat or timeout) against the fresh record — a
+heartbeat that landed between the sweep snapshot and the handler invocation
+means the worker is still alive, and a job reclaimed with a fresh claim time has
+not actually timed out. In both cases the transition is skipped. This
+bidirectional guard prevents four race windows:
 
 - The reconciler snapshots active jobs, then a worker finalizes before the
   reconciler handler runs — the reconciler would otherwise overwrite the
@@ -171,6 +172,10 @@ three race windows:
   handler runs — the worker would otherwise overwrite the reconciler's update.
 - A heartbeat arrives between the sweep snapshot and the reconciler handler —
   the reconciler would otherwise requeue or fail a healthy running job.
+- The reconciler snapshots a timed-out job, but the job is requeued and
+  reclaimed (possibly by the same worker) with a fresh claim time before the
+  handler runs — the reconciler would otherwise fail a new attempt that has
+  not yet timed out.
 
 If a worker crashes without clean abandonment, `JobReconciliationService`
 detects the stale heartbeat and performs the same recovery.

--- a/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
+++ b/docs/contributor/adr/0031-durable-job-orchestration-substrate.md
@@ -153,8 +153,9 @@ Millisecond timestamps break ties within a band.
 When a worker host shuts down (e.g. rolling deployment, scale-down), in-flight
 jobs are abandoned rather than marked as terminal failures. The worker itself
 transitions the job back to Queued, clears the claim fields (`ClaimedBy`,
-`ClaimedAt`, `LastHeartbeatAt`), and re-enqueues it with the applicable retry
-backoff delay.
+`ClaimedAt`, `LastHeartbeatAt`), and re-enqueues it immediately. Shutdown
+requeue always succeeds regardless of the job's retry budget because a host
+shutdown is an infrastructure event, not an execution failure.
 
 Both the worker and the reconciler re-read the current job record before writing
 any state transition. If the record is already terminal or the claim owner has

--- a/docs/contributor/adr/README.md
+++ b/docs/contributor/adr/README.md
@@ -35,6 +35,7 @@ This folder contains Architecture Decision Records (ADRs) for the Honua greenfie
 | [0027](0027-deterministic-intent-clarification-workflow.md) | Deterministic Intent, Clarification, and Plan Validation Workflow | Proposed | 2026-04 |
 | [0028](0028-ai-data-editing-not-allowed.md) | AI-Driven Data Editing Is Not Allowed | Accepted | 2026-04 |
 | [0029](0029-geoprocess-canonical-model-mappings.md) | Geoprocess Canonical Model Mappings | Accepted | 2026-04 |
+| [0031](0031-durable-job-orchestration-substrate.md) | Durable Job Orchestration Substrate | Accepted | 2026-04 |
 
 ## Template
 

--- a/docs/developer/AI_OPERATOR_CONTRACT.md
+++ b/docs/developer/AI_OPERATOR_CONTRACT.md
@@ -825,18 +825,30 @@ Recommended public services:
 - `GetJobResults`
 - `CancelJob`
 
-**Implementation status** (as of #722):
+**Implementation status** (as of #681):
 
 All seven RPCs are wired. `ValidatePlan` and `DryRunPlan` are fully functional
 and enforce structural validation (null plan, valid step kinds, valid artifact
 kinds). `SubmitPlanJob` creates durable job records with idempotency support
 and requires Redis-backed storage. `GetJob` and `CancelJob` are fully wired.
 
+The durable job orchestration substrate (#681,
+[ADR-0031](../contributor/adr/0031-durable-job-orchestration-substrate.md))
+provides the execution foundation: atomic claim via `IJobQueue`, heartbeat
+liveness detection, configurable retry policies (exponential backoff by
+default), timeout enforcement, structured execution logs via
+`IExecutionLogStore`, and artifact reference accumulation on
+`ExecutionJobRecord`. Workers implement `IJobExecutor` per
+`ExecutionJobKind` and receive a `IJobExecutionContext` for progress,
+logging, and artifact publication. The `JobReconciliationService` sweeps
+for expired heartbeats and timed-out jobs in worker hosts.
+
 Stubbed RPCs:
 - `ExecutePlan` enforces authorization then returns `Unimplemented`; callers
   should use `SubmitPlanJob` for asynchronous execution.
 - `GetJobResults` enforces terminal-state preconditions but returns `NotFound`
-  until the execution engine and result storage are implemented.
+  until concrete `IJobExecutor` implementations and result storage are
+  implemented.
 
 Authorization and approval checks are enforced on all mutating RPCs.
 

--- a/docs/developer/AI_OPERATOR_CONTRACT.md
+++ b/docs/developer/AI_OPERATOR_CONTRACT.md
@@ -834,14 +834,20 @@ and requires Redis-backed storage. `GetJob` and `CancelJob` are fully wired.
 
 The durable job orchestration substrate (#681,
 [ADR-0031](../contributor/adr/0031-durable-job-orchestration-substrate.md))
-provides the execution foundation: atomic claim via `IJobQueue`, heartbeat
-liveness detection, configurable retry policies (exponential backoff by
-default), timeout enforcement, structured execution logs via
-`IExecutionLogStore`, and artifact reference accumulation on
-`ExecutionJobRecord`. Workers implement `IJobExecutor` per
+defines the execution contracts and infrastructure: atomic claim via
+`IJobQueue`, heartbeat liveness detection, configurable retry policies
+(exponential backoff by default), timeout enforcement with terminal failure
+semantics, operator cancellation via `ExecutionJobCancellationTokens`,
+structured execution logs via `IExecutionLogStore`, and artifact reference
+accumulation on `ExecutionJobRecord`. Workers implement `IJobExecutor` per
 `ExecutionJobKind` and receive a `IJobExecutionContext` for progress,
 logging, and artifact publication. The `JobReconciliationService` sweeps
 for expired heartbeats and timed-out jobs in worker hosts.
+
+**Note:** The substrate contracts exist but are not yet wired into the
+geoprocessing submission path. `SubmitPlanJob` creates durable job records
+but does not yet enqueue them via `IJobQueue`. End-to-end queue/worker
+integration is follow-on work (#721, #724, #727).
 
 Stubbed RPCs:
 - `ExecutePlan` enforces authorization then returns `Unimplemented`; callers

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -19,6 +19,11 @@ Build applications and integrations with Honua APIs and SDKs.
 - [AI Operator Contract](AI_OPERATOR_CONTRACT.md) — draft canonical MCP/gRPC contract for analyst and builder workflows
 - [Deterministic Operator Workflow Results](DETERMINISTIC_OPERATOR_WORKFLOW_RESULTS.md) — draft stage model and result envelope for AI-first execution
 
+## Internal Architecture
+
+- [Redis Fallback Patterns](REDIS_FALLBACK_PATTERNS.md) — Standardized Redis health monitoring, circuit breaker, and fallback strategies
+- [Service Registration Consolidation](SERVICE_REGISTRATION_CONSOLIDATION.md) — Reusable service registration framework for feature slices
+
 ## Versioning & Migration
 
 - [Versioning Policy](CONTROL_PLANE_VERSIONING_POLICY.md) — Deprecation lifecycle and breaking change rules

--- a/docs/gis/geoprocess-framework-analysis.md
+++ b/docs/gis/geoprocess-framework-analysis.md
@@ -138,7 +138,9 @@ Honua's canonical model supports both modes:
 - **Synchronous**: `ProcessService.ExecutePlan` (currently stubbed, returns
   `Unimplemented` — to be completed in #721)
 - **Asynchronous**: `ProcessService.SubmitPlanJob` → `ExecutionJob` with status
-  polling via `GetJob`
+  polling via `GetJob`. The durable job orchestration substrate
+  ([ADR-0031](../contributor/adr/0031-durable-job-orchestration-substrate.md))
+  provides the claim/heartbeat/retry/cancellation semantics beneath this path.
 
 The canonical model does not force a per-process execution type. Both modes
 operate on the same `AnalysisPlan`. The protocol adapters determine how to

--- a/docs/gis/geoprocess-framework-analysis.md
+++ b/docs/gis/geoprocess-framework-analysis.md
@@ -140,7 +140,8 @@ Honua's canonical model supports both modes:
 - **Asynchronous**: `ProcessService.SubmitPlanJob` → `ExecutionJob` with status
   polling via `GetJob`. The durable job orchestration substrate
   ([ADR-0031](../contributor/adr/0031-durable-job-orchestration-substrate.md))
-  provides the claim/heartbeat/retry/cancellation semantics beneath this path.
+  defines the claim/heartbeat/retry/cancellation contracts that this path will
+  use once wired end-to-end (follow-on: #721).
 
 The canonical model does not force a per-process execution type. Both modes
 operate on the same `AnalysisPlan`. The protocol adapters determine how to

--- a/docs/operator/CONTROL_PLANE_API.md
+++ b/docs/operator/CONTROL_PLANE_API.md
@@ -407,6 +407,15 @@ deterministic stage and plan step counts. Cancellation is supported through the
 cancel endpoint; the server re-reads progress before writing terminal state to
 mitigate TOCTOU races with worker-owned state transitions.
 
+Jobs submitted through the durable job orchestration substrate (via
+`ProcessService.SubmitPlanJob`) surface through these same operations endpoints
+using the `Geoprocessing` operation type. The substrate tracks additional
+claim, heartbeat, and retry state internally through `IExecutionJobStore`;
+structured execution logs are stored via `IExecutionLogStore` and are not yet
+exposed through a public API endpoint. See
+[Operations — Job Orchestration](operations.md#job-orchestration) for
+lifecycle and tuning details.
+
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
 | `/api/v1/admin/performance/database/query-cache/statistics` | GET | Query cache performance statistics |

--- a/docs/operator/CONTROL_PLANE_API.md
+++ b/docs/operator/CONTROL_PLANE_API.md
@@ -404,8 +404,11 @@ Supported `operationType` values: `Upload`, `Import`, `Ingest`, `ExternalImport`
 
 Geoprocessing operations report workflow-specific progress including the current
 deterministic stage and plan step counts. Cancellation is supported through the
-cancel endpoint; the server re-reads progress before writing terminal state to
-mitigate TOCTOU races with worker-owned state transitions.
+cancel endpoint. Operations that have already reached a terminal state
+(`Completed` or `Failed`) return `409 Conflict`; already-cancelled operations
+return `200` idempotently. The server re-reads progress before writing the
+cancellation and checks the durable job store (when present) to mitigate TOCTOU
+races with worker-owned state transitions.
 
 Jobs submitted through the durable job orchestration substrate (via
 `ProcessService.SubmitPlanJob`) surface through these same operations endpoints

--- a/docs/operator/DEPLOYMENT_SCENARIOS.md
+++ b/docs/operator/DEPLOYMENT_SCENARIOS.md
@@ -55,7 +55,7 @@ curl http://localhost:8080/healthz/ready
 
 **Baseline components:**
 - Managed Postgres with backups and monitoring
-- Redis for caching
+- Redis for caching (and **required** when running geoprocessing, ETL, or tile-cache job workloads — see [Operations — Job Orchestration](operations.md#job-orchestration))
 - Container runtime (Kubernetes or managed container service)
 - Edge TLS termination and rate limiting
 

--- a/docs/operator/DEPLOYMENT_SCENARIOS.md
+++ b/docs/operator/DEPLOYMENT_SCENARIOS.md
@@ -83,19 +83,23 @@ curl http://localhost:8080/healthz/ready
 
 Honua's durable job orchestration substrate
 ([ADR-0031](../contributor/adr/0031-durable-job-orchestration-substrate.md))
-separates API-side and worker-side concerns:
+separates API-side and worker-side concerns at the service-registration level:
 
-- **API-only image**: Registers shared queue and log store
-  (`AddJobOrchestration`). Stays lean — no execution or reconciliation
-  overhead. Suitable for request-serving replicas.
-- **Worker or combined image**: Additionally registers the execution host and
-  reconciliation sweep (`AddJobWorker`). Claims and runs queued
-  geoprocessing, ETL, and tile-cache jobs.
+- `AddJobOrchestration()` registers shared queue and log store dependencies.
+  Safe for a lean, request-serving image.
+- `AddJobWorker()` additionally registers the execution host and
+  reconciliation sweep. Intended for worker or combined-mode hosts.
 
-In Scenarios 1–2, a combined image running both API and worker is typical. In
-Scenario 3, consider separating API-serving replicas from worker replicas to
-scale them independently and keep heavyweight execution dependencies out of the
-request path.
+**Current release:** All deployments run a **combined host** that calls both
+methods. Separate API-only and worker-only images are a planned topology for
+Scenario 3 (enterprise scale-out) but are not yet wired as distinct host
+entrypoints. Follow-on work will add build targets or configuration switches
+for independent API and worker images.
+
+In Scenarios 1–2, the combined host is the expected deployment mode. The
+registration split exists so that future enterprise deployments can scale API
+and worker replicas independently and keep heavyweight execution dependencies
+out of the request path.
 
 ---
 

--- a/docs/operator/DEPLOYMENT_SCENARIOS.md
+++ b/docs/operator/DEPLOYMENT_SCENARIOS.md
@@ -90,11 +90,12 @@ separates API-side and worker-side concerns at the service-registration level:
 - `AddJobWorker()` additionally registers the execution host and
   reconciliation sweep. Intended for worker or combined-mode hosts.
 
-**Current release:** All deployments run a **combined host** that calls both
-methods. Separate API-only and worker-only images are a planned topology for
-Scenario 3 (enterprise scale-out) but are not yet wired as distinct host
-entrypoints. Follow-on work will add build targets or configuration switches
-for independent API and worker images.
+**Current release:** The geoprocessing feature registration calls
+`AddJobOrchestration()` to wire the shared queue and log store. `AddJobWorker()`
+(execution host + reconciliation sweep) is not yet invoked from a host
+entrypoint; it will be wired when the first concrete executor is integrated in
+follow-on tickets. Separate API-only and worker-only images are a planned
+topology for Scenario 3 (enterprise scale-out).
 
 In Scenarios 1–2, the combined host is the expected deployment mode. The
 registration split exists so that future enterprise deployments can scale API

--- a/docs/operator/DEPLOYMENT_SCENARIOS.md
+++ b/docs/operator/DEPLOYMENT_SCENARIOS.md
@@ -79,6 +79,26 @@ curl http://localhost:8080/healthz/ready
 
 ---
 
+## **API/Worker Host Separation**
+
+Honua's durable job orchestration substrate
+([ADR-0031](../contributor/adr/0031-durable-job-orchestration-substrate.md))
+separates API-side and worker-side concerns:
+
+- **API-only image**: Registers shared queue and log store
+  (`AddJobOrchestration`). Stays lean — no execution or reconciliation
+  overhead. Suitable for request-serving replicas.
+- **Worker or combined image**: Additionally registers the execution host and
+  reconciliation sweep (`AddJobWorker`). Claims and runs queued
+  geoprocessing, ETL, and tile-cache jobs.
+
+In Scenarios 1–2, a combined image running both API and worker is typical. In
+Scenario 3, consider separating API-serving replicas from worker replicas to
+scale them independently and keep heavyweight execution dependencies out of the
+request path.
+
+---
+
 ## **Related Documentation**
 
 - [Security](security.md)

--- a/docs/operator/README.md
+++ b/docs/operator/README.md
@@ -26,7 +26,7 @@ Deploy, configure, monitor, and manage Honua Server.
 - [Control Plane API](CONTROL_PLANE_API.md) — Admin REST API for connections, layers, services, and migration inventory scans
 - [GeoServer Migration Guide](../gis/tutorials/geoserver-migration-guide.md) — Discovery-only scanner workflow, compatibility review, and dry-run import planning
 - [Tile Operations](tile-operations-runbook.md) — Vector tile seeding, warming, invalidation
-- [Operations](operations.md) — Backups, migrations, connection pooling, query tuning
+- [Operations](operations.md) — Backups, migrations, connection pooling, query tuning, job orchestration, workspace lifecycle
 
 ## Monitoring
 

--- a/docs/operator/infrastructure.md
+++ b/docs/operator/infrastructure.md
@@ -51,7 +51,7 @@ See `.env.example` in the repo root for every available setting.
 
 - **Honua Server** is a stateless container. Scale horizontally by adding replicas.
 - **PostGIS** is the only required dependency. All protocols read from and write to the same database.
-- **Redis** is optional for caching (Honua falls back to in-memory caching for single-node). However, Redis is **required** when running job orchestration workloads (geoprocessing, ETL, tile-cache jobs) because the durable job queue, execution log store, and reconciliation state use Redis-backed storage. See [Operations — Job Orchestration](operations.md#job-orchestration).
+- **Redis** is optional for caching (Honua falls back to in-memory caching for single-node). However, Redis is **required** when running job orchestration workloads (geoprocessing, ETL, tile-cache jobs) because the durable job queue, execution log store, and reconciliation state use Redis-backed storage. Enable Redis persistence (AOF recommended, or RDB with a short save interval) so that queued and in-flight job state survives Redis restarts; without persistence, a Redis restart loses all pending jobs and forces reconciliation recovery for any claimed work. See [Operations — Job Orchestration](operations.md#job-orchestration).
 - **Object storage** (S3/MinIO) is optional, used only for file import workflows.
 - **TLS and rate limiting** are handled at the edge (ALB, API Gateway, Ingress Controller). Honua does not terminate TLS.
 
@@ -105,7 +105,8 @@ AOT images start faster and use less memory. Keep JIT cloud-targeted tags as deb
 
 - [ ] Set `HONUA_ADMIN_PASSWORD` to a strong secret
 - [ ] Use a managed PostGIS database (RDS, Azure Flexible Server) or a hardened self-hosted instance
-- [ ] Enable Redis for multi-node deployments
+- [ ] Enable Redis for multi-node deployments (and for any deployment running job orchestration workloads)
+- [ ] Enable Redis persistence (AOF or RDB) when running job orchestration to preserve queue state across restarts
 - [ ] Terminate TLS at the ingress / load balancer
 - [ ] Configure OIDC if you need browser-based admin access — see [Security](security.md)
 - [ ] Set `HONUA_SKIP_MIGRATIONS=true` for serverless (run migrations out-of-band)

--- a/docs/operator/infrastructure.md
+++ b/docs/operator/infrastructure.md
@@ -51,7 +51,7 @@ See `.env.example` in the repo root for every available setting.
 
 - **Honua Server** is a stateless container. Scale horizontally by adding replicas.
 - **PostGIS** is the only required dependency. All protocols read from and write to the same database.
-- **Redis** is optional. Without it, Honua falls back to in-memory caching (fine for single-node).
+- **Redis** is optional for caching (Honua falls back to in-memory caching for single-node). However, Redis is **required** when running job orchestration workloads (geoprocessing, ETL, tile-cache jobs) because the durable job queue, execution log store, and reconciliation state use Redis-backed storage. See [Operations — Job Orchestration](operations.md#job-orchestration).
 - **Object storage** (S3/MinIO) is optional, used only for file import workflows.
 - **TLS and rate limiting** are handled at the edge (ALB, API Gateway, Ingress Controller). Honua does not terminate TLS.
 

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -46,7 +46,7 @@ background sweep.
 | Level | Signal |
 |-------|--------|
 | Information | Worker started/stopped, job execution started, job completed, operator cancellation |
-| Warning | Job not found after claim, no executor for job kind, job abandoned for retry, no executors registered at startup, job timeout, state transition skipped (job cancelled or reclaimed between claim and Running, or reconciler intervention), heartbeat pump faulted (finalization still proceeds), transient heartbeat write failure (pump retries on next interval) |
+| Warning | Job not found after claim, no executor for job kind, job abandoned for retry, no executors registered at startup, job timeout, state transition skipped (job cancelled or reclaimed between claim and Running, or reconciler intervention), heartbeat pump faulted (finalization still proceeds), transient heartbeat write failure (pump retries on next interval), per-attempt warning log append failed (requeue/terminal transition still proceeds) |
 | Error | Job execution exception, claim loop error |
 
 **JobReconciliationService** (liveness sweep):

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -53,7 +53,7 @@ background sweep.
 
 | Level | Signal |
 |-------|--------|
-| Information | Reconciliation skipped — job already terminal or claim owner changed since sweep snapshot; heartbeat refreshed since sweep snapshot (worker still alive); timeout no longer expired since sweep snapshot (job reclaimed with fresh claim time) |
+| Information | Service started/stopped, reconciliation skipped — job already terminal or claim owner changed since sweep snapshot; heartbeat refreshed since sweep snapshot (worker still alive); timeout no longer expired since sweep snapshot (job reclaimed with fresh claim time) |
 | Debug | Sweep results when at least one job was reconciled (count out of active total) |
 | Warning | Heartbeat expired — job requeued for retry |
 | Error | Heartbeat expired with no retries remaining, timeout expiry, or sweep failure |

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -46,21 +46,58 @@ background sweep.
 | Level | Signal |
 |-------|--------|
 | Information | Worker started/stopped, job execution started, job completed, operator cancellation |
-| Warning | Job not found after claim, no executor for job kind, job abandoned for retry, no executors registered at startup |
-| Error | Job execution exception, claim loop error, job timeout |
+| Warning | Job not found after claim, no executor for job kind, job abandoned for retry, no executors registered at startup, job timeout, state transition skipped (reconciler intervention) |
+| Error | Job execution exception, claim loop error |
 
 **JobReconciliationService** (liveness sweep):
 
 | Level | Signal |
 |-------|--------|
-| Debug | Routine sweep results (reconciled count out of active total) |
+| Debug | Sweep results when at least one job was reconciled (count out of active total) |
 | Warning | Heartbeat expired — job requeued for retry |
 | Error | Heartbeat expired with no retries remaining, timeout expiry, or sweep failure |
 
-Monitor for both `JobExecutionService` and `JobReconciliationService`
-entries in worker hosts to detect execution failures, stale heartbeats,
-abandoned jobs, and retry exhaustion. For lifecycle details and tuning,
-see [Operations — Job Orchestration](operations.md#job-orchestration).
+**RedisJobQueue** (queue operations and claim recovery):
+
+| Level | Signal |
+|-------|--------|
+| Information | Job enqueued, job claimed, job requeued |
+| Warning | Orphaned claim requeued (claim succeeded but store update failed), claim rolled back after store failure |
+| Error | Claim rollback failed (orphaned claim will be caught by reconciliation) |
+
+Monitor for `JobExecutionService`, `JobReconciliationService`, and
+`RedisJobQueue` entries in worker hosts to detect execution failures,
+stale heartbeats, abandoned jobs, retry exhaustion, and claim-recovery
+events. For lifecycle details and tuning, see
+[Operations — Job Orchestration](operations.md#job-orchestration).
+
+---
+
+## Workspace Lifecycle Observability
+
+Background cleanup and lifecycle operations emit log entries from
+`WorkspaceCleanupService` and `WorkspaceLifecycleService`.
+
+**WorkspaceCleanupService** (periodic sweep):
+
+| Level | Signal |
+|-------|--------|
+| Information | Service started/stopped, cleanup disabled, sweep results (expired/deleted/artifact counts) |
+| Debug | Sweep started |
+| Warning | Partial error during cleanup (individual workspace failure) |
+| Error | Sweep failed |
+
+**WorkspaceLifecycleService** (workspace and artifact operations):
+
+| Level | Signal |
+|-------|--------|
+| Information | Workspace created, workspace expired, workspace deleted, artifact promoted |
+| Warning | Artifact addition rejected (wrong state or expired), promotion source transition failed, cleanup skipped (orphan risk) |
+| Error | Cleanup error for individual workspace, promotion rollback failed (duplicate artifact may exist) |
+
+Monitor for these entries to detect cleanup failures, quota-related
+rejections, and promotion errors. For configuration and retention
+details, see [Operations — Workspace Lifecycle](operations.md#workspace-lifecycle).
 
 ---
 

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -45,7 +45,7 @@ background sweep.
 
 | Level | Signal |
 |-------|--------|
-| Information | Worker started/stopped, job execution started, job completed, operator cancellation |
+| Information | Worker started/stopped, job execution started, job completed, operator cancellation, durable cancellation signal honoured during abandon |
 | Warning | Job not found after claim, no executor for job kind, job abandoned for retry, no executors registered at startup, job timeout, state transition skipped (job cancelled or reclaimed between claim and Running, or reconciler intervention), heartbeat pump faulted (finalization still proceeds), transient heartbeat write failure (pump retries on next interval), per-attempt warning log append failed (requeue/terminal transition still proceeds) |
 | Error | Job execution exception, claim loop error, pre-execution shutdown requeue failed (stale-claim reconciliation will recover) |
 

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -46,14 +46,14 @@ background sweep.
 | Level | Signal |
 |-------|--------|
 | Information | Worker started/stopped, job execution started, job completed, operator cancellation |
-| Warning | Job not found after claim, no executor for job kind, job abandoned for retry, no executors registered at startup, job timeout, state transition skipped (reconciler intervention) |
+| Warning | Job not found after claim, no executor for job kind, job abandoned for retry, no executors registered at startup, job timeout, state transition skipped (job cancelled or reclaimed between claim and Running, or reconciler intervention) |
 | Error | Job execution exception, claim loop error |
 
 **JobReconciliationService** (liveness sweep):
 
 | Level | Signal |
 |-------|--------|
-| Information | Reconciliation skipped — job already terminal or claim owner changed since sweep snapshot |
+| Information | Reconciliation skipped — job already terminal or claim owner changed since sweep snapshot; heartbeat refreshed since sweep snapshot (worker still alive); timeout no longer expired since sweep snapshot (job reclaimed with fresh claim time) |
 | Debug | Sweep results when at least one job was reconciled (count out of active total) |
 | Warning | Heartbeat expired — job requeued for retry |
 | Error | Heartbeat expired with no retries remaining, timeout expiry, or sweep failure |

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -71,6 +71,21 @@ stale heartbeats, abandoned jobs, retry exhaustion, and claim-recovery
 events. For lifecycle details and tuning, see
 [Operations — Job Orchestration](operations.md#job-orchestration).
 
+**Recommended alerts:**
+
+| Condition | Suggested threshold | Signal source |
+|-----------|---------------------|---------------|
+| Repeated heartbeat expiry | > 2 expiry events in 10 min | `JobReconciliationService` Warning/Error |
+| Retry exhaustion spike | > 1 exhaustion event in 5 min | `JobReconciliationService` Error |
+| Claim rollback failures | Any occurrence | `RedisJobQueue` Error (`ClaimRollbackFailed`) |
+| Worker with no executors | Any occurrence at startup | `JobExecutionService` Warning |
+| Sustained claim-loop errors | > 3 errors in 5 min | `JobExecutionService` Error |
+
+Queue depth is available via `IJobQueue.GetQueueDepthAsync` but is not yet
+exposed through a public metrics endpoint. Operators requiring queue depth
+alerting can query the Redis sorted set `controlplane:jobqueue:pending`
+directly until a metrics projection is added.
+
 ---
 
 ## Workspace Lifecycle Observability

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -63,7 +63,7 @@ background sweep.
 | Level | Signal |
 |-------|--------|
 | Information | Job enqueued, job claimed, job requeued |
-| Warning | Orphaned claim requeued (claim succeeded but store update failed), claim rolled back after store failure, claim scan visit threshold exceeded |
+| Warning | Orphaned claim requeued (claim succeeded but store update failed), claim rolled back after store failure, claim scan traverse threshold exceeded |
 | Error | Claim rollback failed (orphaned claim will be caught by reconciliation) |
 
 Monitor for `JobExecutionService`, `JobReconciliationService`, and
@@ -81,7 +81,7 @@ events. For lifecycle details and tuning, see
 | Claim rollback failures | Any occurrence | `RedisJobQueue` Error (`ClaimRollbackFailed`) |
 | Worker with no executors | Any occurrence at startup | `JobExecutionService` Warning |
 | Sustained claim-loop errors | > 3 errors in 5 min | `JobExecutionService` Error |
-| Claim scan visit threshold exceeded | > 1 occurrence in 5 min | `RedisJobQueue` Warning (`ClaimScanVisitThresholdExceeded`) |
+| Claim scan traverse threshold exceeded | > 1 occurrence in 5 min | `RedisJobQueue` Warning (`ClaimScanTraverseThresholdExceeded`) |
 
 Queue depth is available via `IJobQueue.GetQueueDepthAsync` but is not yet
 exposed through a public metrics endpoint. Operators requiring queue depth

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -35,6 +35,23 @@ Admin-only diagnostics:
 
 ---
 
+## Job Orchestration Observability
+
+Worker hosts running `AddJobWorker()` emit log entries from the
+`JobReconciliationService` background sweep:
+
+| Level | Signal |
+|-------|--------|
+| Debug | Routine sweep results (reconciled count out of active total) |
+| Warning | Heartbeat expired — job requeued for retry |
+| Error | Heartbeat expired with no retries remaining, timeout expiry, or sweep failure |
+
+Monitor for `JobReconciliationService` entries in worker hosts to detect
+stale heartbeats, abandoned jobs, and retry exhaustion. For lifecycle
+details and tuning, see [Operations — Job Orchestration](operations.md#job-orchestration).
+
+---
+
 ## OpenTelemetry
 
 Honua uses standard OpenTelemetry APIs.

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -38,7 +38,18 @@ Admin-only diagnostics:
 ## Job Orchestration Observability
 
 Worker hosts running `AddJobWorker()` emit log entries from the
-`JobReconciliationService` background sweep:
+`JobExecutionService` claim loop and the `JobReconciliationService`
+background sweep.
+
+**JobExecutionService** (claim and execution):
+
+| Level | Signal |
+|-------|--------|
+| Information | Worker started/stopped, job execution started, job completed, operator cancellation |
+| Warning | Job not found after claim, no executor for job kind, job abandoned for retry, no executors registered at startup |
+| Error | Job execution exception, claim loop error, job timeout |
+
+**JobReconciliationService** (liveness sweep):
 
 | Level | Signal |
 |-------|--------|
@@ -46,9 +57,10 @@ Worker hosts running `AddJobWorker()` emit log entries from the
 | Warning | Heartbeat expired — job requeued for retry |
 | Error | Heartbeat expired with no retries remaining, timeout expiry, or sweep failure |
 
-Monitor for `JobReconciliationService` entries in worker hosts to detect
-stale heartbeats, abandoned jobs, and retry exhaustion. For lifecycle
-details and tuning, see [Operations — Job Orchestration](operations.md#job-orchestration).
+Monitor for both `JobExecutionService` and `JobReconciliationService`
+entries in worker hosts to detect execution failures, stale heartbeats,
+abandoned jobs, and retry exhaustion. For lifecycle details and tuning,
+see [Operations — Job Orchestration](operations.md#job-orchestration).
 
 ---
 

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -47,7 +47,7 @@ background sweep.
 |-------|--------|
 | Information | Worker started/stopped, job execution started, job completed, operator cancellation |
 | Warning | Job not found after claim, no executor for job kind, job abandoned for retry, no executors registered at startup, job timeout, state transition skipped (job cancelled or reclaimed between claim and Running, or reconciler intervention), heartbeat pump faulted (finalization still proceeds), transient heartbeat write failure (pump retries on next interval), per-attempt warning log append failed (requeue/terminal transition still proceeds) |
-| Error | Job execution exception, claim loop error |
+| Error | Job execution exception, claim loop error, pre-execution shutdown requeue failed (stale-claim reconciliation will recover) |
 
 **JobReconciliationService** (liveness sweep):
 

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -63,7 +63,7 @@ background sweep.
 | Level | Signal |
 |-------|--------|
 | Information | Job enqueued, job claimed, job requeued |
-| Warning | Orphaned claim requeued (claim succeeded but store update failed), claim rolled back after store failure |
+| Warning | Orphaned claim requeued (claim succeeded but store update failed), claim rolled back after store failure, claim scan visit budget exhausted |
 | Error | Claim rollback failed (orphaned claim will be caught by reconciliation) |
 
 Monitor for `JobExecutionService`, `JobReconciliationService`, and
@@ -81,6 +81,7 @@ events. For lifecycle details and tuning, see
 | Claim rollback failures | Any occurrence | `RedisJobQueue` Error (`ClaimRollbackFailed`) |
 | Worker with no executors | Any occurrence at startup | `JobExecutionService` Warning |
 | Sustained claim-loop errors | > 3 errors in 5 min | `JobExecutionService` Error |
+| Claim scan visit budget exhaustion | > 1 occurrence in 5 min | `RedisJobQueue` Warning (`ClaimScanVisitBudgetExhausted`) |
 
 Queue depth is available via `IJobQueue.GetQueueDepthAsync` but is not yet
 exposed through a public metrics endpoint. Operators requiring queue depth

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -63,7 +63,7 @@ background sweep.
 | Level | Signal |
 |-------|--------|
 | Information | Job enqueued, job claimed, job requeued |
-| Warning | Orphaned claim requeued (claim succeeded but store update failed), claim rolled back after store failure, claim scan visit budget exhausted |
+| Warning | Orphaned claim requeued (claim succeeded but store update failed), claim rolled back after store failure, claim scan visit threshold exceeded |
 | Error | Claim rollback failed (orphaned claim will be caught by reconciliation) |
 
 Monitor for `JobExecutionService`, `JobReconciliationService`, and
@@ -81,7 +81,7 @@ events. For lifecycle details and tuning, see
 | Claim rollback failures | Any occurrence | `RedisJobQueue` Error (`ClaimRollbackFailed`) |
 | Worker with no executors | Any occurrence at startup | `JobExecutionService` Warning |
 | Sustained claim-loop errors | > 3 errors in 5 min | `JobExecutionService` Error |
-| Claim scan visit budget exhaustion | > 1 occurrence in 5 min | `RedisJobQueue` Warning (`ClaimScanVisitBudgetExhausted`) |
+| Claim scan visit threshold exceeded | > 1 occurrence in 5 min | `RedisJobQueue` Warning (`ClaimScanVisitThresholdExceeded`) |
 
 Queue depth is available via `IJobQueue.GetQueueDepthAsync` but is not yet
 exposed through a public metrics endpoint. Operators requiring queue depth

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -53,6 +53,7 @@ background sweep.
 
 | Level | Signal |
 |-------|--------|
+| Information | Reconciliation skipped — job already terminal or claim owner changed since sweep snapshot |
 | Debug | Sweep results when at least one job was reconciled (count out of active total) |
 | Warning | Heartbeat expired — job requeued for retry |
 | Error | Heartbeat expired with no retries remaining, timeout expiry, or sweep failure |

--- a/docs/operator/monitoring.md
+++ b/docs/operator/monitoring.md
@@ -46,7 +46,7 @@ background sweep.
 | Level | Signal |
 |-------|--------|
 | Information | Worker started/stopped, job execution started, job completed, operator cancellation |
-| Warning | Job not found after claim, no executor for job kind, job abandoned for retry, no executors registered at startup, job timeout, state transition skipped (job cancelled or reclaimed between claim and Running, or reconciler intervention) |
+| Warning | Job not found after claim, no executor for job kind, job abandoned for retry, no executors registered at startup, job timeout, state transition skipped (job cancelled or reclaimed between claim and Running, or reconciler intervention), heartbeat pump faulted (finalization still proceeds), transient heartbeat write failure (pump retries on next interval) |
 | Error | Job execution exception, claim loop error |
 
 **JobReconciliationService** (liveness sweep):

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -355,7 +355,9 @@ marked as terminal failures. The worker itself transitions the job back to
 Queued, clears the claim fields (`ClaimedBy`, `ClaimedAt`,
 `LastHeartbeatAt`), and re-enqueues it immediately. Shutdown requeue
 always succeeds regardless of the job's retry budget because a host
-shutdown is an infrastructure event, not an execution failure. Both the worker and the reconciler re-read the current job record
+shutdown is an infrastructure event, not an execution failure.
+
+Both the worker and the reconciler re-read the current job record
 before writing any state transition. If the record is already terminal or
 the claim owner has changed, the writer skips its update. Additionally,
 the reconciler re-validates the expiry predicate (heartbeat or timeout)

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -243,10 +243,11 @@ If the pump task does fault for any reason, finalization still proceeds
 from the executor outcome. The reconciliation service
 sweeps active jobs every 30 seconds. If a worker's last heartbeat exceeds
 the heartbeat timeout (default: 90 seconds), the job is considered
-abandoned. When `LastHeartbeatAt` has not yet been set (the window between
-claim and first heartbeat pump), the reconciler uses `ClaimedAt` as the
-reference timestamp. If retries remain, the reconciler requeues the job
-with a computed backoff delay; otherwise the job transitions to Failed.
+abandoned. The claim itself sets `LastHeartbeatAt` to the claim time, so
+the reconciler normally uses this value; as a defensive fallback it uses
+`ClaimedAt` if `LastHeartbeatAt` is ever null. If retries remain, the
+reconciler requeues the job with a computed backoff delay; otherwise the
+job transitions to Failed.
 
 ### Stale Claim Recovery
 

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -238,6 +238,18 @@ the job is considered abandoned. When `LastHeartbeatAt` has not yet been set
 requeues the job with a computed backoff delay; otherwise the job transitions
 to Failed.
 
+### Stale Claim Recovery
+
+The queue uses a two-phase claim: an atomic Redis move from the pending
+set to the claimed set, followed by a job store update. If the store
+update fails (e.g. transient Redis error), the claim is rolled back
+immediately. If the rollback also fails, the reconciliation service
+detects the orphaned claim after 60 seconds and requeues the job
+automatically. No operator intervention is required; monitor for
+`RedisJobQueue` Warning entries (`OrphanedClaimRequeued`,
+`ClaimRolledBack`) or Error entries (`ClaimRollbackFailed`) if you
+want visibility into recovery events.
+
 ### Priority Queue
 
 Jobs are dequeued in priority order. Within a priority band, FIFO ordering
@@ -292,9 +304,12 @@ Active jobs surface through the existing operations endpoints:
 > `IExecutionJobStore` and is not yet projected to the operations surface.
 > A substrate-level projection is a follow-on integration point.
 
-The reconciliation service logs sweep results at Debug level and heartbeat/
-timeout expiry at Warning/Error level. Monitor for `JobReconciliationService`
-log entries in worker hosts.
+The reconciliation service logs sweep results at Debug level only when at
+least one job was reconciled; clean sweeps are silent. Heartbeat and
+timeout expiry are logged at Warning/Error level. See
+[Monitoring — Job Orchestration Observability](monitoring.md#job-orchestration-observability)
+for the full log level table across `JobExecutionService`,
+`JobReconciliationService`, and `RedisJobQueue`.
 
 ### Graceful Shutdown
 
@@ -302,10 +317,13 @@ When a worker host shuts down, in-flight jobs are abandoned rather than
 marked as terminal failures. The worker itself transitions the job back to
 Queued, clears the claim fields (`ClaimedBy`, `ClaimedAt`,
 `LastHeartbeatAt`), and re-enqueues it with the applicable retry backoff
-delay. If a worker crashes without clean abandonment, the reconciliation
-service detects the stale heartbeat and performs the same recovery. This
-ensures rolling deployments and scale-down events do not permanently fail
-jobs that still have retry budget.
+delay. If the reconciliation service has already transitioned the job to a
+terminal or requeued state, the worker's shutdown handler safely skips the
+state transition to avoid overwriting the authoritative update. If a worker
+crashes without clean abandonment, the reconciliation service detects the
+stale heartbeat and performs the same recovery. This ensures rolling
+deployments and scale-down events do not permanently fail jobs that still
+have retry budget.
 
 ---
 

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -367,9 +367,12 @@ policy field on the record before enqueuing.
 When a worker host shuts down, in-flight jobs are abandoned rather than
 marked as terminal failures. The worker itself transitions the job back to
 Queued, clears the claim fields (`ClaimedBy`, `ClaimedAt`,
-`LastHeartbeatAt`), and re-enqueues it immediately. Shutdown requeue
-always succeeds regardless of the job's retry budget because a host
-shutdown is an infrastructure event, not an execution failure.
+`LastHeartbeatAt`), and re-enqueues it immediately. This applies both
+during active execution and during the pre-execution window between
+claim and Running — if shutdown arrives before the executor is entered,
+the claim loop performs the same force-requeue. Shutdown requeue always
+succeeds regardless of the job's retry budget because a host shutdown is
+an infrastructure event, not an execution failure.
 
 Both the worker and the reconciler re-read the current job record
 before writing any state transition. If the record is already terminal or

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -204,6 +204,17 @@ logs.
 > reconciliation overhead. See
 > [ADR-0031](../contributor/adr/0031-durable-job-orchestration-substrate.md).
 
+### Supported Job Kinds
+
+| Kind | Description |
+|------|-------------|
+| Geoprocessing | Analytical compute workloads (buffer, spatial join, etc.) |
+| ExtractTransformLoad | Data movement and transformation workloads |
+| TileCache | Tile cache generation or refresh workloads |
+
+Workers can filter which job kinds they claim. In the default configuration,
+a single worker host processes all kinds.
+
 ### Job Lifecycle
 
 | State | Meaning |
@@ -224,11 +235,27 @@ the job is considered abandoned. If retries remain, the reconciler requeues
 the job with a computed backoff delay; otherwise the job transitions to
 Failed.
 
+### Priority Queue
+
+Jobs are dequeued in priority order. Within a priority band, FIFO ordering
+applies.
+
+| Priority | Use case |
+|----------|----------|
+| Critical | Operator-initiated urgent work |
+| High | Time-sensitive processing |
+| Normal | Default for most workloads |
+| Low | Background or deferrable work |
+
 ### Retry Policy
 
 Default: 3 attempts with exponential backoff starting at 30 seconds, capped
 at 10 minutes. Per-job override is supported via `JobRetryPolicy` on the
 `ExecutionJobRecord`.
+
+Supported backoff strategies: `Fixed` (constant delay), `Linear` (delay
+grows linearly per attempt), `Exponential` (delay doubles per attempt).
+Use `JobRetryPolicy.None` to disable retries for a specific job.
 
 ### Timeout Policy
 
@@ -256,6 +283,14 @@ Active jobs surface through the existing operations endpoints:
 The reconciliation service logs sweep results at Debug level and heartbeat/
 timeout expiry at Warning/Error level. Monitor for `JobReconciliationService`
 log entries in worker hosts.
+
+### Graceful Shutdown
+
+When a worker host shuts down, in-flight jobs are abandoned rather than
+marked as terminal failures. The claim fields (`ClaimedBy`, `ClaimedAt`)
+are cleared so the reconciler can requeue the job for another worker.
+This ensures rolling deployments and scale-down events do not permanently
+fail jobs that still have retry budget.
 
 ---
 

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -263,10 +263,11 @@ Jobs are dequeued in priority order. Within a priority band, FIFO ordering
 applies. Delayed entries (jobs requeued with a visibility delay for retry
 backoff) and kind-mismatched entries do not consume the claim scan budget,
 so a backlog of delayed retries or jobs for other worker kinds cannot
-starve ready work in lower-priority bands. A hard visit ceiling (1000
-entries) prevents unbounded iteration when the queue front is dominated by
-delayed or mismatched entries; exhaustion of this ceiling is logged at
-Warning level.
+starve ready work in lower-priority bands. The scan terminates when the
+scan budget (100 claimable candidates) is exhausted or the queue is
+drained. A visit counter tracks total entries examined; exceeding the
+visit threshold (1000 entries) is logged at Warning level to signal
+queue pathology, but does not halt the scan.
 
 | Priority | Use case |
 |----------|----------|

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -185,11 +185,14 @@ per-kind executor tickets (#721, #724, #727).
 
 > **Deployment note:** The substrate is split into API-side and worker-side
 > registrations. The API image registers shared infrastructure (queue, log
-> store) via `AddJobOrchestration()`. The worker or combined-mode image
-> additionally registers the execution host and reconciliation sweep via
-> `AddJobWorker()`. Lean API-only deployments do not run execution or
-> reconciliation overhead. See
-> [ADR-0031](../contributor/adr/0031-durable-job-orchestration-substrate.md).
+> store) via `AddJobOrchestration()`. A future worker or combined-mode image
+> will additionally register the execution host and reconciliation sweep via
+> `AddJobWorker()`. `AddJobWorker()` is not yet invoked from a host
+> entrypoint; it will be wired when the first concrete executor is
+> integrated in follow-on tickets (#721, #724, #727). Lean API-only
+> deployments will not run execution or reconciliation overhead. See
+> [ADR-0031](../contributor/adr/0031-durable-job-orchestration-substrate.md)
+> and [Deployment Scenarios](DEPLOYMENT_SCENARIOS.md#apiworker-host-separation).
 
 ### Supported Job Kinds
 
@@ -303,8 +306,10 @@ with 7-day retention applied when the owning worker finalizes the job.
 
 When a job is abandoned and requeued for retry, any warnings reported by the
 executor are persisted to the structured log before clearing them from the
-requeued record. On terminal failure (retries exhausted), warnings are
-retained on the job record for post-mortem inspection.
+requeued record. This persistence is best-effort: a transient log-store
+failure is logged at Warning level but does not block the durable
+requeue or terminal transition. On terminal failure (retries exhausted),
+warnings are retained on the job record for post-mortem inspection.
 
 > **Note:** Execution logs are stored internally but are not yet exposed
 > through a public REST endpoint. Retrieval is available only through

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -191,10 +191,12 @@ All settings live under `OgcProcesses` (env prefix `OgcProcesses__`):
 
 ## Job Orchestration
 
-Geoprocessing, ETL, and tile-cache workloads run through a durable job
-orchestration substrate. The substrate handles queuing, claim/heartbeat
+The durable job orchestration substrate provides queuing, claim/heartbeat
 liveness, retry, cancellation, progress reporting, and structured execution
-logs.
+logs for geoprocessing, ETL, and tile-cache workloads. The substrate
+contract and infrastructure are implemented; end-to-end wiring from
+submission endpoints through the queue to worker execution lands with the
+per-kind executor tickets (#721, #724, #727).
 
 > **Deployment note:** The substrate is split into API-side and worker-side
 > registrations. The API image registers shared infrastructure (queue, log

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -234,7 +234,9 @@ at 10 minutes. Per-job override is supported via `JobRetryPolicy` on the
 
 Default maximum execution duration is 1 hour. Long-running ETL or
 geoprocessing workloads can use the 24-hour policy. Jobs exceeding their
-timeout are marked Failed by the reconciler.
+timeout are marked Failed directly by the worker (without retry). The
+reconciler serves as a fallback for jobs whose workers stop reporting
+heartbeats.
 
 ### Structured Execution Logs
 

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -268,10 +268,10 @@ applies. Delayed entries (jobs requeued with a visibility delay for retry
 backoff) and kind-mismatched entries do not consume the claim scan budget,
 so a backlog of delayed retries or jobs for other worker kinds cannot
 starve ready work in lower-priority bands. The scan terminates when the
-scan budget (100 claimable candidates) is exhausted or the queue is
-drained. A visit counter tracks total entries examined; exceeding the
-visit threshold (1000 entries) is logged at Warning level to signal
-queue pathology, but does not halt the scan.
+scan budget (100 claimable candidates) is exhausted, the visit budget
+(1000 total entries examined) is exhausted, or the queue is drained.
+Exceeding the visit threshold is logged at Warning level to signal
+queue pathology.
 
 | Priority | Use case |
 |----------|----------|

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -217,14 +217,20 @@ a single worker host processes all kinds.
 
 Workers poll for claimable jobs every 5 seconds. Once a job is claimed,
 the worker registers its cancellation token and re-reads the job record
-before promoting to Running. If the job was cancelled or reclaimed by
-another worker during the claim-to-Running window, the worker skips
-execution and cleans up the stale queue entry. This prevents operator
-cancellations arriving between claim and Running from being silently
-overwritten.
+before promoting to Running. If the job was cancelled or reached another
+terminal state during the claim-to-Running window, the worker skips
+execution and removes the queue entry. If the job was requeued or
+reclaimed by another worker, the worker skips execution but preserves
+the queue entry since it belongs to the new attempt. This prevents
+operator cancellations arriving between claim and Running from being
+silently overwritten, while also protecting pending retries from
+accidental deletion.
 
 Once the Running transition succeeds, the worker pumps heartbeats at the
-configured interval (default: 30 seconds). The reconciliation service
+configured interval (default: 30 seconds). The heartbeat pump, progress
+reports, and artifact publications all verify ownership before writing —
+if the reconciler requeues the job or another worker reclaims it, the
+stale worker's writes are silently dropped. The reconciliation service
 sweeps active jobs every 30 seconds. If a worker's last heartbeat exceeds
 the heartbeat timeout (default: 90 seconds), the job is considered
 abandoned. When `LastHeartbeatAt` has not yet been set (the window between

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -265,12 +265,12 @@ want visibility into recovery events.
 
 Jobs are dequeued in priority order. Within a priority band, FIFO ordering
 applies. Delayed entries (jobs requeued with a visibility delay for retry
-backoff) and kind-mismatched entries do not consume the claim scan budget,
+backoff) and kind-mismatched entries do not consume the scan budget,
 so a backlog of delayed retries or jobs for other worker kinds cannot
 starve ready work in lower-priority bands. The scan terminates when the
-scan budget (100 claimable candidates) is exhausted, the visit budget
-(1000 total entries examined) is exhausted, or the queue is drained.
-Exceeding the visit threshold is logged at Warning level to signal
+scan budget (100 claimable candidates) is exhausted, the traverse budget
+(5000 total entries traversed) is exhausted, or the queue is drained.
+Exceeding the traverse threshold is logged at Warning level to signal
 queue pathology.
 
 | Priority | Use case |

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -311,6 +311,32 @@ timeout expiry are logged at Warning/Error level. See
 for the full log level table across `JobExecutionService`,
 `JobReconciliationService`, and `RedisJobQueue`.
 
+### Policy Defaults and Tuning
+
+The substrate's timing and retry behavior is governed by built-in defaults on
+the policy models. Per-job overrides are set on the `ExecutionJobRecord` at
+submission time.
+
+| Parameter | Default | Notes |
+|-----------|---------|-------|
+| Worker claim poll interval | 5 s | How often workers check for claimable jobs |
+| Heartbeat interval | 30 s | `JobHeartbeatPolicy.Interval` — how often the worker refreshes liveness |
+| Heartbeat timeout | 90 s | `JobHeartbeatPolicy.Timeout` — stale threshold before reconciler acts |
+| Reconciliation sweep interval | 30 s | How often the reconciler checks active jobs for expiry |
+| Stale claim threshold | 60 s | Orphaned claims in the claimed set are recovered after this window |
+| Retry max attempts | 3 | `JobRetryPolicy.MaxAttempts` — includes initial attempt (1 = no retries) |
+| Retry backoff strategy | Exponential | `JobRetryPolicy.BackoffStrategy` — Fixed, Linear, or Exponential |
+| Retry base delay | 30 s | `JobRetryPolicy.BaseDelay` — starting delay for first retry |
+| Retry max delay | 10 min | `JobRetryPolicy.MaxDelay` — upper bound on computed backoff |
+| Execution timeout | 1 h | `JobTimeoutPolicy.MaxDuration` — default ceiling |
+| Long-running timeout | 24 h | `JobTimeoutPolicy.LongRunning` preset for ETL/large workloads |
+| Execution log retention | 7 d | TTL applied to Redis log lists at job finalization |
+
+These values are compile-time defaults on the policy record types. To change
+defaults for all jobs, modify the submission path that creates
+`ExecutionJobRecord` instances. To change a single job, set the corresponding
+policy field on the record before enqueuing.
+
 ### Graceful Shutdown
 
 When a worker host shuts down, in-flight jobs are abandoned rather than

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -343,13 +343,24 @@ When a worker host shuts down, in-flight jobs are abandoned rather than
 marked as terminal failures. The worker itself transitions the job back to
 Queued, clears the claim fields (`ClaimedBy`, `ClaimedAt`,
 `LastHeartbeatAt`), and re-enqueues it with the applicable retry backoff
-delay. If the reconciliation service has already transitioned the job to a
-terminal or requeued state, the worker's shutdown handler safely skips the
-state transition to avoid overwriting the authoritative update. If a worker
-crashes without clean abandonment, the reconciliation service detects the
-stale heartbeat and performs the same recovery. This ensures rolling
-deployments and scale-down events do not permanently fail jobs that still
-have retry budget.
+delay. Both the worker and the reconciler re-read the current job record
+before writing any state transition. If the record is already terminal or
+the claim owner has changed, the writer skips its update. This
+bidirectional guard prevents two specific race windows:
+
+- **Worker completes after reconciler snapshot**: the reconciler snapshots
+  active jobs, then a worker finalizes the job before the reconciler
+  handler runs. Without the guard the reconciler would overwrite the
+  terminal state.
+- **Reconciler transitions before worker finalizes**: the reconciler
+  requeues or fails the job, then the worker's post-execution handler
+  runs. Without the guard the worker would overwrite the reconciler's
+  update.
+
+If a worker crashes without clean abandonment, the reconciliation service
+detects the stale heartbeat and performs the same recovery. This ensures
+rolling deployments and scale-down events do not permanently fail jobs
+that still have retry budget.
 
 ---
 

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -202,7 +202,7 @@ per-kind executor tickets (#721, #724, #727).
 | ExtractTransformLoad | Data movement and transformation workloads |
 | TileCache | Tile cache generation or refresh workloads |
 
-Workers can filter which job kinds they claim. In the default configuration,
+Workers can filter which job kinds they claim. In the default configuration
 a single worker host processes all kinds.
 
 ### Job Lifecycle
@@ -265,13 +265,13 @@ want visibility into recovery events.
 
 Jobs are dequeued in priority order. Within a priority band, FIFO ordering
 applies. Delayed entries (jobs requeued with a visibility delay for retry
-backoff) and kind-mismatched entries do not consume the scan budget,
-so a backlog of delayed retries or jobs for other worker kinds cannot
-starve ready work in lower-priority bands. The scan terminates when the
-scan budget (100 claimable candidates) is exhausted, the traverse budget
-(5000 total entries traversed) is exhausted, or the queue is drained.
-Exceeding the traverse threshold is logged at Warning level to signal
-queue pathology.
+backoff) and kind-mismatched entries do not consume the scan budget.
+Each poll scans up to 100 claimable candidates within a traverse window
+of 5,000 total entries. A rotating cursor advances the window across
+successive polls so that ready jobs beyond the first traverse window are
+discovered on subsequent claim attempts. When the queue is drained from
+the cursor position, the cursor resets to the beginning. Exceeding the
+traverse threshold is logged at Warning level to signal queue pathology.
 
 | Priority | Use case |
 |----------|----------|

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -407,6 +407,15 @@ stale worker's cancellation token source. This ensures that a subsequent
 API-side `Cancel()` call does not return a false positive for a token that
 no longer corresponds to an active execution.
 
+In split API/worker deployments, the API host has no local cancellation
+notifier for jobs running on remote workers. When a cancel request arrives
+for a claimed job and no local notifier can signal the worker, the API
+persists a `CancellationRequestedAt` timestamp on the job record as a
+durable cancellation signal. The worker observes this signal during its
+next heartbeat read and cancels locally. If the worker's heartbeat expires
+before it processes the signal, the reconciler honours the request with a
+terminal Cancelled state instead of retrying.
+
 If a worker crashes without clean abandonment, the reconciliation service
 detects the stale heartbeat and performs the same recovery. This ensures
 rolling deployments and scale-down events do not permanently fail jobs

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -272,6 +272,10 @@ phase, optional metadata) through `IExecutionLogStore`. Logs are
 append-only during execution and read-only after terminal state. Redis-backed
 with configurable retention (default: 7 days).
 
+> **Note:** Execution logs are stored internally but are not yet exposed
+> through a public REST endpoint. Retrieval is available only through
+> direct Redis access or internal diagnostics.
+
 ### Monitoring
 
 Active jobs surface through the existing operations endpoints:
@@ -280,6 +284,11 @@ Active jobs surface through the existing operations endpoints:
 - `GET /api/v1/admin/operations/{operationId}` — job progress and status
 - `GET /api/v1/admin/operations/type/Geoprocessing` — geoprocessing jobs
 
+> **Note:** The operations endpoints read from `IUniversalProgressStore`.
+> Execution job progress written through `IJobExecutionContext` is stored in
+> `IExecutionJobStore` and is not yet projected to the operations surface.
+> A substrate-level projection is a follow-on integration point.
+
 The reconciliation service logs sweep results at Debug level and heartbeat/
 timeout expiry at Warning/Error level. Monitor for `JobReconciliationService`
 log entries in worker hosts.
@@ -287,10 +296,13 @@ log entries in worker hosts.
 ### Graceful Shutdown
 
 When a worker host shuts down, in-flight jobs are abandoned rather than
-marked as terminal failures. The claim fields (`ClaimedBy`, `ClaimedAt`)
-are cleared so the reconciler can requeue the job for another worker.
-This ensures rolling deployments and scale-down events do not permanently
-fail jobs that still have retry budget.
+marked as terminal failures. The worker itself transitions the job back to
+Queued, clears the claim fields (`ClaimedBy`, `ClaimedAt`,
+`LastHeartbeatAt`), and re-enqueues it with the applicable retry backoff
+delay. If a worker crashes without clean abandonment, the reconciliation
+service detects the stale heartbeat and performs the same recovery. This
+ensures rolling deployments and scale-down events do not permanently fail
+jobs that still have retry budget.
 
 ---
 

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -256,7 +256,10 @@ Jobs are dequeued in priority order. Within a priority band, FIFO ordering
 applies. Delayed entries (jobs requeued with a visibility delay for retry
 backoff) and kind-mismatched entries do not consume the claim scan budget,
 so a backlog of delayed retries or jobs for other worker kinds cannot
-starve ready work in lower-priority bands.
+starve ready work in lower-priority bands. A hard visit ceiling (1000
+entries) prevents unbounded iteration when the queue front is dominated by
+delayed or mismatched entries; exhaustion of this ceiling is logged at
+Warning level.
 
 | Priority | Use case |
 |----------|----------|
@@ -333,7 +336,7 @@ submission time.
 | Reconciliation sweep interval | 30 s | How often the reconciler checks active jobs for expiry |
 | Stale claim threshold | 60 s | Orphaned claims in the claimed set are recovered after this window |
 | Retry max attempts | 3 | `JobRetryPolicy.MaxAttempts` — includes initial attempt (1 = no retries) |
-| Retry backoff strategy | Exponential | `JobRetryPolicy.BackoffStrategy` — Fixed, Linear, or Exponential |
+| Retry backoff strategy | Exponential | `JobRetryPolicy.Strategy` — Fixed, Linear, or Exponential |
 | Retry base delay | 30 s | `JobRetryPolicy.BaseDelay` — starting delay for first retry |
 | Retry max delay | 10 min | `JobRetryPolicy.MaxDelay` — upper bound on computed backoff |
 | Execution timeout | 1 h | `JobTimeoutPolicy.MaxDuration` — default ceiling |

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -353,6 +353,23 @@ have retry budget.
 
 ---
 
+## OGC API Processes
+
+The OGC API Processes adapter is always registered and serves routes under
+`/ogc/processes`. Job lifecycle operations (execute, list, status, results,
+dismiss) require Redis-backed durable storage; they return `503` when the
+store is not configured.
+
+### Configuration
+
+All settings live under `OgcProcesses` (env prefix `OgcProcesses__`):
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `DefaultJobLimit` | 100 | Maximum jobs returned per `GET /ogc/processes/jobs` request |
+
+---
+
 ## Workspace Lifecycle
 
 Geoprocessing workspaces manage temporary and durable artifacts produced by

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -228,12 +228,15 @@ a single worker host processes all kinds.
 
 ### Heartbeat and Liveness
 
-Workers pump heartbeats at a configurable interval (default: 30 seconds).
+Workers poll for claimable jobs every 5 seconds. Once a job is claimed,
+the worker pumps heartbeats at the configured interval (default: 30 seconds).
 The reconciliation service sweeps active jobs every 30 seconds. If a
 worker's last heartbeat exceeds the heartbeat timeout (default: 90 seconds),
-the job is considered abandoned. If retries remain, the reconciler requeues
-the job with a computed backoff delay; otherwise the job transitions to
-Failed.
+the job is considered abandoned. When `LastHeartbeatAt` has not yet been set
+(the window between claim and first heartbeat pump), the reconciler uses
+`ClaimedAt` as the reference timestamp. If retries remain, the reconciler
+requeues the job with a computed backoff delay; otherwise the job transitions
+to Failed.
 
 ### Priority Queue
 
@@ -270,7 +273,7 @@ heartbeats.
 Workers append `ExecutionLogEntry` records (timestamp, level, message,
 phase, optional metadata) through `IExecutionLogStore`. Logs are
 append-only during execution and read-only after terminal state. Redis-backed
-with configurable retention (default: 7 days).
+with 7-day retention applied when the owning worker finalizes the job.
 
 > **Note:** Execution logs are stored internally but are not yet exposed
 > through a public REST endpoint. Retrieval is available only through

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -345,8 +345,9 @@ policy field on the record before enqueuing.
 When a worker host shuts down, in-flight jobs are abandoned rather than
 marked as terminal failures. The worker itself transitions the job back to
 Queued, clears the claim fields (`ClaimedBy`, `ClaimedAt`,
-`LastHeartbeatAt`), and re-enqueues it with the applicable retry backoff
-delay. Both the worker and the reconciler re-read the current job record
+`LastHeartbeatAt`), and re-enqueues it immediately. Shutdown requeue
+always succeeds regardless of the job's retry budget because a host
+shutdown is an infrastructure event, not an execution failure. Both the worker and the reconciler re-read the current job record
 before writing any state transition. If the record is already terminal or
 the claim owner has changed, the writer skips its update. Additionally,
 the reconciler re-validates the expiry predicate (heartbeat or timeout)

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -174,21 +174,6 @@ Honua uses a layered caching approach:
 
 ---
 
-## OGC API Processes
-
-The OGC API Processes adapter is always registered and serves routes under
-`/ogc/processes`. Job lifecycle operations (execute, list, status, results,
-dismiss) require Redis-backed durable storage; they return `503` when the
-store is not configured.
-
-### Configuration
-
-All settings live under `OgcProcesses` (env prefix `OgcProcesses__`):
-
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `DefaultJobLimit` | 100 | Maximum jobs returned per `GET /ogc/processes/jobs` request |
-
 ## Job Orchestration
 
 The durable job orchestration substrate provides queuing, claim/heartbeat
@@ -231,14 +216,21 @@ a single worker host processes all kinds.
 ### Heartbeat and Liveness
 
 Workers poll for claimable jobs every 5 seconds. Once a job is claimed,
-the worker pumps heartbeats at the configured interval (default: 30 seconds).
-The reconciliation service sweeps active jobs every 30 seconds. If a
-worker's last heartbeat exceeds the heartbeat timeout (default: 90 seconds),
-the job is considered abandoned. When `LastHeartbeatAt` has not yet been set
-(the window between claim and first heartbeat pump), the reconciler uses
-`ClaimedAt` as the reference timestamp. If retries remain, the reconciler
-requeues the job with a computed backoff delay; otherwise the job transitions
-to Failed.
+the worker registers its cancellation token and re-reads the job record
+before promoting to Running. If the job was cancelled or reclaimed by
+another worker during the claim-to-Running window, the worker skips
+execution and cleans up the stale queue entry. This prevents operator
+cancellations arriving between claim and Running from being silently
+overwritten.
+
+Once the Running transition succeeds, the worker pumps heartbeats at the
+configured interval (default: 30 seconds). The reconciliation service
+sweeps active jobs every 30 seconds. If a worker's last heartbeat exceeds
+the heartbeat timeout (default: 90 seconds), the job is considered
+abandoned. When `LastHeartbeatAt` has not yet been set (the window between
+claim and first heartbeat pump), the reconciler uses `ClaimedAt` as the
+reference timestamp. If retries remain, the reconciler requeues the job
+with a computed backoff delay; otherwise the job transitions to Failed.
 
 ### Stale Claim Recovery
 
@@ -255,7 +247,10 @@ want visibility into recovery events.
 ### Priority Queue
 
 Jobs are dequeued in priority order. Within a priority band, FIFO ordering
-applies.
+applies. Delayed entries (jobs requeued with a visibility delay for retry
+backoff) and kind-mismatched entries do not consume the claim scan budget,
+so a backlog of delayed retries or jobs for other worker kinds cannot
+starve ready work in lower-priority bands.
 
 | Priority | Use case |
 |----------|----------|
@@ -347,8 +342,13 @@ Queued, clears the claim fields (`ClaimedBy`, `ClaimedAt`,
 `LastHeartbeatAt`), and re-enqueues it with the applicable retry backoff
 delay. Both the worker and the reconciler re-read the current job record
 before writing any state transition. If the record is already terminal or
-the claim owner has changed, the writer skips its update. This
-bidirectional guard prevents two specific race windows:
+the claim owner has changed, the writer skips its update. Additionally,
+the reconciler re-validates the expiry predicate (heartbeat or timeout)
+against the fresh record — a heartbeat that landed between the sweep
+snapshot and the handler invocation means the worker is still alive, and a
+job reclaimed with a fresh claim time has not actually timed out. In both
+cases the transition is skipped. This bidirectional guard prevents four
+specific race windows:
 
 - **Worker completes after reconciler snapshot**: the reconciler snapshots
   active jobs, then a worker finalizes the job before the reconciler
@@ -358,6 +358,15 @@ bidirectional guard prevents two specific race windows:
   requeues or fails the job, then the worker's post-execution handler
   runs. Without the guard the worker would overwrite the reconciler's
   update.
+- **Heartbeat arrives between sweep and handler**: a heartbeat lands
+  after the reconciler's sweep snapshot but before the handler runs.
+  Without the guard the reconciler would requeue or fail a healthy
+  running job.
+- **Timeout snapshot outdated by reclaim**: the reconciler snapshots a
+  timed-out job, but the job is requeued and reclaimed (possibly by the
+  same worker) with a fresh claim time before the handler runs. Without
+  the guard the reconciler would fail a new attempt that has not yet
+  timed out.
 
 If a worker crashes without clean abandonment, the reconciliation service
 detects the stale heartbeat and performs the same recovery. This ensures

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -230,7 +230,14 @@ Once the Running transition succeeds, the worker pumps heartbeats at the
 configured interval (default: 30 seconds). The heartbeat pump, progress
 reports, and artifact publications all verify ownership before writing —
 if the reconciler requeues the job or another worker reclaims it, the
-stale worker's writes are silently dropped. The reconciliation service
+stale worker's writes are silently dropped. When a new worker registers
+its cancellation token for a reclaimed job, the previous worker's token
+source is cancelled automatically so the stale executor observes
+cancellation promptly even if the reconciler's Revoke has not yet run.
+Transient store failures during heartbeat persistence are caught and
+logged; the pump continues on the next interval rather than faulting.
+If the pump task does fault for any reason, finalization still proceeds
+from the executor outcome. The reconciliation service
 sweeps active jobs every 30 seconds. If a worker's last heartbeat exceeds
 the heartbeat timeout (default: 90 seconds), the job is considered
 abandoned. When `LastHeartbeatAt` has not yet been set (the window between

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -290,6 +290,11 @@ phase, optional metadata) through `IExecutionLogStore`. Logs are
 append-only during execution and read-only after terminal state. Redis-backed
 with 7-day retention applied when the owning worker finalizes the job.
 
+When a job is abandoned and requeued for retry, any warnings reported by the
+executor are persisted to the structured log before clearing them from the
+requeued record. On terminal failure (retries exhausted), warnings are
+retained on the job record for post-mortem inspection.
+
 > **Note:** Execution logs are stored internally but are not yet exposed
 > through a public REST endpoint. Retrieval is available only through
 > direct Redis access or internal diagnostics.
@@ -374,6 +379,11 @@ specific race windows:
   same worker) with a fresh claim time before the handler runs. Without
   the guard the reconciler would fail a new attempt that has not yet
   timed out.
+
+When the reconciler requeues or terminally fails a job, it also revokes the
+stale worker's cancellation token source. This ensures that a subsequent
+API-side `Cancel()` call does not return a false positive for a token that
+no longer corresponds to an active execution.
 
 If a worker crashes without clean abandonment, the reconciliation service
 detects the stale heartbeat and performs the same recovery. This ensures

--- a/docs/operator/operations.md
+++ b/docs/operator/operations.md
@@ -189,6 +189,72 @@ All settings live under `OgcProcesses` (env prefix `OgcProcesses__`):
 |---------|---------|-------------|
 | `DefaultJobLimit` | 100 | Maximum jobs returned per `GET /ogc/processes/jobs` request |
 
+## Job Orchestration
+
+Geoprocessing, ETL, and tile-cache workloads run through a durable job
+orchestration substrate. The substrate handles queuing, claim/heartbeat
+liveness, retry, cancellation, progress reporting, and structured execution
+logs.
+
+> **Deployment note:** The substrate is split into API-side and worker-side
+> registrations. The API image registers shared infrastructure (queue, log
+> store) via `AddJobOrchestration()`. The worker or combined-mode image
+> additionally registers the execution host and reconciliation sweep via
+> `AddJobWorker()`. Lean API-only deployments do not run execution or
+> reconciliation overhead. See
+> [ADR-0031](../contributor/adr/0031-durable-job-orchestration-substrate.md).
+
+### Job Lifecycle
+
+| State | Meaning |
+|-------|---------|
+| Queued | In the queue, not yet claimed by a worker |
+| Provisioning | Worker has claimed the job, preparing to execute |
+| Running | Execution is in progress |
+| Succeeded | Terminal: completed successfully |
+| Failed | Terminal: failed (may be retried if policy allows) |
+| Cancelled | Terminal: cancelled by user or system |
+
+### Heartbeat and Liveness
+
+Workers pump heartbeats at a configurable interval (default: 30 seconds).
+The reconciliation service sweeps active jobs every 30 seconds. If a
+worker's last heartbeat exceeds the heartbeat timeout (default: 90 seconds),
+the job is considered abandoned. If retries remain, the reconciler requeues
+the job with a computed backoff delay; otherwise the job transitions to
+Failed.
+
+### Retry Policy
+
+Default: 3 attempts with exponential backoff starting at 30 seconds, capped
+at 10 minutes. Per-job override is supported via `JobRetryPolicy` on the
+`ExecutionJobRecord`.
+
+### Timeout Policy
+
+Default maximum execution duration is 1 hour. Long-running ETL or
+geoprocessing workloads can use the 24-hour policy. Jobs exceeding their
+timeout are marked Failed by the reconciler.
+
+### Structured Execution Logs
+
+Workers append `ExecutionLogEntry` records (timestamp, level, message,
+phase, optional metadata) through `IExecutionLogStore`. Logs are
+append-only during execution and read-only after terminal state. Redis-backed
+with configurable retention (default: 7 days).
+
+### Monitoring
+
+Active jobs surface through the existing operations endpoints:
+
+- `GET /api/v1/admin/operations/active` — lists all active operations
+- `GET /api/v1/admin/operations/{operationId}` — job progress and status
+- `GET /api/v1/admin/operations/type/Geoprocessing` — geoprocessing jobs
+
+The reconciliation service logs sweep results at Debug level and heartbeat/
+timeout expiry at Warning/Error level. Monitor for `JobReconciliationService`
+log entries in worker hosts.
+
 ---
 
 ## Workspace Lifecycle

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -124,6 +124,40 @@ curl http://localhost:8080/api/v1/admin/import/jobs
 
 ---
 
+## Job Orchestration Issues
+
+**Symptom**: jobs stuck in Provisioning or Running without progress.
+
+**Quick triage**:
+```bash
+# Check worker host logs for heartbeat/claim events
+docker logs honua-worker 2>&1 | grep -E "JobExecutionService|JobReconciliationService|RedisJobQueue"
+
+# Verify Redis connectivity (job queue, execution logs, and claim state require Redis)
+redis-cli -h redis ping
+redis-cli -h redis ZCARD controlplane:jobqueue:pending
+```
+
+**Common causes and fixes**:
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Jobs stay Queued | No worker host running `AddJobWorker()` | Deploy a worker or combined-mode host |
+| Heartbeat expiry warnings | Worker crashed or network partition | Check worker health; reconciler auto-recovers |
+| Retry exhaustion errors | Executor fails repeatedly | Check executor logs for root cause |
+| Claim rollback warnings | Transient Redis error during claim | Self-healing; monitor frequency |
+| Claim scan budget exhaustion | Queue front dominated by delayed retries | Review retry backoff settings; clear stale entries |
+| `503` on OGC Processes or GPServer job routes | Redis not configured | Enable Redis — see [Infrastructure](infrastructure.md) |
+
+The reconciliation service automatically recovers abandoned jobs when heartbeats
+expire. No operator intervention is required unless retry budgets are exhausted.
+For log-level details and alerting thresholds, see
+[Monitoring — Job Orchestration Observability](monitoring.md#job-orchestration-observability).
+For policy tuning, see
+[Operations — Job Orchestration](operations.md#job-orchestration).
+
+---
+
 ## Spatial Query Problems
 
 **FeatureServer bbox query**:

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -142,7 +142,7 @@ redis-cli -h redis ZCARD controlplane:jobqueue:pending
 
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
-| Jobs stay Queued | No worker host running `AddJobWorker()` | Deploy a worker or combined-mode host |
+| Jobs stay Queued | No worker host running `AddJobWorker()` | Follow-on: worker-mode hosting lands with per-kind executor tickets (#721, #724, #727) |
 | Heartbeat expiry warnings | Worker crashed or network partition | Check worker health; reconciler auto-recovers |
 | Retry exhaustion errors | Executor fails repeatedly | Check executor logs for root cause |
 | Claim rollback warnings | Transient Redis error during claim | Self-healing; monitor frequency |

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -146,7 +146,7 @@ redis-cli -h redis ZCARD controlplane:jobqueue:pending
 | Heartbeat expiry warnings | Worker crashed or network partition | Check worker health; reconciler auto-recovers |
 | Retry exhaustion errors | Executor fails repeatedly | Check executor logs for root cause |
 | Claim rollback warnings | Transient Redis error during claim | Self-healing; monitor frequency |
-| Claim scan budget exhaustion | Queue front dominated by delayed retries | Review retry backoff settings; clear stale entries |
+| Claim scan traverse threshold | Queue front dominated by delayed retries | Review retry backoff settings; clear stale entries |
 | `503` on OGC Processes or GPServer job routes | Redis not configured | Enable Redis — see [Infrastructure](infrastructure.md) |
 
 The reconciliation service automatically recovers abandoned jobs when heartbeats

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/IExecutionLogStore.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/IExecutionLogStore.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Core.Features.ControlPlane.Abstractions;
+
+/// <summary>
+/// Durable store for structured execution log entries produced by job executors.
+/// Entries are append-only during execution and read-only after terminal state.
+/// </summary>
+public interface IExecutionLogStore
+{
+    /// <summary>
+    /// Appends a structured log entry for the specified job.
+    /// </summary>
+    /// <param name="operationId">Stable job identifier.</param>
+    /// <param name="entry">Log entry to append.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task AppendAsync(
+        string operationId,
+        ExecutionLogEntry entry,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves all structured log entries for the specified job in chronological order.
+    /// </summary>
+    /// <param name="operationId">Stable job identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Log entries in append order.</returns>
+    Task<IReadOnlyList<ExecutionLogEntry>> GetLogsAsync(
+        string operationId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets a time-to-live on the log entries for the specified job.
+    /// Called when a job reaches terminal state to schedule eventual cleanup.
+    /// </summary>
+    /// <param name="operationId">Stable job identifier.</param>
+    /// <param name="ttl">Retention period from now.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SetRetentionAsync(
+        string operationId,
+        TimeSpan ttl,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/IJobExecutor.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/IJobExecutor.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Core.Features.ControlPlane.Abstractions;
+
+/// <summary>
+/// Worker-side contract for executing a claimed job. Implementations are registered
+/// per <see cref="ExecutionJobKind"/> and invoked by the worker host when a job
+/// is claimed from the queue.
+/// </summary>
+public interface IJobExecutor
+{
+    /// <summary>
+    /// The job kind this executor handles.
+    /// </summary>
+    ExecutionJobKind Kind { get; }
+
+    /// <summary>
+    /// Executes the job. The implementation should report progress, append structured
+    /// logs, and publish artifact references through <paramref name="context"/>.
+    /// </summary>
+    /// <param name="job">The claimed execution job record.</param>
+    /// <param name="context">
+    /// Runtime context providing progress reporting, structured logging,
+    /// artifact publication, and cooperative cancellation.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token that is triggered when the job is cancelled or
+    /// the worker is shutting down.
+    /// </param>
+    /// <returns>
+    /// The terminal status of the job. Implementations should return
+    /// <see cref="ExecutionJobStatus.Succeeded"/> or <see cref="ExecutionJobStatus.Failed"/>.
+    /// </returns>
+    Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Result returned by an <see cref="IJobExecutor"/> after execution completes.
+/// </summary>
+public sealed record JobExecutionResult
+{
+    /// <summary>
+    /// Terminal status of the execution.
+    /// </summary>
+    public required ExecutionJobStatus Status { get; init; }
+
+    /// <summary>
+    /// Error message when the execution failed.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Warnings collected during execution.
+    /// </summary>
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+
+    /// <summary>
+    /// Creates a successful result.
+    /// </summary>
+    public static JobExecutionResult Succeeded(IReadOnlyList<string>? warnings = null)
+        => new()
+        {
+            Status = ExecutionJobStatus.Succeeded,
+            Warnings = warnings ?? []
+        };
+
+    /// <summary>
+    /// Creates a failed result.
+    /// </summary>
+    public static JobExecutionResult Failed(string errorMessage, IReadOnlyList<string>? warnings = null)
+        => new()
+        {
+            Status = ExecutionJobStatus.Failed,
+            ErrorMessage = errorMessage,
+            Warnings = warnings ?? []
+        };
+}
+
+/// <summary>
+/// Runtime context provided to <see cref="IJobExecutor"/> implementations during execution.
+/// Mediates all side effects (progress, logs, artifacts) through the substrate rather than
+/// requiring executors to depend on infrastructure directly.
+/// </summary>
+public interface IJobExecutionContext
+{
+    /// <summary>
+    /// Stable identifier of the executing job.
+    /// </summary>
+    string OperationId { get; }
+
+    /// <summary>
+    /// Reports progress for the executing job.
+    /// </summary>
+    /// <param name="percentComplete">Completion percentage (0-100), or null if indeterminate.</param>
+    /// <param name="phase">Human-readable phase description.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ReportProgressAsync(
+        double? percentComplete,
+        string? phase,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Appends a structured log entry for the executing job.
+    /// </summary>
+    /// <param name="entry">Log entry to append.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task AppendLogAsync(
+        ExecutionLogEntry entry,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Registers an artifact reference produced by the executing job.
+    /// </summary>
+    /// <param name="artifactReference">Stable artifact reference string.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task PublishArtifactAsync(
+        string artifactReference,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/IJobQueue.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/IJobQueue.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics.CodeAnalysis;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Core.Features.ControlPlane.Abstractions;
+
+/// <summary>
+/// Durable job queue with atomic claim semantics for distributing execution jobs
+/// across worker instances. The queue mediates the boundary between the API-facing
+/// submission path and the worker-facing execution path.
+/// </summary>
+[SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Queue accurately describes the durable job distribution primitive")]
+public interface IJobQueue
+{
+    /// <summary>
+    /// Enqueues a job for execution. The job must already be persisted in
+    /// <see cref="IExecutionJobStore"/> before enqueuing.
+    /// </summary>
+    /// <param name="operationId">Stable job identifier.</param>
+    /// <param name="priority">Relative priority influencing dequeue order.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task EnqueueAsync(
+        string operationId,
+        OperationPriority priority = OperationPriority.Normal,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically claims the next available job that matches the requested kinds.
+    /// The claim associates the job with a <paramref name="workerId"/> and sets
+    /// a lease that must be renewed through heartbeats.
+    /// </summary>
+    /// <param name="workerId">Stable identifier of the claiming worker.</param>
+    /// <param name="acceptedKinds">
+    /// Optional filter for job kinds this worker can execute.
+    /// Null accepts all kinds.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The claimed job identifier, or null if the queue is empty.</returns>
+    Task<string?> TryClaimAsync(
+        string workerId,
+        IReadOnlySet<ExecutionJobKind>? acceptedKinds = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Re-enqueues a job that was previously claimed. Used when a worker abandons
+    /// a job or the reconciler detects an expired heartbeat and the retry policy
+    /// permits another attempt.
+    /// </summary>
+    /// <param name="operationId">Stable job identifier.</param>
+    /// <param name="priority">Priority for the re-enqueued attempt.</param>
+    /// <param name="visibleAfter">
+    /// Optional delay before the job becomes visible for claiming again,
+    /// used to implement backoff between retries.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RequeueAsync(
+        string operationId,
+        OperationPriority priority = OperationPriority.Normal,
+        TimeSpan? visibleAfter = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a job from the queue. Called when a job reaches a terminal state
+    /// (succeeded, failed without remaining retries, or cancelled).
+    /// </summary>
+    /// <param name="operationId">Stable job identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RemoveAsync(
+        string operationId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the approximate number of jobs currently in the queue.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<long> GetQueueDepthAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/IJobTerminalCallback.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/IJobTerminalCallback.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Core.Features.ControlPlane.Abstractions;
+
+/// <summary>
+/// Receives notification when a durable execution job transitions to a terminal
+/// state. Implementations synchronize feature-specific side-effect stores
+/// (e.g. admin progress) with the authoritative execution job record.
+/// </summary>
+/// <remarks>
+/// Callbacks are invoked best-effort after the authoritative store write.
+/// A failing callback must not block the terminal transition.
+/// </remarks>
+public interface IJobTerminalCallback
+{
+    /// <summary>
+    /// Called after a job has been durably written to a terminal status.
+    /// </summary>
+    ValueTask OnTerminalAsync(ExecutionJobRecord job, CancellationToken cancellationToken);
+}

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/OperationInterfaces.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/OperationInterfaces.cs
@@ -138,6 +138,21 @@ public interface IExecutionJobStore : IOperationStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Atomically persists the execution job record only when the stored version
+    /// matches the record's <see cref="ExecutionJobRecord.Version"/>. The stored
+    /// version is incremented on success. Returns <c>false</c> on version conflict,
+    /// indicating a concurrent write was detected and the caller should re-read.
+    /// </summary>
+    /// <param name="job">Execution job record with the expected version.</param>
+    /// <param name="ttl">Optional retention period.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True when updated; false when a concurrent write was detected.</returns>
+    Task<bool> TrySetAsync(
+        ExecutionJobRecord job,
+        TimeSpan? ttl = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Lists active execution jobs, optionally filtered by job kind.
     /// </summary>
     /// <param name="kind">Optional execution job kind filter.</param>

--- a/src/Honua.Core/Features/ControlPlane/Domain/ExecutionLog.cs
+++ b/src/Honua.Core/Features/ControlPlane/Domain/ExecutionLog.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.ControlPlane.Domain;
+
+/// <summary>
+/// Severity levels for structured execution log entries.
+/// </summary>
+public enum ExecutionLogLevel
+{
+    /// <summary>
+    /// Verbose diagnostic information.
+    /// </summary>
+    Debug,
+
+    /// <summary>
+    /// Informational progress messages.
+    /// </summary>
+    Info,
+
+    /// <summary>
+    /// Non-fatal conditions that may require attention.
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// Errors that may not halt execution but indicate problems.
+    /// </summary>
+    Error
+}
+
+/// <summary>
+/// A single structured log entry produced during execution job processing.
+/// Workers append entries through <see cref="Abstractions.IExecutionLogStore"/>;
+/// API callers read them for diagnostics and audit.
+/// </summary>
+public sealed record ExecutionLogEntry
+{
+    /// <summary>
+    /// UTC timestamp when the entry was recorded.
+    /// </summary>
+    public required DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>
+    /// Severity level for this entry.
+    /// </summary>
+    public required ExecutionLogLevel Level { get; init; }
+
+    /// <summary>
+    /// Human-readable log message.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// Execution phase active when this entry was recorded (e.g., "Provisioning", "Step 3/5").
+    /// </summary>
+    public string? Phase { get; init; }
+
+    /// <summary>
+    /// Optional structured metadata for machine-readable diagnostics.
+    /// Keys and values are opaque strings to preserve AOT compatibility.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Metadata { get; init; }
+}

--- a/src/Honua.Core/Features/ControlPlane/Domain/JobPolicies.cs
+++ b/src/Honua.Core/Features/ControlPlane/Domain/JobPolicies.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.ControlPlane.Domain;
+
+/// <summary>
+/// Backoff strategy used when retrying failed execution jobs.
+/// </summary>
+public enum BackoffStrategy
+{
+    /// <summary>
+    /// No additional delay between retries beyond the base interval.
+    /// </summary>
+    Fixed,
+
+    /// <summary>
+    /// Delay increases linearly with each retry attempt.
+    /// </summary>
+    Linear,
+
+    /// <summary>
+    /// Delay doubles with each retry attempt.
+    /// </summary>
+    Exponential
+}
+
+/// <summary>
+/// Retry policy governing how failed execution jobs are retried.
+/// </summary>
+public sealed record JobRetryPolicy
+{
+    /// <summary>
+    /// Default retry policy: 3 attempts with exponential backoff starting at 30 seconds.
+    /// </summary>
+    public static readonly JobRetryPolicy Default = new()
+    {
+        MaxAttempts = 3,
+        Strategy = BackoffStrategy.Exponential,
+        BaseDelay = TimeSpan.FromSeconds(30),
+        MaxDelay = TimeSpan.FromMinutes(10)
+    };
+
+    /// <summary>
+    /// No-retry policy for jobs that should not be retried on failure.
+    /// </summary>
+    public static readonly JobRetryPolicy None = new()
+    {
+        MaxAttempts = 1,
+        Strategy = BackoffStrategy.Fixed,
+        BaseDelay = TimeSpan.Zero,
+        MaxDelay = TimeSpan.Zero
+    };
+
+    /// <summary>
+    /// Maximum number of execution attempts including the initial attempt.
+    /// A value of 1 means no retries.
+    /// </summary>
+    public int MaxAttempts { get; init; } = 3;
+
+    /// <summary>
+    /// Backoff strategy applied between retry attempts.
+    /// </summary>
+    public BackoffStrategy Strategy { get; init; } = BackoffStrategy.Exponential;
+
+    /// <summary>
+    /// Base delay before the first retry. Subsequent delays are computed from this
+    /// value according to <see cref="Strategy"/>.
+    /// </summary>
+    public TimeSpan BaseDelay { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Upper bound on the computed delay between retries.
+    /// </summary>
+    public TimeSpan MaxDelay { get; init; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Computes the delay before the given retry attempt using the configured backoff strategy.
+    /// </summary>
+    /// <param name="attemptNumber">One-based attempt number (2 = first retry).</param>
+    /// <returns>Delay before this attempt should start.</returns>
+    public TimeSpan ComputeDelay(int attemptNumber)
+    {
+        if (attemptNumber <= 1)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var retryIndex = attemptNumber - 2; // 0-based retry index
+        var delay = Strategy switch
+        {
+            BackoffStrategy.Fixed => BaseDelay,
+            BackoffStrategy.Linear => TimeSpan.FromTicks(BaseDelay.Ticks * (retryIndex + 1)),
+            BackoffStrategy.Exponential => TimeSpan.FromTicks(BaseDelay.Ticks * (1L << retryIndex)),
+            _ => BaseDelay
+        };
+
+        return delay > MaxDelay ? MaxDelay : delay;
+    }
+
+    /// <summary>
+    /// Returns true when the given attempt count has not exceeded the maximum.
+    /// </summary>
+    /// <param name="attemptCount">Current completed attempt count.</param>
+    public bool ShouldRetry(int attemptCount) => attemptCount < MaxAttempts;
+}
+
+/// <summary>
+/// Heartbeat policy governing worker liveness detection for claimed execution jobs.
+/// </summary>
+public sealed record JobHeartbeatPolicy
+{
+    /// <summary>
+    /// Default heartbeat policy: 30-second interval, 90-second timeout.
+    /// </summary>
+    public static readonly JobHeartbeatPolicy Default = new()
+    {
+        Interval = TimeSpan.FromSeconds(30),
+        Timeout = TimeSpan.FromSeconds(90)
+    };
+
+    /// <summary>
+    /// Expected interval at which workers send heartbeat signals.
+    /// </summary>
+    public TimeSpan Interval { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Duration after the last heartbeat before the job is considered abandoned.
+    /// Must be greater than <see cref="Interval"/> to allow for transient delays.
+    /// </summary>
+    public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(90);
+
+    /// <summary>
+    /// Returns true when the heartbeat has expired relative to <paramref name="now"/>.
+    /// </summary>
+    /// <param name="lastHeartbeat">Timestamp of the last heartbeat.</param>
+    /// <param name="now">Current time.</param>
+    public bool IsExpired(DateTimeOffset lastHeartbeat, DateTimeOffset now)
+        => (now - lastHeartbeat) > Timeout;
+}
+
+/// <summary>
+/// Timeout policy governing maximum execution duration for jobs.
+/// </summary>
+public sealed record JobTimeoutPolicy
+{
+    /// <summary>
+    /// Default timeout policy: 1 hour maximum execution time.
+    /// </summary>
+    public static readonly JobTimeoutPolicy Default = new()
+    {
+        MaxDuration = TimeSpan.FromHours(1)
+    };
+
+    /// <summary>
+    /// Long-running timeout policy: 24 hours for ETL or large geoprocessing workloads.
+    /// </summary>
+    public static readonly JobTimeoutPolicy LongRunning = new()
+    {
+        MaxDuration = TimeSpan.FromHours(24)
+    };
+
+    /// <summary>
+    /// Maximum wall-clock duration for job execution. The job is marked as failed
+    /// if it exceeds this duration.
+    /// </summary>
+    public TimeSpan MaxDuration { get; init; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Returns true when the job has exceeded the maximum execution duration.
+    /// </summary>
+    /// <param name="startedAt">When the job execution started.</param>
+    /// <param name="now">Current time.</param>
+    public bool IsExpired(DateTimeOffset startedAt, DateTimeOffset now)
+        => (now - startedAt) > MaxDuration;
+}

--- a/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
+++ b/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
@@ -657,6 +657,13 @@ public sealed record ExecutionJobRecord
     /// </summary>
     public DateTimeOffset? LastHeartbeatAt { get; init; }
 
+    /// <summary>
+    /// Time when cancellation was durably requested via the API. Workers observe
+    /// this signal during heartbeat and cancel locally; the reconciler honours it
+    /// when the worker's heartbeat expires before the signal is processed.
+    /// </summary>
+    public DateTimeOffset? CancellationRequestedAt { get; init; }
+
     // -----------------------------------------------------------------------
     // Retry tracking (ticket #681)
     // -----------------------------------------------------------------------

--- a/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
+++ b/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
@@ -636,6 +636,70 @@ public sealed record ExecutionJobRecord
     /// Backend execution specification.
     /// </summary>
     public required ExecutionJobSpec Spec { get; init; }
+
+    // -----------------------------------------------------------------------
+    // Claim and heartbeat fields (ticket #681)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Stable identifier of the worker that claimed this job for execution.
+    /// Null when the job has not been claimed.
+    /// </summary>
+    public string? ClaimedBy { get; init; }
+
+    /// <summary>
+    /// Time when the job was claimed by a worker.
+    /// </summary>
+    public DateTimeOffset? ClaimedAt { get; init; }
+
+    /// <summary>
+    /// Time of the most recent heartbeat signal from the executing worker.
+    /// </summary>
+    public DateTimeOffset? LastHeartbeatAt { get; init; }
+
+    // -----------------------------------------------------------------------
+    // Retry tracking (ticket #681)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Number of execution attempts completed so far (including the current attempt).
+    /// </summary>
+    public int AttemptCount { get; init; }
+
+    /// <summary>
+    /// Earliest time the next retry attempt may begin.
+    /// Null when no retry is pending.
+    /// </summary>
+    public DateTimeOffset? NextRetryAt { get; init; }
+
+    // -----------------------------------------------------------------------
+    // Policies (ticket #681)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Retry policy governing failure retry behavior. Null uses the system default.
+    /// </summary>
+    public JobRetryPolicy? RetryPolicy { get; init; }
+
+    /// <summary>
+    /// Heartbeat policy governing worker liveness detection. Null uses the system default.
+    /// </summary>
+    public JobHeartbeatPolicy? HeartbeatPolicy { get; init; }
+
+    /// <summary>
+    /// Timeout policy governing maximum execution duration. Null uses the system default.
+    /// </summary>
+    public JobTimeoutPolicy? TimeoutPolicy { get; init; }
+
+    // -----------------------------------------------------------------------
+    // Artifact references (ticket #681)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// References to artifacts produced during execution, appended by the worker
+    /// through the execution context.
+    /// </summary>
+    public IReadOnlyList<string> ArtifactReferences { get; init; } = Array.Empty<string>();
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
+++ b/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
@@ -578,6 +578,11 @@ public sealed record ExecutionJobRecord
     public required ExecutionJobStatus Status { get; init; }
 
     /// <summary>
+    /// Optimistic concurrency version token incremented on every store write.
+    /// </summary>
+    public long Version { get; init; }
+
+    /// <summary>
     /// Relative operator priority.
     /// </summary>
     public OperationPriority Priority { get; init; } = OperationPriority.Normal;

--- a/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
@@ -12,6 +12,7 @@ using Honua.Core.Features.Raster.Domain;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Models;
 using Honua.Server.Features.Infrastructure.Progress;
+using Honua.Server.Features.Infrastructure;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Honua.Server.Features.Admin;
@@ -200,14 +201,7 @@ internal static class OperationsProgressEndpoints
         // Cancelled (if interrupted) or Completed (if rendering already finished).
         // Writing Cancelled here would race with the worker's Completed write and
         // could hide a successfully rendered result.
-        var workerOwnsTerminalState = false;
-        foreach (var notifier in cancellationNotifiers)
-        {
-            if (notifier.Cancel(operationId))
-            {
-                workerOwnsTerminalState = true;
-            }
-        }
+        var workerOwnsTerminalState = cancellationNotifiers.CancelAny(operationId);
 
         if (workerOwnsTerminalState)
         {

--- a/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
@@ -289,22 +289,33 @@ internal static class OperationsProgressEndpoints
         if (jobStore != null)
         {
             var executionJob = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-            if (executionJob != null && !IsExecutionJobTerminal(executionJob.Status))
+            if (executionJob != null)
             {
-                var jobNow = DateTimeOffset.UtcNow;
-                var cancelledJob = executionJob with
+                if (executionJob.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
                 {
-                    Status = ExecutionJobStatus.Cancelled,
-                    UpdatedAt = jobNow,
-                    CompletedAt = jobNow,
-                    CurrentPhase = "Cancelled"
-                };
-                await jobStore.SetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    return ProblemDetailsHelpers.CreateAdminProblem(
+                        StatusCodes.Status409Conflict,
+                        "Conflict",
+                        $"Operation '{operationId}' reached terminal state '{executionJob.Status}' in the durable job store before cancellation could be applied");
+                }
 
-                var jobQueue = httpContext.RequestServices.GetService<IJobQueue>();
-                if (jobQueue != null)
+                if (!IsExecutionJobTerminal(executionJob.Status))
                 {
-                    await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
+                    var jobNow = DateTimeOffset.UtcNow;
+                    var cancelledJob = executionJob with
+                    {
+                        Status = ExecutionJobStatus.Cancelled,
+                        UpdatedAt = jobNow,
+                        CompletedAt = jobNow,
+                        CurrentPhase = "Cancelled"
+                    };
+                    await jobStore.SetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                    var jobQueue = httpContext.RequestServices.GetService<IJobQueue>();
+                    if (jobQueue != null)
+                    {
+                        await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
+                    }
                 }
             }
         }

--- a/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
@@ -156,17 +156,51 @@ internal static class OperationsProgressEndpoints
             return;
         }
 
-        if (!IsExecutionJobTerminal(executionJob.Status))
+        if (executionJob.Status is ExecutionJobStatus.Cancelled)
         {
-            var now = DateTimeOffset.UtcNow;
-            var cancelled = executionJob with
+            await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        if (IsExecutionJobTerminal(executionJob.Status))
+        {
+            return;
+        }
+
+        if (executionJob.ClaimedBy != null)
+        {
+            if (!executionJob.CancellationRequestedAt.HasValue)
             {
-                Status = ExecutionJobStatus.Cancelled,
-                UpdatedAt = now,
-                CompletedAt = now,
-                CurrentPhase = "Cancelled"
-            };
-            await jobStore.SetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var now = DateTimeOffset.UtcNow;
+                var requested = executionJob with
+                {
+                    CancellationRequestedAt = now,
+                    UpdatedAt = now
+                };
+
+                await jobStore.TrySetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+
+            return;
+        }
+
+        var cancelledNow = DateTimeOffset.UtcNow;
+        var cancelled = executionJob with
+        {
+            Status = ExecutionJobStatus.Cancelled,
+            UpdatedAt = cancelledNow,
+            CompletedAt = cancelledNow,
+            CurrentPhase = "Cancelled"
+        };
+
+        var wroteCancelled = await jobStore.TrySetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!wroteCancelled)
+        {
+            var conflict = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+            if (conflict?.Status is not ExecutionJobStatus.Cancelled)
+            {
+                return;
+            }
         }
 
         await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);

--- a/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
@@ -12,6 +12,7 @@ using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Core.Features.Raster.Domain;
 using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.ControlPlane;
 using Honua.Server.Features.Infrastructure.Models;
 using Honua.Server.Features.Infrastructure.Progress;
 using Honua.Server.Features.Infrastructure;
@@ -134,11 +135,6 @@ internal static class OperationsProgressEndpoints
         return JsonSerializer.SerializeToElement(operation);
     }
 
-    private static bool IsExecutionJobTerminal(ExecutionJobStatus status)
-        => status is ExecutionJobStatus.Succeeded
-            or ExecutionJobStatus.Failed
-            or ExecutionJobStatus.Cancelled;
-
     private static async Task TryReconcileDurableCancelAsync(
         HttpContext httpContext,
         string operationId,
@@ -156,85 +152,14 @@ internal static class OperationsProgressEndpoints
             return;
         }
 
-        if (executionJob.Status is ExecutionJobStatus.Cancelled)
-        {
-            await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
-            return;
-        }
+        var cancelOutcome = await ExecutionJobCancellationHelper.TryApplyAsync(
+            jobStore,
+            operationId,
+            executionJob,
+            "Cancelled",
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        if (IsExecutionJobTerminal(executionJob.Status))
-        {
-            return;
-        }
-
-        if (executionJob.ClaimedBy != null)
-        {
-            var current = executionJob;
-
-            for (var casAttempt = 0; casAttempt < 3; casAttempt++)
-            {
-                if (current.CancellationRequestedAt.HasValue || current.Status == ExecutionJobStatus.Cancelled)
-                {
-                    break;
-                }
-
-                var now = DateTimeOffset.UtcNow;
-                var requested = current with
-                {
-                    CancellationRequestedAt = now,
-                    UpdatedAt = now
-                };
-
-                if (await jobStore.TrySetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false))
-                {
-                    break;
-                }
-
-                current = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-                if (current == null || IsExecutionJobTerminal(current.Status))
-                {
-                    break;
-                }
-            }
-
-            return;
-        }
-
-        var current2 = executionJob;
-        var cancelConfirmed = false;
-
-        for (var casAttempt = 0; casAttempt < 3; casAttempt++)
-        {
-            if (current2.Status == ExecutionJobStatus.Cancelled)
-            {
-                cancelConfirmed = true;
-                break;
-            }
-
-            var cancelledNow = DateTimeOffset.UtcNow;
-            var cancelled = current2 with
-            {
-                Status = ExecutionJobStatus.Cancelled,
-                UpdatedAt = cancelledNow,
-                CompletedAt = cancelledNow,
-                CurrentPhase = "Cancelled"
-            };
-
-            if (await jobStore.TrySetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false))
-            {
-                cancelConfirmed = true;
-                break;
-            }
-
-            current2 = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-            if (current2 == null || IsExecutionJobTerminal(current2.Status))
-            {
-                cancelConfirmed = current2?.Status == ExecutionJobStatus.Cancelled;
-                break;
-            }
-        }
-
-        if (cancelConfirmed)
+        if (cancelOutcome.State == ExecutionJobCancellationState.Cancelled)
         {
             await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
         }
@@ -429,108 +354,43 @@ internal static class OperationsProgressEndpoints
             var executionJob = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
             if (executionJob != null)
             {
-                if (executionJob.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
+                var cancelOutcome = await ExecutionJobCancellationHelper.TryApplyAsync(
+                    jobStore,
+                    operationId,
+                    executionJob,
+                    "Cancelled",
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                switch (cancelOutcome.State)
                 {
-                    return ProblemDetailsHelpers.CreateAdminProblem(
-                        StatusCodes.Status409Conflict,
-                        "Conflict",
-                        $"Operation '{operationId}' reached terminal state '{executionJob.Status}' in the durable job store before cancellation could be applied");
-                }
-
-                if (!IsExecutionJobTerminal(executionJob.Status))
-                {
-                    // If the job is actively claimed by a remote worker whose
-                    // local notifier is unreachable, persist a durable
-                    // cancellation signal instead of writing terminal state.
-                    if (executionJob.ClaimedBy != null)
-                    {
-                        var reqNow = DateTimeOffset.UtcNow;
-                        var current = executionJob;
-                        var cancelSignalConfirmed = current.CancellationRequestedAt.HasValue;
-
-                        for (var casAttempt = 0; !cancelSignalConfirmed && casAttempt < 3; casAttempt++)
+                    case ExecutionJobCancellationState.Cancelled:
+                        await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case ExecutionJobCancellationState.CancellationRequested:
+                        var delegated = new CancelOperationResponse
                         {
-                            var requested = current with
-                            {
-                                CancellationRequestedAt = reqNow,
-                                UpdatedAt = reqNow
-                            };
-                            if (await jobStore.TrySetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false))
-                            {
-                                cancelSignalConfirmed = true;
-                                break;
-                            }
-
-                            current = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-                            if (current == null || current.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
-                            {
-                                return ProblemDetailsHelpers.CreateAdminProblem(
-                                    StatusCodes.Status409Conflict,
-                                    "Conflict",
-                                    $"Operation '{operationId}' reached terminal state '{current?.Status}' before cancellation could be applied");
-                            }
-
-                            cancelSignalConfirmed = current.CancellationRequestedAt.HasValue
-                                || current.Status == ExecutionJobStatus.Cancelled;
-                        }
-
-                        if (cancelSignalConfirmed)
-                        {
-                            var delegated = new CancelOperationResponse
-                            {
-                                OperationId = operationId,
-                                Message = "Operation cancellation requested",
-                                Type = progress.Type
-                            };
-                            return Results.Json(delegated, OperationsProgressJsonContext.Default.CancelOperationResponse);
-                        }
-                    }
-
-                    var jobNow = DateTimeOffset.UtcNow;
-                    {
-                        var current = executionJob;
-                        var cancelConfirmed = false;
-
-                        for (var casAttempt = 0; casAttempt < 3; casAttempt++)
-                        {
-                            var cancelledJob = current with
-                            {
-                                Status = ExecutionJobStatus.Cancelled,
-                                UpdatedAt = jobNow,
-                                CompletedAt = jobNow,
-                                CurrentPhase = "Cancelled"
-                            };
-                            if (await jobStore.TrySetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false))
-                            {
-                                cancelConfirmed = true;
-                                break;
-                            }
-
-                            current = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-                            if (current == null || current.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
-                            {
-                                return ProblemDetailsHelpers.CreateAdminProblem(
-                                    StatusCodes.Status409Conflict,
-                                    "Conflict",
-                                    $"Operation '{operationId}' reached terminal state '{current?.Status}' before cancellation could be applied");
-                            }
-
-                            if (current.Status == ExecutionJobStatus.Cancelled)
-                            {
-                                cancelConfirmed = true;
-                                break;
-                            }
-                        }
-
-                        if (cancelConfirmed)
-                        {
-                            await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
-                        }
-                    }
-                }
-                else if (executionJob.Status is ExecutionJobStatus.Cancelled)
-                {
-                    await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
+                            OperationId = operationId,
+                            Message = "Operation cancellation requested",
+                            Type = progress.Type
+                        };
+                        return Results.Json(delegated, OperationsProgressJsonContext.Default.CancelOperationResponse);
+                    case ExecutionJobCancellationState.TerminalConflict:
+                        return ProblemDetailsHelpers.CreateAdminProblem(
+                            StatusCodes.Status409Conflict,
+                            "Conflict",
+                            $"Operation '{operationId}' reached terminal state '{cancelOutcome.Job?.Status}' in the durable job store before cancellation could be applied");
+                    case ExecutionJobCancellationState.Missing:
+                        return ProblemDetailsHelpers.CreateAdminProblem(
+                            StatusCodes.Status409Conflict,
+                            "Conflict",
+                            $"Operation '{operationId}' was deleted before cancellation could be applied");
+                    case ExecutionJobCancellationState.Unconfirmed:
+                        return ProblemDetailsHelpers.CreateAdminProblem(
+                            StatusCodes.Status409Conflict,
+                            "Conflict",
+                            $"Operation '{operationId}' cancellation could not be confirmed after retries.");
+                    default:
+                        throw new InvalidOperationException($"Unexpected durable cancellation outcome '{cancelOutcome.State}'.");
                 }
             }
         }

--- a/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
@@ -3,6 +3,8 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Domain;
@@ -132,6 +134,11 @@ internal static class OperationsProgressEndpoints
         return JsonSerializer.SerializeToElement(operation);
     }
 
+    private static bool IsExecutionJobTerminal(ExecutionJobStatus status)
+        => status is ExecutionJobStatus.Succeeded
+            or ExecutionJobStatus.Failed
+            or ExecutionJobStatus.Cancelled;
+
     private static void NormalizeCanonicalProperty(JsonObject operation, string propertyName, JsonNode? value)
     {
         var duplicateKeys = new List<string>();
@@ -159,6 +166,7 @@ internal static class OperationsProgressEndpoints
         string operationId,
         [FromServices] IUniversalProgressStore progressStore,
         [FromServices] IEnumerable<IJobCancellationNotifier> cancellationNotifiers,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(operationId))
@@ -272,6 +280,33 @@ internal static class OperationsProgressEndpoints
                 StatusCodes.Status409Conflict,
                 "Conflict",
                 $"Operation '{operationId}' reached terminal state '{preWriteProgress.Status}' before cancellation could be applied");
+        }
+
+        // If this operation is backed by a durable execution job, synchronize the
+        // cancellation to the authoritative job store and remove from the queue so
+        // the job does not remain claimable after the admin cancel.
+        var jobStore = httpContext.RequestServices.GetService<IExecutionJobStore>();
+        if (jobStore != null)
+        {
+            var executionJob = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+            if (executionJob != null && !IsExecutionJobTerminal(executionJob.Status))
+            {
+                var jobNow = DateTimeOffset.UtcNow;
+                var cancelledJob = executionJob with
+                {
+                    Status = ExecutionJobStatus.Cancelled,
+                    UpdatedAt = jobNow,
+                    CompletedAt = jobNow,
+                    CurrentPhase = "Cancelled"
+                };
+                await jobStore.SetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                var jobQueue = httpContext.RequestServices.GetService<IJobQueue>();
+                if (jobQueue != null)
+                {
+                    await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
+                }
+            }
         }
 
         var cancelledProgress = latestCancellable.WithCancellation(DateTimeOffset.UtcNow, "Cancelled by user");

--- a/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
@@ -169,41 +169,75 @@ internal static class OperationsProgressEndpoints
 
         if (executionJob.ClaimedBy != null)
         {
-            if (!executionJob.CancellationRequestedAt.HasValue)
+            var current = executionJob;
+
+            for (var casAttempt = 0; casAttempt < 3; casAttempt++)
             {
+                if (current.CancellationRequestedAt.HasValue || current.Status == ExecutionJobStatus.Cancelled)
+                {
+                    break;
+                }
+
                 var now = DateTimeOffset.UtcNow;
-                var requested = executionJob with
+                var requested = current with
                 {
                     CancellationRequestedAt = now,
                     UpdatedAt = now
                 };
 
-                await jobStore.TrySetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false);
+                if (await jobStore.TrySetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false))
+                {
+                    break;
+                }
+
+                current = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+                if (current == null || IsExecutionJobTerminal(current.Status))
+                {
+                    break;
+                }
             }
 
             return;
         }
 
-        var cancelledNow = DateTimeOffset.UtcNow;
-        var cancelled = executionJob with
-        {
-            Status = ExecutionJobStatus.Cancelled,
-            UpdatedAt = cancelledNow,
-            CompletedAt = cancelledNow,
-            CurrentPhase = "Cancelled"
-        };
+        var current2 = executionJob;
+        var cancelConfirmed = false;
 
-        var wroteCancelled = await jobStore.TrySetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false);
-        if (!wroteCancelled)
+        for (var casAttempt = 0; casAttempt < 3; casAttempt++)
         {
-            var conflict = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-            if (conflict?.Status is not ExecutionJobStatus.Cancelled)
+            if (current2.Status == ExecutionJobStatus.Cancelled)
             {
-                return;
+                cancelConfirmed = true;
+                break;
+            }
+
+            var cancelledNow = DateTimeOffset.UtcNow;
+            var cancelled = current2 with
+            {
+                Status = ExecutionJobStatus.Cancelled,
+                UpdatedAt = cancelledNow,
+                CompletedAt = cancelledNow,
+                CurrentPhase = "Cancelled"
+            };
+
+            if (await jobStore.TrySetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                cancelConfirmed = true;
+                break;
+            }
+
+            current2 = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+            if (current2 == null || IsExecutionJobTerminal(current2.Status))
+            {
+                cancelConfirmed = current2?.Status == ExecutionJobStatus.Cancelled;
+                break;
             }
         }
 
-        await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
+        if (cancelConfirmed)
+        {
+            await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     private static async Task TryRemoveJobQueueEntryAsync(
@@ -411,53 +445,88 @@ internal static class OperationsProgressEndpoints
                     if (executionJob.ClaimedBy != null)
                     {
                         var reqNow = DateTimeOffset.UtcNow;
-                        var requested = executionJob with
+                        var current = executionJob;
+                        var cancelSignalConfirmed = current.CancellationRequestedAt.HasValue;
+
+                        for (var casAttempt = 0; !cancelSignalConfirmed && casAttempt < 3; casAttempt++)
                         {
-                            CancellationRequestedAt = reqNow,
-                            UpdatedAt = reqNow
-                        };
-                        if (!await jobStore.TrySetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false))
-                        {
-                            var conflict = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-                            if (conflict != null && IsExecutionJobTerminal(conflict.Status))
+                            var requested = current with
+                            {
+                                CancellationRequestedAt = reqNow,
+                                UpdatedAt = reqNow
+                            };
+                            if (await jobStore.TrySetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false))
+                            {
+                                cancelSignalConfirmed = true;
+                                break;
+                            }
+
+                            current = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+                            if (current == null || current.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
                             {
                                 return ProblemDetailsHelpers.CreateAdminProblem(
                                     StatusCodes.Status409Conflict,
                                     "Conflict",
-                                    $"Operation '{operationId}' reached terminal state '{conflict.Status}' before cancellation could be applied");
+                                    $"Operation '{operationId}' reached terminal state '{current?.Status}' before cancellation could be applied");
                             }
+
+                            cancelSignalConfirmed = current.CancellationRequestedAt.HasValue
+                                || current.Status == ExecutionJobStatus.Cancelled;
                         }
 
-                        var delegated = new CancelOperationResponse
+                        if (cancelSignalConfirmed)
                         {
-                            OperationId = operationId,
-                            Message = "Operation cancellation requested",
-                            Type = progress.Type
-                        };
-                        return Results.Json(delegated, OperationsProgressJsonContext.Default.CancelOperationResponse);
+                            var delegated = new CancelOperationResponse
+                            {
+                                OperationId = operationId,
+                                Message = "Operation cancellation requested",
+                                Type = progress.Type
+                            };
+                            return Results.Json(delegated, OperationsProgressJsonContext.Default.CancelOperationResponse);
+                        }
                     }
 
                     var jobNow = DateTimeOffset.UtcNow;
-                    var cancelledJob = executionJob with
                     {
-                        Status = ExecutionJobStatus.Cancelled,
-                        UpdatedAt = jobNow,
-                        CompletedAt = jobNow,
-                        CurrentPhase = "Cancelled"
-                    };
-                    if (!await jobStore.TrySetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false))
-                    {
-                        var conflict = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-                        if (conflict != null && IsExecutionJobTerminal(conflict.Status))
+                        var current = executionJob;
+                        var cancelConfirmed = false;
+
+                        for (var casAttempt = 0; casAttempt < 3; casAttempt++)
                         {
-                            return ProblemDetailsHelpers.CreateAdminProblem(
-                                StatusCodes.Status409Conflict,
-                                "Conflict",
-                                $"Operation '{operationId}' reached terminal state '{conflict.Status}' before cancellation could be applied");
+                            var cancelledJob = current with
+                            {
+                                Status = ExecutionJobStatus.Cancelled,
+                                UpdatedAt = jobNow,
+                                CompletedAt = jobNow,
+                                CurrentPhase = "Cancelled"
+                            };
+                            if (await jobStore.TrySetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false))
+                            {
+                                cancelConfirmed = true;
+                                break;
+                            }
+
+                            current = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+                            if (current == null || current.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
+                            {
+                                return ProblemDetailsHelpers.CreateAdminProblem(
+                                    StatusCodes.Status409Conflict,
+                                    "Conflict",
+                                    $"Operation '{operationId}' reached terminal state '{current?.Status}' before cancellation could be applied");
+                            }
+
+                            if (current.Status == ExecutionJobStatus.Cancelled)
+                            {
+                                cancelConfirmed = true;
+                                break;
+                            }
+                        }
+
+                        if (cancelConfirmed)
+                        {
+                            await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
                         }
                     }
-
-                    await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
                 }
                 else if (executionJob.Status is ExecutionJobStatus.Cancelled)
                 {

--- a/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
@@ -301,6 +301,28 @@ internal static class OperationsProgressEndpoints
 
                 if (!IsExecutionJobTerminal(executionJob.Status))
                 {
+                    // If the job is actively claimed by a remote worker whose
+                    // local notifier is unreachable, persist a durable
+                    // cancellation signal instead of writing terminal state.
+                    if (executionJob.ClaimedBy != null)
+                    {
+                        var reqNow = DateTimeOffset.UtcNow;
+                        var requested = executionJob with
+                        {
+                            CancellationRequestedAt = reqNow,
+                            UpdatedAt = reqNow
+                        };
+                        await jobStore.SetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                        var delegated = new CancelOperationResponse
+                        {
+                            OperationId = operationId,
+                            Message = "Operation cancellation requested",
+                            Type = progress.Type
+                        };
+                        return Results.Json(delegated, OperationsProgressJsonContext.Default.CancelOperationResponse);
+                    }
+
                     var jobNow = DateTimeOffset.UtcNow;
                     var cancelledJob = executionJob with
                     {

--- a/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
@@ -187,12 +187,23 @@ internal static class OperationsProgressEndpoints
                 $"Operation '{operationId}' not found");
         }
 
-        if (progress.Status is OperationStatus.Completed or OperationStatus.Failed or OperationStatus.Cancelled)
+        if (progress.Status is OperationStatus.Completed or OperationStatus.Failed)
         {
             return ProblemDetailsHelpers.CreateAdminProblem(
-                StatusCodes.Status400BadRequest,
-                ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
-                "Operation is already completed, failed, or cancelled");
+                StatusCodes.Status409Conflict,
+                "Conflict",
+                $"Operation '{operationId}' reached terminal state '{progress.Status}' before cancellation could be applied");
+        }
+
+        if (progress.Status is OperationStatus.Cancelled)
+        {
+            var alreadyCancelled = new CancelOperationResponse
+            {
+                OperationId = operationId,
+                Message = "Operation cancellation requested",
+                Type = progress.Type
+            };
+            return Results.Json(alreadyCancelled, OperationsProgressJsonContext.Default.CancelOperationResponse);
         }
 
         if (progress is not ICancellableOperationProgress cancellableProgress)

--- a/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
@@ -382,7 +382,17 @@ internal static class OperationsProgressEndpoints
                             CancellationRequestedAt = reqNow,
                             UpdatedAt = reqNow
                         };
-                        await jobStore.SetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false);
+                        if (!await jobStore.TrySetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false))
+                        {
+                            var conflict = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+                            if (conflict != null && IsExecutionJobTerminal(conflict.Status))
+                            {
+                                return ProblemDetailsHelpers.CreateAdminProblem(
+                                    StatusCodes.Status409Conflict,
+                                    "Conflict",
+                                    $"Operation '{operationId}' reached terminal state '{conflict.Status}' before cancellation could be applied");
+                            }
+                        }
 
                         var delegated = new CancelOperationResponse
                         {
@@ -401,7 +411,17 @@ internal static class OperationsProgressEndpoints
                         CompletedAt = jobNow,
                         CurrentPhase = "Cancelled"
                     };
-                    await jobStore.SetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    if (!await jobStore.TrySetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false))
+                    {
+                        var conflict = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+                        if (conflict != null && IsExecutionJobTerminal(conflict.Status))
+                        {
+                            return ProblemDetailsHelpers.CreateAdminProblem(
+                                StatusCodes.Status409Conflict,
+                                "Conflict",
+                                $"Operation '{operationId}' reached terminal state '{conflict.Status}' before cancellation could be applied");
+                        }
+                    }
 
                     await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
                 }

--- a/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
@@ -139,6 +139,28 @@ internal static class OperationsProgressEndpoints
             or ExecutionJobStatus.Failed
             or ExecutionJobStatus.Cancelled;
 
+    private static async Task TryRemoveJobQueueEntryAsync(
+        HttpContext httpContext,
+        string operationId,
+        CancellationToken cancellationToken)
+    {
+        var jobQueue = httpContext.RequestServices.GetService<IJobQueue>();
+        if (jobQueue == null)
+        {
+            return;
+        }
+
+        try
+        {
+            await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Best-effort: the durable store is authoritative and stale-claim
+            // reconciliation or later terminal cleanup will repair the queue.
+        }
+    }
+
     private static void NormalizeCanonicalProperty(JsonObject operation, string propertyName, JsonNode? value)
     {
         var duplicateKeys = new List<string>();
@@ -344,26 +366,11 @@ internal static class OperationsProgressEndpoints
                     };
                     await jobStore.SetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-                    var jobQueue = httpContext.RequestServices.GetService<IJobQueue>();
-                    if (jobQueue != null)
-                    {
-                        await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
-                    }
+                    await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
                 }
                 else if (executionJob.Status is ExecutionJobStatus.Cancelled)
                 {
-                    var jobQueue = httpContext.RequestServices.GetService<IJobQueue>();
-                    if (jobQueue != null)
-                    {
-                        try
-                        {
-                            await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
-                        }
-                        catch (Exception)
-                        {
-                            // Best-effort: stale-claim reconciler will repair.
-                        }
-                    }
+                    await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
@@ -350,6 +350,21 @@ internal static class OperationsProgressEndpoints
                         await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
                     }
                 }
+                else if (executionJob.Status is ExecutionJobStatus.Cancelled)
+                {
+                    var jobQueue = httpContext.RequestServices.GetService<IJobQueue>();
+                    if (jobQueue != null)
+                    {
+                        try
+                        {
+                            await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (Exception)
+                        {
+                            // Best-effort: stale-claim reconciler will repair.
+                        }
+                    }
+                }
             }
         }
 

--- a/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OperationsProgressEndpoints.cs
@@ -139,6 +139,39 @@ internal static class OperationsProgressEndpoints
             or ExecutionJobStatus.Failed
             or ExecutionJobStatus.Cancelled;
 
+    private static async Task TryReconcileDurableCancelAsync(
+        HttpContext httpContext,
+        string operationId,
+        CancellationToken cancellationToken)
+    {
+        var jobStore = httpContext.RequestServices.GetService<IExecutionJobStore>();
+        if (jobStore == null)
+        {
+            return;
+        }
+
+        var executionJob = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+        if (executionJob == null)
+        {
+            return;
+        }
+
+        if (!IsExecutionJobTerminal(executionJob.Status))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var cancelled = executionJob with
+            {
+                Status = ExecutionJobStatus.Cancelled,
+                UpdatedAt = now,
+                CompletedAt = now,
+                CurrentPhase = "Cancelled"
+            };
+            await jobStore.SetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        await TryRemoveJobQueueEntryAsync(httpContext, operationId, cancellationToken).ConfigureAwait(false);
+    }
+
     private static async Task TryRemoveJobQueueEntryAsync(
         HttpContext httpContext,
         string operationId,
@@ -219,6 +252,8 @@ internal static class OperationsProgressEndpoints
 
         if (progress.Status is OperationStatus.Cancelled)
         {
+            await TryReconcileDurableCancelAsync(httpContext, operationId, cancellationToken);
+
             var alreadyCancelled = new CancelOperationResponse
             {
                 OperationId = operationId,
@@ -280,6 +315,8 @@ internal static class OperationsProgressEndpoints
 
         if (latestProgress.Status is OperationStatus.Cancelled)
         {
+            await TryReconcileDurableCancelAsync(httpContext, operationId, cancellationToken);
+
             var alreadyCancelled = new CancelOperationResponse
             {
                 OperationId = operationId,

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -274,7 +274,14 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         {
             if (_jobQueue != null)
             {
-                await _jobQueue.RemoveAsync(jobId, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await _jobQueue.RemoveAsync(jobId, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    GeoprocessingServiceLog.QueueRemovalFailed(_logger, jobId, ex);
+                }
             }
 
             var staleProgress = await _progressStore.GetProgressAsync<GeoprocessingProgress>(
@@ -337,7 +344,14 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             {
                 if (_jobQueue != null)
                 {
-                    await _jobQueue.RemoveAsync(jobId, cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        await _jobQueue.RemoveAsync(jobId, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        GeoprocessingServiceLog.QueueRemovalFailed(_logger, jobId, ex);
+                    }
                 }
 
                 var staleProgress = await _progressStore.GetProgressAsync<GeoprocessingProgress>(
@@ -387,7 +401,14 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
 
         if (_jobQueue != null)
         {
-            await _jobQueue.RemoveAsync(jobId, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await _jobQueue.RemoveAsync(jobId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                GeoprocessingServiceLog.QueueRemovalFailed(_logger, jobId, ex);
+            }
         }
 
         var progress = await _progressStore.GetProgressAsync<GeoprocessingProgress>(

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -311,7 +311,14 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         var latest = await jobStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
         if (latest != null && IsTerminal(latest.Status))
         {
-            return;
+            if (latest.Status == ExecutionJobStatus.Cancelled)
+            {
+                return;
+            }
+
+            GeoprocessingServiceLog.CancelRejectedTerminal(_logger, jobId, latest.Status.ToString());
+            throw new GeoprocessingPreconditionFailedException(
+                $"Job '{jobId}' is in terminal state '{latest.Status}' and cannot be cancelled.");
         }
 
         var now = DateTimeOffset.UtcNow;

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -335,6 +335,20 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         {
             if (latest.Status == ExecutionJobStatus.Cancelled)
             {
+                if (_jobQueue != null)
+                {
+                    await _jobQueue.RemoveAsync(jobId, cancellationToken).ConfigureAwait(false);
+                }
+
+                var staleProgress = await _progressStore.GetProgressAsync<GeoprocessingProgress>(
+                    jobId, cancellationToken).ConfigureAwait(false);
+                if (staleProgress != null && staleProgress.Status != OperationStatus.Cancelled)
+                {
+                    var reconciledProgress = staleProgress.WithCancellation(DateTimeOffset.UtcNow, "Cancelled");
+                    await _progressStore.SetProgressAsync(
+                        jobId, reconciledProgress, ProgressRetention, cancellationToken).ConfigureAwait(false);
+                }
+
                 return;
             }
 

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -24,6 +24,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
     private static readonly TimeSpan ProgressRetention = TimeSpan.FromDays(7);
 
     private readonly IExecutionJobStore? _jobStore;
+    private readonly IJobQueue? _jobQueue;
     private readonly IUniversalProgressStore _progressStore;
     private readonly IJobCancellationNotifier _cancellationNotifier;
     private readonly IOperatorAuthorizationEvaluator _authEvaluator;
@@ -36,7 +37,8 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         IOperatorAuthorizationEvaluator authEvaluator,
         IOperatorApprovalEvaluator approvalEvaluator,
         ILogger<GeoprocessingJobService> logger,
-        IExecutionJobStore? jobStore = null)
+        IExecutionJobStore? jobStore = null,
+        IJobQueue? jobQueue = null)
     {
         _progressStore = progressStore;
         _cancellationNotifier = cancellationNotifier;
@@ -44,6 +46,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         _approvalEvaluator = approvalEvaluator;
         _logger = logger;
         _jobStore = jobStore;
+        _jobQueue = jobQueue;
     }
 
     public void EnsureCallerAuthorized(
@@ -320,6 +323,11 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         };
 
         await jobStore.SetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        if (_jobQueue != null)
+        {
+            await _jobQueue.RemoveAsync(jobId, cancellationToken).ConfigureAwait(false);
+        }
 
         var progress = await _progressStore.GetProgressAsync<GeoprocessingProgress>(
             jobId, cancellationToken).ConfigureAwait(false);

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -11,6 +11,7 @@ using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Server.Features.Infrastructure;
 
 namespace Honua.Server.Features.Geoprocessing;
@@ -271,7 +272,21 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
 
         if (job.Status == ExecutionJobStatus.Cancelled)
         {
-            return; // Idempotent success
+            if (_jobQueue != null)
+            {
+                await _jobQueue.RemoveAsync(jobId, cancellationToken).ConfigureAwait(false);
+            }
+
+            var staleProgress = await _progressStore.GetProgressAsync<GeoprocessingProgress>(
+                jobId, cancellationToken).ConfigureAwait(false);
+            if (staleProgress != null && staleProgress.Status != OperationStatus.Cancelled)
+            {
+                var reconciledProgress = staleProgress.WithCancellation(DateTimeOffset.UtcNow, "Cancelled");
+                await _progressStore.SetProgressAsync(
+                    jobId, reconciledProgress, ProgressRetention, cancellationToken).ConfigureAwait(false);
+            }
+
+            return;
         }
 
         if (IsTerminal(job.Status))

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -328,6 +328,23 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
                 $"Job '{jobId}' is in terminal state '{latest.Status}' and cannot be cancelled.");
         }
 
+        // If the job is actively claimed by a worker but no local notifier
+        // could cancel it, the worker is on a remote host. Persist a durable
+        // cancellation signal instead of writing terminal Cancelled — the
+        // worker will observe it during its next heartbeat read.
+        if (latest.ClaimedBy != null)
+        {
+            var reqNow = DateTimeOffset.UtcNow;
+            var requested = latest with
+            {
+                CancellationRequestedAt = reqNow,
+                UpdatedAt = reqNow
+            };
+            await jobStore.SetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false);
+            GeoprocessingServiceLog.JobCancellationDelegated(_logger, jobId);
+            return;
+        }
+
         var now = DateTimeOffset.UtcNow;
         var cancelled = latest with
         {

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -11,6 +11,7 @@ using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Server.Features.Infrastructure;
 
 namespace Honua.Server.Features.Geoprocessing;
 
@@ -26,14 +27,14 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
     private readonly IExecutionJobStore? _jobStore;
     private readonly IJobQueue? _jobQueue;
     private readonly IUniversalProgressStore _progressStore;
-    private readonly IJobCancellationNotifier _cancellationNotifier;
+    private readonly IReadOnlyList<IJobCancellationNotifier> _cancellationNotifiers;
     private readonly IOperatorAuthorizationEvaluator _authEvaluator;
     private readonly IOperatorApprovalEvaluator _approvalEvaluator;
     private readonly ILogger<GeoprocessingJobService> _logger;
 
     public GeoprocessingJobService(
         IUniversalProgressStore progressStore,
-        IJobCancellationNotifier cancellationNotifier,
+        IEnumerable<IJobCancellationNotifier> cancellationNotifiers,
         IOperatorAuthorizationEvaluator authEvaluator,
         IOperatorApprovalEvaluator approvalEvaluator,
         ILogger<GeoprocessingJobService> logger,
@@ -41,7 +42,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         IJobQueue? jobQueue = null)
     {
         _progressStore = progressStore;
-        _cancellationNotifier = cancellationNotifier;
+        _cancellationNotifiers = cancellationNotifiers.ToArray();
         _authEvaluator = authEvaluator;
         _approvalEvaluator = approvalEvaluator;
         _logger = logger;
@@ -299,7 +300,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
                 "Job cancellation requires approval.");
         }
 
-        var workerOwnsTerminalState = _cancellationNotifier.Cancel(jobId);
+        var workerOwnsTerminalState = _cancellationNotifiers.CancelAny(jobId);
 
         if (workerOwnsTerminalState)
         {

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -309,7 +309,14 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         }
 
         var latest = await jobStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
-        if (latest != null && IsTerminal(latest.Status))
+        if (latest == null)
+        {
+            GeoprocessingServiceLog.JobNotFound(_logger, jobId);
+            throw new GeoprocessingNotFoundException(
+                $"Job '{jobId}' was not found on re-read and could not be cancelled.");
+        }
+
+        if (IsTerminal(latest.Status))
         {
             if (latest.Status == ExecutionJobStatus.Cancelled)
             {
@@ -322,7 +329,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         }
 
         var now = DateTimeOffset.UtcNow;
-        var cancelled = (latest ?? job) with
+        var cancelled = latest with
         {
             Status = ExecutionJobStatus.Cancelled,
             UpdatedAt = now,

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -383,7 +383,16 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
                 CancellationRequestedAt = reqNow,
                 UpdatedAt = reqNow
             };
-            await jobStore.SetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (!await jobStore.TrySetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                var conflict = await jobStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
+                if (conflict != null && IsTerminal(conflict.Status) && conflict.Status != ExecutionJobStatus.Cancelled)
+                {
+                    throw new GeoprocessingPreconditionFailedException(
+                        $"Job '{jobId}' reached terminal state '{conflict.Status}' before cancellation could be applied.");
+                }
+            }
+
             GeoprocessingServiceLog.JobCancellationDelegated(_logger, jobId);
             return;
         }
@@ -397,7 +406,15 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             CurrentPhase = "Cancelled"
         };
 
-        await jobStore.SetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!await jobStore.TrySetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false))
+        {
+            var conflict = await jobStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
+            if (conflict != null && IsTerminal(conflict.Status) && conflict.Status != ExecutionJobStatus.Cancelled)
+            {
+                throw new GeoprocessingPreconditionFailedException(
+                    $"Job '{jobId}' reached terminal state '{conflict.Status}' before cancellation could be applied.");
+            }
+        }
 
         if (_jobQueue != null)
         {

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -198,24 +198,10 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         }
         catch (Exception) when (!cancellationToken.IsCancellationRequested)
         {
-            // Rollback the just-created job to prevent stranded Queued records
-            // that no reconciler will repair (reconciler skips Queued status).
-            try
-            {
-                var failedJob = jobRecord with
-                {
-                    Status = ExecutionJobStatus.Failed,
-                    UpdatedAt = DateTimeOffset.UtcNow,
-                    CompletedAt = DateTimeOffset.UtcNow,
-                    ErrorMessage = "Submission failed: progress or queue persistence error.",
-                    CurrentPhase = "Failed (submission)"
-                };
-                await jobStore.TrySetAsync(failedJob, cancellationToken: CancellationToken.None).ConfigureAwait(false);
-            }
-            catch
-            {
-                // Best-effort rollback; job TTL or manual intervention will repair.
-            }
+            await ExecutionJobSubmissionHelper.TryRollbackCreatedJobAsync(
+                jobStore,
+                jobId,
+                CancellationToken.None).ConfigureAwait(false);
 
             throw;
         }
@@ -601,8 +587,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
 
     private static void EnsureSubmissionDidNotRollback(ExecutionJobRecord existing)
     {
-        if (existing.Status == ExecutionJobStatus.Failed
-            && string.Equals(existing.CurrentPhase, "Failed (submission)", StringComparison.Ordinal))
+        if (ExecutionJobSubmissionHelper.IsSubmissionRollback(existing))
         {
             throw new InvalidOperationException(
                 $"Job '{existing.OperationId}' submission previously failed before queueing. Retry with a new idempotency key.");

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -187,8 +187,12 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         await _progressStore.SetProgressAsync(jobId, progress, ProgressRetention, cancellationToken)
             .ConfigureAwait(false);
 
+        if (_jobQueue != null)
+        {
+            await _jobQueue.EnqueueAsync(jobId, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
         GeoprocessingServiceLog.JobSubmitted(_logger, jobId, plan.PlanId);
-        GeoprocessingServiceLog.JobSubmittedStubbed(_logger, jobId);
 
         return jobRecord;
     }
@@ -378,19 +382,40 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         if (latest.ClaimedBy != null)
         {
             var reqNow = DateTimeOffset.UtcNow;
-            var requested = latest with
+            var current = latest;
+            var cancelSignalConfirmed = current.CancellationRequestedAt.HasValue;
+
+            for (var casAttempt = 0; !cancelSignalConfirmed && casAttempt < 3; casAttempt++)
             {
-                CancellationRequestedAt = reqNow,
-                UpdatedAt = reqNow
-            };
-            if (!await jobStore.TrySetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false))
-            {
-                var conflict = await jobStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
-                if (conflict != null && IsTerminal(conflict.Status) && conflict.Status != ExecutionJobStatus.Cancelled)
+                var requested = current with
+                {
+                    CancellationRequestedAt = reqNow,
+                    UpdatedAt = reqNow
+                };
+                if (await jobStore.TrySetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false))
+                {
+                    cancelSignalConfirmed = true;
+                    break;
+                }
+
+                current = await jobStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false)
+                    ?? throw new GeoprocessingNotFoundException(
+                        $"Job '{jobId}' was deleted during cancellation.");
+
+                if (current.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
                 {
                     throw new GeoprocessingPreconditionFailedException(
-                        $"Job '{jobId}' reached terminal state '{conflict.Status}' before cancellation could be applied.");
+                        $"Job '{jobId}' reached terminal state '{current.Status}' before cancellation could be applied.");
                 }
+
+                cancelSignalConfirmed = current.CancellationRequestedAt.HasValue
+                    || current.Status == ExecutionJobStatus.Cancelled;
+            }
+
+            if (!cancelSignalConfirmed)
+            {
+                throw new GeoprocessingPreconditionFailedException(
+                    $"Job '{jobId}' cancellation signal could not be confirmed after retries.");
             }
 
             GeoprocessingServiceLog.JobCancellationDelegated(_logger, jobId);
@@ -398,21 +423,47 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         }
 
         var now = DateTimeOffset.UtcNow;
-        var cancelled = latest with
         {
-            Status = ExecutionJobStatus.Cancelled,
-            UpdatedAt = now,
-            CompletedAt = now,
-            CurrentPhase = "Cancelled"
-        };
+            var current = latest;
+            var cancelConfirmed = false;
 
-        if (!await jobStore.TrySetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false))
-        {
-            var conflict = await jobStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false);
-            if (conflict != null && IsTerminal(conflict.Status) && conflict.Status != ExecutionJobStatus.Cancelled)
+            for (var casAttempt = 0; casAttempt < 3; casAttempt++)
+            {
+                var cancelled = current with
+                {
+                    Status = ExecutionJobStatus.Cancelled,
+                    UpdatedAt = now,
+                    CompletedAt = now,
+                    CurrentPhase = "Cancelled"
+                };
+
+                if (await jobStore.TrySetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false))
+                {
+                    cancelConfirmed = true;
+                    break;
+                }
+
+                current = await jobStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false)
+                    ?? throw new GeoprocessingNotFoundException(
+                        $"Job '{jobId}' was deleted during cancellation.");
+
+                if (current.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
+                {
+                    throw new GeoprocessingPreconditionFailedException(
+                        $"Job '{jobId}' reached terminal state '{current.Status}' before cancellation could be applied.");
+                }
+
+                if (current.Status == ExecutionJobStatus.Cancelled)
+                {
+                    cancelConfirmed = true;
+                    break;
+                }
+            }
+
+            if (!cancelConfirmed)
             {
                 throw new GeoprocessingPreconditionFailedException(
-                    $"Job '{jobId}' reached terminal state '{conflict.Status}' before cancellation could be applied.");
+                    $"Job '{jobId}' cancellation could not be confirmed after retries.");
             }
         }
 

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -13,6 +13,7 @@ using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Server.Features.Infrastructure;
+using Honua.Server.Features.Infrastructure.ControlPlane;
 
 namespace Honua.Server.Features.Geoprocessing;
 
@@ -176,6 +177,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             if (existing != null)
             {
                 EnsureMatchingIdempotentRequest(existing, requestFingerprint);
+                EnsureSubmissionDidNotRollback(existing);
                 GeoprocessingServiceLog.JobSubmittedIdempotent(_logger, jobId);
                 return existing;
             }
@@ -183,13 +185,39 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             throw new InvalidOperationException("Failed to create or locate execution job.");
         }
 
-        var progress = GeoprocessingProgress.CreateForSubmittedJob(jobId, plan.PlanId);
-        await _progressStore.SetProgressAsync(jobId, progress, ProgressRetention, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (_jobQueue != null)
+        try
         {
-            await _jobQueue.EnqueueAsync(jobId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var progress = GeoprocessingProgress.CreateForSubmittedJob(jobId, plan.PlanId);
+            await _progressStore.SetProgressAsync(jobId, progress, ProgressRetention, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (_jobQueue != null)
+            {
+                await _jobQueue.EnqueueAsync(jobId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Rollback the just-created job to prevent stranded Queued records
+            // that no reconciler will repair (reconciler skips Queued status).
+            try
+            {
+                var failedJob = jobRecord with
+                {
+                    Status = ExecutionJobStatus.Failed,
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                    CompletedAt = DateTimeOffset.UtcNow,
+                    ErrorMessage = "Submission failed: progress or queue persistence error.",
+                    CurrentPhase = "Failed (submission)"
+                };
+                await jobStore.TrySetAsync(failedJob, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort rollback; job TTL or manual intervention will repair.
+            }
+
+            throw;
         }
 
         GeoprocessingServiceLog.JobSubmitted(_logger, jobId, plan.PlanId);
@@ -375,97 +403,36 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
                 $"Job '{jobId}' is in terminal state '{latest.Status}' and cannot be cancelled.");
         }
 
-        // If the job is actively claimed by a worker but no local notifier
-        // could cancel it, the worker is on a remote host. Persist a durable
-        // cancellation signal instead of writing terminal Cancelled — the
-        // worker will observe it during its next heartbeat read.
-        if (latest.ClaimedBy != null)
+        var cancelOutcome = await ExecutionJobCancellationHelper.TryApplyAsync(
+            jobStore,
+            jobId,
+            latest,
+            "Cancelled",
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        switch (cancelOutcome.State)
         {
-            var reqNow = DateTimeOffset.UtcNow;
-            var current = latest;
-            var cancelSignalConfirmed = current.CancellationRequestedAt.HasValue;
-
-            for (var casAttempt = 0; !cancelSignalConfirmed && casAttempt < 3; casAttempt++)
-            {
-                var requested = current with
-                {
-                    CancellationRequestedAt = reqNow,
-                    UpdatedAt = reqNow
-                };
-                if (await jobStore.TrySetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false))
-                {
-                    cancelSignalConfirmed = true;
-                    break;
-                }
-
-                current = await jobStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false)
-                    ?? throw new GeoprocessingNotFoundException(
-                        $"Job '{jobId}' was deleted during cancellation.");
-
-                if (current.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
-                {
-                    throw new GeoprocessingPreconditionFailedException(
-                        $"Job '{jobId}' reached terminal state '{current.Status}' before cancellation could be applied.");
-                }
-
-                cancelSignalConfirmed = current.CancellationRequestedAt.HasValue
-                    || current.Status == ExecutionJobStatus.Cancelled;
-            }
-
-            if (!cancelSignalConfirmed)
-            {
+            case ExecutionJobCancellationState.CancellationRequested:
+                GeoprocessingServiceLog.JobCancellationDelegated(_logger, jobId);
+                return;
+            case ExecutionJobCancellationState.TerminalConflict:
+                GeoprocessingServiceLog.CancelRejectedTerminal(_logger, jobId, cancelOutcome.Job!.Status.ToString());
                 throw new GeoprocessingPreconditionFailedException(
-                    $"Job '{jobId}' cancellation signal could not be confirmed after retries.");
-            }
-
-            GeoprocessingServiceLog.JobCancellationDelegated(_logger, jobId);
-            return;
+                    $"Job '{jobId}' reached terminal state '{cancelOutcome.Job.Status}' before cancellation could be applied.");
+            case ExecutionJobCancellationState.Missing:
+                GeoprocessingServiceLog.JobNotFound(_logger, jobId);
+                throw new GeoprocessingNotFoundException(
+                    $"Job '{jobId}' was deleted during cancellation.");
+            case ExecutionJobCancellationState.Unconfirmed:
+                throw new GeoprocessingPreconditionFailedException(
+                    $"Job '{jobId}' cancellation could not be confirmed after retries.");
+            case ExecutionJobCancellationState.Cancelled:
+                break;
+            default:
+                throw new InvalidOperationException($"Unexpected durable cancellation outcome '{cancelOutcome.State}'.");
         }
 
         var now = DateTimeOffset.UtcNow;
-        {
-            var current = latest;
-            var cancelConfirmed = false;
-
-            for (var casAttempt = 0; casAttempt < 3; casAttempt++)
-            {
-                var cancelled = current with
-                {
-                    Status = ExecutionJobStatus.Cancelled,
-                    UpdatedAt = now,
-                    CompletedAt = now,
-                    CurrentPhase = "Cancelled"
-                };
-
-                if (await jobStore.TrySetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false))
-                {
-                    cancelConfirmed = true;
-                    break;
-                }
-
-                current = await jobStore.GetAsync(jobId, cancellationToken).ConfigureAwait(false)
-                    ?? throw new GeoprocessingNotFoundException(
-                        $"Job '{jobId}' was deleted during cancellation.");
-
-                if (current.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
-                {
-                    throw new GeoprocessingPreconditionFailedException(
-                        $"Job '{jobId}' reached terminal state '{current.Status}' before cancellation could be applied.");
-                }
-
-                if (current.Status == ExecutionJobStatus.Cancelled)
-                {
-                    cancelConfirmed = true;
-                    break;
-                }
-            }
-
-            if (!cancelConfirmed)
-            {
-                throw new GeoprocessingPreconditionFailedException(
-                    $"Job '{jobId}' cancellation could not be confirmed after retries.");
-            }
-        }
 
         if (_jobQueue != null)
         {
@@ -630,6 +597,16 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         }
 
         throw new GeoprocessingIdempotencyConflictException();
+    }
+
+    private static void EnsureSubmissionDidNotRollback(ExecutionJobRecord existing)
+    {
+        if (existing.Status == ExecutionJobStatus.Failed
+            && string.Equals(existing.CurrentPhase, "Failed (submission)", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Job '{existing.OperationId}' submission previously failed before queueing. Retry with a new idempotency key.");
+        }
     }
 
     internal static bool IsTerminal(ExecutionJobStatus status)

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobTerminalCallback.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobTerminalCallback.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Domain;
+
+namespace Honua.Server.Features.Geoprocessing;
+
+/// <summary>
+/// Synchronizes the admin progress store when a geoprocessing execution job
+/// reaches a terminal state, keeping the admin operations API consistent with
+/// the authoritative <see cref="IExecutionJobStore"/> record.
+/// </summary>
+internal sealed partial class GeoprocessingJobTerminalCallback(
+    IUniversalProgressStore progressStore,
+    ILogger<GeoprocessingJobTerminalCallback> logger) : IJobTerminalCallback
+{
+    private static readonly TimeSpan ProgressRetention = TimeSpan.FromDays(7);
+
+    public async ValueTask OnTerminalAsync(ExecutionJobRecord job, CancellationToken cancellationToken)
+    {
+        if (job.Spec.Kind != ExecutionJobKind.Geoprocessing)
+        {
+            return;
+        }
+
+        try
+        {
+            var progress = await progressStore.GetProgressAsync<GeoprocessingProgress>(
+                job.OperationId, cancellationToken).ConfigureAwait(false);
+            if (progress == null)
+            {
+                return;
+            }
+
+            if (progress.Status is OperationStatus.Completed or OperationStatus.Failed or OperationStatus.Cancelled)
+            {
+                return;
+            }
+
+            var completedAt = job.CompletedAt ?? DateTimeOffset.UtcNow;
+
+            GeoprocessingProgress? updated = job.Status switch
+            {
+                ExecutionJobStatus.Succeeded => progress with
+                {
+                    WorkflowStatus = GeoprocessingWorkflowStatus.Completed,
+                    CurrentStageStatus = GeoprocessingStageStatus.Completed,
+                    CompletedAt = completedAt,
+                    CurrentPhase = "Completed"
+                },
+                ExecutionJobStatus.Failed => progress with
+                {
+                    WorkflowStatus = GeoprocessingWorkflowStatus.Failed,
+                    CurrentStageStatus = GeoprocessingStageStatus.Failed,
+                    CompletedAt = completedAt,
+                    ErrorMessage = job.ErrorMessage,
+                    CurrentPhase = "Failed"
+                },
+                ExecutionJobStatus.Cancelled => (GeoprocessingProgress)progress.WithCancellation(
+                    completedAt, "Cancelled"),
+                _ => null
+            };
+
+            if (updated != null)
+            {
+                await progressStore.SetProgressAsync(
+                    job.OperationId, updated, ProgressRetention, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.ProgressSyncFailed(logger, job.OperationId, ex);
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(8020, LogLevel.Warning, "Failed to synchronize admin progress for terminal job {OperationId}; admin view may be stale until TTL expiry")]
+        public static partial void ProgressSyncFailed(ILogger logger, string operationId, Exception exception);
+    }
+}

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -61,6 +61,9 @@ internal static class GeoprocessingServiceCollectionExtensions
         // Shared geoprocessing job service (#723) — consumed by gRPC and REST adapters
         services.TryAddSingleton<IGeoprocessingJobService, GeoprocessingJobService>();
 
+        // Job orchestration substrate: queue, log store (ticket #681)
+        services.AddJobOrchestration();
+
         return services;
     }
 }

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceLog.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceLog.cs
@@ -90,6 +90,12 @@ internal static partial class GeoprocessingServiceLog
         ILogger logger,
         string policyRef);
 
+    [LoggerMessage(8015, LogLevel.Warning, "Queue cleanup failed for cancelled job {JobId}; stale-claim reconciler will repair")]
+    public static partial void QueueRemovalFailed(
+        ILogger logger,
+        string jobId,
+        Exception exception);
+
     [LoggerMessage(8020, LogLevel.Information, "Map package created: MapPackageId={MapPackageId}, Status={Status}")]
     public static partial void MapPackageCreated(
         ILogger logger,

--- a/src/Honua.Server/Features/Import/GeoServerImportEndpoints.cs
+++ b/src/Honua.Server/Features/Import/GeoServerImportEndpoints.cs
@@ -267,16 +267,9 @@ internal static partial class GeoServerImportEndpoints
                     statusCode: StatusCodes.Status202Accepted)
                 .ExecuteAsync(context);
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("Distributed import queue is unavailable", StringComparison.OrdinalIgnoreCase))
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Distributed import", StringComparison.OrdinalIgnoreCase) && ex.Message.Contains("unavailable", StringComparison.OrdinalIgnoreCase))
         {
-            if (jobManager != null && !string.IsNullOrWhiteSpace(jobId) && !jobQueued)
-            {
-                await ImportEndpointCoordinationHelper.DeleteQueuedStateAsync(
-                    jobManager.RequestStore,
-                    jobManager.ProgressStore,
-                    jobId,
-                    CancellationToken.None).ConfigureAwait(false);
-            }
+            await TryRollbackQueuedStateAsync(jobManager, jobId, jobQueued);
 
             Log.ImportStartFailed(GetLogger(context), request.GeoServerRestUrl, ex);
             await AdminResponseWriter.WriteErrorAsync(
@@ -286,14 +279,7 @@ internal static partial class GeoServerImportEndpoints
         }
         catch (ArgumentException ex)
         {
-            if (jobManager != null && !string.IsNullOrWhiteSpace(jobId) && !jobQueued)
-            {
-                await ImportEndpointCoordinationHelper.DeleteQueuedStateAsync(
-                    jobManager.RequestStore,
-                    jobManager.ProgressStore,
-                    jobId,
-                    CancellationToken.None).ConfigureAwait(false);
-            }
+            await TryRollbackQueuedStateAsync(jobManager, jobId, jobQueued);
 
             Log.ImportStartFailed(GetLogger(context), request.GeoServerRestUrl, ex);
             await AdminResponseWriter.WriteErrorAsync(
@@ -303,17 +289,32 @@ internal static partial class GeoServerImportEndpoints
         }
         catch (Exception ex)
         {
-            if (jobManager != null && !string.IsNullOrWhiteSpace(jobId) && !jobQueued)
-            {
-                await ImportEndpointCoordinationHelper.DeleteQueuedStateAsync(
-                    jobManager.RequestStore,
-                    jobManager.ProgressStore,
-                    jobId,
-                    CancellationToken.None).ConfigureAwait(false);
-            }
+            await TryRollbackQueuedStateAsync(jobManager, jobId, jobQueued);
 
             Log.ImportStartFailed(GetLogger(context), request.GeoServerRestUrl, ex);
             await AdminResponseWriter.WriteErrorAsync(context, "Failed to queue import job", StatusCodes.Status500InternalServerError);
+        }
+    }
+
+    private static async Task TryRollbackQueuedStateAsync(
+        GeoServerImportJobManager? jobManager, string? jobId, bool jobQueued)
+    {
+        if (jobManager == null || string.IsNullOrWhiteSpace(jobId) || jobQueued)
+        {
+            return;
+        }
+
+        try
+        {
+            await ImportEndpointCoordinationHelper.DeleteQueuedStateAsync(
+                jobManager.RequestStore,
+                jobManager.ProgressStore,
+                jobId,
+                CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort rollback; state will expire via TTL.
         }
     }
 

--- a/src/Honua.Server/Features/Import/GeoservicesImportEndpoints.cs
+++ b/src/Honua.Server/Features/Import/GeoservicesImportEndpoints.cs
@@ -273,16 +273,9 @@ internal static partial class GeoservicesImportEndpoints
                     statusCode: StatusCodes.Status202Accepted)
                 .ExecuteAsync(context);
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("Distributed import queue is unavailable", StringComparison.OrdinalIgnoreCase))
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Distributed import", StringComparison.OrdinalIgnoreCase) && ex.Message.Contains("unavailable", StringComparison.OrdinalIgnoreCase))
         {
-            if (jobManager != null && !string.IsNullOrWhiteSpace(jobId) && !jobQueued)
-            {
-                await ImportEndpointCoordinationHelper.DeleteQueuedStateAsync(
-                    jobManager.RequestStore,
-                    jobManager.ProgressStore,
-                    jobId,
-                    CancellationToken.None).ConfigureAwait(false);
-            }
+            await TryRollbackQueuedStateAsync(jobManager, jobId, jobQueued);
 
             Log.ImportStartFailed(GetLogger(context), request.ServiceUrl, request.LayerId, ex);
             await AdminResponseWriter.WriteErrorAsync(
@@ -292,17 +285,32 @@ internal static partial class GeoservicesImportEndpoints
         }
         catch (Exception ex)
         {
-            if (jobManager != null && !string.IsNullOrWhiteSpace(jobId) && !jobQueued)
-            {
-                await ImportEndpointCoordinationHelper.DeleteQueuedStateAsync(
-                    jobManager.RequestStore,
-                    jobManager.ProgressStore,
-                    jobId,
-                    CancellationToken.None).ConfigureAwait(false);
-            }
+            await TryRollbackQueuedStateAsync(jobManager, jobId, jobQueued);
 
             Log.ImportStartFailed(GetLogger(context), request.ServiceUrl, request.LayerId, ex);
             await AdminResponseWriter.WriteErrorAsync(context, "Failed to queue import job", StatusCodes.Status500InternalServerError);
+        }
+    }
+
+    private static async Task TryRollbackQueuedStateAsync(
+        IDistributedImportJobManager? jobManager, string? jobId, bool jobQueued)
+    {
+        if (jobManager == null || string.IsNullOrWhiteSpace(jobId) || jobQueued)
+        {
+            return;
+        }
+
+        try
+        {
+            await ImportEndpointCoordinationHelper.DeleteQueuedStateAsync(
+                jobManager.RequestStore,
+                jobManager.ProgressStore,
+                jobId,
+                CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort rollback; state will expire via TTL.
         }
     }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/ControlPlaneJsonContext.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/ControlPlaneJsonContext.cs
@@ -13,6 +13,7 @@ namespace Honua.Server.Features.Infrastructure.ControlPlane;
 [JsonSerializable(typeof(ExecutionJobRecord))]
 [JsonSerializable(typeof(DeployTargetDefinition))]
 [JsonSerializable(typeof(ExecutionJobDefinition))]
+[JsonSerializable(typeof(ExecutionLogEntry))]
 internal sealed partial class ControlPlaneJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/ExecutionJobCancellationHelper.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/ExecutionJobCancellationHelper.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Server.Features.Infrastructure.ControlPlane;
+
+internal enum ExecutionJobCancellationState
+{
+    Cancelled,
+    CancellationRequested,
+    TerminalConflict,
+    Missing,
+    Unconfirmed
+}
+
+internal readonly record struct ExecutionJobCancellationResult(
+    ExecutionJobCancellationState State,
+    ExecutionJobRecord? Job);
+
+internal static class ExecutionJobCancellationHelper
+{
+    public static bool IsTerminal(ExecutionJobStatus status)
+        => status is ExecutionJobStatus.Succeeded
+            or ExecutionJobStatus.Failed
+            or ExecutionJobStatus.Cancelled;
+
+    public static async Task<ExecutionJobCancellationResult> TryApplyAsync(
+        IExecutionJobStore jobStore,
+        string operationId,
+        ExecutionJobRecord initialJob,
+        string cancelledPhase,
+        int maxAttempts = 3,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(jobStore);
+        ArgumentException.ThrowIfNullOrWhiteSpace(operationId);
+
+        var current = initialJob;
+
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            if (current.Status == ExecutionJobStatus.Cancelled)
+            {
+                return new(ExecutionJobCancellationState.Cancelled, current);
+            }
+
+            if (IsTerminal(current.Status))
+            {
+                return new(ExecutionJobCancellationState.TerminalConflict, current);
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            if (current.ClaimedBy != null)
+            {
+                if (current.CancellationRequestedAt.HasValue)
+                {
+                    return new(ExecutionJobCancellationState.CancellationRequested, current);
+                }
+
+                var requested = current with
+                {
+                    CancellationRequestedAt = now,
+                    UpdatedAt = now
+                };
+
+                if (await jobStore.TrySetAsync(requested, cancellationToken: cancellationToken).ConfigureAwait(false))
+                {
+                    return new(ExecutionJobCancellationState.CancellationRequested, requested);
+                }
+            }
+            else
+            {
+                var cancelled = current with
+                {
+                    Status = ExecutionJobStatus.Cancelled,
+                    UpdatedAt = now,
+                    CompletedAt = now,
+                    CurrentPhase = cancelledPhase
+                };
+
+                if (await jobStore.TrySetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false))
+                {
+                    return new(ExecutionJobCancellationState.Cancelled, cancelled);
+                }
+            }
+
+            current = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+            if (current == null)
+            {
+                return new(ExecutionJobCancellationState.Missing, null);
+            }
+        }
+
+        if (current.Status == ExecutionJobStatus.Cancelled)
+        {
+            return new(ExecutionJobCancellationState.Cancelled, current);
+        }
+
+        if (IsTerminal(current.Status))
+        {
+            return new(ExecutionJobCancellationState.TerminalConflict, current);
+        }
+
+        if (current.ClaimedBy != null && current.CancellationRequestedAt.HasValue)
+        {
+            return new(ExecutionJobCancellationState.CancellationRequested, current);
+        }
+
+        return new(ExecutionJobCancellationState.Unconfirmed, current);
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/ExecutionJobCancellationTokens.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/ExecutionJobCancellationTokens.cs
@@ -49,6 +49,28 @@ internal sealed class ExecutionJobCancellationTokens : IJobCancellationNotifier
     }
 
     /// <summary>
+    /// Cancels and removes the tracked token source for the specified job.
+    /// Used by the reconciliation service to clean up stale tokens when a job
+    /// is requeued or terminally failed, ensuring that subsequent
+    /// <see cref="Cancel"/> calls do not return a false positive for a
+    /// token that no longer corresponds to an active execution.
+    /// </summary>
+    public void Revoke(string jobId)
+    {
+        if (_tokens.TryRemove(jobId, out var cts))
+        {
+            try
+            {
+                cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The execution service disposed the CTS — the job already completed.
+            }
+        }
+    }
+
+    /// <summary>
     /// Removes the tracked token source after job completion or cancellation.
     /// </summary>
     public void Remove(string jobId)

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/ExecutionJobCancellationTokens.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/ExecutionJobCancellationTokens.cs
@@ -32,7 +32,13 @@ internal sealed class ExecutionJobCancellationTokens : IJobCancellationNotifier
     public CancellationTokenSource CreateLinkedTokenSource(string jobId, string claimHandle, params CancellationToken[] linkedTokens)
     {
         var cts = CancellationTokenSource.CreateLinkedTokenSource(linkedTokens);
-        _tokens[jobId] = new CancellationEntry(cts, claimHandle);
+        var newEntry = new CancellationEntry(cts, claimHandle);
+        _tokens.AddOrUpdate(jobId, newEntry, (_, existing) =>
+        {
+            try { existing.Cts.Cancel(); }
+            catch (ObjectDisposedException) { }
+            return newEntry;
+        });
         return cts;
     }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/ExecutionJobCancellationTokens.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/ExecutionJobCancellationTokens.cs
@@ -11,30 +11,39 @@ namespace Honua.Server.Features.Infrastructure.ControlPlane;
 /// work can be aborted when a job is cancelled via the API or admin endpoint.
 /// Follows the same pattern as <c>PrintJobCancellationTokens</c>.
 /// </summary>
+/// <remarks>
+/// Each tracked entry stores a claim handle (typically the workerId) alongside the CTS.
+/// <see cref="Remove"/> and <see cref="Revoke"/> only act when the caller's claim handle
+/// matches the tracked entry, preventing a stale worker's cleanup from removing a CTS
+/// registered by a new worker that reclaimed the same job after a requeue.
+/// </remarks>
 internal sealed class ExecutionJobCancellationTokens : IJobCancellationNotifier
 {
-    private readonly ConcurrentDictionary<string, CancellationTokenSource> _tokens = new(StringComparer.Ordinal);
+    private sealed record CancellationEntry(CancellationTokenSource Cts, string ClaimHandle);
+
+    private readonly ConcurrentDictionary<string, CancellationEntry> _tokens = new(StringComparer.Ordinal);
 
     /// <summary>
-    /// Creates a linked <see cref="CancellationTokenSource"/> for the job and tracks it.
+    /// Creates a linked <see cref="CancellationTokenSource"/> for the job and tracks it
+    /// alongside <paramref name="claimHandle"/>.
     /// The returned source is linked to the supplied tokens so host shutdown and timeout
     /// also cancel job work.
     /// </summary>
-    public CancellationTokenSource CreateLinkedTokenSource(string jobId, params CancellationToken[] linkedTokens)
+    public CancellationTokenSource CreateLinkedTokenSource(string jobId, string claimHandle, params CancellationToken[] linkedTokens)
     {
         var cts = CancellationTokenSource.CreateLinkedTokenSource(linkedTokens);
-        _tokens[jobId] = cts;
+        _tokens[jobId] = new CancellationEntry(cts, claimHandle);
         return cts;
     }
 
     /// <inheritdoc />
     public bool Cancel(string jobId)
     {
-        if (_tokens.TryGetValue(jobId, out var cts))
+        if (_tokens.TryGetValue(jobId, out var entry))
         {
             try
             {
-                cts.Cancel();
+                entry.Cts.Cancel();
                 return true;
             }
             catch (ObjectDisposedException)
@@ -49,32 +58,62 @@ internal sealed class ExecutionJobCancellationTokens : IJobCancellationNotifier
     }
 
     /// <summary>
-    /// Cancels and removes the tracked token source for the specified job.
+    /// Cancels and removes the tracked token source for the specified job, but only
+    /// when the tracked entry's claim handle matches <paramref name="claimHandle"/>.
     /// Used by the reconciliation service to clean up stale tokens when a job
     /// is requeued or terminally failed, ensuring that subsequent
     /// <see cref="Cancel"/> calls do not return a false positive for a
     /// token that no longer corresponds to an active execution.
     /// </summary>
-    public void Revoke(string jobId)
+    /// <remarks>
+    /// If a new worker has already registered a CTS for this job (different claim handle),
+    /// this method is a no-op — the new worker's CTS is preserved.
+    /// </remarks>
+    public void Revoke(string jobId, string claimHandle)
     {
-        if (_tokens.TryRemove(jobId, out var cts))
+        if (_tokens.TryGetValue(jobId, out var entry) && entry.ClaimHandle == claimHandle)
         {
-            try
+            // Atomic compare-and-remove: only succeeds when the entry (CTS reference +
+            // handle) still matches, preventing removal of a CTS registered by a new claim.
+            // CancellationEntry is a record — equality includes CTS reference equality,
+            // so a replacement entry with a different CTS instance will not match.
+            if (TryRemoveEntry(jobId, entry))
             {
-                cts.Cancel();
-            }
-            catch (ObjectDisposedException)
-            {
-                // The execution service disposed the CTS — the job already completed.
+                try
+                {
+                    entry.Cts.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The execution service disposed the CTS — the job already completed.
+                }
             }
         }
     }
 
     /// <summary>
-    /// Removes the tracked token source after job completion or cancellation.
+    /// Removes the tracked token source after job completion or cancellation, but only
+    /// when the tracked entry's claim handle matches <paramref name="claimHandle"/>.
     /// </summary>
-    public void Remove(string jobId)
+    /// <remarks>
+    /// If a new worker reclaimed the job and registered a fresh CTS between the requeue
+    /// and this cleanup, the new entry is preserved.
+    /// </remarks>
+    public void Remove(string jobId, string claimHandle)
     {
-        _tokens.TryRemove(jobId, out _);
+        if (_tokens.TryGetValue(jobId, out var entry) && entry.ClaimHandle == claimHandle)
+        {
+            TryRemoveEntry(jobId, entry);
+        }
     }
+
+    /// <summary>
+    /// Atomic compare-and-remove via <see cref="ICollection{T}.Remove(T)"/> on the
+    /// concurrent dictionary. Only succeeds when the value at <paramref name="jobId"/>
+    /// is still the same instance — if another thread replaced the entry between
+    /// the caller's <c>TryGetValue</c> and this call, the removal is a no-op.
+    /// </summary>
+    private bool TryRemoveEntry(string jobId, CancellationEntry expectedEntry)
+        => ((ICollection<KeyValuePair<string, CancellationEntry>>)_tokens)
+            .Remove(new KeyValuePair<string, CancellationEntry>(jobId, expectedEntry));
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/ExecutionJobCancellationTokens.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/ExecutionJobCancellationTokens.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using Honua.Core.Features.Infrastructure.Abstractions;
+
+namespace Honua.Server.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Tracks per-job cancellation token sources for execution jobs so that in-flight
+/// work can be aborted when a job is cancelled via the API or admin endpoint.
+/// Follows the same pattern as <c>PrintJobCancellationTokens</c>.
+/// </summary>
+internal sealed class ExecutionJobCancellationTokens : IJobCancellationNotifier
+{
+    private readonly ConcurrentDictionary<string, CancellationTokenSource> _tokens = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Creates a linked <see cref="CancellationTokenSource"/> for the job and tracks it.
+    /// The returned source is linked to the supplied tokens so host shutdown and timeout
+    /// also cancel job work.
+    /// </summary>
+    public CancellationTokenSource CreateLinkedTokenSource(string jobId, params CancellationToken[] linkedTokens)
+    {
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(linkedTokens);
+        _tokens[jobId] = cts;
+        return cts;
+    }
+
+    /// <inheritdoc />
+    public bool Cancel(string jobId)
+    {
+        if (_tokens.TryGetValue(jobId, out var cts))
+        {
+            try
+            {
+                cts.Cancel();
+                return true;
+            }
+            catch (ObjectDisposedException)
+            {
+                // The execution service disposed the CTS between our TryGetValue
+                // and this Cancel call — the job already completed, so this is a no-op.
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Removes the tracked token source after job completion or cancellation.
+    /// </summary>
+    public void Remove(string jobId)
+    {
+        _tokens.TryRemove(jobId, out _);
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/ExecutionJobSubmissionHelper.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/ExecutionJobSubmissionHelper.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Server.Features.Infrastructure.ControlPlane;
+
+internal static class ExecutionJobSubmissionHelper
+{
+    internal const string SubmissionFailurePhase = "Failed (submission)";
+    internal const string SubmissionFailureMessage = "Submission failed: progress or queue persistence error.";
+
+    public static async Task TryRollbackCreatedJobAsync(
+        IExecutionJobStore jobStore,
+        string operationId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(jobStore);
+        ArgumentException.ThrowIfNullOrWhiteSpace(operationId);
+
+        try
+        {
+            var current = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+            if (current == null || current.Status != ExecutionJobStatus.Queued)
+            {
+                return;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            var failedJob = current with
+            {
+                Status = ExecutionJobStatus.Failed,
+                UpdatedAt = now,
+                CompletedAt = now,
+                ErrorMessage = SubmissionFailureMessage,
+                CurrentPhase = SubmissionFailurePhase
+            };
+
+            await jobStore.TrySetAsync(failedJob, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort rollback; job TTL or manual intervention will repair.
+        }
+    }
+
+    public static bool IsSubmissionRollback(ExecutionJobRecord job)
+        => job.Status == ExecutionJobStatus.Failed
+            && string.Equals(job.CurrentPhase, SubmissionFailurePhase, StringComparison.Ordinal);
+}

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -92,6 +92,15 @@ internal sealed partial class JobExecutionService(
             return;
         }
 
+        // Register the per-job CTS before the ownership re-check and Running
+        // transition so that operator cancellation arriving from this point is
+        // delivered through the token rather than as a direct store write that
+        // the subsequent Running transition could overwrite.
+        var timeoutPolicy = job.TimeoutPolicy ?? JobTimeoutPolicy.Default;
+        using var timeoutCts = new CancellationTokenSource(timeoutPolicy.MaxDuration);
+        using var jobCts = cancellationTokens.CreateLinkedTokenSource(
+            operationId, stoppingToken, timeoutCts.Token);
+
         // Re-read before promoting to Running to catch cancellations that arrived
         // after the claim but before the worker registered its CTS.
         job = await jobStore.GetAsync(operationId, stoppingToken).ConfigureAwait(false);
@@ -102,6 +111,7 @@ internal sealed partial class JobExecutionService(
                 Log.TerminalStateSkipped(logger, operationId, job.Status.ToString());
             }
 
+            cancellationTokens.Remove(operationId);
             await jobQueue.RemoveAsync(operationId, stoppingToken).ConfigureAwait(false);
             return;
         }
@@ -118,15 +128,6 @@ internal sealed partial class JobExecutionService(
         await jobStore.SetAsync(running, cancellationToken: stoppingToken).ConfigureAwait(false);
 
         Log.JobExecutionStarted(logger, operationId, executor.Kind.ToString());
-
-        // Separate timeout CTS so we can distinguish timeout from operator cancellation.
-        var timeoutPolicy = job.TimeoutPolicy ?? JobTimeoutPolicy.Default;
-        using var timeoutCts = new CancellationTokenSource(timeoutPolicy.MaxDuration);
-
-        // Register with cancellation token registry so operator cancellation can reach us.
-        // The linked CTS combines host stopping, timeout, and operator cancellation.
-        using var jobCts = cancellationTokens.CreateLinkedTokenSource(
-            operationId, stoppingToken, timeoutCts.Token);
 
         // Create execution context with heartbeat pump.
         using var context = new JobExecutionContext(

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -99,14 +99,14 @@ internal sealed partial class JobExecutionService(
         var timeoutPolicy = job.TimeoutPolicy ?? JobTimeoutPolicy.Default;
         using var timeoutCts = new CancellationTokenSource(timeoutPolicy.MaxDuration);
         using var jobCts = cancellationTokens.CreateLinkedTokenSource(
-            operationId, stoppingToken, timeoutCts.Token);
+            operationId, workerId, stoppingToken, timeoutCts.Token);
 
         // Re-read before promoting to Running to catch cancellations that arrived
         // after the claim but before the worker registered its CTS.
         job = await jobStore.GetAsync(operationId, stoppingToken).ConfigureAwait(false);
         if (job == null)
         {
-            cancellationTokens.Remove(operationId);
+            cancellationTokens.Remove(operationId, workerId);
             await jobQueue.RemoveAsync(operationId, stoppingToken).ConfigureAwait(false);
             return;
         }
@@ -114,7 +114,7 @@ internal sealed partial class JobExecutionService(
         if (IsTerminalOrNotOwnedBy(job, workerId))
         {
             Log.TerminalStateSkipped(logger, operationId, job.Status.ToString());
-            cancellationTokens.Remove(operationId);
+            cancellationTokens.Remove(operationId, workerId);
 
             // Only remove the queue entry for terminal jobs. Requeued or reclaimed
             // jobs have a queue entry that belongs to the new attempt.
@@ -216,7 +216,7 @@ internal sealed partial class JobExecutionService(
         }
         finally
         {
-            cancellationTokens.Remove(operationId);
+            cancellationTokens.Remove(operationId, workerId);
         }
     }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -16,6 +16,7 @@ internal sealed partial class JobExecutionService(
     IExecutionJobStore jobStore,
     IEnumerable<IJobExecutor> executors,
     ExecutionJobCancellationTokens cancellationTokens,
+    IEnumerable<IJobTerminalCallback> terminalCallbacks,
     IExecutionLogStore? logStore,
     ILogger<JobExecutionService> logger) : BackgroundService
 {
@@ -311,6 +312,7 @@ internal sealed partial class JobExecutionService(
             await logStore.SetRetentionAsync(operationId, LogRetention, cancellationToken).ConfigureAwait(false);
         }
 
+        await NotifyTerminalAsync(final, cancellationToken).ConfigureAwait(false);
         Log.JobExecutionCompleted(logger, operationId, result.Status.ToString());
     }
 
@@ -352,6 +354,7 @@ internal sealed partial class JobExecutionService(
             await logStore.SetRetentionAsync(operationId, LogRetention, cancellationToken).ConfigureAwait(false);
         }
 
+        await NotifyTerminalAsync(terminal, cancellationToken).ConfigureAwait(false);
         Log.JobExecutionCompleted(logger, operationId, terminalStatus.ToString());
     }
 
@@ -394,6 +397,7 @@ internal sealed partial class JobExecutionService(
                 await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
             }
 
+            await NotifyTerminalAsync(cancelled, cancellationToken).ConfigureAwait(false);
             return;
         }
 
@@ -479,6 +483,23 @@ internal sealed partial class JobExecutionService(
             if (logStore != null)
             {
                 await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+            }
+
+            await NotifyTerminalAsync(failed, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task NotifyTerminalAsync(ExecutionJobRecord job, CancellationToken cancellationToken)
+    {
+        foreach (var callback in terminalCallbacks)
+        {
+            try
+            {
+                await callback.OnTerminalAsync(job, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.TerminalCallbackFailed(logger, job.OperationId, ex);
             }
         }
     }
@@ -574,6 +595,9 @@ internal sealed partial class JobExecutionService(
 
         [LoggerMessage(9068, LogLevel.Information, "Abandon honoured durable cancellation signal for job {OperationId}")]
         public static partial void AbandonHonouredDurableCancellation(ILogger logger, string operationId);
+
+        [LoggerMessage(9069, LogLevel.Warning, "Terminal callback failed for job {OperationId}; admin progress may be stale")]
+        public static partial void TerminalCallbackFailed(ILogger logger, string operationId, Exception exception);
     }
 }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -141,7 +141,7 @@ internal sealed partial class JobExecutionService(
 
         // Create execution context with heartbeat pump.
         using var context = new JobExecutionContext(
-            operationId, workerId, jobStore, logStore, job.HeartbeatPolicy ?? JobHeartbeatPolicy.Default);
+            operationId, workerId, jobStore, logStore, job.HeartbeatPolicy ?? JobHeartbeatPolicy.Default, logger);
 
         // Start heartbeat pump in background.
         using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(jobCts.Token);
@@ -159,6 +159,10 @@ internal sealed partial class JobExecutionService(
             catch (OperationCanceledException)
             {
                 // Expected when cancellation reaches the pump.
+            }
+            catch (Exception ex)
+            {
+                Log.HeartbeatPumpFaulted(logger, operationId, ex);
             }
         }
 
@@ -452,6 +456,9 @@ internal sealed partial class JobExecutionService(
 
         [LoggerMessage(9062, LogLevel.Warning, "Skipping state transition for job {OperationId}: current status is {Status} (reconciler or another worker intervened)")]
         public static partial void TerminalStateSkipped(ILogger logger, string operationId, string status);
+
+        [LoggerMessage(9063, LogLevel.Warning, "Heartbeat pump faulted for job {OperationId}; finalization will proceed from executor outcome")]
+        public static partial void HeartbeatPumpFaulted(ILogger logger, string operationId, Exception exception);
     }
 }
 
@@ -461,12 +468,13 @@ internal sealed partial class JobExecutionService(
 /// Serializes read-modify-write operations on the job record to prevent concurrent
 /// heartbeat, progress, and artifact writes from clobbering each other.
 /// </summary>
-internal sealed class JobExecutionContext(
+internal sealed partial class JobExecutionContext(
     string operationId,
     string workerId,
     IExecutionJobStore jobStore,
     IExecutionLogStore? logStore,
-    JobHeartbeatPolicy heartbeatPolicy) : IJobExecutionContext, IDisposable
+    JobHeartbeatPolicy heartbeatPolicy,
+    ILogger logger) : IJobExecutionContext, IDisposable
 {
     private readonly SemaphoreSlim _writeLock = new(1, 1);
 
@@ -605,12 +613,22 @@ internal sealed class JobExecutionContext(
             {
                 break;
             }
+            catch (Exception ex)
+            {
+                Log.HeartbeatWriteFailed(logger, operationId, ex);
+            }
         }
     }
 
     private bool IsOwnedBy(ExecutionJobRecord job)
         => job.Status is ExecutionJobStatus.Provisioning or ExecutionJobStatus.Running
            && job.ClaimedBy == workerId;
+
+    private static partial class Log
+    {
+        [LoggerMessage(9064, LogLevel.Warning, "Heartbeat write failed for job {OperationId}; pump will retry on next interval")]
+        public static partial void HeartbeatWriteFailed(ILogger logger, string operationId, Exception exception);
+    }
 
     public void Dispose() => _writeLock.Dispose();
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -88,7 +88,7 @@ internal sealed partial class JobExecutionService(
         if (!_executorMap.TryGetValue(job.Spec.Kind, out var executor))
         {
             Log.NoExecutorForKind(logger, operationId, job.Spec.Kind.ToString());
-            await AbandonJobAsync(job, "No executor registered for job kind.", stoppingToken).ConfigureAwait(false);
+            await AbandonJobAsync(job, workerId, "No executor registered for job kind.", stoppingToken).ConfigureAwait(false);
             return;
         }
 
@@ -119,7 +119,7 @@ internal sealed partial class JobExecutionService(
             operationId, jobStore, logStore, job.HeartbeatPolicy ?? JobHeartbeatPolicy.Default);
 
         // Start heartbeat pump in background.
-        using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+        using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(jobCts.Token);
         var heartbeatTask = context.RunHeartbeatPumpAsync(heartbeatCts.Token);
 
         // Stops the heartbeat pump and waits for it to finish so that no
@@ -144,12 +144,12 @@ internal sealed partial class JobExecutionService(
 
             if (result.Status == ExecutionJobStatus.Succeeded)
             {
-                await FinalizeJobAsync(operationId, result, stoppingToken).ConfigureAwait(false);
+                await FinalizeJobAsync(operationId, workerId, result, CancellationToken.None).ConfigureAwait(false);
             }
             else
             {
                 // Executor returned failure — route through retry policy.
-                await AbandonJobAsync(running, result.ErrorMessage ?? "Execution failed.", stoppingToken)
+                await AbandonJobAsync(running, workerId, result.ErrorMessage ?? "Execution failed.", CancellationToken.None)
                     .ConfigureAwait(false);
             }
         }
@@ -159,14 +159,14 @@ internal sealed partial class JobExecutionService(
             // Worker is shutting down; abandon the job so it can be retried.
             // Use CancellationToken.None so store/queue cleanup can complete
             // after the host stopping signal has fired.
-            await AbandonJobAsync(running, "Worker shutdown.", CancellationToken.None).ConfigureAwait(false);
+            await AbandonJobAsync(running, workerId, "Worker shutdown.", CancellationToken.None).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
             await StopHeartbeatPumpAsync().ConfigureAwait(false);
             Log.JobTimedOut(logger, operationId, timeoutPolicy.MaxDuration);
             // Timeout — terminal failure, do not retry.
-            await TerminateJobAsync(operationId, ExecutionJobStatus.Failed,
+            await TerminateJobAsync(operationId, workerId, ExecutionJobStatus.Failed,
                 $"Execution timed out after {timeoutPolicy.MaxDuration}.", CancellationToken.None)
                 .ConfigureAwait(false);
         }
@@ -175,7 +175,7 @@ internal sealed partial class JobExecutionService(
             await StopHeartbeatPumpAsync().ConfigureAwait(false);
             Log.JobCancelledByOperator(logger, operationId);
             // Operator cancellation — terminal cancelled state.
-            await TerminateJobAsync(operationId, ExecutionJobStatus.Cancelled,
+            await TerminateJobAsync(operationId, workerId, ExecutionJobStatus.Cancelled,
                 "Cancelled by operator.", CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception ex)
@@ -183,7 +183,7 @@ internal sealed partial class JobExecutionService(
             await StopHeartbeatPumpAsync().ConfigureAwait(false);
             Log.JobExecutionFailed(logger, operationId, ex);
             // Execution exception — route through retry policy.
-            await AbandonJobAsync(running, ex.Message, stoppingToken).ConfigureAwait(false);
+            await AbandonJobAsync(running, workerId, ex.Message, CancellationToken.None).ConfigureAwait(false);
         }
         finally
         {
@@ -193,12 +193,19 @@ internal sealed partial class JobExecutionService(
 
     private async Task FinalizeJobAsync(
         string operationId,
+        string workerId,
         JobExecutionResult result,
         CancellationToken cancellationToken)
     {
         var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
         if (job == null)
         {
+            return;
+        }
+
+        if (IsTerminalOrNotOwnedBy(job, workerId))
+        {
+            Log.TerminalStateSkipped(logger, operationId, job.Status.ToString());
             return;
         }
 
@@ -227,6 +234,7 @@ internal sealed partial class JobExecutionService(
 
     private async Task TerminateJobAsync(
         string operationId,
+        string workerId,
         ExecutionJobStatus terminalStatus,
         string reason,
         CancellationToken cancellationToken)
@@ -234,6 +242,12 @@ internal sealed partial class JobExecutionService(
         var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
         if (job == null)
         {
+            return;
+        }
+
+        if (IsTerminalOrNotOwnedBy(job, workerId))
+        {
+            Log.TerminalStateSkipped(logger, operationId, job.Status.ToString());
             return;
         }
 
@@ -260,11 +274,19 @@ internal sealed partial class JobExecutionService(
 
     private async Task AbandonJobAsync(
         ExecutionJobRecord job,
+        string workerId,
         string reason,
         CancellationToken cancellationToken)
     {
         // Re-read to capture progress and artifact updates made during execution.
         var current = await jobStore.GetAsync(job.OperationId, cancellationToken).ConfigureAwait(false) ?? job;
+
+        if (IsTerminalOrNotOwnedBy(current, workerId))
+        {
+            Log.TerminalStateSkipped(logger, current.OperationId, current.Status.ToString());
+            return;
+        }
+
         var retryPolicy = current.RetryPolicy ?? JobRetryPolicy.Default;
 
         if (retryPolicy.ShouldRetry(current.AttemptCount))
@@ -312,6 +334,16 @@ internal sealed partial class JobExecutionService(
         }
     }
 
+    /// <summary>
+    /// Returns <c>true</c> when the job record is no longer in an active state owned
+    /// by <paramref name="workerId"/>, indicating that the reconciler or another
+    /// worker has already transitioned the job. Callers should skip their own
+    /// state transition to avoid overwriting the authoritative update.
+    /// </summary>
+    private static bool IsTerminalOrNotOwnedBy(ExecutionJobRecord job, string workerId)
+        => job.Status is not (ExecutionJobStatus.Provisioning or ExecutionJobStatus.Running)
+           || job.ClaimedBy != workerId;
+
     private static partial class Log
     {
         [LoggerMessage(9050, LogLevel.Information, "Job execution worker started: {WorkerId}")]
@@ -349,6 +381,9 @@ internal sealed partial class JobExecutionService(
 
         [LoggerMessage(9061, LogLevel.Warning, "No job executors registered for worker {WorkerId}; claim loop will not match any jobs")]
         public static partial void NoExecutorsRegistered(ILogger logger, string workerId);
+
+        [LoggerMessage(9062, LogLevel.Warning, "Skipping state transition for job {OperationId}: current status is {Status} (reconciler or another worker intervened)")]
+        public static partial void TerminalStateSkipped(ILogger logger, string operationId, string status);
     }
 }
 
@@ -458,6 +493,14 @@ internal sealed class JobExecutionContext(
                 {
                     var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
                     if (job == null)
+                    {
+                        break;
+                    }
+
+                    // Stop pumping if the reconciler already marked this job terminal.
+                    if (job.Status is ExecutionJobStatus.Succeeded
+                        or ExecutionJobStatus.Failed
+                        or ExecutionJobStatus.Cancelled)
                     {
                         break;
                     }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -440,14 +440,21 @@ internal sealed partial class JobExecutionService(
     /// the 48-character budget.
     /// </summary>
     internal static string GenerateWorkerId()
+        => GenerateWorkerId(Environment.MachineName, Guid.NewGuid());
+
+    internal static string GenerateWorkerId(string machineName, Guid workerGuid)
     {
-        var guid = Guid.NewGuid().ToString("N");
-        var prefix = $"worker-{Environment.MachineName}";
+        var guid = workerGuid.ToString("N");
+        var safeMachineName = string.IsNullOrWhiteSpace(machineName) ? "unknown" : machineName;
+        var prefix = $"worker-{safeMachineName}";
         const int maxLength = 48;
         const int separatorLength = 1;
         var maxPrefixLength = maxLength - guid.Length - separatorLength;
         if (prefix.Length > maxPrefixLength)
+        {
             prefix = prefix[..maxPrefixLength];
+        }
+
         return $"{prefix}-{guid}";
     }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -291,6 +291,7 @@ internal sealed partial class JobExecutionService(
         };
 
         await jobStore.SetAsync(final, cancellationToken: cancellationToken).ConfigureAwait(false);
+        cancellationTokens.Remove(operationId, workerId);
         await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
 
         if (logStore != null)
@@ -331,6 +332,7 @@ internal sealed partial class JobExecutionService(
         };
 
         await jobStore.SetAsync(terminal, cancellationToken: cancellationToken).ConfigureAwait(false);
+        cancellationTokens.Remove(operationId, workerId);
         await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
 
         if (logStore != null)
@@ -409,20 +411,17 @@ internal sealed partial class JobExecutionService(
             };
             await jobStore.SetAsync(abandoned, cancellationToken: cancellationToken).ConfigureAwait(false);
 
+            // Clear the tracked CTS immediately after the authoritative store
+            // transition to Queued, before the queue write. If RequeueAsync
+            // fails, cancel paths will not delegate to the dead worker and
+            // the stale-claim reconciler will repair the queue state.
+            cancellationTokens.Remove(current.OperationId, workerId);
+
             await jobQueue.RequeueAsync(
                 current.OperationId,
                 current.Priority,
                 delay > TimeSpan.Zero ? delay : null,
                 cancellationToken).ConfigureAwait(false);
-
-            // Clear the tracked CTS immediately so that Cancel() returns false
-            // for a job this worker no longer owns. Without this, a cancel
-            // arriving between requeue and the ProcessJobAsync finally block
-            // would be delegated to a worker that already dropped ownership,
-            // causing the cancellation to be silently swallowed while the
-            // retried job stays queued. The finally-block Remove is retained
-            // as a no-op safety net.
-            cancellationTokens.Remove(current.OperationId, workerId);
         }
         else
         {
@@ -437,6 +436,7 @@ internal sealed partial class JobExecutionService(
                 CurrentPhase = "Failed (abandoned)"
             };
             await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
+            cancellationTokens.Remove(current.OperationId, workerId);
             await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
 
             if (logStore != null)

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -92,6 +92,20 @@ internal sealed partial class JobExecutionService(
             return;
         }
 
+        // Re-read before promoting to Running to catch cancellations that arrived
+        // after the claim but before the worker registered its CTS.
+        job = await jobStore.GetAsync(operationId, stoppingToken).ConfigureAwait(false);
+        if (job == null || IsTerminalOrNotOwnedBy(job, workerId))
+        {
+            if (job != null)
+            {
+                Log.TerminalStateSkipped(logger, operationId, job.Status.ToString());
+            }
+
+            await jobQueue.RemoveAsync(operationId, stoppingToken).ConfigureAwait(false);
+            return;
+        }
+
         // Transition to Running.
         var now = DateTimeOffset.UtcNow;
         var running = job with

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -113,10 +113,25 @@ internal sealed partial class JobExecutionService(
         using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
         var heartbeatTask = context.RunHeartbeatPumpAsync(heartbeatCts.Token);
 
+        // Stops the heartbeat pump and waits for it to finish so that no
+        // in-flight heartbeat write can clobber the terminal-state update.
+        async Task StopHeartbeatPumpAsync()
+        {
+            await heartbeatCts.CancelAsync().ConfigureAwait(false);
+            try
+            {
+                await heartbeatTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when cancellation reaches the pump.
+            }
+        }
+
         try
         {
             var result = await executor.ExecuteAsync(running, context, jobCts.Token).ConfigureAwait(false);
-            await heartbeatCts.CancelAsync().ConfigureAwait(false);
+            await StopHeartbeatPumpAsync().ConfigureAwait(false);
 
             if (result.Status == ExecutionJobStatus.Succeeded)
             {
@@ -131,13 +146,13 @@ internal sealed partial class JobExecutionService(
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
-            await heartbeatCts.CancelAsync().ConfigureAwait(false);
+            await StopHeartbeatPumpAsync().ConfigureAwait(false);
             // Worker is shutting down; abandon the job so it can be retried.
             await AbandonJobAsync(running, "Worker shutdown.", stoppingToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
-            await heartbeatCts.CancelAsync().ConfigureAwait(false);
+            await StopHeartbeatPumpAsync().ConfigureAwait(false);
             Log.JobTimedOut(logger, operationId, timeoutPolicy.MaxDuration);
             // Timeout — terminal failure, do not retry.
             await TerminateJobAsync(operationId, ExecutionJobStatus.Failed,
@@ -146,7 +161,7 @@ internal sealed partial class JobExecutionService(
         }
         catch (OperationCanceledException)
         {
-            await heartbeatCts.CancelAsync().ConfigureAwait(false);
+            await StopHeartbeatPumpAsync().ConfigureAwait(false);
             Log.JobCancelledByOperator(logger, operationId);
             // Operator cancellation — terminal cancelled state.
             await TerminateJobAsync(operationId, ExecutionJobStatus.Cancelled,
@@ -154,7 +169,7 @@ internal sealed partial class JobExecutionService(
         }
         catch (Exception ex)
         {
-            await heartbeatCts.CancelAsync().ConfigureAwait(false);
+            await StopHeartbeatPumpAsync().ConfigureAwait(false);
             Log.JobExecutionFailed(logger, operationId, ex);
             // Execution exception — route through retry policy.
             await AbandonJobAsync(running, ex.Message, stoppingToken).ConfigureAwait(false);
@@ -162,16 +177,6 @@ internal sealed partial class JobExecutionService(
         finally
         {
             cancellationTokens.Remove(operationId);
-        }
-
-        // Ensure heartbeat pump stops cleanly.
-        try
-        {
-            await heartbeatTask.ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected.
         }
     }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -271,18 +271,25 @@ internal sealed partial class JobExecutionService(
         {
             Log.JobAbandoned(logger, current.OperationId, reason);
 
+            var delay = retryPolicy.ComputeDelay(current.AttemptCount + 1);
+            var now = DateTimeOffset.UtcNow;
             var abandoned = current with
             {
                 Status = ExecutionJobStatus.Queued,
                 ClaimedBy = null,
                 ClaimedAt = null,
                 LastHeartbeatAt = null,
-                UpdatedAt = DateTimeOffset.UtcNow,
-                CurrentPhase = $"Requeued: {reason}"
+                UpdatedAt = now,
+                CurrentPhase = $"Requeued: {reason}",
+                PercentComplete = null,
+                ErrorMessage = null,
+                ProviderOperationId = null,
+                CompletedAt = null,
+                ArtifactReferences = Array.Empty<string>(),
+                NextRetryAt = delay > TimeSpan.Zero ? now.Add(delay) : null
             };
             await jobStore.SetAsync(abandoned, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            var delay = retryPolicy.ComputeDelay(current.AttemptCount + 1);
             await jobQueue.RequeueAsync(
                 current.OperationId,
                 current.Priority,

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -380,6 +380,11 @@ internal sealed partial class JobExecutionService(
             };
             await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
             await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+
+            if (logStore != null)
+            {
+                await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -365,6 +365,15 @@ internal sealed partial class JobExecutionService(
                 current.Priority,
                 delay > TimeSpan.Zero ? delay : null,
                 cancellationToken).ConfigureAwait(false);
+
+            // Clear the tracked CTS immediately so that Cancel() returns false
+            // for a job this worker no longer owns. Without this, a cancel
+            // arriving between requeue and the ProcessJobAsync finally block
+            // would be delegated to a worker that already dropped ownership,
+            // causing the cancellation to be silently swallowed while the
+            // retried job stays queued. The finally-block Remove is retained
+            // as a no-op safety net.
+            cancellationTokens.Remove(current.OperationId, workerId);
         }
         else
         {

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -104,15 +104,25 @@ internal sealed partial class JobExecutionService(
         // Re-read before promoting to Running to catch cancellations that arrived
         // after the claim but before the worker registered its CTS.
         job = await jobStore.GetAsync(operationId, stoppingToken).ConfigureAwait(false);
-        if (job == null || IsTerminalOrNotOwnedBy(job, workerId))
+        if (job == null)
         {
-            if (job != null)
-            {
-                Log.TerminalStateSkipped(logger, operationId, job.Status.ToString());
-            }
-
             cancellationTokens.Remove(operationId);
             await jobQueue.RemoveAsync(operationId, stoppingToken).ConfigureAwait(false);
+            return;
+        }
+
+        if (IsTerminalOrNotOwnedBy(job, workerId))
+        {
+            Log.TerminalStateSkipped(logger, operationId, job.Status.ToString());
+            cancellationTokens.Remove(operationId);
+
+            // Only remove the queue entry for terminal jobs. Requeued or reclaimed
+            // jobs have a queue entry that belongs to the new attempt.
+            if (IsTerminal(job.Status))
+            {
+                await jobQueue.RemoveAsync(operationId, stoppingToken).ConfigureAwait(false);
+            }
+
             return;
         }
 
@@ -131,7 +141,7 @@ internal sealed partial class JobExecutionService(
 
         // Create execution context with heartbeat pump.
         using var context = new JobExecutionContext(
-            operationId, jobStore, logStore, job.HeartbeatPolicy ?? JobHeartbeatPolicy.Default);
+            operationId, workerId, jobStore, logStore, job.HeartbeatPolicy ?? JobHeartbeatPolicy.Default);
 
         // Start heartbeat pump in background.
         using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(jobCts.Token);
@@ -359,6 +369,11 @@ internal sealed partial class JobExecutionService(
         => job.Status is not (ExecutionJobStatus.Provisioning or ExecutionJobStatus.Running)
            || job.ClaimedBy != workerId;
 
+    private static bool IsTerminal(ExecutionJobStatus status)
+        => status is ExecutionJobStatus.Succeeded
+            or ExecutionJobStatus.Failed
+            or ExecutionJobStatus.Cancelled;
+
     private static partial class Log
     {
         [LoggerMessage(9050, LogLevel.Information, "Job execution worker started: {WorkerId}")]
@@ -410,6 +425,7 @@ internal sealed partial class JobExecutionService(
 /// </summary>
 internal sealed class JobExecutionContext(
     string operationId,
+    string workerId,
     IExecutionJobStore jobStore,
     IExecutionLogStore? logStore,
     JobHeartbeatPolicy heartbeatPolicy) : IJobExecutionContext, IDisposable
@@ -427,7 +443,7 @@ internal sealed class JobExecutionContext(
         try
         {
             var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-            if (job == null)
+            if (job == null || !IsOwnedBy(job))
             {
                 return;
             }
@@ -465,7 +481,7 @@ internal sealed class JobExecutionContext(
         try
         {
             var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-            if (job == null)
+            if (job == null || !IsOwnedBy(job))
             {
                 return;
             }
@@ -512,10 +528,9 @@ internal sealed class JobExecutionContext(
                         break;
                     }
 
-                    // Stop pumping if the reconciler already marked this job terminal.
-                    if (job.Status is ExecutionJobStatus.Succeeded
-                        or ExecutionJobStatus.Failed
-                        or ExecutionJobStatus.Cancelled)
+                    // Stop pumping if the reconciler already marked this job terminal
+                    // or ownership has moved to another worker.
+                    if (!IsOwnedBy(job))
                     {
                         break;
                     }
@@ -538,6 +553,10 @@ internal sealed class JobExecutionContext(
             }
         }
     }
+
+    private bool IsOwnedBy(ExecutionJobRecord job)
+        => job.Status is ExecutionJobStatus.Provisioning or ExecutionJobStatus.Running
+           && job.ClaimedBy == workerId;
 
     public void Dispose() => _writeLock.Dispose();
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -477,9 +477,26 @@ internal sealed partial class JobExecutionService(
                 }
             }
 
-            var delay = forceRequeue ? TimeSpan.Zero : retryPolicy.ComputeDelay(current.AttemptCount + 1);
+            // Re-read before the requeue write to catch cancellation signals
+            // that arrived during the log-append phase.
+            var latestBeforeRequeue = await jobStore.GetAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+            if (latestBeforeRequeue == null || IsTerminalOrNotOwnedBy(latestBeforeRequeue, workerId))
+            {
+                cancellationTokens.Remove(current.OperationId, workerId);
+                return;
+            }
+
+            if (latestBeforeRequeue.CancellationRequestedAt.HasValue)
+            {
+                Log.AbandonHonouredDurableCancellation(logger, current.OperationId);
+                await TerminateJobAsync(current.OperationId, workerId, ExecutionJobStatus.Cancelled,
+                    "Cancelled by operator (durable signal honoured during abandon).", cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            var delay = forceRequeue ? TimeSpan.Zero : retryPolicy.ComputeDelay(latestBeforeRequeue.AttemptCount + 1);
             var now = DateTimeOffset.UtcNow;
-            var abandoned = current with
+            var abandoned = latestBeforeRequeue with
             {
                 Status = ExecutionJobStatus.Queued,
                 ClaimedBy = null,
@@ -501,47 +518,63 @@ internal sealed partial class JobExecutionService(
             // transition to Queued, before the queue write. If RequeueAsync
             // fails, cancel paths will not delegate to the dead worker and
             // the stale-claim reconciler will repair the queue state.
-            cancellationTokens.Remove(current.OperationId, workerId);
+            cancellationTokens.Remove(latestBeforeRequeue.OperationId, workerId);
 
             await jobQueue.RequeueAsync(
-                current.OperationId,
-                current.Priority,
+                latestBeforeRequeue.OperationId,
+                latestBeforeRequeue.Priority,
                 delay > TimeSpan.Zero ? delay : null,
                 cancellationToken).ConfigureAwait(false);
         }
         else
         {
+            // Re-read before the fail write to catch late cancellation signals.
+            var latestBeforeFail = await jobStore.GetAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+            if (latestBeforeFail == null || IsTerminalOrNotOwnedBy(latestBeforeFail, workerId))
+            {
+                cancellationTokens.Remove(current.OperationId, workerId);
+                return;
+            }
+
+            if (latestBeforeFail.CancellationRequestedAt.HasValue)
+            {
+                Log.AbandonHonouredDurableCancellation(logger, current.OperationId);
+                await TerminateJobAsync(current.OperationId, workerId, ExecutionJobStatus.Cancelled,
+                    "Cancelled by operator (durable signal honoured during abandon).", cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
             var now = DateTimeOffset.UtcNow;
-            var failed = current with
+            var failed = latestBeforeFail with
             {
                 Status = ExecutionJobStatus.Failed,
                 UpdatedAt = now,
                 CompletedAt = now,
                 ErrorMessage = $"Job abandoned: {reason}",
-                Warnings = warnings ?? current.Warnings,
+                Warnings = warnings ?? latestBeforeFail.Warnings,
                 CurrentPhase = "Failed (abandoned)"
             };
             await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
-            cancellationTokens.Remove(current.OperationId, workerId);
+            cancellationTokens.Remove(latestBeforeFail.OperationId, workerId);
 
             try
             {
-                await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+                await jobQueue.RemoveAsync(latestBeforeFail.OperationId, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                Log.QueueRemovalFailed(logger, current.OperationId, ex);
+                Log.QueueRemovalFailed(logger, latestBeforeFail.OperationId, ex);
             }
 
             if (logStore != null)
             {
                 try
                 {
-                    await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+                    await logStore.SetRetentionAsync(latestBeforeFail.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
-                    Log.LogRetentionFailed(logger, current.OperationId, ex);
+                    Log.LogRetentionFailed(logger, latestBeforeFail.OperationId, ex);
                 }
             }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -102,7 +102,7 @@ internal sealed partial class JobExecutionService(
         jobCts.CancelAfter(timeoutPolicy.MaxDuration);
 
         // Create execution context with heartbeat pump.
-        var context = new JobExecutionContext(
+        using var context = new JobExecutionContext(
             operationId, jobStore, logStore, job.HeartbeatPolicy ?? JobHeartbeatPolicy.Default);
 
         // Start heartbeat pump in background.
@@ -114,7 +114,16 @@ internal sealed partial class JobExecutionService(
             var result = await executor.ExecuteAsync(running, context, jobCts.Token).ConfigureAwait(false);
             await heartbeatCts.CancelAsync().ConfigureAwait(false);
 
-            await FinalizeJobAsync(operationId, result, stoppingToken).ConfigureAwait(false);
+            if (result.Status == ExecutionJobStatus.Succeeded)
+            {
+                await FinalizeJobAsync(operationId, result, stoppingToken).ConfigureAwait(false);
+            }
+            else
+            {
+                // Executor returned failure — route through retry policy.
+                await AbandonJobAsync(running, result.ErrorMessage ?? "Execution failed.", stoppingToken)
+                    .ConfigureAwait(false);
+            }
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
@@ -125,16 +134,16 @@ internal sealed partial class JobExecutionService(
         catch (OperationCanceledException)
         {
             await heartbeatCts.CancelAsync().ConfigureAwait(false);
-            // Job was cancelled or timed out.
-            var cancelResult = JobExecutionResult.Failed("Job was cancelled or timed out.");
-            await FinalizeJobAsync(operationId, cancelResult, stoppingToken).ConfigureAwait(false);
+            // Timeout or cancellation — route through retry policy.
+            await AbandonJobAsync(running, "Job was cancelled or timed out.", stoppingToken)
+                .ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             await heartbeatCts.CancelAsync().ConfigureAwait(false);
             Log.JobExecutionFailed(logger, operationId, ex);
-            var failResult = JobExecutionResult.Failed(ex.Message);
-            await FinalizeJobAsync(operationId, failResult, stoppingToken).ConfigureAwait(false);
+            // Execution exception — route through retry policy.
+            await AbandonJobAsync(running, ex.Message, stoppingToken).ConfigureAwait(false);
         }
 
         // Ensure heartbeat pump stops cleanly.
@@ -187,13 +196,15 @@ internal sealed partial class JobExecutionService(
         string reason,
         CancellationToken cancellationToken)
     {
-        var retryPolicy = job.RetryPolicy ?? JobRetryPolicy.Default;
+        // Re-read to capture progress and artifact updates made during execution.
+        var current = await jobStore.GetAsync(job.OperationId, cancellationToken).ConfigureAwait(false) ?? job;
+        var retryPolicy = current.RetryPolicy ?? JobRetryPolicy.Default;
 
-        if (retryPolicy.ShouldRetry(job.AttemptCount))
+        if (retryPolicy.ShouldRetry(current.AttemptCount))
         {
-            Log.JobAbandoned(logger, job.OperationId, reason);
+            Log.JobAbandoned(logger, current.OperationId, reason);
 
-            var abandoned = job with
+            var abandoned = current with
             {
                 Status = ExecutionJobStatus.Queued,
                 ClaimedBy = null,
@@ -204,17 +215,17 @@ internal sealed partial class JobExecutionService(
             };
             await jobStore.SetAsync(abandoned, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            var delay = retryPolicy.ComputeDelay(job.AttemptCount + 1);
+            var delay = retryPolicy.ComputeDelay(current.AttemptCount + 1);
             await jobQueue.RequeueAsync(
-                job.OperationId,
-                job.Priority,
+                current.OperationId,
+                current.Priority,
                 delay > TimeSpan.Zero ? delay : null,
                 cancellationToken).ConfigureAwait(false);
         }
         else
         {
             var now = DateTimeOffset.UtcNow;
-            var failed = job with
+            var failed = current with
             {
                 Status = ExecutionJobStatus.Failed,
                 UpdatedAt = now,
@@ -223,7 +234,7 @@ internal sealed partial class JobExecutionService(
                 CurrentPhase = "Failed (abandoned)"
             };
             await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
-            await jobQueue.RemoveAsync(job.OperationId, cancellationToken).ConfigureAwait(false);
+            await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -261,13 +272,17 @@ internal sealed partial class JobExecutionService(
 /// <summary>
 /// Execution context provided to <see cref="IJobExecutor"/> during job execution.
 /// Mediates heartbeat pumping, progress reporting, log appending, and artifact publication.
+/// Serializes read-modify-write operations on the job record to prevent concurrent
+/// heartbeat, progress, and artifact writes from clobbering each other.
 /// </summary>
 internal sealed class JobExecutionContext(
     string operationId,
     IExecutionJobStore jobStore,
     IExecutionLogStore? logStore,
-    JobHeartbeatPolicy heartbeatPolicy) : IJobExecutionContext
+    JobHeartbeatPolicy heartbeatPolicy) : IJobExecutionContext, IDisposable
 {
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
     public string OperationId => operationId;
 
     public async Task ReportProgressAsync(
@@ -275,20 +290,28 @@ internal sealed class JobExecutionContext(
         string? phase,
         CancellationToken cancellationToken = default)
     {
-        var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-        if (job == null)
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            return;
-        }
+            var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+            if (job == null)
+            {
+                return;
+            }
 
-        var updated = job with
+            var updated = job with
+            {
+                PercentComplete = percentComplete,
+                CurrentPhase = phase ?? job.CurrentPhase,
+                UpdatedAt = DateTimeOffset.UtcNow,
+                LastHeartbeatAt = DateTimeOffset.UtcNow
+            };
+            await jobStore.SetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        finally
         {
-            PercentComplete = percentComplete,
-            CurrentPhase = phase ?? job.CurrentPhase,
-            UpdatedAt = DateTimeOffset.UtcNow,
-            LastHeartbeatAt = DateTimeOffset.UtcNow
-        };
-        await jobStore.SetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
+            _writeLock.Release();
+        }
     }
 
     public async Task AppendLogAsync(
@@ -305,20 +328,28 @@ internal sealed class JobExecutionContext(
         string artifactReference,
         CancellationToken cancellationToken = default)
     {
-        var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-        if (job == null)
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            return;
-        }
+            var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+            if (job == null)
+            {
+                return;
+            }
 
-        var refs = new List<string>(job.ArtifactReferences) { artifactReference };
-        var updated = job with
+            var refs = new List<string>(job.ArtifactReferences) { artifactReference };
+            var updated = job with
+            {
+                ArtifactReferences = refs,
+                UpdatedAt = DateTimeOffset.UtcNow,
+                LastHeartbeatAt = DateTimeOffset.UtcNow
+            };
+            await jobStore.SetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        finally
         {
-            ArtifactReferences = refs,
-            UpdatedAt = DateTimeOffset.UtcNow,
-            LastHeartbeatAt = DateTimeOffset.UtcNow
-        };
-        await jobStore.SetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
+            _writeLock.Release();
+        }
     }
 
     /// <summary>
@@ -339,18 +370,26 @@ internal sealed class JobExecutionContext(
 
             try
             {
-                var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-                if (job == null)
+                await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
                 {
-                    break;
-                }
+                    var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+                    if (job == null)
+                    {
+                        break;
+                    }
 
-                var updated = job with
+                    var updated = job with
+                    {
+                        LastHeartbeatAt = DateTimeOffset.UtcNow,
+                        UpdatedAt = DateTimeOffset.UtcNow
+                    };
+                    await jobStore.SetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                finally
                 {
-                    LastHeartbeatAt = DateTimeOffset.UtcNow,
-                    UpdatedAt = DateTimeOffset.UtcNow
-                };
-                await jobStore.SetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    _writeLock.Release();
+                }
             }
             catch (OperationCanceledException)
             {
@@ -358,4 +397,6 @@ internal sealed class JobExecutionContext(
             }
         }
     }
+
+    public void Dispose() => _writeLock.Dispose();
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -175,7 +175,8 @@ internal sealed partial class JobExecutionService(
             return;
         }
 
-        // Transition to Running.
+        // Transition to Running. Use CAS to prevent overwriting a concurrent
+        // cancel signal or terminal write that landed after the re-read above.
         var now = DateTimeOffset.UtcNow;
         var running = job with
         {
@@ -184,7 +185,12 @@ internal sealed partial class JobExecutionService(
             LastHeartbeatAt = now,
             CurrentPhase = "Running"
         };
-        await jobStore.SetAsync(running, cancellationToken: stoppingToken).ConfigureAwait(false);
+        if (!await jobStore.TrySetAsync(running, cancellationToken: stoppingToken).ConfigureAwait(false))
+        {
+            Log.TerminalStateSkipped(logger, operationId, "CAS conflict on Running transition");
+            cancellationTokens.Remove(operationId, workerId);
+            return;
+        }
 
         Log.JobExecutionStarted(logger, operationId, executor.Kind.ToString());
 
@@ -303,7 +309,13 @@ internal sealed partial class JobExecutionService(
             CurrentPhase = result.Status == ExecutionJobStatus.Succeeded ? "Completed" : "Failed"
         };
 
-        await jobStore.SetAsync(final, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!await jobStore.TrySetAsync(final, cancellationToken: cancellationToken).ConfigureAwait(false))
+        {
+            Log.TerminalStateSkipped(logger, operationId, "CAS conflict on finalize");
+            cancellationTokens.Remove(operationId, workerId);
+            return;
+        }
+
         cancellationTokens.Remove(operationId, workerId);
 
         try
@@ -360,7 +372,13 @@ internal sealed partial class JobExecutionService(
             CurrentPhase = terminalStatus == ExecutionJobStatus.Cancelled ? "Cancelled" : "Failed"
         };
 
-        await jobStore.SetAsync(terminal, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!await jobStore.TrySetAsync(terminal, cancellationToken: cancellationToken).ConfigureAwait(false))
+        {
+            Log.TerminalStateSkipped(logger, operationId, "CAS conflict on terminate");
+            cancellationTokens.Remove(operationId, workerId);
+            return;
+        }
+
         cancellationTokens.Remove(operationId, workerId);
 
         try
@@ -418,7 +436,12 @@ internal sealed partial class JobExecutionService(
                 ErrorMessage = "Cancelled by operator (durable signal honoured during abandon).",
                 CurrentPhase = "Cancelled"
             };
-            await jobStore.SetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (!await jobStore.TrySetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                cancellationTokens.Remove(current.OperationId, workerId);
+                return;
+            }
+
             cancellationTokens.Remove(current.OperationId, workerId);
 
             try
@@ -512,7 +535,11 @@ internal sealed partial class JobExecutionService(
                 Warnings = Array.Empty<string>(),
                 NextRetryAt = delay > TimeSpan.Zero ? now.Add(delay) : null
             };
-            await jobStore.SetAsync(abandoned, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (!await jobStore.TrySetAsync(abandoned, cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                cancellationTokens.Remove(latestBeforeRequeue.OperationId, workerId);
+                return;
+            }
 
             // Clear the tracked CTS immediately after the authoritative store
             // transition to Queued, before the queue write. If RequeueAsync
@@ -554,7 +581,12 @@ internal sealed partial class JobExecutionService(
                 Warnings = warnings ?? latestBeforeFail.Warnings,
                 CurrentPhase = "Failed (abandoned)"
             };
-            await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (!await jobStore.TrySetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                cancellationTokens.Remove(latestBeforeFail.OperationId, workerId);
+                return;
+            }
+
             cancellationTokens.Remove(latestBeforeFail.OperationId, workerId);
 
             try

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -372,6 +372,31 @@ internal sealed partial class JobExecutionService(
             return;
         }
 
+        if (current.CancellationRequestedAt.HasValue)
+        {
+            Log.AbandonHonouredDurableCancellation(logger, current.OperationId);
+
+            var cancelNow = DateTimeOffset.UtcNow;
+            var cancelled = current with
+            {
+                Status = ExecutionJobStatus.Cancelled,
+                UpdatedAt = cancelNow,
+                CompletedAt = cancelNow,
+                ErrorMessage = "Cancelled by operator (durable signal honoured during abandon).",
+                CurrentPhase = "Cancelled"
+            };
+            await jobStore.SetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false);
+            cancellationTokens.Remove(current.OperationId, workerId);
+            await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+
+            if (logStore != null)
+            {
+                await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+            }
+
+            return;
+        }
+
         var retryPolicy = current.RetryPolicy ?? JobRetryPolicy.Default;
 
         if (forceRequeue || retryPolicy.ShouldRetry(current.AttemptCount))
@@ -546,6 +571,9 @@ internal sealed partial class JobExecutionService(
 
         [LoggerMessage(9066, LogLevel.Error, "Failed to requeue job {OperationId} during pre-execution shutdown; stale-claim reconciliation will recover")]
         public static partial void PreExecShutdownCleanupFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9068, LogLevel.Information, "Abandon honoured durable cancellation signal for job {OperationId}")]
+        public static partial void AbandonHonouredDurableCancellation(ILogger logger, string operationId);
     }
 }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -330,17 +330,26 @@ internal sealed partial class JobExecutionService(
 
             // Persist per-attempt warnings to structured execution logs before
             // clearing them from the requeued record, so they remain observable.
+            // Best-effort: a transient log-store failure must not block the
+            // durable requeue/terminal transition.
             if (warnings is { Count: > 0 } && logStore != null)
             {
-                foreach (var warning in warnings)
+                try
                 {
-                    await logStore.AppendAsync(current.OperationId, new ExecutionLogEntry
+                    foreach (var warning in warnings)
                     {
-                        Timestamp = DateTimeOffset.UtcNow,
-                        Level = ExecutionLogLevel.Warning,
-                        Message = warning,
-                        Phase = $"Attempt {current.AttemptCount} (requeuing)"
-                    }, cancellationToken).ConfigureAwait(false);
+                        await logStore.AppendAsync(current.OperationId, new ExecutionLogEntry
+                        {
+                            Timestamp = DateTimeOffset.UtcNow,
+                            Level = ExecutionLogLevel.Warning,
+                            Message = warning,
+                            Phase = $"Attempt {current.AttemptCount} (requeuing)"
+                        }, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.WarningLogAppendFailed(logger, current.OperationId, ex);
                 }
             }
 
@@ -459,6 +468,9 @@ internal sealed partial class JobExecutionService(
 
         [LoggerMessage(9063, LogLevel.Warning, "Heartbeat pump faulted for job {OperationId}; finalization will proceed from executor outcome")]
         public static partial void HeartbeatPumpFaulted(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9065, LogLevel.Warning, "Failed to persist per-attempt warnings for job {OperationId}; requeue/terminal transition will proceed")]
+        public static partial void WarningLogAppendFailed(ILogger logger, string operationId, Exception exception);
     }
 }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -15,6 +15,7 @@ internal sealed partial class JobExecutionService(
     IJobQueue jobQueue,
     IExecutionJobStore jobStore,
     IEnumerable<IJobExecutor> executors,
+    ExecutionJobCancellationTokens cancellationTokens,
     IExecutionLogStore? logStore,
     ILogger<JobExecutionService> logger) : BackgroundService
 {
@@ -26,7 +27,8 @@ internal sealed partial class JobExecutionService(
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var workerId = $"worker-{Environment.MachineName}-{Guid.NewGuid():N}"[..48];
+        var raw = $"worker-{Environment.MachineName}-{Guid.NewGuid():N}";
+        var workerId = raw.Length > 48 ? raw[..48] : raw;
         Log.WorkerStarted(logger, workerId);
 
         while (!stoppingToken.IsCancellationRequested)
@@ -94,12 +96,14 @@ internal sealed partial class JobExecutionService(
 
         Log.JobExecutionStarted(logger, operationId, executor.Kind.ToString());
 
-        // Create cancellation that combines host stopping and per-job cancellation.
-        using var jobCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
-
-        // Set up timeout if configured.
+        // Separate timeout CTS so we can distinguish timeout from operator cancellation.
         var timeoutPolicy = job.TimeoutPolicy ?? JobTimeoutPolicy.Default;
-        jobCts.CancelAfter(timeoutPolicy.MaxDuration);
+        using var timeoutCts = new CancellationTokenSource(timeoutPolicy.MaxDuration);
+
+        // Register with cancellation token registry so operator cancellation can reach us.
+        // The linked CTS combines host stopping, timeout, and operator cancellation.
+        using var jobCts = cancellationTokens.CreateLinkedTokenSource(
+            operationId, stoppingToken, timeoutCts.Token);
 
         // Create execution context with heartbeat pump.
         using var context = new JobExecutionContext(
@@ -131,12 +135,22 @@ internal sealed partial class JobExecutionService(
             // Worker is shutting down; abandon the job so it can be retried.
             await AbandonJobAsync(running, "Worker shutdown.", stoppingToken).ConfigureAwait(false);
         }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            await heartbeatCts.CancelAsync().ConfigureAwait(false);
+            Log.JobTimedOut(logger, operationId, timeoutPolicy.MaxDuration);
+            // Timeout — terminal failure, do not retry.
+            await TerminateJobAsync(operationId, ExecutionJobStatus.Failed,
+                $"Execution timed out after {timeoutPolicy.MaxDuration}.", CancellationToken.None)
+                .ConfigureAwait(false);
+        }
         catch (OperationCanceledException)
         {
             await heartbeatCts.CancelAsync().ConfigureAwait(false);
-            // Timeout or cancellation — route through retry policy.
-            await AbandonJobAsync(running, "Job was cancelled or timed out.", stoppingToken)
-                .ConfigureAwait(false);
+            Log.JobCancelledByOperator(logger, operationId);
+            // Operator cancellation — terminal cancelled state.
+            await TerminateJobAsync(operationId, ExecutionJobStatus.Cancelled,
+                "Cancelled by operator.", CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -144,6 +158,10 @@ internal sealed partial class JobExecutionService(
             Log.JobExecutionFailed(logger, operationId, ex);
             // Execution exception — route through retry policy.
             await AbandonJobAsync(running, ex.Message, stoppingToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            cancellationTokens.Remove(operationId);
         }
 
         // Ensure heartbeat pump stops cleanly.
@@ -189,6 +207,39 @@ internal sealed partial class JobExecutionService(
         }
 
         Log.JobExecutionCompleted(logger, operationId, result.Status.ToString());
+    }
+
+    private async Task TerminateJobAsync(
+        string operationId,
+        ExecutionJobStatus terminalStatus,
+        string reason,
+        CancellationToken cancellationToken)
+    {
+        var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+        if (job == null)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var terminal = job with
+        {
+            Status = terminalStatus,
+            UpdatedAt = now,
+            CompletedAt = now,
+            ErrorMessage = reason,
+            CurrentPhase = terminalStatus == ExecutionJobStatus.Cancelled ? "Cancelled" : "Failed"
+        };
+
+        await jobStore.SetAsync(terminal, cancellationToken: cancellationToken).ConfigureAwait(false);
+        await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
+
+        if (logStore != null)
+        {
+            await logStore.SetRetentionAsync(operationId, LogRetention, cancellationToken).ConfigureAwait(false);
+        }
+
+        Log.JobExecutionCompleted(logger, operationId, terminalStatus.ToString());
     }
 
     private async Task AbandonJobAsync(
@@ -266,6 +317,12 @@ internal sealed partial class JobExecutionService(
 
         [LoggerMessage(9058, LogLevel.Error, "Claim loop error")]
         public static partial void ClaimLoopError(ILogger logger, Exception exception);
+
+        [LoggerMessage(9059, LogLevel.Warning, "Job timed out: {OperationId}, MaxDuration={MaxDuration}")]
+        public static partial void JobTimedOut(ILogger logger, string operationId, TimeSpan maxDuration);
+
+        [LoggerMessage(9060, LogLevel.Information, "Job cancelled by operator: {OperationId}")]
+        public static partial void JobCancelledByOperator(ILogger logger, string operationId);
     }
 }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -30,12 +30,21 @@ internal sealed partial class JobExecutionService(
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var raw = $"worker-{Environment.MachineName}-{Guid.NewGuid():N}";
-        var workerId = raw.Length > 48 ? raw[..48] : raw;
+        var workerId = GenerateWorkerId();
 
         if (_acceptedKinds.Count == 0)
         {
             Log.NoExecutorsRegistered(logger, workerId);
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+            }
+
+            Log.WorkerStopped(logger, workerId);
+            return;
         }
 
         Log.WorkerStarted(logger, workerId);
@@ -424,6 +433,23 @@ internal sealed partial class JobExecutionService(
         => status is ExecutionJobStatus.Succeeded
             or ExecutionJobStatus.Failed
             or ExecutionJobStatus.Cancelled;
+
+    /// <summary>
+    /// Builds a worker ID that always preserves the full GUID suffix for ownership
+    /// uniqueness, truncating the machine-name prefix when necessary to stay within
+    /// the 48-character budget.
+    /// </summary>
+    internal static string GenerateWorkerId()
+    {
+        var guid = Guid.NewGuid().ToString("N");
+        var prefix = $"worker-{Environment.MachineName}";
+        const int maxLength = 48;
+        const int separatorLength = 1;
+        var maxPrefixLength = maxLength - guid.Length - separatorLength;
+        if (prefix.Length > maxPrefixLength)
+            prefix = prefix[..maxPrefixLength];
+        return $"{prefix}-{guid}";
+    }
 
     private static partial class Log
     {

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -317,7 +317,14 @@ internal sealed partial class JobExecutionService(
 
         if (logStore != null)
         {
-            await logStore.SetRetentionAsync(operationId, LogRetention, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await logStore.SetRetentionAsync(operationId, LogRetention, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.LogRetentionFailed(logger, operationId, ex);
+            }
         }
 
         await NotifyTerminalAsync(final, cancellationToken).ConfigureAwait(false);
@@ -367,7 +374,14 @@ internal sealed partial class JobExecutionService(
 
         if (logStore != null)
         {
-            await logStore.SetRetentionAsync(operationId, LogRetention, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await logStore.SetRetentionAsync(operationId, LogRetention, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.LogRetentionFailed(logger, operationId, ex);
+            }
         }
 
         await NotifyTerminalAsync(terminal, cancellationToken).ConfigureAwait(false);
@@ -418,7 +432,14 @@ internal sealed partial class JobExecutionService(
 
             if (logStore != null)
             {
-                await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Log.LogRetentionFailed(logger, current.OperationId, ex);
+                }
             }
 
             await NotifyTerminalAsync(cancelled, cancellationToken).ConfigureAwait(false);
@@ -514,7 +535,14 @@ internal sealed partial class JobExecutionService(
 
             if (logStore != null)
             {
-                await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Log.LogRetentionFailed(logger, current.OperationId, ex);
+                }
             }
 
             await NotifyTerminalAsync(failed, cancellationToken).ConfigureAwait(false);
@@ -633,6 +661,9 @@ internal sealed partial class JobExecutionService(
 
         [LoggerMessage(9071, LogLevel.Warning, "Queue removal failed for terminal job {OperationId}; stale-claim reconciler will repair")]
         public static partial void QueueRemovalFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9073, LogLevel.Warning, "Log retention set failed for terminal job {OperationId}; execution logs may expire early")]
+        public static partial void LogRetentionFailed(ILogger logger, string operationId, Exception exception);
     }
 }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -183,10 +183,12 @@ internal sealed partial class JobExecutionService(
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
             await StopHeartbeatPumpAsync().ConfigureAwait(false);
-            // Worker is shutting down; abandon the job so it can be retried.
+            // Worker is shutting down; always requeue regardless of retry budget
+            // because this is an infrastructure event, not an execution failure.
             // Use CancellationToken.None so store/queue cleanup can complete
             // after the host stopping signal has fired.
-            await AbandonJobAsync(running, workerId, "Worker shutdown.", CancellationToken.None).ConfigureAwait(false);
+            await AbandonJobAsync(running, workerId, "Worker shutdown.",
+                CancellationToken.None, forceRequeue: true).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
@@ -304,7 +306,8 @@ internal sealed partial class JobExecutionService(
         string workerId,
         string reason,
         CancellationToken cancellationToken,
-        IReadOnlyList<string>? warnings = null)
+        IReadOnlyList<string>? warnings = null,
+        bool forceRequeue = false)
     {
         // Re-read to capture progress and artifact updates made during execution.
         var current = await jobStore.GetAsync(job.OperationId, cancellationToken).ConfigureAwait(false) ?? job;
@@ -317,7 +320,7 @@ internal sealed partial class JobExecutionService(
 
         var retryPolicy = current.RetryPolicy ?? JobRetryPolicy.Default;
 
-        if (retryPolicy.ShouldRetry(current.AttemptCount))
+        if (forceRequeue || retryPolicy.ShouldRetry(current.AttemptCount))
         {
             Log.JobAbandoned(logger, current.OperationId, reason);
 
@@ -337,7 +340,7 @@ internal sealed partial class JobExecutionService(
                 }
             }
 
-            var delay = retryPolicy.ComputeDelay(current.AttemptCount + 1);
+            var delay = forceRequeue ? TimeSpan.Zero : retryPolicy.ComputeDelay(current.AttemptCount + 1);
             var now = DateTimeOffset.UtcNow;
             var abandoned = current with
             {
@@ -488,9 +491,25 @@ internal sealed class JobExecutionContext(
         ExecutionLogEntry entry,
         CancellationToken cancellationToken = default)
     {
-        if (logStore != null)
+        if (logStore == null)
         {
+            return;
+        }
+
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+            if (job == null || !IsOwnedBy(job))
+            {
+                return;
+            }
+
             await logStore.AppendAsync(operationId, entry, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
         }
     }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -772,7 +772,7 @@ internal sealed partial class JobExecutionContext(
                 UpdatedAt = DateTimeOffset.UtcNow,
                 LastHeartbeatAt = DateTimeOffset.UtcNow
             };
-            await jobStore.SetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await jobStore.TrySetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -826,7 +826,7 @@ internal sealed partial class JobExecutionContext(
                 UpdatedAt = DateTimeOffset.UtcNow,
                 LastHeartbeatAt = DateTimeOffset.UtcNow
             };
-            await jobStore.SetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await jobStore.TrySetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -883,7 +883,7 @@ internal sealed partial class JobExecutionContext(
                         LastHeartbeatAt = DateTimeOffset.UtcNow,
                         UpdatedAt = DateTimeOffset.UtcNow
                     };
-                    await jobStore.SetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    await jobStore.TrySetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
                 finally
                 {

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -1,0 +1,361 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Server.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Worker-side hosted service that claims jobs from the queue, dispatches them
+/// to the appropriate <see cref="IJobExecutor"/>, manages heartbeat pumping
+/// during execution, and finalizes job state on completion or failure.
+/// </summary>
+internal sealed partial class JobExecutionService(
+    IJobQueue jobQueue,
+    IExecutionJobStore jobStore,
+    IEnumerable<IJobExecutor> executors,
+    IExecutionLogStore? logStore,
+    ILogger<JobExecutionService> logger) : BackgroundService
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan LogRetention = TimeSpan.FromDays(7);
+
+    private readonly Dictionary<ExecutionJobKind, IJobExecutor> _executorMap =
+        executors.ToDictionary(e => e.Kind);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var workerId = $"worker-{Environment.MachineName}-{Guid.NewGuid():N}"[..48];
+        Log.WorkerStarted(logger, workerId);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var claimedId = await jobQueue.TryClaimAsync(
+                    workerId, cancellationToken: stoppingToken).ConfigureAwait(false);
+
+                if (claimedId != null)
+                {
+                    await ProcessJobAsync(claimedId, workerId, stoppingToken).ConfigureAwait(false);
+                    continue; // Try to claim the next job immediately.
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                Log.ClaimLoopError(logger, ex);
+            }
+
+            try
+            {
+                await Task.Delay(PollInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+
+        Log.WorkerStopped(logger, workerId);
+    }
+
+    private async Task ProcessJobAsync(string operationId, string workerId, CancellationToken stoppingToken)
+    {
+        var job = await jobStore.GetAsync(operationId, stoppingToken).ConfigureAwait(false);
+        if (job == null)
+        {
+            Log.JobNotFoundDuringExecution(logger, operationId);
+            await jobQueue.RemoveAsync(operationId, stoppingToken).ConfigureAwait(false);
+            return;
+        }
+
+        if (!_executorMap.TryGetValue(job.Spec.Kind, out var executor))
+        {
+            Log.NoExecutorForKind(logger, operationId, job.Spec.Kind.ToString());
+            await AbandonJobAsync(job, "No executor registered for job kind.", stoppingToken).ConfigureAwait(false);
+            return;
+        }
+
+        // Transition to Running.
+        var now = DateTimeOffset.UtcNow;
+        var running = job with
+        {
+            Status = ExecutionJobStatus.Running,
+            UpdatedAt = now,
+            LastHeartbeatAt = now,
+            CurrentPhase = "Running"
+        };
+        await jobStore.SetAsync(running, cancellationToken: stoppingToken).ConfigureAwait(false);
+
+        Log.JobExecutionStarted(logger, operationId, executor.Kind.ToString());
+
+        // Create cancellation that combines host stopping and per-job cancellation.
+        using var jobCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+
+        // Set up timeout if configured.
+        var timeoutPolicy = job.TimeoutPolicy ?? JobTimeoutPolicy.Default;
+        jobCts.CancelAfter(timeoutPolicy.MaxDuration);
+
+        // Create execution context with heartbeat pump.
+        var context = new JobExecutionContext(
+            operationId, jobStore, logStore, job.HeartbeatPolicy ?? JobHeartbeatPolicy.Default);
+
+        // Start heartbeat pump in background.
+        using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+        var heartbeatTask = context.RunHeartbeatPumpAsync(heartbeatCts.Token);
+
+        try
+        {
+            var result = await executor.ExecuteAsync(running, context, jobCts.Token).ConfigureAwait(false);
+            await heartbeatCts.CancelAsync().ConfigureAwait(false);
+
+            await FinalizeJobAsync(operationId, result, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            await heartbeatCts.CancelAsync().ConfigureAwait(false);
+            // Worker is shutting down; abandon the job so it can be retried.
+            await AbandonJobAsync(running, "Worker shutdown.", stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            await heartbeatCts.CancelAsync().ConfigureAwait(false);
+            // Job was cancelled or timed out.
+            var cancelResult = JobExecutionResult.Failed("Job was cancelled or timed out.");
+            await FinalizeJobAsync(operationId, cancelResult, stoppingToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            await heartbeatCts.CancelAsync().ConfigureAwait(false);
+            Log.JobExecutionFailed(logger, operationId, ex);
+            var failResult = JobExecutionResult.Failed(ex.Message);
+            await FinalizeJobAsync(operationId, failResult, stoppingToken).ConfigureAwait(false);
+        }
+
+        // Ensure heartbeat pump stops cleanly.
+        try
+        {
+            await heartbeatTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected.
+        }
+    }
+
+    private async Task FinalizeJobAsync(
+        string operationId,
+        JobExecutionResult result,
+        CancellationToken cancellationToken)
+    {
+        var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+        if (job == null)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var final = job with
+        {
+            Status = result.Status,
+            UpdatedAt = now,
+            CompletedAt = now,
+            ErrorMessage = result.ErrorMessage,
+            Warnings = result.Warnings,
+            PercentComplete = result.Status == ExecutionJobStatus.Succeeded ? 100 : job.PercentComplete,
+            CurrentPhase = result.Status == ExecutionJobStatus.Succeeded ? "Completed" : "Failed"
+        };
+
+        await jobStore.SetAsync(final, cancellationToken: cancellationToken).ConfigureAwait(false);
+        await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
+
+        if (logStore != null)
+        {
+            await logStore.SetRetentionAsync(operationId, LogRetention, cancellationToken).ConfigureAwait(false);
+        }
+
+        Log.JobExecutionCompleted(logger, operationId, result.Status.ToString());
+    }
+
+    private async Task AbandonJobAsync(
+        ExecutionJobRecord job,
+        string reason,
+        CancellationToken cancellationToken)
+    {
+        var retryPolicy = job.RetryPolicy ?? JobRetryPolicy.Default;
+
+        if (retryPolicy.ShouldRetry(job.AttemptCount))
+        {
+            Log.JobAbandoned(logger, job.OperationId, reason);
+
+            var abandoned = job with
+            {
+                Status = ExecutionJobStatus.Queued,
+                ClaimedBy = null,
+                ClaimedAt = null,
+                LastHeartbeatAt = null,
+                UpdatedAt = DateTimeOffset.UtcNow,
+                CurrentPhase = $"Requeued: {reason}"
+            };
+            await jobStore.SetAsync(abandoned, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            var delay = retryPolicy.ComputeDelay(job.AttemptCount + 1);
+            await jobQueue.RequeueAsync(
+                job.OperationId,
+                job.Priority,
+                delay > TimeSpan.Zero ? delay : null,
+                cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            var now = DateTimeOffset.UtcNow;
+            var failed = job with
+            {
+                Status = ExecutionJobStatus.Failed,
+                UpdatedAt = now,
+                CompletedAt = now,
+                ErrorMessage = $"Job abandoned: {reason}",
+                CurrentPhase = "Failed (abandoned)"
+            };
+            await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await jobQueue.RemoveAsync(job.OperationId, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9050, LogLevel.Information, "Job execution worker started: {WorkerId}")]
+        public static partial void WorkerStarted(ILogger logger, string workerId);
+
+        [LoggerMessage(9051, LogLevel.Information, "Job execution worker stopped: {WorkerId}")]
+        public static partial void WorkerStopped(ILogger logger, string workerId);
+
+        [LoggerMessage(9052, LogLevel.Information, "Job execution started: {OperationId}, Kind={Kind}")]
+        public static partial void JobExecutionStarted(ILogger logger, string operationId, string kind);
+
+        [LoggerMessage(9053, LogLevel.Information, "Job execution completed: {OperationId}, Status={Status}")]
+        public static partial void JobExecutionCompleted(ILogger logger, string operationId, string status);
+
+        [LoggerMessage(9054, LogLevel.Error, "Job execution failed: {OperationId}")]
+        public static partial void JobExecutionFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9055, LogLevel.Warning, "Job not found during execution: {OperationId}")]
+        public static partial void JobNotFoundDuringExecution(ILogger logger, string operationId);
+
+        [LoggerMessage(9056, LogLevel.Warning, "No executor registered for job kind: {OperationId}, Kind={Kind}")]
+        public static partial void NoExecutorForKind(ILogger logger, string operationId, string kind);
+
+        [LoggerMessage(9057, LogLevel.Warning, "Job abandoned: {OperationId}, Reason={Reason}")]
+        public static partial void JobAbandoned(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9058, LogLevel.Error, "Claim loop error")]
+        public static partial void ClaimLoopError(ILogger logger, Exception exception);
+    }
+}
+
+/// <summary>
+/// Execution context provided to <see cref="IJobExecutor"/> during job execution.
+/// Mediates heartbeat pumping, progress reporting, log appending, and artifact publication.
+/// </summary>
+internal sealed class JobExecutionContext(
+    string operationId,
+    IExecutionJobStore jobStore,
+    IExecutionLogStore? logStore,
+    JobHeartbeatPolicy heartbeatPolicy) : IJobExecutionContext
+{
+    public string OperationId => operationId;
+
+    public async Task ReportProgressAsync(
+        double? percentComplete,
+        string? phase,
+        CancellationToken cancellationToken = default)
+    {
+        var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+        if (job == null)
+        {
+            return;
+        }
+
+        var updated = job with
+        {
+            PercentComplete = percentComplete,
+            CurrentPhase = phase ?? job.CurrentPhase,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            LastHeartbeatAt = DateTimeOffset.UtcNow
+        };
+        await jobStore.SetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task AppendLogAsync(
+        ExecutionLogEntry entry,
+        CancellationToken cancellationToken = default)
+    {
+        if (logStore != null)
+        {
+            await logStore.AppendAsync(operationId, entry, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task PublishArtifactAsync(
+        string artifactReference,
+        CancellationToken cancellationToken = default)
+    {
+        var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+        if (job == null)
+        {
+            return;
+        }
+
+        var refs = new List<string>(job.ArtifactReferences) { artifactReference };
+        var updated = job with
+        {
+            ArtifactReferences = refs,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            LastHeartbeatAt = DateTimeOffset.UtcNow
+        };
+        await jobStore.SetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Pumps heartbeat signals at the configured interval until cancelled.
+    /// </summary>
+    internal async Task RunHeartbeatPumpAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(heartbeatPolicy.Interval, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+
+            try
+            {
+                var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+                if (job == null)
+                {
+                    break;
+                }
+
+                var updated = job with
+                {
+                    LastHeartbeatAt = DateTimeOffset.UtcNow,
+                    UpdatedAt = DateTimeOffset.UtcNow
+                };
+                await jobStore.SetAsync(updated, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -51,19 +51,46 @@ internal sealed partial class JobExecutionService(
 
         while (!stoppingToken.IsCancellationRequested)
         {
+            string? claimedId = null;
+
             try
             {
-                var claimedId = await jobQueue.TryClaimAsync(
+                claimedId = await jobQueue.TryClaimAsync(
                     workerId, _acceptedKinds, stoppingToken).ConfigureAwait(false);
 
                 if (claimedId != null)
                 {
                     await ProcessJobAsync(claimedId, workerId, stoppingToken).ConfigureAwait(false);
-                    continue; // Try to claim the next job immediately.
+                    continue;
                 }
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
+                // If shutdown arrived during the pre-execution phase of
+                // ProcessJobAsync, the job is still claimed but was never
+                // handed to the executor try/catch that handles shutdown
+                // requeue. Force-requeue here so the job returns to the
+                // pending queue immediately instead of waiting for heartbeat
+                // expiry.
+                if (claimedId != null)
+                {
+                    try
+                    {
+                        var job = await jobStore.GetAsync(claimedId, CancellationToken.None).ConfigureAwait(false);
+                        if (job != null && !IsTerminalOrNotOwnedBy(job, workerId))
+                        {
+                            await AbandonJobAsync(job, workerId, "Worker shutdown.",
+                                CancellationToken.None, forceRequeue: true).ConfigureAwait(false);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.PreExecShutdownCleanupFailed(logger, claimedId, ex);
+                    }
+
+                    cancellationTokens.Remove(claimedId, workerId);
+                }
+
                 break;
             }
             catch (Exception ex)
@@ -504,6 +531,9 @@ internal sealed partial class JobExecutionService(
 
         [LoggerMessage(9065, LogLevel.Warning, "Failed to persist per-attempt warnings for job {OperationId}; requeue/terminal transition will proceed")]
         public static partial void WarningLogAppendFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9066, LogLevel.Error, "Failed to requeue job {OperationId} during pre-execution shutdown; stale-claim reconciliation will recover")]
+        public static partial void PreExecShutdownCleanupFailed(ILogger logger, string operationId, Exception exception);
     }
 }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -174,8 +174,10 @@ internal sealed partial class JobExecutionService(
             else
             {
                 // Executor returned failure — route through retry policy.
-                await AbandonJobAsync(running, workerId, result.ErrorMessage ?? "Execution failed.", CancellationToken.None)
-                    .ConfigureAwait(false);
+                // Thread executor warnings so they are persisted on terminal
+                // failure and logged to structured execution logs on retry.
+                await AbandonJobAsync(running, workerId, result.ErrorMessage ?? "Execution failed.",
+                    CancellationToken.None, result.Warnings).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
@@ -301,7 +303,8 @@ internal sealed partial class JobExecutionService(
         ExecutionJobRecord job,
         string workerId,
         string reason,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IReadOnlyList<string>? warnings = null)
     {
         // Re-read to capture progress and artifact updates made during execution.
         var current = await jobStore.GetAsync(job.OperationId, cancellationToken).ConfigureAwait(false) ?? job;
@@ -318,6 +321,22 @@ internal sealed partial class JobExecutionService(
         {
             Log.JobAbandoned(logger, current.OperationId, reason);
 
+            // Persist per-attempt warnings to structured execution logs before
+            // clearing them from the requeued record, so they remain observable.
+            if (warnings is { Count: > 0 } && logStore != null)
+            {
+                foreach (var warning in warnings)
+                {
+                    await logStore.AppendAsync(current.OperationId, new ExecutionLogEntry
+                    {
+                        Timestamp = DateTimeOffset.UtcNow,
+                        Level = ExecutionLogLevel.Warning,
+                        Message = warning,
+                        Phase = $"Attempt {current.AttemptCount} (requeuing)"
+                    }, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
             var delay = retryPolicy.ComputeDelay(current.AttemptCount + 1);
             var now = DateTimeOffset.UtcNow;
             var abandoned = current with
@@ -333,6 +352,7 @@ internal sealed partial class JobExecutionService(
                 ProviderOperationId = null,
                 CompletedAt = null,
                 ArtifactReferences = Array.Empty<string>(),
+                Warnings = Array.Empty<string>(),
                 NextRetryAt = delay > TimeSpan.Zero ? now.Add(delay) : null
             };
             await jobStore.SetAsync(abandoned, cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -352,6 +372,7 @@ internal sealed partial class JobExecutionService(
                 UpdatedAt = now,
                 CompletedAt = now,
                 ErrorMessage = $"Job abandoned: {reason}",
+                Warnings = warnings ?? current.Warnings,
                 CurrentPhase = "Failed (abandoned)"
             };
             await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -242,12 +242,25 @@ internal sealed partial class JobExecutionService(
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
             await StopHeartbeatPumpAsync().ConfigureAwait(false);
-            // Worker is shutting down; always requeue regardless of retry budget
-            // because this is an infrastructure event, not an execution failure.
-            // Use CancellationToken.None so store/queue cleanup can complete
-            // after the host stopping signal has fired.
-            await AbandonJobAsync(running, workerId, "Worker shutdown.",
-                CancellationToken.None, forceRequeue: true).ConfigureAwait(false);
+
+            // Timeout takes precedence over shutdown: a timed-out job must
+            // fail terminally per ADR-0031, even when shutdown also fired.
+            if (timeoutCts.IsCancellationRequested)
+            {
+                Log.JobTimedOut(logger, operationId, timeoutPolicy.MaxDuration);
+                await TerminateJobAsync(operationId, workerId, ExecutionJobStatus.Failed,
+                    $"Execution timed out after {timeoutPolicy.MaxDuration}.", CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                // Worker is shutting down; always requeue regardless of retry budget
+                // because this is an infrastructure event, not an execution failure.
+                // Use CancellationToken.None so store/queue cleanup can complete
+                // after the host stopping signal has fired.
+                await AbandonJobAsync(running, workerId, "Worker shutdown.",
+                    CancellationToken.None, forceRequeue: true).ConfigureAwait(false);
+            }
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -162,6 +162,18 @@ internal sealed partial class JobExecutionService(
             return;
         }
 
+        // A durable cancellation signal may have been written by a remote API
+        // host between the claim and the CTS registration. Honour it before
+        // promoting to Running.
+        if (job.CancellationRequestedAt.HasValue)
+        {
+            Log.JobCancelledByOperator(logger, operationId);
+            await TerminateJobAsync(operationId, workerId, ExecutionJobStatus.Cancelled,
+                "Cancelled by operator (durable signal).", CancellationToken.None).ConfigureAwait(false);
+            cancellationTokens.Remove(operationId, workerId);
+            return;
+        }
+
         // Transition to Running.
         var now = DateTimeOffset.UtcNow;
         var running = job with
@@ -177,7 +189,7 @@ internal sealed partial class JobExecutionService(
 
         // Create execution context with heartbeat pump.
         using var context = new JobExecutionContext(
-            operationId, workerId, jobStore, logStore, job.HeartbeatPolicy ?? JobHeartbeatPolicy.Default, logger);
+            operationId, workerId, jobStore, logStore, job.HeartbeatPolicy ?? JobHeartbeatPolicy.Default, jobCts, logger);
 
         // Start heartbeat pump in background.
         using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(jobCts.Token);
@@ -549,6 +561,7 @@ internal sealed partial class JobExecutionContext(
     IExecutionJobStore jobStore,
     IExecutionLogStore? logStore,
     JobHeartbeatPolicy heartbeatPolicy,
+    CancellationTokenSource? durableCancellationCts,
     ILogger logger) : IJobExecutionContext, IDisposable
 {
     private readonly SemaphoreSlim _writeLock = new(1, 1);
@@ -669,6 +682,16 @@ internal sealed partial class JobExecutionContext(
                     // or ownership has moved to another worker.
                     if (!IsOwnedBy(job))
                     {
+                        break;
+                    }
+
+                    // A remote API host persisted a durable cancellation signal.
+                    // Cancel the local CTS so the executor receives the signal
+                    // through its CancellationToken.
+                    if (job.CancellationRequestedAt.HasValue && durableCancellationCts != null)
+                    {
+                        try { durableCancellationCts.Cancel(); }
+                        catch (ObjectDisposedException) { }
                         break;
                     }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -305,7 +305,15 @@ internal sealed partial class JobExecutionService(
 
         await jobStore.SetAsync(final, cancellationToken: cancellationToken).ConfigureAwait(false);
         cancellationTokens.Remove(operationId, workerId);
-        await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.QueueRemovalFailed(logger, operationId, ex);
+        }
 
         if (logStore != null)
         {
@@ -347,7 +355,15 @@ internal sealed partial class JobExecutionService(
 
         await jobStore.SetAsync(terminal, cancellationToken: cancellationToken).ConfigureAwait(false);
         cancellationTokens.Remove(operationId, workerId);
-        await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await jobQueue.RemoveAsync(operationId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.QueueRemovalFailed(logger, operationId, ex);
+        }
 
         if (logStore != null)
         {
@@ -390,7 +406,15 @@ internal sealed partial class JobExecutionService(
             };
             await jobStore.SetAsync(cancelled, cancellationToken: cancellationToken).ConfigureAwait(false);
             cancellationTokens.Remove(current.OperationId, workerId);
-            await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.QueueRemovalFailed(logger, current.OperationId, ex);
+            }
 
             if (logStore != null)
             {
@@ -478,7 +502,15 @@ internal sealed partial class JobExecutionService(
             };
             await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
             cancellationTokens.Remove(current.OperationId, workerId);
-            await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.QueueRemovalFailed(logger, current.OperationId, ex);
+            }
 
             if (logStore != null)
             {
@@ -598,6 +630,9 @@ internal sealed partial class JobExecutionService(
 
         [LoggerMessage(9069, LogLevel.Warning, "Terminal callback failed for job {OperationId}; admin progress may be stale")]
         public static partial void TerminalCallbackFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9071, LogLevel.Warning, "Queue removal failed for terminal job {OperationId}; stale-claim reconciler will repair")]
+        public static partial void QueueRemovalFailed(ILogger logger, string operationId, Exception exception);
     }
 }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobExecutionService.cs
@@ -25,10 +25,19 @@ internal sealed partial class JobExecutionService(
     private readonly Dictionary<ExecutionJobKind, IJobExecutor> _executorMap =
         executors.ToDictionary(e => e.Kind);
 
+    private readonly HashSet<ExecutionJobKind> _acceptedKinds =
+        new(executors.Select(e => e.Kind));
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var raw = $"worker-{Environment.MachineName}-{Guid.NewGuid():N}";
         var workerId = raw.Length > 48 ? raw[..48] : raw;
+
+        if (_acceptedKinds.Count == 0)
+        {
+            Log.NoExecutorsRegistered(logger, workerId);
+        }
+
         Log.WorkerStarted(logger, workerId);
 
         while (!stoppingToken.IsCancellationRequested)
@@ -36,7 +45,7 @@ internal sealed partial class JobExecutionService(
             try
             {
                 var claimedId = await jobQueue.TryClaimAsync(
-                    workerId, cancellationToken: stoppingToken).ConfigureAwait(false);
+                    workerId, _acceptedKinds, stoppingToken).ConfigureAwait(false);
 
                 if (claimedId != null)
                 {
@@ -148,7 +157,9 @@ internal sealed partial class JobExecutionService(
         {
             await StopHeartbeatPumpAsync().ConfigureAwait(false);
             // Worker is shutting down; abandon the job so it can be retried.
-            await AbandonJobAsync(running, "Worker shutdown.", stoppingToken).ConfigureAwait(false);
+            // Use CancellationToken.None so store/queue cleanup can complete
+            // after the host stopping signal has fired.
+            await AbandonJobAsync(running, "Worker shutdown.", CancellationToken.None).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
@@ -328,6 +339,9 @@ internal sealed partial class JobExecutionService(
 
         [LoggerMessage(9060, LogLevel.Information, "Job cancelled by operator: {OperationId}")]
         public static partial void JobCancelledByOperator(ILogger logger, string operationId);
+
+        [LoggerMessage(9061, LogLevel.Warning, "No job executors registered for worker {WorkerId}; claim loop will not match any jobs")]
+        public static partial void NoExecutorsRegistered(ILogger logger, string workerId);
     }
 }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobOrchestrationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobOrchestrationServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Server.Features.Geoprocessing;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using StackExchange.Redis;
 
@@ -76,6 +77,8 @@ internal static class JobOrchestrationServiceCollectionExtensions
         services.TryAddSingleton<ExecutionJobCancellationTokens>();
         services.AddSingleton<IJobCancellationNotifier>(
             sp => sp.GetRequiredService<ExecutionJobCancellationTokens>());
+
+        services.AddSingleton<IJobTerminalCallback, GeoprocessingJobTerminalCallback>();
 
         services.AddHostedService<JobExecutionService>();
         services.AddHostedService<JobReconciliationService>();

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobOrchestrationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobOrchestrationServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.Infrastructure.Abstractions;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using StackExchange.Redis;
 
@@ -71,6 +72,10 @@ internal static class JobOrchestrationServiceCollectionExtensions
         {
             return services;
         }
+
+        services.TryAddSingleton<ExecutionJobCancellationTokens>();
+        services.AddSingleton<IJobCancellationNotifier>(
+            sp => sp.GetRequiredService<ExecutionJobCancellationTokens>());
 
         services.AddHostedService<JobExecutionService>();
         services.AddHostedService<JobReconciliationService>();

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobOrchestrationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobOrchestrationServiceCollectionExtensions.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using StackExchange.Redis;
+
+namespace Honua.Server.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Registers durable job orchestration services, separated into API-side and
+/// worker-side concerns to preserve a lean serving runtime. The API image
+/// registers only <see cref="AddJobOrchestration"/>; the worker image
+/// additionally registers <see cref="AddJobWorker"/>.
+/// </summary>
+internal static class JobOrchestrationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers API-side job orchestration dependencies: the durable job store,
+    /// job queue, and execution log store. These are shared between the API
+    /// serving path and background workers.
+    /// </summary>
+    /// <remarks>
+    /// This method is safe to call from the default serving image. It does not
+    /// register heavyweight execution or reconciliation services.
+    /// </remarks>
+    public static IServiceCollection AddJobOrchestration(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // Job store is already registered by AddGeoprocessing; guard for idempotency.
+        // Queue and log store require Redis.
+        if (!services.Any(d => d.ServiceType == typeof(IConnectionMultiplexer)))
+        {
+            return services;
+        }
+
+        services.TryAddSingleton<IJobQueue>(sp =>
+            new RedisJobQueue(
+                sp.GetRequiredService<IConnectionMultiplexer>(),
+                sp.GetRequiredService<IExecutionJobStore>(),
+                sp.GetRequiredService<ILogger<RedisJobQueue>>()));
+
+        services.TryAddSingleton<IExecutionLogStore>(sp =>
+            new RedisExecutionLogStore(
+                sp.GetRequiredService<IConnectionMultiplexer>(),
+                sp.GetRequiredService<ILogger<RedisExecutionLogStore>>()));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers worker-side job execution services: the execution host that
+    /// claims and runs jobs, and the reconciliation service that detects expired
+    /// heartbeats and applies retry policies.
+    /// </summary>
+    /// <remarks>
+    /// This method registers <see cref="BackgroundService"/> implementations that
+    /// should only be activated in a worker or combined-mode host. Calling this
+    /// from a lean API-only image would introduce execution overhead.
+    /// </remarks>
+    public static IServiceCollection AddJobWorker(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // Requires orchestration services to be registered first.
+        if (!services.Any(d => d.ServiceType == typeof(IJobQueue)))
+        {
+            return services;
+        }
+
+        services.AddHostedService<JobExecutionService>();
+        services.AddHostedService<JobReconciliationService>();
+
+        return services;
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobOrchestrationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobOrchestrationServiceCollectionExtensions.cs
@@ -35,11 +35,14 @@ internal static class JobOrchestrationServiceCollectionExtensions
             return services;
         }
 
-        services.TryAddSingleton<IJobQueue>(sp =>
+        services.TryAddSingleton<RedisJobQueue>(sp =>
             new RedisJobQueue(
                 sp.GetRequiredService<IConnectionMultiplexer>(),
                 sp.GetRequiredService<IExecutionJobStore>(),
                 sp.GetRequiredService<ILogger<RedisJobQueue>>()));
+
+        services.TryAddSingleton<IJobQueue>(sp => sp.GetRequiredService<RedisJobQueue>());
+        services.TryAddSingleton<IQueueClaimReconciler>(sp => sp.GetRequiredService<RedisJobQueue>());
 
         services.TryAddSingleton<IExecutionLogStore>(sp =>
             new RedisExecutionLogStore(

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -142,6 +142,16 @@ internal sealed partial class JobReconciliationService(
             return;
         }
 
+        // Re-validate heartbeat expiry against the fresh record. A heartbeat
+        // landing between the sweep snapshot and this handler means the worker
+        // is still alive — skip the transition to avoid duplicate execution.
+        var freshNow = DateTimeOffset.UtcNow;
+        if (!ShouldExpireHeartbeat(current!, freshNow))
+        {
+            Log.ReconciliationSkippedHeartbeatRefreshed(logger, snapshot.OperationId);
+            return;
+        }
+
         var retryPolicy = current!.RetryPolicy ?? JobRetryPolicy.Default;
 
         if (retryPolicy.ShouldRetry(current.AttemptCount))
@@ -254,5 +264,8 @@ internal sealed partial class JobReconciliationService(
 
         [LoggerMessage(9047, LogLevel.Information, "Reconciliation skipped for job {OperationId}: current status is {Status} (state changed since sweep snapshot)")]
         public static partial void ReconciliationSkippedStale(ILogger logger, string operationId, string status);
+
+        [LoggerMessage(9048, LogLevel.Information, "Reconciliation skipped for job {OperationId}: heartbeat refreshed since sweep snapshot")]
+        public static partial void ReconciliationSkippedHeartbeatRefreshed(ILogger logger, string operationId);
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -181,14 +181,21 @@ internal sealed partial class JobReconciliationService(
 
             cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
 
-            await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.QueueRemovalFailed(logger, current.OperationId, ex);
+            }
 
             if (logStore != null)
             {
-                await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+                await logStore.SetRetentionAsync(current.OperationId, LogRetention, CancellationToken.None).ConfigureAwait(false);
             }
 
-            await NotifyTerminalAsync(cancelledJob, cancellationToken).ConfigureAwait(false);
+            await NotifyTerminalAsync(cancelledJob, CancellationToken.None).ConfigureAwait(false);
             return true;
         }
 
@@ -244,14 +251,21 @@ internal sealed partial class JobReconciliationService(
 
             cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
 
-            await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.QueueRemovalFailed(logger, current.OperationId, ex);
+            }
 
             if (logStore != null)
             {
-                await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+                await logStore.SetRetentionAsync(current.OperationId, LogRetention, CancellationToken.None).ConfigureAwait(false);
             }
 
-            await NotifyTerminalAsync(failed, cancellationToken).ConfigureAwait(false);
+            await NotifyTerminalAsync(failed, CancellationToken.None).ConfigureAwait(false);
         }
 
         return true;
@@ -299,14 +313,21 @@ internal sealed partial class JobReconciliationService(
         // store transition, before the queue write.
         cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
 
-        await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.QueueRemovalFailed(logger, current.OperationId, ex);
+        }
 
         if (logStore != null)
         {
-            await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+            await logStore.SetRetentionAsync(current.OperationId, LogRetention, CancellationToken.None).ConfigureAwait(false);
         }
 
-        await NotifyTerminalAsync(failed, cancellationToken).ConfigureAwait(false);
+        await NotifyTerminalAsync(failed, CancellationToken.None).ConfigureAwait(false);
         return true;
     }
 
@@ -374,5 +395,8 @@ internal sealed partial class JobReconciliationService(
 
         [LoggerMessage(9070, LogLevel.Warning, "Terminal callback failed for job {OperationId}; admin progress may be stale")]
         public static partial void TerminalCallbackFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9072, LogLevel.Warning, "Queue removal failed for terminal job {OperationId}; stale-claim reconciler will repair")]
+        public static partial void QueueRemovalFailed(ILogger logger, string operationId, Exception exception);
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -204,7 +204,10 @@ internal sealed partial class JobReconciliationService(
                 ArtifactReferences = Array.Empty<string>(),
                 NextRetryAt = delay > TimeSpan.Zero ? now.Add(delay) : null
             };
-            await jobStore.SetAsync(abandoned, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (!await jobStore.TrySetAsync(abandoned, cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                return false;
+            }
 
             // Revoke the stale CTS immediately after the authoritative store
             // transition to Queued, before the queue write. If RequeueAsync
@@ -242,7 +245,10 @@ internal sealed partial class JobReconciliationService(
                 ErrorMessage = $"Worker heartbeat expired after {preFail.AttemptCount} attempt(s).",
                 CurrentPhase = "Failed (heartbeat expired)"
             };
-            await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (!await jobStore.TrySetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                return false;
+            }
 
             cancellationTokens.Revoke(preFail.OperationId, snapshot.ClaimedBy!);
 
@@ -309,7 +315,10 @@ internal sealed partial class JobReconciliationService(
             ErrorMessage = $"Job exceeded maximum execution duration of {(current.TimeoutPolicy ?? JobTimeoutPolicy.Default).MaxDuration}.",
             CurrentPhase = "Failed (timeout)"
         };
-        await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!await jobStore.TrySetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false))
+        {
+            return false;
+        }
 
         // Signal and remove the stale CTS immediately after the authoritative
         // store transition, before the queue write.
@@ -375,7 +384,10 @@ internal sealed partial class JobReconciliationService(
             ErrorMessage = "Cancelled by operator (durable signal honoured by reconciler).",
             CurrentPhase = "Cancelled"
         };
-        await jobStore.SetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!await jobStore.TrySetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false))
+        {
+            return false;
+        }
 
         cancellationTokens.Revoke(job.OperationId, claimedBy);
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Server.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Background service that sweeps active execution jobs for expired heartbeats
+/// and timed-out executions, applying retry or terminal-failure policies.
+/// </summary>
+internal sealed partial class JobReconciliationService(
+    IExecutionJobStore jobStore,
+    IJobQueue jobQueue,
+    ILogger<JobReconciliationService> logger) : BackgroundService
+{
+    private static readonly TimeSpan SweepInterval = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan LogRetention = TimeSpan.FromDays(7);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        Log.ReconciliationStarted(logger);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await SweepActiveJobsAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                Log.ReconciliationSweepFailed(logger, ex);
+            }
+
+            try
+            {
+                await Task.Delay(SweepInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+
+        Log.ReconciliationStopped(logger);
+    }
+
+    private async Task SweepActiveJobsAsync(CancellationToken cancellationToken)
+    {
+        var activeJobs = await jobStore.ListActiveAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        var now = DateTimeOffset.UtcNow;
+        var reconciled = 0;
+
+        foreach (var job in activeJobs)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (job.Status is ExecutionJobStatus.Queued)
+            {
+                continue; // Not yet claimed; nothing to reconcile.
+            }
+
+            if (ShouldExpireHeartbeat(job, now))
+            {
+                await HandleHeartbeatExpiryAsync(job, now, cancellationToken).ConfigureAwait(false);
+                reconciled++;
+                continue;
+            }
+
+            if (ShouldExpireTimeout(job, now))
+            {
+                await HandleTimeoutExpiryAsync(job, now, cancellationToken).ConfigureAwait(false);
+                reconciled++;
+            }
+        }
+
+        if (reconciled > 0)
+        {
+            Log.ReconciliationSweepCompleted(logger, reconciled, activeJobs.Count);
+        }
+    }
+
+    private static bool ShouldExpireHeartbeat(ExecutionJobRecord job, DateTimeOffset now)
+    {
+        if (job.Status is not (ExecutionJobStatus.Provisioning or ExecutionJobStatus.Running))
+        {
+            return false;
+        }
+
+        var lastHeartbeat = job.LastHeartbeatAt ?? job.ClaimedAt;
+        if (!lastHeartbeat.HasValue)
+        {
+            return false;
+        }
+
+        var policy = job.HeartbeatPolicy ?? JobHeartbeatPolicy.Default;
+        return policy.IsExpired(lastHeartbeat.Value, now);
+    }
+
+    private static bool ShouldExpireTimeout(ExecutionJobRecord job, DateTimeOffset now)
+    {
+        if (job.Status is not (ExecutionJobStatus.Provisioning or ExecutionJobStatus.Running))
+        {
+            return false;
+        }
+
+        var startedAt = job.ClaimedAt;
+        if (!startedAt.HasValue)
+        {
+            return false;
+        }
+
+        var policy = job.TimeoutPolicy ?? JobTimeoutPolicy.Default;
+        return policy.IsExpired(startedAt.Value, now);
+    }
+
+    private async Task HandleHeartbeatExpiryAsync(
+        ExecutionJobRecord job,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        var retryPolicy = job.RetryPolicy ?? JobRetryPolicy.Default;
+
+        if (retryPolicy.ShouldRetry(job.AttemptCount))
+        {
+            Log.HeartbeatExpiredRetrying(logger, job.OperationId, job.AttemptCount, retryPolicy.MaxAttempts);
+
+            var abandoned = job with
+            {
+                Status = ExecutionJobStatus.Queued,
+                ClaimedBy = null,
+                ClaimedAt = null,
+                LastHeartbeatAt = null,
+                UpdatedAt = now,
+                CurrentPhase = $"Retrying (attempt {job.AttemptCount + 1}/{retryPolicy.MaxAttempts})"
+            };
+            await jobStore.SetAsync(abandoned, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            var delay = retryPolicy.ComputeDelay(job.AttemptCount + 1);
+            await jobQueue.RequeueAsync(
+                job.OperationId,
+                job.Priority,
+                delay > TimeSpan.Zero ? delay : null,
+                cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            Log.HeartbeatExpiredFailed(logger, job.OperationId, job.AttemptCount);
+
+            var failed = job with
+            {
+                Status = ExecutionJobStatus.Failed,
+                UpdatedAt = now,
+                CompletedAt = now,
+                ErrorMessage = $"Worker heartbeat expired after {job.AttemptCount} attempt(s).",
+                CurrentPhase = "Failed (heartbeat expired)"
+            };
+            await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await jobQueue.RemoveAsync(job.OperationId, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task HandleTimeoutExpiryAsync(
+        ExecutionJobRecord job,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        Log.TimeoutExpired(logger, job.OperationId);
+
+        var failed = job with
+        {
+            Status = ExecutionJobStatus.Failed,
+            UpdatedAt = now,
+            CompletedAt = now,
+            ErrorMessage = $"Job exceeded maximum execution duration of {(job.TimeoutPolicy ?? JobTimeoutPolicy.Default).MaxDuration}.",
+            CurrentPhase = "Failed (timeout)"
+        };
+        await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
+        await jobQueue.RemoveAsync(job.OperationId, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9040, LogLevel.Information, "Job reconciliation service started")]
+        public static partial void ReconciliationStarted(ILogger logger);
+
+        [LoggerMessage(9041, LogLevel.Information, "Job reconciliation service stopped")]
+        public static partial void ReconciliationStopped(ILogger logger);
+
+        [LoggerMessage(9042, LogLevel.Debug, "Reconciliation sweep completed: {Reconciled} reconciled out of {Total} active")]
+        public static partial void ReconciliationSweepCompleted(ILogger logger, int reconciled, int total);
+
+        [LoggerMessage(9043, LogLevel.Error, "Reconciliation sweep failed")]
+        public static partial void ReconciliationSweepFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(9044, LogLevel.Warning, "Heartbeat expired for job {OperationId}: retrying (attempt {AttemptCount}/{MaxAttempts})")]
+        public static partial void HeartbeatExpiredRetrying(ILogger logger, string operationId, int attemptCount, int maxAttempts);
+
+        [LoggerMessage(9045, LogLevel.Error, "Heartbeat expired for job {OperationId}: no retries remaining after {AttemptCount} attempts")]
+        public static partial void HeartbeatExpiredFailed(ILogger logger, string operationId, int attemptCount);
+
+        [LoggerMessage(9046, LogLevel.Error, "Job {OperationId} exceeded maximum execution duration")]
+        public static partial void TimeoutExpired(ILogger logger, string operationId);
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -192,7 +192,14 @@ internal sealed partial class JobReconciliationService(
 
             if (logStore != null)
             {
-                await logStore.SetRetentionAsync(current.OperationId, LogRetention, CancellationToken.None).ConfigureAwait(false);
+                try
+                {
+                    await logStore.SetRetentionAsync(current.OperationId, LogRetention, CancellationToken.None).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Log.LogRetentionFailed(logger, current.OperationId, ex);
+                }
             }
 
             await NotifyTerminalAsync(cancelledJob, CancellationToken.None).ConfigureAwait(false);
@@ -262,7 +269,14 @@ internal sealed partial class JobReconciliationService(
 
             if (logStore != null)
             {
-                await logStore.SetRetentionAsync(current.OperationId, LogRetention, CancellationToken.None).ConfigureAwait(false);
+                try
+                {
+                    await logStore.SetRetentionAsync(current.OperationId, LogRetention, CancellationToken.None).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Log.LogRetentionFailed(logger, current.OperationId, ex);
+                }
             }
 
             await NotifyTerminalAsync(failed, CancellationToken.None).ConfigureAwait(false);
@@ -324,7 +338,14 @@ internal sealed partial class JobReconciliationService(
 
         if (logStore != null)
         {
-            await logStore.SetRetentionAsync(current.OperationId, LogRetention, CancellationToken.None).ConfigureAwait(false);
+            try
+            {
+                await logStore.SetRetentionAsync(current.OperationId, LogRetention, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.LogRetentionFailed(logger, current.OperationId, ex);
+            }
         }
 
         await NotifyTerminalAsync(failed, CancellationToken.None).ConfigureAwait(false);
@@ -398,5 +419,8 @@ internal sealed partial class JobReconciliationService(
 
         [LoggerMessage(9072, LogLevel.Warning, "Queue removal failed for terminal job {OperationId}; stale-claim reconciler will repair")]
         public static partial void QueueRemovalFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9074, LogLevel.Warning, "Log retention set failed for terminal job {OperationId}; execution logs may expire early")]
+        public static partial void LogRetentionFailed(ILogger logger, string operationId, Exception exception);
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -129,25 +129,34 @@ internal sealed partial class JobReconciliationService(
     }
 
     private async Task HandleHeartbeatExpiryAsync(
-        ExecutionJobRecord job,
+        ExecutionJobRecord snapshot,
         DateTimeOffset now,
         CancellationToken cancellationToken)
     {
-        var retryPolicy = job.RetryPolicy ?? JobRetryPolicy.Default;
-
-        if (retryPolicy.ShouldRetry(job.AttemptCount))
+        // Re-read the current record to avoid overwriting a job that completed
+        // between the sweep snapshot and this handler invocation.
+        var current = await jobStore.GetAsync(snapshot.OperationId, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (IsStaleSnapshot(snapshot, current))
         {
-            Log.HeartbeatExpiredRetrying(logger, job.OperationId, job.AttemptCount, retryPolicy.MaxAttempts);
+            Log.ReconciliationSkippedStale(logger, snapshot.OperationId, current?.Status.ToString() ?? "deleted");
+            return;
+        }
 
-            var delay = retryPolicy.ComputeDelay(job.AttemptCount + 1);
-            var abandoned = job with
+        var retryPolicy = current!.RetryPolicy ?? JobRetryPolicy.Default;
+
+        if (retryPolicy.ShouldRetry(current.AttemptCount))
+        {
+            Log.HeartbeatExpiredRetrying(logger, current.OperationId, current.AttemptCount, retryPolicy.MaxAttempts);
+
+            var delay = retryPolicy.ComputeDelay(current.AttemptCount + 1);
+            var abandoned = current with
             {
                 Status = ExecutionJobStatus.Queued,
                 ClaimedBy = null,
                 ClaimedAt = null,
                 LastHeartbeatAt = null,
                 UpdatedAt = now,
-                CurrentPhase = $"Retrying (attempt {job.AttemptCount + 1}/{retryPolicy.MaxAttempts})",
+                CurrentPhase = $"Retrying (attempt {current.AttemptCount + 1}/{retryPolicy.MaxAttempts})",
                 PercentComplete = null,
                 ErrorMessage = null,
                 ProviderOperationId = null,
@@ -158,46 +167,67 @@ internal sealed partial class JobReconciliationService(
             await jobStore.SetAsync(abandoned, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             await jobQueue.RequeueAsync(
-                job.OperationId,
-                job.Priority,
+                current.OperationId,
+                current.Priority,
                 delay > TimeSpan.Zero ? delay : null,
                 cancellationToken).ConfigureAwait(false);
         }
         else
         {
-            Log.HeartbeatExpiredFailed(logger, job.OperationId, job.AttemptCount);
+            Log.HeartbeatExpiredFailed(logger, current.OperationId, current.AttemptCount);
 
-            var failed = job with
+            var failed = current with
             {
                 Status = ExecutionJobStatus.Failed,
                 UpdatedAt = now,
                 CompletedAt = now,
-                ErrorMessage = $"Worker heartbeat expired after {job.AttemptCount} attempt(s).",
+                ErrorMessage = $"Worker heartbeat expired after {current.AttemptCount} attempt(s).",
                 CurrentPhase = "Failed (heartbeat expired)"
             };
             await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
-            await jobQueue.RemoveAsync(job.OperationId, cancellationToken).ConfigureAwait(false);
+            await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
         }
     }
 
     private async Task HandleTimeoutExpiryAsync(
-        ExecutionJobRecord job,
+        ExecutionJobRecord snapshot,
         DateTimeOffset now,
         CancellationToken cancellationToken)
     {
-        Log.TimeoutExpired(logger, job.OperationId);
+        // Re-read the current record to avoid overwriting a job that completed
+        // between the sweep snapshot and this handler invocation.
+        var current = await jobStore.GetAsync(snapshot.OperationId, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (IsStaleSnapshot(snapshot, current))
+        {
+            Log.ReconciliationSkippedStale(logger, snapshot.OperationId, current?.Status.ToString() ?? "deleted");
+            return;
+        }
 
-        var failed = job with
+        Log.TimeoutExpired(logger, current!.OperationId);
+
+        var failed = current with
         {
             Status = ExecutionJobStatus.Failed,
             UpdatedAt = now,
             CompletedAt = now,
-            ErrorMessage = $"Job exceeded maximum execution duration of {(job.TimeoutPolicy ?? JobTimeoutPolicy.Default).MaxDuration}.",
+            ErrorMessage = $"Job exceeded maximum execution duration of {(current.TimeoutPolicy ?? JobTimeoutPolicy.Default).MaxDuration}.",
             CurrentPhase = "Failed (timeout)"
         };
         await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
-        await jobQueue.RemoveAsync(job.OperationId, cancellationToken).ConfigureAwait(false);
+        await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Returns <c>true</c> when the fresh record has already moved past the state
+    /// captured in the sweep snapshot — the worker finalized the job, another
+    /// process intervened, or the record was deleted.
+    /// </summary>
+    private static bool IsStaleSnapshot(ExecutionJobRecord snapshot, ExecutionJobRecord? current)
+        => current is null
+           || current.Status is ExecutionJobStatus.Succeeded
+               or ExecutionJobStatus.Failed
+               or ExecutionJobStatus.Cancelled
+           || current.ClaimedBy != snapshot.ClaimedBy;
 
     private static partial class Log
     {
@@ -221,5 +251,8 @@ internal sealed partial class JobReconciliationService(
 
         [LoggerMessage(9046, LogLevel.Error, "Job {OperationId} exceeded maximum execution duration")]
         public static partial void TimeoutExpired(ILogger logger, string operationId);
+
+        [LoggerMessage(9047, LogLevel.Information, "Reconciliation skipped for job {OperationId}: current status is {Status} (state changed since sweep snapshot)")]
+        public static partial void ReconciliationSkippedStale(ILogger logger, string operationId, string status);
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -14,6 +14,7 @@ internal sealed partial class JobReconciliationService(
     IExecutionJobStore jobStore,
     IJobQueue jobQueue,
     IQueueClaimReconciler claimReconciler,
+    ExecutionJobCancellationTokens cancellationTokens,
     ILogger<JobReconciliationService> logger) : BackgroundService
 {
     private static readonly TimeSpan SweepInterval = TimeSpan.FromSeconds(30);
@@ -181,6 +182,11 @@ internal sealed partial class JobReconciliationService(
                 current.Priority,
                 delay > TimeSpan.Zero ? delay : null,
                 cancellationToken).ConfigureAwait(false);
+
+            // Clean up any stale CTS left by the previous worker so that a
+            // Cancel() call after requeue does not falsely report that an
+            // active worker owns the terminal-state transition.
+            cancellationTokens.Revoke(current.OperationId);
         }
         else
         {
@@ -196,6 +202,8 @@ internal sealed partial class JobReconciliationService(
             };
             await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
             await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+
+            cancellationTokens.Revoke(current.OperationId);
         }
     }
 
@@ -236,6 +244,9 @@ internal sealed partial class JobReconciliationService(
         };
         await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
         await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+
+        // Signal and remove any stale CTS so the hung worker stops work.
+        cancellationTokens.Revoke(current.OperationId);
     }
 
     /// <summary>

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -276,16 +276,16 @@ internal sealed partial class JobReconciliationService(
     }
 
     /// <summary>
-    /// Returns <c>true</c> when the fresh record has already moved past the state
-    /// captured in the sweep snapshot — the worker finalized the job, another
-    /// process intervened, or the record was deleted.
+    /// Returns <c>true</c> when the fresh record is no longer the same actively
+    /// claimed attempt captured in the sweep snapshot. This mirrors the worker-
+    /// side ownership guard so the reconciler only mutates jobs that are still
+    /// in an active state owned by the same claim.
     /// </summary>
     private static bool IsStaleSnapshot(ExecutionJobRecord snapshot, ExecutionJobRecord? current)
         => current is null
-           || current.Status is ExecutionJobStatus.Succeeded
-               or ExecutionJobStatus.Failed
-               or ExecutionJobStatus.Cancelled
-           || current.ClaimedBy != snapshot.ClaimedBy;
+           || current.Status is not (ExecutionJobStatus.Provisioning or ExecutionJobStatus.Running)
+           || string.IsNullOrWhiteSpace(current.ClaimedBy)
+           || !string.Equals(current.ClaimedBy, snapshot.ClaimedBy, StringComparison.Ordinal);
 
     private static partial class Log
     {

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -15,6 +15,7 @@ internal sealed partial class JobReconciliationService(
     IJobQueue jobQueue,
     IQueueClaimReconciler claimReconciler,
     ExecutionJobCancellationTokens cancellationTokens,
+    IExecutionLogStore? logStore,
     ILogger<JobReconciliationService> logger) : BackgroundService
 {
     private static readonly TimeSpan SweepInterval = TimeSpan.FromSeconds(30);
@@ -203,6 +204,11 @@ internal sealed partial class JobReconciliationService(
             await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
             await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
 
+            if (logStore != null)
+            {
+                await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+            }
+
             cancellationTokens.Revoke(current.OperationId);
         }
     }
@@ -244,6 +250,11 @@ internal sealed partial class JobReconciliationService(
         };
         await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
         await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+
+        if (logStore != null)
+        {
+            await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+        }
 
         // Signal and remove any stale CTS so the hung worker stops work.
         cancellationTokens.Revoke(current.OperationId);

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -213,6 +213,17 @@ internal sealed partial class JobReconciliationService(
             return;
         }
 
+        // Re-validate timeout expiry against the fresh record. A requeued-and-
+        // reclaimed job (possibly by the same worker) will have a fresh ClaimedAt
+        // that resets the timeout window — skip the transition to avoid failing
+        // a new attempt that has not actually timed out.
+        var freshNow = DateTimeOffset.UtcNow;
+        if (!ShouldExpireTimeout(current!, freshNow))
+        {
+            Log.ReconciliationSkippedTimeoutRefreshed(logger, snapshot.OperationId);
+            return;
+        }
+
         Log.TimeoutExpired(logger, current!.OperationId);
 
         var failed = current with
@@ -267,5 +278,8 @@ internal sealed partial class JobReconciliationService(
 
         [LoggerMessage(9048, LogLevel.Information, "Reconciliation skipped for job {OperationId}: heartbeat refreshed since sweep snapshot")]
         public static partial void ReconciliationSkippedHeartbeatRefreshed(ILogger logger, string operationId);
+
+        [LoggerMessage(9049, LogLevel.Information, "Reconciliation skipped for job {OperationId}: timeout no longer expired since sweep snapshot")]
+        public static partial void ReconciliationSkippedTimeoutRefreshed(ILogger logger, string operationId);
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -15,6 +15,7 @@ internal sealed partial class JobReconciliationService(
     IJobQueue jobQueue,
     IQueueClaimReconciler claimReconciler,
     ExecutionJobCancellationTokens cancellationTokens,
+    IEnumerable<IJobTerminalCallback> terminalCallbacks,
     IExecutionLogStore? logStore,
     ILogger<JobReconciliationService> logger) : BackgroundService
 {
@@ -187,6 +188,7 @@ internal sealed partial class JobReconciliationService(
                 await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
             }
 
+            await NotifyTerminalAsync(cancelledJob, cancellationToken).ConfigureAwait(false);
             return true;
         }
 
@@ -248,6 +250,8 @@ internal sealed partial class JobReconciliationService(
             {
                 await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
             }
+
+            await NotifyTerminalAsync(failed, cancellationToken).ConfigureAwait(false);
         }
 
         return true;
@@ -302,7 +306,23 @@ internal sealed partial class JobReconciliationService(
             await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
         }
 
+        await NotifyTerminalAsync(failed, cancellationToken).ConfigureAwait(false);
         return true;
+    }
+
+    private async Task NotifyTerminalAsync(ExecutionJobRecord job, CancellationToken cancellationToken)
+    {
+        foreach (var callback in terminalCallbacks)
+        {
+            try
+            {
+                await callback.OnTerminalAsync(job, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.TerminalCallbackFailed(logger, job.OperationId, ex);
+            }
+        }
     }
 
     /// <summary>
@@ -351,5 +371,8 @@ internal sealed partial class JobReconciliationService(
 
         [LoggerMessage(9067, LogLevel.Information, "Heartbeat expired for job {OperationId}: honouring durable cancellation signal")]
         public static partial void HeartbeatExpiredCancellationHonoured(ILogger logger, string operationId);
+
+        [LoggerMessage(9070, LogLevel.Warning, "Terminal callback failed for job {OperationId}; admin progress may be stale")]
+        public static partial void TerminalCallbackFailed(ILogger logger, string operationId, Exception exception);
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -166,54 +166,30 @@ internal sealed partial class JobReconciliationService(
         // worker either never observed the signal or crashed before acting on it.
         if (current!.CancellationRequestedAt.HasValue)
         {
-            Log.HeartbeatExpiredCancellationHonoured(logger, current.OperationId);
-
-            var cancelledNow = DateTimeOffset.UtcNow;
-            var cancelledJob = current with
-            {
-                Status = ExecutionJobStatus.Cancelled,
-                UpdatedAt = cancelledNow,
-                CompletedAt = cancelledNow,
-                ErrorMessage = "Cancelled by operator (durable signal honoured by reconciler).",
-                CurrentPhase = "Cancelled"
-            };
-            await jobStore.SetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false);
-
-            cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
-
-            try
-            {
-                await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                Log.QueueRemovalFailed(logger, current.OperationId, ex);
-            }
-
-            if (logStore != null)
-            {
-                try
-                {
-                    await logStore.SetRetentionAsync(current.OperationId, LogRetention, CancellationToken.None).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    Log.LogRetentionFailed(logger, current.OperationId, ex);
-                }
-            }
-
-            await NotifyTerminalAsync(cancelledJob, CancellationToken.None).ConfigureAwait(false);
-            return true;
+            return await TransitionToCancelledFromDurableSignalAsync(current, snapshot.ClaimedBy!, cancellationToken).ConfigureAwait(false);
         }
 
         var retryPolicy = current.RetryPolicy ?? JobRetryPolicy.Default;
 
         if (retryPolicy.ShouldRetry(current.AttemptCount))
         {
-            Log.HeartbeatExpiredRetrying(logger, current.OperationId, current.AttemptCount, retryPolicy.MaxAttempts);
+            // Re-read before the retry write to catch cancellation signals
+            // that arrived between the initial check and this write.
+            var preRetry = await jobStore.GetAsync(current!.OperationId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (IsStaleSnapshot(snapshot, preRetry))
+            {
+                return false;
+            }
 
-            var delay = retryPolicy.ComputeDelay(current.AttemptCount + 1);
-            var abandoned = current with
+            if (preRetry!.CancellationRequestedAt.HasValue)
+            {
+                return await TransitionToCancelledFromDurableSignalAsync(preRetry, snapshot.ClaimedBy!, cancellationToken).ConfigureAwait(false);
+            }
+
+            Log.HeartbeatExpiredRetrying(logger, preRetry.OperationId, preRetry.AttemptCount, retryPolicy.MaxAttempts);
+
+            var delay = retryPolicy.ComputeDelay(preRetry.AttemptCount + 1);
+            var abandoned = preRetry with
             {
                 Status = ExecutionJobStatus.Queued,
                 ClaimedBy = null,
@@ -234,48 +210,60 @@ internal sealed partial class JobReconciliationService(
             // transition to Queued, before the queue write. If RequeueAsync
             // fails, cancel paths will not delegate to the dead worker and
             // the stale-claim reconciler will repair the queue state.
-            cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
+            cancellationTokens.Revoke(preRetry.OperationId, snapshot.ClaimedBy!);
 
             await jobQueue.RequeueAsync(
-                current.OperationId,
-                current.Priority,
+                preRetry.OperationId,
+                preRetry.Priority,
                 delay > TimeSpan.Zero ? delay : null,
                 cancellationToken).ConfigureAwait(false);
         }
         else
         {
-            Log.HeartbeatExpiredFailed(logger, current.OperationId, current.AttemptCount);
+            // Re-read before the fail write to catch late cancellation signals.
+            var preFail = await jobStore.GetAsync(current!.OperationId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (IsStaleSnapshot(snapshot, preFail))
+            {
+                return false;
+            }
 
-            var failed = current with
+            if (preFail!.CancellationRequestedAt.HasValue)
+            {
+                return await TransitionToCancelledFromDurableSignalAsync(preFail, snapshot.ClaimedBy!, cancellationToken).ConfigureAwait(false);
+            }
+
+            Log.HeartbeatExpiredFailed(logger, preFail.OperationId, preFail.AttemptCount);
+
+            var failed = preFail with
             {
                 Status = ExecutionJobStatus.Failed,
                 UpdatedAt = now,
                 CompletedAt = now,
-                ErrorMessage = $"Worker heartbeat expired after {current.AttemptCount} attempt(s).",
+                ErrorMessage = $"Worker heartbeat expired after {preFail.AttemptCount} attempt(s).",
                 CurrentPhase = "Failed (heartbeat expired)"
             };
             await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
+            cancellationTokens.Revoke(preFail.OperationId, snapshot.ClaimedBy!);
 
             try
             {
-                await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+                await jobQueue.RemoveAsync(preFail.OperationId, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                Log.QueueRemovalFailed(logger, current.OperationId, ex);
+                Log.QueueRemovalFailed(logger, preFail.OperationId, ex);
             }
 
             if (logStore != null)
             {
                 try
                 {
-                    await logStore.SetRetentionAsync(current.OperationId, LogRetention, CancellationToken.None).ConfigureAwait(false);
+                    await logStore.SetRetentionAsync(preFail.OperationId, LogRetention, CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
-                    Log.LogRetentionFailed(logger, current.OperationId, ex);
+                    Log.LogRetentionFailed(logger, preFail.OperationId, ex);
                 }
             }
 
@@ -365,6 +353,55 @@ internal sealed partial class JobReconciliationService(
                 Log.TerminalCallbackFailed(logger, job.OperationId, ex);
             }
         }
+    }
+
+    /// <summary>
+    /// Shared cancel-from-durable-signal path used by heartbeat-expiry handlers
+    /// when <see cref="ExecutionJobRecord.CancellationRequestedAt"/> is set.
+    /// </summary>
+    private async Task<bool> TransitionToCancelledFromDurableSignalAsync(
+        ExecutionJobRecord job,
+        string claimedBy,
+        CancellationToken cancellationToken)
+    {
+        Log.HeartbeatExpiredCancellationHonoured(logger, job.OperationId);
+
+        var now = DateTimeOffset.UtcNow;
+        var cancelledJob = job with
+        {
+            Status = ExecutionJobStatus.Cancelled,
+            UpdatedAt = now,
+            CompletedAt = now,
+            ErrorMessage = "Cancelled by operator (durable signal honoured by reconciler).",
+            CurrentPhase = "Cancelled"
+        };
+        await jobStore.SetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        cancellationTokens.Revoke(job.OperationId, claimedBy);
+
+        try
+        {
+            await jobQueue.RemoveAsync(job.OperationId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.QueueRemovalFailed(logger, job.OperationId, ex);
+        }
+
+        if (logStore != null)
+        {
+            try
+            {
+                await logStore.SetRetentionAsync(job.OperationId, LogRetention, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.LogRetentionFailed(logger, job.OperationId, ex);
+            }
+        }
+
+        await NotifyTerminalAsync(cancelledJob, CancellationToken.None).ConfigureAwait(false);
+        return true;
     }
 
     /// <summary>

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -139,6 +139,7 @@ internal sealed partial class JobReconciliationService(
         {
             Log.HeartbeatExpiredRetrying(logger, job.OperationId, job.AttemptCount, retryPolicy.MaxAttempts);
 
+            var delay = retryPolicy.ComputeDelay(job.AttemptCount + 1);
             var abandoned = job with
             {
                 Status = ExecutionJobStatus.Queued,
@@ -146,11 +147,16 @@ internal sealed partial class JobReconciliationService(
                 ClaimedAt = null,
                 LastHeartbeatAt = null,
                 UpdatedAt = now,
-                CurrentPhase = $"Retrying (attempt {job.AttemptCount + 1}/{retryPolicy.MaxAttempts})"
+                CurrentPhase = $"Retrying (attempt {job.AttemptCount + 1}/{retryPolicy.MaxAttempts})",
+                PercentComplete = null,
+                ErrorMessage = null,
+                ProviderOperationId = null,
+                CompletedAt = null,
+                ArtifactReferences = Array.Empty<string>(),
+                NextRetryAt = delay > TimeSpan.Zero ? now.Add(delay) : null
             };
             await jobStore.SetAsync(abandoned, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            var delay = retryPolicy.ComputeDelay(job.AttemptCount + 1);
             await jobQueue.RequeueAsync(
                 job.OperationId,
                 job.Priority,

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -160,7 +160,37 @@ internal sealed partial class JobReconciliationService(
             return false;
         }
 
-        var retryPolicy = current!.RetryPolicy ?? JobRetryPolicy.Default;
+        // If cancellation was durably requested before the heartbeat expired,
+        // honour it with a terminal Cancelled state instead of retrying. The
+        // worker either never observed the signal or crashed before acting on it.
+        if (current!.CancellationRequestedAt.HasValue)
+        {
+            Log.HeartbeatExpiredCancellationHonoured(logger, current.OperationId);
+
+            var cancelledNow = DateTimeOffset.UtcNow;
+            var cancelledJob = current with
+            {
+                Status = ExecutionJobStatus.Cancelled,
+                UpdatedAt = cancelledNow,
+                CompletedAt = cancelledNow,
+                ErrorMessage = "Cancelled by operator (durable signal honoured by reconciler).",
+                CurrentPhase = "Cancelled"
+            };
+            await jobStore.SetAsync(cancelledJob, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
+
+            await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
+
+            if (logStore != null)
+            {
+                await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
+            }
+
+            return true;
+        }
+
+        var retryPolicy = current.RetryPolicy ?? JobRetryPolicy.Default;
 
         if (retryPolicy.ShouldRetry(current.AttemptCount))
         {
@@ -318,5 +348,8 @@ internal sealed partial class JobReconciliationService(
 
         [LoggerMessage(9049, LogLevel.Information, "Reconciliation skipped for job {OperationId}: timeout no longer expired since sweep snapshot")]
         public static partial void ReconciliationSkippedTimeoutRefreshed(ILogger logger, string operationId);
+
+        [LoggerMessage(9067, LogLevel.Information, "Heartbeat expired for job {OperationId}: honouring durable cancellation signal")]
+        public static partial void HeartbeatExpiredCancellationHonoured(ILogger logger, string operationId);
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -67,16 +67,18 @@ internal sealed partial class JobReconciliationService(
                 continue; // Not yet claimed; nothing to reconcile.
             }
 
-            if (ShouldExpireHeartbeat(job, now))
+            // Timeout takes precedence: timed-out jobs must fail terminally
+            // even when the heartbeat has also expired and retries remain.
+            if (ShouldExpireTimeout(job, now))
             {
-                await HandleHeartbeatExpiryAsync(job, now, cancellationToken).ConfigureAwait(false);
+                await HandleTimeoutExpiryAsync(job, now, cancellationToken).ConfigureAwait(false);
                 reconciled++;
                 continue;
             }
 
-            if (ShouldExpireTimeout(job, now))
+            if (ShouldExpireHeartbeat(job, now))
             {
-                await HandleTimeoutExpiryAsync(job, now, cancellationToken).ConfigureAwait(false);
+                await HandleHeartbeatExpiryAsync(job, now, cancellationToken).ConfigureAwait(false);
                 reconciled++;
             }
         }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -13,9 +13,11 @@ namespace Honua.Server.Features.Infrastructure.ControlPlane;
 internal sealed partial class JobReconciliationService(
     IExecutionJobStore jobStore,
     IJobQueue jobQueue,
+    IQueueClaimReconciler claimReconciler,
     ILogger<JobReconciliationService> logger) : BackgroundService
 {
     private static readonly TimeSpan SweepInterval = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan StaleClaimThreshold = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan LogRetention = TimeSpan.FromDays(7);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -83,6 +85,11 @@ internal sealed partial class JobReconciliationService(
         {
             Log.ReconciliationSweepCompleted(logger, reconciled, activeJobs.Count);
         }
+
+        // Reconcile orphaned claims where the queue move succeeded but the
+        // subsequent store update failed.
+        await claimReconciler.ReconcileStaleClaimsAsync(StaleClaimThreshold, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private static bool ShouldExpireHeartbeat(ExecutionJobRecord job, DateTimeOffset now)

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -184,16 +184,17 @@ internal sealed partial class JobReconciliationService(
             };
             await jobStore.SetAsync(abandoned, cancellationToken: cancellationToken).ConfigureAwait(false);
 
+            // Revoke the stale CTS immediately after the authoritative store
+            // transition to Queued, before the queue write. If RequeueAsync
+            // fails, cancel paths will not delegate to the dead worker and
+            // the stale-claim reconciler will repair the queue state.
+            cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
+
             await jobQueue.RequeueAsync(
                 current.OperationId,
                 current.Priority,
                 delay > TimeSpan.Zero ? delay : null,
                 cancellationToken).ConfigureAwait(false);
-
-            // Clean up any stale CTS left by the previous worker so that a
-            // Cancel() call after requeue does not falsely report that an
-            // active worker owns the terminal-state transition.
-            cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
         }
         else
         {
@@ -208,14 +209,15 @@ internal sealed partial class JobReconciliationService(
                 CurrentPhase = "Failed (heartbeat expired)"
             };
             await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
+
             await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
 
             if (logStore != null)
             {
                 await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
             }
-
-            cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
         }
 
         return true;
@@ -258,15 +260,17 @@ internal sealed partial class JobReconciliationService(
             CurrentPhase = "Failed (timeout)"
         };
         await jobStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        // Signal and remove the stale CTS immediately after the authoritative
+        // store transition, before the queue write.
+        cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
+
         await jobQueue.RemoveAsync(current.OperationId, cancellationToken).ConfigureAwait(false);
 
         if (logStore != null)
         {
             await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
         }
-
-        // Signal and remove any stale CTS so the hung worker stops work.
-        cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
 
         return true;
     }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/JobReconciliationService.cs
@@ -73,15 +73,20 @@ internal sealed partial class JobReconciliationService(
             // even when the heartbeat has also expired and retries remain.
             if (ShouldExpireTimeout(job, now))
             {
-                await HandleTimeoutExpiryAsync(job, now, cancellationToken).ConfigureAwait(false);
-                reconciled++;
+                if (await HandleTimeoutExpiryAsync(job, now, cancellationToken).ConfigureAwait(false))
+                {
+                    reconciled++;
+                }
+
                 continue;
             }
 
             if (ShouldExpireHeartbeat(job, now))
             {
-                await HandleHeartbeatExpiryAsync(job, now, cancellationToken).ConfigureAwait(false);
-                reconciled++;
+                if (await HandleHeartbeatExpiryAsync(job, now, cancellationToken).ConfigureAwait(false))
+                {
+                    reconciled++;
+                }
             }
         }
 
@@ -130,7 +135,8 @@ internal sealed partial class JobReconciliationService(
         return policy.IsExpired(startedAt.Value, now);
     }
 
-    private async Task HandleHeartbeatExpiryAsync(
+    /// <returns><c>true</c> when state was actually mutated; <c>false</c> when skipped.</returns>
+    private async Task<bool> HandleHeartbeatExpiryAsync(
         ExecutionJobRecord snapshot,
         DateTimeOffset now,
         CancellationToken cancellationToken)
@@ -141,7 +147,7 @@ internal sealed partial class JobReconciliationService(
         if (IsStaleSnapshot(snapshot, current))
         {
             Log.ReconciliationSkippedStale(logger, snapshot.OperationId, current?.Status.ToString() ?? "deleted");
-            return;
+            return false;
         }
 
         // Re-validate heartbeat expiry against the fresh record. A heartbeat
@@ -151,7 +157,7 @@ internal sealed partial class JobReconciliationService(
         if (!ShouldExpireHeartbeat(current!, freshNow))
         {
             Log.ReconciliationSkippedHeartbeatRefreshed(logger, snapshot.OperationId);
-            return;
+            return false;
         }
 
         var retryPolicy = current!.RetryPolicy ?? JobRetryPolicy.Default;
@@ -187,7 +193,7 @@ internal sealed partial class JobReconciliationService(
             // Clean up any stale CTS left by the previous worker so that a
             // Cancel() call after requeue does not falsely report that an
             // active worker owns the terminal-state transition.
-            cancellationTokens.Revoke(current.OperationId);
+            cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
         }
         else
         {
@@ -209,11 +215,14 @@ internal sealed partial class JobReconciliationService(
                 await logStore.SetRetentionAsync(current.OperationId, LogRetention, cancellationToken).ConfigureAwait(false);
             }
 
-            cancellationTokens.Revoke(current.OperationId);
+            cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
         }
+
+        return true;
     }
 
-    private async Task HandleTimeoutExpiryAsync(
+    /// <returns><c>true</c> when state was actually mutated; <c>false</c> when skipped.</returns>
+    private async Task<bool> HandleTimeoutExpiryAsync(
         ExecutionJobRecord snapshot,
         DateTimeOffset now,
         CancellationToken cancellationToken)
@@ -224,7 +233,7 @@ internal sealed partial class JobReconciliationService(
         if (IsStaleSnapshot(snapshot, current))
         {
             Log.ReconciliationSkippedStale(logger, snapshot.OperationId, current?.Status.ToString() ?? "deleted");
-            return;
+            return false;
         }
 
         // Re-validate timeout expiry against the fresh record. A requeued-and-
@@ -235,7 +244,7 @@ internal sealed partial class JobReconciliationService(
         if (!ShouldExpireTimeout(current!, freshNow))
         {
             Log.ReconciliationSkippedTimeoutRefreshed(logger, snapshot.OperationId);
-            return;
+            return false;
         }
 
         Log.TimeoutExpired(logger, current!.OperationId);
@@ -257,7 +266,9 @@ internal sealed partial class JobReconciliationService(
         }
 
         // Signal and remove any stale CTS so the hung worker stops work.
-        cancellationTokens.Revoke(current.OperationId);
+        cancellationTokens.Revoke(current.OperationId, snapshot.ClaimedBy!);
+
+        return true;
     }
 
     /// <summary>

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisExecutionJobStore.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisExecutionJobStore.cs
@@ -16,6 +16,16 @@ internal sealed partial class RedisExecutionJobStore(
     ILogger<RedisExecutionJobStore> logger) : IExecutionJobStore
 {
     private static readonly TimeSpan DefaultRetention = TimeSpan.FromDays(7);
+
+    private const string CasSetScript = """
+        local current = redis.call('GET', KEYS[1])
+        if current == false then return 0 end
+        local v = tonumber(string.match(current, '"version":(%d+)')) or 0
+        if v ~= tonumber(ARGV[1]) then return 0 end
+        redis.call('SET', KEYS[1], ARGV[2], 'PX', tonumber(ARGV[3]))
+        return 1
+        """;
+
     private readonly IDatabase _database = redis.GetDatabase();
 
     public Task<bool> TryAcquireLeaseAsync(
@@ -55,7 +65,8 @@ internal sealed partial class RedisExecutionJobStore(
         ArgumentNullException.ThrowIfNull(job);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var payload = JsonSerializer.Serialize(job, ControlPlaneJsonContext.Default.ExecutionJobRecord);
+        var versioned = job with { Version = 1 };
+        var payload = JsonSerializer.Serialize(versioned, ControlPlaneJsonContext.Default.ExecutionJobRecord);
         var created = await _database.StringSetAsync(
                 GetJobKey(job.OperationId),
                 payload,
@@ -68,8 +79,8 @@ internal sealed partial class RedisExecutionJobStore(
             return false;
         }
 
-        await UpdateActiveIndexesAsync(job).ConfigureAwait(false);
-        Log.ExecutionJobCreated(logger, job.OperationId, job.Spec.Kind.ToString(), job.Status.ToString());
+        await UpdateActiveIndexesAsync(versioned).ConfigureAwait(false);
+        Log.ExecutionJobCreated(logger, job.OperationId, versioned.Spec.Kind.ToString(), versioned.Status.ToString());
         return true;
     }
 
@@ -96,15 +107,46 @@ internal sealed partial class RedisExecutionJobStore(
         ArgumentNullException.ThrowIfNull(job);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var payload = JsonSerializer.Serialize(job, ControlPlaneJsonContext.Default.ExecutionJobRecord);
+        var versioned = job with { Version = job.Version + 1 };
+        var payload = JsonSerializer.Serialize(versioned, ControlPlaneJsonContext.Default.ExecutionJobRecord);
         await _database.StringSetAsync(
                 GetJobKey(job.OperationId),
                 payload,
                 ttl ?? DefaultRetention)
             .ConfigureAwait(false);
 
-        await UpdateActiveIndexesAsync(job).ConfigureAwait(false);
-        Log.ExecutionJobUpdated(logger, job.OperationId, job.Status.ToString());
+        await UpdateActiveIndexesAsync(versioned).ConfigureAwait(false);
+        Log.ExecutionJobUpdated(logger, job.OperationId, versioned.Status.ToString());
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TrySetAsync(
+        ExecutionJobRecord job,
+        TimeSpan? ttl = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var versioned = job with { Version = job.Version + 1 };
+        var payload = JsonSerializer.Serialize(versioned, ControlPlaneJsonContext.Default.ExecutionJobRecord);
+        var retention = ttl ?? DefaultRetention;
+
+        var result = await _database.ScriptEvaluateAsync(
+            CasSetScript,
+            keys: [(RedisKey)GetJobKey(job.OperationId)],
+            values: [(RedisValue)job.Version, (RedisValue)payload, (RedisValue)(long)retention.TotalMilliseconds])
+            .ConfigureAwait(false);
+
+        if ((long)result != 1)
+        {
+            Log.CasConflict(logger, job.OperationId, job.Version);
+            return false;
+        }
+
+        await UpdateActiveIndexesAsync(versioned).ConfigureAwait(false);
+        Log.ExecutionJobUpdated(logger, job.OperationId, versioned.Status.ToString());
+        return true;
     }
 
     public async Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(
@@ -197,5 +239,11 @@ internal sealed partial class RedisExecutionJobStore(
             ILogger logger,
             string operationId,
             string status);
+
+        [LoggerMessage(9012, LogLevel.Debug, "CAS conflict for execution job {OperationId} at version {Version}; concurrent write detected")]
+        public static partial void CasConflict(
+            ILogger logger,
+            string operationId,
+            long version);
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisExecutionLogStore.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisExecutionLogStore.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using StackExchange.Redis;
+
+namespace Honua.Server.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Redis-backed append-only store for structured execution log entries.
+/// Uses a Redis list per operation for chronological ordering.
+/// </summary>
+internal sealed partial class RedisExecutionLogStore(
+    IConnectionMultiplexer redis,
+    ILogger<RedisExecutionLogStore> logger) : IExecutionLogStore
+{
+    private static readonly TimeSpan DefaultRetention = TimeSpan.FromDays(7);
+    private readonly IDatabase _database = redis.GetDatabase();
+
+    public async Task AppendAsync(
+        string operationId,
+        ExecutionLogEntry entry,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var payload = JsonSerializer.Serialize(entry, ControlPlaneJsonContext.Default.ExecutionLogEntry);
+        var key = GetLogKey(operationId);
+        await _database.ListRightPushAsync(key, payload).ConfigureAwait(false);
+
+        // Ensure the key has a TTL so logs don't persist indefinitely if
+        // SetRetentionAsync is never called.
+        var ttl = await _database.KeyTimeToLiveAsync(key).ConfigureAwait(false);
+        if (!ttl.HasValue)
+        {
+            await _database.KeyExpireAsync(key, DefaultRetention).ConfigureAwait(false);
+        }
+
+        Log.LogEntryAppended(logger, operationId, entry.Level.ToString());
+    }
+
+    public async Task<IReadOnlyList<ExecutionLogEntry>> GetLogsAsync(
+        string operationId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var values = await _database.ListRangeAsync(GetLogKey(operationId)).ConfigureAwait(false);
+        var entries = new List<ExecutionLogEntry>(values.Length);
+
+        foreach (var value in values)
+        {
+            if (!value.HasValue)
+            {
+                continue;
+            }
+
+            var entry = JsonSerializer.Deserialize(value.ToString(), ControlPlaneJsonContext.Default.ExecutionLogEntry);
+            if (entry != null)
+            {
+                entries.Add(entry);
+            }
+        }
+
+        return entries;
+    }
+
+    public async Task SetRetentionAsync(
+        string operationId,
+        TimeSpan ttl,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await _database.KeyExpireAsync(GetLogKey(operationId), ttl).ConfigureAwait(false);
+    }
+
+    private static string GetLogKey(string operationId) => $"controlplane:job:log:{operationId}";
+
+    private static partial class Log
+    {
+        [LoggerMessage(9030, LogLevel.Debug, "Execution log entry appended: {OperationId}, Level={Level}")]
+        public static partial void LogEntryAppended(ILogger logger, string operationId, string level);
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using StackExchange.Redis;
+
+namespace Honua.Server.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Redis-backed durable job queue with atomic claim semantics.
+/// Uses a sorted set keyed by priority score for dequeue ordering and
+/// per-job metadata hashes for claim tracking.
+/// </summary>
+internal sealed partial class RedisJobQueue(
+    IConnectionMultiplexer redis,
+    IExecutionJobStore jobStore,
+    ILogger<RedisJobQueue> logger) : IJobQueue
+{
+    private const string QueueKey = "controlplane:jobqueue:pending";
+    private const string ClaimedSetKey = "controlplane:jobqueue:claimed";
+
+    private readonly IDatabase _database = redis.GetDatabase();
+
+    public async Task EnqueueAsync(
+        string operationId,
+        OperationPriority priority = OperationPriority.Normal,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var score = ComputeScore(priority, DateTimeOffset.UtcNow);
+        await _database.SortedSetAddAsync(QueueKey, operationId, score).ConfigureAwait(false);
+
+        Log.JobEnqueued(logger, operationId, priority.ToString());
+    }
+
+    public async Task<string?> TryClaimAsync(
+        string workerId,
+        IReadOnlySet<ExecutionJobKind>? acceptedKinds = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Scan the sorted set from highest priority (lowest score) to find a claimable job.
+        // We use ZPOPMIN-style iteration rather than a Lua script to stay simple and
+        // avoid blocking other queue consumers during the job store lookup.
+        const int batchSize = 10;
+        var now = DateTimeOffset.UtcNow;
+
+        var candidates = await _database.SortedSetRangeByRankAsync(
+            QueueKey, 0, batchSize - 1).ConfigureAwait(false);
+
+        foreach (var candidate in candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!candidate.HasValue)
+            {
+                continue;
+            }
+
+            var operationId = candidate.ToString();
+
+            // Filter delayed jobs (requeue with visibility delay).
+            var meta = await _database.HashGetAllAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
+            var visibleAfter = GetVisibleAfter(meta);
+            if (visibleAfter.HasValue && visibleAfter.Value > now)
+            {
+                continue;
+            }
+
+            // Load the job record to check kind filter and current status.
+            var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+            if (job == null || IsTerminal(job.Status))
+            {
+                // Stale entry; remove from queue.
+                await _database.SortedSetRemoveAsync(QueueKey, operationId).ConfigureAwait(false);
+                continue;
+            }
+
+            if (acceptedKinds != null && !acceptedKinds.Contains(job.Spec.Kind))
+            {
+                continue;
+            }
+
+            // Attempt atomic claim: remove from pending and add to claimed.
+            var removed = await _database.SortedSetRemoveAsync(QueueKey, operationId).ConfigureAwait(false);
+            if (!removed)
+            {
+                // Another worker claimed it first.
+                continue;
+            }
+
+            await _database.SortedSetAddAsync(ClaimedSetKey, operationId, now.ToUnixTimeMilliseconds())
+                .ConfigureAwait(false);
+
+            await _database.HashSetAsync(GetClaimMetaKey(operationId),
+            [
+                new HashEntry("workerId", workerId),
+                new HashEntry("claimedAt", now.ToUnixTimeMilliseconds().ToString())
+            ]).ConfigureAwait(false);
+
+            // Update the job record with claim metadata.
+            var claimed = job with
+            {
+                Status = ExecutionJobStatus.Provisioning,
+                ClaimedBy = workerId,
+                ClaimedAt = now,
+                LastHeartbeatAt = now,
+                AttemptCount = job.AttemptCount + 1,
+                UpdatedAt = now,
+                CurrentPhase = "Claimed"
+            };
+            await jobStore.SetAsync(claimed, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            Log.JobClaimed(logger, operationId, workerId);
+            return operationId;
+        }
+
+        return null;
+    }
+
+    public async Task RequeueAsync(
+        string operationId,
+        OperationPriority priority = OperationPriority.Normal,
+        TimeSpan? visibleAfter = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Remove from claimed set.
+        await _database.SortedSetRemoveAsync(ClaimedSetKey, operationId).ConfigureAwait(false);
+
+        // Set visibility delay if requested.
+        if (visibleAfter.HasValue && visibleAfter.Value > TimeSpan.Zero)
+        {
+            var visibleAt = DateTimeOffset.UtcNow.Add(visibleAfter.Value);
+            await _database.HashSetAsync(GetClaimMetaKey(operationId),
+            [
+                new HashEntry("visibleAfter", visibleAt.ToUnixTimeMilliseconds().ToString())
+            ]).ConfigureAwait(false);
+        }
+        else
+        {
+            await _database.KeyDeleteAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
+        }
+
+        var score = ComputeScore(priority, DateTimeOffset.UtcNow);
+        await _database.SortedSetAddAsync(QueueKey, operationId, score).ConfigureAwait(false);
+
+        Log.JobRequeued(logger, operationId);
+    }
+
+    public async Task RemoveAsync(
+        string operationId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await _database.SortedSetRemoveAsync(QueueKey, operationId).ConfigureAwait(false);
+        await _database.SortedSetRemoveAsync(ClaimedSetKey, operationId).ConfigureAwait(false);
+        await _database.KeyDeleteAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
+
+        Log.JobRemovedFromQueue(logger, operationId);
+    }
+
+    public async Task<long> GetQueueDepthAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await _database.SortedSetLengthAsync(QueueKey).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Computes a sort score that orders by priority (descending) then by enqueue time (ascending).
+    /// Lower scores are dequeued first. Critical=0, High=1e12, Normal=2e12, Low=3e12, plus
+    /// millisecond timestamp to break ties by FIFO order.
+    /// </summary>
+    private static double ComputeScore(OperationPriority priority, DateTimeOffset enqueueTime)
+    {
+        var priorityBucket = priority switch
+        {
+            OperationPriority.Critical => 0d,
+            OperationPriority.High => 1_000_000_000_000d,
+            OperationPriority.Normal => 2_000_000_000_000d,
+            OperationPriority.Low => 3_000_000_000_000d,
+            _ => 2_000_000_000_000d
+        };
+
+        return priorityBucket + enqueueTime.ToUnixTimeMilliseconds();
+    }
+
+    private static DateTimeOffset? GetVisibleAfter(HashEntry[] meta)
+    {
+        foreach (var entry in meta)
+        {
+            if (entry.Name == "visibleAfter" && long.TryParse(entry.Value.ToString(), out var ms))
+            {
+                return DateTimeOffset.FromUnixTimeMilliseconds(ms);
+            }
+        }
+
+        return null;
+    }
+
+    private static string GetClaimMetaKey(string operationId) => $"controlplane:jobqueue:meta:{operationId}";
+
+    private static bool IsTerminal(ExecutionJobStatus status)
+        => status is ExecutionJobStatus.Succeeded
+            or ExecutionJobStatus.Failed
+            or ExecutionJobStatus.Cancelled;
+
+    private static partial class Log
+    {
+        [LoggerMessage(9020, LogLevel.Information, "Job enqueued: {OperationId}, Priority={Priority}")]
+        public static partial void JobEnqueued(ILogger logger, string operationId, string priority);
+
+        [LoggerMessage(9021, LogLevel.Information, "Job claimed: {OperationId} by worker {WorkerId}")]
+        public static partial void JobClaimed(ILogger logger, string operationId, string workerId);
+
+        [LoggerMessage(9022, LogLevel.Information, "Job requeued: {OperationId}")]
+        public static partial void JobRequeued(ILogger logger, string operationId);
+
+        [LoggerMessage(9023, LogLevel.Debug, "Job removed from queue: {OperationId}")]
+        public static partial void JobRemovedFromQueue(ILogger logger, string operationId);
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -34,6 +34,7 @@ internal sealed partial class RedisJobQueue(
     private const string QueueKey = "controlplane:jobqueue:pending";
     private const string ClaimedSetKey = "controlplane:jobqueue:claimed";
     private const int MaxScanEntries = 100;
+    private const int MaxVisitEntries = 1000;
 
     /// <summary>
     /// Lua script that atomically removes a job from the pending set and adds it
@@ -89,14 +90,13 @@ internal sealed partial class RedisJobQueue(
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Paginate through the sorted set to find a claimable job. Tracks removed
-        // entries so offset adjustments stay correct across batches.
         const int batchSize = 10;
         var now = DateTimeOffset.UtcNow;
         long offset = 0;
         var totalScanned = 0;
+        var totalVisited = 0;
 
-        while (totalScanned < MaxScanEntries)
+        while (totalScanned < MaxScanEntries && totalVisited < MaxVisitEntries)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -121,10 +121,8 @@ internal sealed partial class RedisJobQueue(
 
                 var operationId = candidate.ToString();
 
-                // Filter delayed jobs (requeue with visibility delay).
-                // Invisible entries do not consume the scan budget so that
-                // a backlog of delayed retries cannot starve ready work in
-                // lower-priority bands.
+                totalVisited++;
+
                 var meta = await _database.HashGetAllAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
                 var visibleAfter = GetVisibleAfter(meta);
                 if (visibleAfter.HasValue && visibleAfter.Value > now)
@@ -143,8 +141,6 @@ internal sealed partial class RedisJobQueue(
                     continue;
                 }
 
-                // Kind-mismatched entries do not consume the claim scan budget
-                // so dedicated workers can reach their own jobs deeper in the queue.
                 if (acceptedKinds != null && !acceptedKinds.Contains(job.Spec.Kind))
                 {
                     continue;
@@ -201,8 +197,12 @@ internal sealed partial class RedisJobQueue(
                 return operationId;
             }
 
-            // Advance past entries that were not removed from the set.
             offset += candidates.Length - removedFromSet;
+        }
+
+        if (totalVisited >= MaxVisitEntries)
+        {
+            Log.ClaimScanVisitBudgetExhausted(logger, totalVisited, totalScanned);
         }
 
         return null;
@@ -401,5 +401,8 @@ internal sealed partial class RedisJobQueue(
 
         [LoggerMessage(9026, LogLevel.Error, "Claim rollback failed: {OperationId}")]
         public static partial void ClaimRollbackFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9027, LogLevel.Warning, "Claim scan visit budget exhausted: visited {Visited} entries, scanned {Scanned} claimable candidates")]
+        public static partial void ClaimScanVisitBudgetExhausted(ILogger logger, int visited, int scanned);
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -96,7 +96,7 @@ internal sealed partial class RedisJobQueue(
         var totalScanned = 0;
         var totalVisited = 0;
 
-        while (totalScanned < MaxScanEntries && totalVisited < MaxVisitEntries)
+        while (totalScanned < MaxScanEntries)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -202,7 +202,7 @@ internal sealed partial class RedisJobQueue(
 
         if (totalVisited >= MaxVisitEntries)
         {
-            Log.ClaimScanVisitBudgetExhausted(logger, totalVisited, totalScanned);
+            Log.ClaimScanVisitThresholdExceeded(logger, totalVisited, totalScanned);
         }
 
         return null;
@@ -295,8 +295,20 @@ internal sealed partial class RedisJobQueue(
                 // Orphaned claim: removed from pending but store was never advanced.
                 await _database.SortedSetRemoveAsync(ClaimedSetKey, operationId).ConfigureAwait(false);
                 await _database.KeyDeleteAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
-                var score = ComputeScore(job.Priority, DateTimeOffset.UtcNow);
+
+                var hasDelayedRetry = job.NextRetryAt.HasValue && job.NextRetryAt.Value > DateTimeOffset.UtcNow;
+                var enqueueTime = hasDelayedRetry ? job.NextRetryAt!.Value : DateTimeOffset.UtcNow;
+                var score = ComputeScore(job.Priority, enqueueTime);
                 await _database.SortedSetAddAsync(QueueKey, operationId, score).ConfigureAwait(false);
+
+                if (hasDelayedRetry)
+                {
+                    await _database.HashSetAsync(GetClaimMetaKey(operationId),
+                    [
+                        new HashEntry("visibleAfter", job.NextRetryAt!.Value.ToUnixTimeMilliseconds().ToString())
+                    ]).ConfigureAwait(false);
+                }
+
                 Log.OrphanedClaimRequeued(logger, operationId);
             }
             else if (job.Status is ExecutionJobStatus.Provisioning or ExecutionJobStatus.Running
@@ -402,7 +414,7 @@ internal sealed partial class RedisJobQueue(
         [LoggerMessage(9026, LogLevel.Error, "Claim rollback failed: {OperationId}")]
         public static partial void ClaimRollbackFailed(ILogger logger, string operationId, Exception exception);
 
-        [LoggerMessage(9027, LogLevel.Warning, "Claim scan visit budget exhausted: visited {Visited} entries, scanned {Scanned} claimable candidates")]
-        public static partial void ClaimScanVisitBudgetExhausted(ILogger logger, int visited, int scanned);
+        [LoggerMessage(9027, LogLevel.Warning, "Claim scan visit threshold exceeded: visited {Visited} entries, scanned {Scanned} claimable candidates")]
+        public static partial void ClaimScanVisitThresholdExceeded(ILogger logger, int visited, int scanned);
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -69,6 +69,7 @@ internal sealed partial class RedisJobQueue(
         """;
 
     private readonly IDatabase _database = redis.GetDatabase();
+    private long _traverseCursor;
 
     public async Task EnqueueAsync(
         string operationId,
@@ -92,7 +93,7 @@ internal sealed partial class RedisJobQueue(
 
         const int batchSize = 10;
         var now = DateTimeOffset.UtcNow;
-        long offset = 0;
+        long offset = Interlocked.Read(ref _traverseCursor);
         var totalScanned = 0;
         var totalTraversed = 0;
         var totalSkipped = 0;
@@ -106,6 +107,11 @@ internal sealed partial class RedisJobQueue(
 
             if (candidates.Length == 0)
             {
+                if (offset > 0)
+                {
+                    Interlocked.Exchange(ref _traverseCursor, 0);
+                }
+
                 break;
             }
 
@@ -205,6 +211,7 @@ internal sealed partial class RedisJobQueue(
 
         if (totalTraversed >= MaxTraverseEntries)
         {
+            Interlocked.Exchange(ref _traverseCursor, offset);
             Log.ClaimScanTraverseThresholdExceeded(logger, totalTraversed, totalScanned, totalSkipped);
         }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -96,7 +96,7 @@ internal sealed partial class RedisJobQueue(
         var totalScanned = 0;
         var totalVisited = 0;
 
-        while (totalScanned < MaxScanEntries)
+        while (totalScanned < MaxScanEntries && totalVisited < MaxVisitEntries)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -9,6 +9,19 @@ using StackExchange.Redis;
 namespace Honua.Server.Features.Infrastructure.ControlPlane;
 
 /// <summary>
+/// Detects and recovers claims that were orphaned between the atomic queue move
+/// and the subsequent job store update.
+/// </summary>
+internal interface IQueueClaimReconciler
+{
+    /// <summary>
+    /// Scans for stale claims older than <paramref name="staleThreshold"/> whose
+    /// backing job record has not advanced past Queued, and requeues them.
+    /// </summary>
+    Task ReconcileStaleClaimsAsync(TimeSpan staleThreshold, CancellationToken cancellationToken);
+}
+
+/// <summary>
 /// Redis-backed durable job queue with atomic claim semantics.
 /// Uses a sorted set keyed by priority score for dequeue ordering and
 /// per-job metadata hashes for claim tracking.
@@ -16,10 +29,26 @@ namespace Honua.Server.Features.Infrastructure.ControlPlane;
 internal sealed partial class RedisJobQueue(
     IConnectionMultiplexer redis,
     IExecutionJobStore jobStore,
-    ILogger<RedisJobQueue> logger) : IJobQueue
+    ILogger<RedisJobQueue> logger) : IJobQueue, IQueueClaimReconciler
 {
     private const string QueueKey = "controlplane:jobqueue:pending";
     private const string ClaimedSetKey = "controlplane:jobqueue:claimed";
+    private const int MaxScanEntries = 100;
+
+    /// <summary>
+    /// Lua script that atomically removes a job from the pending set and adds it
+    /// to the claimed set. Returns 1 on success, 0 if another worker claimed first.
+    /// KEYS[1] = pending set, KEYS[2] = claimed set.
+    /// ARGV[1] = operationId, ARGV[2] = claim timestamp (ms).
+    /// </summary>
+    private const string AtomicClaimScript = """
+        local removed = redis.call('ZREM', KEYS[1], ARGV[1])
+        if removed == 1 then
+            redis.call('ZADD', KEYS[2], ARGV[2], ARGV[1])
+            return 1
+        end
+        return 0
+        """;
 
     private readonly IDatabase _database = redis.GetDatabase();
 
@@ -43,80 +72,112 @@ internal sealed partial class RedisJobQueue(
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Scan the sorted set from highest priority (lowest score) to find a claimable job.
-        // We use ZPOPMIN-style iteration rather than a Lua script to stay simple and
-        // avoid blocking other queue consumers during the job store lookup.
+        // Paginate through the sorted set to find a claimable job. Tracks removed
+        // entries so offset adjustments stay correct across batches.
         const int batchSize = 10;
         var now = DateTimeOffset.UtcNow;
+        long offset = 0;
+        var totalScanned = 0;
 
-        var candidates = await _database.SortedSetRangeByRankAsync(
-            QueueKey, 0, batchSize - 1).ConfigureAwait(false);
-
-        foreach (var candidate in candidates)
+        while (totalScanned < MaxScanEntries)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!candidate.HasValue)
+            var candidates = await _database.SortedSetRangeByRankAsync(
+                QueueKey, offset, offset + batchSize - 1).ConfigureAwait(false);
+
+            if (candidates.Length == 0)
             {
-                continue;
+                break;
             }
 
-            var operationId = candidate.ToString();
+            var removedFromSet = 0;
 
-            // Filter delayed jobs (requeue with visibility delay).
-            var meta = await _database.HashGetAllAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
-            var visibleAfter = GetVisibleAfter(meta);
-            if (visibleAfter.HasValue && visibleAfter.Value > now)
+            foreach (var candidate in candidates)
             {
-                continue;
+                totalScanned++;
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (!candidate.HasValue)
+                {
+                    continue;
+                }
+
+                var operationId = candidate.ToString();
+
+                // Filter delayed jobs (requeue with visibility delay).
+                var meta = await _database.HashGetAllAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
+                var visibleAfter = GetVisibleAfter(meta);
+                if (visibleAfter.HasValue && visibleAfter.Value > now)
+                {
+                    continue;
+                }
+
+                // Load the job record to check kind filter and current status.
+                var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+                if (job == null || IsTerminal(job.Status))
+                {
+                    // Stale entry; remove from queue.
+                    await _database.SortedSetRemoveAsync(QueueKey, operationId).ConfigureAwait(false);
+                    removedFromSet++;
+                    continue;
+                }
+
+                if (acceptedKinds != null && !acceptedKinds.Contains(job.Spec.Kind))
+                {
+                    continue;
+                }
+
+                // Attempt atomic claim: remove from pending and add to claimed in a
+                // single Lua evaluation to prevent the window where the job exists in
+                // neither set.
+                var claimResult = (int)await _database.ScriptEvaluateAsync(
+                    AtomicClaimScript,
+                    [(RedisKey)QueueKey, (RedisKey)ClaimedSetKey],
+                    [(RedisValue)operationId, now.ToUnixTimeMilliseconds()]).ConfigureAwait(false);
+
+                if (claimResult == 0)
+                {
+                    // Another worker claimed it first.
+                    removedFromSet++;
+                    continue;
+                }
+
+                await _database.HashSetAsync(GetClaimMetaKey(operationId),
+                [
+                    new HashEntry("workerId", workerId),
+                    new HashEntry("claimedAt", now.ToUnixTimeMilliseconds().ToString())
+                ]).ConfigureAwait(false);
+
+                // Persist claim metadata to the job store. If this fails, roll back the
+                // Redis claim so the job returns to the pending queue.
+                var claimed = job with
+                {
+                    Status = ExecutionJobStatus.Provisioning,
+                    ClaimedBy = workerId,
+                    ClaimedAt = now,
+                    LastHeartbeatAt = now,
+                    AttemptCount = job.AttemptCount + 1,
+                    UpdatedAt = now,
+                    CurrentPhase = "Claimed"
+                };
+
+                try
+                {
+                    await jobStore.SetAsync(claimed, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    await RollBackClaimAsync(operationId, job.Priority).ConfigureAwait(false);
+                    throw;
+                }
+
+                Log.JobClaimed(logger, operationId, workerId);
+                return operationId;
             }
 
-            // Load the job record to check kind filter and current status.
-            var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
-            if (job == null || IsTerminal(job.Status))
-            {
-                // Stale entry; remove from queue.
-                await _database.SortedSetRemoveAsync(QueueKey, operationId).ConfigureAwait(false);
-                continue;
-            }
-
-            if (acceptedKinds != null && !acceptedKinds.Contains(job.Spec.Kind))
-            {
-                continue;
-            }
-
-            // Attempt atomic claim: remove from pending and add to claimed.
-            var removed = await _database.SortedSetRemoveAsync(QueueKey, operationId).ConfigureAwait(false);
-            if (!removed)
-            {
-                // Another worker claimed it first.
-                continue;
-            }
-
-            await _database.SortedSetAddAsync(ClaimedSetKey, operationId, now.ToUnixTimeMilliseconds())
-                .ConfigureAwait(false);
-
-            await _database.HashSetAsync(GetClaimMetaKey(operationId),
-            [
-                new HashEntry("workerId", workerId),
-                new HashEntry("claimedAt", now.ToUnixTimeMilliseconds().ToString())
-            ]).ConfigureAwait(false);
-
-            // Update the job record with claim metadata.
-            var claimed = job with
-            {
-                Status = ExecutionJobStatus.Provisioning,
-                ClaimedBy = workerId,
-                ClaimedAt = now,
-                LastHeartbeatAt = now,
-                AttemptCount = job.AttemptCount + 1,
-                UpdatedAt = now,
-                CurrentPhase = "Claimed"
-            };
-            await jobStore.SetAsync(claimed, cancellationToken: cancellationToken).ConfigureAwait(false);
-
-            Log.JobClaimed(logger, operationId, workerId);
-            return operationId;
+            // Advance past entries that were not removed from the set.
+            offset += candidates.Length - removedFromSet;
         }
 
         return null;
@@ -133,7 +194,9 @@ internal sealed partial class RedisJobQueue(
         // Remove from claimed set.
         await _database.SortedSetRemoveAsync(ClaimedSetKey, operationId).ConfigureAwait(false);
 
-        // Set visibility delay if requested.
+        // Set visibility delay if requested, and encode the visibility time into the
+        // sorted-set score so delayed jobs sort after currently-visible jobs within
+        // the same priority band.
         if (visibleAfter.HasValue && visibleAfter.Value > TimeSpan.Zero)
         {
             var visibleAt = DateTimeOffset.UtcNow.Add(visibleAfter.Value);
@@ -141,14 +204,17 @@ internal sealed partial class RedisJobQueue(
             [
                 new HashEntry("visibleAfter", visibleAt.ToUnixTimeMilliseconds().ToString())
             ]).ConfigureAwait(false);
+
+            var score = ComputeScore(priority, visibleAt);
+            await _database.SortedSetAddAsync(QueueKey, operationId, score).ConfigureAwait(false);
         }
         else
         {
             await _database.KeyDeleteAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
-        }
 
-        var score = ComputeScore(priority, DateTimeOffset.UtcNow);
-        await _database.SortedSetAddAsync(QueueKey, operationId, score).ConfigureAwait(false);
+            var score = ComputeScore(priority, DateTimeOffset.UtcNow);
+            await _database.SortedSetAddAsync(QueueKey, operationId, score).ConfigureAwait(false);
+        }
 
         Log.JobRequeued(logger, operationId);
     }
@@ -166,10 +232,76 @@ internal sealed partial class RedisJobQueue(
         Log.JobRemovedFromQueue(logger, operationId);
     }
 
+    /// <inheritdoc />
+    public async Task ReconcileStaleClaimsAsync(
+        TimeSpan staleThreshold,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var thresholdScore = (double)DateTimeOffset.UtcNow.Subtract(staleThreshold).ToUnixTimeMilliseconds();
+        var staleEntries = await _database.SortedSetRangeByScoreAsync(
+            ClaimedSetKey, 0, thresholdScore).ConfigureAwait(false);
+
+        foreach (var entry in staleEntries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!entry.HasValue)
+            {
+                continue;
+            }
+
+            var operationId = entry.ToString();
+            var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+
+            if (job == null || IsTerminal(job.Status))
+            {
+                // Record expired or already terminal. Clean up claimed set.
+                await _database.SortedSetRemoveAsync(ClaimedSetKey, operationId).ConfigureAwait(false);
+                await _database.KeyDeleteAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
+                continue;
+            }
+
+            if (job.Status == ExecutionJobStatus.Queued)
+            {
+                // Orphaned claim: removed from pending but store was never advanced.
+                await _database.SortedSetRemoveAsync(ClaimedSetKey, operationId).ConfigureAwait(false);
+                await _database.KeyDeleteAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
+                var score = ComputeScore(job.Priority, DateTimeOffset.UtcNow);
+                await _database.SortedSetAddAsync(QueueKey, operationId, score).ConfigureAwait(false);
+                Log.OrphanedClaimRequeued(logger, operationId);
+            }
+            // Provisioning/Running with expired heartbeat is handled by the main
+            // reconciliation sweep.
+        }
+    }
+
     public async Task<long> GetQueueDepthAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         return await _database.SortedSetLengthAsync(QueueKey).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Best-effort rollback after a successful Lua claim when the subsequent
+    /// job store update fails.
+    /// </summary>
+    private async Task RollBackClaimAsync(string operationId, OperationPriority priority)
+    {
+        try
+        {
+            await _database.SortedSetRemoveAsync(ClaimedSetKey, operationId).ConfigureAwait(false);
+            await _database.KeyDeleteAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
+            var score = ComputeScore(priority, DateTimeOffset.UtcNow);
+            await _database.SortedSetAddAsync(QueueKey, operationId, score).ConfigureAwait(false);
+            Log.ClaimRolledBack(logger, operationId);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort; stale-claim reconciliation is the safety net.
+            Log.ClaimRollbackFailed(logger, operationId, ex);
+        }
     }
 
     /// <summary>
@@ -224,5 +356,14 @@ internal sealed partial class RedisJobQueue(
 
         [LoggerMessage(9023, LogLevel.Debug, "Job removed from queue: {OperationId}")]
         public static partial void JobRemovedFromQueue(ILogger logger, string operationId);
+
+        [LoggerMessage(9024, LogLevel.Warning, "Orphaned claim requeued: {OperationId}")]
+        public static partial void OrphanedClaimRequeued(ILogger logger, string operationId);
+
+        [LoggerMessage(9025, LogLevel.Warning, "Claim rolled back after store update failure: {OperationId}")]
+        public static partial void ClaimRolledBack(ILogger logger, string operationId);
+
+        [LoggerMessage(9026, LogLevel.Error, "Claim rollback failed: {OperationId}")]
+        public static partial void ClaimRollbackFailed(ILogger logger, string operationId, Exception exception);
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -122,11 +122,13 @@ internal sealed partial class RedisJobQueue(
                 var operationId = candidate.ToString();
 
                 // Filter delayed jobs (requeue with visibility delay).
+                // Invisible entries do not consume the scan budget so that
+                // a backlog of delayed retries cannot starve ready work in
+                // lower-priority bands.
                 var meta = await _database.HashGetAllAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
                 var visibleAfter = GetVisibleAfter(meta);
                 if (visibleAfter.HasValue && visibleAfter.Value > now)
                 {
-                    totalScanned++;
                     continue;
                 }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -293,21 +293,21 @@ internal sealed partial class RedisJobQueue(
             if (job.Status == ExecutionJobStatus.Queued)
             {
                 // Orphaned claim: removed from pending but store was never advanced.
-                await _database.SortedSetRemoveAsync(ClaimedSetKey, operationId).ConfigureAwait(false);
-                await _database.KeyDeleteAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
-
+                // Use atomic Lua script to prevent a window where the job exists in
+                // neither set if the move is interrupted mid-operation.
                 var hasDelayedRetry = job.NextRetryAt.HasValue && job.NextRetryAt.Value > DateTimeOffset.UtcNow;
                 var enqueueTime = hasDelayedRetry ? job.NextRetryAt!.Value : DateTimeOffset.UtcNow;
                 var score = ComputeScore(job.Priority, enqueueTime);
-                await _database.SortedSetAddAsync(QueueKey, operationId, score).ConfigureAwait(false);
 
-                if (hasDelayedRetry)
-                {
-                    await _database.HashSetAsync(GetClaimMetaKey(operationId),
-                    [
-                        new HashEntry("visibleAfter", job.NextRetryAt!.Value.ToUnixTimeMilliseconds().ToString())
-                    ]).ConfigureAwait(false);
-                }
+                RedisValue visibleAfterArg = hasDelayedRetry
+                    ? job.NextRetryAt!.Value.ToUnixTimeMilliseconds().ToString()
+                    : RedisValue.EmptyString;
+
+                await _database.ScriptEvaluateAsync(
+                    AtomicRequeueScript,
+                    [(RedisKey)ClaimedSetKey, (RedisKey)QueueKey, (RedisKey)GetClaimMetaKey(operationId)],
+                    [(RedisValue)operationId, score, visibleAfterArg])
+                    .ConfigureAwait(false);
 
                 Log.OrphanedClaimRequeued(logger, operationId);
             }
@@ -333,16 +333,20 @@ internal sealed partial class RedisJobQueue(
 
     /// <summary>
     /// Best-effort rollback after a successful Lua claim when the subsequent
-    /// job store update fails.
+    /// job store update fails. Uses the same atomic Lua script as
+    /// <see cref="RequeueAsync"/> to prevent a window where the job exists
+    /// in neither set.
     /// </summary>
     private async Task RollBackClaimAsync(string operationId, OperationPriority priority)
     {
         try
         {
-            await _database.SortedSetRemoveAsync(ClaimedSetKey, operationId).ConfigureAwait(false);
-            await _database.KeyDeleteAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
             var score = ComputeScore(priority, DateTimeOffset.UtcNow);
-            await _database.SortedSetAddAsync(QueueKey, operationId, score).ConfigureAwait(false);
+            await _database.ScriptEvaluateAsync(
+                AtomicRequeueScript,
+                [(RedisKey)ClaimedSetKey, (RedisKey)QueueKey, (RedisKey)GetClaimMetaKey(operationId)],
+                [(RedisValue)operationId, score, RedisValue.EmptyString])
+                .ConfigureAwait(false);
             Log.ClaimRolledBack(logger, operationId);
         }
         catch (Exception ex)

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -181,7 +181,8 @@ internal sealed partial class RedisJobQueue(
                     LastHeartbeatAt = now,
                     AttemptCount = job.AttemptCount + 1,
                     UpdatedAt = now,
-                    CurrentPhase = "Claimed"
+                    CurrentPhase = "Claimed",
+                    NextRetryAt = null
                 };
 
                 try
@@ -296,8 +297,17 @@ internal sealed partial class RedisJobQueue(
                 await _database.SortedSetAddAsync(QueueKey, operationId, score).ConfigureAwait(false);
                 Log.OrphanedClaimRequeued(logger, operationId);
             }
-            // Provisioning/Running with expired heartbeat is handled by the main
-            // reconciliation sweep.
+            else if (job.Status is ExecutionJobStatus.Provisioning or ExecutionJobStatus.Running
+                     && job.LastHeartbeatAt.HasValue)
+            {
+                // Healthy long-running job: refresh the claimed-set score to the
+                // last heartbeat time so future sweeps skip it until the heartbeat
+                // genuinely goes cold. Expired heartbeats are handled by the main
+                // reconciliation sweep in JobReconciliationService.
+                await _database.SortedSetAddAsync(
+                    ClaimedSetKey, operationId,
+                    (double)job.LastHeartbeatAt.Value.ToUnixTimeMilliseconds()).ConfigureAwait(false);
+            }
         }
     }
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -178,8 +178,9 @@ internal sealed partial class RedisJobQueue(
                     new HashEntry("claimedAt", now.ToUnixTimeMilliseconds().ToString())
                 ]).ConfigureAwait(false);
 
-                // Persist claim metadata to the job store. If this fails, roll back the
-                // Redis claim so the job returns to the pending queue.
+                // Persist claim metadata to the job store. Use CAS so a concurrent
+                // cancel or terminal transition cannot be overwritten by the claim.
+                // If the store write fails, repair the Redis claim state.
                 var claimed = job with
                 {
                     Status = ExecutionJobStatus.Provisioning,
@@ -194,7 +195,20 @@ internal sealed partial class RedisJobQueue(
 
                 try
                 {
-                    await jobStore.SetAsync(claimed, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    if (!await jobStore.TrySetAsync(claimed, cancellationToken: cancellationToken).ConfigureAwait(false))
+                    {
+                        var conflict = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+                        if (conflict == null || IsTerminal(conflict.Status))
+                        {
+                            await ClearClaimAsync(operationId).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            await RollBackClaimAsync(operationId, conflict.Priority).ConfigureAwait(false);
+                        }
+
+                        continue;
+                    }
                 }
                 catch
                 {
@@ -358,6 +372,20 @@ internal sealed partial class RedisJobQueue(
                 [(RedisValue)operationId, score, RedisValue.EmptyString])
                 .ConfigureAwait(false);
             Log.ClaimRolledBack(logger, operationId);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort; stale-claim reconciliation is the safety net.
+            Log.ClaimRollbackFailed(logger, operationId, ex);
+        }
+    }
+
+    private async Task ClearClaimAsync(string operationId)
+    {
+        try
+        {
+            await _database.SortedSetRemoveAsync(ClaimedSetKey, operationId).ConfigureAwait(false);
+            await _database.KeyDeleteAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -96,7 +96,7 @@ internal sealed partial class RedisJobQueue(
         var totalScanned = 0;
         var totalVisited = 0;
 
-        while (totalScanned < MaxScanEntries && totalVisited < MaxVisitEntries)
+        while (totalScanned < MaxScanEntries)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -50,6 +50,23 @@ internal sealed partial class RedisJobQueue(
         return 0
         """;
 
+    /// <summary>
+    /// Lua script that atomically removes a job from the claimed set and adds it
+    /// back to the pending set. Optionally sets or clears visibility metadata.
+    /// KEYS[1] = claimed set, KEYS[2] = pending set, KEYS[3] = claim meta hash.
+    /// ARGV[1] = operationId, ARGV[2] = score, ARGV[3] = visibleAfterMs (empty to clear meta).
+    /// </summary>
+    private const string AtomicRequeueScript = """
+        redis.call('ZREM', KEYS[1], ARGV[1])
+        redis.call('ZADD', KEYS[2], ARGV[2], ARGV[1])
+        if ARGV[3] ~= '' then
+            redis.call('HSET', KEYS[3], 'visibleAfter', ARGV[3])
+        else
+            redis.call('DEL', KEYS[3])
+        end
+        return 1
+        """;
+
     private readonly IDatabase _database = redis.GetDatabase();
 
     public async Task EnqueueAsync(
@@ -196,29 +213,31 @@ internal sealed partial class RedisJobQueue(
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Remove from claimed set.
-        await _database.SortedSetRemoveAsync(ClaimedSetKey, operationId).ConfigureAwait(false);
+        // Atomically move from claimed → pending and update visibility metadata
+        // in a single Lua evaluation to prevent the window where the job exists
+        // in neither set.
+        var metaKey = GetClaimMetaKey(operationId);
 
-        // Set visibility delay if requested, and encode the visibility time into the
-        // sorted-set score so delayed jobs sort after currently-visible jobs within
-        // the same priority band.
         if (visibleAfter.HasValue && visibleAfter.Value > TimeSpan.Zero)
         {
             var visibleAt = DateTimeOffset.UtcNow.Add(visibleAfter.Value);
-            await _database.HashSetAsync(GetClaimMetaKey(operationId),
-            [
-                new HashEntry("visibleAfter", visibleAt.ToUnixTimeMilliseconds().ToString())
-            ]).ConfigureAwait(false);
-
             var score = ComputeScore(priority, visibleAt);
-            await _database.SortedSetAddAsync(QueueKey, operationId, score).ConfigureAwait(false);
+
+            await _database.ScriptEvaluateAsync(
+                AtomicRequeueScript,
+                [(RedisKey)ClaimedSetKey, (RedisKey)QueueKey, (RedisKey)metaKey],
+                [(RedisValue)operationId, score, visibleAt.ToUnixTimeMilliseconds().ToString()])
+                .ConfigureAwait(false);
         }
         else
         {
-            await _database.KeyDeleteAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
-
             var score = ComputeScore(priority, DateTimeOffset.UtcNow);
-            await _database.SortedSetAddAsync(QueueKey, operationId, score).ConfigureAwait(false);
+
+            await _database.ScriptEvaluateAsync(
+                AtomicRequeueScript,
+                [(RedisKey)ClaimedSetKey, (RedisKey)QueueKey, (RedisKey)metaKey],
+                [(RedisValue)operationId, score, RedisValue.EmptyString])
+                .ConfigureAwait(false);
         }
 
         Log.JobRequeued(logger, operationId);

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -34,7 +34,7 @@ internal sealed partial class RedisJobQueue(
     private const string QueueKey = "controlplane:jobqueue:pending";
     private const string ClaimedSetKey = "controlplane:jobqueue:claimed";
     private const int MaxScanEntries = 100;
-    private const int MaxVisitEntries = 1000;
+    private const int MaxTraverseEntries = 5000;
 
     /// <summary>
     /// Lua script that atomically removes a job from the pending set and adds it
@@ -94,9 +94,10 @@ internal sealed partial class RedisJobQueue(
         var now = DateTimeOffset.UtcNow;
         long offset = 0;
         var totalScanned = 0;
-        var totalVisited = 0;
+        var totalTraversed = 0;
+        var totalSkipped = 0;
 
-        while (totalScanned < MaxScanEntries && totalVisited < MaxVisitEntries)
+        while (totalScanned < MaxScanEntries && totalTraversed < MaxTraverseEntries)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -121,12 +122,13 @@ internal sealed partial class RedisJobQueue(
 
                 var operationId = candidate.ToString();
 
-                totalVisited++;
+                totalTraversed++;
 
                 var meta = await _database.HashGetAllAsync(GetClaimMetaKey(operationId)).ConfigureAwait(false);
                 var visibleAfter = GetVisibleAfter(meta);
                 if (visibleAfter.HasValue && visibleAfter.Value > now)
                 {
+                    totalSkipped++;
                     continue;
                 }
 
@@ -143,6 +145,7 @@ internal sealed partial class RedisJobQueue(
 
                 if (acceptedKinds != null && !acceptedKinds.Contains(job.Spec.Kind))
                 {
+                    totalSkipped++;
                     continue;
                 }
 
@@ -200,9 +203,9 @@ internal sealed partial class RedisJobQueue(
             offset += candidates.Length - removedFromSet;
         }
 
-        if (totalVisited >= MaxVisitEntries)
+        if (totalTraversed >= MaxTraverseEntries)
         {
-            Log.ClaimScanVisitThresholdExceeded(logger, totalVisited, totalScanned);
+            Log.ClaimScanTraverseThresholdExceeded(logger, totalTraversed, totalScanned, totalSkipped);
         }
 
         return null;
@@ -418,7 +421,7 @@ internal sealed partial class RedisJobQueue(
         [LoggerMessage(9026, LogLevel.Error, "Claim rollback failed: {OperationId}")]
         public static partial void ClaimRollbackFailed(ILogger logger, string operationId, Exception exception);
 
-        [LoggerMessage(9027, LogLevel.Warning, "Claim scan visit threshold exceeded: visited {Visited} entries, scanned {Scanned} claimable candidates")]
-        public static partial void ClaimScanVisitThresholdExceeded(ILogger logger, int visited, int scanned);
+        [LoggerMessage(9027, LogLevel.Warning, "Claim scan traverse threshold exceeded: traversed {Traversed} entries, scanned {Scanned} claimable candidates, skipped {Skipped} delayed/kind-mismatched")]
+        public static partial void ClaimScanTraverseThresholdExceeded(ILogger logger, int traversed, int scanned, int skipped);
     }
 }

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisJobQueue.cs
@@ -95,7 +95,6 @@ internal sealed partial class RedisJobQueue(
 
             foreach (var candidate in candidates)
             {
-                totalScanned++;
                 cancellationToken.ThrowIfCancellationRequested();
 
                 if (!candidate.HasValue)
@@ -110,6 +109,7 @@ internal sealed partial class RedisJobQueue(
                 var visibleAfter = GetVisibleAfter(meta);
                 if (visibleAfter.HasValue && visibleAfter.Value > now)
                 {
+                    totalScanned++;
                     continue;
                 }
 
@@ -120,13 +120,18 @@ internal sealed partial class RedisJobQueue(
                     // Stale entry; remove from queue.
                     await _database.SortedSetRemoveAsync(QueueKey, operationId).ConfigureAwait(false);
                     removedFromSet++;
+                    totalScanned++;
                     continue;
                 }
 
+                // Kind-mismatched entries do not consume the claim scan budget
+                // so dedicated workers can reach their own jobs deeper in the queue.
                 if (acceptedKinds != null && !acceptedKinds.Contains(job.Spec.Kind))
                 {
                     continue;
                 }
+
+                totalScanned++;
 
                 // Attempt atomic claim: remove from pending and add to claimed in a
                 // single Lua evaluation to prevent the window where the job exists in

--- a/src/Honua.Server/Features/Infrastructure/Coordination/RedisDistributedLeaderElection.cs
+++ b/src/Honua.Server/Features/Infrastructure/Coordination/RedisDistributedLeaderElection.cs
@@ -323,7 +323,7 @@ internal sealed partial class RedisDistributedLeaderElection : IDistributedLeade
         {
             try
             {
-                _ = Task.Run(async () => await ReleaseLeadershipAsync());
+                ReleaseLeadershipAsync().GetAwaiter().GetResult();
             }
             catch
             {

--- a/src/Honua.Server/Features/Infrastructure/JobCancellationNotifierExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/JobCancellationNotifierExtensions.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Abstractions;
+
+namespace Honua.Server.Features.Infrastructure;
+
+/// <summary>
+/// Shared fan-out helpers for job-cancellation notifiers.
+/// </summary>
+internal static class JobCancellationNotifierExtensions
+{
+    /// <summary>
+    /// Signals every registered notifier for <paramref name="jobId"/> and
+    /// returns <c>true</c> when any worker confirms it owns the terminal-state
+    /// transition.
+    /// </summary>
+    public static bool CancelAny(
+        this IEnumerable<IJobCancellationNotifier> cancellationNotifiers,
+        string jobId)
+    {
+        ArgumentNullException.ThrowIfNull(cancellationNotifiers);
+        ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
+
+        var workerOwnsTerminalState = false;
+
+        foreach (var notifier in cancellationNotifiers)
+        {
+            if (notifier.Cancel(jobId))
+            {
+                workerOwnsTerminalState = true;
+            }
+        }
+
+        return workerOwnsTerminalState;
+    }
+}

--- a/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
@@ -8,6 +8,7 @@ using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure;
@@ -312,9 +313,23 @@ internal static class JobEndpoints
             return JobNotFoundResult(jobId);
         }
 
-        // Already dismissed — return current status
+        // Already dismissed — reconcile side effects and return current status
         if (job.Status == ExecutionJobStatus.Cancelled)
         {
+            if (jobQueue != null)
+            {
+                await jobQueue.RemoveAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+            }
+
+            var staleProgress = await progressStore.GetProgressAsync<GeoprocessingProgress>(
+                jobId, context.RequestAborted).ConfigureAwait(false);
+            if (staleProgress != null && staleProgress.Status != OperationStatus.Cancelled)
+            {
+                var reconciledProgress = staleProgress.WithCancellation(DateTimeOffset.UtcNow, "Dismissed via OGC API");
+                await progressStore.SetProgressAsync(
+                    jobId, reconciledProgress, TimeSpan.FromDays(7), context.RequestAborted).ConfigureAwait(false);
+            }
+
             var baseUrl2 = BaseUrlResolver.GetBaseUrl(context);
             return Results.Json(
                 OgcProcessesConversionHelpers.ToOgcStatusInfo(

--- a/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
@@ -318,7 +318,14 @@ internal static class JobEndpoints
         {
             if (jobQueue != null)
             {
-                await jobQueue.RemoveAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                try
+                {
+                    await jobQueue.RemoveAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    OgcProcessesLog.QueueRemovalFailed(logger, jobId, ex);
+                }
             }
 
             var staleProgress = await progressStore.GetProgressAsync<GeoprocessingProgress>(
@@ -404,7 +411,14 @@ internal static class JobEndpoints
 
                 if (jobQueue != null)
                 {
-                    await jobQueue.RemoveAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                    try
+                    {
+                        await jobQueue.RemoveAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        OgcProcessesLog.QueueRemovalFailed(logger, jobId, ex);
+                    }
                 }
 
                 var staleProgress = await progressStore.GetProgressAsync<GeoprocessingProgress>(
@@ -448,7 +462,14 @@ internal static class JobEndpoints
 
                 if (jobQueue != null)
                 {
-                    await jobQueue.RemoveAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                    try
+                    {
+                        await jobQueue.RemoveAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        OgcProcessesLog.QueueRemovalFailed(logger, jobId, ex);
+                    }
                 }
 
                 var progress = await progressStore.GetProgressAsync<GeoprocessingProgress>(

--- a/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Helpers;
+using Honua.Server.Features.Infrastructure;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.OgcProcesses.Models;
 using Honua.ServiceDefaults;
@@ -276,7 +277,7 @@ internal static class JobEndpoints
         string jobId,
         HttpContext context,
         ILogger<OgcProcessesEndpointsLog> logger,
-        IJobCancellationNotifier cancellationNotifier,
+        IEnumerable<IJobCancellationNotifier> cancellationNotifiers,
         IUniversalProgressStore progressStore,
         [FromServices] IExecutionJobStore? jobStore = null,
         [FromServices] IJobQueue? jobQueue = null)
@@ -355,7 +356,7 @@ internal static class JobEndpoints
         }
 
         // Attempt cancellation via the canonical notifier
-        var workerOwnsTerminalState = cancellationNotifier.Cancel(jobId);
+        var workerOwnsTerminalState = cancellationNotifiers.CancelAny(jobId);
 
         if (!workerOwnsTerminalState)
         {

--- a/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
@@ -402,6 +402,20 @@ internal static class JobEndpoints
                         StatusCodes.Status409Conflict);
                 }
 
+                if (jobQueue != null)
+                {
+                    await jobQueue.RemoveAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                }
+
+                var staleProgress = await progressStore.GetProgressAsync<GeoprocessingProgress>(
+                    jobId, context.RequestAborted).ConfigureAwait(false);
+                if (staleProgress != null && staleProgress.Status != OperationStatus.Cancelled)
+                {
+                    var reconciledProgress = staleProgress.WithCancellation(DateTimeOffset.UtcNow, "Dismissed via OGC API");
+                    await progressStore.SetProgressAsync(
+                        jobId, reconciledProgress, TimeSpan.FromDays(7), context.RequestAborted).ConfigureAwait(false);
+                }
+
                 job = latest;
             }
             else if (latest.ClaimedBy != null)

--- a/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.ControlPlane;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure;
 using Honua.Server.Features.Ogc.Common;
@@ -432,84 +433,47 @@ internal static class JobEndpoints
 
                 job = latest;
             }
-            else if (latest.ClaimedBy != null)
-            {
-                // Job is actively claimed by a remote worker whose local
-                // notifier is unreachable. Persist a durable cancellation
-                // signal so the worker observes it during its next heartbeat.
-                var reqNow = DateTimeOffset.UtcNow;
-                var current = latest;
-                var cancelSignalConfirmed = current.CancellationRequestedAt.HasValue;
-
-                for (var casAttempt = 0; !cancelSignalConfirmed && casAttempt < 3; casAttempt++)
-                {
-                    var requested = current with
-                    {
-                        CancellationRequestedAt = reqNow,
-                        UpdatedAt = reqNow
-                    };
-                    if (await jobStore.TrySetAsync(requested, cancellationToken: context.RequestAborted).ConfigureAwait(false))
-                    {
-                        cancelSignalConfirmed = true;
-                        current = requested;
-                        break;
-                    }
-
-                    current = await jobStore.GetAsync(jobId, context.RequestAborted).ConfigureAwait(false);
-                    if (current == null || current.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
-                    {
-                        var terminalStatus = current != null
-                            ? OgcProcessesConversionHelpers.ToOgcStatus(current.Status)
-                            : "unknown";
-                        OgcProcessesLog.DismissRejectedTerminal(logger, jobId, terminalStatus);
-                        return Results.Json(
-                            new OgcProcessError
-                            {
-                                Type = "about:blank",
-                                Title = "Cannot dismiss completed job",
-                                Status = StatusCodes.Status409Conflict,
-                                Detail = $"Job '{jobId}' reached terminal state '{terminalStatus}' before dismiss could be applied."
-                            },
-                            OgcProcessesJsonContext.Default.OgcProcessError,
-                            MediaTypes.Json,
-                            StatusCodes.Status409Conflict);
-                    }
-
-                    cancelSignalConfirmed = current.CancellationRequestedAt.HasValue
-                        || current.Status == ExecutionJobStatus.Cancelled;
-                }
-
-                job = current;
-            }
             else
             {
-                // Unclaimed job — transition to cancelled directly.
-                var now = DateTimeOffset.UtcNow;
-                var current = latest;
-                var cancelConfirmed = false;
+                var cancelOutcome = await ExecutionJobCancellationHelper.TryApplyAsync(
+                    jobStore,
+                    jobId,
+                    latest,
+                    "Dismissed",
+                    cancellationToken: context.RequestAborted).ConfigureAwait(false);
 
-                for (var casAttempt = 0; casAttempt < 3; casAttempt++)
+                switch (cancelOutcome.State)
                 {
-                    var cancelled = current with
-                    {
-                        Status = ExecutionJobStatus.Cancelled,
-                        UpdatedAt = now,
-                        CompletedAt = now,
-                        CurrentPhase = "Dismissed"
-                    };
+                    case ExecutionJobCancellationState.Cancelled:
+                        if (jobQueue != null)
+                        {
+                            try
+                            {
+                                await jobQueue.RemoveAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                            }
+                            catch (Exception ex)
+                            {
+                                OgcProcessesLog.QueueRemovalFailed(logger, jobId, ex);
+                            }
+                        }
 
-                    if (await jobStore.TrySetAsync(cancelled, cancellationToken: context.RequestAborted).ConfigureAwait(false))
-                    {
-                        cancelConfirmed = true;
-                        current = cancelled;
+                        var progress = await progressStore.GetProgressAsync<GeoprocessingProgress>(
+                            jobId, context.RequestAborted).ConfigureAwait(false);
+                        if (progress != null)
+                        {
+                            var cancelledProgress = progress.WithCancellation(DateTimeOffset.UtcNow, "Dismissed via OGC API");
+                            await progressStore.SetProgressAsync(
+                                jobId, cancelledProgress, TimeSpan.FromDays(7), context.RequestAborted).ConfigureAwait(false);
+                        }
+
+                        job = cancelOutcome.Job ?? latest;
                         break;
-                    }
-
-                    current = await jobStore.GetAsync(jobId, context.RequestAborted).ConfigureAwait(false);
-                    if (current == null || current.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
-                    {
-                        var terminalStatus = current != null
-                            ? OgcProcessesConversionHelpers.ToOgcStatus(current.Status)
+                    case ExecutionJobCancellationState.CancellationRequested:
+                        job = cancelOutcome.Job ?? latest;
+                        break;
+                    case ExecutionJobCancellationState.TerminalConflict:
+                        var terminalStatus = cancelOutcome.Job != null
+                            ? OgcProcessesConversionHelpers.ToOgcStatus(cancelOutcome.Job.Status)
                             : "unknown";
                         OgcProcessesLog.DismissRejectedTerminal(logger, jobId, terminalStatus);
                         return Results.Json(
@@ -523,40 +487,23 @@ internal static class JobEndpoints
                             OgcProcessesJsonContext.Default.OgcProcessError,
                             MediaTypes.Json,
                             StatusCodes.Status409Conflict);
-                    }
-
-                    if (current.Status == ExecutionJobStatus.Cancelled)
-                    {
-                        cancelConfirmed = true;
-                        break;
-                    }
+                    case ExecutionJobCancellationState.Missing:
+                        return JobNotFoundResult(jobId);
+                    case ExecutionJobCancellationState.Unconfirmed:
+                        return Results.Json(
+                            new OgcProcessError
+                            {
+                                Type = "about:blank",
+                                Title = "Dismiss could not be confirmed",
+                                Status = StatusCodes.Status409Conflict,
+                                Detail = $"Job '{jobId}' dismiss could not be confirmed after retries."
+                            },
+                            OgcProcessesJsonContext.Default.OgcProcessError,
+                            MediaTypes.Json,
+                            StatusCodes.Status409Conflict);
+                    default:
+                        throw new InvalidOperationException($"Unexpected durable cancellation outcome '{cancelOutcome.State}'.");
                 }
-
-                if (cancelConfirmed)
-                {
-                    if (jobQueue != null)
-                    {
-                        try
-                        {
-                            await jobQueue.RemoveAsync(jobId, context.RequestAborted).ConfigureAwait(false);
-                        }
-                        catch (Exception ex)
-                        {
-                            OgcProcessesLog.QueueRemovalFailed(logger, jobId, ex);
-                        }
-                    }
-
-                    var progress = await progressStore.GetProgressAsync<GeoprocessingProgress>(
-                        jobId, context.RequestAborted).ConfigureAwait(false);
-                    if (progress != null)
-                    {
-                        var cancelledProgress = progress.WithCancellation(now, "Dismissed via OGC API");
-                        await progressStore.SetProgressAsync(
-                            jobId, cancelledProgress, TimeSpan.FromDays(7), context.RequestAborted).ConfigureAwait(false);
-                    }
-                }
-
-                job = current;
             }
         }
         else

--- a/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
@@ -363,7 +363,13 @@ internal static class JobEndpoints
             // Re-read to catch concurrent terminal transitions (e.g. reconciler
             // revoked the stale CTS after requeue or terminal failure).
             var latest = await jobStore.GetAsync(jobId, context.RequestAborted).ConfigureAwait(false);
-            if (latest != null && OgcProcessesConversionHelpers.IsTerminal(latest.Status))
+            if (latest == null)
+            {
+                OgcProcessesLog.JobNotFound(logger, jobId);
+                return JobNotFoundResult(jobId);
+            }
+
+            if (OgcProcessesConversionHelpers.IsTerminal(latest.Status))
             {
                 if (latest.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
                 {
@@ -387,7 +393,7 @@ internal static class JobEndpoints
             {
                 // No active worker — transition to cancelled directly.
                 var now = DateTimeOffset.UtcNow;
-                var cancelled = (latest ?? job) with
+                var cancelled = latest with
                 {
                     Status = ExecutionJobStatus.Cancelled,
                     UpdatedAt = now,

--- a/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
@@ -438,89 +438,125 @@ internal static class JobEndpoints
                 // notifier is unreachable. Persist a durable cancellation
                 // signal so the worker observes it during its next heartbeat.
                 var reqNow = DateTimeOffset.UtcNow;
-                var requested = latest with
+                var current = latest;
+                var cancelSignalConfirmed = current.CancellationRequestedAt.HasValue;
+
+                for (var casAttempt = 0; !cancelSignalConfirmed && casAttempt < 3; casAttempt++)
                 {
-                    CancellationRequestedAt = reqNow,
-                    UpdatedAt = reqNow
-                };
-                if (!await jobStore.TrySetAsync(requested, cancellationToken: context.RequestAborted).ConfigureAwait(false))
-                {
-                    var conflict = await jobStore.GetAsync(jobId, context.RequestAborted).ConfigureAwait(false);
-                    if (conflict != null && OgcProcessesConversionHelpers.IsTerminal(conflict.Status)
-                        && conflict.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
+                    var requested = current with
                     {
-                        OgcProcessesLog.DismissRejectedTerminal(logger, jobId, OgcProcessesConversionHelpers.ToOgcStatus(conflict.Status));
+                        CancellationRequestedAt = reqNow,
+                        UpdatedAt = reqNow
+                    };
+                    if (await jobStore.TrySetAsync(requested, cancellationToken: context.RequestAborted).ConfigureAwait(false))
+                    {
+                        cancelSignalConfirmed = true;
+                        current = requested;
+                        break;
+                    }
+
+                    current = await jobStore.GetAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                    if (current == null || current.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
+                    {
+                        var terminalStatus = current != null
+                            ? OgcProcessesConversionHelpers.ToOgcStatus(current.Status)
+                            : "unknown";
+                        OgcProcessesLog.DismissRejectedTerminal(logger, jobId, terminalStatus);
                         return Results.Json(
                             new OgcProcessError
                             {
                                 Type = "about:blank",
                                 Title = "Cannot dismiss completed job",
                                 Status = StatusCodes.Status409Conflict,
-                                Detail = $"Job '{jobId}' reached terminal state '{OgcProcessesConversionHelpers.ToOgcStatus(conflict.Status)}' before dismiss could be applied."
+                                Detail = $"Job '{jobId}' reached terminal state '{terminalStatus}' before dismiss could be applied."
                             },
                             OgcProcessesJsonContext.Default.OgcProcessError,
                             MediaTypes.Json,
                             StatusCodes.Status409Conflict);
                     }
+
+                    cancelSignalConfirmed = current.CancellationRequestedAt.HasValue
+                        || current.Status == ExecutionJobStatus.Cancelled;
                 }
 
-                job = requested;
+                job = current;
             }
             else
             {
                 // Unclaimed job — transition to cancelled directly.
                 var now = DateTimeOffset.UtcNow;
-                var cancelled = latest with
-                {
-                    Status = ExecutionJobStatus.Cancelled,
-                    UpdatedAt = now,
-                    CompletedAt = now,
-                    CurrentPhase = "Dismissed"
-                };
+                var current = latest;
+                var cancelConfirmed = false;
 
-                if (!await jobStore.TrySetAsync(cancelled, cancellationToken: context.RequestAborted).ConfigureAwait(false))
+                for (var casAttempt = 0; casAttempt < 3; casAttempt++)
                 {
-                    var conflict = await jobStore.GetAsync(jobId, context.RequestAborted).ConfigureAwait(false);
-                    if (conflict != null && OgcProcessesConversionHelpers.IsTerminal(conflict.Status)
-                        && conflict.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
+                    var cancelled = current with
                     {
-                        OgcProcessesLog.DismissRejectedTerminal(logger, jobId, OgcProcessesConversionHelpers.ToOgcStatus(conflict.Status));
+                        Status = ExecutionJobStatus.Cancelled,
+                        UpdatedAt = now,
+                        CompletedAt = now,
+                        CurrentPhase = "Dismissed"
+                    };
+
+                    if (await jobStore.TrySetAsync(cancelled, cancellationToken: context.RequestAborted).ConfigureAwait(false))
+                    {
+                        cancelConfirmed = true;
+                        current = cancelled;
+                        break;
+                    }
+
+                    current = await jobStore.GetAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                    if (current == null || current.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
+                    {
+                        var terminalStatus = current != null
+                            ? OgcProcessesConversionHelpers.ToOgcStatus(current.Status)
+                            : "unknown";
+                        OgcProcessesLog.DismissRejectedTerminal(logger, jobId, terminalStatus);
                         return Results.Json(
                             new OgcProcessError
                             {
                                 Type = "about:blank",
                                 Title = "Cannot dismiss completed job",
                                 Status = StatusCodes.Status409Conflict,
-                                Detail = $"Job '{jobId}' reached terminal state '{OgcProcessesConversionHelpers.ToOgcStatus(conflict.Status)}' before dismiss could be applied."
+                                Detail = $"Job '{jobId}' reached terminal state '{terminalStatus}' before dismiss could be applied."
                             },
                             OgcProcessesJsonContext.Default.OgcProcessError,
                             MediaTypes.Json,
                             StatusCodes.Status409Conflict);
                     }
-                }
 
-                if (jobQueue != null)
-                {
-                    try
+                    if (current.Status == ExecutionJobStatus.Cancelled)
                     {
-                        await jobQueue.RemoveAsync(jobId, context.RequestAborted).ConfigureAwait(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        OgcProcessesLog.QueueRemovalFailed(logger, jobId, ex);
+                        cancelConfirmed = true;
+                        break;
                     }
                 }
 
-                var progress = await progressStore.GetProgressAsync<GeoprocessingProgress>(
-                    jobId, context.RequestAborted).ConfigureAwait(false);
-                if (progress != null)
+                if (cancelConfirmed)
                 {
-                    var cancelledProgress = progress.WithCancellation(now, "Dismissed via OGC API");
-                    await progressStore.SetProgressAsync(
-                        jobId, cancelledProgress, TimeSpan.FromDays(7), context.RequestAborted).ConfigureAwait(false);
+                    if (jobQueue != null)
+                    {
+                        try
+                        {
+                            await jobQueue.RemoveAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            OgcProcessesLog.QueueRemovalFailed(logger, jobId, ex);
+                        }
+                    }
+
+                    var progress = await progressStore.GetProgressAsync<GeoprocessingProgress>(
+                        jobId, context.RequestAborted).ConfigureAwait(false);
+                    if (progress != null)
+                    {
+                        var cancelledProgress = progress.WithCancellation(now, "Dismissed via OGC API");
+                        await progressStore.SetProgressAsync(
+                            jobId, cancelledProgress, TimeSpan.FromDays(7), context.RequestAborted).ConfigureAwait(false);
+                    }
                 }
 
-                job = cancelled;
+                job = current;
             }
         }
         else

--- a/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
@@ -358,28 +358,39 @@ internal static class JobEndpoints
 
         if (!workerOwnsTerminalState)
         {
-            // No worker handling this job — transition to cancelled directly
-            var now = DateTimeOffset.UtcNow;
-            var cancelled = job with
+            // Re-read to catch concurrent terminal transitions (e.g. reconciler
+            // revoked the stale CTS after requeue or terminal failure).
+            var latest = await jobStore.GetAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+            if (latest != null && OgcProcessesConversionHelpers.IsTerminal(latest.Status))
             {
-                Status = ExecutionJobStatus.Cancelled,
-                UpdatedAt = now,
-                CompletedAt = now,
-                CurrentPhase = "Dismissed"
-            };
-
-            await jobStore.SetAsync(cancelled, cancellationToken: context.RequestAborted).ConfigureAwait(false);
-
-            var progress = await progressStore.GetProgressAsync<GeoprocessingProgress>(
-                jobId, context.RequestAborted).ConfigureAwait(false);
-            if (progress != null)
-            {
-                var cancelledProgress = progress.WithCancellation(now, "Dismissed via OGC API");
-                await progressStore.SetProgressAsync(
-                    jobId, cancelledProgress, TimeSpan.FromDays(7), context.RequestAborted).ConfigureAwait(false);
+                // Job already reached a terminal state; return current status.
+                job = latest;
             }
+            else
+            {
+                // No active worker — transition to cancelled directly.
+                var now = DateTimeOffset.UtcNow;
+                var cancelled = (latest ?? job) with
+                {
+                    Status = ExecutionJobStatus.Cancelled,
+                    UpdatedAt = now,
+                    CompletedAt = now,
+                    CurrentPhase = "Dismissed"
+                };
 
-            job = cancelled;
+                await jobStore.SetAsync(cancelled, cancellationToken: context.RequestAborted).ConfigureAwait(false);
+
+                var progress = await progressStore.GetProgressAsync<GeoprocessingProgress>(
+                    jobId, context.RequestAborted).ConfigureAwait(false);
+                if (progress != null)
+                {
+                    var cancelledProgress = progress.WithCancellation(now, "Dismissed via OGC API");
+                    await progressStore.SetProgressAsync(
+                        jobId, cancelledProgress, TimeSpan.FromDays(7), context.RequestAborted).ConfigureAwait(false);
+                }
+
+                job = cancelled;
+            }
         }
         else
         {

--- a/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
@@ -389,9 +389,23 @@ internal static class JobEndpoints
 
                 job = latest;
             }
+            else if (latest.ClaimedBy != null)
+            {
+                // Job is actively claimed by a remote worker whose local
+                // notifier is unreachable. Persist a durable cancellation
+                // signal so the worker observes it during its next heartbeat.
+                var reqNow = DateTimeOffset.UtcNow;
+                var requested = latest with
+                {
+                    CancellationRequestedAt = reqNow,
+                    UpdatedAt = reqNow
+                };
+                await jobStore.SetAsync(requested, cancellationToken: context.RequestAborted).ConfigureAwait(false);
+                job = requested;
+            }
             else
             {
-                // No active worker — transition to cancelled directly.
+                // Unclaimed job — transition to cancelled directly.
                 var now = DateTimeOffset.UtcNow;
                 var cancelled = latest with
                 {

--- a/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
@@ -365,7 +365,22 @@ internal static class JobEndpoints
             var latest = await jobStore.GetAsync(jobId, context.RequestAborted).ConfigureAwait(false);
             if (latest != null && OgcProcessesConversionHelpers.IsTerminal(latest.Status))
             {
-                // Job already reached a terminal state; return current status.
+                if (latest.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
+                {
+                    OgcProcessesLog.DismissRejectedTerminal(logger, jobId, OgcProcessesConversionHelpers.ToOgcStatus(latest.Status));
+                    return Results.Json(
+                        new OgcProcessError
+                        {
+                            Type = "about:blank",
+                            Title = "Cannot dismiss completed job",
+                            Status = StatusCodes.Status409Conflict,
+                            Detail = $"Job '{jobId}' is in terminal state '{OgcProcessesConversionHelpers.ToOgcStatus(latest.Status)}' and cannot be dismissed."
+                        },
+                        OgcProcessesJsonContext.Default.OgcProcessError,
+                        MediaTypes.Json,
+                        StatusCodes.Status409Conflict);
+                }
+
                 job = latest;
             }
             else

--- a/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
@@ -278,7 +278,8 @@ internal static class JobEndpoints
         ILogger<OgcProcessesEndpointsLog> logger,
         IJobCancellationNotifier cancellationNotifier,
         IUniversalProgressStore progressStore,
-        [FromServices] IExecutionJobStore? jobStore = null)
+        [FromServices] IExecutionJobStore? jobStore = null,
+        [FromServices] IJobQueue? jobQueue = null)
     {
         EnrichActivity("DismissJob");
 
@@ -379,6 +380,11 @@ internal static class JobEndpoints
                 };
 
                 await jobStore.SetAsync(cancelled, cancellationToken: context.RequestAborted).ConfigureAwait(false);
+
+                if (jobQueue != null)
+                {
+                    await jobQueue.RemoveAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                }
 
                 var progress = await progressStore.GetProgressAsync<GeoprocessingProgress>(
                     jobId, context.RequestAborted).ConfigureAwait(false);

--- a/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/JobEndpoints.cs
@@ -443,7 +443,27 @@ internal static class JobEndpoints
                     CancellationRequestedAt = reqNow,
                     UpdatedAt = reqNow
                 };
-                await jobStore.SetAsync(requested, cancellationToken: context.RequestAborted).ConfigureAwait(false);
+                if (!await jobStore.TrySetAsync(requested, cancellationToken: context.RequestAborted).ConfigureAwait(false))
+                {
+                    var conflict = await jobStore.GetAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                    if (conflict != null && OgcProcessesConversionHelpers.IsTerminal(conflict.Status)
+                        && conflict.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
+                    {
+                        OgcProcessesLog.DismissRejectedTerminal(logger, jobId, OgcProcessesConversionHelpers.ToOgcStatus(conflict.Status));
+                        return Results.Json(
+                            new OgcProcessError
+                            {
+                                Type = "about:blank",
+                                Title = "Cannot dismiss completed job",
+                                Status = StatusCodes.Status409Conflict,
+                                Detail = $"Job '{jobId}' reached terminal state '{OgcProcessesConversionHelpers.ToOgcStatus(conflict.Status)}' before dismiss could be applied."
+                            },
+                            OgcProcessesJsonContext.Default.OgcProcessError,
+                            MediaTypes.Json,
+                            StatusCodes.Status409Conflict);
+                    }
+                }
+
                 job = requested;
             }
             else
@@ -458,7 +478,26 @@ internal static class JobEndpoints
                     CurrentPhase = "Dismissed"
                 };
 
-                await jobStore.SetAsync(cancelled, cancellationToken: context.RequestAborted).ConfigureAwait(false);
+                if (!await jobStore.TrySetAsync(cancelled, cancellationToken: context.RequestAborted).ConfigureAwait(false))
+                {
+                    var conflict = await jobStore.GetAsync(jobId, context.RequestAborted).ConfigureAwait(false);
+                    if (conflict != null && OgcProcessesConversionHelpers.IsTerminal(conflict.Status)
+                        && conflict.Status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed)
+                    {
+                        OgcProcessesLog.DismissRejectedTerminal(logger, jobId, OgcProcessesConversionHelpers.ToOgcStatus(conflict.Status));
+                        return Results.Json(
+                            new OgcProcessError
+                            {
+                                Type = "about:blank",
+                                Title = "Cannot dismiss completed job",
+                                Status = StatusCodes.Status409Conflict,
+                                Detail = $"Job '{jobId}' reached terminal state '{OgcProcessesConversionHelpers.ToOgcStatus(conflict.Status)}' before dismiss could be applied."
+                            },
+                            OgcProcessesJsonContext.Default.OgcProcessError,
+                            MediaTypes.Json,
+                            StatusCodes.Status409Conflict);
+                    }
+                }
 
                 if (jobQueue != null)
                 {

--- a/src/Honua.Server/Features/OgcProcesses/OgcProcessesLog.cs
+++ b/src/Honua.Server/Features/OgcProcesses/OgcProcessesLog.cs
@@ -64,6 +64,9 @@ internal static partial class OgcProcessesLog
     [LoggerMessage(8135, LogLevel.Warning, "OGC Job dismiss rejected (terminal): JobId={JobId}, Status={Status}")]
     public static partial void DismissRejectedTerminal(ILogger logger, string jobId, string status);
 
+    [LoggerMessage(8136, LogLevel.Warning, "OGC dismiss queue cleanup failed: JobId={JobId}; stale-claim reconciler will repair")]
+    public static partial void QueueRemovalFailed(ILogger logger, string jobId, Exception exception);
+
     // 8140-8149: Job list
     [LoggerMessage(8140, LogLevel.Information, "OGC Job list requested")]
     public static partial void JobListRequested(ILogger logger);

--- a/src/Honua.Server/Features/OgcProcesses/ProcessEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/ProcessEndpoints.cs
@@ -11,6 +11,7 @@ using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.ControlPlane;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Ogc.Common;
 using Honua.Server.Features.OgcProcesses.Models;
@@ -368,24 +369,10 @@ internal static class ProcessEndpoints
         }
         catch (Exception) when (!context.RequestAborted.IsCancellationRequested)
         {
-            // Rollback the just-created job to prevent stranded Queued records
-            // that no reconciler will repair (reconciler skips Queued status).
-            try
-            {
-                var failedJob = jobRecord with
-                {
-                    Status = ExecutionJobStatus.Failed,
-                    UpdatedAt = DateTimeOffset.UtcNow,
-                    CompletedAt = DateTimeOffset.UtcNow,
-                    ErrorMessage = "Submission failed: progress or queue persistence error.",
-                    CurrentPhase = "Failed (submission)"
-                };
-                await jobStore.TrySetAsync(failedJob, cancellationToken: CancellationToken.None).ConfigureAwait(false);
-            }
-            catch
-            {
-                // Best-effort rollback; job TTL or manual intervention will repair.
-            }
+            await ExecutionJobSubmissionHelper.TryRollbackCreatedJobAsync(
+                jobStore,
+                jobId,
+                CancellationToken.None).ConfigureAwait(false);
 
             throw;
         }

--- a/src/Honua.Server/Features/OgcProcesses/ProcessEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/ProcessEndpoints.cs
@@ -355,13 +355,39 @@ internal static class ProcessEndpoints
 
         await jobStore.TryCreateAsync(jobRecord, cancellationToken: context.RequestAborted).ConfigureAwait(false);
 
-        var progress = GeoprocessingProgress.CreateForSubmittedJob(jobId, planId);
-        await progressStore.SetProgressAsync(jobId, progress, TimeSpan.FromDays(7), context.RequestAborted)
-            .ConfigureAwait(false);
-
-        if (jobQueue != null)
+        try
         {
-            await jobQueue.EnqueueAsync(jobId, cancellationToken: context.RequestAborted).ConfigureAwait(false);
+            var progress = GeoprocessingProgress.CreateForSubmittedJob(jobId, planId);
+            await progressStore.SetProgressAsync(jobId, progress, TimeSpan.FromDays(7), context.RequestAborted)
+                .ConfigureAwait(false);
+
+            if (jobQueue != null)
+            {
+                await jobQueue.EnqueueAsync(jobId, cancellationToken: context.RequestAborted).ConfigureAwait(false);
+            }
+        }
+        catch (Exception) when (!context.RequestAborted.IsCancellationRequested)
+        {
+            // Rollback the just-created job to prevent stranded Queued records
+            // that no reconciler will repair (reconciler skips Queued status).
+            try
+            {
+                var failedJob = jobRecord with
+                {
+                    Status = ExecutionJobStatus.Failed,
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                    CompletedAt = DateTimeOffset.UtcNow,
+                    ErrorMessage = "Submission failed: progress or queue persistence error.",
+                    CurrentPhase = "Failed (submission)"
+                };
+                await jobStore.TrySetAsync(failedJob, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort rollback; job TTL or manual intervention will repair.
+            }
+
+            throw;
         }
 
         OgcProcessesLog.JobCreated(logger, jobId, processId);

--- a/src/Honua.Server/Features/OgcProcesses/ProcessEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/ProcessEndpoints.cs
@@ -184,7 +184,8 @@ internal static class ProcessEndpoints
         HttpContext context,
         ILogger<OgcProcessesEndpointsLog> logger,
         IUniversalProgressStore progressStore,
-        [FromServices] IExecutionJobStore? jobStore = null)
+        [FromServices] IExecutionJobStore? jobStore = null,
+        [FromServices] IJobQueue? jobQueue = null)
     {
         EnrichActivity("ExecuteProcess");
 
@@ -357,6 +358,11 @@ internal static class ProcessEndpoints
         var progress = GeoprocessingProgress.CreateForSubmittedJob(jobId, planId);
         await progressStore.SetProgressAsync(jobId, progress, TimeSpan.FromDays(7), context.RequestAborted)
             .ConfigureAwait(false);
+
+        if (jobQueue != null)
+        {
+            await jobQueue.EnqueueAsync(jobId, cancellationToken: context.RequestAborted).ConfigureAwait(false);
+        }
 
         OgcProcessesLog.JobCreated(logger, jobId, processId);
 

--- a/tests/Honua.Core.Tests/Features/ControlPlane/JobPoliciesTests.cs
+++ b/tests/Honua.Core.Tests/Features/ControlPlane/JobPoliciesTests.cs
@@ -1,0 +1,330 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Core.Tests.Features.ControlPlane;
+
+/// <summary>
+/// Tests for job retry, heartbeat, and timeout policy models.
+/// </summary>
+public class JobPoliciesTests
+{
+    // -----------------------------------------------------------------------
+    // JobRetryPolicy
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void RetryPolicy_Default_HasReasonableDefaults()
+    {
+        var policy = JobRetryPolicy.Default;
+        Assert.Equal(3, policy.MaxAttempts);
+        Assert.Equal(BackoffStrategy.Exponential, policy.Strategy);
+        Assert.Equal(TimeSpan.FromSeconds(30), policy.BaseDelay);
+        Assert.Equal(TimeSpan.FromMinutes(10), policy.MaxDelay);
+    }
+
+    [Fact]
+    public void RetryPolicy_None_DoesNotRetry()
+    {
+        var policy = JobRetryPolicy.None;
+        Assert.Equal(1, policy.MaxAttempts);
+        Assert.False(policy.ShouldRetry(1));
+    }
+
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(1, true)]
+    [InlineData(2, true)]
+    [InlineData(3, false)]
+    [InlineData(4, false)]
+    public void RetryPolicy_ShouldRetry_RespectsMaxAttempts(int attemptCount, bool expected)
+    {
+        var policy = JobRetryPolicy.Default; // MaxAttempts = 3
+        Assert.Equal(expected, policy.ShouldRetry(attemptCount));
+    }
+
+    [Fact]
+    public void RetryPolicy_ComputeDelay_FirstAttemptIsZero()
+    {
+        var policy = JobRetryPolicy.Default;
+        Assert.Equal(TimeSpan.Zero, policy.ComputeDelay(1));
+    }
+
+    [Fact]
+    public void RetryPolicy_ComputeDelay_FixedStrategy_ReturnsSameDelay()
+    {
+        var policy = new JobRetryPolicy
+        {
+            MaxAttempts = 5,
+            Strategy = BackoffStrategy.Fixed,
+            BaseDelay = TimeSpan.FromSeconds(10),
+            MaxDelay = TimeSpan.FromMinutes(5)
+        };
+
+        Assert.Equal(TimeSpan.FromSeconds(10), policy.ComputeDelay(2));
+        Assert.Equal(TimeSpan.FromSeconds(10), policy.ComputeDelay(3));
+        Assert.Equal(TimeSpan.FromSeconds(10), policy.ComputeDelay(4));
+    }
+
+    [Fact]
+    public void RetryPolicy_ComputeDelay_LinearStrategy_ScalesLinearly()
+    {
+        var policy = new JobRetryPolicy
+        {
+            MaxAttempts = 5,
+            Strategy = BackoffStrategy.Linear,
+            BaseDelay = TimeSpan.FromSeconds(10),
+            MaxDelay = TimeSpan.FromMinutes(5)
+        };
+
+        Assert.Equal(TimeSpan.FromSeconds(10), policy.ComputeDelay(2));  // retryIndex=0: 10*(0+1)
+        Assert.Equal(TimeSpan.FromSeconds(20), policy.ComputeDelay(3));  // retryIndex=1: 10*(1+1)
+        Assert.Equal(TimeSpan.FromSeconds(30), policy.ComputeDelay(4));  // retryIndex=2: 10*(2+1)
+    }
+
+    [Fact]
+    public void RetryPolicy_ComputeDelay_ExponentialStrategy_DoublesEachTime()
+    {
+        var policy = new JobRetryPolicy
+        {
+            MaxAttempts = 5,
+            Strategy = BackoffStrategy.Exponential,
+            BaseDelay = TimeSpan.FromSeconds(10),
+            MaxDelay = TimeSpan.FromMinutes(5)
+        };
+
+        Assert.Equal(TimeSpan.FromSeconds(10), policy.ComputeDelay(2));  // 10 * 2^0
+        Assert.Equal(TimeSpan.FromSeconds(20), policy.ComputeDelay(3));  // 10 * 2^1
+        Assert.Equal(TimeSpan.FromSeconds(40), policy.ComputeDelay(4));  // 10 * 2^2
+    }
+
+    [Fact]
+    public void RetryPolicy_ComputeDelay_CapsAtMaxDelay()
+    {
+        var policy = new JobRetryPolicy
+        {
+            MaxAttempts = 10,
+            Strategy = BackoffStrategy.Exponential,
+            BaseDelay = TimeSpan.FromSeconds(30),
+            MaxDelay = TimeSpan.FromMinutes(2)
+        };
+
+        // attempt 5: retryIndex=3 => 30 * 2^3 = 240 seconds = 4 minutes > MaxDelay
+        var delay = policy.ComputeDelay(5);
+        Assert.Equal(TimeSpan.FromMinutes(2), delay);
+    }
+
+    // -----------------------------------------------------------------------
+    // JobHeartbeatPolicy
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void HeartbeatPolicy_Default_TimeoutExceedsInterval()
+    {
+        var policy = JobHeartbeatPolicy.Default;
+        Assert.True(policy.Timeout > policy.Interval);
+    }
+
+    [Fact]
+    public void HeartbeatPolicy_IsExpired_ReturnsFalse_WhenWithinTimeout()
+    {
+        var policy = JobHeartbeatPolicy.Default;
+        var now = DateTimeOffset.UtcNow;
+        var lastHeartbeat = now.AddSeconds(-30); // Exactly at interval
+
+        Assert.False(policy.IsExpired(lastHeartbeat, now));
+    }
+
+    [Fact]
+    public void HeartbeatPolicy_IsExpired_ReturnsTrue_WhenBeyondTimeout()
+    {
+        var policy = JobHeartbeatPolicy.Default; // Timeout = 90s
+        var now = DateTimeOffset.UtcNow;
+        var lastHeartbeat = now.AddSeconds(-91);
+
+        Assert.True(policy.IsExpired(lastHeartbeat, now));
+    }
+
+    [Fact]
+    public void HeartbeatPolicy_IsExpired_ReturnsTrue_WhenExactlyAtTimeout()
+    {
+        var policy = new JobHeartbeatPolicy
+        {
+            Interval = TimeSpan.FromSeconds(10),
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+        var now = DateTimeOffset.UtcNow;
+        var lastHeartbeat = now.AddSeconds(-31);
+
+        Assert.True(policy.IsExpired(lastHeartbeat, now));
+    }
+
+    // -----------------------------------------------------------------------
+    // JobTimeoutPolicy
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void TimeoutPolicy_Default_IsOneHour()
+    {
+        Assert.Equal(TimeSpan.FromHours(1), JobTimeoutPolicy.Default.MaxDuration);
+    }
+
+    [Fact]
+    public void TimeoutPolicy_LongRunning_Is24Hours()
+    {
+        Assert.Equal(TimeSpan.FromHours(24), JobTimeoutPolicy.LongRunning.MaxDuration);
+    }
+
+    [Fact]
+    public void TimeoutPolicy_IsExpired_ReturnsFalse_WhenWithinDuration()
+    {
+        var policy = JobTimeoutPolicy.Default;
+        var now = DateTimeOffset.UtcNow;
+        var startedAt = now.AddMinutes(-30);
+
+        Assert.False(policy.IsExpired(startedAt, now));
+    }
+
+    [Fact]
+    public void TimeoutPolicy_IsExpired_ReturnsTrue_WhenBeyondDuration()
+    {
+        var policy = JobTimeoutPolicy.Default;
+        var now = DateTimeOffset.UtcNow;
+        var startedAt = now.AddHours(-1).AddSeconds(-1);
+
+        Assert.True(policy.IsExpired(startedAt, now));
+    }
+
+    // -----------------------------------------------------------------------
+    // ExecutionJobRecord with new fields
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ExecutionJobRecord_NewFields_HaveSaneDefaults()
+    {
+        var record = new ExecutionJobRecord
+        {
+            OperationId = "test-1",
+            Status = ExecutionJobStatus.Queued,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "test"
+            }
+        };
+
+        Assert.Null(record.ClaimedBy);
+        Assert.Null(record.ClaimedAt);
+        Assert.Null(record.LastHeartbeatAt);
+        Assert.Equal(0, record.AttemptCount);
+        Assert.Null(record.NextRetryAt);
+        Assert.Null(record.RetryPolicy);
+        Assert.Null(record.HeartbeatPolicy);
+        Assert.Null(record.TimeoutPolicy);
+        Assert.Empty(record.ArtifactReferences);
+    }
+
+    [Fact]
+    public void ExecutionJobRecord_WithClaimFields_PreservesValues()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var record = new ExecutionJobRecord
+        {
+            OperationId = "test-2",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = now.AddMinutes(-5),
+            UpdatedAt = now,
+            ClaimedBy = "worker-1",
+            ClaimedAt = now.AddMinutes(-1),
+            LastHeartbeatAt = now,
+            AttemptCount = 2,
+            RetryPolicy = JobRetryPolicy.Default,
+            HeartbeatPolicy = JobHeartbeatPolicy.Default,
+            TimeoutPolicy = JobTimeoutPolicy.Default,
+            ArtifactReferences = ["artifact://output/layer1"],
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "test"
+            }
+        };
+
+        Assert.Equal("worker-1", record.ClaimedBy);
+        Assert.Equal(now.AddMinutes(-1), record.ClaimedAt);
+        Assert.Equal(now, record.LastHeartbeatAt);
+        Assert.Equal(2, record.AttemptCount);
+        Assert.NotNull(record.RetryPolicy);
+        Assert.NotNull(record.HeartbeatPolicy);
+        Assert.NotNull(record.TimeoutPolicy);
+        Assert.Single(record.ArtifactReferences);
+    }
+
+    // -----------------------------------------------------------------------
+    // JobExecutionResult
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void JobExecutionResult_Succeeded_SetsCorrectStatus()
+    {
+        var result = JobExecutionResult.Succeeded();
+        Assert.Equal(ExecutionJobStatus.Succeeded, result.Status);
+        Assert.Null(result.ErrorMessage);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void JobExecutionResult_Failed_SetsErrorMessage()
+    {
+        var result = JobExecutionResult.Failed("Something broke", ["warn1"]);
+        Assert.Equal(ExecutionJobStatus.Failed, result.Status);
+        Assert.Equal("Something broke", result.ErrorMessage);
+        Assert.Single(result.Warnings);
+    }
+
+    // -----------------------------------------------------------------------
+    // ExecutionLogEntry
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ExecutionLogEntry_CanBeConstructed_WithMinimalFields()
+    {
+        var entry = new ExecutionLogEntry
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Level = ExecutionLogLevel.Info,
+            Message = "Processing step 1"
+        };
+
+        Assert.Equal(ExecutionLogLevel.Info, entry.Level);
+        Assert.Null(entry.Phase);
+        Assert.Null(entry.Metadata);
+    }
+
+    [Fact]
+    public void ExecutionLogEntry_CanInclude_PhaseAndMetadata()
+    {
+        var entry = new ExecutionLogEntry
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Level = ExecutionLogLevel.Warning,
+            Message = "CRS mismatch",
+            Phase = "Step 2/5",
+            Metadata = new Dictionary<string, string>
+            {
+                ["sourceCrs"] = "EPSG:4326",
+                ["targetCrs"] = "EPSG:3857"
+            }
+        };
+
+        Assert.Equal("Step 2/5", entry.Phase);
+        Assert.Equal(2, entry.Metadata!.Count);
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
@@ -148,6 +148,52 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/operations/{operationId}/cancel")]
+    public async Task CancelOperation_WhenDurableJobAlreadySucceeded_Returns409()
+    {
+        var jobStore = _fixture.GetOptionalService<IExecutionJobStore>();
+        if (jobStore == null)
+        {
+            return; // Job orchestration not registered; skip.
+        }
+
+        var operationId = $"gp-{Guid.NewGuid():N}";
+        var now = DateTimeOffset.UtcNow;
+        var jobRecord = new ExecutionJobRecord
+        {
+            OperationId = operationId,
+            Status = ExecutionJobStatus.Succeeded,
+            CreatedAt = now,
+            UpdatedAt = now,
+            CompletedAt = now,
+            CurrentPhase = "Completed",
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "test-admin-cancel-terminal"
+            }
+        };
+
+        await jobStore.TryCreateAsync(jobRecord, TimeSpan.FromMinutes(5));
+
+        // Progress store still shows Processing (stale), but durable job is terminal
+        var progress = GeoprocessingProgress.CreateForSubmittedJob(operationId, "admin-cancel-terminal-test");
+        await _progressStore.SetProgressAsync(operationId, progress, TimeSpan.FromMinutes(5));
+        _operationIds.Add(operationId);
+
+        var response = await _client.PostAsync($"/api/v1/admin/operations/{operationId}/cancel", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+        // Progress store should not have been overwritten to Cancelled
+        var updatedProgress = await _progressStore.GetProgressAsync(operationId);
+        updatedProgress.Should().NotBeNull();
+        updatedProgress!.Status.Should().NotBe(OperationStatus.Cancelled);
+    }
+
+    [IntegrationTest]
     [Endpoint("GET /api/v1/admin/operations/active")]
     public async Task ListActiveOperations_WhenFiltered_ReturnsOnlyActive()
     {

--- a/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
@@ -194,6 +194,53 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/operations/{operationId}/cancel")]
+    public async Task CancelOperation_WhenDurableJobAlreadyCancelled_CleansUpQueueAndReturns200()
+    {
+        var jobStore = _fixture.GetOptionalService<IExecutionJobStore>();
+        var jobQueue = _fixture.GetOptionalService<IJobQueue>();
+        if (jobStore == null || jobQueue == null)
+        {
+            return; // Job orchestration not registered; skip.
+        }
+
+        var operationId = $"gp-{Guid.NewGuid():N}";
+        var now = DateTimeOffset.UtcNow;
+        var jobRecord = new ExecutionJobRecord
+        {
+            OperationId = operationId,
+            Status = ExecutionJobStatus.Cancelled,
+            CreatedAt = now.AddMinutes(-5),
+            UpdatedAt = now,
+            CompletedAt = now,
+            CurrentPhase = "Cancelled",
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "test-already-cancelled"
+            }
+        };
+
+        await jobStore.TryCreateAsync(jobRecord, TimeSpan.FromMinutes(5));
+        await jobQueue.EnqueueAsync(operationId);
+
+        var progress = GeoprocessingProgress.CreateForSubmittedJob(operationId, "already-cancelled-test") with
+        {
+            WorkflowStatus = GeoprocessingWorkflowStatus.Cancelled,
+            CurrentStageStatus = GeoprocessingStageStatus.Cancelled,
+            CompletedAt = now
+        };
+        await _progressStore.SetProgressAsync(operationId, progress, TimeSpan.FromMinutes(5));
+        _operationIds.Add(operationId);
+
+        var response = await _client.PostAsync($"/api/v1/admin/operations/{operationId}/cancel", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
     [Endpoint("GET /api/v1/admin/operations/active")]
     public async Task ListActiveOperations_WhenFiltered_ReturnsOnlyActive()
     {

--- a/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
@@ -241,6 +241,71 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/operations/{operationId}/cancel")]
+    public async Task CancelOperation_WhenQueueRemovalFailsAfterDurableCancel_StillReturns200AndUpdatesProgress()
+    {
+        var fixture = new WebAppFixture()
+            .ReplaceService<IJobQueue>(new ThrowingRemoveJobQueue());
+
+        await fixture.InitializeAsync();
+
+        var client = fixture.Client;
+        var progressStore = fixture.GetService<IUniversalProgressStore>();
+        var jobStore = fixture.GetOptionalService<IExecutionJobStore>();
+        var jobQueue = fixture.GetOptionalService<IJobQueue>();
+        if (jobStore == null || jobQueue == null)
+        {
+            await fixture.DisposeAsync();
+            return; // Job orchestration not registered; skip.
+        }
+
+        var operationId = $"gp-{Guid.NewGuid():N}";
+        var now = DateTimeOffset.UtcNow;
+
+        try
+        {
+            var jobRecord = new ExecutionJobRecord
+            {
+                OperationId = operationId,
+                Status = ExecutionJobStatus.Queued,
+                CreatedAt = now,
+                UpdatedAt = now,
+                CurrentPhase = "Queued",
+                Spec = new ExecutionJobSpec
+                {
+                    Kind = ExecutionJobKind.Geoprocessing,
+                    TargetKind = BatchComputeTargetKind.KubernetesJob,
+                    Backend = "local",
+                    WorkloadName = "test-admin-cancel-remove-failure"
+                }
+            };
+
+            await jobStore.TryCreateAsync(jobRecord, TimeSpan.FromMinutes(5));
+            await jobQueue.EnqueueAsync(operationId);
+
+            var progress = GeoprocessingProgress.CreateForSubmittedJob(operationId, "admin-cancel-remove-failure");
+            await progressStore.SetProgressAsync(operationId, progress, TimeSpan.FromMinutes(5));
+
+            var response = await client.PostAsync($"/api/v1/admin/operations/{operationId}/cancel", null);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var updatedJob = await jobStore.GetAsync(operationId);
+            updatedJob.Should().NotBeNull();
+            updatedJob!.Status.Should().Be(ExecutionJobStatus.Cancelled);
+
+            var updatedProgress = await progressStore.GetProgressAsync(operationId);
+            updatedProgress.Should().NotBeNull();
+            updatedProgress!.Status.Should().Be(OperationStatus.Cancelled);
+        }
+        finally
+        {
+            await progressStore.DeleteProgressAsync(operationId);
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
     [Endpoint("GET /api/v1/admin/operations/active")]
     public async Task ListActiveOperations_WhenFiltered_ReturnsOnlyActive()
     {
@@ -468,5 +533,43 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
         }
 
         return count;
+    }
+
+    private sealed class ThrowingRemoveJobQueue : IJobQueue
+    {
+        private readonly HashSet<string> _operationIds = [];
+
+        public Task EnqueueAsync(
+            string operationId,
+            OperationPriority priority = OperationPriority.Normal,
+            CancellationToken cancellationToken = default)
+        {
+            _operationIds.Add(operationId);
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> TryClaimAsync(
+            string workerId,
+            IReadOnlySet<ExecutionJobKind>? acceptedKinds = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(_operationIds.FirstOrDefault());
+
+        public Task RequeueAsync(
+            string operationId,
+            OperationPriority priority = OperationPriority.Normal,
+            TimeSpan? visibleAfter = null,
+            CancellationToken cancellationToken = default)
+        {
+            _operationIds.Add(operationId);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAsync(
+            string operationId,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Simulated queue removal failure");
+
+        public Task<long> GetQueueDepthAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult((long)_operationIds.Count);
     }
 }

--- a/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
+using Honua.Server.Tests.Helpers;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -369,6 +370,66 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
             var updatedProgress = await progressStore.GetProgressAsync(operationId);
             updatedProgress.Should().NotBeNull();
             updatedProgress!.Status.Should().Be(OperationStatus.Cancelled);
+        }
+        finally
+        {
+            await progressStore.DeleteProgressAsync(operationId);
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/operations/{operationId}/cancel")]
+    public async Task CancelOperation_WhenDurableCancelCannotBeConfirmed_Returns409AndPreservesProgress()
+    {
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
+        var jobQueue = Substitute.For<IJobQueue>();
+        var fixture = new WebAppFixture()
+            .ReplaceService<IExecutionJobStore>(jobStore)
+            .ReplaceService<IJobQueue>(jobQueue);
+
+        await fixture.InitializeAsync();
+
+        var client = fixture.Client;
+        var progressStore = fixture.GetService<IUniversalProgressStore>();
+        var operationId = $"gp-{Guid.NewGuid():N}";
+        var now = DateTimeOffset.UtcNow;
+
+        try
+        {
+            var jobRecord = new ExecutionJobRecord
+            {
+                OperationId = operationId,
+                Status = ExecutionJobStatus.Queued,
+                CreatedAt = now,
+                UpdatedAt = now,
+                CurrentPhase = "Queued",
+                Spec = new ExecutionJobSpec
+                {
+                    Kind = ExecutionJobKind.Geoprocessing,
+                    TargetKind = BatchComputeTargetKind.KubernetesJob,
+                    Backend = "local",
+                    WorkloadName = "test-admin-cancel-unconfirmed"
+                }
+            };
+
+            jobStore.GetAsync(operationId, Arg.Any<CancellationToken>())
+                .Returns(jobRecord, jobRecord, jobRecord, jobRecord);
+            jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+                .Returns(false);
+
+            var progress = GeoprocessingProgress.CreateForSubmittedJob(operationId, "admin-cancel-unconfirmed");
+            await progressStore.SetProgressAsync(operationId, progress, TimeSpan.FromMinutes(5));
+
+            var response = await client.PostAsync($"/api/v1/admin/operations/{operationId}/cancel", null);
+
+            response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+            var updatedProgress = await progressStore.GetProgressAsync(operationId);
+            updatedProgress.Should().NotBeNull();
+            updatedProgress!.Status.Should().NotBe(OperationStatus.Cancelled);
+
+            await jobQueue.DidNotReceive().RemoveAsync(operationId, Arg.Any<CancellationToken>());
         }
         finally
         {

--- a/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
@@ -13,6 +13,7 @@ using Honua.Core.Features.Infrastructure.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using NSubstitute;
 
 namespace Honua.Server.Tests.Features.Admin;
 
@@ -238,6 +239,77 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
         var response = await _client.PostAsync($"/api/v1/admin/operations/{operationId}/cancel", null);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/operations/{operationId}/cancel")]
+    public async Task CancelOperation_WhenProgressAlreadyCancelledAndDurableJobClaimed_PersistsSignalWithoutRemovingClaim()
+    {
+        var fixture = new WebAppFixture();
+        var jobQueue = Substitute.For<IJobQueue>();
+        fixture.ReplaceService<IJobQueue>(jobQueue);
+
+        await fixture.InitializeAsync();
+
+        var client = fixture.Client;
+        var progressStore = fixture.GetService<IUniversalProgressStore>();
+        var jobStore = fixture.GetOptionalService<IExecutionJobStore>();
+        if (jobStore == null)
+        {
+            await fixture.DisposeAsync();
+            return;
+        }
+
+        var operationId = $"gp-{Guid.NewGuid():N}";
+        var now = DateTimeOffset.UtcNow;
+
+        try
+        {
+            var jobRecord = new ExecutionJobRecord
+            {
+                OperationId = operationId,
+                Status = ExecutionJobStatus.Running,
+                CreatedAt = now.AddMinutes(-1),
+                UpdatedAt = now,
+                ClaimedBy = "worker-remote",
+                ClaimedAt = now.AddSeconds(-30),
+                LastHeartbeatAt = now.AddSeconds(-5),
+                CurrentPhase = "Running",
+                Spec = new ExecutionJobSpec
+                {
+                    Kind = ExecutionJobKind.Geoprocessing,
+                    TargetKind = BatchComputeTargetKind.KubernetesJob,
+                    Backend = "local",
+                    WorkloadName = "test-admin-reconcile-claimed-cancel"
+                }
+            };
+
+            await jobStore.TryCreateAsync(jobRecord, TimeSpan.FromMinutes(5));
+
+            var progress = GeoprocessingProgress.CreateForSubmittedJob(operationId, "already-cancelled-running") with
+            {
+                WorkflowStatus = GeoprocessingWorkflowStatus.Cancelled,
+                CurrentStageStatus = GeoprocessingStageStatus.Cancelled,
+                CompletedAt = now
+            };
+            await progressStore.SetProgressAsync(operationId, progress, TimeSpan.FromMinutes(5));
+
+            var response = await client.PostAsync($"/api/v1/admin/operations/{operationId}/cancel", null);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var updatedJob = await jobStore.GetAsync(operationId);
+            updatedJob.Should().NotBeNull();
+            updatedJob!.Status.Should().Be(ExecutionJobStatus.Running);
+            updatedJob.CancellationRequestedAt.Should().NotBeNull();
+
+            await jobQueue.DidNotReceive().RemoveAsync(operationId, Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            await progressStore.DeleteProgressAsync(operationId);
+            await fixture.DisposeAsync();
+        }
     }
 
     [IntegrationTest]

--- a/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
@@ -298,7 +298,7 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/operations/{operationId}/cancel")]
-    public async Task CancelOperation_AlreadyCancelled_ReturnsIdempotent()
+    public async Task CancelOperation_AlreadyCancelled_ReturnsIdempotent200()
     {
         var operationId = Guid.NewGuid().ToString("N");
         var progress = UploadProgress.CreateInitial(operationId, "double-cancel.geojson", 10) with
@@ -311,12 +311,12 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
 
         var response = await _client.PostAsync($"/api/v1/admin/operations/{operationId}/cancel", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/operations/{operationId}/cancel")]
-    public async Task CancelOperation_CompletedOperation_ReturnsBadRequest()
+    public async Task CancelOperation_CompletedOperation_Returns409Conflict()
     {
         var operationId = Guid.NewGuid().ToString("N");
         var progress = UploadProgress.CreateInitial(operationId, "completed.geojson", 50) with
@@ -329,7 +329,7 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
 
         var response = await _client.PostAsync($"/api/v1/admin/operations/{operationId}/cancel", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 
     [IntegrationTest]

--- a/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
@@ -4,6 +4,8 @@
 using System.Net;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
@@ -92,6 +94,57 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
         var updated = await _progressStore.GetProgressAsync(operationId);
         updated.Should().NotBeNull();
         updated!.Status.Should().Be(OperationStatus.Cancelled);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/operations/{operationId}/cancel")]
+    public async Task CancelOperation_WhenBackedByExecutionJob_CancelsJobStoreAndRemovesFromQueue()
+    {
+        var jobStore = _fixture.GetOptionalService<IExecutionJobStore>();
+        var jobQueue = _fixture.GetOptionalService<IJobQueue>();
+        if (jobStore == null || jobQueue == null)
+        {
+            return; // Job orchestration not registered; skip.
+        }
+
+        var operationId = $"gp-{Guid.NewGuid():N}";
+        var now = DateTimeOffset.UtcNow;
+        var jobRecord = new ExecutionJobRecord
+        {
+            OperationId = operationId,
+            Status = ExecutionJobStatus.Queued,
+            CreatedAt = now,
+            UpdatedAt = now,
+            CurrentPhase = "Queued",
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "test-admin-cancel"
+            }
+        };
+
+        await jobStore.TryCreateAsync(jobRecord, TimeSpan.FromMinutes(5));
+        await jobQueue.EnqueueAsync(operationId);
+
+        var progress = GeoprocessingProgress.CreateForSubmittedJob(operationId, "admin-cancel-test");
+        await _progressStore.SetProgressAsync(operationId, progress, TimeSpan.FromMinutes(5));
+        _operationIds.Add(operationId);
+
+        var response = await _client.PostAsync($"/api/v1/admin/operations/{operationId}/cancel", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var updatedJob = await jobStore.GetAsync(operationId);
+        updatedJob.Should().NotBeNull();
+        updatedJob!.Status.Should().Be(ExecutionJobStatus.Cancelled);
+        updatedJob.CompletedAt.Should().NotBeNull();
+
+        var queueDepth = await jobQueue.GetQueueDepthAsync();
+        var updatedProgress = await _progressStore.GetProgressAsync(operationId);
+        updatedProgress.Should().NotBeNull();
+        updatedProgress!.Status.Should().Be(OperationStatus.Cancelled);
     }
 
     [IntegrationTest]

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -44,7 +44,7 @@ public sealed class GeoprocessingJobServiceTests
             .Returns(ApprovalRequirement.NotRequired());
 
         _sut = new GeoprocessingJobService(
-            _progressStore, _cancellationNotifier,
+            _progressStore, [_cancellationNotifier],
             _authEvaluator, _approvalEvaluator,
             NullLogger<GeoprocessingJobService>.Instance,
             _jobStore, _jobQueue);
@@ -143,7 +143,7 @@ public sealed class GeoprocessingJobServiceTests
     public async Task SubmitJob_WithoutJobStore_ThrowsStoreUnavailable()
     {
         var sut = new GeoprocessingJobService(
-            _progressStore, _cancellationNotifier,
+            _progressStore, [_cancellationNotifier],
             _authEvaluator, _approvalEvaluator,
             NullLogger<GeoprocessingJobService>.Instance,
             jobStore: null);
@@ -279,6 +279,36 @@ public sealed class GeoprocessingJobServiceTests
 
         await _sut.CancelJobAsync("job-1", CreatePrincipal());
 
+        await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_LaterNotifierOwnsTerminalState_DoesNotDependOnRegistrationOrder()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Running);
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+
+        var firstNotifier = Substitute.For<IJobCancellationNotifier>();
+        firstNotifier.Cancel("job-1").Returns(false);
+
+        var secondNotifier = Substitute.For<IJobCancellationNotifier>();
+        secondNotifier.Cancel("job-1").Returns(true);
+
+        var sut = new GeoprocessingJobService(
+            _progressStore,
+            [firstNotifier, secondNotifier],
+            _authEvaluator,
+            _approvalEvaluator,
+            NullLogger<GeoprocessingJobService>.Instance,
+            _jobStore,
+            _jobQueue);
+
+        await sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        firstNotifier.Received(1).Cancel("job-1");
+        secondNotifier.Received(1).Cancel("job-1");
         await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -312,6 +312,39 @@ public sealed class GeoprocessingJobServiceTests
         await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_ReReadFindsSucceeded_ThrowsPreconditionFailed()
+    {
+        var queued = CreateJobRecord("job-1", ExecutionJobStatus.Queued);
+        var succeeded = CreateJobRecord("job-1", ExecutionJobStatus.Succeeded);
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>())
+            .Returns(queued, succeeded);
+        _cancellationNotifier.Cancel("job-1").Returns(false);
+
+        var act = () => _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await act.Should().ThrowAsync<GeoprocessingPreconditionFailedException>();
+        await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_ReReadFindsCancelled_SucceedsIdempotently()
+    {
+        var queued = CreateJobRecord("job-1", ExecutionJobStatus.Queued);
+        var cancelled = CreateJobRecord("job-1", ExecutionJobStatus.Cancelled);
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>())
+            .Returns(queued, cancelled);
+        _cancellationNotifier.Cancel("job-1").Returns(false);
+
+        await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
     // -----------------------------------------------------------------------
     // ProcessId disambiguation
     // -----------------------------------------------------------------------

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -14,6 +14,7 @@ using Honua.Server.Features.Geoprocessing;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.Extensions.Logging.Abstractions;
+using Honua.Server.Tests.Helpers;
 using NSubstitute;
 
 namespace Honua.Server.Tests.Features.Geoprocessing;
@@ -25,7 +26,7 @@ namespace Honua.Server.Tests.Features.Geoprocessing;
 [Protocol(Protocols.GPServer)]
 public sealed class GeoprocessingJobServiceTests
 {
-    private readonly IExecutionJobStore _jobStore = Substitute.For<IExecutionJobStore>();
+    private readonly IExecutionJobStore _jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
     private readonly IJobQueue _jobQueue = Substitute.For<IJobQueue>();
     private readonly IUniversalProgressStore _progressStore = Substitute.For<IUniversalProgressStore>();
     private readonly IJobCancellationNotifier _cancellationNotifier = Substitute.For<IJobCancellationNotifier>();
@@ -409,7 +410,7 @@ public sealed class GeoprocessingJobServiceTests
 
         await _sut.CancelJobAsync("job-1", CreatePrincipal());
 
-        await _jobStore.Received(1).SetAsync(
+        await _jobStore.Received(1).TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j =>
                 j.OperationId == "job-1" &&
                 j.CancellationRequestedAt.HasValue &&
@@ -431,7 +432,7 @@ public sealed class GeoprocessingJobServiceTests
 
         await _sut.CancelJobAsync("job-1", CreatePrincipal());
 
-        await _jobStore.Received(1).SetAsync(
+        await _jobStore.Received(1).TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j =>
                 j.OperationId == "job-1" &&
                 j.Status == ExecutionJobStatus.Cancelled),
@@ -478,7 +479,7 @@ public sealed class GeoprocessingJobServiceTests
 
         await _sut.CancelJobAsync("job-1", CreatePrincipal());
 
-        await _jobStore.Received(1).SetAsync(
+        await _jobStore.Received(1).TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j =>
                 j.OperationId == "job-1" &&
                 j.Status == ExecutionJobStatus.Cancelled),

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -26,6 +26,7 @@ namespace Honua.Server.Tests.Features.Geoprocessing;
 public sealed class GeoprocessingJobServiceTests
 {
     private readonly IExecutionJobStore _jobStore = Substitute.For<IExecutionJobStore>();
+    private readonly IJobQueue _jobQueue = Substitute.For<IJobQueue>();
     private readonly IUniversalProgressStore _progressStore = Substitute.For<IUniversalProgressStore>();
     private readonly IJobCancellationNotifier _cancellationNotifier = Substitute.For<IJobCancellationNotifier>();
     private readonly IOperatorAuthorizationEvaluator _authEvaluator = Substitute.For<IOperatorAuthorizationEvaluator>();
@@ -46,7 +47,7 @@ public sealed class GeoprocessingJobServiceTests
             _progressStore, _cancellationNotifier,
             _authEvaluator, _approvalEvaluator,
             NullLogger<GeoprocessingJobService>.Instance,
-            _jobStore);
+            _jobStore, _jobQueue);
     }
 
     // -----------------------------------------------------------------------
@@ -251,6 +252,34 @@ public sealed class GeoprocessingJobServiceTests
         var act = async () => await _sut.CancelJobAsync("job-1", CreatePrincipal());
 
         await act.Should().ThrowAsync<GeoprocessingApprovalRequiredException>();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_NoActiveWorker_RemovesFromQueue()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Queued);
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+        _cancellationNotifier.Cancel("job-1").Returns(false);
+
+        await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await _jobQueue.Received(1).RemoveAsync("job-1", Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_WorkerOwnsTerminalState_DoesNotCallRemove()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Running);
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+        _cancellationNotifier.Cancel("job-1").Returns(true);
+
+        await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -370,6 +370,54 @@ public sealed class GeoprocessingJobServiceTests
             Arg.Any<CancellationToken>());
     }
 
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_ClaimedByRemoteWorker_SetsDurableCancellationSignal()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Running) with
+        {
+            ClaimedBy = "worker-remote-1",
+            ClaimedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            LastHeartbeatAt = DateTimeOffset.UtcNow.AddSeconds(-5)
+        };
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+        _cancellationNotifier.Cancel("job-1").Returns(false);
+
+        await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await _jobStore.Received(1).SetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.OperationId == "job-1" &&
+                j.CancellationRequestedAt.HasValue &&
+                j.Status == ExecutionJobStatus.Running),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_UnclaimedJob_WritesCancelledDirectly()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Queued);
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+        _cancellationNotifier.Cancel("job-1").Returns(false);
+
+        await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await _jobStore.Received(1).SetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.OperationId == "job-1" &&
+                j.Status == ExecutionJobStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await _jobQueue.Received(1).RemoveAsync("job-1", Arg.Any<CancellationToken>());
+    }
+
     // -----------------------------------------------------------------------
     // ProcessId disambiguation
     // -----------------------------------------------------------------------

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -141,6 +141,23 @@ public sealed class GeoprocessingJobServiceTests
     [UnitTest]
     [Operation(Operations.Create)]
     [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_WithValidPlan_EnqueuesJob()
+    {
+        _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var plan = CreateValidPlan();
+        var job = await _sut.SubmitJobAsync(plan, null, CreatePrincipal());
+
+        await _jobQueue.Received(1).EnqueueAsync(
+            job.OperationId,
+            Arg.Any<OperationPriority>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
     public async Task SubmitJob_WithoutJobStore_ThrowsStoreUnavailable()
     {
         var sut = new GeoprocessingJobService(
@@ -485,6 +502,126 @@ public sealed class GeoprocessingJobServiceTests
                 j.Status == ExecutionJobStatus.Cancelled),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_ClaimedCasConflict_RetriesUntilSignalConfirmed()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Running) with
+        {
+            ClaimedBy = "worker-remote-1",
+            ClaimedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            LastHeartbeatAt = DateTimeOffset.UtcNow.AddSeconds(-5)
+        };
+        var freshRecord = record with { UpdatedAt = DateTimeOffset.UtcNow };
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>())
+            .Returns(record, record, freshRecord);
+        _cancellationNotifier.Cancel("job-1").Returns(false);
+
+        _jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false, true);
+
+        await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await _jobStore.Received(2).TrySetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.OperationId == "job-1" &&
+                j.CancellationRequestedAt.HasValue),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_ClaimedCasConflict_ReReadShowsSignal_SucceedsWithoutRetry()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Running) with
+        {
+            ClaimedBy = "worker-remote-1"
+        };
+        var conflictRecord = record with
+        {
+            CancellationRequestedAt = DateTimeOffset.UtcNow
+        };
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>())
+            .Returns(record, record, conflictRecord);
+        _cancellationNotifier.Cancel("job-1").Returns(false);
+
+        _jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await _jobStore.Received(1).TrySetAsync(
+            Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_UnclaimedCasConflict_RetriesUntilCancelConfirmed()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Queued);
+        var freshRecord = record with { UpdatedAt = DateTimeOffset.UtcNow };
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>())
+            .Returns(record, record, freshRecord);
+        _cancellationNotifier.Cancel("job-1").Returns(false);
+
+        _jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false, true);
+
+        await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await _jobStore.Received(2).TrySetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.OperationId == "job-1" &&
+                j.Status == ExecutionJobStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await _jobQueue.Received(1).RemoveAsync("job-1", Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_UnclaimedCasConflict_ReReadShowsSucceeded_ThrowsPrecondition()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Queued);
+        var succeededRecord = CreateJobRecord("job-1", ExecutionJobStatus.Succeeded);
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>())
+            .Returns(record, record, succeededRecord);
+        _cancellationNotifier.Cancel("job-1").Returns(false);
+
+        _jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var act = async () => await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await act.Should().ThrowAsync<GeoprocessingPreconditionFailedException>();
+        await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_CasExhausted_ThrowsPreconditionFailed()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Queued);
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+        _cancellationNotifier.Cancel("job-1").Returns(false);
+
+        _jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var act = async () => await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await act.Should().ThrowAsync<GeoprocessingPreconditionFailedException>()
+            .WithMessage("*could not be confirmed*");
+        await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -441,6 +441,51 @@ public sealed class GeoprocessingJobServiceTests
         await _jobQueue.Received(1).RemoveAsync("job-1", Arg.Any<CancellationToken>());
     }
 
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_AlreadyCancelled_ContinuesWhenQueueRemovalFails()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Cancelled);
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+        _jobQueue.RemoveAsync("job-1", Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        var staleProgress = GeoprocessingProgress.CreateForSubmittedJob("job-1", "plan-1");
+        _progressStore.GetProgressAsync<GeoprocessingProgress>("job-1", Arg.Any<CancellationToken>())
+            .Returns(staleProgress);
+
+        await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await _progressStore.Received(1).SetProgressAsync(
+            "job-1",
+            Arg.Is<Honua.Core.Features.Infrastructure.Domain.IOperationProgress>(p =>
+                p.Status == Honua.Core.Features.Infrastructure.Domain.OperationStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_DirectCancel_ContinuesWhenQueueRemovalFails()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Queued);
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+        _cancellationNotifier.Cancel("job-1").Returns(false);
+        _jobQueue.RemoveAsync("job-1", Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await _jobStore.Received(1).SetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.OperationId == "job-1" &&
+                j.Status == ExecutionJobStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
     // -----------------------------------------------------------------------
     // ProcessId disambiguation
     // -----------------------------------------------------------------------

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -222,6 +222,29 @@ public sealed class GeoprocessingJobServiceTests
         await _sut.CancelJobAsync("job-1", CreatePrincipal());
 
         _cancellationNotifier.DidNotReceive().Cancel(Arg.Any<string>());
+        await _jobQueue.Received(1).RemoveAsync("job-1", Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_AlreadyCancelled_ReconcilesStalProgressStore()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Cancelled);
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>()).Returns(record);
+
+        var staleProgress = GeoprocessingProgress.CreateForSubmittedJob("job-1", "plan-1");
+        _progressStore.GetProgressAsync<GeoprocessingProgress>("job-1", Arg.Any<CancellationToken>())
+            .Returns(staleProgress);
+
+        await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await _progressStore.Received(1).SetProgressAsync(
+            "job-1",
+            Arg.Is<Honua.Core.Features.Infrastructure.Domain.IOperationProgress>(p =>
+                p.Status == Honua.Core.Features.Infrastructure.Domain.OperationStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [UnitTest]

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -345,6 +345,31 @@ public sealed class GeoprocessingJobServiceTests
         await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_ReReadFindsDeleted_ThrowsNotFoundWithoutRecreatingJob()
+    {
+        var queued = CreateJobRecord("job-1", ExecutionJobStatus.Queued);
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>())
+            .Returns(queued, (ExecutionJobRecord?)null);
+        _cancellationNotifier.Cancel("job-1").Returns(false);
+
+        var act = () => _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        await act.Should().ThrowAsync<GeoprocessingNotFoundException>();
+        await _jobStore.DidNotReceive().SetAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+        await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _progressStore.DidNotReceive().SetProgressAsync(
+            Arg.Any<string>(),
+            Arg.Any<Honua.Core.Features.Infrastructure.Domain.IOperationProgress>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
     // -----------------------------------------------------------------------
     // ProcessId disambiguation
     // -----------------------------------------------------------------------

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -355,7 +355,7 @@ public sealed class GeoprocessingJobServiceTests
     [UnitTest]
     [Operation(Operations.Delete)]
     [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
-    public async Task CancelJob_ReReadFindsCancelled_SucceedsIdempotently()
+    public async Task CancelJob_ReReadFindsCancelled_ReconcilesSideEffectsIdempotently()
     {
         var queued = CreateJobRecord("job-1", ExecutionJobStatus.Queued);
         var cancelled = CreateJobRecord("job-1", ExecutionJobStatus.Cancelled);
@@ -365,7 +365,7 @@ public sealed class GeoprocessingJobServiceTests
 
         await _sut.CancelJobAsync("job-1", CreatePrincipal());
 
-        await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _jobQueue.Received(1).RemoveAsync("job-1", Arg.Any<CancellationToken>());
     }
 
     [UnitTest]

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -666,8 +666,15 @@ public sealed class GeoprocessingJobServiceTests
     [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
     public async Task SubmitJob_EnqueueFails_RollsBackJobToFailed()
     {
+        ExecutionJobRecord? createdJob = null;
         _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-            .Returns(true);
+            .Returns(call =>
+            {
+                createdJob = call.Arg<ExecutionJobRecord>();
+                return true;
+            });
+        _jobStore.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => createdJob == null ? null : createdJob with { Version = 1 });
         _jobQueue.EnqueueAsync(Arg.Any<string>(), Arg.Any<OperationPriority>(), Arg.Any<CancellationToken>())
             .Returns<Task>(_ => throw new InvalidOperationException("Redis unavailable"));
 
@@ -686,6 +693,7 @@ public sealed class GeoprocessingJobServiceTests
         await _jobStore.Received().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j =>
                 j.Status == ExecutionJobStatus.Failed &&
+                j.Version == 1 &&
                 j.ErrorMessage!.Contains("progress or queue persistence")),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -624,6 +624,105 @@ public sealed class GeoprocessingJobServiceTests
         await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
+    [UnitTest]
+    [Operation(Operations.Delete)]
+    [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}/cancel")]
+    public async Task CancelJob_UnclaimedCasConflict_JobBecomeClaimed_SwitchesToDurableSignal()
+    {
+        var record = CreateJobRecord("job-1", ExecutionJobStatus.Queued);
+        var claimedRecord = record with
+        {
+            ClaimedBy = "worker-remote-1",
+            ClaimedAt = DateTimeOffset.UtcNow,
+            Status = ExecutionJobStatus.Running,
+            LastHeartbeatAt = DateTimeOffset.UtcNow
+        };
+
+        // Initial reads return unclaimed; CAS fails; re-read shows claimed.
+        _jobStore.GetAsync("job-1", Arg.Any<CancellationToken>())
+            .Returns(record, record, claimedRecord);
+        _cancellationNotifier.Cancel("job-1").Returns(false);
+
+        _jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false, true);
+
+        await _sut.CancelJobAsync("job-1", CreatePrincipal());
+
+        // Must have written CancellationRequestedAt, not terminal Cancelled.
+        await _jobStore.Received().TrySetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.OperationId == "job-1" &&
+                j.CancellationRequestedAt.HasValue &&
+                j.Status != ExecutionJobStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        // Queue should NOT have been cleaned up — worker owns the terminal state.
+        await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_EnqueueFails_RollsBackJobToFailed()
+    {
+        _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _jobQueue.EnqueueAsync(Arg.Any<string>(), Arg.Any<OperationPriority>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Redis unavailable"));
+
+        var plan = new AnalysisPlan
+        {
+            PlanId = "plan-rollback",
+            IntentId = "intent-1",
+            Steps = [new AnalysisPlanStep { StepId = "s1", Kind = AnalysisPlanStepKind.Geoprocess, ProcessId = "buf" }]
+        };
+
+        var act = async () => await _sut.SubmitJobAsync(plan, null, CreatePrincipal());
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        // The job record must have been rolled back to Failed.
+        await _jobStore.Received().TrySetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.Status == ExecutionJobStatus.Failed &&
+                j.ErrorMessage!.Contains("progress or queue persistence")),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_IdempotentRetryAfterSubmissionRollback_ThrowsInsteadOfReturningFailedRecord()
+    {
+        var plan = CreateValidPlan();
+        var idempotencyKey = "retry-submission-rollback";
+        var jobId = GeoprocessingJobService.CreateJobId(idempotencyKey);
+        var requestFingerprint = GeoprocessingJobService.CreateRequestFingerprint(plan);
+
+        var failedSubmission = CreateJobRecord(jobId, ExecutionJobStatus.Failed) with
+        {
+            CurrentPhase = "Failed (submission)",
+            ErrorMessage = "Submission failed: progress or queue persistence error.",
+            Audit = new OperationAuditInfo
+            {
+                IdempotencyKey = idempotencyKey,
+                RequestFingerprint = requestFingerprint
+            }
+        };
+
+        _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _jobStore.GetAsync(jobId, Arg.Any<CancellationToken>())
+            .Returns(failedSubmission);
+
+        var act = async () => await _sut.SubmitJobAsync(plan, idempotencyKey, CreatePrincipal());
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*previously failed before queueing*");
+    }
+
     // -----------------------------------------------------------------------
     // ProcessId disambiguation
     // -----------------------------------------------------------------------

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GrpcProcessServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GrpcProcessServiceTests.cs
@@ -14,6 +14,7 @@ using Honua.Server.Features.Geoprocessing;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.AspNetCore.Http;
+using Honua.Server.Tests.Helpers;
 using NSubstitute;
 using Proto = Geospatial.V1;
 
@@ -25,7 +26,7 @@ namespace Honua.Server.Tests.Features.Geoprocessing;
 [Protocol(Protocols.Grpc)]
 public sealed class GrpcProcessServiceTests
 {
-    private readonly IExecutionJobStore _jobStore = Substitute.For<IExecutionJobStore>();
+    private readonly IExecutionJobStore _jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
     private readonly IUniversalProgressStore _progressStore = Substitute.For<IUniversalProgressStore>();
     private readonly IJobCancellationNotifier _cancellationNotifier = Substitute.For<IJobCancellationNotifier>();
     private readonly IOperatorAuthorizationEvaluator _authEvaluator = Substitute.For<IOperatorAuthorizationEvaluator>();
@@ -354,7 +355,7 @@ public sealed class GrpcProcessServiceTests
 
         response.Should().NotBeNull();
         _cancellationNotifier.Received(1).Cancel("job-123");
-        await _jobStore.Received(1).SetAsync(
+        await _jobStore.Received(1).TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
             Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GrpcProcessServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GrpcProcessServiceTests.cs
@@ -43,7 +43,7 @@ public sealed class GrpcProcessServiceTests
             .Returns(ApprovalRequirement.NotRequired());
 
         var jobService = new GeoprocessingJobService(
-            _progressStore, _cancellationNotifier,
+            _progressStore, [_cancellationNotifier],
             _authEvaluator, _approvalEvaluator,
             Microsoft.Extensions.Logging.Abstractions.NullLogger<GeoprocessingJobService>.Instance,
             _jobStore);

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -849,6 +849,62 @@ public sealed class JobExecutionServiceTests
     }
 
     /// <summary>
+    /// The generated worker ID must always contain a full 32-hex-char GUID suffix,
+    /// even when the machine hostname is very long. Without this, two workers on
+    /// long-hostname nodes can share the same truncated ID, breaking ownership guards.
+    /// </summary>
+    [UnitTest]
+    public void GenerateWorkerId_AlwaysPreservesFullGuid()
+    {
+        var workerId = JobExecutionService.GenerateWorkerId();
+
+        Assert.True(workerId.Length <= 48);
+
+        var lastDash = workerId.LastIndexOf('-');
+        Assert.True(lastDash >= 0, "Worker ID must contain a GUID suffix separated by '-'");
+
+        var guidPart = workerId[(lastDash + 1)..];
+        Assert.Equal(32, guidPart.Length);
+        Assert.True(guidPart.All(c => "0123456789abcdef".Contains(c)),
+            "GUID suffix must be 32 lowercase hex characters");
+    }
+
+    /// <summary>
+    /// When a worker has no executors registered, it must not enter the claim
+    /// loop. Without this guard, the worker performs O(n) Redis scans every
+    /// poll interval for no benefit.
+    /// </summary>
+    [UnitTest]
+    public async Task ExecuteAsync_SkipsClaimLoop_WhenNoExecutorsRegistered()
+    {
+        var jobQueue = Substitute.For<IJobQueue>();
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, Array.Empty<IJobExecutor>(), cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        await service.StartAsync(cts.Token);
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(250));
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        await service.StopAsync(CancellationToken.None);
+
+        await jobQueue.DidNotReceive().TryClaimAsync(
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlySet<ExecutionJobKind>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Invokes the private ProcessJobAsync method via reflection.
     /// Follows the same test pattern used in <see cref="JobReconciliationServiceTests"/>.
     /// </summary>

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -285,6 +285,113 @@ public sealed class JobExecutionServiceTests
     }
 
     /// <summary>
+    /// Regression: executor warnings must be persisted on the terminal failed
+    /// record when no retries remain, so clients rendering job.Warnings see them.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_PersistsWarnings_WhenExecutorReturnsFailure_NoRetries()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = new JobRetryPolicy
+            {
+                MaxAttempts = 1,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            }
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        // First read for executor lookup, second for CTS re-check, third for
+        // Running transition read-back, fourth inside AbandonJobAsync re-read.
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.TryClaimAsync(Arg.Any<string>(), Arg.Any<IReadOnlySet<ExecutionJobKind>>(), Arg.Any<CancellationToken>())
+            .Returns(provisioning.OperationId, (string?)null);
+
+        var executorWarnings = new List<string> { "Projection mismatch", "CRS fallback used" };
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Failed("Transform failed", executorWarnings));
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        // The terminal failed record must carry the executor warnings.
+        await jobStore.Received().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.Status == ExecutionJobStatus.Failed &&
+                j.Warnings.Count == 2 &&
+                j.Warnings[0] == "Projection mismatch"),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: when executor returns failure with warnings and retries
+    /// remain, warnings must be cleared from the requeued record to prevent
+    /// stale per-attempt warnings from leaking to the next attempt.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_ClearsWarnings_WhenExecutorReturnsFailure_WithRetries()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = new JobRetryPolicy
+            {
+                MaxAttempts = 3,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.FromSeconds(1),
+                MaxDelay = TimeSpan.FromMinutes(1)
+            }
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.TryClaimAsync(Arg.Any<string>(), Arg.Any<IReadOnlySet<ExecutionJobKind>>(), Arg.Any<CancellationToken>())
+            .Returns(provisioning.OperationId, (string?)null);
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Failed("Transient failure", ["Warning A"]));
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        // The requeued record must have cleared warnings.
+        await jobStore.Received().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.Status == ExecutionJobStatus.Queued &&
+                j.Warnings.Count == 0),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Invokes the private ProcessJobAsync method via reflection.
     /// Follows the same test pattern used in <see cref="JobReconciliationServiceTests"/>.
     /// </summary>

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -1405,6 +1405,87 @@ public sealed class JobExecutionServiceTests
             Arg.Any<CancellationToken>());
     }
 
+    [UnitTest]
+    public async Task ProcessJob_Finalize_NotifiesTerminalCallback_WhenLogRetentionFails()
+    {
+        var provisioning = CreateProvisioningJob();
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.TryClaimAsync(Arg.Any<string>(), Arg.Any<IReadOnlySet<ExecutionJobKind>>(), Arg.Any<CancellationToken>())
+            .Returns(provisioning.OperationId, (string?)null);
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Succeeded());
+
+        var logStore = Substitute.For<IExecutionLogStore>();
+        logStore.SetRetentionAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        var terminalCallback = Substitute.For<IJobTerminalCallback>();
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, [terminalCallback], logStore,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        await terminalCallback.Received(1).OnTerminalAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Succeeded),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    public async Task ProcessJob_AbandonTerminal_NotifiesTerminalCallback_WhenLogRetentionFails()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = JobRetryPolicy.None
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.TryClaimAsync(Arg.Any<string>(), Arg.Any<IReadOnlySet<ExecutionJobKind>>(), Arg.Any<CancellationToken>())
+            .Returns(provisioning.OperationId, (string?)null);
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Failed("Permanent failure"));
+
+        var logStore = Substitute.For<IExecutionLogStore>();
+        logStore.SetRetentionAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        var terminalCallback = Substitute.For<IJobTerminalCallback>();
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, [terminalCallback], logStore,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        await terminalCallback.Received(1).OnTerminalAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
+            Arg.Any<CancellationToken>());
+    }
+
     /// <summary>
     /// Invokes the private ProcessJobAsync method via reflection.
     /// Follows the same test pattern used in <see cref="JobReconciliationServiceTests"/>.

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -549,6 +549,105 @@ public sealed class JobExecutionServiceTests
     }
 
     /// <summary>
+    /// Regression: after a worker requeues a job on executor failure with retries
+    /// remaining, the tracked CTS must be removed immediately so that a cancel
+    /// request arriving in the window between requeue and ProcessJobAsync's finally
+    /// block is not incorrectly delegated to a worker that no longer owns the job.
+    /// Without the fix, Cancel() returns true in this window and the API caller
+    /// trusts the worker to persist Cancelled — but the worker already dropped
+    /// ownership, so the cancel is silently swallowed and the job stays Queued.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_RemovesCtsAfterRetryRequeue_SoCancelIsNotFalselyDelegated()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = new JobRetryPolicy
+            {
+                MaxAttempts = 3,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            }
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Failed("Transient failure"));
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        // After ProcessJobAsync completes, Cancel must return false: the CTS
+        // was removed during AbandonJobAsync (after the requeue) so API
+        // callers will not falsely delegate cancellation to a worker that
+        // has already dropped ownership.
+        Assert.False(cancellationTokens.Cancel(provisioning.OperationId));
+    }
+
+    /// <summary>
+    /// Regression: shutdown-triggered requeue must also clear the tracked CTS
+    /// immediately to prevent cancel-delegation to a worker that dropped ownership.
+    /// Shutdown requeues bypass the retry budget (<see cref="JobRetryPolicy.None"/>)
+    /// and must still clean up the CTS before the finally block.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_RemovesCtsAfterShutdownRequeue_SoCancelIsNotFalselyDelegated()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = JobRetryPolicy.None
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var stoppingCts = new CancellationTokenSource();
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(async callInfo =>
+            {
+                await stoppingCts.CancelAsync().ConfigureAwait(false);
+                callInfo.Arg<CancellationToken>().ThrowIfCancellationRequested();
+                return JobExecutionResult.Succeeded(); // Unreachable.
+            });
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId,
+            provisioning.ClaimedBy!, stoppingCts.Token);
+
+        // After shutdown requeue, Cancel must return false.
+        Assert.False(cancellationTokens.Cancel(provisioning.OperationId));
+    }
+
+    /// <summary>
     /// Regression: when a job is requeued and immediately reclaimed by another worker,
     /// the stale worker's finally-block Remove must not delete the new worker's CTS.
     /// </summary>

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -712,6 +712,65 @@ public sealed class JobExecutionServiceTests
     }
 
     /// <summary>
+    /// Regression: a durable cancellation signal racing with worker shutdown must
+    /// be honoured by AbandonJobAsync instead of requeueing the job to an indefinite
+    /// Queued state that the reconciler does not sweep.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_ShutdownRequeue_HonoursDurableCancellationSignal()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = JobRetryPolicy.None,
+            CancellationRequestedAt = DateTimeOffset.UtcNow.AddSeconds(-1)
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var stoppingCts = new CancellationTokenSource();
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(async callInfo =>
+            {
+                await stoppingCts.CancelAsync().ConfigureAwait(false);
+                callInfo.Arg<CancellationToken>().ThrowIfCancellationRequested();
+                return JobExecutionResult.Succeeded();
+            });
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId,
+            provisioning.ClaimedBy!, stoppingCts.Token);
+
+        await jobStore.Received().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.Status == ExecutionJobStatus.Cancelled &&
+                j.CompletedAt.HasValue),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.Received().RemoveAsync(provisioning.OperationId, Arg.Any<CancellationToken>());
+
+        await jobQueue.DidNotReceive().RequeueAsync(
+            Arg.Any<string>(),
+            Arg.Any<OperationPriority>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Regression: after the authoritative store write in FinalizeJobAsync, the CTS
     /// must be removed before RemoveAsync so that a Redis hang does not leave a
     /// stale CTS that falsely accepts cancel delegation.

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -922,6 +922,78 @@ public sealed class JobExecutionServiceTests
     }
 
     /// <summary>
+    /// Regression: when the host stops after TryClaimAsync succeeds but before
+    /// the executor try/catch is reached, the claimed job must be immediately
+    /// requeued by the ExecuteAsync shutdown handler instead of being left in
+    /// Provisioning until heartbeat expiry.
+    /// </summary>
+    [UnitTest]
+    public async Task ExecuteAsync_RequeuesClaimedJob_WhenShutdownDuringPreExecution()
+    {
+        var provisioning = CreateProvisioningJob();
+
+        string? capturedWorkerId = null;
+        var stoppingCts = new CancellationTokenSource();
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.TryClaimAsync(Arg.Any<string>(), Arg.Any<IReadOnlySet<ExecutionJobKind>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedWorkerId = callInfo.ArgAt<string>(0);
+                stoppingCts.Cancel();
+                return (string?)provisioning.OperationId;
+            });
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                callInfo.Arg<CancellationToken>().ThrowIfCancellationRequested();
+                return (ExecutionJobRecord?)(provisioning with { ClaimedBy = capturedWorkerId });
+            });
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await service.StartAsync(stoppingCts.Token);
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(500));
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        await service.StopAsync(CancellationToken.None);
+
+        // The job must be requeued, not left to heartbeat expiry.
+        await jobStore.Received().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.Status == ExecutionJobStatus.Queued &&
+                j.ClaimedBy == null),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.Received().RequeueAsync(
+            provisioning.OperationId,
+            Arg.Any<OperationPriority>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        // Executor must NOT have been invoked.
+        await executor.DidNotReceive().ExecuteAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<IJobExecutionContext>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Invokes the private ProcessJobAsync method via reflection.
     /// Follows the same test pattern used in <see cref="JobReconciliationServiceTests"/>.
     /// </summary>

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -549,6 +549,58 @@ public sealed class JobExecutionServiceTests
     }
 
     /// <summary>
+    /// Regression: when a job is requeued and immediately reclaimed by another worker,
+    /// the stale worker's finally-block Remove must not delete the new worker's CTS.
+    /// </summary>
+    [UnitTest]
+    public void Remove_PreservesNewWorkerCts_WhenJobReclaimedAfterRequeue()
+    {
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        // Worker A registers CTS.
+        using var ctsA = cancellationTokens.CreateLinkedTokenSource(
+            "job-1", "worker-A", CancellationToken.None);
+
+        // Job is requeued; Worker B claims and registers a new CTS.
+        using var ctsB = cancellationTokens.CreateLinkedTokenSource(
+            "job-1", "worker-B", CancellationToken.None);
+
+        // Worker A's finally block runs — must NOT remove Worker B's CTS.
+        cancellationTokens.Remove("job-1", "worker-A");
+
+        // Worker B's CTS must still be cancellable via the operator path.
+        Assert.True(cancellationTokens.Cancel("job-1"));
+        Assert.True(ctsB.IsCancellationRequested);
+    }
+
+    /// <summary>
+    /// Regression: when the reconciler requeues a job and a new worker claims it
+    /// before Revoke runs, the Revoke must not cancel the new worker's CTS.
+    /// </summary>
+    [UnitTest]
+    public void Revoke_PreservesNewWorkerCts_WhenJobReclaimedBeforeRevoke()
+    {
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        // Worker A registered CTS (simulated by reconciler tracking).
+        using var ctsA = cancellationTokens.CreateLinkedTokenSource(
+            "job-1", "worker-A", CancellationToken.None);
+
+        // Job was requeued; Worker B claims and registers before Revoke runs.
+        using var ctsB = cancellationTokens.CreateLinkedTokenSource(
+            "job-1", "worker-B", CancellationToken.None);
+
+        // Reconciler's Revoke targets worker-A — must NOT cancel worker-B's CTS.
+        cancellationTokens.Revoke("job-1", "worker-A");
+
+        Assert.False(ctsB.IsCancellationRequested);
+
+        // Operator cancellation must still reach the new worker.
+        Assert.True(cancellationTokens.Cancel("job-1"));
+        Assert.True(ctsB.IsCancellationRequested);
+    }
+
+    /// <summary>
     /// Invokes the private ProcessJobAsync method via reflection.
     /// Follows the same test pattern used in <see cref="JobReconciliationServiceTests"/>.
     /// </summary>

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -1487,6 +1487,123 @@ public sealed class JobExecutionServiceTests
     }
 
     /// <summary>
+    /// Regression: a durable cancellation signal that arrives during the retry-
+    /// preparation phase (log appends) must be honoured by the pre-requeue re-read
+    /// instead of being silently overwritten by the requeue write.
+    /// </summary>
+    [UnitTest]
+    public async Task AbandonJob_HonoursCancellation_WhenSignalArrivesDuringRetryPrep()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = new JobRetryPolicy
+            {
+                MaxAttempts = 3,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.FromSeconds(1),
+                MaxDelay = TimeSpan.FromMinutes(1)
+            }
+        };
+
+        var withCancel = provisioning with
+        {
+            CancellationRequestedAt = DateTimeOffset.UtcNow
+        };
+
+        var callCount = 0;
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                // Reads 1-3: executor lookup, CTS re-read, AbandonJobAsync re-read — no cancel.
+                // Read 4+: pre-requeue re-read and TerminateJobAsync — cancel signal present.
+                return callCount <= 3 ? provisioning : withCancel;
+            });
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Failed("Transient failure"));
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        await jobStore.Received().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.DidNotReceive().RequeueAsync(
+            Arg.Any<string>(), Arg.Any<OperationPriority>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: a durable cancellation signal that arrives before the terminal
+    /// fail write (retries exhausted) must be honoured by the pre-fail re-read.
+    /// </summary>
+    [UnitTest]
+    public async Task AbandonJob_HonoursCancellation_WhenSignalArrivesBeforeFailWrite()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = JobRetryPolicy.None
+        };
+
+        var withCancel = provisioning with
+        {
+            CancellationRequestedAt = DateTimeOffset.UtcNow
+        };
+
+        var callCount = 0;
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                // Reads 1-3: executor lookup, CTS re-read, AbandonJobAsync re-read — no cancel.
+                // Read 4+: pre-fail re-read and TerminateJobAsync — cancel signal present.
+                return callCount <= 3 ? provisioning : withCancel;
+            });
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Failed("Permanent failure"));
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        await jobStore.Received().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Invokes the private ProcessJobAsync method via reflection.
     /// Follows the same test pattern used in <see cref="JobReconciliationServiceTests"/>.
     /// </summary>

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -207,7 +207,7 @@ public sealed class JobExecutionServiceTests
         using var context = new JobExecutionContext(
             running.OperationId, "worker-stale", jobStore, null,
             new JobHeartbeatPolicy { Interval = TimeSpan.FromMilliseconds(10), Timeout = TimeSpan.FromSeconds(30) },
-            NullLogger.Instance);
+            null, NullLogger.Instance);
 
         // The pump should detect the ownership change and exit without writing.
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -243,7 +243,7 @@ public sealed class JobExecutionServiceTests
         using var context = new JobExecutionContext(
             running.OperationId, "worker-stale", jobStore, null,
             JobHeartbeatPolicy.Default,
-            NullLogger.Instance);
+            null, NullLogger.Instance);
 
         await context.ReportProgressAsync(50, "Processing", CancellationToken.None);
 
@@ -277,7 +277,7 @@ public sealed class JobExecutionServiceTests
         using var context = new JobExecutionContext(
             running.OperationId, "worker-stale", jobStore, null,
             JobHeartbeatPolicy.Default,
-            NullLogger.Instance);
+            null, NullLogger.Instance);
 
         await context.PublishArtifactAsync("s3://bucket/artifact.zip", CancellationToken.None);
 
@@ -596,7 +596,7 @@ public sealed class JobExecutionServiceTests
         using var context = new JobExecutionContext(
             running.OperationId, "worker-stale", jobStore, logStore,
             JobHeartbeatPolicy.Default,
-            NullLogger.Instance);
+            null, NullLogger.Instance);
 
         await context.AppendLogAsync(new ExecutionLogEntry
         {
@@ -943,7 +943,7 @@ public sealed class JobExecutionServiceTests
         using var context = new JobExecutionContext(
             running.OperationId, running.ClaimedBy!, jobStore, null,
             new JobHeartbeatPolicy { Interval = TimeSpan.FromMilliseconds(10), Timeout = TimeSpan.FromSeconds(30) },
-            NullLogger.Instance);
+            null, NullLogger.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(80));
 
@@ -976,7 +976,7 @@ public sealed class JobExecutionServiceTests
         using var context = new JobExecutionContext(
             running.OperationId, running.ClaimedBy!, jobStore, null,
             new JobHeartbeatPolicy { Interval = TimeSpan.FromMilliseconds(10), Timeout = TimeSpan.FromSeconds(30) },
-            NullLogger.Instance);
+            null, NullLogger.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
         await context.RunHeartbeatPumpAsync(cts.Token);
@@ -1183,6 +1183,84 @@ public sealed class JobExecutionServiceTests
             Arg.Any<ExecutionJobRecord>(),
             Arg.Any<IJobExecutionContext>(),
             Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: a durable cancellation signal (CancellationRequestedAt) set by
+    /// a remote API host before the worker transitions to Running must be honoured
+    /// so the job does not proceed to execution.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_SkipsExecution_WhenDurableCancellationSignalIsSet()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            CancellationRequestedAt = DateTimeOffset.UtcNow.AddSeconds(-2)
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Running),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await executor.DidNotReceive().ExecuteAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<IJobExecutionContext>(),
+            Arg.Any<CancellationToken>());
+
+        await jobStore.Received().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: the heartbeat pump must detect a durable cancellation signal
+    /// and cancel the per-job CTS so the executor receives the cancellation
+    /// through its CancellationToken.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatPump_CancelsJobCts_WhenDurableCancellationSignalDetected()
+    {
+        var running = CreateProvisioningJob(claimedBy: "worker-test") with
+        {
+            Status = ExecutionJobStatus.Running
+        };
+        var withSignal = running with
+        {
+            CancellationRequestedAt = DateTimeOffset.UtcNow
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
+            .Returns(withSignal);
+
+        using var jobCts = new CancellationTokenSource();
+        using var context = new JobExecutionContext(
+            running.OperationId, "worker-test", jobStore, null,
+            new JobHeartbeatPolicy { Interval = TimeSpan.FromMilliseconds(10), Timeout = TimeSpan.FromSeconds(30) },
+            jobCts, NullLogger.Instance);
+
+        using var pumpTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await context.RunHeartbeatPumpAsync(pumpTimeout.Token);
+
+        Assert.True(jobCts.IsCancellationRequested);
     }
 
     /// <summary>

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -93,7 +93,8 @@ public sealed class JobExecutionServiceTests
 
     /// <summary>
     /// Regression: if another worker reclaimed the job before this worker
-    /// transitions to Running, this worker must bail out.
+    /// transitions to Running, this worker must bail out without deleting
+    /// the queue entry that now belongs to the new owner.
     /// </summary>
     [UnitTest]
     public async Task ProcessJob_SkipsExecution_WhenClaimOwnerChangedBeforeRunningTransition()
@@ -130,6 +131,156 @@ public sealed class JobExecutionServiceTests
         await executor.DidNotReceive().ExecuteAsync(
             Arg.Any<ExecutionJobRecord>(),
             Arg.Any<IJobExecutionContext>(),
+            Arg.Any<CancellationToken>());
+
+        // The queue entry belongs to the new owner — must not be removed.
+        await jobQueue.DidNotReceive().RemoveAsync(
+            provisioning.OperationId, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: a requeued job (status=Queued, ClaimedBy=null) must not have
+    /// its queue entry deleted by the stale worker that lost ownership.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_DoesNotRemoveQueue_WhenJobRequeuedBeforeRunningTransition()
+    {
+        var provisioning = CreateProvisioningJob(claimedBy: "worker-test");
+        var requeued = provisioning with
+        {
+            Status = ExecutionJobStatus.Queued,
+            ClaimedBy = null,
+            ClaimedAt = null,
+            LastHeartbeatAt = null,
+            CurrentPhase = "Requeued: Worker shutdown."
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning, requeued);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, "worker-test");
+
+        // Execution must be skipped.
+        await executor.DidNotReceive().ExecuteAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<IJobExecutionContext>(),
+            Arg.Any<CancellationToken>());
+
+        // The queue entry is the pending retry — must not be removed.
+        await jobQueue.DidNotReceive().RemoveAsync(
+            provisioning.OperationId, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: a stale worker's heartbeat pump must stop when
+    /// the job has been reclaimed by another worker.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatPump_Stops_WhenOwnershipChanges()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var running = CreateProvisioningJob(claimedBy: "worker-stale") with
+        {
+            Status = ExecutionJobStatus.Running
+        };
+        var reclaimed = running with
+        {
+            ClaimedBy = "worker-new",
+            ClaimedAt = now
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
+            .Returns(reclaimed);
+
+        using var context = new JobExecutionContext(
+            running.OperationId, "worker-stale", jobStore, null,
+            new JobHeartbeatPolicy { Interval = TimeSpan.FromMilliseconds(10), Timeout = TimeSpan.FromSeconds(30) });
+
+        // The pump should detect the ownership change and exit without writing.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await context.RunHeartbeatPumpAsync(cts.Token);
+
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: a stale worker's progress report must be silently
+    /// dropped when ownership has moved to another worker.
+    /// </summary>
+    [UnitTest]
+    public async Task ReportProgress_Skips_WhenOwnershipLost()
+    {
+        var running = CreateProvisioningJob(claimedBy: "worker-stale") with
+        {
+            Status = ExecutionJobStatus.Running
+        };
+        var reclaimed = running with
+        {
+            ClaimedBy = "worker-new",
+            ClaimedAt = DateTimeOffset.UtcNow
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
+            .Returns(reclaimed);
+
+        using var context = new JobExecutionContext(
+            running.OperationId, "worker-stale", jobStore, null,
+            JobHeartbeatPolicy.Default);
+
+        await context.ReportProgressAsync(50, "Processing", CancellationToken.None);
+
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: a stale worker's artifact publication must be silently
+    /// dropped when ownership has moved to another worker.
+    /// </summary>
+    [UnitTest]
+    public async Task PublishArtifact_Skips_WhenOwnershipLost()
+    {
+        var running = CreateProvisioningJob(claimedBy: "worker-stale") with
+        {
+            Status = ExecutionJobStatus.Running
+        };
+        var reclaimed = running with
+        {
+            ClaimedBy = "worker-new",
+            ClaimedAt = DateTimeOffset.UtcNow
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
+            .Returns(reclaimed);
+
+        using var context = new JobExecutionContext(
+            running.OperationId, "worker-stale", jobStore, null,
+            JobHeartbeatPolicy.Default);
+
+        await context.PublishArtifactAsync("s3://bucket/artifact.zip", CancellationToken.None);
+
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Verifies that the execution service re-reads job state before promoting
+/// a claimed job to Running, preventing resurrection of jobs that were
+/// cancelled between claim and worker startup.
+/// </summary>
+[Collection("Unit")]
+public sealed class JobExecutionServiceTests
+{
+    private static ExecutionJobRecord CreateProvisioningJob(
+        string operationId = "job-1",
+        string claimedBy = "worker-test")
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new ExecutionJobRecord
+        {
+            OperationId = operationId,
+            Status = ExecutionJobStatus.Provisioning,
+            CreatedAt = now.AddMinutes(-1),
+            UpdatedAt = now,
+            ClaimedBy = claimedBy,
+            ClaimedAt = now,
+            LastHeartbeatAt = now,
+            AttemptCount = 1,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "test"
+            }
+        };
+    }
+
+    /// <summary>
+    /// Regression: a cancel arriving between TryClaimAsync and ProcessJobAsync
+    /// must not be overwritten by the Running transition.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_SkipsExecution_WhenJobCancelledBeforeRunningTransition()
+    {
+        var provisioning = CreateProvisioningJob();
+        var cancelled = provisioning with
+        {
+            Status = ExecutionJobStatus.Cancelled,
+            CompletedAt = DateTimeOffset.UtcNow,
+            ErrorMessage = "Cancelled by operator."
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        // First read returns Provisioning (for executor lookup); re-read returns Cancelled.
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning, cancelled);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        // The worker must NOT write a Running record.
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Running),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        // The executor must NOT have been invoked.
+        await executor.DidNotReceive().ExecuteAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<IJobExecutionContext>(),
+            Arg.Any<CancellationToken>());
+
+        // The stale queue entry should be cleaned up.
+        await jobQueue.Received(1).RemoveAsync(provisioning.OperationId, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: if another worker reclaimed the job before this worker
+    /// transitions to Running, this worker must bail out.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_SkipsExecution_WhenClaimOwnerChangedBeforeRunningTransition()
+    {
+        var provisioning = CreateProvisioningJob(claimedBy: "worker-test");
+        var reclaimedByOther = provisioning with
+        {
+            ClaimedBy = "worker-other",
+            ClaimedAt = DateTimeOffset.UtcNow
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        // First read returns our claim; re-read shows a different owner.
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning, reclaimedByOther);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, "worker-test");
+
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Running),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await executor.DidNotReceive().ExecuteAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<IJobExecutionContext>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Invokes the private ProcessJobAsync method via reflection.
+    /// Follows the same test pattern used in <see cref="JobReconciliationServiceTests"/>.
+    /// </summary>
+    private static async Task InvokeProcessJobAsync(
+        JobExecutionService service,
+        string operationId,
+        string workerId)
+    {
+        var method = typeof(JobExecutionService).GetMethod(
+            "ProcessJobAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        var task = (Task)method!.Invoke(service, [operationId, workerId, CancellationToken.None])!;
+        await task.ConfigureAwait(false);
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -4,6 +4,7 @@
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.Server.Tests.Helpers;
 using Honua.TestKit.Attributes;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -58,7 +59,7 @@ public sealed class JobExecutionServiceTests
             ErrorMessage = "Cancelled by operator."
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         // First read returns Provisioning (for executor lookup); re-read returns Cancelled.
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning, cancelled);
@@ -76,7 +77,7 @@ public sealed class JobExecutionServiceTests
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
 
         // The worker must NOT write a Running record.
-        await jobStore.DidNotReceive().SetAsync(
+        await jobStore.DidNotReceive().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Running),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
@@ -106,7 +107,7 @@ public sealed class JobExecutionServiceTests
             ClaimedAt = DateTimeOffset.UtcNow
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         // First read returns our claim; re-read shows a different owner.
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning, reclaimedByOther);
@@ -123,7 +124,7 @@ public sealed class JobExecutionServiceTests
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, "worker-test");
 
-        await jobStore.DidNotReceive().SetAsync(
+        await jobStore.DidNotReceive().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Running),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
@@ -155,7 +156,7 @@ public sealed class JobExecutionServiceTests
             CurrentPhase = "Requeued: Worker shutdown."
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning, requeued);
 
@@ -200,7 +201,7 @@ public sealed class JobExecutionServiceTests
             ClaimedAt = now
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
             .Returns(reclaimed);
 
@@ -236,7 +237,7 @@ public sealed class JobExecutionServiceTests
             ClaimedAt = DateTimeOffset.UtcNow
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
             .Returns(reclaimed);
 
@@ -270,7 +271,7 @@ public sealed class JobExecutionServiceTests
             ClaimedAt = DateTimeOffset.UtcNow
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
             .Returns(reclaimed);
 
@@ -305,7 +306,7 @@ public sealed class JobExecutionServiceTests
             }
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         // First read for executor lookup, second for CTS re-check, third for
         // Running transition read-back, fourth inside AbandonJobAsync re-read.
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
@@ -333,7 +334,7 @@ public sealed class JobExecutionServiceTests
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
 
         // The terminal failed record must carry the executor warnings.
-        await jobStore.Received().SetAsync(
+        await jobStore.Received().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j =>
                 j.Status == ExecutionJobStatus.Failed &&
                 j.Warnings.Count == 2 &&
@@ -361,7 +362,7 @@ public sealed class JobExecutionServiceTests
             }
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -411,7 +412,7 @@ public sealed class JobExecutionServiceTests
             }
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -436,7 +437,7 @@ public sealed class JobExecutionServiceTests
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
 
         // The requeued record must have cleared warnings.
-        await jobStore.Received().SetAsync(
+        await jobStore.Received().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j =>
                 j.Status == ExecutionJobStatus.Queued &&
                 j.Warnings.Count == 0),
@@ -463,7 +464,7 @@ public sealed class JobExecutionServiceTests
             }
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -490,7 +491,7 @@ public sealed class JobExecutionServiceTests
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
 
         // The job must still be requeued despite the log-store failure.
-        await jobStore.Received().SetAsync(
+        await jobStore.Received().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j =>
                 j.Status == ExecutionJobStatus.Queued &&
                 j.Warnings.Count == 0),
@@ -518,7 +519,7 @@ public sealed class JobExecutionServiceTests
             RetryPolicy = JobRetryPolicy.None
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -549,7 +550,7 @@ public sealed class JobExecutionServiceTests
             provisioning.ClaimedBy!, stoppingCts.Token);
 
         // The job must be requeued (Queued), not permanently failed.
-        await jobStore.Received().SetAsync(
+        await jobStore.Received().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j =>
                 j.Status == ExecutionJobStatus.Queued &&
                 j.ClaimedBy == null),
@@ -563,7 +564,7 @@ public sealed class JobExecutionServiceTests
             Arg.Any<CancellationToken>());
 
         // Must NOT have been terminally failed.
-        await jobStore.DidNotReceive().SetAsync(
+        await jobStore.DidNotReceive().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
@@ -587,7 +588,7 @@ public sealed class JobExecutionServiceTests
             ClaimedAt = DateTimeOffset.UtcNow
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
             .Returns(reclaimed);
 
@@ -635,7 +636,7 @@ public sealed class JobExecutionServiceTests
             }
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -678,7 +679,7 @@ public sealed class JobExecutionServiceTests
             RetryPolicy = JobRetryPolicy.None
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -725,7 +726,7 @@ public sealed class JobExecutionServiceTests
             CancellationRequestedAt = DateTimeOffset.UtcNow.AddSeconds(-1)
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -754,7 +755,7 @@ public sealed class JobExecutionServiceTests
         await InvokeProcessJobAsync(service, provisioning.OperationId,
             provisioning.ClaimedBy!, stoppingCts.Token);
 
-        await jobStore.Received().SetAsync(
+        await jobStore.Received().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j =>
                 j.Status == ExecutionJobStatus.Cancelled &&
                 j.CompletedAt.HasValue),
@@ -780,7 +781,7 @@ public sealed class JobExecutionServiceTests
     {
         var provisioning = CreateProvisioningJob();
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -823,7 +824,7 @@ public sealed class JobExecutionServiceTests
     {
         var provisioning = CreateProvisioningJob();
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -881,7 +882,7 @@ public sealed class JobExecutionServiceTests
             }
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -929,7 +930,7 @@ public sealed class JobExecutionServiceTests
             RetryPolicy = JobRetryPolicy.None
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -995,7 +996,7 @@ public sealed class JobExecutionServiceTests
     {
         var running = CreateProvisioningJob() with { Status = ExecutionJobStatus.Running };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
             .Returns<ExecutionJobRecord?>(_ => throw new InvalidOperationException("Simulated store failure"));
 
@@ -1022,7 +1023,7 @@ public sealed class JobExecutionServiceTests
         var running = CreateProvisioningJob() with { Status = ExecutionJobStatus.Running };
 
         var callCount = 0;
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
@@ -1146,7 +1147,7 @@ public sealed class JobExecutionServiceTests
     public async Task ExecuteAsync_SkipsClaimLoop_WhenNoExecutorsRegistered()
     {
         var jobQueue = Substitute.For<IJobQueue>();
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
@@ -1195,7 +1196,7 @@ public sealed class JobExecutionServiceTests
                 return (string?)provisioning.OperationId;
             });
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
@@ -1224,7 +1225,7 @@ public sealed class JobExecutionServiceTests
         await service.StopAsync(CancellationToken.None);
 
         // The job must be requeued, not left to heartbeat expiry.
-        await jobStore.Received().SetAsync(
+        await jobStore.Received().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j =>
                 j.Status == ExecutionJobStatus.Queued &&
                 j.ClaimedBy == null),
@@ -1257,7 +1258,7 @@ public sealed class JobExecutionServiceTests
             CancellationRequestedAt = DateTimeOffset.UtcNow.AddSeconds(-2)
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -1273,7 +1274,7 @@ public sealed class JobExecutionServiceTests
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
 
-        await jobStore.DidNotReceive().SetAsync(
+        await jobStore.DidNotReceive().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Running),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
@@ -1283,7 +1284,7 @@ public sealed class JobExecutionServiceTests
             Arg.Any<IJobExecutionContext>(),
             Arg.Any<CancellationToken>());
 
-        await jobStore.Received().SetAsync(
+        await jobStore.Received().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
@@ -1306,7 +1307,7 @@ public sealed class JobExecutionServiceTests
             CancellationRequestedAt = DateTimeOffset.UtcNow
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
             .Returns(withSignal);
 
@@ -1333,7 +1334,7 @@ public sealed class JobExecutionServiceTests
     {
         var provisioning = CreateProvisioningJob();
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -1375,7 +1376,7 @@ public sealed class JobExecutionServiceTests
             RetryPolicy = JobRetryPolicy.None
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -1410,7 +1411,7 @@ public sealed class JobExecutionServiceTests
     {
         var provisioning = CreateProvisioningJob();
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -1452,7 +1453,7 @@ public sealed class JobExecutionServiceTests
             RetryPolicy = JobRetryPolicy.None
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(provisioning);
 
@@ -1511,7 +1512,7 @@ public sealed class JobExecutionServiceTests
         };
 
         var callCount = 0;
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
@@ -1538,7 +1539,7 @@ public sealed class JobExecutionServiceTests
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
 
-        await jobStore.Received().SetAsync(
+        await jobStore.Received().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
@@ -1565,7 +1566,7 @@ public sealed class JobExecutionServiceTests
         };
 
         var callCount = 0;
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
@@ -1592,12 +1593,12 @@ public sealed class JobExecutionServiceTests
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
 
-        await jobStore.Received().SetAsync(
+        await jobStore.Received().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
 
-        await jobStore.DidNotReceive().SetAsync(
+        await jobStore.DidNotReceive().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -870,6 +870,23 @@ public sealed class JobExecutionServiceTests
     }
 
     /// <summary>
+    /// Regression: even when the machine hostname exceeds the available prefix
+    /// budget, the generated worker ID must keep the full GUID claim token and
+    /// only truncate the hostname portion.
+    /// </summary>
+    [UnitTest]
+    public void GenerateWorkerId_TruncatesHostnamePrefix_ButPreservesFullGuidSuffix()
+    {
+        const string machineName = "averyverylonghostnamethatexceedstheworkerbudget";
+        var workerGuid = Guid.ParseExact("0123456789abcdef0123456789abcdef", "N");
+
+        var workerId = JobExecutionService.GenerateWorkerId(machineName, workerGuid);
+
+        Assert.Equal("worker-averyver-0123456789abcdef0123456789abcdef", workerId);
+        Assert.Equal(48, workerId.Length);
+    }
+
+    /// <summary>
     /// When a worker has no executors registered, it must not enter the claim
     /// loop. Without this guard, the worker performs O(n) Redis scans every
     /// poll interval for no benefit.

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -70,7 +70,7 @@ public sealed class JobExecutionServiceTests
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
@@ -118,7 +118,7 @@ public sealed class JobExecutionServiceTests
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, "worker-test");
@@ -166,7 +166,7 @@ public sealed class JobExecutionServiceTests
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, "worker-test");
@@ -327,7 +327,7 @@ public sealed class JobExecutionServiceTests
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
@@ -381,7 +381,7 @@ public sealed class JobExecutionServiceTests
         var logStore = Substitute.For<IExecutionLogStore>();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, logStore,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), logStore,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
@@ -430,7 +430,7 @@ public sealed class JobExecutionServiceTests
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
@@ -484,7 +484,7 @@ public sealed class JobExecutionServiceTests
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, logStore,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), logStore,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
@@ -542,7 +542,7 @@ public sealed class JobExecutionServiceTests
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId,
@@ -652,7 +652,7 @@ public sealed class JobExecutionServiceTests
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
@@ -701,7 +701,7 @@ public sealed class JobExecutionServiceTests
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId,
@@ -748,7 +748,7 @@ public sealed class JobExecutionServiceTests
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId,
@@ -804,7 +804,7 @@ public sealed class JobExecutionServiceTests
             .Returns(JobExecutionResult.Succeeded());
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
@@ -852,7 +852,7 @@ public sealed class JobExecutionServiceTests
             });
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
@@ -907,7 +907,7 @@ public sealed class JobExecutionServiceTests
             .Returns(JobExecutionResult.Failed("Transient failure"));
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
@@ -953,7 +953,7 @@ public sealed class JobExecutionServiceTests
             .Returns(JobExecutionResult.Failed("Permanent failure"));
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
@@ -1150,7 +1150,7 @@ public sealed class JobExecutionServiceTests
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, Array.Empty<IJobExecutor>(), cancellationTokens, null,
+            jobQueue, jobStore, Array.Empty<IJobExecutor>(), cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
@@ -1209,7 +1209,7 @@ public sealed class JobExecutionServiceTests
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await service.StartAsync(stoppingCts.Token);
@@ -1268,7 +1268,7 @@ public sealed class JobExecutionServiceTests
         var cancellationTokens = new ExecutionJobCancellationTokens();
 
         var service = new JobExecutionService(
-            jobQueue, jobStore, [executor], cancellationTokens, null,
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
             NullLogger<JobExecutionService>.Instance);
 
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -641,6 +641,72 @@ public sealed class JobExecutionServiceTests
     }
 
     /// <summary>
+    /// Regression: when both shutdown and timeout fire concurrently, the
+    /// timed-out job must fail terminally instead of being force-requeued.
+    /// ADR-0031 says timed-out jobs are not retried.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_ShutdownAndTimeout_FailsTerminallyInsteadOfRequeue()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            TimeoutPolicy = new JobTimeoutPolicy { MaxDuration = TimeSpan.FromMilliseconds(50) },
+            RetryPolicy = JobRetryPolicy.None
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var stoppingCts = new CancellationTokenSource();
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(async callInfo =>
+            {
+                // Wait for the timeout to fire, then also trigger shutdown.
+                await Task.Delay(TimeSpan.FromMilliseconds(100), CancellationToken.None).ConfigureAwait(false);
+                await stoppingCts.CancelAsync().ConfigureAwait(false);
+                callInfo.Arg<CancellationToken>().ThrowIfCancellationRequested();
+                return JobExecutionResult.Succeeded(); // Unreachable.
+            });
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, Array.Empty<IJobTerminalCallback>(), null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId,
+            provisioning.ClaimedBy!, stoppingCts.Token);
+
+        // The job must be terminally failed (timeout), not requeued.
+        await jobStore.Received().TrySetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        // Must NOT have been requeued.
+        await jobStore.DidNotReceive().TrySetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.Status == ExecutionJobStatus.Queued &&
+                j.ClaimedBy == null),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.DidNotReceive().RequeueAsync(
+            Arg.Any<string>(),
+            Arg.Any<OperationPriority>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Regression: a stale worker's log append must be silently dropped
     /// when ownership has moved to another worker, preventing log pollution
     /// into the next attempt's or terminal state's log stream.

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -392,19 +392,127 @@ public sealed class JobExecutionServiceTests
     }
 
     /// <summary>
+    /// Regression: a graceful host shutdown must always requeue the job, even
+    /// when the retry budget is exhausted (<see cref="JobRetryPolicy.None"/>).
+    /// Infrastructure shutdown is not an execution failure and must not
+    /// permanently fail jobs that have no retry budget.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_RequeuesJob_WhenShutdownWithNoRetryPolicy()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = JobRetryPolicy.None
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var stoppingCts = new CancellationTokenSource();
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(async callInfo =>
+            {
+                // Simulate host shutdown during execution.
+                await stoppingCts.CancelAsync().ConfigureAwait(false);
+                callInfo.Arg<CancellationToken>().ThrowIfCancellationRequested();
+                return JobExecutionResult.Succeeded(); // Unreachable.
+            });
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId,
+            provisioning.ClaimedBy!, stoppingCts.Token);
+
+        // The job must be requeued (Queued), not permanently failed.
+        await jobStore.Received().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.Status == ExecutionJobStatus.Queued &&
+                j.ClaimedBy == null),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.Received().RequeueAsync(
+            provisioning.OperationId,
+            Arg.Any<OperationPriority>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        // Must NOT have been terminally failed.
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: a stale worker's log append must be silently dropped
+    /// when ownership has moved to another worker, preventing log pollution
+    /// into the next attempt's or terminal state's log stream.
+    /// </summary>
+    [UnitTest]
+    public async Task AppendLog_Skips_WhenOwnershipLost()
+    {
+        var running = CreateProvisioningJob(claimedBy: "worker-stale") with
+        {
+            Status = ExecutionJobStatus.Running
+        };
+        var reclaimed = running with
+        {
+            ClaimedBy = "worker-new",
+            ClaimedAt = DateTimeOffset.UtcNow
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
+            .Returns(reclaimed);
+
+        var logStore = Substitute.For<IExecutionLogStore>();
+
+        using var context = new JobExecutionContext(
+            running.OperationId, "worker-stale", jobStore, logStore,
+            JobHeartbeatPolicy.Default);
+
+        await context.AppendLogAsync(new ExecutionLogEntry
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Level = ExecutionLogLevel.Info,
+            Message = "Stale log entry that should be dropped"
+        }, CancellationToken.None);
+
+        // The log store must NOT have been written to.
+        await logStore.DidNotReceive().AppendAsync(
+            Arg.Any<string>(),
+            Arg.Any<ExecutionLogEntry>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Invokes the private ProcessJobAsync method via reflection.
     /// Follows the same test pattern used in <see cref="JobReconciliationServiceTests"/>.
     /// </summary>
     private static async Task InvokeProcessJobAsync(
         JobExecutionService service,
         string operationId,
-        string workerId)
+        string workerId,
+        CancellationToken stoppingToken = default)
     {
         var method = typeof(JobExecutionService).GetMethod(
             "ProcessJobAsync",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
-        var task = (Task)method!.Invoke(service, [operationId, workerId, CancellationToken.None])!;
+        var task = (Task)method!.Invoke(service, [operationId, workerId, stoppingToken])!;
         await task.ConfigureAwait(false);
     }
 }

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -340,6 +340,56 @@ public sealed class JobExecutionServiceTests
     }
 
     /// <summary>
+    /// Regression: when retries are exhausted and the job transitions to terminal
+    /// Failed, the execution log retention must be set so structured logs remain
+    /// accessible for post-mortem inspection.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_SetsLogRetention_WhenRetriesExhausted()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = new JobRetryPolicy
+            {
+                MaxAttempts = 1,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            }
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.TryClaimAsync(Arg.Any<string>(), Arg.Any<IReadOnlySet<ExecutionJobKind>>(), Arg.Any<CancellationToken>())
+            .Returns(provisioning.OperationId, (string?)null);
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Failed("Transform failed"));
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+        var logStore = Substitute.For<IExecutionLogStore>();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, logStore,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        await logStore.Received(1).SetRetentionAsync(
+            provisioning.OperationId,
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Regression: when executor returns failure with warnings and retries
     /// remain, warnings must be cleared from the requeued record to prevent
     /// stale per-attempt warnings from leaking to the next attempt.

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -214,7 +214,7 @@ public sealed class JobExecutionServiceTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await context.RunHeartbeatPumpAsync(cts.Token);
 
-        await jobStore.DidNotReceive().SetAsync(
+        await jobStore.DidNotReceive().TrySetAsync(
             Arg.Any<ExecutionJobRecord>(),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
@@ -248,7 +248,7 @@ public sealed class JobExecutionServiceTests
 
         await context.ReportProgressAsync(50, "Processing", CancellationToken.None);
 
-        await jobStore.DidNotReceive().SetAsync(
+        await jobStore.DidNotReceive().TrySetAsync(
             Arg.Any<ExecutionJobRecord>(),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
@@ -282,8 +282,78 @@ public sealed class JobExecutionServiceTests
 
         await context.PublishArtifactAsync("s3://bucket/artifact.zip", CancellationToken.None);
 
-        await jobStore.DidNotReceive().SetAsync(
+        await jobStore.DidNotReceive().TrySetAsync(
             Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: a progress update racing with a terminal or cancellation write
+    /// must skip the stale write instead of clobbering the newer durable state.
+    /// </summary>
+    [UnitTest]
+    public async Task ReportProgress_Skips_WhenTrySetConflicts()
+    {
+        var running = CreateProvisioningJob() with
+        {
+            Status = ExecutionJobStatus.Running
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
+        jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
+            .Returns(running);
+        jobStore.TrySetAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        using var context = new JobExecutionContext(
+            running.OperationId, running.ClaimedBy!, jobStore, null,
+            JobHeartbeatPolicy.Default,
+            null, NullLogger.Instance);
+
+        await context.ReportProgressAsync(50, "Processing", CancellationToken.None);
+
+        await jobStore.Received(1).TrySetAsync(
+            Arg.Is<ExecutionJobRecord>(job => job.Status == ExecutionJobStatus.Running),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: artifact publication racing with a terminal or cancellation
+    /// write must skip the stale durable update instead of reviving the old claim.
+    /// </summary>
+    [UnitTest]
+    public async Task PublishArtifact_Skips_WhenTrySetConflicts()
+    {
+        var running = CreateProvisioningJob() with
+        {
+            Status = ExecutionJobStatus.Running
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
+        jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
+            .Returns(running);
+        jobStore.TrySetAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        using var context = new JobExecutionContext(
+            running.OperationId, running.ClaimedBy!, jobStore, null,
+            JobHeartbeatPolicy.Default,
+            null, NullLogger.Instance);
+
+        await context.PublishArtifactAsync("s3://bucket/artifact.zip", CancellationToken.None);
+
+        await jobStore.Received(1).TrySetAsync(
+            Arg.Is<ExecutionJobRecord>(job =>
+                job.Status == ExecutionJobStatus.Running
+                && job.ArtifactReferences.Contains("s3://bucket/artifact.zip")),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
     }
@@ -1042,7 +1112,7 @@ public sealed class JobExecutionServiceTests
         await context.RunHeartbeatPumpAsync(cts.Token);
 
         // The pump continued past the transient failure and wrote at least one heartbeat.
-        await jobStore.Received().SetAsync(
+        await jobStore.Received().TrySetAsync(
             Arg.Any<ExecutionJobRecord>(),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -1323,6 +1323,89 @@ public sealed class JobExecutionServiceTests
     }
 
     /// <summary>
+    /// Regression: after the authoritative store write, a queue removal failure
+    /// must not prevent the terminal callback from firing. The admin API reads
+    /// from the progress store (synced by the callback), so skipping it leaves
+    /// stale in-progress state until TTL expiry.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_Finalize_NotifiesTerminalCallback_WhenQueueRemovalFails()
+    {
+        var provisioning = CreateProvisioningJob();
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.RemoveAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Succeeded());
+
+        var terminalCallback = Substitute.For<IJobTerminalCallback>();
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, [terminalCallback], null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        await terminalCallback.Received(1).OnTerminalAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Succeeded),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: terminal callback must fire even when queue removal fails
+    /// in the abandon path (retries exhausted).
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_AbandonTerminal_NotifiesTerminalCallback_WhenQueueRemovalFails()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = JobRetryPolicy.None
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.RemoveAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Failed("Permanent failure"));
+
+        var terminalCallback = Substitute.For<IJobTerminalCallback>();
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, [terminalCallback], null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        await terminalCallback.Received(1).OnTerminalAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Invokes the private ProcessJobAsync method via reflection.
     /// Follows the same test pattern used in <see cref="JobReconciliationServiceTests"/>.
     /// </summary>

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -445,6 +445,66 @@ public sealed class JobExecutionServiceTests
     }
 
     /// <summary>
+    /// Regression: a transient log-store failure during per-attempt warning
+    /// persistence must not block the durable requeue transition. The job
+    /// must still be requeued with cleared warnings.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_RequeuesJob_WhenWarningLogAppendThrows()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = new JobRetryPolicy
+            {
+                MaxAttempts = 3,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            }
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Failed("Transient failure", ["Warning A", "Warning B"]));
+
+        var logStore = Substitute.For<IExecutionLogStore>();
+        logStore.AppendAsync(Arg.Any<string>(), Arg.Any<ExecutionLogEntry>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated log-store outage"));
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, logStore,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        // The job must still be requeued despite the log-store failure.
+        await jobStore.Received().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.Status == ExecutionJobStatus.Queued &&
+                j.Warnings.Count == 0),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.Received().RequeueAsync(
+            provisioning.OperationId,
+            Arg.Any<OperationPriority>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Regression: a graceful host shutdown must always requeue the job, even
     /// when the retry budget is exhausted (<see cref="JobRetryPolicy.None"/>).
     /// Infrastructure shutdown is not an execution failure and must not

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -206,7 +206,8 @@ public sealed class JobExecutionServiceTests
 
         using var context = new JobExecutionContext(
             running.OperationId, "worker-stale", jobStore, null,
-            new JobHeartbeatPolicy { Interval = TimeSpan.FromMilliseconds(10), Timeout = TimeSpan.FromSeconds(30) });
+            new JobHeartbeatPolicy { Interval = TimeSpan.FromMilliseconds(10), Timeout = TimeSpan.FromSeconds(30) },
+            NullLogger.Instance);
 
         // The pump should detect the ownership change and exit without writing.
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -241,7 +242,8 @@ public sealed class JobExecutionServiceTests
 
         using var context = new JobExecutionContext(
             running.OperationId, "worker-stale", jobStore, null,
-            JobHeartbeatPolicy.Default);
+            JobHeartbeatPolicy.Default,
+            NullLogger.Instance);
 
         await context.ReportProgressAsync(50, "Processing", CancellationToken.None);
 
@@ -274,7 +276,8 @@ public sealed class JobExecutionServiceTests
 
         using var context = new JobExecutionContext(
             running.OperationId, "worker-stale", jobStore, null,
-            JobHeartbeatPolicy.Default);
+            JobHeartbeatPolicy.Default,
+            NullLogger.Instance);
 
         await context.PublishArtifactAsync("s3://bucket/artifact.zip", CancellationToken.None);
 
@@ -532,7 +535,8 @@ public sealed class JobExecutionServiceTests
 
         using var context = new JobExecutionContext(
             running.OperationId, "worker-stale", jobStore, logStore,
-            JobHeartbeatPolicy.Default);
+            JobHeartbeatPolicy.Default,
+            NullLogger.Instance);
 
         await context.AppendLogAsync(new ExecutionLogEntry
         {
@@ -645,6 +649,91 @@ public sealed class JobExecutionServiceTests
 
         // After shutdown requeue, Cancel must return false.
         Assert.False(cancellationTokens.Cancel(provisioning.OperationId));
+    }
+
+    /// <summary>
+    /// Regression: when a new worker reclaims a job, the old worker's CTS must be
+    /// cancelled during registration so the stale worker observes cancellation even
+    /// if Revoke has not yet run.
+    /// </summary>
+    [UnitTest]
+    public void CreateLinkedTokenSource_CancelsOldCts_WhenJobReclaimedByNewWorker()
+    {
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        using var ctsA = cancellationTokens.CreateLinkedTokenSource(
+            "job-1", "worker-A", CancellationToken.None);
+
+        // Worker B claims and registers — must cancel Worker A's stale CTS.
+        using var ctsB = cancellationTokens.CreateLinkedTokenSource(
+            "job-1", "worker-B", CancellationToken.None);
+
+        Assert.True(ctsA.IsCancellationRequested);
+        Assert.False(ctsB.IsCancellationRequested);
+    }
+
+    /// <summary>
+    /// Regression: heartbeat pump store failures must not fault the task.
+    /// If the pump task faults and StopHeartbeatPumpAsync only catches
+    /// OperationCanceledException, the store exception propagates up and
+    /// skips finalization. The pump must catch non-cancellation exceptions
+    /// and continue pumping on the next interval.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatPump_DoesNotFaultTask_WhenStoreThrowsPersistently()
+    {
+        var running = CreateProvisioningJob() with { Status = ExecutionJobStatus.Running };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
+            .Returns<ExecutionJobRecord?>(_ => throw new InvalidOperationException("Simulated store failure"));
+
+        using var context = new JobExecutionContext(
+            running.OperationId, running.ClaimedBy!, jobStore, null,
+            new JobHeartbeatPolicy { Interval = TimeSpan.FromMilliseconds(10), Timeout = TimeSpan.FromSeconds(30) },
+            NullLogger.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(80));
+
+        // Must complete without throwing despite persistent store failures.
+        await context.RunHeartbeatPumpAsync(cts.Token);
+    }
+
+    /// <summary>
+    /// Regression: a single transient store failure must not kill the heartbeat
+    /// pump. The pump must catch the exception, log it, and continue pumping
+    /// on the next interval so that the reconciler does not declare the worker
+    /// dead due to a brief Redis blip.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatPump_ContinuesAfterTransientStoreFailure()
+    {
+        var running = CreateProvisioningJob() with { Status = ExecutionJobStatus.Running };
+
+        var callCount = 0;
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(running.OperationId, Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+                if (count == 1)
+                    throw new InvalidOperationException("Transient failure");
+                return running;
+            });
+
+        using var context = new JobExecutionContext(
+            running.OperationId, running.ClaimedBy!, jobStore, null,
+            new JobHeartbeatPolicy { Interval = TimeSpan.FromMilliseconds(10), Timeout = TimeSpan.FromSeconds(30) },
+            NullLogger.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        await context.RunHeartbeatPumpAsync(cts.Token);
+
+        // The pump continued past the transient failure and wrote at least one heartbeat.
+        await jobStore.Received().SetAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
     }
 
     /// <summary>

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobExecutionServiceTests.cs
@@ -658,7 +658,7 @@ public sealed class JobExecutionServiceTests
         await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
 
         // After ProcessJobAsync completes, Cancel must return false: the CTS
-        // was removed during AbandonJobAsync (after the requeue) so API
+        // was removed during AbandonJobAsync (before the requeue) so API
         // callers will not falsely delegate cancellation to a worker that
         // has already dropped ownership.
         Assert.False(cancellationTokens.Cancel(provisioning.OperationId));
@@ -709,6 +709,198 @@ public sealed class JobExecutionServiceTests
 
         // After shutdown requeue, Cancel must return false.
         Assert.False(cancellationTokens.Cancel(provisioning.OperationId));
+    }
+
+    /// <summary>
+    /// Regression: after the authoritative store write in FinalizeJobAsync, the CTS
+    /// must be removed before RemoveAsync so that a Redis hang does not leave a
+    /// stale CTS that falsely accepts cancel delegation.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_Finalize_RemovesCtsBeforeQueueRemove_SoRemoveFailureDoesNotLeakStaleCts()
+    {
+        var provisioning = CreateProvisioningJob();
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+        bool ctsRemovedBeforeQueueIo = false;
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.RemoveAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                ctsRemovedBeforeQueueIo = !cancellationTokens.Cancel(provisioning.OperationId);
+                return Task.CompletedTask;
+            });
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Succeeded());
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        Assert.True(ctsRemovedBeforeQueueIo,
+            "CTS must be removed after authoritative store write and before queue RemoveAsync");
+    }
+
+    /// <summary>
+    /// Regression: after the authoritative store write in TerminateJobAsync, the CTS
+    /// must be removed before RemoveAsync so that a Redis hang does not leave a
+    /// stale CTS that falsely accepts cancel delegation.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_Terminate_RemovesCtsBeforeQueueRemove_SoRemoveFailureDoesNotLeakStaleCts()
+    {
+        var provisioning = CreateProvisioningJob();
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+        bool ctsRemovedBeforeQueueIo = false;
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.RemoveAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                ctsRemovedBeforeQueueIo = !cancellationTokens.Cancel(provisioning.OperationId);
+                return Task.CompletedTask;
+            });
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                cancellationTokens.Cancel(provisioning.OperationId);
+                callInfo.Arg<CancellationToken>().ThrowIfCancellationRequested();
+                return JobExecutionResult.Succeeded();
+            });
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        Assert.True(ctsRemovedBeforeQueueIo,
+            "CTS must be removed after authoritative store write and before queue RemoveAsync");
+    }
+
+    /// <summary>
+    /// Regression: after the authoritative store transition to Queued in
+    /// AbandonJobAsync, the CTS must be removed before RequeueAsync so that
+    /// a Redis failure does not leave a stale CTS that falsely accepts cancel
+    /// delegation while the stale-claim reconciler repairs the queue.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_AbandonRequeue_RemovesCtsBeforeQueueRequeue_SoRequeueFailureDoesNotLeakStaleCts()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = new JobRetryPolicy
+            {
+                MaxAttempts = 3,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            }
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+        bool ctsRemovedBeforeQueueIo = false;
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.RequeueAsync(
+                Arg.Any<string>(), Arg.Any<OperationPriority>(),
+                Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                ctsRemovedBeforeQueueIo = !cancellationTokens.Cancel(provisioning.OperationId);
+                return Task.CompletedTask;
+            });
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Failed("Transient failure"));
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        Assert.True(ctsRemovedBeforeQueueIo,
+            "CTS must be removed after authoritative store write and before queue RequeueAsync");
+    }
+
+    /// <summary>
+    /// Regression: after the authoritative store write in AbandonJobAsync's terminal
+    /// path (retries exhausted), the CTS must be removed before RemoveAsync so that
+    /// a Redis hang does not leave a stale CTS that falsely accepts cancel delegation.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessJob_AbandonTerminal_RemovesCtsBeforeQueueRemove_SoRemoveFailureDoesNotLeakStaleCts()
+    {
+        var provisioning = CreateProvisioningJob() with
+        {
+            RetryPolicy = JobRetryPolicy.None
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(provisioning);
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+        bool ctsRemovedBeforeQueueIo = false;
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.RemoveAsync(provisioning.OperationId, Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                ctsRemovedBeforeQueueIo = !cancellationTokens.Cancel(provisioning.OperationId);
+                return Task.CompletedTask;
+            });
+
+        var executor = Substitute.For<IJobExecutor>();
+        executor.Kind.Returns(ExecutionJobKind.Geoprocessing);
+        executor.ExecuteAsync(
+                Arg.Any<ExecutionJobRecord>(),
+                Arg.Any<IJobExecutionContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(JobExecutionResult.Failed("Permanent failure"));
+
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens, null,
+            NullLogger<JobExecutionService>.Instance);
+
+        await InvokeProcessJobAsync(service, provisioning.OperationId, provisioning.ClaimedBy!);
+
+        Assert.True(ctsRemovedBeforeQueueIo,
+            "CTS must be removed after authoritative store write and before queue RemoveAsync");
     }
 
     /// <summary>

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -1,0 +1,283 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Verifies that the reconciliation service re-reads job state before applying
+/// heartbeat or timeout transitions, preventing overwrites of jobs that completed
+/// between the sweep snapshot and the handler invocation.
+/// </summary>
+[Collection("Unit")]
+public sealed class JobReconciliationServiceTests
+{
+    private static ExecutionJobRecord CreateRunningJob(
+        string operationId = "job-1",
+        string claimedBy = "worker-1",
+        int attemptCount = 1,
+        JobRetryPolicy? retryPolicy = null,
+        JobHeartbeatPolicy? heartbeatPolicy = null,
+        JobTimeoutPolicy? timeoutPolicy = null)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new ExecutionJobRecord
+        {
+            OperationId = operationId,
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = now.AddMinutes(-10),
+            UpdatedAt = now.AddMinutes(-2),
+            ClaimedBy = claimedBy,
+            ClaimedAt = now.AddMinutes(-5),
+            LastHeartbeatAt = now.AddMinutes(-3),
+            AttemptCount = attemptCount,
+            RetryPolicy = retryPolicy,
+            HeartbeatPolicy = heartbeatPolicy ?? new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(10),
+                Timeout = TimeSpan.FromSeconds(30)
+            },
+            TimeoutPolicy = timeoutPolicy ?? new JobTimeoutPolicy
+            {
+                MaxDuration = TimeSpan.FromMinutes(3)
+            },
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "test"
+            }
+        };
+    }
+
+    [UnitTest]
+    public async Task HeartbeatExpiry_SkipsTransition_WhenJobAlreadySucceeded()
+    {
+        var snapshot = CreateRunningJob(
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            });
+
+        var succeeded = snapshot with
+        {
+            Status = ExecutionJobStatus.Succeeded,
+            CompletedAt = DateTimeOffset.UtcNow
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(succeeded);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler,
+            NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        // The store should NOT have been written to with a Failed/Queued update.
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.Status == ExecutionJobStatus.Failed || j.Status == ExecutionJobStatus.Queued),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await jobQueue.DidNotReceive().RequeueAsync(
+            Arg.Any<string>(), Arg.Any<OperationPriority>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    public async Task TimeoutExpiry_SkipsTransition_WhenJobAlreadySucceeded()
+    {
+        var snapshot = CreateRunningJob(
+            timeoutPolicy: new JobTimeoutPolicy { MaxDuration = TimeSpan.FromSeconds(1) });
+        // Ensure ClaimedAt is old enough to trigger timeout.
+        snapshot = snapshot with { ClaimedAt = DateTimeOffset.UtcNow.AddMinutes(-10) };
+
+        var succeeded = snapshot with
+        {
+            Status = ExecutionJobStatus.Succeeded,
+            CompletedAt = DateTimeOffset.UtcNow
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([succeeded.Status == ExecutionJobStatus.Succeeded ? snapshot : snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(succeeded);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler,
+            NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    public async Task HeartbeatExpiry_SkipsTransition_WhenClaimChangedToAnotherWorker()
+    {
+        var snapshot = CreateRunningJob(
+            claimedBy: "worker-1",
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            });
+
+        var reclaimedByOther = snapshot with
+        {
+            ClaimedBy = "worker-2",
+            ClaimedAt = DateTimeOffset.UtcNow,
+            LastHeartbeatAt = DateTimeOffset.UtcNow
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(reclaimedByOther);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler,
+            NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.Status == ExecutionJobStatus.Failed || j.Status == ExecutionJobStatus.Queued),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    public async Task HeartbeatExpiry_SkipsTransition_WhenJobDeleted()
+    {
+        var snapshot = CreateRunningJob(
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            });
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns((ExecutionJobRecord?)null);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler,
+            NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    public async Task HeartbeatExpiry_StillRetries_WhenJobRemainsActiveAndOwnedBySameWorker()
+    {
+        var snapshot = CreateRunningJob(
+            retryPolicy: new JobRetryPolicy
+            {
+                MaxAttempts = 3,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.FromSeconds(5),
+                MaxDelay = TimeSpan.FromMinutes(1)
+            },
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            },
+            timeoutPolicy: new JobTimeoutPolicy
+            {
+                // Large timeout so only the heartbeat check fires.
+                MaxDuration = TimeSpan.FromHours(24)
+            });
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        // Re-read returns the same active record — no intervening completion.
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(snapshot);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler,
+            NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        // The reconciler should proceed with the retry transition.
+        await jobStore.Received(1).SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Queued),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.Received(1).RequeueAsync(
+            snapshot.OperationId,
+            Arg.Any<OperationPriority>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Invokes the reconciler's sweep logic once without running the full
+    /// BackgroundService loop. Uses reflection to call the private method
+    /// since the service is internal and sealed.
+    /// </summary>
+    private static async Task RunSingleSweepAsync(
+        JobReconciliationService service,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(JobReconciliationService).GetMethod(
+            "SweepActiveJobsAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        var task = (Task)method!.Invoke(service, [cancellationToken])!;
+        await task.ConfigureAwait(false);
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -485,6 +485,107 @@ public sealed class JobReconciliationServiceTests
     }
 
     /// <summary>
+    /// Regression: when <c>RequeueAsync</c> fails after the store transition to
+    /// Queued, the stale CTS must already be revoked so cancel paths do not
+    /// delegate to a dead worker. The stale-claim reconciler repairs the queue.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatExpiry_Requeue_RevokesCtBeforeRequeueAsync_SoRequeueFailureDoesNotLeakStaleCts()
+    {
+        var snapshot = CreateRunningJob(
+            retryPolicy: new JobRetryPolicy
+            {
+                MaxAttempts = 3,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.FromSeconds(5),
+                MaxDelay = TimeSpan.FromMinutes(1)
+            },
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            },
+            timeoutPolicy: new JobTimeoutPolicy
+            {
+                MaxDuration = TimeSpan.FromHours(24)
+            });
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(snapshot);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.RequeueAsync(
+            Arg.Any<string>(), Arg.Any<OperationPriority>(),
+            Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+        using var staleCts = cancellationTokens.CreateLinkedTokenSource(
+            snapshot.OperationId, snapshot.ClaimedBy!, CancellationToken.None);
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, cancellationTokens,
+            logStore: null, NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        // The sweep propagates the RequeueAsync exception, but the CTS
+        // must already be revoked before that exception fires.
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            RunSingleSweepAsync(service, cts.Token));
+
+        Assert.True(staleCts.IsCancellationRequested);
+        Assert.False(cancellationTokens.Cancel(snapshot.OperationId));
+    }
+
+    /// <summary>
+    /// Regression: when <c>RemoveAsync</c> fails after the store transition to
+    /// Failed (timeout), the stale CTS must already be revoked so cancel paths
+    /// do not delegate to a dead worker.
+    /// </summary>
+    [UnitTest]
+    public async Task TimeoutExpiry_RevokesCtsBeforeQueueRemove_SoRemoveFailureDoesNotLeakStaleCts()
+    {
+        var snapshot = CreateRunningJob(
+            timeoutPolicy: new JobTimeoutPolicy { MaxDuration = TimeSpan.FromSeconds(1) });
+        snapshot = snapshot with { ClaimedAt = DateTimeOffset.UtcNow.AddMinutes(-10) };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(snapshot);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.RemoveAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+        using var staleCts = cancellationTokens.CreateLinkedTokenSource(
+            snapshot.OperationId, snapshot.ClaimedBy!, CancellationToken.None);
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, cancellationTokens,
+            logStore: null, NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            RunSingleSweepAsync(service, cts.Token));
+
+        Assert.True(staleCts.IsCancellationRequested);
+        Assert.False(cancellationTokens.Cancel(snapshot.OperationId));
+    }
+
+    /// <summary>
     /// Invokes the reconciler's sweep logic once without running the full
     /// BackgroundService loop. Uses reflection to call the private method
     /// since the service is internal and sealed.

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -83,7 +83,7 @@ public sealed class JobReconciliationServiceTests
         var claimReconciler = Substitute.For<IQueueClaimReconciler>();
 
         var service = new JobReconciliationService(
-            jobStore, jobQueue, claimReconciler,
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
             NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -125,7 +125,7 @@ public sealed class JobReconciliationServiceTests
         var claimReconciler = Substitute.For<IQueueClaimReconciler>();
 
         var service = new JobReconciliationService(
-            jobStore, jobQueue, claimReconciler,
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
             NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -167,7 +167,7 @@ public sealed class JobReconciliationServiceTests
         var claimReconciler = Substitute.For<IQueueClaimReconciler>();
 
         var service = new JobReconciliationService(
-            jobStore, jobQueue, claimReconciler,
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
             NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -200,7 +200,7 @@ public sealed class JobReconciliationServiceTests
         var claimReconciler = Substitute.For<IQueueClaimReconciler>();
 
         var service = new JobReconciliationService(
-            jobStore, jobQueue, claimReconciler,
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
             NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -247,7 +247,7 @@ public sealed class JobReconciliationServiceTests
         var claimReconciler = Substitute.For<IQueueClaimReconciler>();
 
         var service = new JobReconciliationService(
-            jobStore, jobQueue, claimReconciler,
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
             NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -298,7 +298,7 @@ public sealed class JobReconciliationServiceTests
         var claimReconciler = Substitute.For<IQueueClaimReconciler>();
 
         var service = new JobReconciliationService(
-            jobStore, jobQueue, claimReconciler,
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
             NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -357,7 +357,7 @@ public sealed class JobReconciliationServiceTests
         var claimReconciler = Substitute.For<IQueueClaimReconciler>();
 
         var service = new JobReconciliationService(
-            jobStore, jobQueue, claimReconciler,
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
             NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -370,6 +370,110 @@ public sealed class JobReconciliationServiceTests
             Arg.Any<CancellationToken>());
 
         await jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: when the reconciler requeues a job after heartbeat expiry,
+    /// any stale CTS left by the previous worker must be revoked so that a
+    /// subsequent Cancel() call returns false and the API caller writes
+    /// Cancelled directly instead of delegating to a stale worker.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatExpiry_Requeue_RevokesStaleWorkerCancellationToken()
+    {
+        var snapshot = CreateRunningJob(
+            retryPolicy: new JobRetryPolicy
+            {
+                MaxAttempts = 3,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.FromSeconds(5),
+                MaxDelay = TimeSpan.FromMinutes(1)
+            },
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            },
+            timeoutPolicy: new JobTimeoutPolicy
+            {
+                MaxDuration = TimeSpan.FromHours(24)
+            });
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(snapshot);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        // Simulate a stale worker CTS registered before the sweep.
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+        using var staleCts = cancellationTokens.CreateLinkedTokenSource(
+            snapshot.OperationId, CancellationToken.None);
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, cancellationTokens,
+            NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        // The stale CTS must have been cancelled by Revoke.
+        Assert.True(staleCts.IsCancellationRequested);
+
+        // A subsequent Cancel() must return false — the stale token was removed.
+        Assert.False(cancellationTokens.Cancel(snapshot.OperationId));
+    }
+
+    /// <summary>
+    /// Regression: when the reconciler terminally fails a job after heartbeat
+    /// expiry (no retries remaining), the stale CTS must also be revoked.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatExpiry_TerminalFailure_RevokesStaleWorkerCancellationToken()
+    {
+        var snapshot = CreateRunningJob(
+            retryPolicy: new JobRetryPolicy
+            {
+                MaxAttempts = 1,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            },
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            },
+            timeoutPolicy: new JobTimeoutPolicy
+            {
+                MaxDuration = TimeSpan.FromHours(24)
+            });
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(snapshot);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+        using var staleCts = cancellationTokens.CreateLinkedTokenSource(
+            snapshot.OperationId, CancellationToken.None);
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, cancellationTokens,
+            NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        Assert.True(staleCts.IsCancellationRequested);
+        Assert.False(cancellationTokens.Cancel(snapshot.OperationId));
     }
 
     /// <summary>

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -661,11 +661,11 @@ public sealed class JobReconciliationServiceTests
 
     /// <summary>
     /// Regression: when <c>RemoveAsync</c> fails after the store transition to
-    /// Failed (timeout), the stale CTS must already be revoked so cancel paths
-    /// do not delegate to a dead worker.
+    /// Failed (timeout), the stale CTS must already be revoked and the terminal
+    /// callback must still fire despite the queue failure.
     /// </summary>
     [UnitTest]
-    public async Task TimeoutExpiry_RevokesCtsBeforeQueueRemove_SoRemoveFailureDoesNotLeakStaleCts()
+    public async Task TimeoutExpiry_RevokesCtsAndNotifiesCallback_WhenQueueRemovalFails()
     {
         var snapshot = CreateRunningJob(
             timeoutPolicy: new JobTimeoutPolicy { MaxDuration = TimeSpan.FromSeconds(1) });
@@ -688,17 +688,21 @@ public sealed class JobReconciliationServiceTests
         using var staleCts = cancellationTokens.CreateLinkedTokenSource(
             snapshot.OperationId, snapshot.ClaimedBy!, CancellationToken.None);
 
+        var terminalCallback = Substitute.For<IJobTerminalCallback>();
+
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, cancellationTokens,
-            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
+            [terminalCallback], null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            RunSingleSweepAsync(service, cts.Token));
+        await RunSingleSweepAsync(service, cts.Token);
 
         Assert.True(staleCts.IsCancellationRequested);
         Assert.False(cancellationTokens.Cancel(snapshot.OperationId));
+
+        await terminalCallback.Received(1).OnTerminalAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
+            Arg.Any<CancellationToken>());
     }
 
     /// <summary>
@@ -755,6 +759,110 @@ public sealed class JobReconciliationServiceTests
             Arg.Any<string>(), Arg.Any<OperationPriority>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
 
         await jobQueue.Received(1).RemoveAsync(snapshot.OperationId, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: when queue removal fails after a heartbeat-expired terminal
+    /// failure, the terminal callback must still fire so the admin progress store
+    /// reflects the correct terminal state.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatExpiry_TerminalFailure_NotifiesCallback_WhenQueueRemovalFails()
+    {
+        var snapshot = CreateRunningJob(
+            retryPolicy: new JobRetryPolicy
+            {
+                MaxAttempts = 1,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            },
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            },
+            timeoutPolicy: new JobTimeoutPolicy
+            {
+                MaxDuration = TimeSpan.FromHours(24)
+            });
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(snapshot);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+        var terminalCallback = Substitute.For<IJobTerminalCallback>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
+            [terminalCallback], null, NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        await terminalCallback.Received(1).OnTerminalAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: when queue removal fails for a heartbeat-expired job honouring
+    /// a durable cancellation signal, the terminal callback must still fire.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatExpiry_DurableCancellation_NotifiesCallback_WhenQueueRemovalFails()
+    {
+        var snapshot = CreateRunningJob(
+            retryPolicy: new JobRetryPolicy
+            {
+                MaxAttempts = 3,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.FromSeconds(5),
+                MaxDelay = TimeSpan.FromMinutes(1)
+            },
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            },
+            timeoutPolicy: new JobTimeoutPolicy
+            {
+                MaxDuration = TimeSpan.FromHours(24)
+            }) with
+        {
+            CancellationRequestedAt = DateTimeOffset.UtcNow.AddSeconds(-5)
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(snapshot);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        jobQueue.RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+        var terminalCallback = Substitute.For<IJobTerminalCallback>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
+            [terminalCallback], null, NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        await terminalCallback.Received(1).OnTerminalAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
+            Arg.Any<CancellationToken>());
     }
 
     /// <summary>

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -865,6 +865,129 @@ public sealed class JobReconciliationServiceTests
             Arg.Any<CancellationToken>());
     }
 
+    [UnitTest]
+    public async Task HeartbeatExpiry_TerminalFailure_NotifiesCallback_WhenLogRetentionFails()
+    {
+        var snapshot = CreateRunningJob(
+            retryPolicy: new JobRetryPolicy
+            {
+                MaxAttempts = 1,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            },
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            },
+            timeoutPolicy: new JobTimeoutPolicy
+            {
+                MaxDuration = TimeSpan.FromHours(24)
+            });
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(snapshot);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+        var terminalCallback = Substitute.For<IJobTerminalCallback>();
+
+        var logStore = Substitute.For<IExecutionLogStore>();
+        logStore.SetRetentionAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
+            [terminalCallback], logStore, NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        await terminalCallback.Received(1).OnTerminalAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    public async Task TimeoutExpiry_NotifiesCallback_WhenLogRetentionFails()
+    {
+        var snapshot = CreateRunningJob(
+            timeoutPolicy: new JobTimeoutPolicy { MaxDuration = TimeSpan.FromSeconds(1) });
+        snapshot = snapshot with { ClaimedAt = DateTimeOffset.UtcNow.AddMinutes(-10) };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(snapshot);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+        var terminalCallback = Substitute.For<IJobTerminalCallback>();
+
+        var logStore = Substitute.For<IExecutionLogStore>();
+        logStore.SetRetentionAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
+            [terminalCallback], logStore, NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        await terminalCallback.Received(1).OnTerminalAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    public async Task HeartbeatExpiry_DurableCancellation_NotifiesCallback_WhenLogRetentionFails()
+    {
+        var snapshot = CreateRunningJob(
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            },
+            timeoutPolicy: new JobTimeoutPolicy
+            {
+                MaxDuration = TimeSpan.FromHours(24)
+            }) with
+        {
+            CancellationRequestedAt = DateTimeOffset.UtcNow.AddSeconds(-5)
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(snapshot);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+        var terminalCallback = Substitute.For<IJobTerminalCallback>();
+
+        var logStore = Substitute.For<IExecutionLogStore>();
+        logStore.SetRetentionAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
+            [terminalCallback], logStore, NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        await terminalCallback.Received(1).OnTerminalAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
+            Arg.Any<CancellationToken>());
+    }
+
     /// <summary>
     /// Invokes the reconciler's sweep logic once without running the full
     /// BackgroundService loop. Uses reflection to call the private method

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -318,6 +318,61 @@ public sealed class JobReconciliationServiceTests
     }
 
     /// <summary>
+    /// Regression: a job that timed out in the sweep snapshot but was requeued
+    /// and reclaimed by the same worker with a fresh ClaimedAt must not be
+    /// failed — the new attempt has not timed out.
+    /// </summary>
+    [UnitTest]
+    public async Task TimeoutExpiry_SkipsTransition_WhenReclaimedBySameWorkerWithFreshClaimTime()
+    {
+        var timeoutPolicy = new JobTimeoutPolicy { MaxDuration = TimeSpan.FromSeconds(1) };
+
+        // Snapshot: old ClaimedAt triggers timeout in the sweep.
+        var snapshot = CreateRunningJob(
+            claimedBy: "worker-1",
+            timeoutPolicy: timeoutPolicy,
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(30),
+                Timeout = TimeSpan.FromHours(24)
+            });
+        snapshot = snapshot with { ClaimedAt = DateTimeOffset.UtcNow.AddMinutes(-10) };
+
+        // Fresh record: same worker reclaimed with a recent ClaimedAt —
+        // the new attempt has not timed out.
+        var reclaimed = snapshot with
+        {
+            ClaimedAt = DateTimeOffset.UtcNow,
+            AttemptCount = snapshot.AttemptCount + 1,
+            LastHeartbeatAt = DateTimeOffset.UtcNow
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(reclaimed);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler,
+            NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        // The reconciler must NOT fail the job.
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Invokes the reconciler's sweep logic once without running the full
     /// BackgroundService loop. Uses reflection to call the private method
     /// since the service is internal and sealed.

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -85,7 +85,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            logStore: null, NullLogger<JobReconciliationService>.Instance);
+            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -127,7 +127,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            logStore: null, NullLogger<JobReconciliationService>.Instance);
+            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -169,7 +169,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            logStore: null, NullLogger<JobReconciliationService>.Instance);
+            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -221,7 +221,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            logStore: null, logger);
+            Array.Empty<IJobTerminalCallback>(), null, logger);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -263,7 +263,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            logStore: null, NullLogger<JobReconciliationService>.Instance);
+            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -310,7 +310,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            logStore: null, NullLogger<JobReconciliationService>.Instance);
+            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -361,7 +361,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            logStore: null, NullLogger<JobReconciliationService>.Instance);
+            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -420,7 +420,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            logStore: null, NullLogger<JobReconciliationService>.Instance);
+            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -467,7 +467,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            logStore: null, logger);
+            Array.Empty<IJobTerminalCallback>(), null, logger);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -531,7 +531,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, cancellationTokens,
-            logStore: null, NullLogger<JobReconciliationService>.Instance);
+            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -585,7 +585,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, cancellationTokens,
-            logStore, NullLogger<JobReconciliationService>.Instance);
+            Array.Empty<IJobTerminalCallback>(), logStore, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -646,7 +646,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, cancellationTokens,
-            logStore: null, NullLogger<JobReconciliationService>.Instance);
+            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
@@ -690,7 +690,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, cancellationTokens,
-            logStore: null, NullLogger<JobReconciliationService>.Instance);
+            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
@@ -741,7 +741,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            logStore: null, NullLogger<JobReconciliationService>.Instance);
+            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -411,7 +411,7 @@ public sealed class JobReconciliationServiceTests
         // Simulate a stale worker CTS registered before the sweep.
         var cancellationTokens = new ExecutionJobCancellationTokens();
         using var staleCts = cancellationTokens.CreateLinkedTokenSource(
-            snapshot.OperationId, CancellationToken.None);
+            snapshot.OperationId, snapshot.ClaimedBy!, CancellationToken.None);
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, cancellationTokens,
@@ -463,7 +463,7 @@ public sealed class JobReconciliationServiceTests
 
         var cancellationTokens = new ExecutionJobCancellationTokens();
         using var staleCts = cancellationTokens.CreateLinkedTokenSource(
-            snapshot.OperationId, CancellationToken.None);
+            snapshot.OperationId, snapshot.ClaimedBy!, CancellationToken.None);
 
         var logStore = Substitute.For<IExecutionLogStore>();
 

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -5,6 +5,7 @@ using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Server.Features.Infrastructure.ControlPlane;
 using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
@@ -178,6 +179,67 @@ public sealed class JobReconciliationServiceTests
                 j.Status == ExecutionJobStatus.Failed || j.Status == ExecutionJobStatus.Queued),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: once the fresh record has moved back to Queued, the
+    /// reconciler must classify the snapshot as stale even if stale claim
+    /// metadata is still present. Only actively claimed attempts are eligible
+    /// for heartbeat expiry handling.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatExpiry_LogsStale_WhenJobMovedBackToQueuedSinceSweep()
+    {
+        var snapshot = CreateRunningJob(
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            },
+            timeoutPolicy: new JobTimeoutPolicy
+            {
+                MaxDuration = TimeSpan.FromHours(24)
+            });
+
+        var requeued = snapshot with
+        {
+            Status = ExecutionJobStatus.Queued,
+            ClaimedAt = null,
+            LastHeartbeatAt = null,
+            CurrentPhase = "Requeued: Worker shutdown."
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(requeued);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+        var logger = new ListLogger<JobReconciliationService>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
+            logStore: null, logger);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await jobQueue.DidNotReceive().RequeueAsync(
+            Arg.Any<string>(), Arg.Any<OperationPriority>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+
+        Assert.Contains(logger.Entries, entry =>
+            entry.EventId.Id == 9047 &&
+            entry.Message.Contains(snapshot.OperationId, StringComparison.Ordinal) &&
+            entry.Message.Contains("Queued", StringComparison.Ordinal));
+        Assert.DoesNotContain(logger.Entries, entry => entry.EventId.Id == 9048);
     }
 
     [UnitTest]
@@ -370,6 +432,60 @@ public sealed class JobReconciliationServiceTests
             Arg.Any<CancellationToken>());
 
         await jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: once the fresh record has moved back to Queued, the timeout
+    /// handler must classify the snapshot as stale rather than as a refreshed
+    /// timeout window. Only actively claimed attempts are eligible for timeout
+    /// expiry handling.
+    /// </summary>
+    [UnitTest]
+    public async Task TimeoutExpiry_LogsStale_WhenJobMovedBackToQueuedSinceSweep()
+    {
+        var snapshot = CreateRunningJob(
+            timeoutPolicy: new JobTimeoutPolicy { MaxDuration = TimeSpan.FromSeconds(1) });
+        snapshot = snapshot with { ClaimedAt = DateTimeOffset.UtcNow.AddMinutes(-10) };
+
+        var requeued = snapshot with
+        {
+            Status = ExecutionJobStatus.Queued,
+            ClaimedAt = null,
+            LastHeartbeatAt = null,
+            CurrentPhase = "Requeued: Worker shutdown."
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(requeued);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+        var logger = new ListLogger<JobReconciliationService>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
+            logStore: null, logger);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await jobQueue.DidNotReceive().RequeueAsync(
+            Arg.Any<string>(), Arg.Any<OperationPriority>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+
+        Assert.Contains(logger.Entries, entry =>
+            entry.EventId.Id == 9047 &&
+            entry.Message.Contains(snapshot.OperationId, StringComparison.Ordinal) &&
+            entry.Message.Contains("Queued", StringComparison.Ordinal));
+        Assert.DoesNotContain(logger.Entries, entry => entry.EventId.Id == 9049);
     }
 
     /// <summary>
@@ -600,5 +716,37 @@ public sealed class JobReconciliationServiceTests
 
         var task = (Task)method!.Invoke(service, [cancellationToken])!;
         await task.ConfigureAwait(false);
+    }
+
+    private sealed class ListLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
+            => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(logLevel, eventId, formatter(state, exception), exception));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel LogLevel, EventId EventId, string Message, Exception? Exception);
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -84,7 +84,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            NullLogger<JobReconciliationService>.Instance);
+            logStore: null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -126,7 +126,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            NullLogger<JobReconciliationService>.Instance);
+            logStore: null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -168,7 +168,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            NullLogger<JobReconciliationService>.Instance);
+            logStore: null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -201,7 +201,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            NullLogger<JobReconciliationService>.Instance);
+            logStore: null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -248,7 +248,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            NullLogger<JobReconciliationService>.Instance);
+            logStore: null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -299,7 +299,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            NullLogger<JobReconciliationService>.Instance);
+            logStore: null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -358,7 +358,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
-            NullLogger<JobReconciliationService>.Instance);
+            logStore: null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -415,7 +415,7 @@ public sealed class JobReconciliationServiceTests
 
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, cancellationTokens,
-            NullLogger<JobReconciliationService>.Instance);
+            logStore: null, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
@@ -465,15 +465,23 @@ public sealed class JobReconciliationServiceTests
         using var staleCts = cancellationTokens.CreateLinkedTokenSource(
             snapshot.OperationId, CancellationToken.None);
 
+        var logStore = Substitute.For<IExecutionLogStore>();
+
         var service = new JobReconciliationService(
             jobStore, jobQueue, claimReconciler, cancellationTokens,
-            NullLogger<JobReconciliationService>.Instance);
+            logStore, NullLogger<JobReconciliationService>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
 
         Assert.True(staleCts.IsCancellationRequested);
         Assert.False(cancellationTokens.Cancel(snapshot.OperationId));
+
+        // Terminal failure must set log retention for post-mortem access.
+        await logStore.Received(1).SetRetentionAsync(
+            snapshot.OperationId,
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
     }
 
     /// <summary>

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -212,6 +212,59 @@ public sealed class JobReconciliationServiceTests
             Arg.Any<CancellationToken>());
     }
 
+    /// <summary>
+    /// Regression: a heartbeat arriving between the sweep snapshot and the
+    /// reconciler handler must prevent the transition — the worker is alive.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatExpiry_SkipsTransition_WhenHeartbeatRefreshedSinceSweep()
+    {
+        var snapshot = CreateRunningJob(
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            },
+            timeoutPolicy: new JobTimeoutPolicy
+            {
+                // Large timeout so only the heartbeat check fires.
+                MaxDuration = TimeSpan.FromHours(24)
+            });
+
+        // The fresh record has a recent heartbeat — worker sent one after the snapshot.
+        var refreshed = snapshot with
+        {
+            LastHeartbeatAt = DateTimeOffset.UtcNow
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(refreshed);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler,
+            NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        // The reconciler must NOT requeue or fail the job.
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.Status == ExecutionJobStatus.Failed || j.Status == ExecutionJobStatus.Queued),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await jobQueue.DidNotReceive().RequeueAsync(
+            Arg.Any<string>(), Arg.Any<OperationPriority>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
     [UnitTest]
     public async Task HeartbeatExpiry_StillRetries_WhenJobRemainsActiveAndOwnedBySameWorker()
     {

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -702,6 +702,62 @@ public sealed class JobReconciliationServiceTests
     }
 
     /// <summary>
+    /// Regression: when a durable cancellation signal (CancellationRequestedAt) is
+    /// set on a job whose heartbeat has expired, the reconciler must transition to
+    /// Cancelled instead of retrying, honouring the operator's cancellation intent.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatExpiry_HonoursDurableCancellationSignal_TransitionsToCancelled()
+    {
+        var snapshot = CreateRunningJob(
+            retryPolicy: new JobRetryPolicy
+            {
+                MaxAttempts = 3,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.FromSeconds(5),
+                MaxDelay = TimeSpan.FromMinutes(1)
+            },
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            },
+            timeoutPolicy: new JobTimeoutPolicy
+            {
+                MaxDuration = TimeSpan.FromHours(24)
+            }) with
+        {
+            CancellationRequestedAt = DateTimeOffset.UtcNow.AddSeconds(-5)
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(snapshot);
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
+            logStore: null, NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        await jobStore.Received(1).SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.DidNotReceive().RequeueAsync(
+            Arg.Any<string>(), Arg.Any<OperationPriority>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+
+        await jobQueue.Received(1).RemoveAsync(snapshot.OperationId, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Invokes the reconciler's sweep logic once without running the full
     /// BackgroundService loop. Uses reflection to call the private method
     /// since the service is internal and sealed.

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -989,6 +989,132 @@ public sealed class JobReconciliationServiceTests
     }
 
     /// <summary>
+    /// Regression: a durable cancellation signal that arrives between the initial
+    /// cancellation check and the retry write must be caught by the pre-retry
+    /// re-read so the reconciler cancels instead of requeueing.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatExpiry_HonoursCancellation_WhenSignalArrivesBeforeRetryWrite()
+    {
+        var snapshot = CreateRunningJob(
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            },
+            timeoutPolicy: new JobTimeoutPolicy
+            {
+                MaxDuration = TimeSpan.FromHours(24)
+            },
+            retryPolicy: new JobRetryPolicy
+            {
+                MaxAttempts = 3,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.FromSeconds(1),
+                MaxDelay = TimeSpan.FromMinutes(1)
+            });
+
+        var withCancel = snapshot with
+        {
+            CancellationRequestedAt = DateTimeOffset.UtcNow
+        };
+
+        var callCount = 0;
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                // Read 1: initial re-read (no cancel). Read 2+: pre-retry re-read (cancel present).
+                return callCount <= 1 ? snapshot : withCancel;
+            });
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
+            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        await jobStore.Received().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobQueue.DidNotReceive().RequeueAsync(
+            Arg.Any<string>(), Arg.Any<OperationPriority>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Regression: a durable cancellation signal that arrives between the initial
+    /// cancellation check and the terminal fail write (retries exhausted) must be
+    /// caught by the pre-fail re-read so the reconciler cancels instead of failing.
+    /// </summary>
+    [UnitTest]
+    public async Task HeartbeatExpiry_HonoursCancellation_WhenSignalArrivesBeforeFailWrite()
+    {
+        var snapshot = CreateRunningJob(
+            heartbeatPolicy: new JobHeartbeatPolicy
+            {
+                Interval = TimeSpan.FromSeconds(1),
+                Timeout = TimeSpan.FromSeconds(1)
+            },
+            timeoutPolicy: new JobTimeoutPolicy
+            {
+                MaxDuration = TimeSpan.FromHours(24)
+            },
+            retryPolicy: new JobRetryPolicy
+            {
+                MaxAttempts = 1,
+                Strategy = BackoffStrategy.Fixed,
+                BaseDelay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            });
+
+        var withCancel = snapshot with
+        {
+            CancellationRequestedAt = DateTimeOffset.UtcNow
+        };
+
+        var callCount = 0;
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([snapshot]);
+        jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                // Read 1: initial re-read (no cancel). Read 2+: pre-fail re-read (cancel present).
+                return callCount <= 1 ? snapshot : withCancel;
+            });
+
+        var jobQueue = Substitute.For<IJobQueue>();
+        var claimReconciler = Substitute.For<IQueueClaimReconciler>();
+
+        var service = new JobReconciliationService(
+            jobStore, jobQueue, claimReconciler, new ExecutionJobCancellationTokens(),
+            Array.Empty<IJobTerminalCallback>(), null, NullLogger<JobReconciliationService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await RunSingleSweepAsync(service, cts.Token);
+
+        await jobStore.Received().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await jobStore.DidNotReceive().SetAsync(
+            Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Invokes the reconciler's sweep logic once without running the full
     /// BackgroundService loop. Uses reflection to call the private method
     /// since the service is internal and sealed.

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/JobReconciliationServiceTests.cs
@@ -4,6 +4,7 @@
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.Server.Tests.Helpers;
 using Honua.TestKit.Attributes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -74,7 +75,7 @@ public sealed class JobReconciliationServiceTests
             CompletedAt = DateTimeOffset.UtcNow
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -116,7 +117,7 @@ public sealed class JobReconciliationServiceTests
             CompletedAt = DateTimeOffset.UtcNow
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([succeeded.Status == ExecutionJobStatus.Succeeded ? snapshot : snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -158,7 +159,7 @@ public sealed class JobReconciliationServiceTests
             LastHeartbeatAt = DateTimeOffset.UtcNow
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -209,7 +210,7 @@ public sealed class JobReconciliationServiceTests
             CurrentPhase = "Requeued: Worker shutdown."
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -252,7 +253,7 @@ public sealed class JobReconciliationServiceTests
                 Timeout = TimeSpan.FromSeconds(1)
             });
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -299,7 +300,7 @@ public sealed class JobReconciliationServiceTests
             LastHeartbeatAt = DateTimeOffset.UtcNow
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -349,7 +350,7 @@ public sealed class JobReconciliationServiceTests
                 MaxDuration = TimeSpan.FromHours(24)
             });
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         // Re-read returns the same active record — no intervening completion.
@@ -367,7 +368,7 @@ public sealed class JobReconciliationServiceTests
         await RunSingleSweepAsync(service, cts.Token);
 
         // The reconciler should proceed with the retry transition.
-        await jobStore.Received(1).SetAsync(
+        await jobStore.Received(1).TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Queued),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
@@ -409,7 +410,7 @@ public sealed class JobReconciliationServiceTests
             LastHeartbeatAt = DateTimeOffset.UtcNow
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -455,7 +456,7 @@ public sealed class JobReconciliationServiceTests
             CurrentPhase = "Requeued: Worker shutdown."
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -515,7 +516,7 @@ public sealed class JobReconciliationServiceTests
                 MaxDuration = TimeSpan.FromHours(24)
             });
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -568,7 +569,7 @@ public sealed class JobReconciliationServiceTests
                 MaxDuration = TimeSpan.FromHours(24)
             });
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -626,7 +627,7 @@ public sealed class JobReconciliationServiceTests
                 MaxDuration = TimeSpan.FromHours(24)
             });
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -671,7 +672,7 @@ public sealed class JobReconciliationServiceTests
             timeoutPolicy: new JobTimeoutPolicy { MaxDuration = TimeSpan.FromSeconds(1) });
         snapshot = snapshot with { ClaimedAt = DateTimeOffset.UtcNow.AddMinutes(-10) };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -734,7 +735,7 @@ public sealed class JobReconciliationServiceTests
             CancellationRequestedAt = DateTimeOffset.UtcNow.AddSeconds(-5)
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -750,7 +751,7 @@ public sealed class JobReconciliationServiceTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
 
-        await jobStore.Received(1).SetAsync(
+        await jobStore.Received(1).TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
@@ -787,7 +788,7 @@ public sealed class JobReconciliationServiceTests
                 MaxDuration = TimeSpan.FromHours(24)
             });
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -840,7 +841,7 @@ public sealed class JobReconciliationServiceTests
             CancellationRequestedAt = DateTimeOffset.UtcNow.AddSeconds(-5)
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -886,7 +887,7 @@ public sealed class JobReconciliationServiceTests
                 MaxDuration = TimeSpan.FromHours(24)
             });
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -919,7 +920,7 @@ public sealed class JobReconciliationServiceTests
             timeoutPolicy: new JobTimeoutPolicy { MaxDuration = TimeSpan.FromSeconds(1) });
         snapshot = snapshot with { ClaimedAt = DateTimeOffset.UtcNow.AddMinutes(-10) };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -962,7 +963,7 @@ public sealed class JobReconciliationServiceTests
             CancellationRequestedAt = DateTimeOffset.UtcNow.AddSeconds(-5)
         };
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -1020,7 +1021,7 @@ public sealed class JobReconciliationServiceTests
         };
 
         var callCount = 0;
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -1041,7 +1042,7 @@ public sealed class JobReconciliationServiceTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
 
-        await jobStore.Received().SetAsync(
+        await jobStore.Received().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
@@ -1082,7 +1083,7 @@ public sealed class JobReconciliationServiceTests
         };
 
         var callCount = 0;
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.ListActiveAsync(kind: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns([snapshot]);
         jobStore.GetAsync(snapshot.OperationId, Arg.Any<CancellationToken>())
@@ -1103,12 +1104,12 @@ public sealed class JobReconciliationServiceTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await RunSingleSweepAsync(service, cts.Token);
 
-        await jobStore.Received().SetAsync(
+        await jobStore.Received().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Cancelled),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
 
-        await jobStore.DidNotReceive().SetAsync(
+        await jobStore.DidNotReceive().TrySetAsync(
             Arg.Is<ExecutionJobRecord>(j => j.Status == ExecutionJobStatus.Failed),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisExecutionSubstrateIntegrationTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisExecutionSubstrateIntegrationTests.cs
@@ -7,6 +7,7 @@ using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Server.Features.Infrastructure.ControlPlane;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
 using Microsoft.Extensions.Logging.Abstractions;
 using StackExchange.Redis;
 
@@ -17,6 +18,8 @@ namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
 /// used by the control-plane worker and reconciler services.
 /// </summary>
 [Collection("Redis")]
+[Protocol(Protocols.Infrastructure)]
+[Operation(Operations.TestInfrastructure)]
 public sealed class RedisExecutionSubstrateIntegrationTests(RedisFixture redis)
 {
     [IntegrationTest]

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisExecutionSubstrateIntegrationTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisExecutionSubstrateIntegrationTests.cs
@@ -1,0 +1,483 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using StackExchange.Redis;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Redis Testcontainers integration coverage for the durable execution substrate
+/// used by the control-plane worker and reconciler services.
+/// </summary>
+[Collection("Redis")]
+public sealed class RedisExecutionSubstrateIntegrationTests(RedisFixture redis)
+{
+    [IntegrationTest]
+    public async Task ExecutionJobStore_WithRedis_SupportsCasUpdatesAndActiveIndexes()
+    {
+        await using var harness = await ControlPlaneRedisHarness.CreateAsync(redis.ConnectionString);
+        var operationId = $"job-{Guid.NewGuid():N}";
+        var job = CreateQueuedJob(operationId);
+
+        var created = await harness.JobStore.TryCreateAsync(job);
+        created.Should().BeTrue();
+
+        var loaded = await harness.JobStore.GetAsync(operationId);
+        loaded.Should().NotBeNull();
+        loaded!.Version.Should().Be(1);
+        loaded.Status.Should().Be(ExecutionJobStatus.Queued);
+
+        var claimTimestamp = DateTimeOffset.UtcNow;
+        var claimed = loaded with
+        {
+            Status = ExecutionJobStatus.Provisioning,
+            ClaimedBy = "worker-integration",
+            ClaimedAt = claimTimestamp,
+            LastHeartbeatAt = claimTimestamp,
+            CurrentPhase = "Claimed"
+        };
+
+        var casApplied = await harness.JobStore.TrySetAsync(claimed);
+        casApplied.Should().BeTrue();
+
+        var afterClaim = await harness.JobStore.GetAsync(operationId);
+        afterClaim.Should().NotBeNull();
+        afterClaim!.Version.Should().Be(2);
+        afterClaim.Status.Should().Be(ExecutionJobStatus.Provisioning);
+
+        var staleWriteApplied = await harness.JobStore.TrySetAsync(claimed with
+        {
+            Status = ExecutionJobStatus.Running,
+            CurrentPhase = "stale-overwrite"
+        });
+        staleWriteApplied.Should().BeFalse();
+
+        var now = DateTimeOffset.UtcNow;
+        await harness.JobStore.SetAsync(afterClaim with
+        {
+            Status = ExecutionJobStatus.Succeeded,
+            UpdatedAt = now,
+            CompletedAt = now,
+            CurrentPhase = "Completed"
+        });
+
+        var activeJobs = await harness.JobStore.ListActiveAsync();
+        activeJobs.Should().NotContain(entry => entry.OperationId == operationId);
+    }
+
+    [IntegrationTest]
+    public async Task ExecutionLogStore_WithRedis_AppendsInOrderAndHonoursRetention()
+    {
+        await using var harness = await ControlPlaneRedisHarness.CreateAsync(redis.ConnectionString);
+        var operationId = $"job-log-{Guid.NewGuid():N}";
+
+        await harness.LogStore.AppendAsync(operationId, new ExecutionLogEntry
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Level = ExecutionLogLevel.Info,
+            Message = "Started execution.",
+            Phase = "Queued"
+        });
+
+        await harness.LogStore.AppendAsync(operationId, new ExecutionLogEntry
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Level = ExecutionLogLevel.Warning,
+            Message = "Completed with warning.",
+            Phase = "Completed"
+        });
+
+        var logs = await harness.LogStore.GetLogsAsync(operationId);
+        logs.Select(entry => entry.Message).Should().Equal(
+            "Started execution.",
+            "Completed with warning.");
+
+        await harness.LogStore.SetRetentionAsync(operationId, TimeSpan.FromMinutes(2));
+
+        var ttl = await harness.GetTtlAsync(GetLogKey(operationId));
+        ttl.Should().NotBeNull();
+        ttl!.Value.Should().BeLessThanOrEqualTo(TimeSpan.FromMinutes(2));
+        ttl.Value.Should().BeGreaterThan(TimeSpan.FromSeconds(30));
+    }
+
+    [IntegrationTest]
+    public async Task JobExecutionService_WithRedis_CompletesJobAndPersistsArtifactsLogsAndCallbacks()
+    {
+        await using var harness = await ControlPlaneRedisHarness.CreateAsync(redis.ConnectionString);
+        var operationId = $"job-exec-{Guid.NewGuid():N}";
+        var callback = new RecordingTerminalCallback();
+        var executor = new DelegatingJobExecutor(
+            ExecutionJobKind.Geoprocessing,
+            async (_, context, cancellationToken) =>
+            {
+                await context.ReportProgressAsync(42, "Running integration step", cancellationToken);
+                await context.AppendLogAsync(new ExecutionLogEntry
+                {
+                    Timestamp = DateTimeOffset.UtcNow,
+                    Level = ExecutionLogLevel.Info,
+                    Message = "Executor reached integration step.",
+                    Phase = "Running"
+                }, cancellationToken);
+                await context.PublishArtifactAsync("s3://integration/results.geojson", cancellationToken);
+                return JobExecutionResult.Succeeded();
+            });
+
+        var service = new JobExecutionService(
+            harness.Queue,
+            harness.JobStore,
+            [executor],
+            new ExecutionJobCancellationTokens(),
+            [callback],
+            harness.LogStore,
+            NullLogger<JobExecutionService>.Instance);
+
+        await harness.JobStore.TryCreateAsync(CreateQueuedJob(operationId));
+        await harness.Queue.EnqueueAsync(operationId);
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            var terminal = await callback.WhenCompleted.WaitAsync(TimeSpan.FromSeconds(10));
+            terminal.OperationId.Should().Be(operationId);
+            terminal.Status.Should().Be(ExecutionJobStatus.Succeeded);
+
+            var stored = await WaitForJobAsync(
+                harness.JobStore,
+                operationId,
+                job => job.Status == ExecutionJobStatus.Succeeded,
+                TimeSpan.FromSeconds(5));
+
+            stored.PercentComplete.Should().Be(100);
+            stored.CurrentPhase.Should().Be("Completed");
+            stored.ArtifactReferences.Should().ContainSingle("s3://integration/results.geojson");
+
+            var logs = await harness.LogStore.GetLogsAsync(operationId);
+            logs.Should().ContainSingle(entry =>
+                entry.Level == ExecutionLogLevel.Info &&
+                entry.Message == "Executor reached integration step.");
+
+            var queueDepth = await harness.Queue.GetQueueDepthAsync();
+            queueDepth.Should().Be(0);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task JobReconciliationService_WithRedis_CancelsDurablyRequestedStaleJob()
+    {
+        await using var harness = await ControlPlaneRedisHarness.CreateAsync(redis.ConnectionString);
+        var operationId = $"job-cancel-{Guid.NewGuid():N}";
+        var callback = new RecordingTerminalCallback();
+        var retryPolicy = new JobRetryPolicy
+        {
+            MaxAttempts = 3,
+            Strategy = BackoffStrategy.Fixed,
+            BaseDelay = TimeSpan.Zero,
+            MaxDelay = TimeSpan.Zero
+        };
+        var heartbeatPolicy = new JobHeartbeatPolicy
+        {
+            Interval = TimeSpan.FromMilliseconds(50),
+            Timeout = TimeSpan.FromMilliseconds(50)
+        };
+
+        await harness.JobStore.TryCreateAsync(CreateQueuedJob(operationId, retryPolicy, heartbeatPolicy));
+        await harness.Queue.EnqueueAsync(operationId);
+
+        var claimedId = await harness.Queue.TryClaimAsync(
+            "worker-stale",
+            new HashSet<ExecutionJobKind> { ExecutionJobKind.Geoprocessing });
+        claimedId.Should().Be(operationId);
+
+        var claimed = await harness.JobStore.GetAsync(operationId);
+        claimed.Should().NotBeNull();
+
+        await harness.LogStore.AppendAsync(operationId, new ExecutionLogEntry
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Level = ExecutionLogLevel.Info,
+            Message = "Worker produced an early log.",
+            Phase = "Running"
+        });
+
+        var staleTimestamp = DateTimeOffset.UtcNow.AddMinutes(-5);
+        await harness.JobStore.SetAsync(claimed! with
+        {
+            Status = ExecutionJobStatus.Running,
+            UpdatedAt = staleTimestamp,
+            ClaimedAt = staleTimestamp,
+            LastHeartbeatAt = staleTimestamp,
+            CurrentPhase = "Running",
+            CancellationRequestedAt = DateTimeOffset.UtcNow.AddSeconds(-1)
+        });
+
+        var service = new JobReconciliationService(
+            harness.JobStore,
+            harness.Queue,
+            harness.Queue,
+            new ExecutionJobCancellationTokens(),
+            [callback],
+            harness.LogStore,
+            NullLogger<JobReconciliationService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            var terminal = await callback.WhenCompleted.WaitAsync(TimeSpan.FromSeconds(10));
+            terminal.OperationId.Should().Be(operationId);
+            terminal.Status.Should().Be(ExecutionJobStatus.Cancelled);
+
+            var stored = await WaitForJobAsync(
+                harness.JobStore,
+                operationId,
+                job => job.Status == ExecutionJobStatus.Cancelled,
+                TimeSpan.FromSeconds(5));
+
+            stored.CurrentPhase.Should().Be("Cancelled");
+            stored.CompletedAt.Should().NotBeNull();
+
+            var queueDepth = await harness.Queue.GetQueueDepthAsync();
+            queueDepth.Should().Be(0);
+
+            var ttl = await harness.GetTtlAsync(GetLogKey(operationId));
+            ttl.Should().NotBeNull();
+            ttl!.Value.Should().BeGreaterThan(TimeSpan.FromDays(6));
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task JobReconciliationService_WithRedis_RequeuesHeartbeatExpiredJobForRetry()
+    {
+        await using var harness = await ControlPlaneRedisHarness.CreateAsync(redis.ConnectionString);
+        var operationId = $"job-retry-{Guid.NewGuid():N}";
+        var callback = new RecordingTerminalCallback();
+        var retryPolicy = new JobRetryPolicy
+        {
+            MaxAttempts = 3,
+            Strategy = BackoffStrategy.Fixed,
+            BaseDelay = TimeSpan.Zero,
+            MaxDelay = TimeSpan.Zero
+        };
+        var heartbeatPolicy = new JobHeartbeatPolicy
+        {
+            Interval = TimeSpan.FromMilliseconds(50),
+            Timeout = TimeSpan.FromMilliseconds(50)
+        };
+
+        await harness.JobStore.TryCreateAsync(CreateQueuedJob(operationId, retryPolicy, heartbeatPolicy));
+        await harness.Queue.EnqueueAsync(operationId);
+
+        var claimedId = await harness.Queue.TryClaimAsync(
+            "worker-retry",
+            new HashSet<ExecutionJobKind> { ExecutionJobKind.Geoprocessing });
+        claimedId.Should().Be(operationId);
+
+        var claimed = await harness.JobStore.GetAsync(operationId);
+        claimed.Should().NotBeNull();
+
+        var staleTimestamp = DateTimeOffset.UtcNow.AddMinutes(-5);
+        await harness.JobStore.SetAsync(claimed! with
+        {
+            Status = ExecutionJobStatus.Running,
+            UpdatedAt = staleTimestamp,
+            ClaimedAt = staleTimestamp,
+            LastHeartbeatAt = staleTimestamp,
+            CurrentPhase = "Running"
+        });
+
+        var service = new JobReconciliationService(
+            harness.JobStore,
+            harness.Queue,
+            harness.Queue,
+            new ExecutionJobCancellationTokens(),
+            [callback],
+            harness.LogStore,
+            NullLogger<JobReconciliationService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            var stored = await WaitForJobAsync(
+                harness.JobStore,
+                operationId,
+                job => job.Status == ExecutionJobStatus.Queued && job.ClaimedBy is null,
+                TimeSpan.FromSeconds(10));
+
+            stored.CurrentPhase.Should().StartWith("Retrying");
+            stored.NextRetryAt.Should().BeNull();
+
+            callback.IsCompleted.Should().BeFalse();
+
+            var queueDepth = await harness.Queue.GetQueueDepthAsync();
+            queueDepth.Should().Be(1);
+
+            var reclaimed = await harness.Queue.TryClaimAsync(
+                "worker-reclaim",
+                new HashSet<ExecutionJobKind> { ExecutionJobKind.Geoprocessing });
+            reclaimed.Should().Be(operationId);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    private static ExecutionJobRecord CreateQueuedJob(
+        string operationId,
+        JobRetryPolicy? retryPolicy = null,
+        JobHeartbeatPolicy? heartbeatPolicy = null)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new ExecutionJobRecord
+        {
+            OperationId = operationId,
+            Status = ExecutionJobStatus.Queued,
+            CreatedAt = now,
+            UpdatedAt = now,
+            RetryPolicy = retryPolicy,
+            HeartbeatPolicy = heartbeatPolicy,
+            TimeoutPolicy = new JobTimeoutPolicy
+            {
+                MaxDuration = TimeSpan.FromMinutes(30)
+            },
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "integration-test",
+                WorkloadName = "redis-substrate-integration"
+            }
+        };
+    }
+
+    private static async Task<ExecutionJobRecord> WaitForJobAsync(
+        RedisExecutionJobStore jobStore,
+        string operationId,
+        Func<ExecutionJobRecord, bool> predicate,
+        TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var job = await jobStore.GetAsync(operationId);
+            if (job != null && predicate(job))
+            {
+                return job;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+        }
+
+        throw new TimeoutException($"Timed out waiting for job '{operationId}' to reach the expected state.");
+    }
+
+    private static string GetLogKey(string operationId) => $"controlplane:job:log:{operationId}";
+
+    private sealed class DelegatingJobExecutor(
+        ExecutionJobKind kind,
+        Func<ExecutionJobRecord, IJobExecutionContext, CancellationToken, Task<JobExecutionResult>> executeAsync)
+        : IJobExecutor
+    {
+        public ExecutionJobKind Kind { get; } = kind;
+
+        public Task<JobExecutionResult> ExecuteAsync(
+            ExecutionJobRecord job,
+            IJobExecutionContext context,
+            CancellationToken cancellationToken)
+            => executeAsync(job, context, cancellationToken);
+    }
+
+    private sealed class RecordingTerminalCallback : IJobTerminalCallback
+    {
+        private readonly TaskCompletionSource<ExecutionJobRecord> _whenCompleted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<ExecutionJobRecord> WhenCompleted => _whenCompleted.Task;
+
+        public bool IsCompleted => _whenCompleted.Task.IsCompleted;
+
+        public ValueTask OnTerminalAsync(ExecutionJobRecord job, CancellationToken cancellationToken)
+        {
+            _whenCompleted.TrySetResult(job);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class ControlPlaneRedisHarness : IAsyncDisposable
+    {
+        private readonly ConnectionMultiplexer _multiplexer;
+
+        private ControlPlaneRedisHarness(ConnectionMultiplexer multiplexer)
+        {
+            _multiplexer = multiplexer;
+            Database = _multiplexer.GetDatabase();
+            Server = GetServer(_multiplexer);
+            JobStore = new RedisExecutionJobStore(_multiplexer, NullLogger<RedisExecutionJobStore>.Instance);
+            LogStore = new RedisExecutionLogStore(_multiplexer, NullLogger<RedisExecutionLogStore>.Instance);
+            Queue = new RedisJobQueue(_multiplexer, JobStore, NullLogger<RedisJobQueue>.Instance);
+        }
+
+        public IDatabase Database { get; }
+
+        public IServer Server { get; }
+
+        public RedisExecutionJobStore JobStore { get; }
+
+        public RedisExecutionLogStore LogStore { get; }
+
+        public RedisJobQueue Queue { get; }
+
+        public static async Task<ControlPlaneRedisHarness> CreateAsync(string connectionString)
+        {
+            var multiplexer = await ConnectionMultiplexer.ConnectAsync(connectionString);
+            var harness = new ControlPlaneRedisHarness(multiplexer);
+            await harness.CleanupAsync();
+            return harness;
+        }
+
+        public async Task<TimeSpan?> GetTtlAsync(string key)
+            => await Database.KeyTimeToLiveAsync(key);
+
+        public async ValueTask DisposeAsync()
+        {
+            await CleanupAsync();
+            await _multiplexer.DisposeAsync();
+        }
+
+        private async Task CleanupAsync()
+        {
+            var keys = Server.Keys(pattern: "controlplane:*").ToArray();
+            if (keys.Length == 0)
+            {
+                return;
+            }
+
+            await Database.KeyDeleteAsync(keys);
+        }
+
+        private static IServer GetServer(ConnectionMultiplexer multiplexer)
+        {
+            var endpoints = multiplexer.GetEndPoints();
+            if (endpoints.Length == 0)
+            {
+                throw new InvalidOperationException("Redis connection string did not provide any endpoints.");
+            }
+
+            return multiplexer.GetServer(endpoints[0]);
+        }
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisExecutionSubstrateIntegrationTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisExecutionSubstrateIntegrationTests.cs
@@ -325,7 +325,10 @@ public sealed class RedisExecutionSubstrateIntegrationTests(RedisFixture redis)
 
             callback.IsCompleted.Should().BeFalse();
 
-            var queueDepth = await harness.Queue.GetQueueDepthAsync();
+            var queueDepth = await WaitForQueueDepthAsync(
+                harness.Queue,
+                depth => depth == 1,
+                TimeSpan.FromSeconds(5));
             queueDepth.Should().Be(1);
 
             var reclaimed = await harness.Queue.TryClaimAsync(
@@ -386,6 +389,26 @@ public sealed class RedisExecutionSubstrateIntegrationTests(RedisFixture redis)
         }
 
         throw new TimeoutException($"Timed out waiting for job '{operationId}' to reach the expected state.");
+    }
+
+    private static async Task<long> WaitForQueueDepthAsync(
+        RedisJobQueue queue,
+        Func<long, bool> predicate,
+        TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var depth = await queue.GetQueueDepthAsync();
+            if (predicate(depth))
+            {
+                return depth;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+        }
+
+        throw new TimeoutException("Timed out waiting for the Redis queue to reach the expected depth.");
     }
 
     private static string GetLogKey(string operationId) => $"controlplane:job:log:{operationId}";

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisJobQueueTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisJobQueueTests.cs
@@ -6,6 +6,7 @@ using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Server.Features.Infrastructure.ControlPlane;
 using Honua.TestKit.Attributes;
+using Honua.Server.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using StackExchange.Redis;
@@ -53,7 +54,7 @@ public sealed class RedisJobQueueTests
         redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
 
         var nextRetryAt = DateTimeOffset.UtcNow.AddMinutes(2);
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(operationId, Arg.Any<CancellationToken>())
             .Returns(CreateQueuedJob(
                 operationId: operationId,
@@ -106,7 +107,7 @@ public sealed class RedisJobQueueTests
         var redis = Substitute.For<IConnectionMultiplexer>();
         redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(operationId, Arg.Any<CancellationToken>())
             .Returns(CreateQueuedJob(operationId: operationId, priority: OperationPriority.Critical));
         jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
@@ -143,7 +144,7 @@ public sealed class RedisJobQueueTests
         var redis = Substitute.For<IConnectionMultiplexer>();
         redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
 
         var result = await queue.TryClaimAsync("worker-traverse-budget");
@@ -208,7 +209,7 @@ public sealed class RedisJobQueueTests
         var redis = Substitute.For<IConnectionMultiplexer>();
         redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(readyJobId, Arg.Any<CancellationToken>())
             .Returns(CreateQueuedJob(operationId: readyJobId));
         jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
@@ -275,7 +276,7 @@ public sealed class RedisJobQueueTests
         var redis = Substitute.For<IConnectionMultiplexer>();
         redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(readyJobId, Arg.Any<CancellationToken>())
             .Returns(CreateQueuedJob(operationId: readyJobId));
         jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
@@ -351,7 +352,7 @@ public sealed class RedisJobQueueTests
         var redis = Substitute.For<IConnectionMultiplexer>();
         redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(readyJobId, Arg.Any<CancellationToken>())
             .Returns(CreateQueuedJob(operationId: readyJobId));
         jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
@@ -411,7 +412,7 @@ public sealed class RedisJobQueueTests
         var redis = Substitute.For<IConnectionMultiplexer>();
         redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
 
-        var jobStore = Substitute.For<IExecutionJobStore>();
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(Arg.Is<string>(id => id.StartsWith("mismatched-")), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisJobQueueTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisJobQueueTests.cs
@@ -110,8 +110,8 @@ public sealed class RedisJobQueueTests
         var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(operationId, Arg.Any<CancellationToken>())
             .Returns(CreateQueuedJob(operationId: operationId, priority: OperationPriority.Critical));
-        jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException(storeFailure));
+        jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<bool>(storeFailure));
 
         var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
 
@@ -123,6 +123,56 @@ public sealed class RedisJobQueueTests
         Assert.False(HasCall(database, nameof(IDatabase.SortedSetRemoveAsync), (RedisKey)ClaimedSetKey, (RedisValue)operationId));
         Assert.False(HasCall(database, nameof(IDatabase.SortedSetAddAsync), (RedisKey)QueueKey, (RedisValue)operationId));
         Assert.False(HasCall(database, nameof(IDatabase.KeyDeleteAsync), (RedisKey)GetClaimMetaKey(operationId)));
+    }
+
+    [UnitTest]
+    public async Task TryClaimAsync_WhenStoreCasConflictAndJobTerminal_ClearsClaimAndReturnsNull()
+    {
+        const string operationId = "job-terminal-conflict";
+
+        var database = Substitute.For<IDatabase>();
+        database.SortedSetRangeByRankAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<Order>(),
+                Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(new RedisValue[] { operationId }));
+        database.HashGetAllAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(Array.Empty<HashEntry>()));
+        database.HashSetAsync(Arg.Any<RedisKey>(), Arg.Any<HashEntry[]>(), Arg.Any<CommandFlags>())
+            .Returns(Task.CompletedTask);
+        database.ScriptEvaluateAsync(
+                Arg.Any<string>(),
+                Arg.Any<RedisKey[]>(),
+                Arg.Any<RedisValue[]>(),
+                Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(RedisResult.Create((RedisValue)"1")));
+
+        var redis = Substitute.For<IConnectionMultiplexer>();
+        redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
+
+        var queued = CreateQueuedJob(operationId: operationId, priority: OperationPriority.High);
+        var cancelled = queued with
+        {
+            Status = ExecutionJobStatus.Cancelled,
+            CompletedAt = DateTimeOffset.UtcNow
+        };
+
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
+        jobStore.GetAsync(operationId, Arg.Any<CancellationToken>())
+            .Returns(queued, cancelled);
+        jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
+
+        var result = await queue.TryClaimAsync("worker-1");
+
+        Assert.Null(result);
+        await database.Received(1).SortedSetRemoveAsync((RedisKey)ClaimedSetKey, (RedisValue)operationId);
+        await database.Received(1).KeyDeleteAsync((RedisKey)GetClaimMetaKey(operationId));
+        Assert.False(HasCall(database, nameof(IDatabase.SortedSetAddAsync), (RedisKey)QueueKey, (RedisValue)operationId));
     }
 
     [UnitTest]
@@ -212,8 +262,8 @@ public sealed class RedisJobQueueTests
         var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(readyJobId, Arg.Any<CancellationToken>())
             .Returns(CreateQueuedJob(operationId: readyJobId));
-        jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
+        jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
 
         var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
 
@@ -279,8 +329,8 @@ public sealed class RedisJobQueueTests
         var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(readyJobId, Arg.Any<CancellationToken>())
             .Returns(CreateQueuedJob(operationId: readyJobId));
-        jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
+        jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
 
         var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
 
@@ -355,8 +405,8 @@ public sealed class RedisJobQueueTests
         var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         jobStore.GetAsync(readyJobId, Arg.Any<CancellationToken>())
             .Returns(CreateQueuedJob(operationId: readyJobId));
-        jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
+        jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
 
         var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
 
@@ -422,8 +472,8 @@ public sealed class RedisJobQueueTests
             });
         jobStore.GetAsync(readyJobId, Arg.Any<CancellationToken>())
             .Returns(CreateQueuedJob(operationId: readyJobId, kind: ExecutionJobKind.ExtractTransformLoad));
-        jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
+        jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
 
         var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
 

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisJobQueueTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisJobQueueTests.cs
@@ -222,6 +222,154 @@ public sealed class RedisJobQueueTests
     }
 
     [UnitTest]
+    public async Task TryClaimAsync_WhenReadyJobBeyondTraverseBudget_FoundOnSubsequentPollViaRotatingCursor()
+    {
+        const string readyJobId = "ready-job-beyond-budget";
+        const int totalDelayed = 5500;
+
+        var database = Substitute.For<IDatabase>();
+        var futureMs = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds()
+            .ToString(CultureInfo.InvariantCulture);
+
+        database.SortedSetRangeByRankAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<Order>(),
+                Arg.Any<CommandFlags>())
+            .Returns(callInfo =>
+            {
+                var start = (long)callInfo[1];
+                var stop = (long)callInfo[2];
+                var results = new List<RedisValue>();
+
+                for (var i = start; i <= stop; i++)
+                {
+                    if (i < totalDelayed)
+                        results.Add($"delayed-{i}");
+                    else if (i == totalDelayed)
+                        results.Add(readyJobId);
+                }
+
+                return Task.FromResult(results.ToArray());
+            });
+
+        database.HashGetAllAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(callInfo =>
+            {
+                var key = ((RedisKey)callInfo[0]).ToString();
+                if (key.Contains("delayed-"))
+                    return Task.FromResult(new[] { new HashEntry("visibleAfter", futureMs) });
+                return Task.FromResult(Array.Empty<HashEntry>());
+            });
+
+        database.HashSetAsync(Arg.Any<RedisKey>(), Arg.Any<HashEntry[]>(), Arg.Any<CommandFlags>())
+            .Returns(Task.CompletedTask);
+        database.ScriptEvaluateAsync(
+                Arg.Any<string>(),
+                Arg.Any<RedisKey[]>(),
+                Arg.Any<RedisValue[]>(),
+                Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(RedisResult.Create((RedisValue)"1")));
+
+        var redis = Substitute.For<IConnectionMultiplexer>();
+        redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(readyJobId, Arg.Any<CancellationToken>())
+            .Returns(CreateQueuedJob(operationId: readyJobId));
+        jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
+
+        var firstResult = await queue.TryClaimAsync("worker-1");
+        Assert.Null(firstResult);
+
+        var secondResult = await queue.TryClaimAsync("worker-1");
+        Assert.Equal(readyJobId, secondResult);
+    }
+
+    [UnitTest]
+    public async Task TryClaimAsync_WhenQueueDrainedFromCursorPosition_CursorResetsToStart()
+    {
+        const string readyJobId = "ready-at-start";
+        var callCount = 0;
+
+        var database = Substitute.For<IDatabase>();
+        var futureMs = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds()
+            .ToString(CultureInfo.InvariantCulture);
+
+        database.SortedSetRangeByRankAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<Order>(),
+                Arg.Any<CommandFlags>())
+            .Returns(callInfo =>
+            {
+                var start = (long)callInfo[1];
+                var currentCall = Interlocked.Increment(ref callCount);
+
+                if (currentCall <= 500)
+                {
+                    return Task.FromResult(Enumerable.Range((int)start, 10)
+                        .Select(i => (RedisValue)$"delayed-{i}").ToArray());
+                }
+
+                if (currentCall == 501)
+                {
+                    return Task.FromResult(Array.Empty<RedisValue>());
+                }
+
+                if (start == 0 && currentCall == 502)
+                {
+                    return Task.FromResult(new RedisValue[] { readyJobId });
+                }
+
+                return Task.FromResult(Array.Empty<RedisValue>());
+            });
+
+        database.HashGetAllAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(callInfo =>
+            {
+                var key = ((RedisKey)callInfo[0]).ToString();
+                if (key.Contains("delayed-"))
+                    return Task.FromResult(new[] { new HashEntry("visibleAfter", futureMs) });
+                return Task.FromResult(Array.Empty<HashEntry>());
+            });
+
+        database.HashSetAsync(Arg.Any<RedisKey>(), Arg.Any<HashEntry[]>(), Arg.Any<CommandFlags>())
+            .Returns(Task.CompletedTask);
+        database.ScriptEvaluateAsync(
+                Arg.Any<string>(),
+                Arg.Any<RedisKey[]>(),
+                Arg.Any<RedisValue[]>(),
+                Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(RedisResult.Create((RedisValue)"1")));
+
+        var redis = Substitute.For<IConnectionMultiplexer>();
+        redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(readyJobId, Arg.Any<CancellationToken>())
+            .Returns(CreateQueuedJob(operationId: readyJobId));
+        jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
+
+        var firstResult = await queue.TryClaimAsync("worker-1");
+        Assert.Null(firstResult);
+
+        var secondResult = await queue.TryClaimAsync("worker-1");
+        Assert.Null(secondResult);
+
+        var thirdResult = await queue.TryClaimAsync("worker-1");
+        Assert.Equal(readyJobId, thirdResult);
+    }
+
+    [UnitTest]
     public async Task TryClaimAsync_WhenKindMismatchedEntriesExceedOldVisitBudget_StillClaimsReadyJob()
     {
         const int mismatchedCount = 1100;

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisJobQueueTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisJobQueueTests.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using StackExchange.Redis;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Verifies that Redis job-queue claim repair stays atomic even when recovery
+/// throws, so queued jobs remain discoverable by either the pending set or the
+/// stale-claim reconciler.
+/// </summary>
+[Collection("Unit")]
+public sealed class RedisJobQueueTests
+{
+    private const string QueueKey = "controlplane:jobqueue:pending";
+    private const string ClaimedSetKey = "controlplane:jobqueue:claimed";
+
+    [UnitTest]
+    public async Task ReconcileStaleClaimsAsync_WhenAtomicRepairThrows_DoesNotFallbackToMultiStepMove()
+    {
+        const string operationId = "job-stale-queued";
+        var repairFailure = new RedisConnectionException(
+            ConnectionFailureType.SocketFailure,
+            "simulated stale-claim repair failure");
+
+        var database = Substitute.For<IDatabase>();
+        database.SortedSetRangeByScoreAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<double>(),
+                Arg.Any<double>(),
+                Arg.Any<Exclude>(),
+                Arg.Any<Order>(),
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(new RedisValue[] { operationId }));
+        database.ScriptEvaluateAsync(
+                Arg.Any<string>(),
+                Arg.Any<RedisKey[]>(),
+                Arg.Any<RedisValue[]>(),
+                Arg.Any<CommandFlags>())
+            .Returns(Task.FromException<RedisResult>(repairFailure));
+
+        var redis = Substitute.For<IConnectionMultiplexer>();
+        redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
+
+        var nextRetryAt = DateTimeOffset.UtcNow.AddMinutes(2);
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(operationId, Arg.Any<CancellationToken>())
+            .Returns(CreateQueuedJob(
+                operationId: operationId,
+                priority: OperationPriority.High,
+                nextRetryAt: nextRetryAt));
+
+        var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
+
+        var exception = await Assert.ThrowsAsync<RedisConnectionException>(() =>
+            queue.ReconcileStaleClaimsAsync(TimeSpan.FromSeconds(60)));
+
+        Assert.Same(repairFailure, exception);
+        Assert.Equal(1, CountCalls(database, nameof(IDatabase.ScriptEvaluateAsync)));
+        Assert.False(HasCall(database, nameof(IDatabase.SortedSetRemoveAsync), (RedisKey)ClaimedSetKey, (RedisValue)operationId));
+        Assert.False(HasCall(database, nameof(IDatabase.SortedSetAddAsync), (RedisKey)QueueKey, (RedisValue)operationId));
+        Assert.False(HasCall(database, nameof(IDatabase.KeyDeleteAsync), (RedisKey)GetClaimMetaKey(operationId)));
+        Assert.False(HasCall(database, nameof(IDatabase.HashSetAsync), (RedisKey)GetClaimMetaKey(operationId)));
+    }
+
+    [UnitTest]
+    public async Task TryClaimAsync_WhenRollbackRepairThrows_DoesNotFallbackToMultiStepMove()
+    {
+        const string operationId = "job-rollback";
+        var storeFailure = new InvalidOperationException("simulated store write failure");
+        var rollbackFailure = new RedisConnectionException(
+            ConnectionFailureType.SocketFailure,
+            "simulated rollback failure");
+
+        var database = Substitute.For<IDatabase>();
+        database.SortedSetRangeByRankAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<Order>(),
+                Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(new RedisValue[] { operationId }));
+        database.HashGetAllAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(Array.Empty<HashEntry>()));
+        database.HashSetAsync(Arg.Any<RedisKey>(), Arg.Any<HashEntry[]>(), Arg.Any<CommandFlags>())
+            .Returns(Task.CompletedTask);
+        database.ScriptEvaluateAsync(
+                Arg.Any<string>(),
+                Arg.Any<RedisKey[]>(),
+                Arg.Any<RedisValue[]>(),
+                Arg.Any<CommandFlags>())
+            .Returns(
+                Task.FromResult(RedisResult.Create((RedisValue)"1")),
+                Task.FromException<RedisResult>(rollbackFailure));
+
+        var redis = Substitute.For<IConnectionMultiplexer>();
+        redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(operationId, Arg.Any<CancellationToken>())
+            .Returns(CreateQueuedJob(operationId: operationId, priority: OperationPriority.Critical));
+        jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(storeFailure));
+
+        var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            queue.TryClaimAsync("worker-1"));
+
+        Assert.Same(storeFailure, exception);
+        Assert.Equal(2, CountCalls(database, nameof(IDatabase.ScriptEvaluateAsync)));
+        Assert.False(HasCall(database, nameof(IDatabase.SortedSetRemoveAsync), (RedisKey)ClaimedSetKey, (RedisValue)operationId));
+        Assert.False(HasCall(database, nameof(IDatabase.SortedSetAddAsync), (RedisKey)QueueKey, (RedisValue)operationId));
+        Assert.False(HasCall(database, nameof(IDatabase.KeyDeleteAsync), (RedisKey)GetClaimMetaKey(operationId)));
+    }
+
+    private static ExecutionJobRecord CreateQueuedJob(
+        string operationId = "job-1",
+        OperationPriority priority = OperationPriority.Normal,
+        DateTimeOffset? nextRetryAt = null)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new ExecutionJobRecord
+        {
+            OperationId = operationId,
+            Status = ExecutionJobStatus.Queued,
+            Priority = priority,
+            CreatedAt = now.AddMinutes(-5),
+            UpdatedAt = now.AddMinutes(-1),
+            NextRetryAt = nextRetryAt,
+            RetryPolicy = JobRetryPolicy.Default,
+            HeartbeatPolicy = JobHeartbeatPolicy.Default,
+            TimeoutPolicy = JobTimeoutPolicy.Default,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "test"
+            }
+        };
+    }
+
+    private static int CountCalls(IDatabase database, string methodName)
+        => database.ReceivedCalls().Count(call => call.GetMethodInfo().Name == methodName);
+
+    private static bool HasCall(IDatabase database, string methodName, params object[] expectedPrefix)
+        => database.ReceivedCalls().Any(call =>
+        {
+            if (call.GetMethodInfo().Name != methodName)
+            {
+                return false;
+            }
+
+            var args = call.GetArguments();
+            if (args.Length < expectedPrefix.Length)
+            {
+                return false;
+            }
+
+            for (var index = 0; index < expectedPrefix.Length; index++)
+            {
+                if (!Equals(args[index], expectedPrefix[index]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        });
+
+    private static string GetClaimMetaKey(string operationId)
+        => $"controlplane:jobqueue:meta:{operationId}";
+}

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisJobQueueTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisJobQueueTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Server.Features.Infrastructure.ControlPlane;
@@ -121,6 +122,37 @@ public sealed class RedisJobQueueTests
         Assert.False(HasCall(database, nameof(IDatabase.SortedSetRemoveAsync), (RedisKey)ClaimedSetKey, (RedisValue)operationId));
         Assert.False(HasCall(database, nameof(IDatabase.SortedSetAddAsync), (RedisKey)QueueKey, (RedisValue)operationId));
         Assert.False(HasCall(database, nameof(IDatabase.KeyDeleteAsync), (RedisKey)GetClaimMetaKey(operationId)));
+    }
+
+    [UnitTest]
+    public async Task TryClaimAsync_WhenAllEntriesDelayed_RespectsVisitBudgetAndTerminates()
+    {
+        var database = Substitute.For<IDatabase>();
+        database.SortedSetRangeByRankAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<Order>(),
+                Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(new RedisValue[] { "delayed-job" }));
+
+        var futureMs = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
+        database.HashGetAllAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(new[] { new HashEntry("visibleAfter", futureMs) }));
+
+        var redis = Substitute.For<IConnectionMultiplexer>();
+        redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
+
+        var result = await queue.TryClaimAsync("worker-visit-budget");
+
+        Assert.Null(result);
+
+        var rangeCallCount = database.ReceivedCalls()
+            .Count(c => c.GetMethodInfo().Name == nameof(IDatabase.SortedSetRangeByRankAsync));
+        Assert.True(rangeCallCount <= 1000, $"Visit budget should cap iteration; got {rangeCallCount} range calls");
     }
 
     private static ExecutionJobRecord CreateQueuedJob(

--- a/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisJobQueueTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisJobQueueTests.cs
@@ -125,7 +125,7 @@ public sealed class RedisJobQueueTests
     }
 
     [UnitTest]
-    public async Task TryClaimAsync_WhenAllEntriesDelayed_RespectsVisitBudgetAndTerminates()
+    public async Task TryClaimAsync_WhenAllEntriesDelayed_RespectsTraverseBudgetAndTerminates()
     {
         var database = Substitute.For<IDatabase>();
         database.SortedSetRangeByRankAsync(
@@ -146,19 +146,148 @@ public sealed class RedisJobQueueTests
         var jobStore = Substitute.For<IExecutionJobStore>();
         var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
 
-        var result = await queue.TryClaimAsync("worker-visit-budget");
+        var result = await queue.TryClaimAsync("worker-traverse-budget");
 
         Assert.Null(result);
 
         var rangeCallCount = database.ReceivedCalls()
             .Count(c => c.GetMethodInfo().Name == nameof(IDatabase.SortedSetRangeByRankAsync));
-        Assert.True(rangeCallCount <= 1000, $"Visit budget should cap iteration; got {rangeCallCount} range calls");
+        Assert.True(rangeCallCount <= 5000, $"Traverse budget should cap iteration; got {rangeCallCount} range calls");
+    }
+
+    [UnitTest]
+    public async Task TryClaimAsync_WhenDelayedEntriesExceedOldVisitBudget_StillClaimsReadyJob()
+    {
+        const int delayedCount = 1100;
+        const string readyJobId = "ready-job-behind-delayed";
+
+        var database = Substitute.For<IDatabase>();
+        database.SortedSetRangeByRankAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<Order>(),
+                Arg.Any<CommandFlags>())
+            .Returns(callInfo =>
+            {
+                var start = (long)callInfo[1];
+                var stop = (long)callInfo[2];
+                var results = new List<RedisValue>();
+
+                for (var i = start; i <= stop && i <= delayedCount; i++)
+                {
+                    results.Add(i < delayedCount ? $"delayed-{i}" : readyJobId);
+                }
+
+                return Task.FromResult(results.ToArray());
+            });
+
+        var futureMs = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds()
+            .ToString(CultureInfo.InvariantCulture);
+        database.HashGetAllAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(callInfo =>
+            {
+                var key = ((RedisKey)callInfo[0]).ToString();
+                if (key.Contains("delayed-"))
+                {
+                    return Task.FromResult(new[] { new HashEntry("visibleAfter", futureMs) });
+                }
+
+                return Task.FromResult(Array.Empty<HashEntry>());
+            });
+
+        database.HashSetAsync(Arg.Any<RedisKey>(), Arg.Any<HashEntry[]>(), Arg.Any<CommandFlags>())
+            .Returns(Task.CompletedTask);
+        database.ScriptEvaluateAsync(
+                Arg.Any<string>(),
+                Arg.Any<RedisKey[]>(),
+                Arg.Any<RedisValue[]>(),
+                Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(RedisResult.Create((RedisValue)"1")));
+
+        var redis = Substitute.For<IConnectionMultiplexer>();
+        redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(readyJobId, Arg.Any<CancellationToken>())
+            .Returns(CreateQueuedJob(operationId: readyJobId));
+        jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
+
+        var result = await queue.TryClaimAsync("worker-1");
+
+        Assert.Equal(readyJobId, result);
+    }
+
+    [UnitTest]
+    public async Task TryClaimAsync_WhenKindMismatchedEntriesExceedOldVisitBudget_StillClaimsReadyJob()
+    {
+        const int mismatchedCount = 1100;
+        const string readyJobId = "ready-job-behind-mismatched";
+        var acceptedKinds = new HashSet<ExecutionJobKind> { ExecutionJobKind.ExtractTransformLoad };
+
+        var database = Substitute.For<IDatabase>();
+        database.SortedSetRangeByRankAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<Order>(),
+                Arg.Any<CommandFlags>())
+            .Returns(callInfo =>
+            {
+                var start = (long)callInfo[1];
+                var stop = (long)callInfo[2];
+                var results = new List<RedisValue>();
+
+                for (var i = start; i <= stop && i <= mismatchedCount; i++)
+                {
+                    results.Add(i < mismatchedCount ? $"mismatched-{i}" : readyJobId);
+                }
+
+                return Task.FromResult(results.ToArray());
+            });
+
+        database.HashGetAllAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(Array.Empty<HashEntry>()));
+        database.HashSetAsync(Arg.Any<RedisKey>(), Arg.Any<HashEntry[]>(), Arg.Any<CommandFlags>())
+            .Returns(Task.CompletedTask);
+        database.ScriptEvaluateAsync(
+                Arg.Any<string>(),
+                Arg.Any<RedisKey[]>(),
+                Arg.Any<RedisValue[]>(),
+                Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(RedisResult.Create((RedisValue)"1")));
+
+        var redis = Substitute.For<IConnectionMultiplexer>();
+        redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
+
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.GetAsync(Arg.Is<string>(id => id.StartsWith("mismatched-")), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var id = (string)callInfo[0];
+                return Task.FromResult<ExecutionJobRecord?>(
+                    CreateQueuedJob(operationId: id, kind: ExecutionJobKind.Geoprocessing));
+            });
+        jobStore.GetAsync(readyJobId, Arg.Any<CancellationToken>())
+            .Returns(CreateQueuedJob(operationId: readyJobId, kind: ExecutionJobKind.ExtractTransformLoad));
+        jobStore.SetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var queue = new RedisJobQueue(redis, jobStore, NullLogger<RedisJobQueue>.Instance);
+
+        var result = await queue.TryClaimAsync("worker-1", acceptedKinds);
+
+        Assert.Equal(readyJobId, result);
     }
 
     private static ExecutionJobRecord CreateQueuedJob(
         string operationId = "job-1",
         OperationPriority priority = OperationPriority.Normal,
-        DateTimeOffset? nextRetryAt = null)
+        DateTimeOffset? nextRetryAt = null,
+        ExecutionJobKind kind = ExecutionJobKind.Geoprocessing)
     {
         var now = DateTimeOffset.UtcNow;
         return new ExecutionJobRecord
@@ -174,7 +303,7 @@ public sealed class RedisJobQueueTests
             TimeoutPolicy = JobTimeoutPolicy.Default,
             Spec = new ExecutionJobSpec
             {
-                Kind = ExecutionJobKind.Geoprocessing,
+                Kind = kind,
                 TargetKind = BatchComputeTargetKind.KubernetesJob,
                 Backend = "local",
                 WorkloadName = "test"

--- a/tests/Honua.Server.Tests/Features/Infrastructure/JobCancellationNotifierExtensionsTests.cs
+++ b/tests/Honua.Server.Tests/Features/Infrastructure/JobCancellationNotifierExtensionsTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Server.Features.Infrastructure;
+using Honua.TestKit.Attributes;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Infrastructure;
+
+/// <summary>
+/// Verifies shared fan-out behavior for multi-worker job cancellation.
+/// </summary>
+[Collection("Unit")]
+public sealed class JobCancellationNotifierExtensionsTests
+{
+    [UnitTest]
+    public void CancelAny_WhenLaterNotifierClaimsJob_ReturnsTrue()
+    {
+        var firstNotifier = Substitute.For<IJobCancellationNotifier>();
+        firstNotifier.Cancel("job-1").Returns(false);
+
+        var secondNotifier = Substitute.For<IJobCancellationNotifier>();
+        secondNotifier.Cancel("job-1").Returns(true);
+
+        var result = new[] { firstNotifier, secondNotifier }.CancelAny("job-1");
+
+        Assert.True(result);
+        firstNotifier.Received(1).Cancel("job-1");
+        secondNotifier.Received(1).Cancel("job-1");
+    }
+
+    [UnitTest]
+    public void CancelAny_WhenNoNotifierClaimsJob_ReturnsFalse()
+    {
+        var firstNotifier = Substitute.For<IJobCancellationNotifier>();
+        var secondNotifier = Substitute.For<IJobCancellationNotifier>();
+
+        var result = new[] { firstNotifier, secondNotifier }.CancelAny("job-1");
+
+        Assert.False(result);
+        firstNotifier.Received(1).Cancel("job-1");
+        secondNotifier.Received(1).Cancel("job-1");
+    }
+}

--- a/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesDismissJobTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesDismissJobTests.cs
@@ -82,6 +82,36 @@ public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.JobDismiss)]
     [Endpoint("DELETE /ogc/processes/jobs/{jobId}")]
+    public async Task DismissJob_AlreadyCancelled_ReturnsOkWhenQueueRemovalFails()
+    {
+        var cancelledJob = new ExecutionJobRecord
+        {
+            OperationId = JobId,
+            Status = ExecutionJobStatus.Cancelled,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            UpdatedAt = DateTimeOffset.UtcNow,
+            CompletedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "test-backend",
+                Kind = ExecutionJobKind.Geoprocessing,
+                WorkloadName = "geo-workload"
+            }
+        };
+
+        _jobStore.GetAsync(JobId, Arg.Any<CancellationToken>()).Returns(cancelledJob);
+        _jobQueue.RemoveAsync(JobId, Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Simulated Redis failure"));
+
+        var response = await _fixture.Client.DeleteAsync($"/ogc/processes/jobs/{JobId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.JobDismiss)]
+    [Endpoint("DELETE /ogc/processes/jobs/{jobId}")]
     public async Task DismissJob_ReReadFindsDeleted_Returns404WithoutRecreatingJob()
     {
         var response = await _fixture.Client.DeleteAsync($"/ogc/processes/jobs/{JobId}");

--- a/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesDismissJobTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesDismissJobTests.cs
@@ -113,6 +113,85 @@ public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.JobDismiss)]
     [Endpoint("DELETE /ogc/processes/jobs/{jobId}")]
+    public async Task DismissJob_UnclaimedCasConflict_RetriesAndDismisses()
+    {
+        var queuedJob = new ExecutionJobRecord
+        {
+            OperationId = JobId,
+            Status = ExecutionJobStatus.Queued,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "test-backend",
+                Kind = ExecutionJobKind.Geoprocessing,
+                WorkloadName = "geo-workload"
+            }
+        };
+
+        _jobStore.GetAsync(JobId, Arg.Any<CancellationToken>()).Returns(queuedJob);
+
+        // First CAS attempt fails (concurrent heartbeat), second succeeds
+        _jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false, true);
+
+        var response = await _fixture.Client.DeleteAsync($"/ogc/processes/jobs/{JobId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await _jobStore.Received(2).TrySetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.OperationId == JobId &&
+                j.Status == ExecutionJobStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await _jobQueue.Received(1).RemoveAsync(JobId, Arg.Any<CancellationToken>());
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.JobDismiss)]
+    [Endpoint("DELETE /ogc/processes/jobs/{jobId}")]
+    public async Task DismissJob_CasConflictRevealsSucceeded_Returns409()
+    {
+        var queuedJob = new ExecutionJobRecord
+        {
+            OperationId = JobId,
+            Status = ExecutionJobStatus.Queued,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "test-backend",
+                Kind = ExecutionJobKind.Geoprocessing,
+                WorkloadName = "geo-workload"
+            }
+        };
+
+        var succeededJob = queuedJob with
+        {
+            Status = ExecutionJobStatus.Succeeded,
+            CompletedAt = DateTimeOffset.UtcNow
+        };
+
+        // Initial reads return queued; CAS re-read reveals succeeded
+        _jobStore.GetAsync(JobId, Arg.Any<CancellationToken>())
+            .Returns(queuedJob, queuedJob, succeededJob);
+
+        _jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var response = await _fixture.Client.DeleteAsync($"/ogc/processes/jobs/{JobId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.JobDismiss)]
+    [Endpoint("DELETE /ogc/processes/jobs/{jobId}")]
     public async Task DismissJob_ReReadFindsDeleted_Returns404WithoutRecreatingJob()
     {
         var response = await _fixture.Client.DeleteAsync($"/ogc/processes/jobs/{JobId}");

--- a/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesDismissJobTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesDismissJobTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.OgcProcesses;
+
+/// <summary>
+/// Verifies that OGC job dismissal does not recreate a cancelled job from a stale
+/// snapshot when the authoritative job record disappears between the initial read
+/// and the post-notifier re-read.
+/// </summary>
+[Collection("Database")]
+[Protocol(Protocols.OgcApiProcesses)]
+public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
+{
+    private const string JobId = "geo-job-001";
+
+    private readonly IExecutionJobStore _jobStore;
+    private readonly IJobQueue _jobQueue;
+    private readonly IUniversalProgressStore _progressStore;
+    private readonly IJobCancellationNotifier _cancellationNotifier;
+    private readonly WebAppFixture _fixture;
+
+    public OgcProcessesDismissJobTests()
+    {
+        _jobStore = Substitute.For<IExecutionJobStore>();
+        _jobQueue = Substitute.For<IJobQueue>();
+        _progressStore = Substitute.For<IUniversalProgressStore>();
+        _cancellationNotifier = Substitute.For<IJobCancellationNotifier>();
+
+        var queuedJob = new ExecutionJobRecord
+        {
+            OperationId = JobId,
+            Status = ExecutionJobStatus.Queued,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "test-backend",
+                Kind = ExecutionJobKind.Geoprocessing,
+                WorkloadName = "geo-workload"
+            }
+        };
+
+        _jobStore.GetAsync(JobId, Arg.Any<CancellationToken>())
+            .Returns(queuedJob, (ExecutionJobRecord?)null);
+        _jobStore.GetAsync(Arg.Is<string>(id => id != JobId), Arg.Any<CancellationToken>())
+            .Returns((ExecutionJobRecord?)null);
+        _jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<ExecutionJobRecord>());
+
+        _cancellationNotifier.Cancel(JobId).Returns(false);
+
+        _fixture = new WebAppFixture()
+            .ReplaceService(_jobStore)
+            .ReplaceService(_jobQueue)
+            .ReplaceService(_progressStore)
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IJobCancellationNotifier>();
+                services.AddSingleton(_cancellationNotifier);
+            });
+    }
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.JobDismiss)]
+    [Endpoint("DELETE /ogc/processes/jobs/{jobId}")]
+    public async Task DismissJob_ReReadFindsDeleted_Returns404WithoutRecreatingJob()
+    {
+        var response = await _fixture.Client.DeleteAsync($"/ogc/processes/jobs/{JobId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        json.RootElement.GetProperty("type").GetString().Should().Contain("no-such-job");
+
+        await _jobStore.DidNotReceive().SetAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+        await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _progressStore.DidNotReceive().SetProgressAsync(
+            Arg.Any<string>(),
+            Arg.Any<Honua.Core.Features.Infrastructure.Domain.IOperationProgress>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesDismissJobTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesDismissJobTests.cs
@@ -192,6 +192,59 @@ public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.JobDismiss)]
     [Endpoint("DELETE /ogc/processes/jobs/{jobId}")]
+    public async Task DismissJob_UnclaimedCasConflict_JobBecomesClaimed_SwitchesToDurableSignal()
+    {
+        var queuedJob = new ExecutionJobRecord
+        {
+            OperationId = JobId,
+            Status = ExecutionJobStatus.Queued,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "test-backend",
+                Kind = ExecutionJobKind.Geoprocessing,
+                WorkloadName = "geo-workload"
+            }
+        };
+
+        var claimedJob = queuedJob with
+        {
+            Status = ExecutionJobStatus.Running,
+            ClaimedBy = "worker-remote-1",
+            ClaimedAt = DateTimeOffset.UtcNow,
+            LastHeartbeatAt = DateTimeOffset.UtcNow
+        };
+
+        // Initial reads return unclaimed; CAS fails; re-read reveals claimed.
+        _jobStore.GetAsync(JobId, Arg.Any<CancellationToken>())
+            .Returns(queuedJob, queuedJob, claimedJob);
+
+        // First CAS fails (direct cancel), second succeeds (durable signal)
+        _jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(false, true);
+
+        var response = await _fixture.Client.DeleteAsync($"/ogc/processes/jobs/{JobId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Must have written CancellationRequestedAt, not terminal Cancelled.
+        await _jobStore.Received().TrySetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.OperationId == JobId &&
+                j.CancellationRequestedAt.HasValue &&
+                j.Status != ExecutionJobStatus.Cancelled),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        // Queue should NOT have been cleaned up — worker owns terminal state.
+        await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.JobDismiss)]
+    [Endpoint("DELETE /ogc/processes/jobs/{jobId}")]
     public async Task DismissJob_ReReadFindsDeleted_Returns404WithoutRecreatingJob()
     {
         var response = await _fixture.Client.DeleteAsync($"/ogc/processes/jobs/{JobId}");

--- a/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesDismissJobTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesDismissJobTests.cs
@@ -12,6 +12,7 @@ using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Honua.Server.Tests.Helpers;
 using NSubstitute;
 
 namespace Honua.Server.Tests.Features.OgcProcesses;
@@ -35,7 +36,7 @@ public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
 
     public OgcProcessesDismissJobTests()
     {
-        _jobStore = Substitute.For<IExecutionJobStore>();
+        _jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
         _jobQueue = Substitute.For<IJobQueue>();
         _progressStore = Substitute.For<IUniversalProgressStore>();
         _cancellationNotifier = Substitute.For<IJobCancellationNotifier>();

--- a/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesExecutionSubmissionTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesExecutionSubmissionTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Server.Tests.Helpers;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.OgcProcesses;
+
+[Collection("Database")]
+[Protocol(Protocols.OgcApiProcesses)]
+public sealed class OgcProcessesExecutionSubmissionTests : IAsyncLifetime
+{
+    private readonly IExecutionJobStore _jobStore;
+    private readonly IJobQueue _jobQueue;
+    private readonly IUniversalProgressStore _progressStore;
+    private readonly WebAppFixture _fixture;
+
+    public OgcProcessesExecutionSubmissionTests()
+    {
+        _jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
+        _jobQueue = Substitute.For<IJobQueue>();
+        _progressStore = Substitute.For<IUniversalProgressStore>();
+
+        ExecutionJobRecord? createdJob = null;
+        _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                createdJob = call.Arg<ExecutionJobRecord>();
+                return true;
+            });
+        _jobStore.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => createdJob == null ? null : createdJob with { Version = 1 });
+        _jobQueue.EnqueueAsync(Arg.Any<string>(), Arg.Any<OperationPriority>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Redis unavailable"));
+
+        _fixture = new WebAppFixture()
+            .ReplaceService(_jobStore)
+            .ReplaceService(_jobQueue)
+            .ReplaceService(_progressStore);
+    }
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.ProcessExecution)]
+    [Endpoint("POST /ogc/processes/processes/{processId}/execution")]
+    public async Task Execute_WhenQueuePersistenceFails_RollsBackCreatedJobUsingFreshVersionToken()
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/ogc/processes/processes/honua-geoprocessing/execution");
+        request.Headers.Add("Prefer", "respond-async");
+        request.Content = new StringContent(
+            """{"inputs":{"plan":{"planId":"plan-rollback","steps":[{"stepId":"s1","kind":"geoprocess","inputs":{"distance":"100"}}]}}}""",
+            Encoding.UTF8,
+            "application/json");
+
+        var response = await _fixture.Client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+
+        await _jobStore.Received().TrySetAsync(
+            Arg.Is<ExecutionJobRecord>(j =>
+                j.Status == ExecutionJobStatus.Failed &&
+                j.Version == 1 &&
+                j.CurrentPhase == "Failed (submission)"),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesJobKindFilterTests.cs
+++ b/tests/Honua.Server.Tests/Features/OgcProcesses/OgcProcessesJobKindFilterTests.cs
@@ -10,6 +10,7 @@ using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.Extensions.DependencyInjection;
+using Honua.Server.Tests.Helpers;
 using NSubstitute;
 
 namespace Honua.Server.Tests.Features.OgcProcesses;
@@ -62,7 +63,7 @@ public sealed class OgcProcessesJobKindFilterTests : IAsyncLifetime
 
     public OgcProcessesJobKindFilterTests()
     {
-        _mockJobStore = Substitute.For<IExecutionJobStore>();
+        _mockJobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
 
         _mockJobStore.GetAsync(EtlJobId, Arg.Any<CancellationToken>())
             .Returns(EtlJob);

--- a/tests/Honua.Server.Tests/Helpers/JobStoreTestExtensions.cs
+++ b/tests/Honua.Server.Tests/Helpers/JobStoreTestExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Helpers;
+
+/// <summary>
+/// Configures <see cref="IExecutionJobStore"/> NSubstitute mocks so that
+/// <see cref="IExecutionJobStore.TrySetAsync"/> delegates to the existing
+/// <see cref="IExecutionJobStore.SetAsync"/> mock and returns <c>true</c>.
+/// </summary>
+internal static class JobStoreTestExtensions
+{
+    internal static IExecutionJobStore WithTrySet(this IExecutionJobStore mock)
+    {
+        mock.TrySetAsync(
+            Arg.Any<ExecutionJobRecord>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>())
+        .Returns(true);
+        return mock;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #681

## Summary
This PR finishes the remaining durable cancellation and submission rollback handling on the durable worker/job substrate so cancellation stays authoritative under CAS conflicts, timeout/shutdown races, and pre-queue submission failures.

## Changes Made
- add a shared execution-job cancellation helper so admin, geoprocessing, and OGC dismiss re-evaluate claimed vs. unclaimed state on every CAS retry
- stop admin cancellation from marking progress Cancelled unless the durable job transition or durable cancellation signal is actually confirmed
- reject idempotent replays of rolled-back submissions and add focused regressions for timeout precedence, claimed-job cancellation transitions, and admin conflict handling

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review