### PR TITLE
feat: End-to-end eval harness for analyst workflows, result packages, and map/app outputs (#734)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,43 @@ jobs:
           cat ./tests/TestResults/server-tests-infra-security.log
           exit "$test_exit_code"
 
+      - name: Run .NET Tests (Server - Operator Eval Harness)
+        timeout-minutes: 20
+        shell: bash
+        run: |
+          set +e
+          dotnet test tests/Honua.Server.Tests/Honua.Server.Tests.csproj \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --filter "FullyQualifiedName~Honua.Server.Tests.Features.Eval|FullyQualifiedName~Honua.Server.Tests.Features.Geoprocessing|FullyQualifiedName~Honua.Server.Tests.Features.OgcProcesses|FullyQualifiedName~Honua.Server.Tests.Features.Grpc" \
+            --logger "trx;LogFileName=server-tests-operator-eval.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults \
+            -- RunConfiguration.MaxCpuCount=1 \
+            > ./tests/TestResults/server-tests-operator-eval.log 2>&1 &
+          test_pid=$!
+
+          while kill -0 "$test_pid" 2>/dev/null; do
+            echo "[server-tests-operator-eval-heartbeat] $(date -u +'%Y-%m-%dT%H:%M:%SZ') running"
+            sleep 30
+          done
+
+          wait "$test_pid"
+          test_exit_code=$?
+          set -e
+
+          cat ./tests/TestResults/server-tests-operator-eval.log
+          exit "$test_exit_code"
+
+      - name: Upload Operator Eval Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: operator-eval-report
+          path: tests/TestResults/eval-report.json
+          if-no-files-found: warn
+
       - name: Run .NET Tests (Architecture)
         timeout-minutes: 10
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,7 @@ jobs:
         with:
           name: operator-eval-report
           path: tests/TestResults/eval-report.json
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Run .NET Tests (Architecture)
         timeout-minutes: 10

--- a/docs/archive/contributor/AI_OPERATOR_ARCHITECTURE.md
+++ b/docs/archive/contributor/AI_OPERATOR_ARCHITECTURE.md
@@ -498,6 +498,16 @@ The evaluation suite should measure:
 - provenance completeness
 - failure recovery behavior
 
+Phase 1 of this strategy is implemented by the end-to-end operator eval harness
+in `tests/Honua.TestKit/Eval/` (see
+[TestKit → Operator Eval Harness](testkit.md#end-to-end-operator-eval-harness)).
+Scenarios declared under `tests/Eval/scenarios/` drive the canonical runtime
+and every protocol adapter through the deterministic stage model and emit a
+versioned `eval-report.json` that `honua-devops-31` consumes as the canonical
+server-side integration gate. Execution-, publish-, package-, and deploy-dependent
+assertions surface as `Skipped(reason)` rows until #730 / #731 / #732 land, so
+the report stays honest about what is proven end-to-end today.
+
 ## Non-Goals
 
 This document does not define:

--- a/docs/archive/contributor/AI_OPERATOR_ARCHITECTURE.md
+++ b/docs/archive/contributor/AI_OPERATOR_ARCHITECTURE.md
@@ -500,7 +500,7 @@ The evaluation suite should measure:
 
 Phase 1 of this strategy is implemented by the end-to-end operator eval harness
 in `tests/Honua.TestKit/Eval/` (see
-[TestKit → Operator Eval Harness](testkit.md#end-to-end-operator-eval-harness)).
+[TestKit → Operator Eval Harness](../../contributor/testkit.md#end-to-end-operator-eval-harness)).
 Scenarios declared under `tests/Eval/scenarios/` drive the canonical runtime
 and every protocol adapter through the deterministic stage model and emit a
 versioned `eval-report.json` that `honua-devops-31` consumes as the canonical

--- a/docs/archive/developer/DETERMINISTIC_OPERATOR_WORKFLOW_RESULTS.md
+++ b/docs/archive/developer/DETERMINISTIC_OPERATOR_WORKFLOW_RESULTS.md
@@ -301,14 +301,17 @@ Claude and Codex evaluations should score:
 The deterministic assertions behind these scores are exercised by the
 end-to-end operator eval harness (`tests/Honua.TestKit/Eval/` plus scenarios
 in `tests/Eval/scenarios/`). Each scenario captures `AnalysisIntent`, compiles
-to an `AnalysisPlan`, validates and dry-runs the plan across gRPC / OGC API
-Processes / GeoServices GPServer, and asserts the expected outcome envelope
-(`isExecutable`, `requiresApproval`, `estimatedArtifactKinds`,
-`terminalWorkflowStatus`, `expectsMapPackage`, `expectsAppPackage`). Results
-are emitted as a versioned `eval-report.json`
+to an `AnalysisPlan`, runs canonical `ValidatePlan` and `DryRun` against the
+gRPC `ProcessService`, and cross-checks plan acceptance through protocol-parity
+probes over OGC API Processes and GeoServices GPServer. Phase 1 asserts the
+outcome envelope (`isExecutable`, `requiresApproval`, `estimatedArtifactKinds`).
+`terminalWorkflowStatus`, `expectsMapPackage`, and `expectsAppPackage` stay in
+the scenario contract for later execution/package stages, but they are not yet
+validated while those stages still report `Skipped`. Results are emitted as a
+versioned `eval-report.json`
 (`reportSchemaVersion = "1"`) so downstream automation can treat the harness
 as a stable gate. See the
-[TestKit Operator Eval Harness](../contributor/testkit.md#end-to-end-operator-eval-harness)
+[TestKit Operator Eval Harness](../../contributor/testkit.md#end-to-end-operator-eval-harness)
 section for scenario authoring and report contract details.
 
 ## Progress Tracking

--- a/docs/archive/developer/DETERMINISTIC_OPERATOR_WORKFLOW_RESULTS.md
+++ b/docs/archive/developer/DETERMINISTIC_OPERATOR_WORKFLOW_RESULTS.md
@@ -298,6 +298,19 @@ Claude and Codex evaluations should score:
 - whether a usable `MapPackage` was produced
 - whether provenance recorded assumptions and clarifications correctly
 
+The deterministic assertions behind these scores are exercised by the
+end-to-end operator eval harness (`tests/Honua.TestKit/Eval/` plus scenarios
+in `tests/Eval/scenarios/`). Each scenario captures `AnalysisIntent`, compiles
+to an `AnalysisPlan`, validates and dry-runs the plan across gRPC / OGC API
+Processes / GeoServices GPServer, and asserts the expected outcome envelope
+(`isExecutable`, `requiresApproval`, `estimatedArtifactKinds`,
+`terminalWorkflowStatus`, `expectsMapPackage`, `expectsAppPackage`). Results
+are emitted as a versioned `eval-report.json`
+(`reportSchemaVersion = "1"`) so downstream automation can treat the harness
+as a stable gate. See the
+[TestKit Operator Eval Harness](../contributor/testkit.md#end-to-end-operator-eval-harness)
+section for scenario authoring and report contract details.
+
 ## Progress Tracking
 
 Geoprocessing workflows report progress through the unified operation progress

--- a/docs/ci/workflow-inventory.md
+++ b/docs/ci/workflow-inventory.md
@@ -1,13 +1,13 @@
 # CI Workflow Inventory
 
 > Canonical inventory of all GitHub Actions workflows across the Honua project.
-> Last updated: 2026-04-03 (ticket #463)
+> Last updated: 2026-04-18 (ticket #734)
 
 ## honua-server
 
 | Workflow file | Name | Tier | Triggers | Merge-blocking | Notes |
 |---|---|---|---|---|---|
-| `ci.yml` | CI | PR | `pull_request`, `push` (trunk) | Yes | Core build, test, architecture gate; includes merge-blocking `esri-leaflet-browser-tests` and uploads STAC plus Esri Leaflet client-compat artifacts |
+| `ci.yml` | CI | PR | `pull_request`, `push` (trunk) | Yes | Core build, test, architecture gate; includes the merge-blocking operator eval harness lane (`Features.Eval|Features.Geoprocessing|Features.OgcProcesses|Features.Grpc`) and uploads `operator-eval-report` plus STAC and Esri Leaflet client-compat artifacts |
 | `pr-validation.yml` | PR Validation | PR | `pull_request` | Yes | Template compliance check |
 | `openapi-contract-governance.yml` | OpenAPI Contract Governance | PR | `pull_request`, `push`, `workflow_dispatch` | Yes | Path-scoped to API surface |
 | `proto-wire-governance.yml` | Proto Wire Governance | PR | `pull_request`, `push`, `workflow_dispatch` | Yes | Path-scoped to `.proto` changes |

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -24,7 +24,7 @@ This section is for people **building or extending** Honua (core contributors, a
 
 ## Testing
 
-- [TestKit (C#)](testkit.md) — fixtures, builders, assertions, parallel execution
+- [TestKit (C#)](testkit.md) — fixtures, builders, assertions, parallel execution, and the operator eval harness/report contract
 - [Public Interface Quality Model](public-interface-quality-model.md) — canonical proof ledger, release evidence rules, and ticket reconciliation for public surfaces
 - [Python Integration Tests](testing-python.md) — pytest OGC and FeatureServer tests
 - [JavaScript Integration Tests](testing-javascript.md) — Vitest protocol coverage plus Playwright Esri Leaflet browser compatibility tests

--- a/docs/contributor/testkit.md
+++ b/docs/contributor/testkit.md
@@ -385,9 +385,12 @@ reflection). Each scenario declares:
   outputs, `assumptionPolicy`)
 - `precompiledPlan` — shape of `AnalysisPlan` (steps, DAG edges, declared
   outputs) used in Phase 1 until the compile seam from #529/#723 lands
-- `expectedOutcome` — asserted `isExecutable`, `requiresApproval`,
-  `estimatedArtifactKinds`, `terminalWorkflowStatus`, and
-  `expectsMapPackage` / `expectsAppPackage` flags
+- `expectedOutcome` — Phase 1 currently asserts `isExecutable`,
+  `requiresApproval`, and `estimatedArtifactKinds`. It also carries forward
+  `terminalWorkflowStatus` plus `expectsMapPackage` / `expectsAppPackage` for
+  later execution/package assertions; today they are forward-declared and not
+  validated against runtime outputs yet (`expectsAppPackage` is the only one
+  that currently affects stage scoping)
 
 The loader resolves scenarios (in order) from `HONUA_EVAL_SCENARIO_ROOT`, the
 `tests/Eval/scenarios/` directory under `Honua.sln`, then the directory next to
@@ -401,12 +404,17 @@ the test binary.
 `ComposeAppPackage` → `PromoteDeployment`. Stages whose upstream capability is
 not yet wired (execution engine, publish surface, package composition, deploy
 promotion) report `Skipped` with a reason rather than failing — only `Failed`
-stages break the gate today.
+stages break the gate today. `SubmitPlanJob` also degrades to
+`Skipped(redis-unavailable)` when the durable Redis-backed job store is absent,
+which keeps local/dev runs honest instead of treating infrastructure gaps as
+contract failures.
 
 `ProtocolParity` cross-checks plan acceptance across gRPC and OGC API
 Processes, and it probes the GPServer `submitJob` surface separately. Because
 the GPServer adapter still lacks a formal task catalog binding, that probe is
 recorded as `Skipped(task-resolution-unavailable)` instead of a false `Passed`.
+When OGC execution cannot enqueue because Redis is unavailable, that probe is
+recorded as `Skipped(service-unavailable)` rather than `Failed`.
 Spans are emitted from the `Honua.Tests.Eval` `ActivitySource` (one span per
 scenario, one per stage).
 

--- a/docs/contributor/testkit.md
+++ b/docs/contributor/testkit.md
@@ -364,6 +364,99 @@ dotnet test --filter "Protocol=Health"
 dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
 ```
 
+## End-to-End Operator Eval Harness
+
+The `Honua.TestKit.Eval` namespace hosts the end-to-end operator-workflow eval
+harness. It drives the canonical `HonuaProcessService` runtime and both
+compatibility adapters (gRPC, OGC API Processes, GeoServices GPServer) through a
+single fixture-backed scenario suite and emits a versioned report that
+`honua-devops-31` treats as the canonical server-side integration gate.
+
+### Authoring scenarios
+
+Scenarios are JSON documents under `tests/Eval/scenarios/*.json`, deserialized
+through the source-generated `EvalJsonContext` (AOT-safe, no runtime
+reflection). Each scenario declares:
+
+- `id`, `name`, `mode` (`Analysis` | `Publish` | `Package` | `Deploy`)
+- `fixtureProfile` (shared-corpus key)
+- `intent` — shape of `AnalysisIntent` (goal, inputs, constraints, requested
+  outputs, `assumptionPolicy`)
+- `precompiledPlan` — shape of `AnalysisPlan` (steps, DAG edges, declared
+  outputs) used in Phase 1 until the compile seam from #529/#723 lands
+- `expectedOutcome` — asserted `isExecutable`, `requiresApproval`,
+  `estimatedArtifactKinds`, `terminalWorkflowStatus`, and
+  `expectsMapPackage` / `expectsAppPackage` flags
+
+The loader resolves scenarios (in order) from `HONUA_EVAL_SCENARIO_ROOT`, the
+`tests/Eval/scenarios/` directory under `Honua.sln`, then the directory next to
+the test binary.
+
+### Stages and protocol parity
+
+`EvalRunner` executes each scenario through a fixed stage sequence:
+`CaptureIntent` → `CompilePlan` → `ValidatePlan` → `DryRun` → `ProtocolParity`
+→ `SubmitPlanJob` → `PollJob` → `GetJobResults` → `ComposeMapPackage` →
+`ComposeAppPackage` → `PromoteDeployment`. Stages whose upstream capability is
+not yet wired (execution engine, publish surface, package composition, deploy
+promotion) report `Skipped` with a reason rather than failing — only `Failed`
+stages break the gate today.
+
+`ProtocolParity` cross-checks plan acceptance across gRPC, OGC API Processes,
+and GeoServices GPServer so divergence between adapters surfaces as a single
+scenario-level diff instead of three unrelated test failures. Spans are emitted
+from the `Honua.Tests.Eval` `ActivitySource` (one span per scenario, one per
+stage).
+
+### Fixture corpus
+
+Fixture resolution is routed through `IEvalFixtureSource`:
+
+- `SharedCorpusFixtureSource` — binds to the geospatial-mcp corpus located by
+  `HONUA_EVAL_CORPUS_PATH`; `HONUA_EVAL_CORPUS_VERSION` is surfaced in the
+  report envelope.
+- `LocalSeedFixtureSource` — falls back to the in-repo `tests/seed/seed.yaml`
+  baseline (`corpusVersion: seed.yaml@v1`) so the harness runs locally without
+  external mounts.
+
+### Report artifact
+
+Each run emits `tests/TestResults/eval-report.json` (override with
+`HONUA_EVAL_REPORT_DIR`) serialized through `EvalJsonContext`. The document is
+pinned to `reportSchemaVersion = "1"` (`EvalReportSchema.Version`) and
+includes:
+
+- `environment` — `corpusSource`, `corpusVersion`, `corpusPath`, `redisAvailable`
+- `scenarios[]` — id, mode, overall `status`
+  (`Passed` / `Failed` / `PassedWithSkips`), per-stage outcomes, protocol parity
+  probes, elapsed ms
+- `rollup` — totals, `firstFailure` pointer, `totalElapsedMs`
+
+`honua-devops-31` pins on the schema version and fails closed on mismatch.
+
+### Running the harness
+
+The harness runs in the **.NET Tests (Server - Operator Eval Harness)** CI
+lane (`ci.yml`), which filters on
+`Features.Eval|Features.Geoprocessing|Features.OgcProcesses|Features.Grpc` and
+uploads the report as the `operator-eval-report` workflow artifact.
+
+Locally:
+
+```bash
+# Run the full operator eval harness lane
+dotnet test tests/Honua.Server.Tests/Honua.Server.Tests.csproj \
+  --filter "FullyQualifiedName~Honua.Server.Tests.Features.Eval"
+
+# Filter by the OperatorEval protocol trait
+dotnet test --filter "Protocol=OperatorEval"
+
+# Point at the shared corpus when available
+HONUA_EVAL_CORPUS_PATH=/path/to/geospatial-mcp \
+HONUA_EVAL_CORPUS_VERSION=core@0001 \
+  dotnet test --filter "Protocol=OperatorEval"
+```
+
 ## Environment Requirements
 
 - Docker (for Testcontainers)

--- a/docs/contributor/testkit.md
+++ b/docs/contributor/testkit.md
@@ -397,7 +397,10 @@ reflection). Each scenario declares:
 
 The loader resolves scenarios (in order) from `HONUA_EVAL_SCENARIO_ROOT`, the
 `tests/Eval/scenarios/` directory under `Honua.sln`, then the directory next to
-the test binary.
+the test binary. When `HONUA_EVAL_SCENARIO_ROOT` is set but points at a
+directory that does not exist, the loader raises `EvalScenarioException`
+instead of silently falling back to the bundled corpus so a typoed override
+cannot mask itself as a green run.
 
 ### Stages and protocol parity
 

--- a/docs/contributor/testkit.md
+++ b/docs/contributor/testkit.md
@@ -402,12 +402,13 @@ reflection). Each scenario declares:
   validated against runtime outputs yet (`expectsAppPackage` is the only one
   that currently affects stage scoping)
 
-The loader resolves scenarios (in order) from `HONUA_EVAL_SCENARIO_ROOT`, the
-`tests/Eval/scenarios/` directory under `Honua.sln`, then the directory next to
-the test binary. When `HONUA_EVAL_SCENARIO_ROOT` is set but points at a
-directory that does not exist, the loader raises `EvalScenarioException`
-instead of silently falling back to the bundled corpus so a typoed override
-cannot mask itself as a green run.
+The loader resolves scenarios (in order) from `HONUA_EVAL_SCENARIO_ROOT`, then
+the `tests/Eval/scenarios/` directory under `Honua.sln`. When
+`HONUA_EVAL_SCENARIO_ROOT` is set but points at a directory that does not
+exist, the loader raises `EvalScenarioException` instead of silently falling
+back to the bundled corpus so a typoed override cannot mask itself as a green
+run. If the loader cannot locate a scenario under either root it also raises
+`EvalScenarioException` with both search locations in the message.
 
 ### Stages and protocol parity
 

--- a/docs/contributor/testkit.md
+++ b/docs/contributor/testkit.md
@@ -426,9 +426,12 @@ expected `isExecutable` value, and `mismatch:{actual}` when it diverges. The
 OGC probe treats `201 Created` as `matched-acceptance` for executable scenarios
 and as `unexpected-acceptance` (Failed) for scenarios that expected rejection;
 conversely `400 Bad Request` is `matched-rejection` (Passed) when the scenario
-expected rejection and `unexpected-rejection` (Failed) otherwise. `503` /
-`501` remain environmental skips, and when OGC execution cannot enqueue
-because Redis is unavailable, that probe is recorded as
+expected rejection and `unexpected-rejection` (Failed) otherwise. `403
+Forbidden` is the OGC adapter's approval-gate rejection emitted after catalog
+validation, so it is `matched-approval-required` (Passed) when the scenario
+expected `requiresApproval: true` and `unexpected-approval-required` (Failed)
+otherwise. `503` / `501` remain environmental skips, and when OGC execution
+cannot enqueue because Redis is unavailable, that probe is recorded as
 `Skipped(service-unavailable)` rather than `Failed`. Because the GPServer
 adapter still lacks a formal task catalog binding, its probe is recorded as
 `Skipped(task-resolution-unavailable)` instead of a false `Passed`. Spans are

--- a/docs/contributor/testkit.md
+++ b/docs/contributor/testkit.md
@@ -386,11 +386,14 @@ reflection). Each scenario declares:
 - `precompiledPlan` — shape of `AnalysisPlan` (steps, DAG edges, declared
   outputs) used in Phase 1 until the compile seam from #529/#723 lands
 - `expectedOutcome` — Phase 1 currently asserts `isExecutable`,
-  `requiresApproval`, and `estimatedArtifactKinds`. It also carries forward
-  `terminalWorkflowStatus` plus `expectsMapPackage` / `expectsAppPackage` for
-  later execution/package assertions; today they are forward-declared and not
-  validated against runtime outputs yet (`expectsAppPackage` is the only one
-  that currently affects stage scoping)
+  `requiresApproval`, and `estimatedArtifactKinds`. `estimatedArtifactKinds` is
+  enforced as an exact set: missing kinds fail with `artifact-kinds-missing` and
+  unexpected kinds fail with `artifact-kinds-unexpected` so drift in either
+  direction is caught. It also carries forward `terminalWorkflowStatus` plus
+  `expectsMapPackage` / `expectsAppPackage` for later execution/package
+  assertions; today they are forward-declared and not validated against runtime
+  outputs yet (`expectsAppPackage` is the only one that currently affects stage
+  scoping)
 
 The loader resolves scenarios (in order) from `HONUA_EVAL_SCENARIO_ROOT`, the
 `tests/Eval/scenarios/` directory under `Honua.sln`, then the directory next to

--- a/docs/contributor/testkit.md
+++ b/docs/contributor/testkit.md
@@ -409,14 +409,31 @@ stages break the gate today. `SubmitPlanJob` also degrades to
 which keeps local/dev runs honest instead of treating infrastructure gaps as
 contract failures.
 
-`ProtocolParity` cross-checks plan acceptance across gRPC and OGC API
-Processes, and it probes the GPServer `submitJob` surface separately. Because
-the GPServer adapter still lacks a formal task catalog binding, that probe is
-recorded as `Skipped(task-resolution-unavailable)` instead of a false `Passed`.
-When OGC execution cannot enqueue because Redis is unavailable, that probe is
-recorded as `Skipped(service-unavailable)` rather than `Failed`.
-Spans are emitted from the `Honua.Tests.Eval` `ActivitySource` (one span per
-scenario, one per stage).
+When a scenario intentionally expects a rejected plan (`isExecutable: false`)
+or an approval-gated plan (`requiresApproval: true`) and `ValidatePlan` matches
+that expectation, `DryRun` and `SubmitPlanJob` are recorded as
+`Skipped(plan-non-executable)` / `Skipped(plan-approval-required)` rather than
+invoking the execution-only RPCs that are contractually guaranteed to reject
+(gRPC `InvalidArgument` for non-executable plans, `FailedPrecondition` for
+approval-gated plans). This keeps negative scenarios expressible without
+polluting the gate with false failures.
+
+`ProtocolParity` cross-checks plan acceptance across gRPC and OGC API Processes
+against the scenario's expected state, and it probes the GPServer `submitJob`
+surface separately. The gRPC probe reports `matched-acceptance` or
+`matched-rejection:{n}-violations` when the validate response matches the
+expected `isExecutable` value, and `mismatch:{actual}` when it diverges. The
+OGC probe treats `201 Created` as `matched-acceptance` for executable scenarios
+and as `unexpected-acceptance` (Failed) for scenarios that expected rejection;
+conversely `400 Bad Request` is `matched-rejection` (Passed) when the scenario
+expected rejection and `unexpected-rejection` (Failed) otherwise. `503` /
+`501` remain environmental skips, and when OGC execution cannot enqueue
+because Redis is unavailable, that probe is recorded as
+`Skipped(service-unavailable)` rather than `Failed`. Because the GPServer
+adapter still lacks a formal task catalog binding, its probe is recorded as
+`Skipped(task-resolution-unavailable)` instead of a false `Passed`. Spans are
+emitted from the `Honua.Tests.Eval` `ActivitySource` (one span per scenario,
+one per stage).
 
 ### Fixture corpus
 

--- a/docs/contributor/testkit.md
+++ b/docs/contributor/testkit.md
@@ -380,20 +380,27 @@ reflection). Each scenario declares:
 
 - `id`, `name`, `mode` (`Analysis` | `Publish` | `Package` | `Deploy`)
 - `fixtureProfile` (seed profile applied to the shared eval schema; all scenarios
-  in one harness run must agree on it)
+  in one harness run must agree on it, and every layer named in `intent.inputs`
+  must be served by that profile's collections in `tests/seed/seed.yaml` —
+  `BundledScenario_DeclaredInputsAreServedByItsFixtureProfile` enforces this at
+  unit-test time so the harness cannot go green against a profile that omits the
+  data a scenario claims to exercise)
 - `intent` — shape of `AnalysisIntent` (goal, inputs, constraints, requested
   outputs, `assumptionPolicy`)
 - `precompiledPlan` — shape of `AnalysisPlan` (steps, DAG edges, declared
   outputs) used in Phase 1 until the compile seam from #529/#723 lands
 - `expectedOutcome` — Phase 1 currently asserts `isExecutable`,
   `requiresApproval`, and `estimatedArtifactKinds`. `estimatedArtifactKinds` is
-  enforced as an exact set: missing kinds fail with `artifact-kinds-missing` and
-  unexpected kinds fail with `artifact-kinds-unexpected` so drift in either
-  direction is caught. It also carries forward `terminalWorkflowStatus` plus
-  `expectsMapPackage` / `expectsAppPackage` for later execution/package
-  assertions; today they are forward-declared and not validated against runtime
-  outputs yet (`expectsAppPackage` is the only one that currently affects stage
-  scoping)
+  enforced as an exact set: missing kinds fail with `artifact-kinds-missing`
+  and unexpected kinds fail with `artifact-kinds-unexpected` so drift in either
+  direction is caught. A proto artifact kind that has no domain counterpart is
+  recorded as a deterministic `artifact-kind-unknown` `DryRun` failure rather
+  than letting the harness throw, so `eval-report.json` is always emitted when
+  the server adds a new proto enum value. It also carries forward
+  `terminalWorkflowStatus` plus `expectsMapPackage` / `expectsAppPackage` for
+  later execution/package assertions; today they are forward-declared and not
+  validated against runtime outputs yet (`expectsAppPackage` is the only one
+  that currently affects stage scoping)
 
 The loader resolves scenarios (in order) from `HONUA_EVAL_SCENARIO_ROOT`, the
 `tests/Eval/scenarios/` directory under `Honua.sln`, then the directory next to

--- a/docs/contributor/testkit.md
+++ b/docs/contributor/testkit.md
@@ -379,7 +379,8 @@ through the source-generated `EvalJsonContext` (AOT-safe, no runtime
 reflection). Each scenario declares:
 
 - `id`, `name`, `mode` (`Analysis` | `Publish` | `Package` | `Deploy`)
-- `fixtureProfile` (shared-corpus key)
+- `fixtureProfile` (seed profile applied to the shared eval schema; all scenarios
+  in one harness run must agree on it)
 - `intent` — shape of `AnalysisIntent` (goal, inputs, constraints, requested
   outputs, `assumptionPolicy`)
 - `precompiledPlan` — shape of `AnalysisPlan` (steps, DAG edges, declared
@@ -402,22 +403,30 @@ not yet wired (execution engine, publish surface, package composition, deploy
 promotion) report `Skipped` with a reason rather than failing — only `Failed`
 stages break the gate today.
 
-`ProtocolParity` cross-checks plan acceptance across gRPC, OGC API Processes,
-and GeoServices GPServer so divergence between adapters surfaces as a single
-scenario-level diff instead of three unrelated test failures. Spans are emitted
-from the `Honua.Tests.Eval` `ActivitySource` (one span per scenario, one per
-stage).
+`ProtocolParity` cross-checks plan acceptance across gRPC and OGC API
+Processes, and it probes the GPServer `submitJob` surface separately. Because
+the GPServer adapter still lacks a formal task catalog binding, that probe is
+recorded as `Skipped(task-resolution-unavailable)` instead of a false `Passed`.
+Spans are emitted from the `Honua.Tests.Eval` `ActivitySource` (one span per
+scenario, one per stage).
 
 ### Fixture corpus
 
-Fixture resolution is routed through `IEvalFixtureSource`:
+Fixture resolution is routed through `IEvalFixtureSource` and applied to the
+shared `WebAppFixture` before host startup:
 
 - `SharedCorpusFixtureSource` — binds to the geospatial-mcp corpus located by
-  `HONUA_EVAL_CORPUS_PATH`; `HONUA_EVAL_CORPUS_VERSION` is surfaced in the
-  report envelope.
+  `HONUA_EVAL_CORPUS_PATH`, which must point to a YAML seed file or a directory
+  containing `seed.yaml`; `HONUA_EVAL_CORPUS_VERSION` is surfaced in the report
+  envelope.
 - `LocalSeedFixtureSource` — falls back to the in-repo `tests/seed/seed.yaml`
   baseline (`corpusVersion: seed.yaml@v1`) so the harness runs locally without
   external mounts.
+
+The harness resolves the single `fixtureProfile` declared by the discoverable
+scenario set and applies that profile with `WebAppFixture.UseSeed(...)`. Mixed
+profiles fail fast because the eval harness intentionally uses one class-scoped
+seeded schema per run.
 
 ### Report artifact
 
@@ -426,7 +435,8 @@ Each run emits `tests/TestResults/eval-report.json` (override with
 pinned to `reportSchemaVersion = "1"` (`EvalReportSchema.Version`) and
 includes:
 
-- `environment` — `corpusSource`, `corpusVersion`, `corpusPath`, `redisAvailable`
+- `environment` — `corpusSource`, `corpusVersion`, `corpusPath`,
+  `redisAvailable` (derived from observed successful `SubmitPlanJob` stages)
 - `scenarios[]` — id, mode, overall `status`
   (`Passed` / `Failed` / `PassedWithSkips`), per-stage outcomes, protocol parity
   probes, elapsed ms

--- a/docs/contributor/testkit.md
+++ b/docs/contributor/testkit.md
@@ -422,14 +422,22 @@ stages break the gate today. `SubmitPlanJob` also degrades to
 which keeps local/dev runs honest instead of treating infrastructure gaps as
 contract failures.
 
-When a scenario intentionally expects a rejected plan (`isExecutable: false`)
-or an approval-gated plan (`requiresApproval: true`) and `ValidatePlan` matches
-that expectation, `DryRun` and `SubmitPlanJob` are recorded as
-`Skipped(plan-non-executable)` / `Skipped(plan-approval-required)` rather than
-invoking the execution-only RPCs that are contractually guaranteed to reject
-(gRPC `InvalidArgument` for non-executable plans, `FailedPrecondition` for
-approval-gated plans). This keeps negative scenarios expressible without
-polluting the gate with false failures.
+`DryRun` is a read operation in the canonical runtime (the gRPC handler
+authorizes it as `OperatorOperation.Read`, and
+`GeoprocessingJobService.DryRunPlan` only enforces plan-structure and catalog
+validity — it does not gate on executability or approval). It therefore still
+runs for scenarios that expect `isExecutable: false` or
+`requiresApproval: true`, and the resulting `DryRun` outcome is scored against
+the scenario's declared `estimatedArtifactKinds` just like any other scenario.
+
+Only `SubmitPlanJob` enforces the execution-only invariants through
+`EnsurePlanExecutable` (rejects non-executable plans as `InvalidArgument`) and
+`EnsureApproved` (rejects approval-gated plans as `FailedPrecondition`). When a
+scenario intentionally expects one of those rejections and `ValidatePlan`
+matches that expectation, `SubmitPlanJob` is recorded as
+`Skipped(plan-non-executable)` or `Skipped(plan-approval-required)` rather
+than invoking the RPC that is contractually guaranteed to reject. This keeps
+negative scenarios expressible without polluting the gate with false failures.
 
 `ProtocolParity` cross-checks plan acceptance across gRPC and OGC API Processes
 against the scenario's expected state, and it probes the GPServer `submitJob`
@@ -447,9 +455,12 @@ otherwise. `503` / `501` remain environmental skips, and when OGC execution
 cannot enqueue because Redis is unavailable, that probe is recorded as
 `Skipped(service-unavailable)` rather than `Failed`. Because the GPServer
 adapter still lacks a formal task catalog binding, its probe is recorded as
-`Skipped(task-resolution-unavailable)` instead of a false `Passed`. Spans are
-emitted from the `Honua.Tests.Eval` `ActivitySource` (one span per scenario,
-one per stage).
+`Skipped(task-resolution-unavailable)` instead of a false `Passed`. When an
+HTTP probe is canceled for a reason other than the outer run's own
+`CancellationToken` (for example an `HttpClient.Timeout` firing), the probe is
+recorded as `Failed(http-timeout)` so the overall scenario keeps its no-throw
+reporting contract instead of aborting mid-run. Spans are emitted from the
+`Honua.Tests.Eval` `ActivitySource` (one span per scenario, one per stage).
 
 ### Fixture corpus
 

--- a/src/Honua.Server/Features/OgcProcesses/CoreEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/CoreEndpoints.cs
@@ -22,9 +22,10 @@ internal static class CoreEndpoints
         "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/core",
         "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/json",
         "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/dismiss",
-        // The /jobs endpoint is implemented (returns the job list in canonical order);
-        // declare it so clients can discover the capability.
-        "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/job-list",
+        // conf/job-list intentionally omitted: the V1 /jobs endpoint lists jobs
+        // but does not yet implement the full conf/job-list requirements
+        // (filtering, paging semantics, links shape). Declare it only when
+        // the implementation fully matches the class.
         "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
         "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/json");
 

--- a/src/Honua.Server/Features/Wfs20/Wfs20DispatcherEndpoint.cs
+++ b/src/Honua.Server/Features/Wfs20/Wfs20DispatcherEndpoint.cs
@@ -199,10 +199,14 @@ internal static class Wfs20DispatcherEndpoint
             }
         }
 
-        // GetCapabilities is inherently XML-only; reject on the Accept header would
-        // break clients that set a broad default like `application/json` as a
-        // catch-all (common in test fixtures and OpenAPI-typed SDK clients).
-        // The server will still respond with application/xml regardless.
+        // GetCapabilities is inherently XML-only. Tolerate catch-all Accept
+        // headers, but honor an explicit rejection of XML (e.g. `q=0` on
+        // application/xml): there is no non-XML representation to fall back on,
+        // so surface 406 Not Acceptable per RFC 9110.
+        if (Wfs20Utilities.AcceptHeaderExplicitlyRejectsXml(context.Request))
+        {
+            return Results.StatusCode(StatusCodes.Status406NotAcceptable);
+        }
 
         var baseUrl = BaseUrlResolver.GetBaseUrl(context);
         var sections = parameters.Get(Wfs20Utilities.ParameterNames.Sections);
@@ -271,10 +275,14 @@ internal static class Wfs20DispatcherEndpoint
             }
 
             // DescribeFeatureType's outputFormat check above already enforces an
-            // XML-compatible format. Don't also reject on the Accept header —
-            // test fixtures and catch-all SDK clients routinely set
-            // `Accept: application/json` and the server always emits XML here
-            // regardless.
+            // XML-compatible format. Tolerate catch-all Accept headers, but
+            // honor an explicit rejection of XML (e.g. `q=0` on
+            // application/xml): there is no non-XML representation to fall back
+            // on, so surface 406 Not Acceptable per RFC 9110.
+            if (Wfs20Utilities.AcceptHeaderExplicitlyRejectsXml(context.Request))
+            {
+                return Results.StatusCode(StatusCodes.Status406NotAcceptable);
+            }
 
             // Handle the request
             var schema = await handler.HandleDescribeFeatureTypeAsync(

--- a/src/Honua.Server/Features/Wfs20/Wfs20Utilities.cs
+++ b/src/Honua.Server/Features/Wfs20/Wfs20Utilities.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Http;
 using Honua.Server.Features.Ogc.Common;
 
 namespace Honua.Server.Features.Wfs20;
@@ -487,5 +489,58 @@ internal static class Wfs20Utilities
 
         normalizedResultType = resultType;
         return false;
+    }
+
+    /// <summary>
+    /// Returns true when the <c>Accept</c> header explicitly rejects XML responses
+    /// (any media range matching <c>application/xml</c>, <c>text/xml</c>, or the
+    /// wildcards with <c>q=0</c>). WFS 2.0 operations are XML-only, so an explicit
+    /// XML rejection should surface as <c>406 Not Acceptable</c> instead of being
+    /// silently ignored.
+    /// </summary>
+    public static bool AcceptHeaderExplicitlyRejectsXml(HttpRequest request)
+    {
+        var values = request.Headers.Accept;
+        if (values.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            foreach (var entry in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (!MediaTypeWithQualityHeaderValue.TryParse(entry, out var parsed))
+                {
+                    continue;
+                }
+
+                if (parsed.Quality is not double quality || quality > 0)
+                {
+                    continue;
+                }
+
+                var mediaType = parsed.MediaType ?? string.Empty;
+                if (MediaTypeMatchesXml(mediaType))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool MediaTypeMatchesXml(string mediaType)
+    {
+        return string.Equals(mediaType, "application/xml", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(mediaType, "text/xml", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(mediaType, "application/*", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(mediaType, "*/*", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/Eval/scenarios/analysis-buffer-places.json
+++ b/tests/Eval/scenarios/analysis-buffer-places.json
@@ -29,8 +29,8 @@
       {
         "stepId": "buffer-places",
         "kind": "Geoprocess",
-        "processId": "honua.geoprocess.buffer",
-        "inputs": { "distance": "500", "units": "meters" },
+        "processId": "analytics.buffer-aggregate",
+        "inputs": { "layerId": "0", "distance": "500", "unit": "meters" },
         "dependsOn": ["query-places"]
       },
       {

--- a/tests/Eval/scenarios/analysis-buffer-places.json
+++ b/tests/Eval/scenarios/analysis-buffer-places.json
@@ -1,0 +1,53 @@
+{
+  "id": "analysis-buffer-places",
+  "name": "Buffer places and summarize overlap",
+  "mode": "Analysis",
+  "fixtureProfile": "core",
+  "intent": {
+    "intentId": "intent-analysis-buffer-places",
+    "goal": "Buffer the seed 'places' layer by 500m and report overlap with roads.",
+    "mode": "analysis",
+    "requestedOutputs": ["FeatureLayer", "Report"],
+    "constraints": {
+      "areaOfInterest": "POLYGON((-180 -90,180 -90,180 90,-180 90,-180 -90))",
+      "spatialReferenceId": 4326,
+      "units": "meters"
+    },
+    "inputs": ["places", "roads"],
+    "assumptionPolicy": "AskWhenMaterial"
+  },
+  "precompiledPlan": {
+    "planId": "plan-analysis-buffer-places",
+    "intentId": "intent-analysis-buffer-places",
+    "steps": [
+      {
+        "stepId": "query-places",
+        "kind": "QueryFeatures",
+        "inputs": { "layer": "places" },
+        "dependsOn": []
+      },
+      {
+        "stepId": "buffer-places",
+        "kind": "Geoprocess",
+        "processId": "honua.geoprocess.buffer",
+        "inputs": { "distance": "500", "units": "meters" },
+        "dependsOn": ["query-places"]
+      },
+      {
+        "stepId": "summarize-overlap",
+        "kind": "Aggregate",
+        "inputs": { "target": "roads" },
+        "dependsOn": ["buffer-places"]
+      }
+    ],
+    "outputs": ["FeatureLayer", "Report"]
+  },
+  "expectedOutcome": {
+    "isExecutable": true,
+    "requiresApproval": false,
+    "estimatedArtifactKinds": ["FeatureLayer", "Report"],
+    "terminalWorkflowStatus": "Completed",
+    "expectsMapPackage": false,
+    "expectsAppPackage": false
+  }
+}

--- a/tests/Eval/scenarios/analysis-buffer-places.json
+++ b/tests/Eval/scenarios/analysis-buffer-places.json
@@ -2,7 +2,7 @@
   "id": "analysis-buffer-places",
   "name": "Buffer places and summarize overlap",
   "mode": "Analysis",
-  "fixtureProfile": "core",
+  "fixtureProfile": "ogc",
   "intent": {
     "intentId": "intent-analysis-buffer-places",
     "goal": "Buffer the seed 'places' layer by 500m and report overlap with roads.",

--- a/tests/Eval/scenarios/package-map-tsunami.json
+++ b/tests/Eval/scenarios/package-map-tsunami.json
@@ -2,7 +2,7 @@
   "id": "package-map-tsunami",
   "name": "Package a tsunami-evacuation operations map",
   "mode": "Package",
-  "fixtureProfile": "core",
+  "fixtureProfile": "ogc",
   "intent": {
     "intentId": "intent-package-map-tsunami",
     "goal": "Compose a map package that overlays roads on buffered places for tsunami evacuation ops.",

--- a/tests/Eval/scenarios/package-map-tsunami.json
+++ b/tests/Eval/scenarios/package-map-tsunami.json
@@ -1,0 +1,59 @@
+{
+  "id": "package-map-tsunami",
+  "name": "Package a tsunami-evacuation operations map",
+  "mode": "Package",
+  "fixtureProfile": "core",
+  "intent": {
+    "intentId": "intent-package-map-tsunami",
+    "goal": "Compose a map package that overlays roads on buffered places for tsunami evacuation ops.",
+    "mode": "package",
+    "requestedOutputs": ["Map", "Report"],
+    "constraints": {
+      "areaOfInterest": "POLYGON((-180 -90,180 -90,180 90,-180 90,-180 -90))",
+      "spatialReferenceId": 4326,
+      "units": "meters"
+    },
+    "inputs": ["places", "roads"],
+    "assumptionPolicy": "AskWhenMaterial"
+  },
+  "precompiledPlan": {
+    "planId": "plan-package-map-tsunami",
+    "intentId": "intent-package-map-tsunami",
+    "steps": [
+      {
+        "stepId": "query-places",
+        "kind": "QueryFeatures",
+        "inputs": { "layer": "places" },
+        "dependsOn": []
+      },
+      {
+        "stepId": "buffer-places",
+        "kind": "Geoprocess",
+        "processId": "honua.geoprocess.buffer",
+        "inputs": { "distance": "1000", "units": "meters" },
+        "dependsOn": ["query-places"]
+      },
+      {
+        "stepId": "query-roads",
+        "kind": "QueryFeatures",
+        "inputs": { "layer": "roads" },
+        "dependsOn": []
+      },
+      {
+        "stepId": "render-ops-map",
+        "kind": "RenderMap",
+        "inputs": { "mapTitle": "Tsunami Evacuation Ops" },
+        "dependsOn": ["buffer-places", "query-roads"]
+      }
+    ],
+    "outputs": ["Map", "Report"]
+  },
+  "expectedOutcome": {
+    "isExecutable": true,
+    "requiresApproval": false,
+    "estimatedArtifactKinds": ["Map", "Report"],
+    "terminalWorkflowStatus": "Completed",
+    "expectsMapPackage": true,
+    "expectsAppPackage": false
+  }
+}

--- a/tests/Eval/scenarios/package-map-tsunami.json
+++ b/tests/Eval/scenarios/package-map-tsunami.json
@@ -29,8 +29,8 @@
       {
         "stepId": "buffer-places",
         "kind": "Geoprocess",
-        "processId": "honua.geoprocess.buffer",
-        "inputs": { "distance": "1000", "units": "meters" },
+        "processId": "analytics.buffer-aggregate",
+        "inputs": { "layerId": "0", "distance": "1000", "unit": "meters" },
         "dependsOn": ["query-places"]
       },
       {

--- a/tests/Eval/scenarios/publish-refresh-roads.json
+++ b/tests/Eval/scenarios/publish-refresh-roads.json
@@ -5,7 +5,7 @@
   "fixtureProfile": "core",
   "intent": {
     "intentId": "intent-publish-refresh-roads",
-    "goal": "Re-run the roads layer projection and republish the canonical layer.",
+    "goal": "Re-simplify the roads layer and republish the canonical layer.",
     "mode": "publish",
     "requestedOutputs": ["FeatureLayer"],
     "constraints": {
@@ -26,17 +26,17 @@
         "dependsOn": []
       },
       {
-        "stepId": "reproject-roads",
+        "stepId": "simplify-roads",
         "kind": "Geoprocess",
-        "processId": "honua.geoprocess.project",
-        "inputs": { "targetSrid": "3857" },
+        "processId": "generalization.simplify-layer",
+        "inputs": { "layerId": "0", "tolerance": "0.001" },
         "dependsOn": ["query-roads"]
       },
       {
         "stepId": "export-roads",
         "kind": "Export",
         "inputs": { "format": "geojson", "layer": "roads" },
-        "dependsOn": ["reproject-roads"]
+        "dependsOn": ["simplify-roads"]
       }
     ],
     "outputs": ["FeatureLayer"]

--- a/tests/Eval/scenarios/publish-refresh-roads.json
+++ b/tests/Eval/scenarios/publish-refresh-roads.json
@@ -2,7 +2,7 @@
   "id": "publish-refresh-roads",
   "name": "Refresh the 'roads' publication with updated features",
   "mode": "Publish",
-  "fixtureProfile": "core",
+  "fixtureProfile": "ogc",
   "intent": {
     "intentId": "intent-publish-refresh-roads",
     "goal": "Re-simplify the roads layer and republish the canonical layer.",

--- a/tests/Eval/scenarios/publish-refresh-roads.json
+++ b/tests/Eval/scenarios/publish-refresh-roads.json
@@ -1,0 +1,52 @@
+{
+  "id": "publish-refresh-roads",
+  "name": "Refresh the 'roads' publication with updated features",
+  "mode": "Publish",
+  "fixtureProfile": "core",
+  "intent": {
+    "intentId": "intent-publish-refresh-roads",
+    "goal": "Re-run the roads layer projection and republish the canonical layer.",
+    "mode": "publish",
+    "requestedOutputs": ["FeatureLayer"],
+    "constraints": {
+      "spatialReferenceId": 4326,
+      "units": "meters"
+    },
+    "inputs": ["roads"],
+    "assumptionPolicy": "UseDefaults"
+  },
+  "precompiledPlan": {
+    "planId": "plan-publish-refresh-roads",
+    "intentId": "intent-publish-refresh-roads",
+    "steps": [
+      {
+        "stepId": "query-roads",
+        "kind": "QueryFeatures",
+        "inputs": { "layer": "roads" },
+        "dependsOn": []
+      },
+      {
+        "stepId": "reproject-roads",
+        "kind": "Geoprocess",
+        "processId": "honua.geoprocess.project",
+        "inputs": { "targetSrid": "3857" },
+        "dependsOn": ["query-roads"]
+      },
+      {
+        "stepId": "export-roads",
+        "kind": "Export",
+        "inputs": { "format": "geojson", "layer": "roads" },
+        "dependsOn": ["reproject-roads"]
+      }
+    ],
+    "outputs": ["FeatureLayer"]
+  },
+  "expectedOutcome": {
+    "isExecutable": true,
+    "requiresApproval": false,
+    "estimatedArtifactKinds": ["FeatureLayer"],
+    "terminalWorkflowStatus": "Completed",
+    "expectsMapPackage": false,
+    "expectsAppPackage": false
+  }
+}

--- a/tests/Honua.Server.Tests/Features/Eval/EvalHarnessFixture.cs
+++ b/tests/Honua.Server.Tests/Features/Eval/EvalHarnessFixture.cs
@@ -32,8 +32,14 @@ public sealed class EvalHarnessFixture : IAsyncLifetime
     /// <inheritdoc />
     public async Task InitializeAsync()
     {
-        await WebApp.InitializeAsync();
+        var scenarios = EvalScenarioLoader.DiscoverScenarioIds()
+            .Select(EvalScenarioLoader.LoadById)
+            .ToArray();
+
         FixtureSource = SharedCorpusFixtureSource.TryCreate() ?? (IEvalFixtureSource)new LocalSeedFixtureSource();
+        var seedProfile = EvalHarnessSupport.ResolveSeedProfile(scenarios);
+        WebApp.UseSeed(FixtureSource.SeedPath, seedProfile);
+        await WebApp.InitializeAsync();
         Runner = new EvalRunner(WebApp, FixtureSource);
     }
 
@@ -84,7 +90,7 @@ public sealed class EvalHarnessFixture : IAsyncLifetime
                 CorpusVersion = FixtureSource.CorpusVersion,
                 CorpusSource = FixtureSource.Id,
                 CorpusPath = FixtureSource.CorpusPath,
-                RedisAvailable = false
+                RedisAvailable = EvalHarnessSupport.DetermineRedisAvailability(snapshot)
             },
             Scenarios = snapshot,
             Rollup = new EvalReportRollup

--- a/tests/Honua.Server.Tests/Features/Eval/EvalHarnessFixture.cs
+++ b/tests/Honua.Server.Tests/Features/Eval/EvalHarnessFixture.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.TestKit;
+using Honua.TestKit.Eval;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Eval;
+
+/// <summary>
+/// Class-scoped fixture that owns the shared <see cref="WebAppFixture"/> for the eval
+/// harness run and aggregates per-scenario results into the versioned
+/// <see cref="EvalReport"/> consumed by honua-devops-31.
+/// </summary>
+public sealed class EvalHarnessFixture : IAsyncLifetime
+{
+    private const string ReportFileName = "eval-report.json";
+
+    private readonly List<EvalScenarioResult> _results = [];
+    private readonly Lock _resultsLock = new();
+
+    /// <summary>Shared web app fixture, initialized once per test class lifetime.</summary>
+    public WebAppFixture WebApp { get; } = new();
+
+    /// <summary>Fixture-corpus source resolved at startup: shared-corpus or local-seed.</summary>
+    public IEvalFixtureSource FixtureSource { get; private set; } = new LocalSeedFixtureSource();
+
+    /// <summary>Bound runner; created once the web host is ready.</summary>
+    public EvalRunner Runner { get; private set; } = null!;
+
+    /// <inheritdoc />
+    public async Task InitializeAsync()
+    {
+        await WebApp.InitializeAsync();
+        FixtureSource = SharedCorpusFixtureSource.TryCreate() ?? (IEvalFixtureSource)new LocalSeedFixtureSource();
+        Runner = new EvalRunner(WebApp, FixtureSource);
+    }
+
+    /// <inheritdoc />
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            EmitReport();
+        }
+        finally
+        {
+            await WebApp.DisposeAsync();
+        }
+    }
+
+    /// <summary>Records the outcome of a scenario run for aggregation into the final report.</summary>
+    public void Record(EvalScenarioResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        lock (_resultsLock)
+        {
+            _results.Add(result);
+        }
+    }
+
+    private void EmitReport()
+    {
+        List<EvalScenarioResult> snapshot;
+        lock (_resultsLock)
+        {
+            snapshot = [.. _results];
+        }
+
+        if (snapshot.Count == 0)
+        {
+            return;
+        }
+
+        var firstFailure = snapshot.FirstOrDefault(s => s.Status == EvalOverallStatus.Failed)?.Id;
+        var totalElapsed = snapshot.Sum(s => s.ElapsedMs);
+
+        var report = new EvalReport
+        {
+            GeneratedAt = DateTimeOffset.UtcNow,
+            Environment = new EvalReportEnvironment
+            {
+                CorpusVersion = FixtureSource.CorpusVersion,
+                CorpusSource = FixtureSource.Id,
+                CorpusPath = FixtureSource.CorpusPath,
+                RedisAvailable = false
+            },
+            Scenarios = snapshot,
+            Rollup = new EvalReportRollup
+            {
+                Total = snapshot.Count,
+                Passed = snapshot.Count(s => s.Status == EvalOverallStatus.Passed),
+                Failed = snapshot.Count(s => s.Status == EvalOverallStatus.Failed),
+                PassedWithSkips = snapshot.Count(s => s.Status == EvalOverallStatus.PassedWithSkips),
+                FirstFailure = firstFailure,
+                TotalElapsedMs = totalElapsed
+            }
+        };
+
+        var outputRoot = ResolveReportDirectory();
+        Directory.CreateDirectory(outputRoot);
+        var reportPath = Path.Combine(outputRoot, ReportFileName);
+        var json = JsonSerializer.Serialize(report, EvalJsonContext.Default.EvalReport);
+        File.WriteAllText(reportPath, json);
+    }
+
+    private static string ResolveReportDirectory()
+    {
+        var overrideDir = Environment.GetEnvironmentVariable("HONUA_EVAL_REPORT_DIR");
+        if (!string.IsNullOrWhiteSpace(overrideDir))
+        {
+            return overrideDir;
+        }
+
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "Honua.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory != null
+            ? Path.Combine(directory.FullName, "tests", "TestResults")
+            : Path.Combine(AppContext.BaseDirectory, "eval-results");
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Eval/EvalHarnessSupportTests.cs
+++ b/tests/Honua.Server.Tests/Features/Eval/EvalHarnessSupportTests.cs
@@ -113,4 +113,29 @@ public sealed class EvalHarnessSupportTests
             tempDirectory.Delete(recursive: true);
         }
     }
+
+    [UnitTest]
+    [Operation(Operations.ContractTesting)]
+    public void EvalScenarioLoader_WithInvalidScenarioRootOverride_FailsClosed()
+    {
+        const string OverrideVariable = "HONUA_EVAL_SCENARIO_ROOT";
+        var original = Environment.GetEnvironmentVariable(OverrideVariable);
+        var missingDirectory = Path.Combine(Path.GetTempPath(), "honua-eval-missing-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Environment.SetEnvironmentVariable(OverrideVariable, missingDirectory);
+
+            var loadAct = () => EvalScenarioLoader.LoadById("analysis-buffer-places");
+            var discoverAct = () => EvalScenarioLoader.DiscoverScenarioIds();
+
+            loadAct.Should().Throw<EvalScenarioException>()
+                .WithMessage($"*{missingDirectory}*directory does not exist*");
+            discoverAct.Should().Throw<EvalScenarioException>()
+                .WithMessage($"*{missingDirectory}*directory does not exist*");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(OverrideVariable, original);
+        }
+    }
 }

--- a/tests/Honua.Server.Tests/Features/Eval/EvalHarnessSupportTests.cs
+++ b/tests/Honua.Server.Tests/Features/Eval/EvalHarnessSupportTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.TestKit.Eval;
+using Honua.TestKit.Seeding;
 using Xunit;
 
 namespace Honua.Server.Tests.Features.Eval;
@@ -112,6 +113,56 @@ public sealed class EvalHarnessSupportTests
         {
             tempDirectory.Delete(recursive: true);
         }
+    }
+
+    [Theory]
+    [MemberData(nameof(BundledScenarioIds))]
+    [Operation(Operations.ContractTesting)]
+    [Trait("Category", "Unit")]
+    public void BundledScenario_DeclaredInputsAreServedByItsFixtureProfile(string scenarioId)
+    {
+        var scenario = EvalScenarioLoader.LoadById(scenarioId);
+        var seedPath = ResolveRepoRelativePath(Path.Combine("tests", "seed", "seed.yaml"));
+
+        File.Exists(seedPath).Should().BeTrue(
+            because: $"seed corpus must be discoverable at '{seedPath}' for eval harness validation");
+
+        var allowed = SeedRunner.GetAllowedCollections(seedPath, scenario.FixtureProfile);
+
+        allowed.Should().NotBeNull(
+            because: $"scenario '{scenarioId}' declares fixtureProfile '{scenario.FixtureProfile}' " +
+                     "which must exist in the seed corpus");
+
+        var missing = scenario.Intent.Inputs
+            .Where(input => !allowed!.Contains(input, StringComparer.OrdinalIgnoreCase))
+            .ToArray();
+
+        missing.Should().BeEmpty(
+            because: $"scenario '{scenarioId}' declares inputs [{string.Join(", ", scenario.Intent.Inputs)}] " +
+                     $"but fixtureProfile '{scenario.FixtureProfile}' only seeds " +
+                     $"[{string.Join(", ", allowed!)}]. Either change fixtureProfile or expand the profile's " +
+                     "collections in tests/seed/seed.yaml so CI provisions the data the scenario claims to exercise.");
+    }
+
+    public static IEnumerable<object[]> BundledScenarioIds()
+    {
+        foreach (var id in EvalScenarioLoader.DiscoverScenarioIds())
+        {
+            yield return [id];
+        }
+    }
+
+    private static string ResolveRepoRelativePath(string relative)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "Honua.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory != null
+            ? Path.Combine(directory.FullName, relative)
+            : Path.Combine(AppContext.BaseDirectory, relative);
     }
 
     [UnitTest]

--- a/tests/Honua.Server.Tests/Features/Eval/EvalHarnessSupportTests.cs
+++ b/tests/Honua.Server.Tests/Features/Eval/EvalHarnessSupportTests.cs
@@ -1,0 +1,116 @@
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Eval;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Eval;
+
+[Protocol(Protocols.OperatorEval)]
+public sealed class EvalHarnessSupportTests
+{
+    [UnitTest]
+    [Operation(Operations.ContractTesting)]
+    public void ResolveSeedProfile_WithMixedScenarioProfiles_Throws()
+    {
+        var scenarios = new[]
+        {
+            new EvalScenario { Id = "core", FixtureProfile = "core" },
+            new EvalScenario { Id = "ogc", FixtureProfile = "ogc" }
+        };
+
+        var act = () => EvalHarnessSupport.ResolveSeedProfile(scenarios);
+
+        act.Should().Throw<EvalScenarioException>()
+            .WithMessage("*single fixture profile*");
+    }
+
+    [UnitTest]
+    [Operation(Operations.ContractTesting)]
+    public void DetermineRedisAvailability_WhenSubmitStagePassed_ReturnsTrue()
+    {
+        var results = new[]
+        {
+            new EvalScenarioResult
+            {
+                Stages =
+                [
+                    new EvalStageOutcome
+                    {
+                        Stage = EvalStageKind.SubmitPlanJob,
+                        Status = EvalStageStatus.Passed
+                    }
+                ]
+            }
+        };
+
+        EvalHarnessSupport.DetermineRedisAvailability(results).Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Operation(Operations.ContractTesting)]
+    public void DetermineRedisAvailability_WhenSubmitStageSkippedForRedisUnavailable_ReturnsFalse()
+    {
+        var results = new[]
+        {
+            new EvalScenarioResult
+            {
+                Stages =
+                [
+                    new EvalStageOutcome
+                    {
+                        Stage = EvalStageKind.SubmitPlanJob,
+                        Status = EvalStageStatus.Skipped,
+                        Reason = "redis-unavailable"
+                    }
+                ]
+            }
+        };
+
+        EvalHarnessSupport.DetermineRedisAvailability(results).Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.ContractTesting)]
+    public void SharedCorpusFixtureSource_TryCreate_WithSeedDirectory_ResolvesSeedPath()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var seedPath = Path.Combine(tempDirectory.FullName, "seed.yaml");
+            File.WriteAllText(seedPath, "version: 1\ncollections: []\nfeatures: []\n");
+
+            var source = SharedCorpusFixtureSource.TryCreate(tempDirectory.FullName, "corpus@123");
+
+            source.Should().NotBeNull();
+            source!.Id.Should().Be("shared");
+            source.CorpusPath.Should().Be(tempDirectory.FullName);
+            source.CorpusVersion.Should().Be("corpus@123");
+            source.SeedPath.Should().Be(seedPath);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [UnitTest]
+    [Operation(Operations.ContractTesting)]
+    public void SharedCorpusFixtureSource_TryCreate_WithMissingSeed_Throws()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var act = () => SharedCorpusFixtureSource.TryCreate(tempDirectory.FullName, "corpus@123");
+
+            act.Should().Throw<InvalidOperationException>()
+                .WithMessage("*must point to a YAML seed file or a directory containing seed.yaml*");
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
+++ b/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
@@ -129,6 +129,93 @@ public sealed class EvalHarnessTests : IClassFixture<EvalHarnessFixture>
     }
 
     /// <summary>
+    /// An approval-gated scenario must still exercise the canonical DryRun contract
+    /// (a Read operation that does not enforce executability or approval) while only
+    /// SubmitPlanJob is skipped because it is the RPC that actually enforces the
+    /// approval gate. Without the split, DryRun would record a synthetic skip and the
+    /// harness would never observe a real artifact-kind mismatch against the seeded
+    /// runtime for approval-gated plans.
+    /// </summary>
+    [IntegrationTest]
+    [Operation(Operations.ContractTesting)]
+    public async Task ApprovalRequiredScenario_RunsDryRun_SkipsOnlySubmitPlanJob()
+    {
+        var approvalFixture = new WebAppFixture()
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IOperatorApprovalEvaluator>();
+                services.AddSingleton<IOperatorApprovalEvaluator>(new DestructiveOnlyApprovalEvaluator());
+            });
+
+        try
+        {
+            await approvalFixture.InitializeAsync();
+            var runner = new EvalRunner(approvalFixture, new LocalSeedFixtureSource());
+            var scenario = BuildDestructiveApprovalScenario();
+
+            var result = await runner.RunAsync(scenario, CancellationToken.None);
+
+            var dryRun = result.Stages.Single(stage => stage.Stage == EvalStageKind.DryRun);
+            dryRun.Status.Should().Be(EvalStageStatus.Passed,
+                because: "DryRun is authorized as a Read operation and must still run against approval-gated plans");
+            dryRun.Reason.Should().BeNull();
+
+            var submit = result.Stages.Single(stage => stage.Stage == EvalStageKind.SubmitPlanJob);
+            submit.Status.Should().Be(EvalStageStatus.Skipped,
+                because: "SubmitPlanJob is the execution-only RPC that enforces EnsureApproved");
+            submit.Reason.Should().Be("plan-approval-required");
+        }
+        finally
+        {
+            await approvalFixture.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// HTTP parity probes must convert transport-level timeouts (e.g. <c>HttpClient.Timeout</c>
+    /// firing) into a deterministic <c>Failed(http-timeout)</c> probe rather than letting
+    /// the <c>TaskCanceledException</c> propagate and abort the scenario. This preserves
+    /// <see cref="EvalRunner.RunAsync"/>'s no-throw reporting contract.
+    /// </summary>
+    [IntegrationTest]
+    [Operation(Operations.ContractTesting)]
+    public async Task Probes_WhenHttpClientTimeoutFires_ReportFailedWithoutAbortingScenario()
+    {
+        var timeoutFixture = new WebAppFixture();
+
+        try
+        {
+            await timeoutFixture.InitializeAsync();
+            // Forcing an extreme client-level timeout guarantees the HTTP probes will
+            // surface OperationCanceledException unrelated to the caller's token. The
+            // fix converts that into a Failed(http-timeout) probe instead of aborting
+            // RunAsync.
+            timeoutFixture.Client.Timeout = TimeSpan.FromTicks(1);
+
+            var runner = new EvalRunner(timeoutFixture, new LocalSeedFixtureSource());
+            var scenario = EvalScenarioLoader.LoadById("analysis-buffer-places");
+
+            var result = await runner.RunAsync(scenario, CancellationToken.None);
+
+            result.Should().NotBeNull();
+
+            var ogcProbe = result.ProtocolParity.Probes
+                .Single(probe => probe.Protocol == Protocols.OgcApiProcesses);
+            ogcProbe.Status.Should().Be(EvalStageStatus.Failed);
+            ogcProbe.Outcome.Should().Be("http-timeout");
+
+            var gpServerProbe = result.ProtocolParity.Probes
+                .Single(probe => probe.Protocol == Protocols.GPServer);
+            gpServerProbe.Status.Should().Be(EvalStageStatus.Failed);
+            gpServerProbe.Outcome.Should().Be("http-timeout");
+        }
+        finally
+        {
+            await timeoutFixture.DisposeAsync();
+        }
+    }
+
+    /// <summary>
     /// Enumerates every scenario id under <c>tests/Eval/scenarios/</c> so the harness
     /// suite expands automatically as the corpus grows.
     /// </summary>

--- a/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
+++ b/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
@@ -1,10 +1,17 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Security.Claims;
 using FluentAssertions;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.TestKit.Eval;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
 
 namespace Honua.Server.Tests.Features.Eval;
@@ -59,6 +66,44 @@ public sealed class EvalHarnessTests : IClassFixture<EvalHarnessFixture>
     }
 
     /// <summary>
+    /// OGC protocol parity must treat a 403 approval-required response as a matched
+    /// rejection when the scenario itself expects <c>RequiresApproval=true</c>. Without
+    /// this, any future approval-gated scenario would incorrectly fail parity even
+    /// though the OGC adapter matches the canonical runtime's approval gate exactly.
+    /// </summary>
+    [IntegrationTest]
+    [Operation(Operations.ContractTesting)]
+    public async Task OgcProbe_ApprovalRequiredScenario_MatchesApprovalRejection()
+    {
+        var approvalFixture = new WebAppFixture()
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IOperatorApprovalEvaluator>();
+                services.AddSingleton<IOperatorApprovalEvaluator>(new DestructiveOnlyApprovalEvaluator());
+            });
+
+        try
+        {
+            await approvalFixture.InitializeAsync();
+            var runner = new EvalRunner(approvalFixture, new LocalSeedFixtureSource());
+            var scenario = BuildDestructiveApprovalScenario();
+
+            var result = await runner.RunAsync(scenario, CancellationToken.None);
+
+            var ogcProbe = result.ProtocolParity.Probes
+                .Single(probe => probe.Protocol == Protocols.OgcApiProcesses);
+
+            ogcProbe.Assertion.Should().Be("plan-shape-accepted");
+            ogcProbe.Outcome.Should().Be("matched-approval-required");
+            ogcProbe.Status.Should().Be(EvalStageStatus.Passed);
+        }
+        finally
+        {
+            await approvalFixture.DisposeAsync();
+        }
+    }
+
+    /// <summary>
     /// Enumerates every scenario id under <c>tests/Eval/scenarios/</c> so the harness
     /// suite expands automatically as the corpus grows.
     /// </summary>
@@ -83,5 +128,58 @@ public sealed class EvalHarnessTests : IClassFixture<EvalHarnessFixture>
                      string.Join(", ", result.Stages
                          .Where(s => s.Status == EvalStageStatus.Failed)
                          .Select(s => $"{s.Stage}({s.Reason})")));
+    }
+
+    private static EvalScenario BuildDestructiveApprovalScenario() => new()
+    {
+        Id = "approval-required-delete-features",
+        Name = "Delete-features plan that must clear the approval gate",
+        Mode = EvalScenarioMode.Analysis,
+        FixtureProfile = "core",
+        Intent = new EvalIntentSpec
+        {
+            IntentId = "intent-approval-required-delete-features",
+            Goal = "Bulk-delete features from the roads layer (destructive; requires approval).",
+            Mode = "analysis",
+            RequestedOutputs = [ArtifactKind.Scalar],
+            Inputs = ["roads"],
+            AssumptionPolicy = AssumptionPolicy.UseDefaults
+        },
+        PrecompiledPlan = new EvalPlanSpec
+        {
+            PlanId = "plan-approval-required-delete-features",
+            IntentId = "intent-approval-required-delete-features",
+            Steps =
+            [
+                new EvalPlanStepSpec
+                {
+                    StepId = "delete-roads",
+                    Kind = AnalysisPlanStepKind.Geoprocess,
+                    ProcessId = "data-management.delete-features",
+                    Inputs = new Dictionary<string, string>
+                    {
+                        ["layerId"] = "0",
+                        ["where"] = "OBJECTID > 0"
+                    }
+                }
+            ],
+            Outputs = [ArtifactKind.Scalar]
+        },
+        ExpectedOutcome = new EvalExpectedOutcome
+        {
+            IsExecutable = true,
+            RequiresApproval = true,
+            EstimatedArtifactKinds = [ArtifactKind.Scalar]
+        }
+    };
+
+    private sealed class DestructiveOnlyApprovalEvaluator : IOperatorApprovalEvaluator
+    {
+        public ApprovalRequirement Evaluate(ClaimsPrincipal principal, OperatorAuthorizationRequest request)
+            => request.IsDestructive
+                ? ApprovalRequirement.Required(
+                    $"operator.destructive.{request.ResourceType.ToString().ToLowerInvariant()}",
+                    "destructive-action-requires-approval")
+                : ApprovalRequirement.NotRequired();
     }
 }

--- a/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
+++ b/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
@@ -26,28 +26,17 @@ public sealed class EvalHarnessTests : IClassFixture<EvalHarnessFixture>
         _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
     }
 
-    /// <summary>Analysis-mode scenario: buffer seeded places and summarize overlap with roads.</summary>
-    [IntegrationTest]
+    /// <summary>
+    /// Runs every scenario discovered under <c>tests/Eval/scenarios/</c> so that adding
+    /// a new JSON scenario automatically contributes to <c>eval-report.json</c> without
+    /// requiring a code change here.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DiscoveredScenarioIds))]
     [Operation(Operations.ContractTesting)]
-    public async Task AnalysisBufferPlaces_PassesEndToEnd()
+    public async Task Scenario_PassesEndToEnd(string scenarioId)
     {
-        await RunScenarioAsync("analysis-buffer-places");
-    }
-
-    /// <summary>Publish-mode scenario: refresh the roads layer publication.</summary>
-    [IntegrationTest]
-    [Operation(Operations.ContractTesting)]
-    public async Task PublishRefreshRoads_PassesEndToEnd()
-    {
-        await RunScenarioAsync("publish-refresh-roads");
-    }
-
-    /// <summary>Package-mode scenario: compose a tsunami-evacuation operations map.</summary>
-    [IntegrationTest]
-    [Operation(Operations.ContractTesting)]
-    public async Task PackageMapTsunami_PassesEndToEnd()
-    {
-        await RunScenarioAsync("package-map-tsunami");
+        await RunScenarioAsync(scenarioId);
     }
 
     /// <summary>
@@ -67,6 +56,18 @@ public sealed class EvalHarnessTests : IClassFixture<EvalHarnessFixture>
         gpServerProbe.Assertion.Should().Be("submit-job-surface");
         gpServerProbe.Status.Should().Be(EvalStageStatus.Skipped);
         gpServerProbe.Outcome.Should().Be("task-resolution-unavailable");
+    }
+
+    /// <summary>
+    /// Enumerates every scenario id under <c>tests/Eval/scenarios/</c> so the harness
+    /// suite expands automatically as the corpus grows.
+    /// </summary>
+    public static IEnumerable<object[]> DiscoveredScenarioIds()
+    {
+        foreach (var id in EvalScenarioLoader.DiscoverScenarioIds())
+        {
+            yield return [id];
+        }
     }
 
     private async Task RunScenarioAsync(string scenarioId)

--- a/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
+++ b/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
@@ -160,7 +160,7 @@ public sealed class EvalHarnessTests : IClassFixture<EvalHarnessFixture>
         Id = "approval-required-delete-features",
         Name = "Delete-features plan that must clear the approval gate",
         Mode = EvalScenarioMode.Analysis,
-        FixtureProfile = "core",
+        FixtureProfile = "ogc",
         Intent = new EvalIntentSpec
         {
             IntentId = "intent-approval-required-delete-features",

--- a/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
+++ b/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
@@ -216,6 +216,28 @@ public sealed class EvalHarnessTests : IClassFixture<EvalHarnessFixture>
     }
 
     /// <summary>
+    /// Caller cancellation of the scenario's <see cref="CancellationToken"/> must abort
+    /// <see cref="EvalRunner.RunAsync"/> with an <see cref="OperationCanceledException"/>
+    /// rather than being swallowed into <c>Failed(grpc-cancelled)</c> stage outcomes.
+    /// gRPC surfaces caller cancellation as <c>StatusCode.Cancelled</c>, so each gRPC
+    /// stage helper must distinguish caller cancel from a server-side cancel status
+    /// and propagate the former unchanged.
+    /// </summary>
+    [IntegrationTest]
+    [Operation(Operations.ContractTesting)]
+    public async Task RunAsync_WhenCallerTokenIsCancelled_PropagatesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var scenario = EvalScenarioLoader.LoadById("analysis-buffer-places");
+
+        var act = async () => await _fixture.Runner.RunAsync(scenario, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    /// <summary>
     /// Enumerates every scenario id under <c>tests/Eval/scenarios/</c> so the harness
     /// suite expands automatically as the corpus grows.
     /// </summary>

--- a/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
+++ b/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
@@ -50,6 +50,25 @@ public sealed class EvalHarnessTests : IClassFixture<EvalHarnessFixture>
         await RunScenarioAsync("package-map-tsunami");
     }
 
+    /// <summary>
+    /// GPServer parity must stay honest until the adapter can bind eval scenarios to a
+    /// formal GP task catalog.
+    /// </summary>
+    [IntegrationTest]
+    [Operation(Operations.ContractTesting)]
+    public async Task AnalysisBufferPlaces_RecordsGpServerProbeAsSkippedUntilTaskBindingExists()
+    {
+        var scenario = EvalScenarioLoader.LoadById("analysis-buffer-places");
+        var result = await _fixture.Runner.RunAsync(scenario, CancellationToken.None);
+
+        var gpServerProbe = result.ProtocolParity.Probes
+            .Single(probe => probe.Protocol == Protocols.GPServer);
+
+        gpServerProbe.Assertion.Should().Be("submit-job-surface");
+        gpServerProbe.Status.Should().Be(EvalStageStatus.Skipped);
+        gpServerProbe.Outcome.Should().Be("task-resolution-unavailable");
+    }
+
     private async Task RunScenarioAsync(string scenarioId)
     {
         var scenario = EvalScenarioLoader.LoadById(scenarioId);

--- a/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
+++ b/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Eval;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Eval;
+
+/// <summary>
+/// End-to-end operator-workflow eval harness. Drives the canonical process runtime and
+/// its gRPC / OGC API Processes / GeoServices GPServer adapters through a fixture-backed
+/// scenario suite and emits the versioned report consumed by honua-devops-31.
+/// </summary>
+[Collection("Database")]
+[Protocol(Protocols.OperatorEval, Protocols.Grpc, Protocols.OgcApiProcesses, Protocols.GPServer)]
+public sealed class EvalHarnessTests : IClassFixture<EvalHarnessFixture>
+{
+    private readonly EvalHarnessFixture _fixture;
+
+    /// <summary>Creates a new instance bound to the shared class-scoped fixture.</summary>
+    public EvalHarnessTests(EvalHarnessFixture fixture)
+    {
+        _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+    }
+
+    /// <summary>Analysis-mode scenario: buffer seeded places and summarize overlap with roads.</summary>
+    [IntegrationTest]
+    [Operation(Operations.ContractTesting)]
+    public async Task AnalysisBufferPlaces_PassesEndToEnd()
+    {
+        await RunScenarioAsync("analysis-buffer-places");
+    }
+
+    /// <summary>Publish-mode scenario: refresh the roads layer publication.</summary>
+    [IntegrationTest]
+    [Operation(Operations.ContractTesting)]
+    public async Task PublishRefreshRoads_PassesEndToEnd()
+    {
+        await RunScenarioAsync("publish-refresh-roads");
+    }
+
+    /// <summary>Package-mode scenario: compose a tsunami-evacuation operations map.</summary>
+    [IntegrationTest]
+    [Operation(Operations.ContractTesting)]
+    public async Task PackageMapTsunami_PassesEndToEnd()
+    {
+        await RunScenarioAsync("package-map-tsunami");
+    }
+
+    private async Task RunScenarioAsync(string scenarioId)
+    {
+        var scenario = EvalScenarioLoader.LoadById(scenarioId);
+        var result = await _fixture.Runner.RunAsync(scenario, CancellationToken.None);
+        _fixture.Record(result);
+
+        // Phase 1: execution-engine and publish-surface stages are intentionally
+        // Skipped; only outright Failed scenarios break the gate.
+        result.Status.Should().NotBe(EvalOverallStatus.Failed,
+            because: $"scenario '{scenarioId}' reported a failed stage: " +
+                     string.Join(", ", result.Stages
+                         .Where(s => s.Status == EvalStageStatus.Failed)
+                         .Select(s => $"{s.Stage}({s.Reason})")));
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
+++ b/tests/Honua.Server.Tests/Features/Eval/EvalHarnessTests.cs
@@ -66,6 +66,31 @@ public sealed class EvalHarnessTests : IClassFixture<EvalHarnessFixture>
     }
 
     /// <summary>
+    /// Dry-run validation must fail when the server reports artifact kinds beyond the
+    /// scenario's declared set. Subset-only comparison would silently accept drift in
+    /// the canonical runtime's artifact surface, weakening the eval gate's contract.
+    /// </summary>
+    [IntegrationTest]
+    [Operation(Operations.ContractTesting)]
+    public async Task DryRun_UnexpectedArtifactKinds_FailsScenario()
+    {
+        var baseScenario = EvalScenarioLoader.LoadById("analysis-buffer-places");
+        var scenario = baseScenario with
+        {
+            ExpectedOutcome = baseScenario.ExpectedOutcome with
+            {
+                EstimatedArtifactKinds = [ArtifactKind.FeatureLayer]
+            }
+        };
+
+        var result = await _fixture.Runner.RunAsync(scenario, CancellationToken.None);
+
+        var dryRun = result.Stages.Single(stage => stage.Stage == EvalStageKind.DryRun);
+        dryRun.Status.Should().Be(EvalStageStatus.Failed);
+        dryRun.Reason.Should().Be("artifact-kinds-unexpected");
+    }
+
+    /// <summary>
     /// OGC protocol parity must treat a 403 approval-required response as a matched
     /// rejection when the scenario itself expects <c>RequiresApproval=true</c>. Without
     /// this, any future approval-gated scenario would incorrectly fail parity even

--- a/tests/Honua.TestKit/Constants/Protocols.cs
+++ b/tests/Honua.TestKit/Constants/Protocols.cs
@@ -139,4 +139,10 @@ public static class Protocols
     /// Model Context Protocol operator surface (planning, execution, lifecycle).
     /// </summary>
     public const string Mcp = "Mcp";
+
+    /// <summary>
+    /// End-to-end operator workflow eval harness (analyst workflows,
+    /// result packages, map/app outputs).
+    /// </summary>
+    public const string OperatorEval = "OperatorEval";
 }

--- a/tests/Honua.TestKit/Eval/EvalFixtureSource.cs
+++ b/tests/Honua.TestKit/Eval/EvalFixtureSource.cs
@@ -19,6 +19,11 @@ public interface IEvalFixtureSource
 
     /// <summary>Resolved corpus path when applicable (shared corpus only).</summary>
     string? CorpusPath { get; }
+
+    /// <summary>
+    /// YAML seed file applied to the shared eval schema before the web host starts.
+    /// </summary>
+    string SeedPath { get; }
 }
 
 /// <summary>
@@ -34,10 +39,11 @@ public sealed class SharedCorpusFixtureSource : IEvalFixtureSource
     /// <summary>Name of the env var used to report the shared corpus version.</summary>
     public const string CorpusVersionEnvVar = "HONUA_EVAL_CORPUS_VERSION";
 
-    private SharedCorpusFixtureSource(string corpusPath, string corpusVersion)
+    private SharedCorpusFixtureSource(string corpusPath, string corpusVersion, string seedPath)
     {
         CorpusPath = corpusPath;
         CorpusVersion = corpusVersion;
+        SeedPath = seedPath;
     }
 
     /// <inheritdoc />
@@ -49,6 +55,9 @@ public sealed class SharedCorpusFixtureSource : IEvalFixtureSource
     /// <inheritdoc />
     public string? CorpusPath { get; }
 
+    /// <inheritdoc />
+    public string SeedPath { get; }
+
     /// <summary>
     /// Attempts to bind to the shared corpus via <see cref="CorpusPathEnvVar"/>. Returns
     /// <c>null</c> when the env var is unset or the directory does not exist.
@@ -56,18 +65,51 @@ public sealed class SharedCorpusFixtureSource : IEvalFixtureSource
     public static SharedCorpusFixtureSource? TryCreate()
     {
         var path = Environment.GetEnvironmentVariable(CorpusPathEnvVar);
-        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+        var version = Environment.GetEnvironmentVariable(CorpusVersionEnvVar);
+        return TryCreate(path, version);
+    }
+
+    internal static SharedCorpusFixtureSource? TryCreate(string? path, string? version)
+    {
+        if (string.IsNullOrWhiteSpace(path))
         {
             return null;
         }
 
-        var version = Environment.GetEnvironmentVariable(CorpusVersionEnvVar);
+        if (!File.Exists(path) && !Directory.Exists(path))
+        {
+            throw new InvalidOperationException(
+                $"{CorpusPathEnvVar} is set to '{path}', but that path does not exist.");
+        }
+
+        var seedPath = ResolveSeedPath(path)
+            ?? throw new InvalidOperationException(
+                $"{CorpusPathEnvVar} must point to a YAML seed file or a directory containing seed.yaml.");
+
         if (string.IsNullOrWhiteSpace(version))
         {
             version = "shared-unversioned";
         }
 
-        return new SharedCorpusFixtureSource(path, version);
+        return new SharedCorpusFixtureSource(path, version, seedPath);
+    }
+
+    private static string? ResolveSeedPath(string path)
+    {
+        if (File.Exists(path))
+        {
+            return path;
+        }
+
+        var candidates = new[]
+        {
+            Path.Combine(path, "seed.yaml"),
+            Path.Combine(path, "seed.yml"),
+            Path.Combine(path, "tests", "seed", "seed.yaml"),
+            Path.Combine(path, "tests", "seed", "seed.yml")
+        };
+
+        return candidates.FirstOrDefault(File.Exists);
     }
 }
 
@@ -87,4 +129,7 @@ public sealed class LocalSeedFixtureSource : IEvalFixtureSource
 
     /// <inheritdoc />
     public string? CorpusPath => null;
+
+    /// <inheritdoc />
+    public string SeedPath => Path.Combine("tests", "seed", "seed.yaml");
 }

--- a/tests/Honua.TestKit/Eval/EvalFixtureSource.cs
+++ b/tests/Honua.TestKit/Eval/EvalFixtureSource.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.TestKit.Eval;
+
+/// <summary>
+/// Resolves the fixture corpus backing a scenario run. Two implementations are
+/// supported: the shared geospatial-mcp corpus (pointed to by
+/// <c>HONUA_EVAL_CORPUS_PATH</c>) and the in-repo <c>tests/seed/seed.yaml</c>
+/// baseline applied through <see cref="PostgresFixture"/>.
+/// </summary>
+public interface IEvalFixtureSource
+{
+    /// <summary>Identifier: <c>shared</c> or <c>local-seed</c>.</summary>
+    string Id { get; }
+
+    /// <summary>Corpus version string used in the report envelope.</summary>
+    string CorpusVersion { get; }
+
+    /// <summary>Resolved corpus path when applicable (shared corpus only).</summary>
+    string? CorpusPath { get; }
+}
+
+/// <summary>
+/// Binds scenarios to the shared geospatial-mcp fixture corpus mounted at
+/// <c>HONUA_EVAL_CORPUS_PATH</c>. Not yet populated in CI; in-repo seed is used
+/// as the fallback when the env var is unset.
+/// </summary>
+public sealed class SharedCorpusFixtureSource : IEvalFixtureSource
+{
+    /// <summary>Name of the env var used to locate the shared corpus.</summary>
+    public const string CorpusPathEnvVar = "HONUA_EVAL_CORPUS_PATH";
+
+    /// <summary>Name of the env var used to report the shared corpus version.</summary>
+    public const string CorpusVersionEnvVar = "HONUA_EVAL_CORPUS_VERSION";
+
+    private SharedCorpusFixtureSource(string corpusPath, string corpusVersion)
+    {
+        CorpusPath = corpusPath;
+        CorpusVersion = corpusVersion;
+    }
+
+    /// <inheritdoc />
+    public string Id => "shared";
+
+    /// <inheritdoc />
+    public string CorpusVersion { get; }
+
+    /// <inheritdoc />
+    public string? CorpusPath { get; }
+
+    /// <summary>
+    /// Attempts to bind to the shared corpus via <see cref="CorpusPathEnvVar"/>. Returns
+    /// <c>null</c> when the env var is unset or the directory does not exist.
+    /// </summary>
+    public static SharedCorpusFixtureSource? TryCreate()
+    {
+        var path = Environment.GetEnvironmentVariable(CorpusPathEnvVar);
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+        {
+            return null;
+        }
+
+        var version = Environment.GetEnvironmentVariable(CorpusVersionEnvVar);
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            version = "shared-unversioned";
+        }
+
+        return new SharedCorpusFixtureSource(path, version);
+    }
+}
+
+/// <summary>
+/// Falls back to the in-repo <c>tests/seed/seed.yaml</c> baseline so the harness
+/// runs locally without external fixture mounts. Satisfies the contract's
+/// "consume shared fixtures instead of ad hoc local-only test data" AC through the
+/// same <c>SeedRunner</c> used by other integration tests.
+/// </summary>
+public sealed class LocalSeedFixtureSource : IEvalFixtureSource
+{
+    /// <inheritdoc />
+    public string Id => "local-seed";
+
+    /// <inheritdoc />
+    public string CorpusVersion => "seed.yaml@v1";
+
+    /// <inheritdoc />
+    public string? CorpusPath => null;
+}

--- a/tests/Honua.TestKit/Eval/EvalFixtureSource.cs
+++ b/tests/Honua.TestKit/Eval/EvalFixtureSource.cs
@@ -60,7 +60,9 @@ public sealed class SharedCorpusFixtureSource : IEvalFixtureSource
 
     /// <summary>
     /// Attempts to bind to the shared corpus via <see cref="CorpusPathEnvVar"/>. Returns
-    /// <c>null</c> when the env var is unset or the directory does not exist.
+    /// <c>null</c> only when the env var is unset or blank. Throws
+    /// <see cref="InvalidOperationException"/> when the env var points at a path that
+    /// does not exist or does not contain a resolvable seed file.
     /// </summary>
     public static SharedCorpusFixtureSource? TryCreate()
     {

--- a/tests/Honua.TestKit/Eval/EvalHarnessSupport.cs
+++ b/tests/Honua.TestKit/Eval/EvalHarnessSupport.cs
@@ -1,0 +1,37 @@
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.TestKit.Eval;
+
+internal static class EvalHarnessSupport
+{
+    public static string? ResolveSeedProfile(IReadOnlyList<EvalScenario> scenarios)
+    {
+        ArgumentNullException.ThrowIfNull(scenarios);
+
+        var profiles = scenarios
+            .Select(scenario => scenario.FixtureProfile)
+            .Where(profile => !string.IsNullOrWhiteSpace(profile))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(profile => profile, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return profiles.Length switch
+        {
+            0 => null,
+            1 => profiles[0],
+            _ => throw new EvalScenarioException(
+                "Eval harness uses one class-scoped seeded schema per run and therefore " +
+                "requires a single fixture profile. " +
+                $"Found multiple profiles: {string.Join(", ", profiles)}.")
+        };
+    }
+
+    public static bool DetermineRedisAvailability(IReadOnlyList<EvalScenarioResult> results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        return results.Any(result => result.Stages.Any(stage =>
+            stage.Stage == EvalStageKind.SubmitPlanJob &&
+            stage.Status == EvalStageStatus.Passed));
+    }
+}

--- a/tests/Honua.TestKit/Eval/EvalJsonContext.cs
+++ b/tests/Honua.TestKit/Eval/EvalJsonContext.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.TestKit.Eval;
+
+/// <summary>
+/// Source-generated <see cref="JsonSerializerContext"/> for eval scenario definitions
+/// and the emitted <see cref="EvalReport"/>. Keeps loader and reporter AOT/trim-safe
+/// with no runtime reflection.
+/// </summary>
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    UseStringEnumConverter = true)]
+[JsonSerializable(typeof(EvalScenario))]
+[JsonSerializable(typeof(EvalIntentSpec))]
+[JsonSerializable(typeof(EvalIntentConstraints))]
+[JsonSerializable(typeof(EvalPlanSpec))]
+[JsonSerializable(typeof(EvalPlanStepSpec))]
+[JsonSerializable(typeof(EvalExpectedOutcome))]
+[JsonSerializable(typeof(EvalReport))]
+[JsonSerializable(typeof(EvalReportEnvironment))]
+[JsonSerializable(typeof(EvalReportRollup))]
+[JsonSerializable(typeof(EvalScenarioResult))]
+[JsonSerializable(typeof(EvalStageOutcome))]
+[JsonSerializable(typeof(EvalProtocolParityOutcome))]
+[JsonSerializable(typeof(EvalProtocolProbe))]
+[JsonSerializable(typeof(EvalProbePayload))]
+[JsonSerializable(typeof(EvalProbePayloadInputs))]
+[JsonSerializable(typeof(IReadOnlyList<EvalScenarioResult>))]
+[JsonSerializable(typeof(IReadOnlyList<EvalStageOutcome>))]
+[JsonSerializable(typeof(IReadOnlyList<EvalProtocolProbe>))]
+public sealed partial class EvalJsonContext : JsonSerializerContext
+{
+}

--- a/tests/Honua.TestKit/Eval/EvalProbePayload.cs
+++ b/tests/Honua.TestKit/Eval/EvalProbePayload.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.TestKit.Eval;
+
+/// <summary>
+/// Wire shape of the body posted to the OGC API Processes execution endpoint
+/// by the protocol-parity probe. Mirrors the OGC canonical inputs envelope:
+/// <c>{ "inputs": { "plan": &lt;AnalysisPlan&gt; } }</c>.
+/// </summary>
+public sealed record EvalProbePayload
+{
+    /// <summary>Inputs envelope carrying the precompiled plan.</summary>
+    [JsonPropertyName("inputs")]
+    public EvalProbePayloadInputs Inputs { get; init; } = new();
+}
+
+/// <summary>Inputs object for <see cref="EvalProbePayload"/>.</summary>
+public sealed record EvalProbePayloadInputs
+{
+    /// <summary>The precompiled plan to submit for execution.</summary>
+    [JsonPropertyName("plan")]
+    public EvalPlanSpec Plan { get; init; } = new();
+}

--- a/tests/Honua.TestKit/Eval/EvalProtoMap.cs
+++ b/tests/Honua.TestKit/Eval/EvalProtoMap.cs
@@ -13,8 +13,13 @@ namespace Honua.TestKit.Eval;
 /// </summary>
 internal static class EvalProtoMap
 {
-    /// <summary>Maps a proto <see cref="Proto.ArtifactKind"/> to the domain enum.</summary>
-    public static ArtifactKind ToDomainArtifactKind(Proto.ArtifactKind kind) => kind switch
+    /// <summary>
+    /// Maps a proto <see cref="Proto.ArtifactKind"/> to the domain enum, or returns
+    /// <c>null</c> when the proto enum has no domain counterpart. Callers record the
+    /// unknown value as a deterministic stage failure rather than throwing so the
+    /// eval report is always emitted.
+    /// </summary>
+    public static ArtifactKind? ToDomainArtifactKind(Proto.ArtifactKind kind) => kind switch
     {
         Proto.ArtifactKind.Scalar => ArtifactKind.Scalar,
         Proto.ArtifactKind.FeatureLayer => ArtifactKind.FeatureLayer,
@@ -24,7 +29,7 @@ internal static class EvalProtoMap
         Proto.ArtifactKind.Report => ArtifactKind.Report,
         Proto.ArtifactKind.Map => ArtifactKind.Map,
         Proto.ArtifactKind.AppBundle => ArtifactKind.AppBundle,
-        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, $"Unsupported proto artifact kind: {kind}")
+        _ => null
     };
 
     /// <summary>Maps a domain <see cref="ArtifactKind"/> to the proto enum.</summary>

--- a/tests/Honua.TestKit/Eval/EvalProtoMap.cs
+++ b/tests/Honua.TestKit/Eval/EvalProtoMap.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Geoprocessing.Domain;
+using Proto = Geospatial.V1;
+
+namespace Honua.TestKit.Eval;
+
+/// <summary>
+/// Stateless enum conversions between the geoprocessing domain types and the
+/// <see cref="Proto"/> messages. Mirrors the server-internal conversion helpers
+/// so the eval harness can round-trip plans without pulling in server internals.
+/// </summary>
+internal static class EvalProtoMap
+{
+    /// <summary>Maps a proto <see cref="Proto.ArtifactKind"/> to the domain enum.</summary>
+    public static ArtifactKind ToDomainArtifactKind(Proto.ArtifactKind kind) => kind switch
+    {
+        Proto.ArtifactKind.Scalar => ArtifactKind.Scalar,
+        Proto.ArtifactKind.FeatureLayer => ArtifactKind.FeatureLayer,
+        Proto.ArtifactKind.Table => ArtifactKind.Table,
+        Proto.ArtifactKind.Raster => ArtifactKind.Raster,
+        Proto.ArtifactKind.File => ArtifactKind.File,
+        Proto.ArtifactKind.Report => ArtifactKind.Report,
+        Proto.ArtifactKind.Map => ArtifactKind.Map,
+        Proto.ArtifactKind.AppBundle => ArtifactKind.AppBundle,
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, $"Unsupported proto artifact kind: {kind}")
+    };
+
+    /// <summary>Maps a domain <see cref="ArtifactKind"/> to the proto enum.</summary>
+    public static Proto.ArtifactKind ToProtoArtifactKind(ArtifactKind kind) => kind switch
+    {
+        ArtifactKind.Scalar => Proto.ArtifactKind.Scalar,
+        ArtifactKind.FeatureLayer => Proto.ArtifactKind.FeatureLayer,
+        ArtifactKind.Table => Proto.ArtifactKind.Table,
+        ArtifactKind.Raster => Proto.ArtifactKind.Raster,
+        ArtifactKind.File => Proto.ArtifactKind.File,
+        ArtifactKind.Report => Proto.ArtifactKind.Report,
+        ArtifactKind.Map => Proto.ArtifactKind.Map,
+        ArtifactKind.AppBundle => Proto.ArtifactKind.AppBundle,
+        _ => Proto.ArtifactKind.Unspecified
+    };
+
+    /// <summary>Maps a domain <see cref="AnalysisPlanStepKind"/> to the proto enum.</summary>
+    public static Proto.PlanStepKind ToProtoPlanStepKind(AnalysisPlanStepKind kind) => kind switch
+    {
+        AnalysisPlanStepKind.QueryFeatures => Proto.PlanStepKind.QueryFeatures,
+        AnalysisPlanStepKind.Geoprocess => Proto.PlanStepKind.Geoprocess,
+        AnalysisPlanStepKind.Aggregate => Proto.PlanStepKind.Aggregate,
+        AnalysisPlanStepKind.RenderMap => Proto.PlanStepKind.RenderMap,
+        AnalysisPlanStepKind.Export => Proto.PlanStepKind.Export,
+        _ => Proto.PlanStepKind.Unspecified
+    };
+}

--- a/tests/Honua.TestKit/Eval/EvalReport.cs
+++ b/tests/Honua.TestKit/Eval/EvalReport.cs
@@ -1,0 +1,249 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.TestKit.Eval;
+
+/// <summary>
+/// Report artifact produced by <see cref="EvalRunner"/> and consumed by downstream
+/// devops automation (honua-devops-31) as the canonical server-side integration gate.
+/// </summary>
+public sealed record EvalReport
+{
+    /// <summary>Schema version of this report document.</summary>
+    [JsonPropertyName("reportSchemaVersion")]
+    public string ReportSchemaVersion { get; init; } = EvalReportSchema.Version;
+
+    /// <summary>Timestamp the report was emitted.</summary>
+    [JsonPropertyName("generatedAt")]
+    public DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>Environment context captured at run time.</summary>
+    [JsonPropertyName("environment")]
+    public EvalReportEnvironment Environment { get; init; } = new();
+
+    /// <summary>Per-scenario result rows.</summary>
+    [JsonPropertyName("scenarios")]
+    public IReadOnlyList<EvalScenarioResult> Scenarios { get; init; } = [];
+
+    /// <summary>Top-level rollup for quick CI readouts.</summary>
+    [JsonPropertyName("rollup")]
+    public EvalReportRollup Rollup { get; init; } = new();
+}
+
+/// <summary>Schema version constant for the eval report.</summary>
+public static class EvalReportSchema
+{
+    /// <summary>Current schema version.</summary>
+    public const string Version = "1";
+}
+
+/// <summary>Environment context captured at run time.</summary>
+public sealed record EvalReportEnvironment
+{
+    /// <summary>Corpus version string (from shared corpus metadata or <c>local-seed</c>).</summary>
+    [JsonPropertyName("corpusVersion")]
+    public string CorpusVersion { get; init; } = "local-seed";
+
+    /// <summary>Corpus source identifier: <c>shared</c> or <c>local-seed</c>.</summary>
+    [JsonPropertyName("corpusSource")]
+    public string CorpusSource { get; init; } = "local-seed";
+
+    /// <summary>Whether a Redis fixture was available during the run.</summary>
+    [JsonPropertyName("redisAvailable")]
+    public bool RedisAvailable { get; init; }
+
+    /// <summary>Resolved filesystem path of the corpus root used, when applicable.</summary>
+    [JsonPropertyName("corpusPath")]
+    public string? CorpusPath { get; init; }
+}
+
+/// <summary>Top-level rollup for quick CI readouts.</summary>
+public sealed record EvalReportRollup
+{
+    /// <summary>Total scenarios executed.</summary>
+    [JsonPropertyName("total")]
+    public int Total { get; init; }
+
+    /// <summary>Scenarios that passed all stages.</summary>
+    [JsonPropertyName("passed")]
+    public int Passed { get; init; }
+
+    /// <summary>Scenarios where at least one stage failed.</summary>
+    [JsonPropertyName("failed")]
+    public int Failed { get; init; }
+
+    /// <summary>Scenarios where all non-skipped stages passed but some were skipped.</summary>
+    [JsonPropertyName("passedWithSkips")]
+    public int PassedWithSkips { get; init; }
+
+    /// <summary>Pointer to the first failed scenario, if any.</summary>
+    [JsonPropertyName("firstFailure")]
+    public string? FirstFailure { get; init; }
+
+    /// <summary>Combined wall-clock duration across scenarios, in milliseconds.</summary>
+    [JsonPropertyName("totalElapsedMs")]
+    public long TotalElapsedMs { get; init; }
+}
+
+/// <summary>Per-scenario result row.</summary>
+public sealed record EvalScenarioResult
+{
+    /// <summary>Scenario identifier.</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Scenario human-readable name.</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Scenario mode.</summary>
+    [JsonPropertyName("mode")]
+    public EvalScenarioMode Mode { get; init; }
+
+    /// <summary>Overall status: <c>Passed</c>, <c>Failed</c>, or <c>PassedWithSkips</c>.</summary>
+    [JsonPropertyName("status")]
+    public EvalOverallStatus Status { get; init; }
+
+    /// <summary>Per-stage outcomes, in execution order.</summary>
+    [JsonPropertyName("stages")]
+    public IReadOnlyList<EvalStageOutcome> Stages { get; init; } = [];
+
+    /// <summary>Protocol parity summary across gRPC and REST adapters.</summary>
+    [JsonPropertyName("protocolParity")]
+    public EvalProtocolParityOutcome ProtocolParity { get; init; } = new();
+
+    /// <summary>Wall-clock duration of the scenario, in milliseconds.</summary>
+    [JsonPropertyName("elapsedMs")]
+    public long ElapsedMs { get; init; }
+}
+
+/// <summary>Per-stage outcome for a scenario.</summary>
+public sealed record EvalStageOutcome
+{
+    /// <summary>Stage identifier.</summary>
+    [JsonPropertyName("stage")]
+    public EvalStageKind Stage { get; init; }
+
+    /// <summary>Stage status.</summary>
+    [JsonPropertyName("status")]
+    public EvalStageStatus Status { get; init; }
+
+    /// <summary>Reason text for skipped or failed stages.</summary>
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+
+    /// <summary>Stage wall-clock duration, in milliseconds.</summary>
+    [JsonPropertyName("elapsedMs")]
+    public long ElapsedMs { get; init; }
+
+    /// <summary>Captured diagnostic detail when the stage failed.</summary>
+    [JsonPropertyName("detail")]
+    public string? Detail { get; init; }
+}
+
+/// <summary>Protocol-parity outcome for a scenario.</summary>
+public sealed record EvalProtocolParityOutcome
+{
+    /// <summary>Overall parity status.</summary>
+    [JsonPropertyName("status")]
+    public EvalStageStatus Status { get; init; } = EvalStageStatus.Skipped;
+
+    /// <summary>Protocol comparison rows keyed by probe name.</summary>
+    [JsonPropertyName("probes")]
+    public IReadOnlyList<EvalProtocolProbe> Probes { get; init; } = [];
+
+    /// <summary>Reason describing any divergence between probes.</summary>
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+}
+
+/// <summary>Single protocol probe outcome (one protocol × one assertion).</summary>
+public sealed record EvalProtocolProbe
+{
+    /// <summary>Protocol identifier (matches <see cref="Constants.Protocols"/>).</summary>
+    [JsonPropertyName("protocol")]
+    public string Protocol { get; init; } = string.Empty;
+
+    /// <summary>Probe label (e.g. <c>plan-shape-accepted</c>).</summary>
+    [JsonPropertyName("assertion")]
+    public string Assertion { get; init; } = string.Empty;
+
+    /// <summary>Observed outcome for this probe.</summary>
+    [JsonPropertyName("outcome")]
+    public string Outcome { get; init; } = string.Empty;
+
+    /// <summary>Probe-specific status.</summary>
+    [JsonPropertyName("status")]
+    public EvalStageStatus Status { get; init; }
+}
+
+/// <summary>Stage identifiers tracked in the report.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<EvalStageKind>))]
+public enum EvalStageKind
+{
+    /// <summary>Capture an analyst intent.</summary>
+    CaptureIntent,
+
+    /// <summary>Compile an executable plan from the intent.</summary>
+    CompilePlan,
+
+    /// <summary>Validate the plan through the canonical runtime.</summary>
+    ValidatePlan,
+
+    /// <summary>Dry-run the plan through the canonical runtime.</summary>
+    DryRun,
+
+    /// <summary>Cross-check plan acceptance across REST protocol adapters.</summary>
+    ProtocolParity,
+
+    /// <summary>Submit the plan for asynchronous execution.</summary>
+    SubmitPlanJob,
+
+    /// <summary>Poll the execution job until it reaches a terminal state.</summary>
+    PollJob,
+
+    /// <summary>Retrieve and validate the result package shape.</summary>
+    GetJobResults,
+
+    /// <summary>Compose and validate the map package binding.</summary>
+    ComposeMapPackage,
+
+    /// <summary>Compose and validate the app package binding.</summary>
+    ComposeAppPackage,
+
+    /// <summary>Run the publish and deployment promotion flow.</summary>
+    PromoteDeployment
+}
+
+/// <summary>Stage outcome status.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<EvalStageStatus>))]
+public enum EvalStageStatus
+{
+    /// <summary>Stage not yet executed.</summary>
+    Pending,
+
+    /// <summary>Stage completed with expected outcomes.</summary>
+    Passed,
+
+    /// <summary>Stage was intentionally skipped (reason captured).</summary>
+    Skipped,
+
+    /// <summary>Stage failed an assertion or raised an unexpected exception.</summary>
+    Failed
+}
+
+/// <summary>Overall scenario status rollup.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<EvalOverallStatus>))]
+public enum EvalOverallStatus
+{
+    /// <summary>All stages passed.</summary>
+    Passed,
+
+    /// <summary>At least one stage failed.</summary>
+    Failed,
+
+    /// <summary>All executed stages passed but some were skipped.</summary>
+    PassedWithSkips
+}

--- a/tests/Honua.TestKit/Eval/EvalRunner.cs
+++ b/tests/Honua.TestKit/Eval/EvalRunner.cs
@@ -323,6 +323,19 @@ public sealed class EvalRunner
                         ElapsedMs = stopwatch.ElapsedMilliseconds
                     }, response);
                 }
+
+                var unexpected = actual.Except(expected).ToArray();
+                if (unexpected.Length > 0)
+                {
+                    return (new EvalStageOutcome
+                    {
+                        Stage = EvalStageKind.DryRun,
+                        Status = EvalStageStatus.Failed,
+                        Reason = "artifact-kinds-unexpected",
+                        Detail = $"Unexpected artifact kinds [{string.Join(",", unexpected)}] were produced by dry-run; expected [{string.Join(",", expected)}].",
+                        ElapsedMs = stopwatch.ElapsedMilliseconds
+                    }, response);
+                }
             }
 
             return (new EvalStageOutcome

--- a/tests/Honua.TestKit/Eval/EvalRunner.cs
+++ b/tests/Honua.TestKit/Eval/EvalRunner.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Net;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using Grpc.Core;
@@ -337,7 +336,7 @@ public sealed class EvalRunner
         var ogcProbe = await ProbeOgcProcessExecutionAsync(scenario, cancellationToken).ConfigureAwait(false);
         probes.Add(ogcProbe);
 
-        var gpServerProbe = await ProbeGPServerServiceInfoAsync(scenario, cancellationToken).ConfigureAwait(false);
+        var gpServerProbe = await ProbeGPServerSubmitJobAsync(cancellationToken).ConfigureAwait(false);
         probes.Add(gpServerProbe);
 
         var statuses = probes.Select(p => p.Status).ToArray();
@@ -548,31 +547,36 @@ public sealed class EvalRunner
         }
     }
 
-    private async Task<EvalProtocolProbe> ProbeGPServerServiceInfoAsync(
-        EvalScenario scenario,
+    private async Task<EvalProtocolProbe> ProbeGPServerSubmitJobAsync(
         CancellationToken cancellationToken)
     {
         try
         {
-            using var response = await _fixture.Client.GetAsync(
-                $"/rest/services/{scenario.Id}/GPServer?f=json", cancellationToken).ConfigureAwait(false);
-
-            if (response.StatusCode == HttpStatusCode.OK)
+            using var content = new FormUrlEncodedContent(new Dictionary<string, string>
             {
-                response.Content.Headers.ContentType ??= new MediaTypeHeaderValue("application/json");
+                ["f"] = "json",
+                ["input_features"] = "eval-placeholder"
+            });
+            using var response = await _fixture.Client.PostAsync(
+                "/rest/services/HonuaEval/GPServer/BufferAnalysis/submitJob",
+                content,
+                cancellationToken).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.NotImplemented)
+            {
                 return new EvalProtocolProbe
                 {
                     Protocol = Constants.Protocols.GPServer,
-                    Assertion = "service-info-reachable",
-                    Outcome = "ok",
-                    Status = EvalStageStatus.Passed
+                    Assertion = "submit-job-surface",
+                    Outcome = "task-resolution-unavailable",
+                    Status = EvalStageStatus.Skipped
                 };
             }
 
             return new EvalProtocolProbe
             {
                 Protocol = Constants.Protocols.GPServer,
-                Assertion = "service-info-reachable",
+                Assertion = "submit-job-surface",
                 Outcome = $"status-{(int)response.StatusCode}",
                 Status = EvalStageStatus.Failed
             };

--- a/tests/Honua.TestKit/Eval/EvalRunner.cs
+++ b/tests/Honua.TestKit/Eval/EvalRunner.cs
@@ -268,6 +268,12 @@ public sealed class EvalRunner
                 ElapsedMs = stopwatch.ElapsedMilliseconds
             }, response);
         }
+        catch (RpcException ex) when (IsCallerCancellation(ex, cancellationToken))
+        {
+            // gRPC surfaces caller cancellation as StatusCode.Cancelled. Rethrow
+            // so RunAsync aborts cleanly instead of recording a false stage failure.
+            throw new OperationCanceledException(ex.Message, ex, cancellationToken);
+        }
         catch (RpcException ex)
         {
             stopwatch.Stop();
@@ -356,6 +362,10 @@ public sealed class EvalRunner
                 Status = EvalStageStatus.Passed,
                 ElapsedMs = stopwatch.ElapsedMilliseconds
             }, response);
+        }
+        catch (RpcException ex) when (IsCallerCancellation(ex, cancellationToken))
+        {
+            throw new OperationCanceledException(ex.Message, ex, cancellationToken);
         }
         catch (RpcException ex)
         {
@@ -468,6 +478,10 @@ public sealed class EvalRunner
                 Status = EvalStageStatus.Passed,
                 ElapsedMs = stopwatch.ElapsedMilliseconds
             }, job);
+        }
+        catch (RpcException ex) when (IsCallerCancellation(ex, cancellationToken))
+        {
+            throw new OperationCanceledException(ex.Message, ex, cancellationToken);
         }
         catch (RpcException ex) when (ex.StatusCode == StatusCode.Unavailable)
         {
@@ -749,6 +763,9 @@ public sealed class EvalRunner
         }
         return headers;
     }
+
+    private static bool IsCallerCancellation(RpcException ex, CancellationToken cancellationToken)
+        => ex.StatusCode == StatusCode.Cancelled && cancellationToken.IsCancellationRequested;
 
     private static EvalOverallStatus RollupScenarioStatus(
         IReadOnlyList<EvalStageOutcome> stages,

--- a/tests/Honua.TestKit/Eval/EvalRunner.cs
+++ b/tests/Honua.TestKit/Eval/EvalRunner.cs
@@ -1,0 +1,738 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Grpc.Net.Client.Web;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Proto = Geospatial.V1;
+
+namespace Honua.TestKit.Eval;
+
+/// <summary>
+/// End-to-end eval harness runner. Drives the canonical runtime and protocol
+/// adapters (gRPC <see cref="Proto.ProcessService"/>, OGC API Processes, GeoServices
+/// GPServer) through a single <see cref="EvalScenario"/> and captures per-stage
+/// outcomes into an <see cref="EvalScenarioResult"/>.
+/// </summary>
+public sealed class EvalRunner
+{
+    /// <summary>
+    /// <see cref="ActivitySource"/> used to emit one span per scenario and per stage.
+    /// Downstream observability in CI consumes these spans through the standard
+    /// <c>Honua.ServiceDefaults</c> telemetry pipeline when enabled.
+    /// </summary>
+    public static readonly ActivitySource ActivitySource = new("Honua.Tests.Eval");
+
+    private readonly WebAppFixture _fixture;
+    private readonly IEvalFixtureSource _fixtureSource;
+
+    /// <summary>Creates a runner bound to the supplied web host and fixture source.</summary>
+    public EvalRunner(WebAppFixture fixture, IEvalFixtureSource fixtureSource)
+    {
+        _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+        _fixtureSource = fixtureSource ?? throw new ArgumentNullException(nameof(fixtureSource));
+    }
+
+    /// <summary>
+    /// Executes all stages for the given scenario. Stages may be <see cref="EvalStageStatus.Skipped"/>
+    /// when upstream capabilities are not yet wired (e.g. execution engine, publish surface).
+    /// Never throws for per-stage failures; surface those through the returned outcome.
+    /// </summary>
+    public async Task<EvalScenarioResult> RunAsync(EvalScenario scenario, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(scenario);
+
+        using var scenarioActivity = ActivitySource.StartActivity("eval.scenario");
+        scenarioActivity?.SetTag("eval.scenario.id", scenario.Id);
+        scenarioActivity?.SetTag("eval.scenario.mode", scenario.Mode.ToString());
+        scenarioActivity?.SetTag("eval.fixture.source", _fixtureSource.Id);
+
+        var overallStopwatch = Stopwatch.StartNew();
+        var stages = new List<EvalStageOutcome>(capacity: 12);
+        EvalProtocolParityOutcome parity = new();
+
+        using var channel = CreateGrpcChannel();
+        var client = new Proto.ProcessService.ProcessServiceClient(channel);
+        var grpcHeaders = BuildGrpcHeaders();
+        var domainPlan = BuildDomainPlan(scenario.PrecompiledPlan);
+
+        stages.Add(RunCaptureIntent(scenario));
+        stages.Add(RunCompilePlan(scenario, domainPlan));
+
+        var validateOutcome = await RunValidatePlanAsync(scenario, client, domainPlan, grpcHeaders, cancellationToken)
+            .ConfigureAwait(false);
+        stages.Add(validateOutcome.Stage);
+
+        var dryRunOutcome = await RunDryRunAsync(scenario, client, domainPlan, grpcHeaders, cancellationToken)
+            .ConfigureAwait(false);
+        stages.Add(dryRunOutcome.Stage);
+
+        parity = await RunProtocolParityAsync(scenario, validateOutcome.Response, cancellationToken).ConfigureAwait(false);
+
+        var submitOutcome = await RunSubmitPlanJobAsync(scenario, client, domainPlan, grpcHeaders, cancellationToken)
+            .ConfigureAwait(false);
+        stages.Add(submitOutcome.Stage);
+
+        stages.Add(BuildSkipOutcome(EvalStageKind.PollJob,
+            "execution-engine-pending", "Execution engine not yet wired (see #732)."));
+        stages.Add(BuildSkipOutcome(EvalStageKind.GetJobResults,
+            "execution-engine-pending", "Result-package retrieval requires the execution engine."));
+
+        stages.Add(BuildModeScopedStage(scenario, EvalStageKind.ComposeMapPackage,
+            scenario.Mode is EvalScenarioMode.Package or EvalScenarioMode.Deploy,
+            "map-package-surface-pending", "Map package surface defined in #730."));
+        stages.Add(BuildModeScopedStage(scenario, EvalStageKind.ComposeAppPackage,
+            scenario.ExpectedOutcome.ExpectsAppPackage,
+            "app-package-surface-pending", "App package surface defined in #731."));
+        stages.Add(BuildModeScopedStage(scenario, EvalStageKind.PromoteDeployment,
+            scenario.Mode is EvalScenarioMode.Deploy,
+            "deploy-surface-pending", "Deployment promotion surface defined in #732."));
+
+        overallStopwatch.Stop();
+
+        var status = RollupScenarioStatus(stages, parity);
+
+        return new EvalScenarioResult
+        {
+            Id = scenario.Id,
+            Name = scenario.Name,
+            Mode = scenario.Mode,
+            Status = status,
+            Stages = stages,
+            ProtocolParity = parity,
+            ElapsedMs = overallStopwatch.ElapsedMilliseconds
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // Stage runners
+    // -----------------------------------------------------------------------
+
+    private EvalStageOutcome RunCaptureIntent(EvalScenario scenario)
+    {
+        using var activity = ActivitySource.StartActivity("eval.stage.capture_intent");
+        activity?.SetTag("eval.scenario.id", scenario.Id);
+
+        var stopwatch = Stopwatch.StartNew();
+        var intent = BuildDomainIntent(scenario.Intent);
+        stopwatch.Stop();
+
+        if (string.IsNullOrWhiteSpace(intent.IntentId) || string.IsNullOrWhiteSpace(intent.Goal))
+        {
+            return new EvalStageOutcome
+            {
+                Stage = EvalStageKind.CaptureIntent,
+                Status = EvalStageStatus.Failed,
+                Reason = "intent-missing-identifiers",
+                Detail = "IntentId and Goal are required for a canonical AnalysisIntent.",
+                ElapsedMs = stopwatch.ElapsedMilliseconds
+            };
+        }
+
+        if (intent.Constraints is { SpatialReferenceId: not null } constraints)
+        {
+            var sridValid = constraints.SpatialReferenceId > 0 && constraints.SpatialReferenceId < 1_000_000;
+            if (!sridValid)
+            {
+                return new EvalStageOutcome
+                {
+                    Stage = EvalStageKind.CaptureIntent,
+                    Status = EvalStageStatus.Failed,
+                    Reason = "srid-out-of-range",
+                    Detail = $"SpatialReferenceId '{constraints.SpatialReferenceId}' outside recognized EPSG range.",
+                    ElapsedMs = stopwatch.ElapsedMilliseconds
+                };
+            }
+        }
+
+        return new EvalStageOutcome
+        {
+            Stage = EvalStageKind.CaptureIntent,
+            Status = EvalStageStatus.Passed,
+            ElapsedMs = stopwatch.ElapsedMilliseconds
+        };
+    }
+
+    private EvalStageOutcome RunCompilePlan(EvalScenario scenario, AnalysisPlan domainPlan)
+    {
+        using var activity = ActivitySource.StartActivity("eval.stage.compile_plan");
+        activity?.SetTag("eval.scenario.id", scenario.Id);
+
+        var stopwatch = Stopwatch.StartNew();
+
+        if (string.IsNullOrWhiteSpace(domainPlan.PlanId)
+            || !string.Equals(domainPlan.IntentId, scenario.Intent.IntentId, StringComparison.Ordinal))
+        {
+            stopwatch.Stop();
+            return new EvalStageOutcome
+            {
+                Stage = EvalStageKind.CompilePlan,
+                Status = EvalStageStatus.Failed,
+                Reason = "plan-intent-mismatch",
+                Detail = "Precompiled plan must bind its IntentId to scenario.intent.intentId.",
+                ElapsedMs = stopwatch.ElapsedMilliseconds
+            };
+        }
+
+        if (domainPlan.Steps.Count == 0)
+        {
+            stopwatch.Stop();
+            return new EvalStageOutcome
+            {
+                Stage = EvalStageKind.CompilePlan,
+                Status = EvalStageStatus.Failed,
+                Reason = "plan-empty",
+                Detail = "Precompiled plan must contain at least one step.",
+                ElapsedMs = stopwatch.ElapsedMilliseconds
+            };
+        }
+
+        stopwatch.Stop();
+        return new EvalStageOutcome
+        {
+            Stage = EvalStageKind.CompilePlan,
+            Status = EvalStageStatus.Passed,
+            ElapsedMs = stopwatch.ElapsedMilliseconds
+        };
+    }
+
+    private async Task<(EvalStageOutcome Stage, Proto.ValidatePlanResponse? Response)> RunValidatePlanAsync(
+        EvalScenario scenario,
+        Proto.ProcessService.ProcessServiceClient client,
+        AnalysisPlan domainPlan,
+        Metadata headers,
+        CancellationToken cancellationToken)
+    {
+        using var activity = ActivitySource.StartActivity("eval.stage.validate_plan");
+        activity?.SetTag("eval.scenario.id", scenario.Id);
+        activity?.SetTag("eval.protocol", "grpc");
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var request = new Proto.ValidatePlanRequest { Plan = ToProtoPlan(domainPlan) };
+            var response = await client.ValidatePlanAsync(request, headers, cancellationToken: cancellationToken);
+            stopwatch.Stop();
+
+            if (response.IsExecutable != scenario.ExpectedOutcome.IsExecutable)
+            {
+                return (new EvalStageOutcome
+                {
+                    Stage = EvalStageKind.ValidatePlan,
+                    Status = EvalStageStatus.Failed,
+                    Reason = "is-executable-mismatch",
+                    Detail = $"Expected IsExecutable={scenario.ExpectedOutcome.IsExecutable} but got {response.IsExecutable} with {response.Violations.Count} violations.",
+                    ElapsedMs = stopwatch.ElapsedMilliseconds
+                }, response);
+            }
+
+            if (response.RequiresApproval != scenario.ExpectedOutcome.RequiresApproval)
+            {
+                return (new EvalStageOutcome
+                {
+                    Stage = EvalStageKind.ValidatePlan,
+                    Status = EvalStageStatus.Failed,
+                    Reason = "requires-approval-mismatch",
+                    Detail = $"Expected RequiresApproval={scenario.ExpectedOutcome.RequiresApproval} but got {response.RequiresApproval}.",
+                    ElapsedMs = stopwatch.ElapsedMilliseconds
+                }, response);
+            }
+
+            return (new EvalStageOutcome
+            {
+                Stage = EvalStageKind.ValidatePlan,
+                Status = EvalStageStatus.Passed,
+                ElapsedMs = stopwatch.ElapsedMilliseconds
+            }, response);
+        }
+        catch (RpcException ex)
+        {
+            stopwatch.Stop();
+            return (new EvalStageOutcome
+            {
+                Stage = EvalStageKind.ValidatePlan,
+                Status = EvalStageStatus.Failed,
+                Reason = $"grpc-{ex.StatusCode}".ToLowerInvariant(),
+                Detail = ex.Status.Detail,
+                ElapsedMs = stopwatch.ElapsedMilliseconds
+            }, null);
+        }
+    }
+
+    private async Task<(EvalStageOutcome Stage, Proto.DryRunPlanResponse? Response)> RunDryRunAsync(
+        EvalScenario scenario,
+        Proto.ProcessService.ProcessServiceClient client,
+        AnalysisPlan domainPlan,
+        Metadata headers,
+        CancellationToken cancellationToken)
+    {
+        using var activity = ActivitySource.StartActivity("eval.stage.dry_run");
+        activity?.SetTag("eval.scenario.id", scenario.Id);
+        activity?.SetTag("eval.protocol", "grpc");
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var request = new Proto.DryRunPlanRequest { Plan = ToProtoPlan(domainPlan) };
+            var response = await client.DryRunPlanAsync(request, headers, cancellationToken: cancellationToken);
+            stopwatch.Stop();
+
+            var expected = scenario.ExpectedOutcome.EstimatedArtifactKinds;
+            var actual = response.EstimatedArtifacts.Select(EvalProtoMap.ToDomainArtifactKind).ToArray();
+
+            if (expected.Count > 0)
+            {
+                var missing = expected.Except(actual).ToArray();
+                if (missing.Length > 0)
+                {
+                    return (new EvalStageOutcome
+                    {
+                        Stage = EvalStageKind.DryRun,
+                        Status = EvalStageStatus.Failed,
+                        Reason = "artifact-kinds-missing",
+                        Detail = $"Expected artifact kinds [{string.Join(",", expected)}] were not all present in dry-run output [{string.Join(",", actual)}].",
+                        ElapsedMs = stopwatch.ElapsedMilliseconds
+                    }, response);
+                }
+            }
+
+            return (new EvalStageOutcome
+            {
+                Stage = EvalStageKind.DryRun,
+                Status = EvalStageStatus.Passed,
+                ElapsedMs = stopwatch.ElapsedMilliseconds
+            }, response);
+        }
+        catch (RpcException ex)
+        {
+            stopwatch.Stop();
+            return (new EvalStageOutcome
+            {
+                Stage = EvalStageKind.DryRun,
+                Status = EvalStageStatus.Failed,
+                Reason = $"grpc-{ex.StatusCode}".ToLowerInvariant(),
+                Detail = ex.Status.Detail,
+                ElapsedMs = stopwatch.ElapsedMilliseconds
+            }, null);
+        }
+    }
+
+    private async Task<EvalProtocolParityOutcome> RunProtocolParityAsync(
+        EvalScenario scenario,
+        Proto.ValidatePlanResponse? grpcValidate,
+        CancellationToken cancellationToken)
+    {
+        using var activity = ActivitySource.StartActivity("eval.stage.protocol_parity");
+        activity?.SetTag("eval.scenario.id", scenario.Id);
+
+        var probes = new List<EvalProtocolProbe>();
+        probes.Add(BuildGrpcValidateProbe(grpcValidate));
+
+        var ogcProbe = await ProbeOgcProcessExecutionAsync(scenario, cancellationToken).ConfigureAwait(false);
+        probes.Add(ogcProbe);
+
+        var gpServerProbe = await ProbeGPServerServiceInfoAsync(scenario, cancellationToken).ConfigureAwait(false);
+        probes.Add(gpServerProbe);
+
+        var statuses = probes.Select(p => p.Status).ToArray();
+        EvalStageStatus rolled;
+        string? reason;
+        if (statuses.Contains(EvalStageStatus.Failed))
+        {
+            rolled = EvalStageStatus.Failed;
+            reason = string.Join("; ", probes.Where(p => p.Status == EvalStageStatus.Failed).Select(p => $"{p.Protocol}:{p.Assertion}:{p.Outcome}"));
+        }
+        else if (statuses.All(s => s == EvalStageStatus.Passed))
+        {
+            rolled = EvalStageStatus.Passed;
+            reason = null;
+        }
+        else
+        {
+            rolled = EvalStageStatus.Skipped;
+            reason = "one-or-more-probes-skipped";
+        }
+
+        return new EvalProtocolParityOutcome
+        {
+            Status = rolled,
+            Probes = probes,
+            Reason = reason
+        };
+    }
+
+    private async Task<(EvalStageOutcome Stage, Proto.ExecutionJob? Job)> RunSubmitPlanJobAsync(
+        EvalScenario scenario,
+        Proto.ProcessService.ProcessServiceClient client,
+        AnalysisPlan domainPlan,
+        Metadata headers,
+        CancellationToken cancellationToken)
+    {
+        using var activity = ActivitySource.StartActivity("eval.stage.submit_plan_job");
+        activity?.SetTag("eval.scenario.id", scenario.Id);
+        activity?.SetTag("eval.protocol", "grpc");
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var request = new Proto.SubmitPlanJobRequest
+            {
+                Plan = ToProtoPlan(domainPlan),
+                IdempotencyKey = $"eval-{scenario.Id}-{Guid.NewGuid():N}"
+            };
+
+            var job = await client.SubmitPlanJobAsync(request, headers, cancellationToken: cancellationToken);
+            stopwatch.Stop();
+
+            if (string.IsNullOrWhiteSpace(job.JobId))
+            {
+                return (new EvalStageOutcome
+                {
+                    Stage = EvalStageKind.SubmitPlanJob,
+                    Status = EvalStageStatus.Failed,
+                    Reason = "missing-job-id",
+                    Detail = "SubmitPlanJob returned an empty JobId.",
+                    ElapsedMs = stopwatch.ElapsedMilliseconds
+                }, job);
+            }
+
+            if (job.Status is not Proto.JobStatus.Queued and not Proto.JobStatus.Provisioning)
+            {
+                return (new EvalStageOutcome
+                {
+                    Stage = EvalStageKind.SubmitPlanJob,
+                    Status = EvalStageStatus.Failed,
+                    Reason = "unexpected-initial-status",
+                    Detail = $"Expected queued/provisioning initial status but got {job.Status}.",
+                    ElapsedMs = stopwatch.ElapsedMilliseconds
+                }, job);
+            }
+
+            return (new EvalStageOutcome
+            {
+                Stage = EvalStageKind.SubmitPlanJob,
+                Status = EvalStageStatus.Passed,
+                ElapsedMs = stopwatch.ElapsedMilliseconds
+            }, job);
+        }
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.Unavailable)
+        {
+            stopwatch.Stop();
+            return (new EvalStageOutcome
+            {
+                Stage = EvalStageKind.SubmitPlanJob,
+                Status = EvalStageStatus.Skipped,
+                Reason = "redis-unavailable",
+                Detail = "Durable job store not configured; SubmitPlanJob requires Redis.",
+                ElapsedMs = stopwatch.ElapsedMilliseconds
+            }, null);
+        }
+        catch (RpcException ex)
+        {
+            stopwatch.Stop();
+            return (new EvalStageOutcome
+            {
+                Stage = EvalStageKind.SubmitPlanJob,
+                Status = EvalStageStatus.Failed,
+                Reason = $"grpc-{ex.StatusCode}".ToLowerInvariant(),
+                Detail = ex.Status.Detail,
+                ElapsedMs = stopwatch.ElapsedMilliseconds
+            }, null);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Protocol parity probes
+    // -----------------------------------------------------------------------
+
+    private static EvalProtocolProbe BuildGrpcValidateProbe(Proto.ValidatePlanResponse? response)
+    {
+        if (response == null)
+        {
+            return new EvalProtocolProbe
+            {
+                Protocol = Constants.Protocols.Grpc,
+                Assertion = "plan-shape-accepted",
+                Outcome = "grpc-failed",
+                Status = EvalStageStatus.Failed
+            };
+        }
+
+        return new EvalProtocolProbe
+        {
+            Protocol = Constants.Protocols.Grpc,
+            Assertion = "plan-shape-accepted",
+            Outcome = response.IsExecutable ? "executable" : $"rejected:{response.Violations.Count}-violations",
+            Status = EvalStageStatus.Passed
+        };
+    }
+
+    private async Task<EvalProtocolProbe> ProbeOgcProcessExecutionAsync(
+        EvalScenario scenario,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(
+                HttpMethod.Post,
+                "/ogc/processes/processes/honua-geoprocessing/execution");
+            request.Headers.Add("Prefer", "respond-async");
+            var body = new EvalProbePayload
+            {
+                Inputs = new EvalProbePayloadInputs { Plan = scenario.PrecompiledPlan }
+            };
+            var payload = JsonSerializer.Serialize(body, EvalJsonContext.Default.EvalProbePayload);
+            request.Content = new StringContent(payload, Encoding.UTF8, "application/json");
+
+            using var response = await _fixture.Client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            // Accept 201 (queued), or 503 (jobStore unavailable in local dev).
+            // The adapter's plan validator is our cross-check: if the canonical runtime
+            // accepts the plan and the OGC validator rejects it, that's a parity failure.
+            if (response.StatusCode == HttpStatusCode.Created)
+            {
+                return new EvalProtocolProbe
+                {
+                    Protocol = Constants.Protocols.OgcApiProcesses,
+                    Assertion = "plan-shape-accepted",
+                    Outcome = "created",
+                    Status = EvalStageStatus.Passed
+                };
+            }
+
+            if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
+            {
+                return new EvalProtocolProbe
+                {
+                    Protocol = Constants.Protocols.OgcApiProcesses,
+                    Assertion = "plan-shape-accepted",
+                    Outcome = "service-unavailable",
+                    Status = EvalStageStatus.Skipped
+                };
+            }
+
+            if (response.StatusCode == HttpStatusCode.NotImplemented)
+            {
+                return new EvalProtocolProbe
+                {
+                    Protocol = Constants.Protocols.OgcApiProcesses,
+                    Assertion = "plan-shape-accepted",
+                    Outcome = "not-implemented",
+                    Status = EvalStageStatus.Skipped
+                };
+            }
+
+            return new EvalProtocolProbe
+            {
+                Protocol = Constants.Protocols.OgcApiProcesses,
+                Assertion = "plan-shape-accepted",
+                Outcome = $"unexpected-{(int)response.StatusCode}",
+                Status = EvalStageStatus.Failed
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            return new EvalProtocolProbe
+            {
+                Protocol = Constants.Protocols.OgcApiProcesses,
+                Assertion = "plan-shape-accepted",
+                Outcome = $"http-error:{ex.Message}",
+                Status = EvalStageStatus.Failed
+            };
+        }
+    }
+
+    private async Task<EvalProtocolProbe> ProbeGPServerServiceInfoAsync(
+        EvalScenario scenario,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var response = await _fixture.Client.GetAsync(
+                $"/rest/services/{scenario.Id}/GPServer?f=json", cancellationToken).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                response.Content.Headers.ContentType ??= new MediaTypeHeaderValue("application/json");
+                return new EvalProtocolProbe
+                {
+                    Protocol = Constants.Protocols.GPServer,
+                    Assertion = "service-info-reachable",
+                    Outcome = "ok",
+                    Status = EvalStageStatus.Passed
+                };
+            }
+
+            return new EvalProtocolProbe
+            {
+                Protocol = Constants.Protocols.GPServer,
+                Assertion = "service-info-reachable",
+                Outcome = $"status-{(int)response.StatusCode}",
+                Status = EvalStageStatus.Failed
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            return new EvalProtocolProbe
+            {
+                Protocol = Constants.Protocols.GPServer,
+                Assertion = "service-info-reachable",
+                Outcome = $"http-error:{ex.Message}",
+                Status = EvalStageStatus.Failed
+            };
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private GrpcChannel CreateGrpcChannel()
+    {
+        var handler = _fixture.CreateHandler();
+        var grpcWebHandler = new GrpcWebHandler(GrpcWebMode.GrpcWeb, handler);
+        return GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+        {
+            HttpHandler = grpcWebHandler
+        });
+    }
+
+    private Metadata BuildGrpcHeaders()
+    {
+        var headers = new Metadata();
+        if (!string.IsNullOrWhiteSpace(_fixture.CurrentSchema))
+        {
+            headers.Add("X-Honua-Test-Schema", _fixture.CurrentSchema);
+        }
+        return headers;
+    }
+
+    private static EvalOverallStatus RollupScenarioStatus(
+        IReadOnlyList<EvalStageOutcome> stages,
+        EvalProtocolParityOutcome parity)
+    {
+        var anyFailed = stages.Any(s => s.Status == EvalStageStatus.Failed) || parity.Status == EvalStageStatus.Failed;
+        if (anyFailed)
+        {
+            return EvalOverallStatus.Failed;
+        }
+
+        var anySkipped = stages.Any(s => s.Status == EvalStageStatus.Skipped) || parity.Status == EvalStageStatus.Skipped;
+        return anySkipped ? EvalOverallStatus.PassedWithSkips : EvalOverallStatus.Passed;
+    }
+
+    private static EvalStageOutcome BuildSkipOutcome(EvalStageKind stage, string reason, string detail)
+        => new()
+        {
+            Stage = stage,
+            Status = EvalStageStatus.Skipped,
+            Reason = reason,
+            Detail = detail,
+            ElapsedMs = 0
+        };
+
+    private static EvalStageOutcome BuildModeScopedStage(
+        EvalScenario scenario,
+        EvalStageKind stage,
+        bool inScope,
+        string skipReason,
+        string skipDetail)
+    {
+        if (!inScope)
+        {
+            return new EvalStageOutcome
+            {
+                Stage = stage,
+                Status = EvalStageStatus.Skipped,
+                Reason = "out-of-scope",
+                Detail = $"Scenario '{scenario.Id}' ({scenario.Mode}) does not exercise {stage}.",
+                ElapsedMs = 0
+            };
+        }
+
+        return BuildSkipOutcome(stage, skipReason, skipDetail);
+    }
+
+    private static AnalysisIntent BuildDomainIntent(EvalIntentSpec spec)
+    {
+        return new AnalysisIntent
+        {
+            IntentId = spec.IntentId,
+            Goal = spec.Goal,
+            Mode = spec.Mode,
+            RequestedOutputs = spec.RequestedOutputs,
+            Constraints = spec.Constraints is null ? null : new IntentConstraints
+            {
+                AreaOfInterest = spec.Constraints.AreaOfInterest,
+                SpatialReferenceId = spec.Constraints.SpatialReferenceId,
+                TimeWindowStart = spec.Constraints.TimeWindowStart,
+                TimeWindowEnd = spec.Constraints.TimeWindowEnd,
+                Units = spec.Constraints.Units
+            },
+            Inputs = spec.Inputs,
+            AssumptionPolicy = spec.AssumptionPolicy
+        };
+    }
+
+    private static AnalysisPlan BuildDomainPlan(EvalPlanSpec spec)
+    {
+        return new AnalysisPlan
+        {
+            PlanId = spec.PlanId,
+            IntentId = spec.IntentId,
+            Steps = spec.Steps.Select(step => new AnalysisPlanStep
+            {
+                StepId = step.StepId,
+                Kind = step.Kind,
+                ProcessId = step.ProcessId,
+                Inputs = step.Inputs,
+                DependsOn = step.DependsOn
+            }).ToArray(),
+            Outputs = spec.Outputs
+        };
+    }
+
+    private static Proto.AnalysisPlan ToProtoPlan(AnalysisPlan plan)
+    {
+        var proto = new Proto.AnalysisPlan
+        {
+            PlanId = plan.PlanId,
+            IntentId = plan.IntentId
+        };
+
+        foreach (var step in plan.Steps)
+        {
+            var protoStep = new Proto.AnalysisPlanStep
+            {
+                StepId = step.StepId,
+                Kind = EvalProtoMap.ToProtoPlanStepKind(step.Kind)
+            };
+
+            if (step.ProcessId != null)
+            {
+                protoStep.ProcessId = step.ProcessId;
+            }
+
+            foreach (var (key, value) in step.Inputs)
+            {
+                protoStep.Inputs[key] = value;
+            }
+
+            protoStep.DependsOn.AddRange(step.DependsOn);
+            proto.Steps.Add(protoStep);
+        }
+
+        foreach (var output in plan.Outputs)
+        {
+            proto.Outputs.Add(EvalProtoMap.ToProtoArtifactKind(output));
+        }
+
+        return proto;
+    }
+}

--- a/tests/Honua.TestKit/Eval/EvalRunner.cs
+++ b/tests/Honua.TestKit/Eval/EvalRunner.cs
@@ -68,32 +68,26 @@ public sealed class EvalRunner
             .ConfigureAwait(false);
         stages.Add(validateOutcome.Stage);
 
-        // When the scenario intentionally expects a non-executable or approval-gated plan and
-        // ValidatePlan matched that expectation, the downstream execution-only RPCs are
-        // contractually guaranteed to reject (InvalidArgument for non-executable plans,
-        // FailedPrecondition for approval-gated plans). Skip those stages with a deterministic
-        // reason so the matched outcome rolls up cleanly.
-        var executionSkip = ResolveExecutionSkipReason(scenario.ExpectedOutcome, validateOutcome);
-
-        if (executionSkip is { } dryRunSkip)
-        {
-            stages.Add(BuildSkipOutcome(EvalStageKind.DryRun, dryRunSkip.Reason, dryRunSkip.Detail));
-        }
-        else
-        {
-            var dryRunOutcome = await RunDryRunAsync(scenario, client, domainPlan, grpcHeaders, cancellationToken)
-                .ConfigureAwait(false);
-            stages.Add(dryRunOutcome.Stage);
-        }
+        // DryRun is a Read operation in the canonical runtime
+        // (HonuaProcessService authorizes it as OperatorOperation.Read, and
+        // GeoprocessingJobService.DryRunPlan only enforces plan-structure and
+        // catalog validity). It does not gate on executability or approval, so
+        // DryRun still runs for scenarios that expect IsExecutable=false or
+        // RequiresApproval=true. Only SubmitPlanJob enforces those gates via
+        // EnsurePlanExecutable / EnsureApproved, so only it is skipped here.
+        var dryRunOutcome = await RunDryRunAsync(scenario, client, domainPlan, grpcHeaders, cancellationToken)
+            .ConfigureAwait(false);
+        stages.Add(dryRunOutcome.Stage);
 
         var parityStopwatch = Stopwatch.StartNew();
         parity = await RunProtocolParityAsync(scenario, validateOutcome.Response, cancellationToken).ConfigureAwait(false);
         parityStopwatch.Stop();
         stages.Add(BuildProtocolParityStageOutcome(parity, parityStopwatch.ElapsedMilliseconds));
 
-        if (executionSkip is { } submitSkip)
+        var submitSkip = ResolveSubmitSkipReason(scenario.ExpectedOutcome, validateOutcome);
+        if (submitSkip is { } skip)
         {
-            stages.Add(BuildSkipOutcome(EvalStageKind.SubmitPlanJob, submitSkip.Reason, submitSkip.Detail));
+            stages.Add(BuildSkipOutcome(EvalStageKind.SubmitPlanJob, skip.Reason, skip.Detail));
         }
         else
         {
@@ -644,6 +638,26 @@ public sealed class EvalRunner
                 Status = EvalStageStatus.Failed
             };
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The outer run was genuinely canceled; let it bubble up so RunAsync
+            // stops cleanly instead of reporting a false probe failure.
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            // HttpClient.Timeout (or any non-caller cancel) surfaces as a
+            // TaskCanceledException/OperationCanceledException. Convert it into
+            // a deterministic failed probe so RunAsync preserves its no-throw
+            // reporting contract for the surrounding scenario.
+            return new EvalProtocolProbe
+            {
+                Protocol = Constants.Protocols.OgcApiProcesses,
+                Assertion = "plan-shape-accepted",
+                Outcome = "http-timeout",
+                Status = EvalStageStatus.Failed
+            };
+        }
     }
 
     private async Task<EvalProtocolProbe> ProbeGPServerSubmitJobAsync(
@@ -687,6 +701,26 @@ public sealed class EvalRunner
                 Protocol = Constants.Protocols.GPServer,
                 Assertion = "service-info-reachable",
                 Outcome = $"http-error:{ex.Message}",
+                Status = EvalStageStatus.Failed
+            };
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The outer run was genuinely canceled; let it bubble up so RunAsync
+            // stops cleanly instead of reporting a false probe failure.
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            // HttpClient.Timeout (or any non-caller cancel) surfaces as a
+            // TaskCanceledException/OperationCanceledException. Convert it into
+            // a deterministic failed probe so RunAsync preserves its no-throw
+            // reporting contract for the surrounding scenario.
+            return new EvalProtocolProbe
+            {
+                Protocol = Constants.Protocols.GPServer,
+                Assertion = "submit-job-surface",
+                Outcome = "http-timeout",
                 Status = EvalStageStatus.Failed
             };
         }
@@ -740,7 +774,7 @@ public sealed class EvalRunner
             ElapsedMs = 0
         };
 
-    private static ExecutionSkipReason? ResolveExecutionSkipReason(
+    private static ExecutionSkipReason? ResolveSubmitSkipReason(
         EvalExpectedOutcome expected,
         (EvalStageOutcome Stage, Proto.ValidatePlanResponse? Response) validateOutcome)
     {
@@ -753,14 +787,14 @@ public sealed class EvalRunner
         {
             return new ExecutionSkipReason(
                 "plan-non-executable",
-                "Scenario expected IsExecutable=false; skipping DryRun and SubmitPlanJob because the canonical runtime rejects non-executable plans.");
+                "Scenario expected IsExecutable=false; skipping SubmitPlanJob because the canonical runtime rejects non-executable plans via EnsurePlanExecutable.");
         }
 
         if (expected.RequiresApproval && validateOutcome.Response.RequiresApproval)
         {
             return new ExecutionSkipReason(
                 "plan-approval-required",
-                "Scenario expected RequiresApproval=true; skipping DryRun and SubmitPlanJob because SubmitPlanJob enforces the approval gate.");
+                "Scenario expected RequiresApproval=true; skipping SubmitPlanJob because SubmitPlanJob enforces the approval gate via EnsureApproved.");
         }
 
         return null;

--- a/tests/Honua.TestKit/Eval/EvalRunner.cs
+++ b/tests/Honua.TestKit/Eval/EvalRunner.cs
@@ -536,7 +536,9 @@ public sealed class EvalRunner
             // Parity is measured against the scenario's expected acceptance state, so a
             // 400 rejection for a plan the canonical runtime also rejects is the passing
             // outcome (matched rejection). 201 with an expected-executable scenario is the
-            // passing outcome for acceptance. 503 / 501 remain environmental skips.
+            // passing outcome for acceptance. 403 is the canonical approval-gate rejection
+            // emitted after catalog validation, so it matches parity whenever the scenario
+            // expects RequiresApproval=true. 503 / 501 remain environmental skips.
             if (response.StatusCode == HttpStatusCode.Created)
             {
                 return new EvalProtocolProbe
@@ -556,6 +558,18 @@ public sealed class EvalRunner
                     Assertion = "plan-shape-accepted",
                     Outcome = expectedExecutable ? "unexpected-rejection" : "matched-rejection",
                     Status = expectedExecutable ? EvalStageStatus.Failed : EvalStageStatus.Passed
+                };
+            }
+
+            if (response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                var expectsApproval = scenario.ExpectedOutcome.RequiresApproval;
+                return new EvalProtocolProbe
+                {
+                    Protocol = Constants.Protocols.OgcApiProcesses,
+                    Assertion = "plan-shape-accepted",
+                    Outcome = expectsApproval ? "matched-approval-required" : "unexpected-approval-required",
+                    Status = expectsApproval ? EvalStageStatus.Passed : EvalStageStatus.Failed
                 };
             }
 

--- a/tests/Honua.TestKit/Eval/EvalRunner.cs
+++ b/tests/Honua.TestKit/Eval/EvalRunner.cs
@@ -72,7 +72,10 @@ public sealed class EvalRunner
             .ConfigureAwait(false);
         stages.Add(dryRunOutcome.Stage);
 
+        var parityStopwatch = Stopwatch.StartNew();
         parity = await RunProtocolParityAsync(scenario, validateOutcome.Response, cancellationToken).ConfigureAwait(false);
+        parityStopwatch.Stop();
+        stages.Add(BuildProtocolParityStageOutcome(parity, parityStopwatch.ElapsedMilliseconds));
 
         var submitOutcome = await RunSubmitPlanJobAsync(scenario, client, domainPlan, grpcHeaders, cancellationToken)
             .ConfigureAwait(false);
@@ -640,6 +643,22 @@ public sealed class EvalRunner
             Detail = detail,
             ElapsedMs = 0
         };
+
+    private static EvalStageOutcome BuildProtocolParityStageOutcome(EvalProtocolParityOutcome parity, long elapsedMs)
+    {
+        var detail = parity.Probes.Count == 0
+            ? null
+            : string.Join("; ", parity.Probes.Select(p => $"{p.Protocol}:{p.Assertion}={p.Outcome}"));
+
+        return new EvalStageOutcome
+        {
+            Stage = EvalStageKind.ProtocolParity,
+            Status = parity.Status,
+            Reason = parity.Reason,
+            Detail = detail,
+            ElapsedMs = elapsedMs
+        };
+    }
 
     private static EvalStageOutcome BuildModeScopedStage(
         EvalScenario scenario,

--- a/tests/Honua.TestKit/Eval/EvalRunner.cs
+++ b/tests/Honua.TestKit/Eval/EvalRunner.cs
@@ -68,18 +68,39 @@ public sealed class EvalRunner
             .ConfigureAwait(false);
         stages.Add(validateOutcome.Stage);
 
-        var dryRunOutcome = await RunDryRunAsync(scenario, client, domainPlan, grpcHeaders, cancellationToken)
-            .ConfigureAwait(false);
-        stages.Add(dryRunOutcome.Stage);
+        // When the scenario intentionally expects a non-executable or approval-gated plan and
+        // ValidatePlan matched that expectation, the downstream execution-only RPCs are
+        // contractually guaranteed to reject (InvalidArgument for non-executable plans,
+        // FailedPrecondition for approval-gated plans). Skip those stages with a deterministic
+        // reason so the matched outcome rolls up cleanly.
+        var executionSkip = ResolveExecutionSkipReason(scenario.ExpectedOutcome, validateOutcome);
+
+        if (executionSkip is { } dryRunSkip)
+        {
+            stages.Add(BuildSkipOutcome(EvalStageKind.DryRun, dryRunSkip.Reason, dryRunSkip.Detail));
+        }
+        else
+        {
+            var dryRunOutcome = await RunDryRunAsync(scenario, client, domainPlan, grpcHeaders, cancellationToken)
+                .ConfigureAwait(false);
+            stages.Add(dryRunOutcome.Stage);
+        }
 
         var parityStopwatch = Stopwatch.StartNew();
         parity = await RunProtocolParityAsync(scenario, validateOutcome.Response, cancellationToken).ConfigureAwait(false);
         parityStopwatch.Stop();
         stages.Add(BuildProtocolParityStageOutcome(parity, parityStopwatch.ElapsedMilliseconds));
 
-        var submitOutcome = await RunSubmitPlanJobAsync(scenario, client, domainPlan, grpcHeaders, cancellationToken)
-            .ConfigureAwait(false);
-        stages.Add(submitOutcome.Stage);
+        if (executionSkip is { } submitSkip)
+        {
+            stages.Add(BuildSkipOutcome(EvalStageKind.SubmitPlanJob, submitSkip.Reason, submitSkip.Detail));
+        }
+        else
+        {
+            var submitOutcome = await RunSubmitPlanJobAsync(scenario, client, domainPlan, grpcHeaders, cancellationToken)
+                .ConfigureAwait(false);
+            stages.Add(submitOutcome.Stage);
+        }
 
         stages.Add(BuildSkipOutcome(EvalStageKind.PollJob,
             "execution-engine-pending", "Execution engine not yet wired (see #732)."));
@@ -334,7 +355,7 @@ public sealed class EvalRunner
         activity?.SetTag("eval.scenario.id", scenario.Id);
 
         var probes = new List<EvalProtocolProbe>();
-        probes.Add(BuildGrpcValidateProbe(grpcValidate));
+        probes.Add(BuildGrpcValidateProbe(grpcValidate, scenario.ExpectedOutcome.IsExecutable));
 
         var ogcProbe = await ProbeOgcProcessExecutionAsync(scenario, cancellationToken).ConfigureAwait(false);
         probes.Add(ogcProbe);
@@ -453,7 +474,7 @@ public sealed class EvalRunner
     // Protocol parity probes
     // -----------------------------------------------------------------------
 
-    private static EvalProtocolProbe BuildGrpcValidateProbe(Proto.ValidatePlanResponse? response)
+    private static EvalProtocolProbe BuildGrpcValidateProbe(Proto.ValidatePlanResponse? response, bool expectedExecutable)
     {
         if (response == null)
         {
@@ -466,11 +487,27 @@ public sealed class EvalRunner
             };
         }
 
+        if (response.IsExecutable != expectedExecutable)
+        {
+            var actualOutcome = response.IsExecutable
+                ? "executable"
+                : $"rejected:{response.Violations.Count}-violations";
+            return new EvalProtocolProbe
+            {
+                Protocol = Constants.Protocols.Grpc,
+                Assertion = "plan-shape-accepted",
+                Outcome = $"mismatch:{actualOutcome}",
+                Status = EvalStageStatus.Failed
+            };
+        }
+
         return new EvalProtocolProbe
         {
             Protocol = Constants.Protocols.Grpc,
             Assertion = "plan-shape-accepted",
-            Outcome = response.IsExecutable ? "executable" : $"rejected:{response.Violations.Count}-violations",
+            Outcome = response.IsExecutable
+                ? "matched-acceptance"
+                : $"matched-rejection:{response.Violations.Count}-violations",
             Status = EvalStageStatus.Passed
         };
     }
@@ -479,6 +516,8 @@ public sealed class EvalRunner
         EvalScenario scenario,
         CancellationToken cancellationToken)
     {
+        var expectedExecutable = scenario.ExpectedOutcome.IsExecutable;
+
         try
         {
             using var request = new HttpRequestMessage(
@@ -494,17 +533,29 @@ public sealed class EvalRunner
 
             using var response = await _fixture.Client.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-            // Accept 201 (queued), or 503 (jobStore unavailable in local dev).
-            // The adapter's plan validator is our cross-check: if the canonical runtime
-            // accepts the plan and the OGC validator rejects it, that's a parity failure.
+            // Parity is measured against the scenario's expected acceptance state, so a
+            // 400 rejection for a plan the canonical runtime also rejects is the passing
+            // outcome (matched rejection). 201 with an expected-executable scenario is the
+            // passing outcome for acceptance. 503 / 501 remain environmental skips.
             if (response.StatusCode == HttpStatusCode.Created)
             {
                 return new EvalProtocolProbe
                 {
                     Protocol = Constants.Protocols.OgcApiProcesses,
                     Assertion = "plan-shape-accepted",
-                    Outcome = "created",
-                    Status = EvalStageStatus.Passed
+                    Outcome = expectedExecutable ? "matched-acceptance" : "unexpected-acceptance",
+                    Status = expectedExecutable ? EvalStageStatus.Passed : EvalStageStatus.Failed
+                };
+            }
+
+            if (response.StatusCode == HttpStatusCode.BadRequest)
+            {
+                return new EvalProtocolProbe
+                {
+                    Protocol = Constants.Protocols.OgcApiProcesses,
+                    Assertion = "plan-shape-accepted",
+                    Outcome = expectedExecutable ? "unexpected-rejection" : "matched-rejection",
+                    Status = expectedExecutable ? EvalStageStatus.Failed : EvalStageStatus.Passed
                 };
             }
 
@@ -643,6 +694,34 @@ public sealed class EvalRunner
             Detail = detail,
             ElapsedMs = 0
         };
+
+    private static ExecutionSkipReason? ResolveExecutionSkipReason(
+        EvalExpectedOutcome expected,
+        (EvalStageOutcome Stage, Proto.ValidatePlanResponse? Response) validateOutcome)
+    {
+        if (validateOutcome.Response is null || validateOutcome.Stage.Status != EvalStageStatus.Passed)
+        {
+            return null;
+        }
+
+        if (!expected.IsExecutable && !validateOutcome.Response.IsExecutable)
+        {
+            return new ExecutionSkipReason(
+                "plan-non-executable",
+                "Scenario expected IsExecutable=false; skipping DryRun and SubmitPlanJob because the canonical runtime rejects non-executable plans.");
+        }
+
+        if (expected.RequiresApproval && validateOutcome.Response.RequiresApproval)
+        {
+            return new ExecutionSkipReason(
+                "plan-approval-required",
+                "Scenario expected RequiresApproval=true; skipping DryRun and SubmitPlanJob because SubmitPlanJob enforces the approval gate.");
+        }
+
+        return null;
+    }
+
+    private readonly record struct ExecutionSkipReason(string Reason, string Detail);
 
     private static EvalStageOutcome BuildProtocolParityStageOutcome(EvalProtocolParityOutcome parity, long elapsedMs)
     {

--- a/tests/Honua.TestKit/Eval/EvalRunner.cs
+++ b/tests/Honua.TestKit/Eval/EvalRunner.cs
@@ -307,7 +307,25 @@ public sealed class EvalRunner
             stopwatch.Stop();
 
             var expected = scenario.ExpectedOutcome.EstimatedArtifactKinds;
-            var actual = response.EstimatedArtifacts.Select(EvalProtoMap.ToDomainArtifactKind).ToArray();
+            var mapped = response.EstimatedArtifacts
+                .Select(k => (Proto: k, Domain: EvalProtoMap.ToDomainArtifactKind(k)))
+                .ToArray();
+
+            var unknownProtoKinds = mapped.Where(x => x.Domain is null).Select(x => x.Proto).ToArray();
+            if (unknownProtoKinds.Length > 0)
+            {
+                stopwatch.Stop();
+                return (new EvalStageOutcome
+                {
+                    Stage = EvalStageKind.DryRun,
+                    Status = EvalStageStatus.Failed,
+                    Reason = "artifact-kind-unknown",
+                    Detail = $"Dry-run returned unmapped proto artifact kind(s) [{string.Join(",", unknownProtoKinds)}].",
+                    ElapsedMs = stopwatch.ElapsedMilliseconds
+                }, response);
+            }
+
+            var actual = mapped.Select(x => x.Domain!.Value).ToArray();
 
             if (expected.Count > 0)
             {

--- a/tests/Honua.TestKit/Eval/EvalScenario.cs
+++ b/tests/Honua.TestKit/Eval/EvalScenario.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.TestKit.Eval;
+
+/// <summary>
+/// Declarative end-to-end eval scenario describing the canonical operator workflow
+/// from intent capture through terminal result validation. Scenarios are authored as
+/// JSON under <c>tests/Eval/scenarios/</c> and consumed by <see cref="EvalRunner"/>.
+/// </summary>
+public sealed record EvalScenario
+{
+    /// <summary>Stable scenario identifier used in reports and CI filters.</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Human-readable scenario name for reports.</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Workflow mode: analysis | publish | package | deploy.</summary>
+    [JsonPropertyName("mode")]
+    public EvalScenarioMode Mode { get; init; } = EvalScenarioMode.Analysis;
+
+    /// <summary>Shared-corpus fixture profile (e.g. <c>core</c>, <c>ogc</c>).</summary>
+    [JsonPropertyName("fixtureProfile")]
+    public string FixtureProfile { get; init; } = "core";
+
+    /// <summary>Analyst intent captured at the start of the workflow.</summary>
+    [JsonPropertyName("intent")]
+    public EvalIntentSpec Intent { get; init; } = new();
+
+    /// <summary>Precompiled plan supplied by the scenario (Phase 1 compile seam).</summary>
+    [JsonPropertyName("precompiledPlan")]
+    public EvalPlanSpec PrecompiledPlan { get; init; } = new();
+
+    /// <summary>Expected outcome envelope asserted by the runner.</summary>
+    [JsonPropertyName("expectedOutcome")]
+    public EvalExpectedOutcome ExpectedOutcome { get; init; } = new();
+}
+
+/// <summary>Workflow mode hint for a scenario.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<EvalScenarioMode>))]
+public enum EvalScenarioMode
+{
+    /// <summary>Analysis-only workflow.</summary>
+    Analysis,
+
+    /// <summary>Publish lifecycle workflow (surface wiring in #730).</summary>
+    Publish,
+
+    /// <summary>Map package composition workflow (surface wiring in #730).</summary>
+    Package,
+
+    /// <summary>Deployment promotion workflow (surface wiring in #732).</summary>
+    Deploy
+}
+
+/// <summary>Serialized shape of <see cref="AnalysisIntent"/> for a scenario.</summary>
+public sealed record EvalIntentSpec
+{
+    /// <summary>Intent identifier.</summary>
+    [JsonPropertyName("intentId")]
+    public string IntentId { get; init; } = string.Empty;
+
+    /// <summary>Natural-language goal.</summary>
+    [JsonPropertyName("goal")]
+    public string Goal { get; init; } = string.Empty;
+
+    /// <summary>Optional mode hint stored on the domain intent.</summary>
+    [JsonPropertyName("mode")]
+    public string? Mode { get; init; }
+
+    /// <summary>Requested output artifact kinds.</summary>
+    [JsonPropertyName("requestedOutputs")]
+    public IReadOnlyList<ArtifactKind> RequestedOutputs { get; init; } = [];
+
+    /// <summary>Spatial, temporal, and unit constraints.</summary>
+    [JsonPropertyName("constraints")]
+    public EvalIntentConstraints? Constraints { get; init; }
+
+    /// <summary>Dataset or layer references.</summary>
+    [JsonPropertyName("inputs")]
+    public IReadOnlyList<string> Inputs { get; init; } = [];
+
+    /// <summary>Strategy for handling assumptions during compilation.</summary>
+    [JsonPropertyName("assumptionPolicy")]
+    public AssumptionPolicy AssumptionPolicy { get; init; } = AssumptionPolicy.AskWhenMaterial;
+}
+
+/// <summary>Serialized shape of <see cref="IntentConstraints"/> for a scenario.</summary>
+public sealed record EvalIntentConstraints
+{
+    /// <summary>WKT polygon, bounding box, or named area-of-interest.</summary>
+    [JsonPropertyName("areaOfInterest")]
+    public string? AreaOfInterest { get; init; }
+
+    /// <summary>EPSG SRID for the area-of-interest.</summary>
+    [JsonPropertyName("spatialReferenceId")]
+    public int? SpatialReferenceId { get; init; }
+
+    /// <summary>Time-window start (ISO 8601).</summary>
+    [JsonPropertyName("timeWindowStart")]
+    public DateTimeOffset? TimeWindowStart { get; init; }
+
+    /// <summary>Time-window end (ISO 8601).</summary>
+    [JsonPropertyName("timeWindowEnd")]
+    public DateTimeOffset? TimeWindowEnd { get; init; }
+
+    /// <summary>Preferred unit system (e.g. "meters").</summary>
+    [JsonPropertyName("units")]
+    public string? Units { get; init; }
+}
+
+/// <summary>Serialized shape of <see cref="AnalysisPlan"/> for a scenario.</summary>
+public sealed record EvalPlanSpec
+{
+    /// <summary>Plan identifier.</summary>
+    [JsonPropertyName("planId")]
+    public string PlanId { get; init; } = string.Empty;
+
+    /// <summary>Back-reference to the originating intent identifier.</summary>
+    [JsonPropertyName("intentId")]
+    public string IntentId { get; init; } = string.Empty;
+
+    /// <summary>Ordered plan steps forming the execution DAG.</summary>
+    [JsonPropertyName("steps")]
+    public IReadOnlyList<EvalPlanStepSpec> Steps { get; init; } = [];
+
+    /// <summary>Artifact kinds the plan promises to produce.</summary>
+    [JsonPropertyName("outputs")]
+    public IReadOnlyList<ArtifactKind> Outputs { get; init; } = [];
+}
+
+/// <summary>Serialized shape of <see cref="AnalysisPlanStep"/> for a scenario.</summary>
+public sealed record EvalPlanStepSpec
+{
+    /// <summary>Step identifier.</summary>
+    [JsonPropertyName("stepId")]
+    public string StepId { get; init; } = string.Empty;
+
+    /// <summary>Step category.</summary>
+    [JsonPropertyName("kind")]
+    public AnalysisPlanStepKind Kind { get; init; }
+
+    /// <summary>Process identifier for <see cref="AnalysisPlanStepKind.Geoprocess"/> steps.</summary>
+    [JsonPropertyName("processId")]
+    public string? ProcessId { get; init; }
+
+    /// <summary>Step-specific inputs, mirroring the proto map&lt;string,string&gt; contract.</summary>
+    [JsonPropertyName("inputs")]
+    public IReadOnlyDictionary<string, string> Inputs { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>Upstream step identifiers.</summary>
+    [JsonPropertyName("dependsOn")]
+    public IReadOnlyList<string> DependsOn { get; init; } = [];
+}
+
+/// <summary>Expected-outcome envelope asserted by the runner.</summary>
+public sealed record EvalExpectedOutcome
+{
+    /// <summary>Expected <see cref="PlanValidationResult.IsExecutable"/> value.</summary>
+    [JsonPropertyName("isExecutable")]
+    public bool IsExecutable { get; init; } = true;
+
+    /// <summary>Expected <see cref="PlanValidationResult.RequiresApproval"/> value.</summary>
+    [JsonPropertyName("requiresApproval")]
+    public bool RequiresApproval { get; init; }
+
+    /// <summary>Expected <see cref="DryRunResult.EstimatedArtifacts"/> set.</summary>
+    [JsonPropertyName("estimatedArtifactKinds")]
+    public IReadOnlyList<ArtifactKind> EstimatedArtifactKinds { get; init; } = [];
+
+    /// <summary>Expected terminal workflow status once execution completes.</summary>
+    [JsonPropertyName("terminalWorkflowStatus")]
+    public GeoprocessingWorkflowStatus? TerminalWorkflowStatus { get; init; }
+
+    /// <summary>Whether the scenario expects a <see cref="AnalysisResultPackage.MapPackageId"/>.</summary>
+    [JsonPropertyName("expectsMapPackage")]
+    public bool ExpectsMapPackage { get; init; }
+
+    /// <summary>Whether the scenario expects a <see cref="AnalysisResultPackage.AppPackageId"/>.</summary>
+    [JsonPropertyName("expectsAppPackage")]
+    public bool ExpectsAppPackage { get; init; }
+}

--- a/tests/Honua.TestKit/Eval/EvalScenario.cs
+++ b/tests/Honua.TestKit/Eval/EvalScenario.cs
@@ -25,7 +25,10 @@ public sealed record EvalScenario
     [JsonPropertyName("mode")]
     public EvalScenarioMode Mode { get; init; } = EvalScenarioMode.Analysis;
 
-    /// <summary>Shared-corpus fixture profile (e.g. <c>core</c>, <c>ogc</c>).</summary>
+    /// <summary>
+    /// Seed profile applied to the class-scoped eval schema (e.g. <c>core</c>,
+    /// <c>ogc</c>). All scenarios in one harness run must agree on this profile.
+    /// </summary>
     [JsonPropertyName("fixtureProfile")]
     public string FixtureProfile { get; init; } = "core";
 

--- a/tests/Honua.TestKit/Eval/EvalScenarioException.cs
+++ b/tests/Honua.TestKit/Eval/EvalScenarioException.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.TestKit.Eval;
+
+/// <summary>
+/// Raised only at the <see cref="EvalRunner"/> boundary when a fatal configuration
+/// or loader error prevents scenario execution. Per-stage failures surface through
+/// <see cref="EvalStageOutcome"/> rather than exceptions.
+/// </summary>
+public sealed class EvalScenarioException : Exception
+{
+    /// <summary>Initializes the exception with the given message.</summary>
+    public EvalScenarioException(string message) : base(message) { }
+
+    /// <summary>Initializes the exception with the given message and inner exception.</summary>
+    public EvalScenarioException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/tests/Honua.TestKit/Eval/EvalScenarioLoader.cs
+++ b/tests/Honua.TestKit/Eval/EvalScenarioLoader.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.TestKit.Eval;
+
+/// <summary>
+/// AOT-safe loader that deserializes <see cref="EvalScenario"/> documents through the
+/// source-generated <see cref="EvalJsonContext"/>. Resolves scenario paths relative
+/// to the nearest <c>Honua.sln</c> or <c>tests/Eval/scenarios/</c> root.
+/// </summary>
+public static class EvalScenarioLoader
+{
+    private const string ScenarioRootSegment = "tests/Eval/scenarios";
+
+    /// <summary>
+    /// Loads a single scenario by identifier. Searches (in order):
+    /// <list type="number">
+    ///   <item>Override path from the <c>HONUA_EVAL_SCENARIO_ROOT</c> environment variable.</item>
+    ///   <item>Co-located scenarios under the solution's <c>tests/Eval/scenarios/</c> directory.</item>
+    ///   <item>Co-located scenarios next to the test binary.</item>
+    /// </list>
+    /// </summary>
+    public static EvalScenario LoadById(string scenarioId)
+    {
+        if (string.IsNullOrWhiteSpace(scenarioId))
+        {
+            throw new EvalScenarioException("Scenario id must be non-empty.");
+        }
+
+        var path = ResolveScenarioPath(scenarioId)
+            ?? throw new EvalScenarioException(
+                $"Scenario '{scenarioId}' not found. Searched {ScenarioRootSegment} relative to the solution root and test binary.");
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            var scenario = JsonSerializer.Deserialize(stream, EvalJsonContext.Default.EvalScenario);
+            if (scenario == null)
+            {
+                throw new EvalScenarioException($"Scenario '{scenarioId}' at '{path}' deserialized to null.");
+            }
+
+            if (!string.Equals(scenario.Id, scenarioId, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new EvalScenarioException(
+                    $"Scenario id mismatch: file declares '{scenario.Id}' but was loaded as '{scenarioId}'.");
+            }
+
+            return scenario;
+        }
+        catch (JsonException ex)
+        {
+            throw new EvalScenarioException($"Failed to parse scenario '{scenarioId}' at '{path}': {ex.Message}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Enumerates all scenario identifiers discoverable under the scenario root.
+    /// Used by CI reporting and the xUnit host to iterate the full corpus.
+    /// </summary>
+    public static IReadOnlyList<string> DiscoverScenarioIds()
+    {
+        var root = ResolveScenarioRoot();
+        if (root == null || !Directory.Exists(root))
+        {
+            return [];
+        }
+
+        return Directory.EnumerateFiles(root, "*.json", SearchOption.TopDirectoryOnly)
+            .Select(Path.GetFileNameWithoutExtension)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(name => name!)
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string? ResolveScenarioPath(string scenarioId)
+    {
+        var root = ResolveScenarioRoot();
+        if (root == null)
+        {
+            return null;
+        }
+
+        var candidate = Path.Combine(root, $"{scenarioId}.json");
+        return File.Exists(candidate) ? candidate : null;
+    }
+
+    private static string? ResolveScenarioRoot()
+    {
+        var overrideRoot = Environment.GetEnvironmentVariable("HONUA_EVAL_SCENARIO_ROOT");
+        if (!string.IsNullOrWhiteSpace(overrideRoot) && Directory.Exists(overrideRoot))
+        {
+            return overrideRoot;
+        }
+
+        var solutionRoot = FindAncestorContaining("Honua.sln");
+        if (solutionRoot != null)
+        {
+            var fromSolution = Path.Combine(solutionRoot, ScenarioRootSegment.Replace('/', Path.DirectorySeparatorChar));
+            if (Directory.Exists(fromSolution))
+            {
+                return fromSolution;
+            }
+        }
+
+        var localRoot = Path.Combine(AppContext.BaseDirectory, ScenarioRootSegment.Replace('/', Path.DirectorySeparatorChar));
+        return Directory.Exists(localRoot) ? localRoot : null;
+    }
+
+    private static string? FindAncestorContaining(string marker)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, marker)))
+        {
+            directory = directory.Parent;
+        }
+        return directory?.FullName;
+    }
+}

--- a/tests/Honua.TestKit/Eval/EvalScenarioLoader.cs
+++ b/tests/Honua.TestKit/Eval/EvalScenarioLoader.cs
@@ -21,6 +21,9 @@ public static class EvalScenarioLoader
     ///   <item>Co-located scenarios under the solution's <c>tests/Eval/scenarios/</c> directory.</item>
     ///   <item>Co-located scenarios next to the test binary.</item>
     /// </list>
+    /// When <c>HONUA_EVAL_SCENARIO_ROOT</c> is set but the directory does not exist, the loader
+    /// fails closed with <see cref="EvalScenarioException"/> rather than falling back to the
+    /// bundled corpus, so a misconfigured override cannot mask a typoed path as a green run.
     /// </summary>
     public static EvalScenario LoadById(string scenarioId)
     {
@@ -91,8 +94,15 @@ public static class EvalScenarioLoader
     private static string? ResolveScenarioRoot()
     {
         var overrideRoot = Environment.GetEnvironmentVariable("HONUA_EVAL_SCENARIO_ROOT");
-        if (!string.IsNullOrWhiteSpace(overrideRoot) && Directory.Exists(overrideRoot))
+        if (!string.IsNullOrWhiteSpace(overrideRoot))
         {
+            if (!Directory.Exists(overrideRoot))
+            {
+                throw new EvalScenarioException(
+                    $"HONUA_EVAL_SCENARIO_ROOT is set to '{overrideRoot}' but the directory does not exist. " +
+                    "Fix the override or unset the variable to use the bundled scenario corpus.");
+            }
+
             return overrideRoot;
         }
 

--- a/tests/Honua.TestKit/Eval/EvalScenarioLoader.cs
+++ b/tests/Honua.TestKit/Eval/EvalScenarioLoader.cs
@@ -8,7 +8,7 @@ namespace Honua.TestKit.Eval;
 /// <summary>
 /// AOT-safe loader that deserializes <see cref="EvalScenario"/> documents through the
 /// source-generated <see cref="EvalJsonContext"/>. Resolves scenario paths relative
-/// to the nearest <c>Honua.sln</c> or <c>tests/Eval/scenarios/</c> root.
+/// to the nearest <c>Honua.sln</c> root.
 /// </summary>
 public static class EvalScenarioLoader
 {
@@ -19,7 +19,6 @@ public static class EvalScenarioLoader
     /// <list type="number">
     ///   <item>Override path from the <c>HONUA_EVAL_SCENARIO_ROOT</c> environment variable.</item>
     ///   <item>Co-located scenarios under the solution's <c>tests/Eval/scenarios/</c> directory.</item>
-    ///   <item>Co-located scenarios next to the test binary.</item>
     /// </list>
     /// When <c>HONUA_EVAL_SCENARIO_ROOT</c> is set but the directory does not exist, the loader
     /// fails closed with <see cref="EvalScenarioException"/> rather than falling back to the
@@ -34,7 +33,8 @@ public static class EvalScenarioLoader
 
         var path = ResolveScenarioPath(scenarioId)
             ?? throw new EvalScenarioException(
-                $"Scenario '{scenarioId}' not found. Searched {ScenarioRootSegment} relative to the solution root and test binary.");
+                $"Scenario '{scenarioId}' not found. Searched {ScenarioRootSegment} under the solution root (Honua.sln). " +
+                "Set HONUA_EVAL_SCENARIO_ROOT to override, or run the tests from inside the repo tree so the loader can locate Honua.sln.");
 
         try
         {
@@ -107,17 +107,13 @@ public static class EvalScenarioLoader
         }
 
         var solutionRoot = FindAncestorContaining("Honua.sln");
-        if (solutionRoot != null)
+        if (solutionRoot == null)
         {
-            var fromSolution = Path.Combine(solutionRoot, ScenarioRootSegment.Replace('/', Path.DirectorySeparatorChar));
-            if (Directory.Exists(fromSolution))
-            {
-                return fromSolution;
-            }
+            return null;
         }
 
-        var localRoot = Path.Combine(AppContext.BaseDirectory, ScenarioRootSegment.Replace('/', Path.DirectorySeparatorChar));
-        return Directory.Exists(localRoot) ? localRoot : null;
+        var fromSolution = Path.Combine(solutionRoot, ScenarioRootSegment.Replace('/', Path.DirectorySeparatorChar));
+        return Directory.Exists(fromSolution) ? fromSolution : null;
     }
 
     private static string? FindAncestorContaining(string marker)

--- a/tests/Honua.TestKit/Honua.TestKit.csproj
+++ b/tests/Honua.TestKit/Honua.TestKit.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="FluentAssertions.Json" Version="6.1.0" />
     <PackageReference Include="FsCheck.Xunit" Version="3.3.2" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
+    <PackageReference Include="Grpc.Net.Client.Web" Version="2.76.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageReference Include="NBomber" Version="6.3.0" />
     <PackageReference Include="Parquet.Net" Version="5.5.0" />

--- a/tests/Honua.TestKit/Seeding/SeedRunner.cs
+++ b/tests/Honua.TestKit/Seeding/SeedRunner.cs
@@ -545,7 +545,9 @@ internal static class SeedRunner
         => declaredType.StartsWith("smallint", StringComparison.Ordinal) ||
            declaredType.StartsWith("integer", StringComparison.Ordinal) ||
            declaredType.StartsWith("bigint", StringComparison.Ordinal) ||
-           declaredType.StartsWith("int", StringComparison.Ordinal) ||
+           declaredType.StartsWith("int2", StringComparison.Ordinal) ||
+           declaredType.StartsWith("int4", StringComparison.Ordinal) ||
+           declaredType.StartsWith("int8", StringComparison.Ordinal) ||
            declaredType.StartsWith("serial", StringComparison.Ordinal) ||
            declaredType.StartsWith("bigserial", StringComparison.Ordinal);
 

--- a/tests/Honua.TestKit/Seeding/SeedRunner.cs
+++ b/tests/Honua.TestKit/Seeding/SeedRunner.cs
@@ -317,7 +317,7 @@ internal static class SeedRunner
             columns.Add(idColumn);
             var paramName = NextParam();
             values.Add($"@{paramName}");
-            AddParameter(paramName, feature.Id);
+            AddParameter(paramName, NormalizeValueForColumn(feature.Id, collection.IdType ?? "serial"));
         }
 
         if (feature.Properties is not null)
@@ -325,7 +325,7 @@ internal static class SeedRunner
             foreach (var (name, value) in feature.Properties)
             {
                 if (collection.Properties is null ||
-                    !collection.Properties.ContainsKey(name))
+                    !collection.Properties.TryGetValue(name, out var propertyType))
                 {
                     throw new InvalidOperationException($"Feature property '{name}' not defined on collection '{collection.Name}'.");
                 }
@@ -334,7 +334,7 @@ internal static class SeedRunner
                 var paramName = NextParam();
                 columns.Add(columnName);
                 values.Add($"@{paramName}");
-                AddParameter(paramName, value);
+                AddParameter(paramName, NormalizeValueForColumn(value, propertyType));
             }
         }
 
@@ -500,6 +500,71 @@ internal static class SeedRunner
             _ => value.ToString()
         };
     }
+
+    private static object? NormalizeValueForColumn(object? value, string declaredType)
+    {
+        var normalized = NormalizeYamlObject(value);
+        if (normalized is not string text)
+        {
+            return normalized;
+        }
+
+        var type = declaredType.Trim().ToLowerInvariant();
+        if (IsIntegerType(type) &&
+            long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var integerValue))
+        {
+            return UsesInt64(type)
+                ? integerValue
+                : checked((int)integerValue);
+        }
+
+        if (IsBooleanType(type) &&
+            bool.TryParse(text, out var boolValue))
+        {
+            return boolValue;
+        }
+
+        if (IsFloatingPointType(type) &&
+            double.TryParse(text, NumberStyles.Float | NumberStyles.AllowThousands,
+                CultureInfo.InvariantCulture, out var doubleValue))
+        {
+            return doubleValue;
+        }
+
+        if (IsDecimalType(type) &&
+            decimal.TryParse(text, NumberStyles.Number, CultureInfo.InvariantCulture,
+                out var decimalValue))
+        {
+            return decimalValue;
+        }
+
+        return normalized;
+    }
+
+    private static bool IsIntegerType(string declaredType)
+        => declaredType.StartsWith("smallint", StringComparison.Ordinal) ||
+           declaredType.StartsWith("integer", StringComparison.Ordinal) ||
+           declaredType.StartsWith("bigint", StringComparison.Ordinal) ||
+           declaredType.StartsWith("int", StringComparison.Ordinal) ||
+           declaredType.StartsWith("serial", StringComparison.Ordinal) ||
+           declaredType.StartsWith("bigserial", StringComparison.Ordinal);
+
+    private static bool UsesInt64(string declaredType)
+        => declaredType.StartsWith("bigint", StringComparison.Ordinal) ||
+           declaredType.StartsWith("bigserial", StringComparison.Ordinal);
+
+    private static bool IsBooleanType(string declaredType)
+        => declaredType.StartsWith("bool", StringComparison.Ordinal) ||
+           declaredType.StartsWith("boolean", StringComparison.Ordinal);
+
+    private static bool IsFloatingPointType(string declaredType)
+        => declaredType.StartsWith("real", StringComparison.Ordinal) ||
+           declaredType.StartsWith("double precision", StringComparison.Ordinal) ||
+           declaredType.StartsWith("float", StringComparison.Ordinal);
+
+    private static bool IsDecimalType(string declaredType)
+        => declaredType.StartsWith("numeric", StringComparison.Ordinal) ||
+           declaredType.StartsWith("decimal", StringComparison.Ordinal);
 }
 
 internal sealed class SeedDefinition

--- a/tests/Honua.TestKit/Seeding/SeedRunner.cs
+++ b/tests/Honua.TestKit/Seeding/SeedRunner.cs
@@ -569,12 +569,15 @@ internal static class SeedRunner
            declaredType.StartsWith("int2", StringComparison.Ordinal) ||
            declaredType.StartsWith("int4", StringComparison.Ordinal) ||
            declaredType.StartsWith("int8", StringComparison.Ordinal) ||
+           declaredType.Equals("int", StringComparison.Ordinal) ||
+           declaredType.StartsWith("int[", StringComparison.Ordinal) ||
            declaredType.StartsWith("serial", StringComparison.Ordinal) ||
            declaredType.StartsWith("bigserial", StringComparison.Ordinal);
 
     private static bool UsesInt64(string declaredType)
         => declaredType.StartsWith("bigint", StringComparison.Ordinal) ||
-           declaredType.StartsWith("bigserial", StringComparison.Ordinal);
+           declaredType.StartsWith("bigserial", StringComparison.Ordinal) ||
+           declaredType.StartsWith("int8", StringComparison.Ordinal);
 
     private static bool IsBooleanType(string declaredType)
         => declaredType.StartsWith("bool", StringComparison.Ordinal) ||

--- a/tests/Honua.TestKit/Seeding/SeedRunner.cs
+++ b/tests/Honua.TestKit/Seeding/SeedRunner.cs
@@ -81,6 +81,27 @@ internal static class SeedRunner
         }
     }
 
+    // Returns the collection names visible to the given profile, or null when the
+    // seed applies every collection (no profile filter). Callers can treat a non-null
+    // result as the strict allow-list for that profile and validate that declared
+    // scenario inputs are a subset before seeding a schema.
+    internal static IReadOnlyCollection<string>? GetAllowedCollections(string seedPath, string? profileName)
+    {
+        if (string.IsNullOrWhiteSpace(seedPath))
+        {
+            throw new ArgumentException("Seed path is required.", nameof(seedPath));
+        }
+
+        if (!File.Exists(seedPath))
+        {
+            throw new FileNotFoundException($"Seed file not found: {seedPath}", seedPath);
+        }
+
+        var seed = LoadSeed(seedPath);
+        var profile = ResolveProfile(seed, profileName);
+        return ResolveAllowedCollections(profile);
+    }
+
     private static async Task ApplyOnceAsync(
         NpgsqlDataSource dataSource,
         string seedPath,


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #734

## Summary
Adds an end-to-end eval harness for analyst workflows, result packages, and map/app outputs (AnalysisPlan → ExecutionJob → ResultPackage → MapPackage → AppPackage lifecycle), and fixes three trunk test regressions that were surfaced by the harness's solution-wide pr-gate sweep.

## Changes Made
- Added `EvalHarnessTests` (theory + integration tests) executing end-to-end against the seeded `ogc` profile
- Added `Scenario_PassesEndToEnd` covering all bundled scenarios
- Added `ProtocolParity` stage driving scenarios from discovery with negative/matched rejection parity
- Added `EvalHarnessSupportTests.BundledScenario_DeclaredInputsAreServedByItsFixtureProfile` enforcing profile↔input alignment
- Class-scoped `eval-report.json` emission pipeline
- **WFS 2.0 content negotiation**: added `Wfs20Utilities.AcceptHeaderExplicitlyRejectsXml` helper; `GetCapabilities` and `DescribeFeatureType` now return 406 when the `Accept` header explicitly rejects XML (`q=0`). Catch-all Accept headers remain tolerated.
- **OGC API Processes conformance**: removed `conf/job-list` class from `/ogc/processes/conformance`. V1 `/jobs` endpoint does not yet meet the full class requirements (filtering, paging, links shape); declare only when the implementation matches the class.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Breaking Changes
None. The WFS 406 behavior only activates for explicit `q=0` rejection — catch-all `Accept: application/json` clients that previously worked continue to work. The OGC Processes conformance change removes a class that was advertised but not fully implemented.

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated

## Release/Deploy Impact
No release or deploy impact.

## Pre-PR Checklist
- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above

🤖 Generated with [Claude Code](https://claude.com/claude-code)