### PR TITLE
feat(#739): runtime rate, concurrency, cost, and backpressure controls for operator execution

### DIFF
--- a/src/Honua.Core/Features/Geoprocessing/Abstractions/IExecutionAdmissionEvaluator.cs
+++ b/src/Honua.Core/Features/Geoprocessing/Abstractions/IExecutionAdmissionEvaluator.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.Core.Features.Geoprocessing.Abstractions;
+
+/// <summary>
+/// Transport-neutral evaluator that gates operator-execution submission on
+/// rate, concurrency, cost, and backpressure controls. Composes with
+/// <c>IOperatorAuthorizationEvaluator</c> and <c>IOperatorApprovalEvaluator</c>
+/// as the "may you now?" gate after authorization and approval have passed.
+/// </summary>
+public interface IExecutionAdmissionEvaluator
+{
+    /// <summary>
+    /// Evaluates whether the request may enter the execution pipeline right now.
+    /// Returns a decision whose outcome and dimension drive throttling, denial,
+    /// and observability without redefining canonical process semantics.
+    /// </summary>
+    Task<ExecutionAdmissionDecision> EvaluateAsync(
+        ExecutionAdmissionRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Geoprocessing/Domain/ExecutionAdmissionDecision.cs
+++ b/src/Honua.Core/Features/Geoprocessing/Domain/ExecutionAdmissionDecision.cs
@@ -133,14 +133,14 @@ public sealed record ExecutionAdmissionDecision
         string reason,
         int retryAfterSeconds,
         ExecutionAdmissionSnapshot snapshot) => new()
-    {
-        Outcome = ExecutionAdmissionOutcome.Throttled,
-        DenyingDimension = dimension,
-        PolicyRef = policyRef,
-        Reason = reason,
-        RetryAfterSeconds = retryAfterSeconds,
-        Snapshot = snapshot
-    };
+        {
+            Outcome = ExecutionAdmissionOutcome.Throttled,
+            DenyingDimension = dimension,
+            PolicyRef = policyRef,
+            Reason = reason,
+            RetryAfterSeconds = retryAfterSeconds,
+            Snapshot = snapshot
+        };
 
     /// <summary>
     /// Creates a denied decision for the given dimension.
@@ -151,12 +151,12 @@ public sealed record ExecutionAdmissionDecision
         string reason,
         int retryAfterSeconds,
         ExecutionAdmissionSnapshot snapshot) => new()
-    {
-        Outcome = ExecutionAdmissionOutcome.Denied,
-        DenyingDimension = dimension,
-        PolicyRef = policyRef,
-        Reason = reason,
-        RetryAfterSeconds = retryAfterSeconds,
-        Snapshot = snapshot
-    };
+        {
+            Outcome = ExecutionAdmissionOutcome.Denied,
+            DenyingDimension = dimension,
+            PolicyRef = policyRef,
+            Reason = reason,
+            RetryAfterSeconds = retryAfterSeconds,
+            Snapshot = snapshot
+        };
 }

--- a/src/Honua.Core/Features/Geoprocessing/Domain/ExecutionAdmissionDecision.cs
+++ b/src/Honua.Core/Features/Geoprocessing/Domain/ExecutionAdmissionDecision.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Geoprocessing.Domain;
+
+/// <summary>
+/// Terminal outcome of an admission evaluation.
+/// </summary>
+public enum ExecutionAdmissionOutcome
+{
+    /// <summary>
+    /// The request is admitted and may enter the execution pipeline.
+    /// </summary>
+    Admitted,
+
+    /// <summary>
+    /// The request exceeded a per-caller rate limit and should be retried later.
+    /// </summary>
+    Throttled,
+
+    /// <summary>
+    /// The request is rejected because a system or partition capacity limit is reached.
+    /// </summary>
+    Denied
+}
+
+/// <summary>
+/// Control dimension that caused a non-admitted outcome.
+/// </summary>
+public enum ExecutionAdmissionDimension
+{
+    /// <summary>
+    /// Per-principal submission rate limit over a sliding window.
+    /// </summary>
+    Rate,
+
+    /// <summary>
+    /// Per-partition active concurrency limit.
+    /// </summary>
+    Concurrency,
+
+    /// <summary>
+    /// Aggregate cost-weight limit within a partition.
+    /// </summary>
+    Cost,
+
+    /// <summary>
+    /// System-wide backpressure limit (global active jobs).
+    /// </summary>
+    Backpressure
+}
+
+/// <summary>
+/// Point-in-time utilization snapshot captured during admission evaluation.
+/// Exposed on the decision so callers and telemetry can observe headroom and load.
+/// </summary>
+public sealed record ExecutionAdmissionSnapshot
+{
+    /// <summary>
+    /// Active job count matching the request partition and kind.
+    /// </summary>
+    public int ActiveJobsInPartition { get; init; }
+
+    /// <summary>
+    /// Active job count across all partitions for all kinds.
+    /// </summary>
+    public int ActiveJobsGlobal { get; init; }
+
+    /// <summary>
+    /// Submissions observed in the current rate window for the principal and kind.
+    /// </summary>
+    public int SubmissionsInWindow { get; init; }
+
+    /// <summary>
+    /// Sum of observed admission cost weights currently active in the partition.
+    /// </summary>
+    public double ActiveCostWeightInPartition { get; init; }
+}
+
+/// <summary>
+/// Result of evaluating an <see cref="ExecutionAdmissionRequest"/>.
+/// Transport-neutral: carries policy metadata, retry hints, and a utilization snapshot
+/// so adapters can translate to protocol-specific responses without re-deriving state.
+/// </summary>
+public sealed record ExecutionAdmissionDecision
+{
+    /// <summary>
+    /// Admission outcome.
+    /// </summary>
+    public required ExecutionAdmissionOutcome Outcome { get; init; }
+
+    /// <summary>
+    /// Dimension that denied the request, or null when admitted.
+    /// </summary>
+    public ExecutionAdmissionDimension? DenyingDimension { get; init; }
+
+    /// <summary>
+    /// Machine-readable policy reference (for example, <c>concurrency:geoprocessing:per-partition</c>).
+    /// Null when admitted.
+    /// </summary>
+    public string? PolicyRef { get; init; }
+
+    /// <summary>
+    /// Human-readable reason for a non-admitted outcome.
+    /// </summary>
+    public string? Reason { get; init; }
+
+    /// <summary>
+    /// Suggested retry delay in seconds for throttled or denied outcomes.
+    /// </summary>
+    public int? RetryAfterSeconds { get; init; }
+
+    /// <summary>
+    /// Utilization snapshot at evaluation time.
+    /// </summary>
+    public required ExecutionAdmissionSnapshot Snapshot { get; init; }
+
+    /// <summary>
+    /// Creates an admitted decision with the captured snapshot.
+    /// </summary>
+    public static ExecutionAdmissionDecision Admitted(ExecutionAdmissionSnapshot snapshot) => new()
+    {
+        Outcome = ExecutionAdmissionOutcome.Admitted,
+        Snapshot = snapshot
+    };
+
+    /// <summary>
+    /// Creates a throttled decision for the given dimension.
+    /// </summary>
+    public static ExecutionAdmissionDecision Throttled(
+        ExecutionAdmissionDimension dimension,
+        string policyRef,
+        string reason,
+        int retryAfterSeconds,
+        ExecutionAdmissionSnapshot snapshot) => new()
+    {
+        Outcome = ExecutionAdmissionOutcome.Throttled,
+        DenyingDimension = dimension,
+        PolicyRef = policyRef,
+        Reason = reason,
+        RetryAfterSeconds = retryAfterSeconds,
+        Snapshot = snapshot
+    };
+
+    /// <summary>
+    /// Creates a denied decision for the given dimension.
+    /// </summary>
+    public static ExecutionAdmissionDecision Denied(
+        ExecutionAdmissionDimension dimension,
+        string policyRef,
+        string reason,
+        int retryAfterSeconds,
+        ExecutionAdmissionSnapshot snapshot) => new()
+    {
+        Outcome = ExecutionAdmissionOutcome.Denied,
+        DenyingDimension = dimension,
+        PolicyRef = policyRef,
+        Reason = reason,
+        RetryAfterSeconds = retryAfterSeconds,
+        Snapshot = snapshot
+    };
+}

--- a/src/Honua.Core/Features/Geoprocessing/Domain/ExecutionAdmissionRequest.cs
+++ b/src/Honua.Core/Features/Geoprocessing/Domain/ExecutionAdmissionRequest.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Core.Features.Geoprocessing.Domain;
+
+/// <summary>
+/// Transport-neutral input to <see cref="Abstractions.IExecutionAdmissionEvaluator"/>.
+/// Carries scoping identifiers for rate, concurrency, cost, and backpressure gates.
+/// </summary>
+public sealed record ExecutionAdmissionRequest
+{
+    /// <summary>
+    /// Workload category being submitted. Scopes concurrency and cost buckets per kind.
+    /// </summary>
+    public required ExecutionJobKind JobKind { get; init; }
+
+    /// <summary>
+    /// Scoping key for concurrency and cost buckets (for example, workspace or tenant id).
+    /// Null collapses to a global partition bucket.
+    /// </summary>
+    public string? PartitionKey { get; init; }
+
+    /// <summary>
+    /// Scoping key for per-principal rate limiting. Null disables rate checks for the request.
+    /// </summary>
+    public string? PrincipalId { get; init; }
+
+    /// <summary>
+    /// Estimated cost weight for the request. 1.0 represents a single-step standard job.
+    /// Callers may pass <see cref="AnalysisPlan.Steps"/> count or a dry-run estimate.
+    /// </summary>
+    public double? EstimatedCostWeight { get; init; }
+
+    /// <summary>
+    /// Relative operator priority. Propagated to the job record on admission.
+    /// </summary>
+    public OperationPriority Priority { get; init; } = OperationPriority.Normal;
+}

--- a/src/Honua.Server/Features/Geoprocessing/ExecutionAdmissionEvaluator.cs
+++ b/src/Honua.Server/Features/Geoprocessing/ExecutionAdmissionEvaluator.cs
@@ -1,0 +1,386 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Geoprocessing;
+
+/// <summary>
+/// Default implementation of <see cref="IExecutionAdmissionEvaluator"/>.
+/// Gates admission on backpressure, concurrency, rate, and cost controls.
+/// Evaluation order short-circuits on the first failing dimension. Backpressure
+/// is checked first to avoid unnecessary partition-scoped work when the system
+/// is globally overloaded.
+/// </summary>
+internal sealed class ExecutionAdmissionEvaluator : IExecutionAdmissionEvaluator
+{
+    /// <summary>
+    /// Key used in <see cref="ExecutionJobSpec.Parameters"/> to persist the cost
+    /// weight at admission time. Observed by the evaluator when summing
+    /// active cost weight for subsequent requests.
+    /// </summary>
+    public const string CostWeightParameterKey = "admission.costWeight";
+
+    /// <summary>
+    /// Key used in <see cref="ExecutionJobSpec.Parameters"/> to persist the
+    /// partition key at admission time so active-cost summation stays scoped.
+    /// </summary>
+    public const string PartitionKeyParameterKey = "admission.partitionKey";
+
+    private const string GlobalPartitionSentinel = "__global__";
+    private const string AnonymousPrincipalSentinel = "__anonymous__";
+
+    private readonly IExecutionJobStore? _jobStore;
+    private readonly IOptionsMonitor<ExecutionAdmissionOptions> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<ExecutionAdmissionEvaluator> _logger;
+
+    private readonly ConcurrentDictionary<string, RateBucket> _rateBuckets = new();
+
+    private readonly Counter<long> _evaluatedCounter;
+
+    public ExecutionAdmissionEvaluator(
+        IOptionsMonitor<ExecutionAdmissionOptions> options,
+        TimeProvider timeProvider,
+        ILogger<ExecutionAdmissionEvaluator> logger,
+        IExecutionJobStore? jobStore = null)
+    {
+        _options = options;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _jobStore = jobStore;
+
+        _evaluatedCounter = HonuaTelemetry.Meter.CreateCounter<long>(
+            "execution.admission.evaluated",
+            unit: "{evaluation}",
+            description: "Count of admission evaluations tagged with outcome and dimension.");
+    }
+
+    public async Task<ExecutionAdmissionDecision> EvaluateAsync(
+        ExecutionAdmissionRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var options = _options.CurrentValue;
+
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity(
+            HonuaTelemetry.Activities.ExecutionAdmission, ActivityKind.Internal);
+        var partitionTag = request.PartitionKey ?? GlobalPartitionSentinel;
+        var principalTag = request.PrincipalId ?? AnonymousPrincipalSentinel;
+        activity?.SetTag("honua.admission.job_kind", request.JobKind.ToString());
+        activity?.SetTag("honua.admission.partition_key", partitionTag);
+        activity?.SetTag("honua.admission.principal_id", principalTag);
+
+        if (!options.Enabled)
+        {
+            var emptySnapshot = new ExecutionAdmissionSnapshot();
+            RecordActivity(activity, ExecutionAdmissionOutcome.Admitted, null);
+            RecordMetric(ExecutionAdmissionOutcome.Admitted, dimension: null, request.JobKind);
+            ExecutionAdmissionLog.Admitted(_logger, request.JobKind.ToString(), partitionTag, principalTag, 0, 0);
+            return ExecutionAdmissionDecision.Admitted(emptySnapshot);
+        }
+
+        var activeGlobal = 0;
+        var activeInPartition = 0;
+        var activeCostWeightInPartition = 0.0;
+
+        if (_jobStore != null)
+        {
+            var active = await _jobStore.ListActiveAsync(kind: null, cancellationToken)
+                .ConfigureAwait(false);
+            activeGlobal = active.Count;
+
+            foreach (var job in active)
+            {
+                if (job.Spec.Kind != request.JobKind)
+                {
+                    continue;
+                }
+
+                if (!MatchesPartition(job, request.PartitionKey))
+                {
+                    continue;
+                }
+
+                activeInPartition++;
+                activeCostWeightInPartition += ReadCostWeight(job);
+            }
+        }
+        else
+        {
+            ExecutionAdmissionLog.JobStoreUnavailable(_logger);
+        }
+
+        var submissionsInWindow = PeekSubmissions(request, options);
+
+        var snapshot = new ExecutionAdmissionSnapshot
+        {
+            ActiveJobsInPartition = activeInPartition,
+            ActiveJobsGlobal = activeGlobal,
+            SubmissionsInWindow = submissionsInWindow,
+            ActiveCostWeightInPartition = activeCostWeightInPartition
+        };
+
+        ExecutionAdmissionLog.Snapshot(
+            _logger, request.JobKind.ToString(), partitionTag,
+            activeInPartition, activeGlobal, submissionsInWindow, activeCostWeightInPartition);
+
+        // 1. Backpressure — cheapest short-circuit when the system is saturated.
+        if (options.MaxConcurrentJobsGlobal > 0 && activeGlobal >= options.MaxConcurrentJobsGlobal)
+        {
+            return Deny(
+                ExecutionAdmissionDimension.Backpressure,
+                $"backpressure:global:{request.JobKind.ToString().ToLowerInvariant()}",
+                $"Global active job limit reached ({activeGlobal}/{options.MaxConcurrentJobsGlobal}).",
+                options.DefaultRetryAfterSeconds,
+                snapshot, request, activity, partitionTag, principalTag);
+        }
+
+        // 2. Concurrency — per-partition active jobs for this kind.
+        if (options.MaxConcurrentJobsPerPartition > 0 && activeInPartition >= options.MaxConcurrentJobsPerPartition)
+        {
+            return Deny(
+                ExecutionAdmissionDimension.Concurrency,
+                $"concurrency:{request.JobKind.ToString().ToLowerInvariant()}:per-partition",
+                $"Partition active job limit reached ({activeInPartition}/{options.MaxConcurrentJobsPerPartition}).",
+                options.DefaultRetryAfterSeconds,
+                snapshot, request, activity, partitionTag, principalTag);
+        }
+
+        // 3. Rate — per-principal sliding-window submissions.
+        // Claim a slot so concurrent requests from the same principal cannot both pass.
+        if (options.MaxSubmissionsPerWindow > 0 && !string.IsNullOrWhiteSpace(request.PrincipalId))
+        {
+            var claimed = TryClaimSubmission(request, options, out var postClaimCount);
+            if (!claimed)
+            {
+                var rateSnapshot = snapshot with { SubmissionsInWindow = postClaimCount };
+                return Throttle(
+                    ExecutionAdmissionDimension.Rate,
+                    $"rate:{request.JobKind.ToString().ToLowerInvariant()}:per-principal",
+                    $"Principal submission rate limit reached ({postClaimCount}/{options.MaxSubmissionsPerWindow} in {options.RateWindowSeconds}s).",
+                    options.DefaultRetryAfterSeconds,
+                    rateSnapshot, request, activity, partitionTag, principalTag);
+            }
+
+            snapshot = snapshot with { SubmissionsInWindow = postClaimCount };
+        }
+
+        // 4. Cost — aggregate cost weight within the partition.
+        if (options.MaxCostWeightPerPartition > 0)
+        {
+            var requestCost = ResolveCostWeight(request);
+            var projectedCost = activeCostWeightInPartition + requestCost;
+            if (projectedCost > options.MaxCostWeightPerPartition)
+            {
+                return Deny(
+                    ExecutionAdmissionDimension.Cost,
+                    $"cost:{request.JobKind.ToString().ToLowerInvariant()}:per-partition",
+                    $"Partition cost weight would exceed limit ({projectedCost:F2}/{options.MaxCostWeightPerPartition:F2}).",
+                    options.DefaultRetryAfterSeconds,
+                    snapshot, request, activity, partitionTag, principalTag);
+            }
+        }
+
+        RecordActivity(activity, ExecutionAdmissionOutcome.Admitted, null);
+        RecordMetric(ExecutionAdmissionOutcome.Admitted, dimension: null, request.JobKind);
+        ExecutionAdmissionLog.Admitted(
+            _logger, request.JobKind.ToString(), partitionTag, principalTag, activeInPartition, activeGlobal);
+
+        return ExecutionAdmissionDecision.Admitted(snapshot);
+    }
+
+    // -----------------------------------------------------------------------
+    // Internals
+    // -----------------------------------------------------------------------
+
+    private ExecutionAdmissionDecision Deny(
+        ExecutionAdmissionDimension dimension,
+        string policyRef,
+        string reason,
+        int retryAfter,
+        ExecutionAdmissionSnapshot snapshot,
+        ExecutionAdmissionRequest request,
+        Activity? activity,
+        string partitionTag,
+        string principalTag)
+    {
+        RecordActivity(activity, ExecutionAdmissionOutcome.Denied, dimension);
+        RecordMetric(ExecutionAdmissionOutcome.Denied, dimension, request.JobKind);
+        ExecutionAdmissionLog.Denied(
+            _logger, dimension.ToString(), policyRef, request.JobKind.ToString(), partitionTag, principalTag, reason);
+        return ExecutionAdmissionDecision.Denied(dimension, policyRef, reason, retryAfter, snapshot);
+    }
+
+    private ExecutionAdmissionDecision Throttle(
+        ExecutionAdmissionDimension dimension,
+        string policyRef,
+        string reason,
+        int retryAfter,
+        ExecutionAdmissionSnapshot snapshot,
+        ExecutionAdmissionRequest request,
+        Activity? activity,
+        string partitionTag,
+        string principalTag)
+    {
+        RecordActivity(activity, ExecutionAdmissionOutcome.Throttled, dimension);
+        RecordMetric(ExecutionAdmissionOutcome.Throttled, dimension, request.JobKind);
+        ExecutionAdmissionLog.Throttled(
+            _logger, dimension.ToString(), policyRef, request.JobKind.ToString(), partitionTag, principalTag, reason);
+        return ExecutionAdmissionDecision.Throttled(dimension, policyRef, reason, retryAfter, snapshot);
+    }
+
+    private static void RecordActivity(
+        Activity? activity, ExecutionAdmissionOutcome outcome, ExecutionAdmissionDimension? dimension)
+    {
+        if (activity == null)
+        {
+            return;
+        }
+
+        activity.SetTag("honua.admission.outcome", outcome.ToString());
+        if (dimension.HasValue)
+        {
+            activity.SetTag("honua.admission.dimension", dimension.Value.ToString());
+            activity.SetStatus(ActivityStatusCode.Error, outcome.ToString());
+        }
+    }
+
+    private void RecordMetric(
+        ExecutionAdmissionOutcome outcome, ExecutionAdmissionDimension? dimension, ExecutionJobKind jobKind)
+    {
+        _evaluatedCounter.Add(1,
+            new KeyValuePair<string, object?>("outcome", outcome.ToString()),
+            new KeyValuePair<string, object?>("dimension", dimension?.ToString() ?? "None"),
+            new KeyValuePair<string, object?>("job_kind", jobKind.ToString()));
+    }
+
+    private static bool MatchesPartition(ExecutionJobRecord job, string? partitionKey)
+    {
+        var jobPartition = ReadPartitionKey(job);
+        if (partitionKey == null)
+        {
+            return jobPartition == null;
+        }
+
+        return string.Equals(jobPartition, partitionKey, StringComparison.Ordinal);
+    }
+
+    private static string? ReadPartitionKey(ExecutionJobRecord job)
+    {
+        if (job.Spec.Parameters.TryGetValue(PartitionKeyParameterKey, out var value) && !string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        return null;
+    }
+
+    private static double ReadCostWeight(ExecutionJobRecord job)
+    {
+        if (job.Spec.Parameters.TryGetValue(CostWeightParameterKey, out var value)
+            && double.TryParse(value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var parsed)
+            && parsed > 0)
+        {
+            return parsed;
+        }
+
+        return 1.0; // Assume a standard-cost job when unlabeled.
+    }
+
+    private static double ResolveCostWeight(ExecutionAdmissionRequest request)
+    {
+        if (request.EstimatedCostWeight is { } weight && weight > 0)
+        {
+            return weight;
+        }
+
+        return 1.0;
+    }
+
+    private int PeekSubmissions(ExecutionAdmissionRequest request, ExecutionAdmissionOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(request.PrincipalId) || options.MaxSubmissionsPerWindow <= 0)
+        {
+            return 0;
+        }
+
+        var key = BuildRateKey(request);
+        if (!_rateBuckets.TryGetValue(key, out var bucket))
+        {
+            return 0;
+        }
+
+        return bucket.Count(_timeProvider.GetUtcNow(), TimeSpan.FromSeconds(options.RateWindowSeconds));
+    }
+
+    private bool TryClaimSubmission(
+        ExecutionAdmissionRequest request, ExecutionAdmissionOptions options, out int count)
+    {
+        var key = BuildRateKey(request);
+        var bucket = _rateBuckets.GetOrAdd(key, static _ => new RateBucket());
+        return bucket.TryClaim(
+            _timeProvider.GetUtcNow(),
+            TimeSpan.FromSeconds(options.RateWindowSeconds),
+            options.MaxSubmissionsPerWindow,
+            out count);
+    }
+
+    private static string BuildRateKey(ExecutionAdmissionRequest request)
+        => $"{request.PrincipalId ?? AnonymousPrincipalSentinel}:{request.JobKind}";
+
+    /// <summary>
+    /// Sliding-window counter. Tracks timestamps of recent submissions and admits
+    /// up to <c>limit</c> claims within the window. Distributed coordination is a
+    /// follow-on; see <see cref="ExecutionAdmissionOptions"/> default rationale.
+    /// </summary>
+    private sealed class RateBucket
+    {
+        private readonly object _sync = new();
+        private readonly Queue<DateTimeOffset> _timestamps = new();
+
+        public int Count(DateTimeOffset now, TimeSpan window)
+        {
+            lock (_sync)
+            {
+                Prune(now, window);
+                return _timestamps.Count;
+            }
+        }
+
+        public bool TryClaim(DateTimeOffset now, TimeSpan window, int limit, out int count)
+        {
+            lock (_sync)
+            {
+                Prune(now, window);
+                if (_timestamps.Count >= limit)
+                {
+                    count = _timestamps.Count;
+                    return false;
+                }
+
+                _timestamps.Enqueue(now);
+                count = _timestamps.Count;
+                return true;
+            }
+        }
+
+        private void Prune(DateTimeOffset now, TimeSpan window)
+        {
+            var threshold = now - window;
+            while (_timestamps.Count > 0 && _timestamps.Peek() <= threshold)
+            {
+                _timestamps.Dequeue();
+            }
+        }
+    }
+}

--- a/src/Honua.Server/Features/Geoprocessing/ExecutionAdmissionLog.cs
+++ b/src/Honua.Server/Features/Geoprocessing/ExecutionAdmissionLog.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Geoprocessing;
+
+/// <summary>
+/// Source-generated structured log methods for execution admission decisions.
+/// Event IDs 8020-8039 reserved for admission (geoprocessing service uses 8000-8019).
+/// </summary>
+internal static partial class ExecutionAdmissionLog
+{
+    [LoggerMessage(8020, LogLevel.Information,
+        "Execution admitted: JobKind={JobKind}, PartitionKey={PartitionKey}, PrincipalId={PrincipalId}, ActiveInPartition={ActiveInPartition}, ActiveGlobal={ActiveGlobal}")]
+    public static partial void Admitted(
+        ILogger logger,
+        string jobKind,
+        string partitionKey,
+        string principalId,
+        int activeInPartition,
+        int activeGlobal);
+
+    [LoggerMessage(8021, LogLevel.Warning,
+        "Execution throttled ({Dimension}): Policy={PolicyRef}, JobKind={JobKind}, PartitionKey={PartitionKey}, PrincipalId={PrincipalId}, Reason={Reason}")]
+    public static partial void Throttled(
+        ILogger logger,
+        string dimension,
+        string policyRef,
+        string jobKind,
+        string partitionKey,
+        string principalId,
+        string reason);
+
+    [LoggerMessage(8022, LogLevel.Warning,
+        "Execution denied ({Dimension}): Policy={PolicyRef}, JobKind={JobKind}, PartitionKey={PartitionKey}, PrincipalId={PrincipalId}, Reason={Reason}")]
+    public static partial void Denied(
+        ILogger logger,
+        string dimension,
+        string policyRef,
+        string jobKind,
+        string partitionKey,
+        string principalId,
+        string reason);
+
+    [LoggerMessage(8023, LogLevel.Debug,
+        "Admission snapshot: JobKind={JobKind}, PartitionKey={PartitionKey}, ActiveInPartition={ActiveInPartition}, ActiveGlobal={ActiveGlobal}, SubmissionsInWindow={SubmissionsInWindow}, ActiveCostWeight={ActiveCostWeight}")]
+    public static partial void Snapshot(
+        ILogger logger,
+        string jobKind,
+        string partitionKey,
+        int activeInPartition,
+        int activeGlobal,
+        int submissionsInWindow,
+        double activeCostWeight);
+
+    [LoggerMessage(8024, LogLevel.Warning,
+        "ExecutionAdmission is enabled but IExecutionJobStore is not registered; backpressure and concurrency gates will skip")]
+    public static partial void JobStoreUnavailable(ILogger logger);
+}

--- a/src/Honua.Server/Features/Geoprocessing/ExecutionAdmissionOptions.cs
+++ b/src/Honua.Server/Features/Geoprocessing/ExecutionAdmissionOptions.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Honua.Server.Features.Geoprocessing;
+
+/// <summary>
+/// Configuration for runtime admission controls on operator execution.
+/// Bound from the <see cref="SectionName"/> section and validated at startup.
+/// Limits set to <c>0</c> disable that dimension.
+/// </summary>
+internal sealed class ExecutionAdmissionOptions
+{
+    /// <summary>
+    /// Configuration section name.
+    /// </summary>
+    public const string SectionName = "ExecutionAdmission";
+
+    /// <summary>
+    /// Master switch. When false, the evaluator admits all requests.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Maximum active jobs per partition + kind. 0 = unlimited.
+    /// </summary>
+    [Range(0, 10000, ErrorMessage = "MaxConcurrentJobsPerPartition must be between 0 and 10000")]
+    public int MaxConcurrentJobsPerPartition { get; set; } = 10;
+
+    /// <summary>
+    /// Maximum active jobs across all partitions and kinds. 0 = unlimited.
+    /// </summary>
+    [Range(0, 100000, ErrorMessage = "MaxConcurrentJobsGlobal must be between 0 and 100000")]
+    public int MaxConcurrentJobsGlobal { get; set; } = 50;
+
+    /// <summary>
+    /// Maximum submissions per principal per rate window. 0 = unlimited.
+    /// </summary>
+    [Range(0, 100000, ErrorMessage = "MaxSubmissionsPerWindow must be between 0 and 100000")]
+    public int MaxSubmissionsPerWindow { get; set; } = 20;
+
+    /// <summary>
+    /// Sliding window length in seconds for the rate gate.
+    /// </summary>
+    [Range(1, 3600, ErrorMessage = "RateWindowSeconds must be between 1 and 3600")]
+    public int RateWindowSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Maximum aggregate cost weight active in a partition. 0 = unlimited.
+    /// </summary>
+    [Range(0, 100000, ErrorMessage = "MaxCostWeightPerPartition must be between 0 and 100000")]
+    public double MaxCostWeightPerPartition { get; set; } = 20.0;
+
+    /// <summary>
+    /// Retry-After hint returned to callers for throttled or denied outcomes, in seconds.
+    /// </summary>
+    [Range(1, 3600, ErrorMessage = "DefaultRetryAfterSeconds must be between 1 and 3600")]
+    public int DefaultRetryAfterSeconds { get; set; } = 10;
+}

--- a/src/Honua.Server/Features/Geoprocessing/GPServer/GPServerEndpoints.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GPServer/GPServerEndpoints.cs
@@ -579,6 +579,11 @@ internal static class GPServerEndpoints
                 LogAndReturn(logger, operation, conflictEx.Message,
                     StandardErrorHelpers.CreateConflict(context, conflictEx.Message)),
 
+            GeoprocessingAdmissionException admissionEx =>
+                LogAndReturn(logger, operation, admissionEx.Message,
+                    StandardErrorHelpers.CreateServiceUnavailable(
+                        context, admissionEx.Message, admissionEx.RetryAfterSeconds)),
+
             _ => LogAndReturn(logger, operation, ex.Message,
                 StandardErrorHelpers.CreateInternalServerError(context,
                     "An error occurred while processing the GP request."))

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobExceptions.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobExceptions.cs
@@ -83,3 +83,46 @@ internal sealed class GeoprocessingIdempotencyConflictException : Exception
     public GeoprocessingIdempotencyConflictException()
         : base("Idempotency key is already associated with a different request.") { }
 }
+
+/// <summary>
+/// Raised when a runtime admission control blocks job submission.
+/// Both Throttled and Denied outcomes surface through this exception; the outcome
+/// and dimension are preserved for protocol mapping, telemetry, and eval harness signals.
+/// </summary>
+internal sealed class GeoprocessingAdmissionException : Exception
+{
+    /// <summary>
+    /// Terminal admission outcome (<see cref="Honua.Core.Features.Geoprocessing.Domain.ExecutionAdmissionOutcome.Throttled"/>
+    /// or <see cref="Honua.Core.Features.Geoprocessing.Domain.ExecutionAdmissionOutcome.Denied"/>).
+    /// </summary>
+    public Honua.Core.Features.Geoprocessing.Domain.ExecutionAdmissionOutcome Outcome { get; }
+
+    /// <summary>
+    /// Control dimension that rejected the request.
+    /// </summary>
+    public Honua.Core.Features.Geoprocessing.Domain.ExecutionAdmissionDimension DenyingDimension { get; }
+
+    /// <summary>
+    /// Machine-readable policy reference that rejected the request.
+    /// </summary>
+    public string PolicyRef { get; }
+
+    /// <summary>
+    /// Suggested retry delay in seconds.
+    /// </summary>
+    public int RetryAfterSeconds { get; }
+
+    public GeoprocessingAdmissionException(
+        Honua.Core.Features.Geoprocessing.Domain.ExecutionAdmissionOutcome outcome,
+        Honua.Core.Features.Geoprocessing.Domain.ExecutionAdmissionDimension dimension,
+        string policyRef,
+        string reason,
+        int retryAfterSeconds)
+        : base(reason)
+    {
+        Outcome = outcome;
+        DenyingDimension = dimension;
+        PolicyRef = policyRef;
+        RetryAfterSeconds = retryAfterSeconds;
+    }
+}

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
@@ -39,6 +40,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
     private readonly AnalyticsLimits _analyticsLimits;
     private readonly IExecutionJobDefinitionRegistry? _workloadRegistry;
     private readonly IReadOnlyList<IBatchComputeBackend> _backends;
+    private readonly IExecutionAdmissionEvaluator? _admissionEvaluator;
     private readonly ILogger<GeoprocessingJobService> _logger;
 
     public GeoprocessingJobService(
@@ -52,7 +54,8 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         IJobQueue? jobQueue = null,
         IOptions<LimitsOptions>? limitsOptions = null,
         IExecutionJobDefinitionRegistry? workloadRegistry = null,
-        IEnumerable<IBatchComputeBackend>? backends = null)
+        IEnumerable<IBatchComputeBackend>? backends = null,
+        IExecutionAdmissionEvaluator? admissionEvaluator = null)
     {
         _progressStore = progressStore;
         _cancellationNotifiers = cancellationNotifiers.ToArray();
@@ -65,6 +68,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         _jobQueue = jobQueue;
         _workloadRegistry = workloadRegistry;
         _backends = backends?.ToArray() ?? Array.Empty<IBatchComputeBackend>();
+        _admissionEvaluator = admissionEvaluator;
     }
 
     public void EnsureCallerAuthorized(
@@ -181,6 +185,23 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             ? new Dictionary<string, string>(protocolMetadata)
             : new Dictionary<string, string>();
 
+        var partitionKey = ResolvePartitionKey(specParams);
+        var costWeight = (double)Math.Max(plan.Steps.Count, 1);
+        var priority = ResolvePriority(specParams);
+
+        var admission = await EnsureAdmittedAsync(
+            plan, principal, partitionKey, costWeight, priority, cancellationToken).ConfigureAwait(false);
+
+        if (admission != null)
+        {
+            specParams[ExecutionAdmissionEvaluator.CostWeightParameterKey] =
+                costWeight.ToString("R", CultureInfo.InvariantCulture);
+            if (!string.IsNullOrEmpty(partitionKey))
+            {
+                specParams[ExecutionAdmissionEvaluator.PartitionKeyParameterKey] = partitionKey;
+            }
+        }
+
         var workload = await ResolveWorkloadAsync(cancellationToken).ConfigureAwait(false);
         var spec = BuildSpec(plan, specParams, workload);
 
@@ -188,6 +209,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         {
             OperationId = jobId,
             Status = ExecutionJobStatus.Queued,
+            Priority = priority,
             CreatedAt = now,
             UpdatedAt = now,
             CurrentPhase = "Queued",
@@ -639,6 +661,83 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
 
         GeoprocessingServiceLog.SubmitRejectedApprovalRequired(_logger, approval.PolicyRef ?? "unknown");
         throw new GeoprocessingApprovalRequiredException(approval.PolicyRef ?? "unknown");
+    }
+
+    private async Task<ExecutionAdmissionDecision?> EnsureAdmittedAsync(
+        AnalysisPlan plan,
+        ClaimsPrincipal principal,
+        string? partitionKey,
+        double costWeight,
+        OperationPriority priority,
+        CancellationToken cancellationToken)
+    {
+        if (_admissionEvaluator == null)
+        {
+            return null;
+        }
+
+        var request = new ExecutionAdmissionRequest
+        {
+            JobKind = ExecutionJobKind.Geoprocessing,
+            PartitionKey = partitionKey,
+            PrincipalId = principal.Identity?.Name,
+            EstimatedCostWeight = costWeight,
+            Priority = priority
+        };
+
+        var decision = await _admissionEvaluator
+            .EvaluateAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (decision.Outcome == ExecutionAdmissionOutcome.Admitted)
+        {
+            return decision;
+        }
+
+        GeoprocessingServiceLog.SubmitRejectedByAdmission(
+            _logger,
+            decision.Outcome.ToString(),
+            decision.DenyingDimension?.ToString() ?? "Unknown",
+            decision.PolicyRef ?? "unknown");
+
+        throw new GeoprocessingAdmissionException(
+            decision.Outcome,
+            decision.DenyingDimension ?? ExecutionAdmissionDimension.Backpressure,
+            decision.PolicyRef ?? "unknown",
+            decision.Reason ?? "Execution admission rejected the request.",
+            decision.RetryAfterSeconds ?? 10);
+    }
+
+    private static string? ResolvePartitionKey(Dictionary<string, string> specParams)
+    {
+        if (specParams.TryGetValue(ExecutionAdmissionEvaluator.PartitionKeyParameterKey, out var explicitKey)
+            && !string.IsNullOrWhiteSpace(explicitKey))
+        {
+            return explicitKey;
+        }
+
+        if (specParams.TryGetValue("workspace.id", out var workspaceId) && !string.IsNullOrWhiteSpace(workspaceId))
+        {
+            return workspaceId;
+        }
+
+        if (specParams.TryGetValue("tenant.id", out var tenantId) && !string.IsNullOrWhiteSpace(tenantId))
+        {
+            return tenantId;
+        }
+
+        return null;
+    }
+
+    private static OperationPriority ResolvePriority(Dictionary<string, string> specParams)
+    {
+        if (specParams.TryGetValue("admission.priority", out var raw)
+            && Enum.TryParse<OperationPriority>(raw, ignoreCase: true, out var parsed))
+        {
+            return parsed;
+        }
+
+        return OperationPriority.Normal;
     }
 
     private IExecutionJobStore RequireJobStore()

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -62,6 +62,15 @@ internal static class GeoprocessingServiceCollectionExtensions
                     sp.GetRequiredService<ILogger<RedisExecutionJobStore>>()));
         }
 
+        // Execution admission controls (ticket #739) — rate, concurrency, cost, backpressure
+        services
+            .AddOptions<ExecutionAdmissionOptions>()
+            .Bind(configuration.GetSection(ExecutionAdmissionOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.TryAddSingleton<IExecutionAdmissionEvaluator, ExecutionAdmissionEvaluator>();
+
         // Shared geoprocessing job service (#723) — consumed by gRPC and REST adapters
         services.TryAddSingleton<IGeoprocessingJobService, GeoprocessingJobService>();
 

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceLog.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceLog.cs
@@ -152,4 +152,11 @@ internal static partial class GeoprocessingServiceLog
     public static partial void RemoteCancelCasExhausted(
         ILogger logger,
         string jobId);
+
+    [LoggerMessage(8028, LogLevel.Warning, "Submit rejected by admission: Outcome={Outcome}, Dimension={Dimension}, Policy={PolicyRef}")]
+    public static partial void SubmitRejectedByAdmission(
+        ILogger logger,
+        string outcome,
+        string dimension,
+        string policyRef);
 }

--- a/src/Honua.Server/Features/Geoprocessing/HonuaProcessService.cs
+++ b/src/Honua.Server/Features/Geoprocessing/HonuaProcessService.cs
@@ -240,6 +240,16 @@ internal sealed class HonuaProcessService : Proto.ProcessService.ProcessServiceB
         GeoprocessingIdempotencyConflictException conflictEx => new RpcException(new Status(
             StatusCode.AlreadyExists, conflictEx.Message)),
 
+        GeoprocessingAdmissionException admissionEx => new RpcException(
+            new Status(StatusCode.ResourceExhausted, admissionEx.Message),
+            new Metadata
+            {
+                { "honua-admission-outcome", admissionEx.Outcome.ToString() },
+                { "honua-admission-dimension", admissionEx.DenyingDimension.ToString() },
+                { "honua-admission-policy-ref", admissionEx.PolicyRef },
+                { "retry-after", admissionEx.RetryAfterSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture) }
+            }),
+
         InvalidOperationException opEx => new RpcException(new Status(
             StatusCode.Internal, opEx.Message)),
 

--- a/src/Honua.Server/Features/OgcProcesses/OgcProcessesLog.cs
+++ b/src/Honua.Server/Features/OgcProcesses/OgcProcessesLog.cs
@@ -84,4 +84,8 @@ internal static partial class OgcProcessesLog
 
     [LoggerMessage(8162, LogLevel.Warning, "OGC Job dismiss rejected (approval required): JobId={JobId}, Policy={PolicyRef}")]
     public static partial void DismissRejectedApprovalRequired(ILogger logger, string jobId, string policyRef);
+
+    // 8170-8179: Admission
+    [LoggerMessage(8170, LogLevel.Warning, "OGC Processes execution rejected by admission: Outcome={Outcome}, Dimension={Dimension}, Policy={PolicyRef}")]
+    public static partial void ExecutionRejectedByAdmission(ILogger logger, string outcome, string dimension, string policyRef);
 }

--- a/src/Honua.Server/Features/OgcProcesses/ProcessEndpoints.cs
+++ b/src/Honua.Server/Features/OgcProcesses/ProcessEndpoints.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -190,7 +191,8 @@ internal static class ProcessEndpoints
         [FromServices] IExecutionJobStore? jobStore = null,
         [FromServices] IJobQueue? jobQueue = null,
         [FromServices] IExecutionJobDefinitionRegistry? workloadRegistry = null,
-        [FromServices] IEnumerable<IBatchComputeBackend>? backends = null)
+        [FromServices] IEnumerable<IBatchComputeBackend>? backends = null,
+        [FromServices] IExecutionAdmissionEvaluator? admissionEvaluator = null)
     {
         EnrichActivity("ExecuteProcess");
 
@@ -370,6 +372,13 @@ internal static class ProcessEndpoints
         }
 
         var planJson = planElement.GetRawText();
+        var stepCount = CountSteps(planElement);
+        var costWeight = (double)Math.Max(stepCount, 1);
+
+        var admissionResult = await EvaluateAdmissionAsync(
+            admissionEvaluator, context, logger, costWeight).ConfigureAwait(false);
+        if (admissionResult != null) return admissionResult;
+
         var now = DateTimeOffset.UtcNow;
         var jobId = $"gp-{Guid.NewGuid():N}";
 
@@ -381,6 +390,8 @@ internal static class ProcessEndpoints
             ? new Dictionary<string, string>(workload.Parameters, StringComparer.Ordinal)
             : new Dictionary<string, string>(StringComparer.Ordinal);
         specParameters[ExecutionJobParameterKeys.GeoprocessingPlanId] = planId;
+        specParameters[ExecutionAdmissionEvaluator.CostWeightParameterKey] =
+            costWeight.ToString("R", CultureInfo.InvariantCulture);
 
         var jobRecord = new ExecutionJobRecord
         {
@@ -767,6 +778,63 @@ internal static class ProcessEndpoints
         OgcProcessesJsonContext.Default.OgcProcessError,
         MediaTypes.Json,
         StatusCodes.Status403Forbidden);
+
+    /// <summary>
+    /// Evaluates runtime admission controls (rate, concurrency, cost, backpressure)
+    /// and returns a 503 response with <c>Retry-After</c> when the request is
+    /// throttled or denied. Returns null when admitted, or when no evaluator is registered.
+    /// Mirrors the gate in <see cref="GeoprocessingJobService"/> so jobs created directly
+    /// by the OGC adapter share the same control model.
+    /// </summary>
+    private static async Task<IResult?> EvaluateAdmissionAsync(
+        IExecutionAdmissionEvaluator? admissionEvaluator,
+        HttpContext context,
+        ILogger logger,
+        double costWeight)
+    {
+        if (admissionEvaluator == null) return null;
+
+        var request = new ExecutionAdmissionRequest
+        {
+            JobKind = ExecutionJobKind.Geoprocessing,
+            PrincipalId = context.User.Identity?.Name,
+            EstimatedCostWeight = costWeight,
+            Priority = OperationPriority.Normal
+        };
+
+        var decision = await admissionEvaluator
+            .EvaluateAsync(request, context.RequestAborted).ConfigureAwait(false);
+
+        if (decision.Outcome == ExecutionAdmissionOutcome.Admitted) return null;
+
+        var retryAfter = decision.RetryAfterSeconds ?? 10;
+        context.Response.Headers["Retry-After"] = retryAfter.ToString(CultureInfo.InvariantCulture);
+        OgcProcessesLog.ExecutionRejectedByAdmission(
+            logger,
+            decision.Outcome.ToString(),
+            decision.DenyingDimension?.ToString() ?? "Unknown",
+            decision.PolicyRef ?? "unknown");
+
+        return Results.Json(
+            new OgcProcessError
+            {
+                Type = "about:blank",
+                Title = "Service unavailable",
+                Status = StatusCodes.Status503ServiceUnavailable,
+                Detail = decision.Reason ?? "Execution admission rejected the request."
+            },
+            OgcProcessesJsonContext.Default.OgcProcessError,
+            MediaTypes.Json,
+            StatusCodes.Status503ServiceUnavailable);
+    }
+
+    private static int CountSteps(System.Text.Json.JsonElement plan)
+    {
+        if (plan.ValueKind != System.Text.Json.JsonValueKind.Object) return 0;
+        if (!plan.TryGetProperty("steps", out var steps)) return 0;
+        if (steps.ValueKind != System.Text.Json.JsonValueKind.Array) return 0;
+        return steps.GetArrayLength();
+    }
 
     private static void EnrichActivity(string operation)
     {

--- a/src/Honua.ServiceDefaults/HonuaTelemetry.cs
+++ b/src/Honua.ServiceDefaults/HonuaTelemetry.cs
@@ -121,6 +121,9 @@ public static class HonuaTelemetry
 
         /// <summary>Anomaly detection activity.</summary>
         public const string AnomalyDetection = "honua.ml.anomaly_detection";
+
+        /// <summary>Operator execution admission evaluation activity.</summary>
+        public const string ExecutionAdmission = "honua.execution.admission";
     }
 
     /// <summary>

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/ExecutionAdmissionEvaluatorTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/ExecutionAdmissionEvaluatorTests.cs
@@ -1,0 +1,388 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Server.Features.Geoprocessing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing;
+
+/// <summary>
+/// Unit tests for <see cref="ExecutionAdmissionEvaluator"/>, which gates
+/// submission on backpressure, concurrency, rate, and cost dimensions.
+/// Exercises each dimension individually plus the short-circuit evaluation
+/// order so callers can rely on the first-failing-dimension contract.
+/// </summary>
+public sealed class ExecutionAdmissionEvaluatorTests
+{
+    private const string Principal = "alice";
+    private const string Partition = "workspace-1";
+
+    private readonly IExecutionJobStore _jobStore = Substitute.For<IExecutionJobStore>();
+    private readonly FakeTimeProvider _time = new();
+
+    public ExecutionAdmissionEvaluatorTests()
+    {
+        _jobStore
+            .ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<ExecutionJobRecord>());
+    }
+
+    [Fact]
+    public async Task Evaluate_WhenDisabled_Admits()
+    {
+        var options = new ExecutionAdmissionOptions { Enabled = false };
+        var sut = CreateSut(options);
+
+        var decision = await sut.EvaluateAsync(CreateRequest());
+
+        decision.Outcome.Should().Be(ExecutionAdmissionOutcome.Admitted);
+        decision.DenyingDimension.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Evaluate_WhenNoLimitsExceeded_Admits()
+    {
+        var sut = CreateSut(DefaultOptions());
+
+        var decision = await sut.EvaluateAsync(CreateRequest());
+
+        decision.Outcome.Should().Be(ExecutionAdmissionOutcome.Admitted);
+        decision.Snapshot.ActiveJobsGlobal.Should().Be(0);
+        decision.Snapshot.ActiveJobsInPartition.Should().Be(0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Backpressure — system-wide global limit
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Evaluate_GlobalLimitReached_DeniesBackpressure()
+    {
+        var options = DefaultOptions();
+        options.MaxConcurrentJobsGlobal = 2;
+
+        SeedActiveJobs(
+            CreateActiveJob("other-1", partition: "other-partition", kind: ExecutionJobKind.TileCache),
+            CreateActiveJob("other-2", partition: "other-partition", kind: ExecutionJobKind.ExtractTransformLoad));
+
+        var sut = CreateSut(options);
+        var decision = await sut.EvaluateAsync(CreateRequest());
+
+        decision.Outcome.Should().Be(ExecutionAdmissionOutcome.Denied);
+        decision.DenyingDimension.Should().Be(ExecutionAdmissionDimension.Backpressure);
+        decision.PolicyRef.Should().StartWith("backpressure:global:");
+        decision.RetryAfterSeconds.Should().BePositive();
+        decision.Snapshot.ActiveJobsGlobal.Should().Be(2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Concurrency — per-partition + kind limit
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Evaluate_PartitionLimitReached_DeniesConcurrency()
+    {
+        var options = DefaultOptions();
+        options.MaxConcurrentJobsPerPartition = 2;
+        options.MaxConcurrentJobsGlobal = 100;
+
+        SeedActiveJobs(
+            CreateActiveJob("gp-1", partition: Partition),
+            CreateActiveJob("gp-2", partition: Partition),
+            // A job in a different partition does not count against this partition's bucket.
+            CreateActiveJob("gp-3", partition: "other-partition"));
+
+        var sut = CreateSut(options);
+        var decision = await sut.EvaluateAsync(CreateRequest());
+
+        decision.Outcome.Should().Be(ExecutionAdmissionOutcome.Denied);
+        decision.DenyingDimension.Should().Be(ExecutionAdmissionDimension.Concurrency);
+        decision.PolicyRef.Should().Contain("concurrency");
+        decision.Snapshot.ActiveJobsInPartition.Should().Be(2);
+        decision.Snapshot.ActiveJobsGlobal.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Evaluate_PartitionLimit_OnlyCountsMatchingKind()
+    {
+        var options = DefaultOptions();
+        options.MaxConcurrentJobsPerPartition = 1;
+        options.MaxConcurrentJobsGlobal = 100;
+
+        // Active job in the same partition but a different kind must not contribute.
+        SeedActiveJobs(CreateActiveJob("etl-1", partition: Partition, kind: ExecutionJobKind.ExtractTransformLoad));
+
+        var sut = CreateSut(options);
+        var decision = await sut.EvaluateAsync(CreateRequest());
+
+        decision.Outcome.Should().Be(ExecutionAdmissionOutcome.Admitted);
+    }
+
+    // -----------------------------------------------------------------------
+    // Rate — per-principal sliding window
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Evaluate_RateLimitReached_ThrottlesRate()
+    {
+        var options = DefaultOptions();
+        options.MaxSubmissionsPerWindow = 2;
+
+        var sut = CreateSut(options);
+
+        (await sut.EvaluateAsync(CreateRequest())).Outcome.Should().Be(ExecutionAdmissionOutcome.Admitted);
+        (await sut.EvaluateAsync(CreateRequest())).Outcome.Should().Be(ExecutionAdmissionOutcome.Admitted);
+
+        var third = await sut.EvaluateAsync(CreateRequest());
+
+        third.Outcome.Should().Be(ExecutionAdmissionOutcome.Throttled);
+        third.DenyingDimension.Should().Be(ExecutionAdmissionDimension.Rate);
+        third.PolicyRef.Should().Contain("rate");
+        third.RetryAfterSeconds.Should().BePositive();
+    }
+
+    [Fact]
+    public async Task Evaluate_RateWindow_ExpiresAfterTimeAdvances()
+    {
+        var options = DefaultOptions();
+        options.MaxSubmissionsPerWindow = 1;
+        options.RateWindowSeconds = 30;
+
+        var sut = CreateSut(options);
+
+        (await sut.EvaluateAsync(CreateRequest())).Outcome.Should().Be(ExecutionAdmissionOutcome.Admitted);
+
+        // Within the window — throttled.
+        (await sut.EvaluateAsync(CreateRequest())).Outcome.Should().Be(ExecutionAdmissionOutcome.Throttled);
+
+        // After the window — admitted again.
+        _time.Advance(TimeSpan.FromSeconds(31));
+        (await sut.EvaluateAsync(CreateRequest())).Outcome.Should().Be(ExecutionAdmissionOutcome.Admitted);
+    }
+
+    [Fact]
+    public async Task Evaluate_AnonymousPrincipal_SkipsRateGate()
+    {
+        var options = DefaultOptions();
+        options.MaxSubmissionsPerWindow = 1;
+
+        var sut = CreateSut(options);
+
+        // Anonymous principal (null) should bypass the rate gate entirely.
+        var anonRequest = new ExecutionAdmissionRequest
+        {
+            JobKind = ExecutionJobKind.Geoprocessing,
+            PartitionKey = Partition,
+            PrincipalId = null,
+            EstimatedCostWeight = 1.0
+        };
+
+        (await sut.EvaluateAsync(anonRequest)).Outcome.Should().Be(ExecutionAdmissionOutcome.Admitted);
+        (await sut.EvaluateAsync(anonRequest)).Outcome.Should().Be(ExecutionAdmissionOutcome.Admitted);
+    }
+
+    // -----------------------------------------------------------------------
+    // Cost — aggregate cost weight per partition
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Evaluate_CostLimitExceeded_DeniesCost()
+    {
+        var options = DefaultOptions();
+        options.MaxCostWeightPerPartition = 10.0;
+
+        // Active cost weight of 8 + a requested weight of 3 = 11 > 10 limit.
+        SeedActiveJobs(CreateActiveJob("gp-heavy", partition: Partition, costWeight: 8.0));
+
+        var sut = CreateSut(options);
+
+        var decision = await sut.EvaluateAsync(CreateRequest(costWeight: 3.0));
+
+        decision.Outcome.Should().Be(ExecutionAdmissionOutcome.Denied);
+        decision.DenyingDimension.Should().Be(ExecutionAdmissionDimension.Cost);
+        decision.PolicyRef.Should().Contain("cost");
+        decision.Snapshot.ActiveCostWeightInPartition.Should().BeApproximately(8.0, 0.001);
+    }
+
+    [Fact]
+    public async Task Evaluate_CostAtLimit_Admits()
+    {
+        var options = DefaultOptions();
+        options.MaxCostWeightPerPartition = 10.0;
+
+        SeedActiveJobs(CreateActiveJob("gp-heavy", partition: Partition, costWeight: 7.0));
+
+        var sut = CreateSut(options);
+        var decision = await sut.EvaluateAsync(CreateRequest(costWeight: 3.0));
+
+        decision.Outcome.Should().Be(ExecutionAdmissionOutcome.Admitted);
+    }
+
+    // -----------------------------------------------------------------------
+    // Short-circuit evaluation order: Backpressure → Concurrency → Rate → Cost
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Evaluate_WhenBackpressureAndConcurrencyBothExceeded_ReportsBackpressureFirst()
+    {
+        var options = DefaultOptions();
+        options.MaxConcurrentJobsGlobal = 1;
+        options.MaxConcurrentJobsPerPartition = 1;
+
+        SeedActiveJobs(CreateActiveJob("gp-1", partition: Partition));
+
+        var sut = CreateSut(options);
+        var decision = await sut.EvaluateAsync(CreateRequest());
+
+        decision.DenyingDimension.Should().Be(ExecutionAdmissionDimension.Backpressure);
+    }
+
+    [Fact]
+    public async Task Evaluate_WhenConcurrencyAndRateBothExceeded_ReportsConcurrencyFirst()
+    {
+        var options = DefaultOptions();
+        options.MaxConcurrentJobsPerPartition = 1;
+        options.MaxSubmissionsPerWindow = 1;
+
+        SeedActiveJobs(CreateActiveJob("gp-1", partition: Partition));
+
+        var sut = CreateSut(options);
+
+        // First request consumes the rate slot and also sees concurrency already at cap.
+        var decision = await sut.EvaluateAsync(CreateRequest());
+
+        decision.DenyingDimension.Should().Be(ExecutionAdmissionDimension.Concurrency);
+    }
+
+    [Fact]
+    public async Task Evaluate_WhenRateAndCostBothExceeded_ReportsRateFirst()
+    {
+        var options = DefaultOptions();
+        options.MaxSubmissionsPerWindow = 1;
+        options.MaxCostWeightPerPartition = 2.0;
+
+        SeedActiveJobs(CreateActiveJob("gp-1", partition: Partition, costWeight: 5.0));
+
+        var sut = CreateSut(options);
+
+        (await sut.EvaluateAsync(CreateRequest())).Outcome.Should().Be(ExecutionAdmissionOutcome.Denied);
+        // That call denied on Cost (rate slot was consumed atomically with the claim).
+        // Second call: both rate and cost would reject; rate is checked first.
+        var decision = await sut.EvaluateAsync(CreateRequest());
+
+        decision.DenyingDimension.Should().Be(ExecutionAdmissionDimension.Rate);
+    }
+
+    // -----------------------------------------------------------------------
+    // Job store missing — do not crash, skip concurrency/cost gates
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Evaluate_WithoutJobStore_SkipsBackpressureAndConcurrencyGates()
+    {
+        var options = DefaultOptions();
+        options.MaxConcurrentJobsGlobal = 0;
+        options.MaxConcurrentJobsPerPartition = 0;
+
+        var sut = new ExecutionAdmissionEvaluator(
+            new TestOptionsMonitor(options),
+            _time,
+            NullLogger<ExecutionAdmissionEvaluator>.Instance,
+            jobStore: null);
+
+        var decision = await sut.EvaluateAsync(CreateRequest());
+
+        decision.Outcome.Should().Be(ExecutionAdmissionOutcome.Admitted);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private ExecutionAdmissionEvaluator CreateSut(ExecutionAdmissionOptions options)
+        => new(
+            new TestOptionsMonitor(options),
+            _time,
+            NullLogger<ExecutionAdmissionEvaluator>.Instance,
+            _jobStore);
+
+    private static ExecutionAdmissionOptions DefaultOptions() => new()
+    {
+        Enabled = true,
+        MaxConcurrentJobsPerPartition = 100,
+        MaxConcurrentJobsGlobal = 100,
+        MaxSubmissionsPerWindow = 100,
+        RateWindowSeconds = 60,
+        MaxCostWeightPerPartition = 1000,
+        DefaultRetryAfterSeconds = 10
+    };
+
+    private static ExecutionAdmissionRequest CreateRequest(double costWeight = 1.0) => new()
+    {
+        JobKind = ExecutionJobKind.Geoprocessing,
+        PartitionKey = Partition,
+        PrincipalId = Principal,
+        EstimatedCostWeight = costWeight
+    };
+
+    private void SeedActiveJobs(params ExecutionJobRecord[] jobs)
+    {
+        _jobStore
+            .ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+            .Returns(jobs);
+    }
+
+    private static ExecutionJobRecord CreateActiveJob(
+        string id,
+        string partition,
+        ExecutionJobKind kind = ExecutionJobKind.Geoprocessing,
+        double costWeight = 1.0)
+    {
+        var parameters = new Dictionary<string, string>
+        {
+            [ExecutionAdmissionEvaluator.PartitionKeyParameterKey] = partition,
+            [ExecutionAdmissionEvaluator.CostWeightParameterKey] =
+                costWeight.ToString("R", System.Globalization.CultureInfo.InvariantCulture)
+        };
+
+        return new ExecutionJobRecord
+        {
+            OperationId = id,
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = kind,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "test-workload",
+                Parameters = parameters
+            }
+        };
+    }
+
+    private sealed class TestOptionsMonitor(ExecutionAdmissionOptions value) : IOptionsMonitor<ExecutionAdmissionOptions>
+    {
+        public ExecutionAdmissionOptions CurrentValue => value;
+
+        public ExecutionAdmissionOptions Get(string? name) => value;
+
+        public IDisposable? OnChange(Action<ExecutionAdmissionOptions, string?> listener) => null;
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now = new(2026, 4, 18, 12, 0, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan delta) => _now += delta;
+    }
+}

--- a/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -8,6 +8,7 @@ using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Server.Features.Geoprocessing;
@@ -1535,6 +1536,79 @@ public sealed class GeoprocessingJobServiceTests
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
     }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_AdmissionDenied_ThrowsAdmissionException()
+    {
+        _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var admission = Substitute.For<IExecutionAdmissionEvaluator>();
+        admission.EvaluateAsync(Arg.Any<ExecutionAdmissionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(ExecutionAdmissionDecision.Denied(
+                ExecutionAdmissionDimension.Concurrency,
+                "concurrency:geoprocessing:per-partition",
+                "Partition active job limit reached.",
+                retryAfterSeconds: 15,
+                new ExecutionAdmissionSnapshot { ActiveJobsInPartition = 10 }));
+
+        var sut = new GeoprocessingJobService(
+            _progressStore,
+            [_cancellationNotifier],
+            _authEvaluator,
+            _approvalEvaluator,
+            new BuiltInProcessCatalog(),
+            NullLogger<GeoprocessingJobService>.Instance,
+            _jobStore,
+            admissionEvaluator: admission);
+
+        var act = async () => await sut.SubmitJobAsync(CreateValidPlan(), null, CreatePrincipal());
+
+        var ex = await act.Should().ThrowAsync<GeoprocessingAdmissionException>();
+        ex.Which.Outcome.Should().Be(ExecutionAdmissionOutcome.Denied);
+        ex.Which.DenyingDimension.Should().Be(ExecutionAdmissionDimension.Concurrency);
+        ex.Which.RetryAfterSeconds.Should().Be(15);
+
+        await _jobStore
+            .DidNotReceive()
+            .TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_WhenAdmitted_PersistsCostWeightInSpecParameters()
+    {
+        _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var admission = Substitute.For<IExecutionAdmissionEvaluator>();
+        admission.EvaluateAsync(Arg.Any<ExecutionAdmissionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(ExecutionAdmissionDecision.Admitted(new ExecutionAdmissionSnapshot()));
+
+        var sut = new GeoprocessingJobService(
+            _progressStore,
+            [_cancellationNotifier],
+            _authEvaluator,
+            _approvalEvaluator,
+            new BuiltInProcessCatalog(),
+            NullLogger<GeoprocessingJobService>.Instance,
+            _jobStore,
+            admissionEvaluator: admission);
+
+        var metadata = new Dictionary<string, string> { ["workspace.id"] = "ws-42" };
+        var job = await sut.SubmitJobAsync(CreateValidPlan(), null, CreatePrincipal(), metadata);
+
+        job.Spec.Parameters.Should().ContainKey(ExecutionAdmissionEvaluator.CostWeightParameterKey);
+        job.Spec.Parameters.Should().ContainKey(ExecutionAdmissionEvaluator.PartitionKeyParameterKey)
+            .WhoseValue.Should().Be("ws-42");
+    }
+
+    // -----------------------------------------------------------------------
+    // GetJobAsync
+    // -----------------------------------------------------------------------
 
     [UnitTest]
     [Operation(Operations.Delete)]


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #739

## Summary
Adds runtime admission controls (rate, concurrency, cost, backpressure) for operator execution. Introduces `IExecutionAdmissionEvaluator` that the canonical `GeoprocessingJobService` and the OGC Processes adapter both consult before creating a job. Denied requests throw `GeoprocessingAdmissionException` (server-side) or return 503 with `Retry-After` (OGC adapter). Admitted requests carry cost-weight and partition-key metadata in their spec parameters.

## Changes Made
- `IExecutionAdmissionEvaluator`, `ExecutionAdmissionRequest`, `ExecutionAdmissionDecision`, and related types in `Honua.Core.Features.Geoprocessing.Abstractions`/`Domain`
- `ExecutionAdmissionEvaluator` implementation in `Honua.Server.Features.Geoprocessing`
- `GeoprocessingJobService` optional dependency on the admission evaluator; cost-weight + partition-key seeded into `specParameters`
- OGC Processes `/ogc/processes/processes/{processId}/execution` consults the same evaluator, returns 503 + `Retry-After` + `ExecutionRejectedByAdmission` log entry when throttled
- Tests: `SubmitJob_AdmissionDenied_ThrowsAdmissionException`, `SubmitJob_WhenAdmitted_PersistsCostWeightInSpecParameters`
- Logs: new id 8028 (`SubmitRejectedByAdmission`) in `GeoprocessingServiceLog`; new id 8170 (`ExecutionRejectedByAdmission`) in `OgcProcessesLog`

## Breaking Changes
None — evaluator is optional; when not registered, behavior is unchanged.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates
- [ ] Release gates
- [ ] Deploy gates

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated

## Release/Deploy Impact
No release or deploy impact.

## Pre-PR Checklist
- [x] Ran \`scripts/pre-pr-check.sh\` and all checks passed
- [x] Commit messages follow conventional format: \`type: description (#issue)\`
- [x] PR title matches main commit message
- [x] Issue number linked above

🤖 Generated with [Claude Code](https://claude.com/claude-code)