### PR TITLE
[codex] chore: follow up #757 final-review cleanup

### DIFF
--- a/src/Honua.Server/Features/Infrastructure/Caching/RedisCacheService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/RedisCacheService.cs
@@ -1335,11 +1335,5 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
 
         [LoggerMessage(1007, LogLevel.Warning, "Failed to serialize cache entry {KeyFamily} {KeyHash}")]
         public static partial void CacheEntrySerializationFailed(ILogger logger, string keyFamily, string keyHash, Exception exception);
-
-        [LoggerMessage(1008, LogLevel.Warning, "Failed to track cache key {KeyFamily} {KeyHash} in Redis index.")]
-        public static partial void IndexTrackFailed(ILogger logger, string keyFamily, string keyHash, Exception exception);
-
-        [LoggerMessage(1009, LogLevel.Warning, "Failed to remove cache key {KeyFamily} {KeyHash} from Redis index.")]
-        public static partial void IndexRemoveFailed(ILogger logger, string keyFamily, string keyHash, Exception exception);
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Services/TemporaryFileServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Services/TemporaryFileServiceTests.cs
@@ -475,6 +475,7 @@ public sealed class TemporaryFileServiceTests : IDisposable
     public async Task StoreTemporaryFileAsync_WithRemoteCloudStorageCountsBytesBeyondFirstThousandObjects()
     {
         var cloudStorage = new FakeCloudFileStorage(CloudStorageProvider.AwsS3);
+        var redis = CreateRedisLeaseMultiplexer();
         for (var i = 0; i < 1001; i++)
         {
             await cloudStorage.UploadAsync(new ByteArrayUploadRequest
@@ -496,11 +497,13 @@ public sealed class TemporaryFileServiceTests : IDisposable
                 MaxTotalStorageBytes = 2025,
                 DefaultExpiration = TimeSpan.FromMinutes(5)
             },
-            cloudStorage);
+            cloudStorage,
+            redis: redis);
 
         Func<Task> act = async () => await service.StoreTemporaryFileAsync([2], "application/octet-stream");
 
-        await act.Should().ThrowAsync<TemporaryStorageLimitExceededException>();
+        var ex = await act.Should().ThrowAsync<TemporaryStorageLimitExceededException>();
+        ex.Which.Message.Should().Contain("maximum capacity");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- tighten the #757 cloud temporary-file byte-count test so it acquires the Redis quota lease and asserts the capacity-specific failure path
- remove unused duplicate Redis index logger methods from `RedisCacheServiceLog`; the live call sites use `RedisCacheIndexLog`

## Why

Final review on #757 found that the regression test could pass on the missing-Redis precondition before it reached the intended capacity check. It also found duplicate source-generated logger definitions with no call sites.

Closes #820

## Validation

- `dotnet format Honua.sln --include tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Services/TemporaryFileServiceTests.cs src/Honua.Server/Features/Infrastructure/Caching/RedisCacheService.cs --no-restore`
- `git diff --check -- tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Services/TemporaryFileServiceTests.cs src/Honua.Server/Features/Infrastructure/Caching/RedisCacheService.cs`
- `/home/makani/honua-agentflow/scripts/with-honua-test-docker-cleanup.sh -- dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --configuration Release --filter FullyQualifiedName~TemporaryFileServiceTests.StoreTemporaryFileAsync_WithRemoteCloudStorageCountsBytesBeyondFirstThousandObjects --logger console;verbosity=minimal`
