### PR TITLE
feat(spec): add public spec validation endpoint

### DIFF
--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -117,6 +117,7 @@ REST API and GitOps-ready management:
 
 ### Spec Plan/Apply Engine
 Terraform-style plan/apply semantics for canonical spec documents ([Spec Engine reference](developer/SPEC_ENGINE.md)):
+- `POST /v1/spec/validate` parses spec DSL or canonical JSON and returns structured diagnostics for workspace linting
 - `POST /v1/spec/plan` returns a DAG with per-node cost estimates and structured warnings (catalog/metadata only — side-effect-free)
 - `POST /v1/spec/apply` streams per-node progress events over SSE, with a mirrored `geospatial.v1.SpecService/ApplySpec` gRPC server-streaming surface
 - `POST /v1/spec/cancel` cooperatively cancels an in-flight run; `GET /v1/spec/artifact/{hash}` retrieves cached outputs

--- a/docs/developer/SPEC_ENGINE.md
+++ b/docs/developer/SPEC_ENGINE.md
@@ -7,7 +7,8 @@ events and serves cache hits without re-invoking the compute backend.
 
 The engine ships as a mixed REST + gRPC surface:
 
-- REST: `POST /v1/spec/plan`, `POST /v1/spec/apply`, `POST /v1/spec/cancel`,
+- REST: `POST /v1/spec/validate`, `POST /v1/spec/plan`,
+  `POST /v1/spec/apply`, `POST /v1/spec/cancel`,
   `GET /v1/spec/artifact/{hash}`
 - gRPC: `geospatial.v1.SpecService/{PlanSpec, ApplySpec, CancelApply}`
   (`src/Honua.Core/Transport/Proto/geospatial/v1/spec_service.proto`)
@@ -39,6 +40,66 @@ Each `nodes[*]` entry:
 | `canonicalFragment` | Canonicalised JSON fragment used as the hash input. When omitted the engine hashes sorted `parameters` + `sourcePins` instead. |
 | `sourcePins` | Optional declared source pins. When absent, mutable sources emit `mutable-source-no-pin`. |
 | `nondeterministic` | Surfaces `nondeterministic-op` during plan. |
+
+## POST /v1/spec/validate
+
+Parses and validates either spec DSL source text or canonical spec JSON. The
+endpoint always returns a `200 OK` validation envelope for syntactically
+readable specs; malformed request envelopes return `400 invalid-request-body`.
+
+```bash
+curl -X POST http://localhost:8080/v1/spec/validate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "grammar \"v1.0\"\nsource hospitals { type = \"layer\", ref = \"catalog:layer:1\" }",
+    "includeCanonicalJson": true
+  }'
+```
+
+Response:
+
+```json
+{
+  "isValid": true,
+  "diagnostics": [],
+  "canonicalJson": "{\"$schema\":\"https://honua.io/spec/grammar/v1.0/spec.json\",...}",
+  "grammar": "v1.0",
+  "operatorCapabilityVersion": "v1.0"
+}
+```
+
+Clients may submit canonical JSON instead of text by sending exactly one
+`spec` object:
+
+```json
+{
+  "spec": {
+    "grammar": "v1.0",
+    "sources": [{ "id": "hospitals", "type": "layer", "ref": "catalog:layer:1" }],
+    "compute": [{ "id": "broken", "op": "does_not_exist" }]
+  }
+}
+```
+
+Validation diagnostics use the grammar diagnostic names
+(`UnknownOperator`, `TypeMismatch`, `MissingRequiredParameter`,
+`UnsupportedGrammarVersion`, etc.) plus source spans when available:
+
+```json
+{
+  "isValid": false,
+  "diagnostics": [
+    {
+      "code": "UnknownOperator",
+      "severity": "error",
+      "message": "Unknown operator 'does_not_exist'. Registered operators: filter, spatial_join, buffer, reproject, zonal_stats, slope.",
+      "span": { "line": 4, "column": 8, "offset": 112, "length": 14 }
+    }
+  ],
+  "grammar": "v1.0",
+  "operatorCapabilityVersion": "v1.0"
+}
+```
 
 ## POST /v1/spec/plan
 

--- a/src/Honua.Core/Features/Spec/Canonical/SpecJsonReader.cs
+++ b/src/Honua.Core/Features/Spec/Canonical/SpecJsonReader.cs
@@ -234,7 +234,7 @@ public static class SpecJsonReader
                     return new LiteralNode(
                         SourceSpan.Synthetic,
                         SpecTypeKind.Number,
-                        Number: element.GetDouble());
+                        Number: ReadFiniteDouble(element));
                 }
 
             case JsonValueKind.True:
@@ -310,7 +310,7 @@ public static class SpecJsonReader
                 literal = new LiteralNode(
                     SourceSpan.Synthetic,
                     kind,
-                    Number: valueEl.GetDouble(),
+                    Number: ReadFiniteDouble(valueEl),
                     Unit: unitEl.GetString());
                 return true;
             }
@@ -318,6 +318,17 @@ public static class SpecJsonReader
 
         literal = null!;
         return false;
+    }
+
+    private static double ReadFiniteDouble(JsonElement element)
+    {
+        var value = element.GetDouble();
+        if (!double.IsFinite(value))
+        {
+            throw new FormatException("Canonical spec JSON numeric values must be finite.");
+        }
+
+        return value;
     }
 
     private static bool TryReadGeometry(JsonElement element, out GeometryLiteral literal)

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -604,6 +604,7 @@ public static class EndpointRegistry
         new("POST", "/mcp"),
 
         // Spec plan / apply engine (#789).
+        new("POST", "/v1/spec/validate"),
         new("POST", "/v1/spec/plan"),
         new("POST", "/v1/spec/apply"),
         new("POST", "/v1/spec/cancel"),

--- a/src/Honua.Server/Features/Grounding/Spec/SpecGroundingEndpointExtensions.cs
+++ b/src/Honua.Server/Features/Grounding/Spec/SpecGroundingEndpointExtensions.cs
@@ -367,6 +367,12 @@ internal static class SpecGroundingEndpointExtensions
             error = $"spec could not be read: {ex.Message}";
             return false;
         }
+        catch (FormatException ex)
+        {
+            document = CreateEmptySpecDocument();
+            error = $"spec could not be read: {ex.Message}";
+            return false;
+        }
     }
 
     private static SpecDocument CreateEmptySpecDocument()

--- a/src/Honua.Server/Features/Spec/Models/SpecRequestModels.cs
+++ b/src/Honua.Server/Features/Spec/Models/SpecRequestModels.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Honua.Core.Features.Spec.Abstractions;
 using Honua.Core.Features.Spec.Domain;
@@ -29,6 +30,21 @@ internal sealed class SpecDocumentRequest
 
     /// <summary>Apply-only: maximum node concurrency. Ignored by <c>/plan</c>.</summary>
     public int? MaxConcurrency { get; init; }
+}
+
+/// <summary>
+/// Body of <c>POST /v1/spec/validate</c>.
+/// </summary>
+internal sealed class SpecValidateRequest
+{
+    /// <summary>Spec source text in the public DSL.</summary>
+    public string? Text { get; init; }
+
+    /// <summary>Canonical JSON spec document emitted by <c>SpecCanonicalizer</c>.</summary>
+    public JsonElement Spec { get; init; }
+
+    /// <summary>When true, valid requests include canonical JSON in the response.</summary>
+    public bool IncludeCanonicalJson { get; init; }
 }
 
 /// <summary>
@@ -79,6 +95,46 @@ internal sealed class SpecPlanResponse
     public required IReadOnlyList<SpecPlanNodeResponse> Nodes { get; init; }
 
     public IReadOnlyList<SpecWarning> Warnings { get; init; } = [];
+}
+
+/// <summary>
+/// Response body for <c>POST /v1/spec/validate</c>.
+/// </summary>
+internal sealed class SpecValidateResponse
+{
+    public required bool IsValid { get; init; }
+
+    public required IReadOnlyList<SpecValidateDiagnosticDto> Diagnostics { get; init; }
+
+    public string? CanonicalJson { get; init; }
+
+    public string? Grammar { get; init; }
+
+    public required string OperatorCapabilityVersion { get; init; }
+}
+
+internal sealed class SpecValidateDiagnosticDto
+{
+    public required string Code { get; init; }
+
+    public required string Severity { get; init; }
+
+    public required string Message { get; init; }
+
+    public string? Path { get; init; }
+
+    public SpecSourceSpanDto? Span { get; init; }
+}
+
+internal sealed class SpecSourceSpanDto
+{
+    public required int Line { get; init; }
+
+    public required int Column { get; init; }
+
+    public required int Offset { get; init; }
+
+    public required int Length { get; init; }
 }
 
 /// <summary>
@@ -154,6 +210,10 @@ internal sealed class SpecProblem
 [JsonSerializable(typeof(SpecNodeRequest))]
 [JsonSerializable(typeof(SpecPlanResponse))]
 [JsonSerializable(typeof(SpecPlanNodeResponse))]
+[JsonSerializable(typeof(SpecValidateRequest))]
+[JsonSerializable(typeof(SpecValidateResponse))]
+[JsonSerializable(typeof(SpecValidateDiagnosticDto))]
+[JsonSerializable(typeof(SpecSourceSpanDto))]
 [JsonSerializable(typeof(SpecCancelRequest))]
 [JsonSerializable(typeof(SpecCancelResponse))]
 [JsonSerializable(typeof(SpecProblem))]

--- a/src/Honua.Server/Features/Spec/SpecEndpoints.cs
+++ b/src/Honua.Server/Features/Spec/SpecEndpoints.cs
@@ -7,6 +7,7 @@ using Honua.Core.Features.Spec.Domain;
 using Honua.Server.Features.Spec.Models;
 using Honua.ServiceDefaults;
 using Microsoft.AspNetCore.Http;
+using SpecCanonicalJsonReader = Honua.Core.Features.Spec.Canonical.SpecJsonReader;
 
 namespace Honua.Server.Features.Spec;
 
@@ -27,6 +28,13 @@ internal static class SpecEndpoints
 
         var group = endpoints.MapGroup("/v1/spec")
             .WithTags("Spec");
+
+        group.MapPost("/validate", HandleValidateAsync)
+            .WithDisplayName("Spec Validate")
+            .WithName("SpecValidate")
+            .WithDescription("Parses and validates spec DSL or canonical JSON, returning structured diagnostics and optional canonical JSON.")
+            .Produces<SpecValidateResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
 
         group.MapPost("/plan", HandlePlanAsync)
             .WithDisplayName("Spec Plan")
@@ -56,6 +64,89 @@ internal static class SpecEndpoints
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         return endpoints;
+    }
+
+    private static async Task<IResult> HandleValidateAsync(
+        HttpContext context,
+        ISpecParser parser,
+        ISpecValidator validator,
+        ISpecCanonicalizer canonicalizer,
+        CancellationToken cancellationToken)
+    {
+        var request = await TryReadValidateRequestAsync(context, cancellationToken).ConfigureAwait(false);
+        if (request is null)
+        {
+            return BuildProblem(StatusCodes.Status400BadRequest,
+                SpecDiagnosticCodes.InvalidRequestBody,
+                "Request body could not be parsed as a spec validation request.");
+        }
+
+        var hasText = !string.IsNullOrWhiteSpace(request.Text);
+        var hasSpec = request.Spec.ValueKind is not JsonValueKind.Undefined and not JsonValueKind.Null;
+        if (hasText == hasSpec)
+        {
+            return BuildProblem(StatusCodes.Status400BadRequest,
+                SpecDiagnosticCodes.InvalidRequestBody,
+                "Body must contain exactly one of 'text' or 'spec'.");
+        }
+
+        if (hasSpec && request.Spec.ValueKind != JsonValueKind.Object)
+        {
+            return BuildProblem(StatusCodes.Status400BadRequest,
+                SpecDiagnosticCodes.InvalidRequestBody,
+                "'spec' must be a canonical JSON object.");
+        }
+
+        var diagnostics = new List<SpecDiagnostic>();
+        SpecDocument? document = null;
+
+        if (hasText)
+        {
+            var parse = parser.Parse(request.Text!);
+            diagnostics.AddRange(parse.Diagnostics);
+            document = parse.Document;
+        }
+        else
+        {
+            try
+            {
+                document = SpecCanonicalJsonReader.Read(request.Spec.GetRawText());
+            }
+            catch (JsonException ex)
+            {
+                diagnostics.Add(SpecDiagnostic.Error(
+                    SpecDiagnosticCode.ParseError,
+                    $"Canonical spec JSON could not be parsed: {ex.Message}",
+                    SourceSpan.Synthetic));
+            }
+            catch (InvalidOperationException ex)
+            {
+                diagnostics.Add(SpecDiagnostic.Error(
+                    SpecDiagnosticCode.ParseError,
+                    $"Canonical spec JSON could not be read: {ex.Message}",
+                    SourceSpan.Synthetic));
+            }
+        }
+
+        if (document is not null && !HasErrorDiagnostics(diagnostics))
+        {
+            var validation = validator.Validate(document);
+            diagnostics.AddRange(validation.Diagnostics);
+        }
+
+        var isValid = document is not null && !HasErrorDiagnostics(diagnostics);
+        var canonicalJson = isValid && request.IncludeCanonicalJson
+            ? canonicalizer.ToJson(document!, indent: false)
+            : null;
+
+        return Results.Json(new SpecValidateResponse
+        {
+            IsValid = isValid,
+            Diagnostics = diagnostics.Select(ToValidateDiagnostic).ToList(),
+            CanonicalJson = canonicalJson,
+            Grammar = document?.Grammar,
+            OperatorCapabilityVersion = SpecGrammarVersion.CurrentOperatorCapability
+        }, SpecJsonContext.Default.SpecValidateResponse);
     }
 
     private static async Task<IResult> HandlePlanAsync(
@@ -325,6 +416,23 @@ internal static class SpecEndpoints
         }
     }
 
+    private static async Task<SpecValidateRequest?> TryReadValidateRequestAsync(
+        HttpContext context,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await JsonSerializer.DeserializeAsync(
+                context.Request.Body,
+                SpecJsonContext.Default.SpecValidateRequest,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
     private static CanonicalSpecDocument ToDocument(SpecDocumentRequest request)
     {
         // `SpecDocumentRequest.Nodes` defaults to an empty list, but System.Text.Json
@@ -442,6 +550,27 @@ internal static class SpecEndpoints
             Warnings = plan.Warnings
         };
     }
+
+    private static SpecValidateDiagnosticDto ToValidateDiagnostic(SpecDiagnostic diagnostic)
+        => new()
+        {
+            Code = diagnostic.Code.ToString(),
+            Severity = diagnostic.Severity.ToString().ToLowerInvariant(),
+            Message = diagnostic.Message,
+            Path = diagnostic.Path,
+            Span = diagnostic.Span.HasLocation
+                ? new SpecSourceSpanDto
+                {
+                    Line = diagnostic.Span.Line,
+                    Column = diagnostic.Span.Column,
+                    Offset = diagnostic.Span.Offset,
+                    Length = diagnostic.Span.Length
+                }
+                : null
+        };
+
+    private static bool HasErrorDiagnostics(IEnumerable<SpecDiagnostic> diagnostics)
+        => diagnostics.Any(diagnostic => diagnostic.Severity == SpecDiagnosticSeverity.Error);
 
     private static IResult BuildProblem(int status, string code, string detail)
     {

--- a/src/Honua.Server/Features/Spec/SpecEndpoints.cs
+++ b/src/Honua.Server/Features/Spec/SpecEndpoints.cs
@@ -126,6 +126,13 @@ internal static class SpecEndpoints
                     $"Canonical spec JSON could not be read: {ex.Message}",
                     SourceSpan.Synthetic));
             }
+            catch (FormatException ex)
+            {
+                diagnostics.Add(SpecDiagnostic.Error(
+                    SpecDiagnosticCode.ParseError,
+                    $"Canonical spec JSON could not be read: {ex.Message}",
+                    SourceSpan.Synthetic));
+            }
         }
 
         if (document is not null && !HasErrorDiagnostics(diagnostics))

--- a/tests/dotnet/Honua.Server.Tests/Features/API/EndpointRegistryDriftTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/API/EndpointRegistryDriftTests.cs
@@ -77,6 +77,7 @@ public sealed class EndpointRegistryDriftTests : IAsyncLifetime
         "POST /v1/spec/apply",
         "POST /v1/spec/cancel",
         "POST /v1/spec/plan",
+        "POST /v1/spec/validate",
     };
 
     [Fact]

--- a/tests/dotnet/Honua.Server.Tests/Features/Grounding/Spec/SpecGroundingEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Grounding/Spec/SpecGroundingEndpointTests.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using Honua.Core.Features.Catalog.Domain;
@@ -189,6 +190,54 @@ public sealed class SpecGroundingEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.GroundingMutate)]
     [Endpoint("POST /v1/grounding/spec/mutate")]
+    public async Task Mutate_CanonicalSpecWithOutOfRangeNumber_ReturnsProblemDetails()
+    {
+        using var response = await _client.PostAsync(
+            "/v1/grounding/spec/mutate",
+            new StringContent(
+                """
+                {
+                  "spec": {
+                    "grammar": "v1.0",
+                    "sources": [
+                      {
+                        "id": "zones",
+                        "type": "layer",
+                        "ref": "catalog:layer:4"
+                      }
+                    ],
+                    "compute": [
+                      {
+                        "id": "broken",
+                        "op": "buffer",
+                        "params": {
+                          "distance": {
+                            "kind": "distance",
+                            "unit": "m",
+                            "value": 1e400
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "turn": "use zones"
+                }
+                """,
+                Encoding.UTF8,
+                "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = payload.RootElement;
+        root.GetProperty("title").GetString().Should().Be("Invalid spec grounding request");
+        root.GetProperty("detail").GetString().Should().Contain("numeric values must be finite");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GroundingMutate)]
+    [Endpoint("POST /v1/grounding/spec/mutate")]
     public async Task Mutate_MissingUnitClarification_ExposesNauticalMilesCandidate()
     {
         using var harness = new SpecGroundingHarness(SpecGroundingTestSupport.CreateLayer(4, "Zones"));
@@ -267,6 +316,53 @@ public sealed class SpecGroundingEndpointTests : IAsyncLifetime
             .Should().Contain(["sources", "compute", "outputs"]);
         sections.Should().OnlyContain(section =>
             CountSentences(section.GetProperty("text").GetString() ?? string.Empty) <= 2);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GroundingSummarize)]
+    [Endpoint("POST /v1/grounding/spec/summarize")]
+    public async Task Summarize_CanonicalSpecWithOutOfRangeNumber_ReturnsProblemDetails()
+    {
+        using var response = await _client.PostAsync(
+            "/v1/grounding/spec/summarize",
+            new StringContent(
+                """
+                {
+                  "spec": {
+                    "grammar": "v1.0",
+                    "sources": [
+                      {
+                        "id": "zones",
+                        "type": "layer",
+                        "ref": "catalog:layer:4"
+                      }
+                    ],
+                    "compute": [
+                      {
+                        "id": "broken",
+                        "op": "buffer",
+                        "params": {
+                          "distance": {
+                            "kind": "distance",
+                            "unit": "m",
+                            "value": 1e400
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+                """,
+                Encoding.UTF8,
+                "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = payload.RootElement;
+        root.GetProperty("title").GetString().Should().Be("Invalid spec grounding request");
+        root.GetProperty("detail").GetString().Should().Contain("numeric values must be finite");
     }
 
     private static int CountSentences(string text)

--- a/tests/dotnet/Honua.Server.Tests/Features/Spec/SpecEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Spec/SpecEndpointsTests.cs
@@ -128,6 +128,56 @@ public sealed class SpecEndpointsTests
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("POST /v1/spec/validate")]
+    public async Task Validate_CanonicalSpecObjectWithOutOfRangeNumber_ReturnsParseDiagnostic()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.PostAsync(
+            "/v1/spec/validate",
+            new StringContent(
+                """
+                {
+                  "spec": {
+                    "grammar": "v1.0",
+                    "sources": [
+                      {
+                        "id": "hospitals",
+                        "type": "layer",
+                        "ref": "catalog:layer:1"
+                      }
+                    ],
+                    "compute": [
+                      {
+                        "id": "broken",
+                        "op": "buffer",
+                        "params": {
+                          "distance": {
+                            "kind": "distance",
+                            "unit": "m",
+                            "value": 1e400
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+                """,
+                Encoding.UTF8,
+                "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = payload.RootElement;
+        Assert.False(root.GetProperty("isValid").GetBoolean());
+        Assert.Contains(root.GetProperty("diagnostics").EnumerateArray(), diagnostic =>
+            diagnostic.GetProperty("code").GetString() == "ParseError" &&
+            diagnostic.GetProperty("severity").GetString() == "error");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /v1/spec/validate")]
     public async Task Validate_WithoutSource_Returns400WithInvalidRequestBody()
     {
         using var factory = new TestWebApplicationFactory();

--- a/tests/dotnet/Honua.Server.Tests/Features/Spec/SpecEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Spec/SpecEndpointsTests.cs
@@ -20,6 +20,130 @@ public sealed class SpecEndpointsTests
 {
     [IntegrationTest]
     [Operation(Operations.Query)]
+    [Endpoint("POST /v1/spec/validate")]
+    public async Task Validate_TextSpec_ReturnsDiagnosticsAndCanonicalJson()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.PostAsync("/v1/spec/validate", JsonContent(new
+        {
+            text = """
+            grammar "v1.0"
+            source hospitals { type = "layer", ref = "catalog:layer:1" }
+            compute buffered {
+              op = buffer
+              inputs = { input = @hospitals }
+              params = { distance = 500.m, crs = "EPSG:3857" }
+            }
+            output result { expr = @buffered }
+            """,
+            includeCanonicalJson = true
+        }));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = payload.RootElement;
+        Assert.True(root.GetProperty("isValid").GetBoolean());
+        Assert.Equal("v1.0", root.GetProperty("grammar").GetString());
+        Assert.Equal("v1.0", root.GetProperty("operatorCapabilityVersion").GetString());
+
+        var canonicalJson = root.GetProperty("canonicalJson").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(canonicalJson));
+        using var canonical = JsonDocument.Parse(canonicalJson!);
+        Assert.Equal("v1.0", canonical.RootElement.GetProperty("grammar").GetString());
+        Assert.Equal("buffer", canonical.RootElement.GetProperty("compute")[0].GetProperty("op").GetString());
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /v1/spec/validate")]
+    public async Task Validate_TextSpecWithUnknownOperator_ReturnsInvalidWithDiagnostic()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.PostAsync("/v1/spec/validate", JsonContent(new
+        {
+            text = """
+            grammar "v1.0"
+            source hospitals { type = "layer", ref = "catalog:layer:1" }
+            compute broken {
+              op = does_not_exist
+              inputs = { input = @hospitals }
+            }
+            """
+        }));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = payload.RootElement;
+        Assert.False(root.GetProperty("isValid").GetBoolean());
+        Assert.Contains(root.GetProperty("diagnostics").EnumerateArray(), diagnostic =>
+            diagnostic.GetProperty("code").GetString() == "UnknownOperator" &&
+            diagnostic.GetProperty("severity").GetString() == "error");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /v1/spec/validate")]
+    public async Task Validate_CanonicalSpecObject_RunsSameValidator()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.PostAsync("/v1/spec/validate", JsonContent(new
+        {
+            spec = new
+            {
+                grammar = "v1.0",
+                sources = new[]
+                {
+                    new
+                    {
+                        id = "hospitals",
+                        type = "layer",
+                        @ref = "catalog:layer:1"
+                    }
+                },
+                compute = new[]
+                {
+                    new
+                    {
+                        id = "broken",
+                        op = "does_not_exist"
+                    }
+                }
+            }
+        }));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = payload.RootElement;
+        Assert.False(root.GetProperty("isValid").GetBoolean());
+        Assert.Contains(root.GetProperty("diagnostics").EnumerateArray(), diagnostic =>
+            diagnostic.GetProperty("code").GetString() == "UnknownOperator");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /v1/spec/validate")]
+    public async Task Validate_WithoutSource_Returns400WithInvalidRequestBody()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.PostAsync(
+            "/v1/spec/validate",
+            new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("invalid-request-body", payload.RootElement.GetProperty("code").GetString());
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
     [Endpoint("POST /v1/spec/plan")]
     public async Task Plan_LinearChain_ReturnsDagWithContentHashesInTopologicalOrder()
     {


### PR DESCRIPTION
## Issue Link
Related to #418
Related to honua-io/honua-server-admin#25 (partial public-validator slice for the AI/spec workspace epic).

## Summary
Adds a public spec validation endpoint so the admin spec workspace can lint DSL or canonical JSON before plan/apply. The endpoint returns structured diagnostics, source spans, grammar/capability metadata, and optional canonical JSON for valid specs.

## Changes Made
- Add `POST /v1/spec/validate` under the existing spec route group.
- Add AOT-safe request/response DTOs for validation diagnostics and source spans.
- Add endpoint registry coverage, endpoint-drift allowlist coverage, and HTTP integration tests for valid DSL, invalid DSL, canonical JSON, and malformed validation requests.
- Update the spec engine and platform docs to describe the public validator contract.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Focused commands run:
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter FullyQualifiedName~SpecEndpointsTests --logger "console;verbosity=minimal"`
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter FullyQualifiedName~SpecGroundingEndpointTests --logger "console;verbosity=minimal"`
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter FullyQualifiedName~EndpointRegistryDriftTests --logger "console;verbosity=minimal"`
- `dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj --filter "FullyQualifiedName~ApiSurfaceCoverageTests|FullyQualifiedName~PublicInterfaceProofLedgerTests|FullyQualifiedName~TestAttributeEnforcementTests" --logger "console;verbosity=minimal"`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

