### PR TITLE
ci: update client interop cache action for node24

### DIFF
--- a/.github/workflows/client-interop-nightly.yml
+++ b/.github/workflows/client-interop-nightly.yml
@@ -109,7 +109,7 @@ jobs:
           echo '{ "features": { "buildkit": true } }' > ~/.docker/config.json
 
       - name: Cache docker buildx layers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/.buildx-cache
           key: client-compat-${{ matrix.lane }}-${{ hashFiles(format('docker/client-compat/{0}/**', matrix.lane)) }}


### PR DESCRIPTION
Related to #855

## Summary
This removes the remaining Node 20 deprecation source found in the server workflows by updating the client interop nightly buildx cache action.

## Changes Made
- Bumped .github/workflows/client-interop-nightly.yml from actions/cache@v4 to actions/cache@v5.

## Gate Impact
- [x] Workflow-only CI maintenance change.
- [ ] Application runtime code changed.
- [ ] Database or API behavior changed.

## Testing
- [x] python3 YAML parse for .github/workflows/client-interop-nightly.yml.
- [x] git diff --check.
- [x] scripts/ci/pre-pr-check.sh not run; scoped workflow-only validation used instead.

## Breaking Changes
None