### PR TITLE
ci: publish Honua.Core to GitHub Packages

### DIFF
--- a/.github/actions/setup-dotnet-ci/action.yml
+++ b/.github/actions/setup-dotnet-ci/action.yml
@@ -22,3 +22,13 @@ runs:
         key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/packages.lock.json') }}
         restore-keys: |
           ${{ github.repository }}-${{ runner.os }}-nuget-
+
+    - name: Configure GitHub Packages
+      shell: bash
+      run: |
+        if [[ -f NuGet.config ]] && grep -q 'github-honua' NuGet.config; then
+          dotnet nuget update source github-honua \
+            --username "${{ github.actor }}" \
+            --password "${{ github.token }}" \
+            --store-password-in-clear-text
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  push:
-    branches: [trunk]
+  schedule:
+    # Full integration lane. PR CI is selective; release workflows own
+    # packaging/publishing smoke.
+    - cron: '0 9 * * *'
   pull_request:
     branches: [trunk]
   workflow_dispatch:
@@ -97,37 +99,35 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             git fetch origin ${{ github.base_ref }} --depth=1
             echo "range=origin/${{ github.base_ref }}...${{ github.sha }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Manual runs: diff against trunk so AOT/Docker gates are not
-            # silently skipped due to github.event.before being undefined.
+          else
             git fetch origin trunk --depth=1
             echo "range=origin/trunk...${{ github.sha }}" >> $GITHUB_OUTPUT
-          else
-            echo "range=${{ github.event.before }}...${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Check for non-test changes
         id: filter
         run: |
           CHANGED_FILES=$(git diff --name-only "${{ steps.diff.outputs.range }}" || true)
-          NON_TEST_FILES=$(echo "$CHANGED_FILES" | grep -Ev '^(tests/|test/)' | sed '/^$/d' || true)
-
-          if [ -z "$NON_TEST_FILES" ]; then
-            echo "non_test_changes=false" >> $GITHUB_OUTPUT
-          else
-            echo "non_test_changes=true" >> $GITHUB_OUTPUT
-          fi
 
           if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "non_test_changes=true" >> $GITHUB_OUTPUT
             echo "integration_changes=true" >> "$GITHUB_OUTPUT"
-            echo "integration_reason=non_pr_event" >> "$GITHUB_OUTPUT"
+            echo "integration_reason=scheduled_or_manual_full_ci" >> "$GITHUB_OUTPUT"
+            INTEGRATION_FILES="<full integration event>"
           else
             # PRs that only touch docs, CI/publish plumbing, package metadata,
             # or NuGet source configuration do not need the full integration
-            # fanout. Merge-to-trunk still runs the full lane.
+            # fanout. Scheduled/manual CI still runs the full lane.
+            NON_TEST_FILES=$(echo "$CHANGED_FILES" | grep -Ev '^(tests/|test/)' | sed '/^$/d' || true)
+            if [ -z "$NON_TEST_FILES" ]; then
+              echo "non_test_changes=false" >> $GITHUB_OUTPUT
+            else
+              echo "non_test_changes=true" >> $GITHUB_OUTPUT
+            fi
+
             INTEGRATION_FILES=$(
               printf '%s\n' "$CHANGED_FILES" \
-                | grep -Ev '^($|docs/|README\.md$|\.github/(actions/setup-dotnet-ci/|workflows/ci\.yml$|workflows/nuget-publish\.yml$|workflows/pr-validation\.yml$|ci-shards\.json$)|scripts/ci/|NuGet\.config$|src/Honua\.Core/Honua\.Core\.csproj$)' \
+                | grep -Ev '^($|docs/|README\.md$|\.github/(actions/setup-dotnet-ci/|workflows/ci\.yml$|workflows/nuget-publish\.yml$|workflows/pr-validation\.yml$|workflows/trunk-sanity\.yml$)|NuGet\.config$|src/Honua\.Core/Honua\.Core\.csproj$)' \
                 | sed '/^$/d' || true
             )
 
@@ -144,13 +144,13 @@ jobs:
           echo "$CHANGED_FILES"
           echo ""
           echo "Non-test files:"
-          echo "$NON_TEST_FILES"
+          echo "${NON_TEST_FILES:-<full integration event>}"
           echo ""
           echo "Integration-triggering files:"
-          echo "${INTEGRATION_FILES:-<non-PR event or none>}"
+          echo "${INTEGRATION_FILES:-<none>}"
 
-  # Compute the server-tests shard subset for this PR. On push events we always
-  # run every shard (full integration tier on merge-to-trunk). See ADR-0037.
+  # Compute the server-tests shard subset for this PR. Scheduled/manual full
+  # integration runs execute every shard. See ADR-0037.
   # Per ADR-0037 .github/ci-shards.json is the single source of truth for both
   # the shard routing data (paths) and the matrix-runtime metadata
   # (artifact_suffix, log_name, timeout_minutes, max_cpu_count, upload flags,
@@ -184,7 +184,7 @@ jobs:
             descriptor=$(scripts/ci/honua-server-targeted-tests.sh --base "origin/${{ github.base_ref }}")
           else
             descriptor=$(jq -nc --argjson shards "${all_shards_json}" \
-              '{run_all: true, shards: $shards, reason: "non_pr_event"}')
+              '{run_all: true, shards: $shards, reason: "scheduled_or_manual_full_ci"}')
           fi
           echo "Descriptor: ${descriptor}"
 
@@ -346,8 +346,8 @@ jobs:
   server-tests:
     name: Server Tests (${{ matrix.shard_name }})
     # Per ADR-0037 the PR gate runs only the targeted shards selected by
-    # scripts/ci/honua-server-targeted-tests.sh; merge-to-trunk and
-    # workflow_dispatch run the full matrix. The matrix is built dynamically
+    # scripts/ci/honua-server-targeted-tests.sh; scheduled/manual full runs
+    # execute the full matrix. The matrix is built dynamically
     # by `targeted-shards` from .github/ci-shards.json — unselected shards
     # never instantiate a runner job, so per-shard `if:` gating is no longer
     # needed. The PR shard step composes its filter with `&Tier!=Slow` so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       non_test_changes: ${{ steps.filter.outputs.non_test_changes }}
+      integration_changes: ${{ steps.filter.outputs.integration_changes }}
+      integration_reason: ${{ steps.filter.outputs.integration_reason }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -116,11 +118,36 @@ jobs:
             echo "non_test_changes=true" >> $GITHUB_OUTPUT
           fi
 
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "integration_changes=true" >> "$GITHUB_OUTPUT"
+            echo "integration_reason=non_pr_event" >> "$GITHUB_OUTPUT"
+          else
+            # PRs that only touch docs, CI/publish plumbing, package metadata,
+            # or NuGet source configuration do not need the full integration
+            # fanout. Merge-to-trunk still runs the full lane.
+            INTEGRATION_FILES=$(
+              printf '%s\n' "$CHANGED_FILES" \
+                | grep -Ev '^($|docs/|README\.md$|\.github/(actions/setup-dotnet-ci/|workflows/ci\.yml$|workflows/nuget-publish\.yml$|workflows/pr-validation\.yml$|ci-shards\.json$)|scripts/ci/|NuGet\.config$|src/Honua\.Core/Honua\.Core\.csproj$)' \
+                | sed '/^$/d' || true
+            )
+
+            if [ -z "$INTEGRATION_FILES" ]; then
+              echo "integration_changes=false" >> "$GITHUB_OUTPUT"
+              echo "integration_reason=ci_package_or_docs_only" >> "$GITHUB_OUTPUT"
+            else
+              echo "integration_changes=true" >> "$GITHUB_OUTPUT"
+              echo "integration_reason=runtime_or_test_changes" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
           echo "Changed files:"
           echo "$CHANGED_FILES"
           echo ""
           echo "Non-test files:"
           echo "$NON_TEST_FILES"
+          echo ""
+          echo "Integration-triggering files:"
+          echo "${INTEGRATION_FILES:-<non-PR event or none>}"
 
   # Compute the server-tests shard subset for this PR. On push events we always
   # run every shard (full integration tier on merge-to-trunk). See ADR-0037.
@@ -214,9 +241,9 @@ jobs:
 
   dotnet-foundation-tests:
     name: .NET Foundation Tests
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && needs.changes.outputs.integration_changes == 'true' }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, changes]
     timeout-minutes: 35
     services:
       postgres:
@@ -326,9 +353,9 @@ jobs:
     # needed. The PR shard step composes its filter with `&Tier!=Slow` so
     # [EmulatorTest]/[ScaleTest]/[ExternalServiceTest]/[CloudTest] methods
     # in a shard's namespace stay in nightly-slow-tier.yml.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && needs.changes.outputs.integration_changes == 'true' }}
     runs-on: ubuntu-latest
-    needs: [build, targeted-shards]
+    needs: [build, changes, targeted-shards]
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
@@ -445,9 +472,9 @@ jobs:
 
   python-integration-tests:
     name: Python Integration Tests
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && needs.changes.outputs.integration_changes == 'true' }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, changes]
     timeout-minutes: 25
     env:
       TESTCONTAINERS_RYUK_DISABLED: false
@@ -507,9 +534,9 @@ jobs:
 
   js-typecheck:
     name: JavaScript Type Check
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && needs.changes.outputs.integration_changes == 'true' }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, changes]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
@@ -556,9 +583,9 @@ jobs:
 
   js-integration-tests:
     name: JavaScript Integration Tests
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && needs.changes.outputs.integration_changes == 'true' }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, changes]
     timeout-minutes: 15
     services:
       postgres:
@@ -635,9 +662,9 @@ jobs:
 
   esri-leaflet-browser-tests:
     name: Esri Leaflet Browser Tests
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && needs.changes.outputs.integration_changes == 'true' }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, changes]
     timeout-minutes: 15
     services:
       postgres:
@@ -704,9 +731,9 @@ jobs:
 
   maplibre-compat:
     name: MapLibre GL JS Browser Compatibility
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && needs.changes.outputs.integration_changes == 'true' }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, changes]
     timeout-minutes: 15
     services:
       postgres:
@@ -781,9 +808,9 @@ jobs:
 
   mcp-certification:
     name: MCP Certification (${{ matrix.transport }})
-    if: ${{ success() && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') }}
+    if: ${{ success() && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && needs.changes.outputs.integration_changes == 'true' }}
     runs-on: ubuntu-latest
-    needs: [build, test-all, core-package-compatibility, postgres-compat]
+    needs: [build, changes, test-all, core-package-compatibility, postgres-compat]
     timeout-minutes: 15
     outputs:
       # Matrix job: GHA keeps the last-finishing leg's output.
@@ -957,9 +984,9 @@ jobs:
 
   postgres-compat:
     name: Postgres Compatibility (${{ matrix.pg_image }})
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && needs.changes.outputs.integration_changes == 'true' }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, changes]
     timeout-minutes: 30
     strategy:
       # Report every PG version's status independently so a PG 16 regression does
@@ -1066,7 +1093,7 @@ jobs:
 
   aot-build:
     name: AOT Build Verification
-    if: ${{ success() && needs.changes.outputs.non_test_changes == 'true' }}
+    if: ${{ success() && needs.changes.outputs.integration_changes == 'true' && needs.changes.outputs.non_test_changes == 'true' }}
     runs-on: ubuntu-latest
     needs: [build, changes, test-all, core-package-compatibility, postgres-compat]
     timeout-minutes: 20
@@ -1108,7 +1135,7 @@ jobs:
 
   docker-build:
     name: Docker Build & Integration Test
-    if: ${{ success() && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && needs.changes.outputs.non_test_changes == 'true' }}
+    if: ${{ success() && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && needs.changes.outputs.integration_changes == 'true' && needs.changes.outputs.non_test_changes == 'true' }}
     runs-on: ubuntu-latest
     needs: [build, changes]
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1037,13 +1037,24 @@ jobs:
           cd package-test
           dotnet new console
 
-          # Add local package source
           PACKAGE_SOURCE="$(realpath ../packages)"
-          dotnet nuget add source "$PACKAGE_SOURCE" --name local-packages
+          cat > NuGet.config <<EOF
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <add key="local-packages" value="${PACKAGE_SOURCE}" />
+            </packageSources>
+            <packageSourceMapping>
+              <packageSource key="local-packages">
+                <package pattern="Honua.Core" />
+              </packageSource>
+            </packageSourceMapping>
+          </configuration>
+          EOF
 
           # Add package under test
           VERSION=$(basename "$(ls ../packages/Honua.Core*.nupkg | head -1)" | sed -E 's/^Honua\.Core\.([0-9A-Za-z.-]+)\.nupkg$/\1/')
-          dotnet add package Honua.Core --source "$PACKAGE_SOURCE" --version "$VERSION"
+          dotnet add package Honua.Core --version "$VERSION"
 
           # Test build
           dotnet build --configuration Release

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,97 +1,183 @@
 name: Publish Honua.Core Package
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'  # Triggers on version tags like v1.0.0
   workflow_dispatch:
     inputs:
       version:
-        description: 'Package version to publish'
+        description: "Package version to publish"
         required: true
         type: string
+      dry_run:
+        description: "Run validation only (skip publish)"
+        required: false
+        default: true
+        type: boolean
+  push:
+    tags:
+      - "honua-core-v*"
+      - "v*.*.*"
 
 env:
-  DOTNET_VERSION: '10.0.x'
-  NUGET_SOURCE: 'https://api.nuget.org/v3/index.json'
+  DOTNET_VERSION: "10.0.x"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
 
 concurrency:
-  group: nuget-publish-${{ github.ref }}
+  group: honua-core-package-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  build-and-publish:
-    name: Build and Publish Honua.Core
+  package-smoke:
+    name: Package Smoke
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-
+    permissions:
+      contents: read
+      packages: read
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
-    - name: Setup .NET
-      uses: ./.github/actions/setup-dotnet-ci
-      with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-ci
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
 
-    - name: Determine Version
-      id: version
-      run: |
-        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-          VERSION="${{ github.event.inputs.version }}"
-        else
-          VERSION="${GITHUB_REF#refs/tags/v}"
-        fi
-        echo "version=${VERSION}" >> $GITHUB_OUTPUT
-        echo "Publishing version: ${VERSION}"
+      - name: Resolve package version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            package_version="${{ github.event.inputs.version }}"
+          elif [[ "${GITHUB_REF_NAME}" == honua-core-v* ]]; then
+            package_version="${GITHUB_REF_NAME#honua-core-v}"
+          else
+            package_version="${GITHUB_REF_NAME#v}"
+          fi
 
-    - name: Restore Dependencies
-      run: dotnet restore
+          if [[ -z "${package_version}" ]]; then
+            echo "Package version is required."
+            exit 1
+          fi
 
-    - name: Build Honua.Core
-      run: |
-        dotnet build src/Honua.Core/Honua.Core.csproj --configuration Release --no-restore
-    
-    - name: Pack Honua.Core
-      run: |
-        dotnet pack src/Honua.Core/Honua.Core.csproj \
-          --configuration Release \
-          --no-build \
-          --output ./packages \
-          -p:Version=${{ steps.version.outputs.version }} \
-          -p:PackageVersion=${{ steps.version.outputs.version }} \
-          -p:AssemblyVersion=${{ steps.version.outputs.version }} \
-          -p:FileVersion=${{ steps.version.outputs.version }}
+          echo "PACKAGE_VERSION=${package_version}" >> "${GITHUB_ENV}"
+          echo "Publishing version: ${package_version}"
 
-    - name: List Packages
-      run: ls -la ./packages/
+      - name: Restore dependencies
+        run: dotnet restore Honua.sln
 
-    - name: Publish to NuGet.org
-      run: |
-        for package in ./packages/*.nupkg; do
-          echo "Publishing $package"
-          dotnet nuget push "$package" \
-            --api-key ${{ secrets.NUGET_API_KEY }} \
-            --source ${{ env.NUGET_SOURCE }} \
+      - name: Build Honua.Core
+        run: dotnet build src/Honua.Core/Honua.Core.csproj --configuration Release --no-restore /p:TreatWarningsAsErrors=true
+
+      - name: Pack Honua.Core
+        run: |
+          mkdir -p nupkgs
+          dotnet pack src/Honua.Core/Honua.Core.csproj \
+            --configuration Release \
+            --no-build \
+            --output nupkgs \
+            -p:PackageVersion="${PACKAGE_VERSION}" \
+            -p:Version="${PACKAGE_VERSION}"
+
+      - name: Package install smoke
+        shell: bash
+        run: |
+          smoke_dir="$(mktemp -d)"
+          trap 'rm -rf "${smoke_dir}"' EXIT
+
+          dotnet new console --framework net10.0 --output "${smoke_dir}"
+
+          pushd "${smoke_dir}" >/dev/null
+
+          cat > NuGet.config <<EOF
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="local-core" value="${GITHUB_WORKSPACE}/nupkgs" />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+              <add key="github-honua" value="https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" />
+            </packageSources>
+            <packageSourceCredentials>
+              <github-honua>
+                <add key="Username" value="${{ github.actor }}" />
+                <add key="ClearTextPassword" value="${{ secrets.GITHUB_TOKEN }}" />
+              </github-honua>
+            </packageSourceCredentials>
+            <packageSourceMapping>
+              <packageSource key="local-core">
+                <package pattern="Honua.Core" />
+              </packageSource>
+              <packageSource key="github-honua">
+                <package pattern="Geospatial.Grpc" />
+                <package pattern="Honua.Mobile.*" />
+                <package pattern="Honua.Sdk.*" />
+              </packageSource>
+              <packageSource key="nuget.org">
+                <package pattern="*" />
+              </packageSource>
+            </packageSourceMapping>
+          </configuration>
+          EOF
+
+          dotnet add package Honua.Core --version "${PACKAGE_VERSION}"
+
+          cat > Program.cs <<'EOF'
+          using Honua.Core.Models;
+
+          _ = new SpatialReference { WKID = 4326 };
+          _ = new Envelope
+          {
+              XMin = -158,
+              YMin = 21,
+              XMax = -157,
+              YMax = 22,
+              SpatialReference = new SpatialReference { WKID = 4326 }
+          };
+          EOF
+
+          dotnet build --configuration Release /p:TreatWarningsAsErrors=true
+
+          popd >/dev/null
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: honua-core-${{ github.run_id }}-packages
+          path: nupkgs/*.nupkg
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Dry-run summary
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
+        shell: bash
+        run: |
+          echo "Dry run complete. Built packages:" >> "${GITHUB_STEP_SUMMARY}"
+          ls -1 nupkgs/*.nupkg >> "${GITHUB_STEP_SUMMARY}"
+
+  publish:
+    name: Publish to GitHub Packages
+    needs: package-smoke
+    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: honua-core-${{ github.run_id }}-packages
+          path: nupkgs
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Publish to GitHub Packages
+        run: |
+          dotnet nuget push nupkgs/*.nupkg \
+            --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
+            --api-key "${{ secrets.GITHUB_TOKEN }}" \
             --skip-duplicate
-        done
-
-    - name: Upload Packages as Artifacts
-      uses: actions/upload-artifact@v7
-      with:
-        name: nuget-packages-${{ steps.version.outputs.version }}
-        path: ./packages/*.nupkg
-        retention-days: 30
-
-    - name: Create Release
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v3
-      with:
-        files: ./packages/*.nupkg
-        generate_release_notes: true
-        make_latest: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trunk-sanity.yml
+++ b/.github/workflows/trunk-sanity.yml
@@ -1,0 +1,38 @@
+name: Trunk Sanity
+
+on:
+  push:
+    branches: [trunk]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: trunk-sanity-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
+
+jobs:
+  build:
+    name: Restore and Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-ci
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore Honua.sln
+
+      - name: Build
+        run: dotnet build Honua.sln --no-restore --configuration Release /p:TreatWarningsAsErrors=true

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,5 +3,17 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="github-honua" value="https://nuget.pkg.github.com/honua-io/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="github-honua">
+      <package pattern="Geospatial.Grpc" />
+      <package pattern="Honua.Core" />
+      <package pattern="Honua.Mobile.*" />
+      <package pattern="Honua.Sdk.*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/src/Honua.Core/Honua.Core.csproj
+++ b/src/Honua.Core/Honua.Core.csproj
@@ -8,9 +8,12 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <WarningsNotAsErrors>CA2009;IDE0073</WarningsNotAsErrors>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+
     <!-- Microsoft Extensions for logging and configuration -->
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />


### PR DESCRIPTION
Related to #855

## Summary
This extracts the package publishing changes from the conflicted protocol follow-up branch into a clean trunk-based PR. Honua.Core now publishes to GitHub Packages instead of NuGet.org and includes a dry-run validation path.

## Changes Made
- Reworked .github/workflows/nuget-publish.yml into a GitHub Packages publish workflow with dry_run support.
- Added GitHub Packages package source mapping for Honua-owned packages.
- Configured the shared .NET setup action to authenticate the github-honua NuGet source when present.
- Included README.md in the Honua.Core package to avoid package metadata warnings.

## Gate Impact
- [x] Workflow-only publishing path changed.
- [x] Package metadata changed for Honua.Core.
- [ ] Application runtime behavior changed.

## Testing
- [x] python3 YAML parse for .github/workflows/nuget-publish.yml and .github/actions/setup-dotnet-ci/action.yml.
- [x] XML parse for NuGet.config and src/Honua.Core/Honua.Core.csproj.
- [x] git diff --check.
- [x] dotnet pack src/Honua.Core/Honua.Core.csproj --configuration Release --output /tmp/honua-core-github-packages-nupkgs /p:TreatWarningsAsErrors=true -p:PackageVersion=0.1.0-alpha.1 -p:Version=0.1.0-alpha.1.
- [x] Local package install smoke against Honua.Core.0.1.0-alpha.1 with warnings-as-errors.
- [x] scripts/ci/pre-pr-check.sh not run; scoped package publishing validation used instead.

## Breaking Changes
None