### PR TITLE
ci: stop heavy workflows on trunk push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
 
             INTEGRATION_FILES=$(
               printf '%s\n' "$CHANGED_FILES" \
-                | grep -Ev '^($|docs/|README\.md$|\.github/(actions/setup-dotnet-ci/|workflows/ci\.yml$|workflows/nuget-publish\.yml$|workflows/pr-validation\.yml$|workflows/trunk-sanity\.yml$)|NuGet\.config$|src/Honua\.Core/Honua\.Core\.csproj$)' \
+                | grep -Ev '^($|docs/|README\.md$|\.github/(actions/setup-dotnet-ci/|workflows/[^/]+\.yml$)|NuGet\.config$|src/Honua\.Core/Honua\.Core\.csproj$)' \
                 | sed '/^$/d' || true
             )
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,7 @@ name: CodeQL
 
 on:
   # Tier: nightly — CodeQL is non-deterministic and slow for routine PRs.
-  # Runs on default branch push and weekly schedule. See docs/ci/gate-model.md.
-  push:
-    branches: [trunk]
+  # Runs on a weekly schedule. See docs/ci/gate-model.md.
   schedule:
     # Run weekly on Monday at 00:00 UTC
     - cron: '0 0 * * 1'

--- a/.github/workflows/control-plane-sdk-governance.yml
+++ b/.github/workflows/control-plane-sdk-governance.yml
@@ -9,14 +9,6 @@ on:
       - 'docs/developer/api-specs/admin-api.json'
       - 'scripts/sdk/generate-control-plane-sdks.sh'
       - '.github/workflows/control-plane-sdk-governance.yml'
-  push:
-    branches:
-      - trunk
-      - main
-    paths:
-      - 'docs/developer/api-specs/admin-api.json'
-      - 'scripts/sdk/generate-control-plane-sdks.sh'
-      - '.github/workflows/control-plane-sdk-governance.yml'
   workflow_dispatch:
     inputs:
       sdk_version:

--- a/.github/workflows/deploy-platform-images.yml
+++ b/.github/workflows/deploy-platform-images.yml
@@ -2,7 +2,6 @@ name: Build & Publish Platform Images
 
 on:
   push:
-    branches: [trunk]
     tags: ["v*"]
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,6 @@ name: Build & Publish Images
 
 on:
   push:
-    branches: [trunk]
     tags: ['v*']
   workflow_dispatch:
 

--- a/.github/workflows/openapi-contract-governance.yml
+++ b/.github/workflows/openapi-contract-governance.yml
@@ -11,16 +11,6 @@ on:
       - 'src/Honua.Server/Features/Infrastructure/Authentication/**'
       - 'scripts/ci/validate-openapi-contracts.sh'
       - '.github/workflows/openapi-contract-governance.yml'
-  push:
-    branches:
-      - trunk
-      - main
-    paths:
-      - 'docs/developer/api-specs/**'
-      - 'src/Honua.Server/Features/Admin/**'
-      - 'src/Honua.Server/Features/Infrastructure/Authentication/**'
-      - 'scripts/ci/validate-openapi-contracts.sh'
-      - '.github/workflows/openapi-contract-governance.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/parity-scorecard-governance.yml
+++ b/.github/workflows/parity-scorecard-governance.yml
@@ -12,17 +12,6 @@ on:
       - 'scripts/ci/check-parity-scorecard-baseline-sync.sh'
       - '.github/workflows/geoservices-parity-nightly.yml'
       - '.github/workflows/parity-scorecard-governance.yml'
-  push:
-    branches:
-      - trunk
-      - main
-    paths:
-      - 'tests/dotnet/Honua.Server.Tests/Import/GeoservicesParityIntegrationTests.cs'
-      - 'tests/dotnet/Honua.Server.Tests/Import/parity-scorecard-baseline.json'
-      - 'scripts/ci/check-parity-scorecard-regression.sh'
-      - 'scripts/ci/check-parity-scorecard-baseline-sync.sh'
-      - '.github/workflows/geoservices-parity-nightly.yml'
-      - '.github/workflows/parity-scorecard-governance.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sdk-server-compatibility.yml
+++ b/.github/workflows/sdk-server-compatibility.yml
@@ -4,9 +4,6 @@ name: SDK Server Compatibility
 
 'on':
   workflow_dispatch:
-  push:
-    branches:
-      - trunk
   schedule:
     - cron: '35 8 * * 1'
 

--- a/docs/ci/gate-model.md
+++ b/docs/ci/gate-model.md
@@ -1,7 +1,7 @@
 # CI Gate Model
 
 > Defines the five-tier quality gate model governing all CI workflows across the Honua project.
-> Last updated: 2026-04-14 (ticket #463)
+> Last updated: 2026-04-29
 
 ## Tier Definitions
 
@@ -23,7 +23,7 @@
 
 4. **New checks default to nightly** unless explicitly justified as PR-blocking. Justification requires: deterministic behavior, sub-5-minute runtime, and author-actionable failure messages.
 
-5. **AOT verification is post-merge/manual until trim debt is retired.** The `AOT Build Verification` job in `ci.yml` runs on `push` to `trunk` and `workflow_dispatch`, not on PRs, because its current failures are not consistently fast or author-actionable within the PR lane.
+5. **AOT verification is scheduled/manual until trim debt is retired.** The `AOT Build Verification` job in `ci.yml` runs in the full scheduled/manual integration lane, not on routine PRs or merge-to-trunk pushes, because its current failures are not consistently fast or author-actionable within the PR lane.
 
 6. **The `Tier=Fast|Integration|Slow` test trait is a sub-tier inside this gate model, not a replacement for it.** ADR-0037 splits the .NET test suite by execution cost so that PRs run the `Tier=Fast` foundation tests plus a targeted subset of `server-tests` shards selected by `scripts/ci/honua-server-targeted-tests.sh`. The `targeted-shards` job emits a JSON `matrix_include` drawn from `.github/ci-shards.json` and `server-tests` consumes it via `strategy.matrix.include: fromJson(...)`, so unselected shards never instantiate a runner. The shard test step composes `&Tier!=Slow` onto the matrix filter so Slow-tagged tests inside a shard's namespace are skipped. `Tier=Slow&Category=Emulator` runs nightly via `nightly-slow-tier.yml`, and the integration tier is re-run nightly by `flaky-detection.yml` for flake reporting. The Scale/Cloud/External slow subfamilies need dedicated workflows once their fixtures are wired up. The five-tier PR/nightly/release/deploy/maintenance gate model above still defines *where* a workflow lives; the trait defines *which subset of tests* runs inside the workflow.
 
@@ -58,7 +58,7 @@ These workflows run on schedule and can be dispatched manually:
 | `cross-server-consume-nightly.yml` | Daily 7:00am UTC | Honua-as-client WMS/WFS/WMTS reads against GeoServer and MapServer reference containers |
 | `windows-client-compat-nightly.yml` | Daily 7:15am UTC | Full CERT-\* matrix certification (18 test cases × 4 protocol lanes) with `.cert.json` envelopes + reusable evidence pack |
 | `pyqgis-client-compat-nightly.yml` | Daily 7:30am UTC | PyQGIS desktop client compatibility (OGC Features + WFS) with per-protocol `.cert.json` envelopes |
-| `sdk-server-compatibility.yml` | Monday 8:35am UTC plus post-merge `trunk` pushes | Manifest-driven last-3 server refs x last-3 SDK sets compatibility matrix through `honua-sdk-js`, `honua-sdk-python`, and `honua-sdk-dotnet`; publishes the `sdk-compatibility-matrix-<run-id>` table artifact and fails on supported-cell regressions |
+| `sdk-server-compatibility.yml` | Monday 8:35am UTC | Manifest-driven last-3 server refs x last-3 SDK sets compatibility matrix through `honua-sdk-js`, `honua-sdk-python`, and `honua-sdk-dotnet`; publishes the `sdk-compatibility-matrix-<run-id>` table artifact and fails on supported-cell regressions |
 | `client-interop-nightly.yml` | Daily 7:00am UTC | Real-client interop matrix via Docker harnesses (`gdal`, `pyqgis`, `openlayers`, `cesium`, `arcgis-stub`); diffs per-lane `.cert.json` envelopes against `tests/baselines/client-compat/` and refreshes `docs/gis/gap-report.md`. Non-blocking until 30 consecutive nightly passes (#806) |
 | `gdal-driver-e2e.yml` | Daily 7:45am UTC | GDAL `ogrinfo` + `ogr2ogr` round-trip against honua-server (ADR-0034 stand-in until `honua-gdal` plugin ships) |
 | `load-soak-nightly.yml` | Scheduled | Load and soak testing |
@@ -79,8 +79,8 @@ These workflows run on schedule and can be dispatched manually:
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `deploy.yml` | Push / manual | Environment promotion |
-| `deploy-platform-images.yml` | Push / manual | Platform image deployment |
+| `deploy.yml` | Tags / manual | Environment promotion |
+| `deploy-platform-images.yml` | Tags / manual | Platform image deployment |
 | `cloud-post-apply-validation.yml` | Workflow call / manual | Post-deploy validation |
 
 ## Maintenance Lane

--- a/docs/ci/workflow-inventory.md
+++ b/docs/ci/workflow-inventory.md
@@ -1,17 +1,18 @@
 # CI Workflow Inventory
 
 > Canonical inventory of all GitHub Actions workflows across the Honua project.
-> Last updated: 2026-04-27 (ticket #809)
+> Last updated: 2026-04-29
 
 ## honua-server
 
 | Workflow file | Name | Tier | Triggers | Merge-blocking | Notes |
 |---|---|---|---|---|---|
-| `ci.yml` | CI | PR | `pull_request`, `push` (trunk) | Yes | Core build, test, architecture gate; per ADR-0037 the `targeted-shards` job runs `scripts/ci/honua-server-targeted-tests.sh` to pick the shards a diff exercises and emits a JSON `matrix_include` drawn from `.github/ci-shards.json`; `server-tests` consumes it via `strategy.matrix.include: fromJson(...)` so PRs only instantiate runners for selected shards (the full 11-shard matrix runs on `push`/dispatch). The shard test step composes its filter as `(matrix.filter)&Tier!=Slow` so `[EmulatorTest]` / `[ScaleTest]` / `[ExternalServiceTest]` / `[CloudTest]` methods sitting in a shard's namespace skip on PRs and trunk pushes; PR shards therefore do not provision LocalStack/Azurite. Includes the merge-blocking operator eval harness lane (`Features.Eval|Features.Geoprocessing|Features.Protocols.Ogc.Api.Processes|Features.Protocols.Grpc|Features.Protocols.Mcp|Features.Protocols.GeoServices.GPServer`) and uploads `operator-eval-report` plus STAC and Esri Leaflet client-compat artifacts |
+| `ci.yml` | CI | PR + nightly | `pull_request`, `schedule`, `workflow_dispatch` | Yes | Core build, test, architecture gate; per ADR-0037 the `targeted-shards` job runs `scripts/ci/honua-server-targeted-tests.sh` to pick the shards a diff exercises and emits a JSON `matrix_include` drawn from `.github/ci-shards.json`; `server-tests` consumes it via `strategy.matrix.include: fromJson(...)` so PRs only instantiate runners for selected shards. The full 11-shard matrix runs only on scheduled/manual full integration runs. The shard test step composes its filter as `(matrix.filter)&Tier!=Slow` so `[EmulatorTest]` / `[ScaleTest]` / `[ExternalServiceTest]` / `[CloudTest]` methods sitting in a shard's namespace skip on PRs; PR shards therefore do not provision LocalStack/Azurite. Includes the merge-blocking operator eval harness lane (`Features.Eval|Features.Geoprocessing|Features.Protocols.Ogc.Api.Processes|Features.Protocols.Grpc|Features.Protocols.Mcp|Features.Protocols.GeoServices.GPServer`) and uploads `operator-eval-report` plus STAC and Esri Leaflet client-compat artifacts |
 | `pr-validation.yml` | PR Validation | PR | `pull_request` | Yes | Template compliance check |
-| `openapi-contract-governance.yml` | OpenAPI Contract Governance | PR | `pull_request`, `push`, `workflow_dispatch` | Yes | Path-scoped to API surface |
-| `control-plane-sdk-governance.yml` | Control Plane SDK Governance | PR + release | `pull_request`, `push`, `workflow_dispatch`, `release` | Yes (PR jobs) | PR governance separate from release publishing |
-| `parity-scorecard-governance.yml` | Parity Scorecard Governance | PR | `pull_request`, `push`, `workflow_dispatch` | Yes | Path-scoped to parity/baseline assets |
+| `openapi-contract-governance.yml` | OpenAPI Contract Governance | PR | `pull_request`, `workflow_dispatch` | Yes | Path-scoped to API surface |
+| `control-plane-sdk-governance.yml` | Control Plane SDK Governance | PR + release | `pull_request`, `workflow_dispatch`, `release` | Yes (PR jobs) | PR governance separate from release publishing |
+| `parity-scorecard-governance.yml` | Parity Scorecard Governance | PR | `pull_request`, `workflow_dispatch` | Yes | Path-scoped to parity/baseline assets |
+| `trunk-sanity.yml` | Trunk Sanity | PR-adjacent sanity | `push` (trunk), `workflow_dispatch` | No | Cheap post-merge restore/build only; heavy CI does not run on merge-to-trunk pushes |
 | `cite-conformance.yml` | OGC CITE Conformance (Features) | nightly | `schedule`, `workflow_dispatch` | No | Weekly Monday 6am UTC |
 | `cite-tiles-conformance.yml` | OGC API Tiles CITE Conformance | nightly | `schedule`, `workflow_dispatch` | No | Weekly Tuesday 6am UTC |
 | `cite-wfs20-conformance.yml` | WFS 2.0 CITE Conformance | nightly | `schedule`, `workflow_dispatch` | No | Weekly Monday 3am UTC |
@@ -25,18 +26,18 @@
 | `cross-server-consume-nightly.yml` | Cross-Server Consume Nightly | nightly | `schedule`, `workflow_dispatch` | No | Daily 7:00am UTC; runs Honua-as-client WMS/WFS/WMTS reads against reference GeoServer and MapServer containers via the Test-environment `/__test/cross-server-consume/proxy` endpoint, uploads TRX/report artifacts, and best-effort commits the refreshed gap report (warns instead of failing if push is blocked) |
 | `windows-client-compat-nightly.yml` | Windows Client Compatibility Certification | nightly | `schedule`, `workflow_dispatch` | No | Daily 7:15am UTC; full CERT-\* matrix (18 test cases × 4 protocol lanes: FeatureServer, OGC Features, MapServer, OData) with per-protocol `.cert.json` envelopes under `certification/`, plus `overall-summary.json`, per-lane transcripts, and `pack/`; supports `--profile smoke` (11-check MVP) and `--profile full` (default) |
 | `pyqgis-client-compat-nightly.yml` | PyQGIS Client Compatibility Certification | nightly | `schedule`, `workflow_dispatch` | No | Daily 7:30am UTC; PyQGIS desktop client compatibility using real QGIS providers against `client-compat-v1.sql`; produces `desktop-qgis-ogc-features.cert.json` and `desktop-qgis-wfs.cert.json` envelopes |
-| `sdk-server-compatibility.yml` | SDK Server Compatibility | nightly | `push` (trunk), `schedule`, `workflow_dispatch` | No | Manifest-driven last-3 server refs x last-3 SDK sets matrix from `docs/developer/sdk-compatibility-versions.json`; runs live compatibility smoke checks through checked-out `honua-sdk-js`, `honua-sdk-python`, and `honua-sdk-dotnet`, validates admin compatibility metadata plus seeded FeatureServer and OGC API Features surfaces, uploads per-cell JSON evidence, and publishes `sdk-compatibility-matrix-<run-id>` with supported-cell regression failure |
+| `sdk-server-compatibility.yml` | SDK Server Compatibility | nightly | `schedule`, `workflow_dispatch` | No | Manifest-driven last-3 server refs x last-3 SDK sets matrix from `docs/developer/sdk-compatibility-versions.json`; runs live compatibility smoke checks through checked-out `honua-sdk-js`, `honua-sdk-python`, and `honua-sdk-dotnet`, validates admin compatibility metadata plus seeded FeatureServer and OGC API Features surfaces, uploads per-cell JSON evidence, and publishes `sdk-compatibility-matrix-<run-id>` with supported-cell regression failure |
 | `client-interop-nightly.yml` | Real-Client Interop Matrix (Nightly) | nightly | `schedule`, `workflow_dispatch` | No | Daily 7:00am UTC; runs the docker/client-compat matrix (`gdal`, `pyqgis`, `openlayers`, `cesium`, `arcgis-stub`) via Docker harnesses, diffs the per-lane `.cert.json` envelopes against `tests/baselines/client-compat/` (gated by `expected-pairs.json`), refreshes `docs/gis/gap-report.md`, and fails strict mode on any baseline `pass`→non-`pass` regression, missing lane envelope, missing expected-pair, or new `fail` in an unbaselined case. Promote to PR-blocking once 30 consecutive nightly passes are observed (#806) |
 | `gdal-driver-e2e.yml` | GDAL Driver End-to-End | nightly | `schedule`, `workflow_dispatch` | No | Daily 7:45am UTC; runs `ogrinfo` + `ogr2ogr` against honua-server using GDAL's built-in `OAPIF:` stand-in driver. Tracks ADR-0034; swaps to `HONUA:` once the `honua-gdal` plugin ships |
 | `load-soak-nightly.yml` | Load/Soak Nightly | nightly | `schedule`, `workflow_dispatch` | No | Scheduled load/soak tests |
 | `nightly-slow-tier.yml` | Nightly Slow Tier (Emulator) | nightly | `schedule`, `workflow_dispatch` | No | Daily 4:00am UTC; runs `--filter "Tier=Slow&Category=Emulator"` across `Honua.Server.Tests`, `Honua.Postgres.Tests`, and `Honua.Core.Tests` — `[EmulatorTest]` only. LocalStack S3 + Azurite are provisioned exclusively by `EmulatorFixture` (Testcontainers); Postgres comes from a GitHub Actions service container. Asserts `HONUA_TEST_DB_URL` before dispatch so a missing connection string fails loudly. The Scale/Cloud/External slow subfamilies (`[ScaleTest]`, `[CloudTest]`, `[ExternalServiceTest]`) need dedicated fixtures (multi-node compose, real cloud credentials, Esri Geoportal) and are tracked as separate workflows. ADR-0037 |
 | `flaky-detection.yml` | Flaky Test Detection | nightly | `schedule`, `workflow_dispatch` | No | Daily 5:00am UTC; re-runs `--filter "Tier=Integration&Tier!=Slow"` three times against a fresh runner, parses TRX output, and uploads `flaky-detection-report` (JSON + per-iteration TRX) plus a `$GITHUB_STEP_SUMMARY` table of inconsistent tests. Always exits 0 — flake detection is a reporting concern, not a gate. ADR-0037 |
 | `security-nightly.yml` | Security Nightly | nightly | `schedule`, `workflow_dispatch` | No | Consolidated NuGet vulnerability scan, Trivy filesystem scan, and container security scan (Hadolint, Trivy, structure tests, runtime constraints) |
-| `codeql.yml` | CodeQL | nightly | `push` (trunk), `schedule` | No | Default-branch + weekly schedule |
+| `codeql.yml` | CodeQL | nightly | `schedule` | No | Weekly security analysis |
 | `nightly-container-build.yml` | Nightly Container Build | nightly | `schedule`, `workflow_dispatch` | No | Scheduled container build |
 | `nuget-publish.yml` | NuGet Publish | release | `push`, `workflow_dispatch` | No | Release-only publishing |
-| `deploy.yml` | Deploy | deploy | `push`, `workflow_dispatch` | No | Environment promotion |
-| `deploy-platform-images.yml` | Deploy Platform Images | deploy | `push`, `workflow_dispatch` | No | Platform image deployment |
+| `deploy.yml` | Deploy | deploy | `push` (tags), `workflow_dispatch` | No | Environment promotion |
+| `deploy-platform-images.yml` | Deploy Platform Images | deploy | `push` (tags), `workflow_dispatch` | No | Platform image deployment |
 | `reusable-sdk-pr-gate.yml` | SDK PR Gate | PR | `workflow_call` | Yes (via caller) | Reusable gate for honua-sdk-js and honua-sdk-dotnet |
 | `cloud-post-apply-validation.yml` | Cloud Post-Apply Validation | deploy | `workflow_call`, `workflow_dispatch` | No | Post-deploy validation |
 
@@ -75,7 +76,7 @@ Additionally, `cite-conformance.yml` (already schedule-only) had dead PR comment
 
 ### CodeQL moved off PR path
 
-`codeql.yml` no longer triggers on `pull_request`. It runs on `push` to trunk and on a weekly schedule. This avoids adding a slow, non-deterministic security scan to every PR cycle.
+`codeql.yml` no longer triggers on `pull_request` or merge-to-trunk push. It runs on a weekly schedule. This avoids adding a slow, non-deterministic security scan to routine PR or merge cycles.
 
 ### PR template and validation redesigned
 

--- a/docs/contributor/CI_QUALITY_GATES.md
+++ b/docs/contributor/CI_QUALITY_GATES.md
@@ -6,14 +6,14 @@ This document summarizes the CI pipelines and quality gates that contributors mu
 
 ## Core Workflows
 
-- `ci.yml`: build, formatting verification, tier-aware test dispatch (PRs run only the `targeted-shards` subset emitted by `scripts/ci/honua-server-targeted-tests.sh`; merge-to-trunk runs the full 11-shard `server-tests` matrix — see [Test Tier Strategy](#test-tier-strategy) and [ADR-0037](adr/0037-unified-ci-test-tier-strategy.md)), merge-blocking Esri Leaflet browser compatibility tests, and MCP certification (see [MCP Certification](mcp-certification.md)).
+- `ci.yml`: build, formatting verification, tier-aware test dispatch (PRs run only the `targeted-shards` subset emitted by `scripts/ci/honua-server-targeted-tests.sh`; scheduled/manual full integration runs the full 11-shard `server-tests` matrix — see [Test Tier Strategy](#test-tier-strategy) and [ADR-0037](adr/0037-unified-ci-test-tier-strategy.md)), merge-blocking Esri Leaflet browser compatibility tests, and MCP certification (see [MCP Certification](mcp-certification.md)).
 - `pr-validation.yml`: PR template compliance validation.
 - `load-soak-nightly.yml`: nightly load/soak testing.
 - `nightly-slow-tier.yml`: nightly `Tier=Slow&Category=Emulator` execution (`[EmulatorTest]` only) across `Honua.Server.Tests`, `Honua.Postgres.Tests`, and `Honua.Core.Tests`. Daily 4am UTC. Scale/Cloud/External slow subfamilies need dedicated fixtures and are tracked as separate workflows.
 - `flaky-detection.yml`: nightly flake reporting — re-runs the integration tier 3× and uploads a flake-candidate report. Daily 5am UTC. See [ADR-0037](adr/0037-unified-ci-test-tier-strategy.md) for the quarantine workflow.
 - `windows-client-compat-nightly.yml`: nightly/manual Windows client compatibility certification (full CERT-\* matrix: 18 test cases × 4 protocol lanes) with per-protocol `.cert.json` envelopes and reusable evidence pack artifacts.
 - `client-interop-nightly.yml`: nightly real-client interop matrix that exercises Honua against actual GIS clients (QGIS, GDAL/OGR, OpenLayers, Cesium, ArcGIS Pro stub) via the Docker harnesses under `docker/client-compat/`. The workflow diffs per-lane `.cert.json` envelopes against `tests/baselines/client-compat/` (gated by `tests/baselines/client-compat/expected-pairs.json`), refreshes `docs/gis/gap-report.md`, and fails on any baseline `pass` regressing to a non-`pass` status, missing lane envelope, or new `fail` in an unbaselined case. Non-PR-blocking until 30 consecutive nightly passes (#806).
-- `codeql.yml`: static analysis (nightly + trunk push; not PR-blocking).
+- `codeql.yml`: static analysis (nightly; not PR-blocking).
 - `container-security.yml`: container security scanning (nightly).
 - `cite-conformance.yml`, `cite-tiles-conformance.yml`, `cite-wfs20-conformance.yml`, `cite-wms-conformance.yml`, `cite-wmts-conformance.yml`, `cite-kml22-conformance.yml`, `cite-gml32-conformance.yml`, `cite-gpkg12-conformance.yml`, `ogc-maps-conformance.yml`: OGC conformance testing (nightly; not PR-blocking).
 - `openapi-contract-governance.yml`: Admin/control-plane OpenAPI contract validation and breaking-change checks.
@@ -24,7 +24,7 @@ This document summarizes the CI pipelines and quality gates that contributors mu
 
 The `ci-gate` job in `ci.yml` is a summary job that depends on all merge-blocking CI jobs (`pr-readiness`, `changes`, `targeted-shards`, `build`, `test-all`, `aot-build`, `js-integration-tests`, `esri-leaflet-browser-tests`, `maplibre-compat`, `mcp-certification`, `core-package-compatibility`, `postgres-compat`, `docker-build`). Configure it as a required status check in branch protection to gate PRs on a single job.
 
-The `targeted-shards` job runs `scripts/ci/honua-server-targeted-tests.sh` to pick the active shards for the diff, then projects the selection into a JSON `matrix_include` array drawn from `.github/ci-shards.json` (the single source of truth for both shard routing and matrix-runtime metadata). The `server-tests` job declares its matrix as `strategy.matrix.include: ${{ fromJson(needs.targeted-shards.outputs.matrix_include) }}`, so **unselected shards never instantiate a runner job** — there is no per-shard checkout, build, or Postgres service container cost for shards a PR did not select. On `push` to `trunk` and `workflow_dispatch` the descriptor is forced to `run_all: true`, so all eleven entries appear in `matrix_include` and run.
+The `targeted-shards` job runs `scripts/ci/honua-server-targeted-tests.sh` to pick the active shards for the diff, then projects the selection into a JSON `matrix_include` array drawn from `.github/ci-shards.json` (the single source of truth for both shard routing and matrix-runtime metadata). The `server-tests` job declares its matrix as `strategy.matrix.include: ${{ fromJson(needs.targeted-shards.outputs.matrix_include) }}`, so **unselected shards never instantiate a runner job** — there is no per-shard checkout, build, or Postgres service container cost for shards a PR did not select. On scheduled full CI and `workflow_dispatch` the descriptor is forced to `run_all: true`, so all eleven entries appear in `matrix_include` and run.
 
 ## Test Tier Strategy
 
@@ -33,7 +33,8 @@ ADR-0037 defines a `Tier` xUnit trait — `Fast`, `Integration`, or `Slow` — t
 | Event | Workflow | Tier scope |
 |---|---|---|
 | Pull Request | `ci.yml` | Foundation tests (Core/Architecture/LoadTests, primarily `Tier=Fast`) plus a `--filter "Tier=Fast"` step against `Honua.Server.Tests` plus the `server-tests` shards selected by `scripts/ci/honua-server-targeted-tests.sh`. The shard step composes its filter as `(matrix.filter)&Tier!=Slow` so `[EmulatorTest]` / `[ScaleTest]` / `[ExternalServiceTest]` / `[CloudTest]` methods sitting in a shard's namespace are skipped on PRs. |
-| Merge to trunk | `ci.yml` (`push`) | Same as PR plus the **full** 11-shard `server-tests` matrix and the Postgres compat matrix. The `&Tier!=Slow` shard filter still applies — Slow stays nightly-only. |
+| Merge to trunk | `trunk-sanity.yml` | Restore and build only. Heavy CI is already covered by PR gates and scheduled/manual full integration runs. |
+| Scheduled/manual full integration | `ci.yml` (`schedule` / `workflow_dispatch`) | Full 11-shard `server-tests` matrix and the Postgres compat matrix. The `&Tier!=Slow` shard filter still applies — Slow stays nightly-only. |
 | Nightly slow tier | `nightly-slow-tier.yml` | `--filter "Tier=Slow&Category=Emulator"` across `Honua.Server.Tests`, `Honua.Postgres.Tests`, `Honua.Core.Tests` — `[EmulatorTest]` only. Scale/Cloud/External slow subfamilies need dedicated workflows. |
 | Nightly flake hunt | `flaky-detection.yml` | Re-runs `--filter "Tier=Integration&Tier!=Slow"` three times and reports inconsistent outcomes (never fails the workflow). |
 

--- a/docs/contributor/adr/0011-testing-strategy.md
+++ b/docs/contributor/adr/0011-testing-strategy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted. Extended by [ADR-0037: Unified CI Test Tier Strategy](0037-unified-ci-test-tier-strategy.md), which adds the `Tier=Fast|Integration|Slow` xUnit trait and defines the PR / merge-to-trunk / nightly execution schedule. This ADR continues to define **what** is tested (API-surface and operation coverage); ADR-0037 defines **when and where** each test runs.
+Accepted. Extended by [ADR-0037: Unified CI Test Tier Strategy](0037-unified-ci-test-tier-strategy.md), which adds the `Tier=Fast|Integration|Slow` xUnit trait and defines the PR / scheduled full integration / nightly execution schedule. This ADR continues to define **what** is tested (API-surface and operation coverage); ADR-0037 defines **when and where** each test runs.
 
 ## Context
 

--- a/docs/contributor/adr/0037-unified-ci-test-tier-strategy.md
+++ b/docs/contributor/adr/0037-unified-ci-test-tier-strategy.md
@@ -82,7 +82,8 @@ default mapping. The mapping is documented in
 | Event           | Workflow                              | What runs                                                                                             |
 |-----------------|---------------------------------------|-------------------------------------------------------------------------------------------------------|
 | Pull Request    | `ci.yml`                              | Build + format + Architecture tests + Tier=Fast across all projects + targeted shards (`server-tests`) composed as `(matrix.filter)&Tier!=Slow` so Slow-tagged tests stay out of the PR lane. |
-| Merge to trunk  | `ci.yml` (push event)                 | Everything PR runs **plus** the full 11-shard `server-tests` matrix and the Postgres compat matrix. The `&Tier!=Slow` exclusion still applies — Slow remains nightly-only. |
+| Merge to trunk  | `trunk-sanity.yml`                    | Restore and build only. Heavy integration coverage comes from PR gates plus scheduled/manual full integration runs. |
+| Full integration | `ci.yml` (schedule / workflow_dispatch) | Full 11-shard `server-tests` matrix and the Postgres compat matrix. The `&Tier!=Slow` exclusion still applies — Slow remains nightly-only. |
 | Nightly (slow)  | `nightly-slow-tier.yml`               | `Tier=Slow&Category=Emulator` (LocalStack S3 + Azurite + Postgres). Scale/Cloud/External slow subfamilies need additional fixtures and are tracked as separate workflows. |
 | Nightly (flake) | `flaky-detection.yml`                 | Re-runs the Integration tier 3× and emits a candidate-flake report.                                   |
 

--- a/docs/contributor/cite-tiles-conformance-testing.md
+++ b/docs/contributor/cite-tiles-conformance-testing.md
@@ -39,7 +39,6 @@ The CITE test suite validates that Honua Server correctly implements the OGC API
 
 CITE Tiles tests run automatically:
 - On pull requests to `trunk`/`main` that touch OGC Tiles/CITE files
-- On pushes to `trunk`/`main` that touch OGC Tiles/CITE files
 - Weekly via scheduled workflow (Tuesdays at 6am UTC)
 - Manually via workflow dispatch
 

--- a/docs/contributor/mcp-certification.md
+++ b/docs/contributor/mcp-certification.md
@@ -45,7 +45,7 @@ MCP-specific test data lives in `tests/seed/mcp.yaml`. It follows the project's 
 
 ### mcp-certification
 
-- **Trigger:** push/PR to `trunk` + manual (`workflow_dispatch`), skips dependabot.
+- **Trigger:** PR to `trunk` plus scheduled/manual full integration runs, skips dependabot.
 - **Matrix:** `transport: [grpc-web, rest]` — runs full suite in parallel per transport.
 - **Steps:** checkout honua-server → shared setup (`.github/actions/setup-honua-mcp`) → `test:certification` → `test:certification:artifact` (generate report) → artifact upload.
 - **Artifact:** `mcp-certification-{transport}`, 30-day retention.

--- a/docs/contributor/testkit.md
+++ b/docs/contributor/testkit.md
@@ -283,7 +283,7 @@ maps to the CI schedule defined in ADR-0037 (`docs/contributor/adr/0037-unified-
 | Attribute | Category | Tier | When it runs |
 |-----------|----------|------|--------------|
 | `[UnitTest]` | `Unit` | `Fast` | Every PR (no DB, no HTTP, no Testcontainers). |
-| `[IntegrationTest]` | `Integration` | `Integration` | Targeted shards on PRs; full matrix on merge-to-trunk. PR shard step composes `(matrix.filter)&Tier!=Slow` so a Slow-tagged sibling in the same shard namespace skips. |
+| `[IntegrationTest]` | `Integration` | `Integration` | Targeted shards on PRs; full matrix on scheduled/manual full integration runs. PR shard step composes `(matrix.filter)&Tier!=Slow` so a Slow-tagged sibling in the same shard namespace skips. |
 | `[EmulatorTest]` | `Integration,Emulator` | `Slow` | `nightly-slow-tier.yml` — runs `Tier=Slow&Category=Emulator` against LocalStack S3 + Azurite + Postgres. |
 | `[ScaleTest]` | `Integration,Scale` | `Slow` | Currently **not** scheduled. Multi-node compose fixtures are tracked as a separate workflow; the trait is in place for the future workflow to opt in. |
 | `[ExternalServiceTest]` | `Integration,External` | `Slow` | Currently **not** scheduled. External service credentials (e.g. Esri Geoportal) are tracked as a separate workflow. |

--- a/docs/developer/MCP_SERVER.md
+++ b/docs/developer/MCP_SERVER.md
@@ -71,7 +71,7 @@ HONUA_BASE_URL="https://honua.example.com" HONUA_TRANSPORT="grpc-web" node dist/
 
 > **Not yet active.** The server-side CI jobs and seed data are landed, but the SDK-side certification scripts (`test:certification`, `test:certification:artifact`, `test:llm-smoke`) are not yet present in `honua-sdk-js` `trunk`. Until those scripts land, the CI jobs skip with a warning annotation and **no certification artifacts are produced**. See [Known gaps](#known-gaps).
 
-Once the SDK-side scripts are available, Honua's CI will run an MCP certification lane on every push and pull request to `trunk` (and on manual dispatch). The suite exercises all 6 tools and 2 resources across both `grpc-web` and `rest` transports. When the `test:certification:artifact` script is also present, the lane produces machine-readable (JSON) and human-readable (Markdown) evidence artifacts; if only `test:certification` is landed, tests run but a CI warning notes the missing artifacts.
+Once the SDK-side scripts are available, Honua's CI will run an MCP certification lane on pull requests to `trunk` and in scheduled/manual full integration runs. The suite exercises all 6 tools and 2 resources across both `grpc-web` and `rest` transports. When the `test:certification:artifact` script is also present, the lane produces machine-readable (JSON) and human-readable (Markdown) evidence artifacts; if only `test:certification` is landed, tests run but a CI warning notes the missing artifacts.
 
 | Area | What is tested |
 |------|----------------|

--- a/docs/developer/SDK_COMPATIBILITY_MATRIX.md
+++ b/docs/developer/SDK_COMPATIBILITY_MATRIX.md
@@ -57,8 +57,8 @@ temporary trunk-lineage commit refs with release tags as soon as the release
 process publishes them.
 
 The `sdk-server-compatibility.yml` workflow flattens this manifest into a
-`fail-fast: false` GitHub Actions matrix on `push` to `trunk`, manual dispatch,
-and the weekly schedule. It publishes per-cell JSON evidence plus a
+`fail-fast: false` GitHub Actions matrix on manual dispatch and the weekly
+schedule. It publishes per-cell JSON evidence plus a
 `sdk-compatibility-matrix-<run-id>` artifact containing a Markdown table and
 machine-readable summary.
 


### PR DESCRIPTION
## Issue Link
Related to #812

## Summary
This removes the remaining heavy branch-push workflows from routine merge-to-trunk execution. PRs stay selective, full integration remains available on schedule/manual dispatch, release publishing stays tag/manual, and trunk pushes keep only the cheap restore/build sanity check.

## Changes Made
- Removed branch-push triggers from SDK compatibility, CodeQL, governance, and image publish workflows.
- Kept tag/manual release publishing for deploy and package workflows.
- Updated CI docs and ADR references to document PR-selective, trunk-sanity-only, and scheduled/manual full integration behavior.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Manual validation performed:
- `git diff --check`
- Parsed all workflow YAML with PyYAML
- Verified push triggers are limited to tag publishes and `trunk-sanity`

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [x] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [x] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran targeted workflow validation instead of the full `scripts/ci/pre-pr-check.sh` because this is a CI trigger/docs change
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review