### PR TITLE
feat: feat(scene): extruded 3D feature layer output (#841)

### DIFF
--- a/docs/gis/README.md
+++ b/docs/gis/README.md
@@ -21,6 +21,7 @@ Connect to Honua from desktop GIS applications and consume geospatial services.
 - [Raster Overview](raster-overview.md) — Raster import, COG registration/direct serving, and remaining mosaic/catalog roadmap status
 - [Terrain-RGB Tiles](terrain-tiles.md) — DEM/raster elevation tiles for MapLibre/Mapbox `raster-dem` clients
 - [Hosted 3D Tiles Scenes](scenes-3dtiles.md) — Already-hosted OGC 3D Tiles tilesets for CesiumJS and other 3D Tiles clients
+- [Extruded 3D Feature Layers (v1)](extruded-3d-feature-layers.md) — Height-driven extrusion metadata on FeatureServer layers (precedes 3D Tiles generation)
 
 ## Protocol Coverage
 

--- a/docs/gis/extruded-3d-feature-layers.md
+++ b/docs/gis/extruded-3d-feature-layers.md
@@ -47,7 +47,7 @@ deserialization is AOT-safe in published builds.
 | --- | --- | --- |
 | `heightField` | yes | Numeric layer field that drives extrusion height. Must reference an `Integer`, `BigInteger`, `Double`, or `Float` field. |
 | `baseHeightField` | no | Optional numeric field for base elevation. Same type rules as `heightField`. |
-| `unit` | no | Vertical unit. One of `meters` (default), `feet`, `usSurveyFeet`. |
+| `unit` | no | Vertical unit. One of `meters` (default), `feet`, `usSurveyFeet`. Recognition is case-insensitive on input (e.g. `METERS` or `Feet`) and the wire form is always emitted in canonical lowercase/camelCase. Any other token (for example `yards`) is rejected with `EXTRUSION_UNIT_UNRECOGNIZED` at the layer metadata endpoint rather than at catalog deserialization, so a misconfigured row never breaks catalog reads. |
 | `defaultHeight` | no | Fallback height when `heightField` is null. Must be `>= 0`. |
 | `materialHint` | no | Free-form hint passed through to downstream 3D generation; not interpreted by this server. |
 

--- a/docs/gis/extruded-3d-feature-layers.md
+++ b/docs/gis/extruded-3d-feature-layers.md
@@ -1,0 +1,113 @@
+# Extruded 3D feature layers (v1)
+
+Honua surfaces simple height-driven extrusion metadata on feature layers so
+2D footprint data can drive client-side 3D rendering and downstream 3D
+Tiles generation without breaking existing 2D feature services. This is a
+metadata-only slice — Honua does not generate meshes or 3D Tiles in this
+release. Mesh generation arrives in [`honua-server-842`](https://github.com/honua-io/honua-server/issues/842).
+
+## What v1 covers
+
+- Per-layer extrusion configuration stored as catalog metadata.
+- A typed `extrusionInfo` block on the GeoServices FeatureServer layer
+  metadata response (`GET /rest/services/{serviceId}/FeatureServer/{layerId}`).
+- Field-resolution and unit validation surfaced through the shared
+  problem-detail pipeline with stable, machine-readable error codes.
+- Byte-for-byte 2D compatibility: when no extrusion is configured the
+  response omits `extrusionInfo` entirely.
+
+## What v1 intentionally defers
+
+- 3D Tiles or I3S generation from the extrusion contract.
+- Complex solids, parametric roofs, BIM/IFC semantics, or mesh editing.
+- Admin UI screens for configuring extrusion (catalog JSON only).
+- New mobile or .NET / JS / Python SDK surface — clients consume the
+  existing FeatureServer layer metadata payload.
+
+## Configuration
+
+Extrusion is a property on the layer's catalog metadata blob, alongside
+`timeInfo` and the access policy. It is persisted as JSONB on
+`honua.layers.metadata` and parsed through `CatalogJsonContext` so
+deserialization is AOT-safe in published builds.
+
+```json
+{
+  "extrusion": {
+    "heightField": "building_height_m",
+    "baseHeightField": "ground_elevation_m",
+    "unit": "meters",
+    "defaultHeight": 3.0,
+    "materialHint": "concrete"
+  }
+}
+```
+
+| Property | Required | Description |
+| --- | --- | --- |
+| `heightField` | yes | Numeric layer field that drives extrusion height. Must reference an `Integer`, `BigInteger`, `Double`, or `Float` field. |
+| `baseHeightField` | no | Optional numeric field for base elevation. Same type rules as `heightField`. |
+| `unit` | no | Vertical unit. One of `meters` (default), `feet`, `usSurveyFeet`. |
+| `defaultHeight` | no | Fallback height when `heightField` is null. Must be `>= 0`. |
+| `materialHint` | no | Free-form hint passed through to downstream 3D generation; not interpreted by this server. |
+
+## Wire format
+
+When `extrusion` is configured, the layer metadata response gains an
+`extrusionInfo` block:
+
+```json
+{
+  "id": 0,
+  "name": "buildings",
+  "type": "Feature Layer",
+  "geometryType": "esriGeometryPolygon",
+  "extrusionInfo": {
+    "enabled": true,
+    "heightField": "building_height_m",
+    "baseHeightField": "ground_elevation_m",
+    "unit": "meters",
+    "defaultHeight": 3.0,
+    "materialHint": "concrete"
+  }
+}
+```
+
+When `extrusion` is null or missing, `extrusionInfo` is omitted entirely
+(the source-generated FeatureServer JSON context omits null properties on
+serialization). Existing 2D clients see the same response they did before
+the extrusion slice landed.
+
+## Validation
+
+Validation runs on every layer metadata request whenever a layer has
+extrusion configured. Failures return HTTP `422 Unprocessable Entity`
+through the shared `StandardErrorHelpers` pipeline; the response body
+carries one or more stable error codes from `ExtrusionErrorCodes`:
+
+| Code | Meaning |
+| --- | --- |
+| `EXTRUSION_HEIGHT_FIELD_MISSING` | `heightField` was missing or empty. |
+| `EXTRUSION_HEIGHT_FIELD_NOT_FOUND` | `heightField` does not exist on the layer. |
+| `EXTRUSION_HEIGHT_FIELD_TYPE_INVALID` | `heightField` is not a supported numeric type. |
+| `EXTRUSION_BASE_FIELD_NOT_FOUND` | `baseHeightField` does not exist on the layer. |
+| `EXTRUSION_BASE_FIELD_TYPE_INVALID` | `baseHeightField` is not a supported numeric type. |
+| `EXTRUSION_UNIT_UNRECOGNIZED` | `unit` is not a recognized value. |
+| `EXTRUSION_NEGATIVE_DEFAULT_HEIGHT` | `defaultHeight` is negative. |
+
+Codes are part of the public contract and stable across releases.
+
+## Determinism for downstream generation
+
+The wire-level `extrusionInfo` is computed deterministically from the
+catalog metadata: field names, units, default height, and material hint
+flow through unchanged. `honua-server-842` (3D Tiles generation) consumes
+this metadata as the canonical input — there is no normalization or
+heuristic step between catalog config and downstream consumers.
+
+## Related references
+
+- [Hosted 3D Tiles scenes](./scenes-3dtiles.md) — serving already-built
+  3D Tiles, complementary to v1 extrusion.
+- [I3S compatibility matrix](./i3s-compatibility-matrix.md) — production
+  I3S serving is out of scope for v1 extrusion.

--- a/docs/gis/feature-server-matrix.md
+++ b/docs/gis/feature-server-matrix.md
@@ -276,6 +276,7 @@ All non-JSON formats also accept `Accept` header negotiation (e.g. `Accept: appl
 | `editingInfo` | Implemented | Present for editable layers. |
 | `templates` | Implemented | Empty array (no feature templates configured). |
 | `timeInfo` | Implemented | Start/end time fields, time extent, track ID. |
+| `extrusionInfo` | Implemented | Honua extension for v1 extruded 3D feature layers. Present only when the layer has `extrusion` configured in its catalog metadata; omitted entirely for 2D-only layers. Carries `enabled`, `heightField`, `baseHeightField`, `unit` (`meters`/`feet`/`usSurveyFeet`), `defaultHeight`, and `materialHint`. Invalid configuration returns `422 Unprocessable Entity` with stable codes from `ExtrusionErrorCodes`. See [Extruded 3D Feature Layers (v1)](extruded-3d-feature-layers.md). |
 | `maxRecordCount` | Implemented | From query limits. |
 | `supportedQueryFormats` | Implemented | Normalized format list plus runtime-supported binary formats (`PBF`, `FGB`, `PARQUET`, `ARROW`, and conditional `GEOBUF` when the backing store exposes native GeoBuf output). |
 

--- a/src/Honua.Core/Features/Catalog/Domain/CatalogJsonContext.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/CatalogJsonContext.cs
@@ -13,7 +13,6 @@ namespace Honua.Core.Features.Catalog.Domain;
 [JsonSerializable(typeof(AccessPolicy))]
 [JsonSerializable(typeof(LayerTimeInfo))]
 [JsonSerializable(typeof(LayerExtrusionInfo))]
-[JsonSerializable(typeof(VerticalUnit))]
 [JsonSerializable(typeof(MapServerConfig))]
 [JsonSerializable(typeof(RasterMosaicSettings))]
 [JsonSerializable(typeof(StacCatalogMetadata))]

--- a/src/Honua.Core/Features/Catalog/Domain/CatalogJsonContext.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/CatalogJsonContext.cs
@@ -12,6 +12,8 @@ namespace Honua.Core.Features.Catalog.Domain;
 [JsonSerializable(typeof(CatalogMetadata))]
 [JsonSerializable(typeof(AccessPolicy))]
 [JsonSerializable(typeof(LayerTimeInfo))]
+[JsonSerializable(typeof(LayerExtrusionInfo))]
+[JsonSerializable(typeof(VerticalUnit))]
 [JsonSerializable(typeof(MapServerConfig))]
 [JsonSerializable(typeof(RasterMosaicSettings))]
 [JsonSerializable(typeof(StacCatalogMetadata))]

--- a/src/Honua.Core/Features/Catalog/Domain/CatalogMetadata.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/CatalogMetadata.cs
@@ -40,6 +40,14 @@ public sealed record CatalogMetadata
     /// Optional raster mosaic defaults for layers backed by multiple rasters.
     /// </summary>
     public RasterMosaicSettings? RasterMosaic { get; init; }
+
+    /// <summary>
+    /// Optional extrusion configuration for 3D feature output.
+    /// Null for 2D-only layers; the GeoServices FeatureServer layer
+    /// response omits the <c>extrusionInfo</c> field entirely when
+    /// this is null.
+    /// </summary>
+    public LayerExtrusionInfo? Extrusion { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Catalog/Domain/ExtrusionErrorCodes.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/ExtrusionErrorCodes.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Catalog.Domain;
+
+/// <summary>
+/// Stable, machine-readable codes used by the v1 extrusion metadata
+/// contract to report invalid <see cref="LayerExtrusionInfo"/> input.
+/// Codes are part of the public API contract and must not be renamed
+/// across releases.
+/// </summary>
+public static class ExtrusionErrorCodes
+{
+    /// <summary>The required height field name was missing or empty.</summary>
+    public const string HeightFieldMissing = "EXTRUSION_HEIGHT_FIELD_MISSING";
+
+    /// <summary>The configured height field does not exist on the layer.</summary>
+    public const string HeightFieldNotFound = "EXTRUSION_HEIGHT_FIELD_NOT_FOUND";
+
+    /// <summary>The configured height field is not a numeric type supported for extrusion.</summary>
+    public const string HeightFieldTypeInvalid = "EXTRUSION_HEIGHT_FIELD_TYPE_INVALID";
+
+    /// <summary>The configured base-height field does not exist on the layer.</summary>
+    public const string BaseFieldNotFound = "EXTRUSION_BASE_FIELD_NOT_FOUND";
+
+    /// <summary>The configured base-height field is not a numeric type supported for extrusion.</summary>
+    public const string BaseFieldTypeInvalid = "EXTRUSION_BASE_FIELD_TYPE_INVALID";
+
+    /// <summary>The configured vertical unit is not a recognized value.</summary>
+    public const string UnitUnrecognized = "EXTRUSION_UNIT_UNRECOGNIZED";
+
+    /// <summary>The configured default height is negative.</summary>
+    public const string NegativeDefaultHeight = "EXTRUSION_NEGATIVE_DEFAULT_HEIGHT";
+}

--- a/src/Honua.Core/Features/Catalog/Domain/ExtrusionValidator.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/ExtrusionValidator.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Catalog.Domain;
+
+/// <summary>
+/// Validates <see cref="LayerExtrusionInfo"/> instances against a layer's
+/// field definitions. Errors are returned as stable, machine-readable
+/// <see cref="ExtrusionErrorCodes"/> values so the metadata pipeline can
+/// surface them through shared problem-detail helpers.
+/// </summary>
+public static class ExtrusionValidator
+{
+    /// <summary>
+    /// Numeric field types supported as extrusion height/base sources.
+    /// </summary>
+    private static readonly FieldType[] _supportedNumericTypes =
+    [
+        FieldType.Integer,
+        FieldType.BigInteger,
+        FieldType.Double,
+        FieldType.Float
+    ];
+
+    /// <summary>
+    /// Validates the supplied extrusion configuration against the layer's
+    /// field schema. Returns an empty list when the configuration is valid.
+    /// </summary>
+    /// <param name="extrusion">Extrusion configuration to validate.</param>
+    /// <param name="fields">Fields available on the layer.</param>
+    /// <returns>Stable error codes for each violation; empty when valid.</returns>
+    public static IReadOnlyList<string> Validate(LayerExtrusionInfo extrusion, IReadOnlyList<FieldDefinition> fields)
+    {
+        ArgumentNullException.ThrowIfNull(extrusion);
+        ArgumentNullException.ThrowIfNull(fields);
+
+        var errors = new List<string>(capacity: 4);
+
+        if (string.IsNullOrWhiteSpace(extrusion.HeightField))
+        {
+            errors.Add(ExtrusionErrorCodes.HeightFieldMissing);
+        }
+        else
+        {
+            var heightField = FindField(fields, extrusion.HeightField);
+            if (heightField is null)
+            {
+                errors.Add(ExtrusionErrorCodes.HeightFieldNotFound);
+            }
+            else if (!IsSupportedNumericType(heightField.Type))
+            {
+                errors.Add(ExtrusionErrorCodes.HeightFieldTypeInvalid);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(extrusion.BaseHeightField))
+        {
+            var baseField = FindField(fields, extrusion.BaseHeightField);
+            if (baseField is null)
+            {
+                errors.Add(ExtrusionErrorCodes.BaseFieldNotFound);
+            }
+            else if (!IsSupportedNumericType(baseField.Type))
+            {
+                errors.Add(ExtrusionErrorCodes.BaseFieldTypeInvalid);
+            }
+        }
+
+        if (!Enum.IsDefined(extrusion.Unit))
+        {
+            errors.Add(ExtrusionErrorCodes.UnitUnrecognized);
+        }
+
+        if (extrusion.DefaultHeight is { } defaultHeight && defaultHeight < 0)
+        {
+            errors.Add(ExtrusionErrorCodes.NegativeDefaultHeight);
+        }
+
+        return errors;
+    }
+
+    private static FieldDefinition? FindField(IReadOnlyList<FieldDefinition> fields, string name)
+    {
+        for (var i = 0; i < fields.Count; i++)
+        {
+            var field = fields[i];
+            if (string.Equals(field.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                return field;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsSupportedNumericType(FieldType type)
+    {
+        for (var i = 0; i < _supportedNumericTypes.Length; i++)
+        {
+            if (_supportedNumericTypes[i] == type)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Honua.Core/Features/Catalog/Domain/ExtrusionValidator.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/ExtrusionValidator.cs
@@ -66,7 +66,8 @@ public static class ExtrusionValidator
             }
         }
 
-        if (!Enum.IsDefined(extrusion.Unit))
+        if (!string.IsNullOrWhiteSpace(extrusion.Unit) &&
+            !VerticalUnits.TryNormalize(extrusion.Unit, out _))
         {
             errors.Add(ExtrusionErrorCodes.UnitUnrecognized);
         }

--- a/src/Honua.Core/Features/Catalog/Domain/LayerExtrusionInfo.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/LayerExtrusionInfo.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Catalog.Domain;
+
+/// <summary>
+/// Extrusion configuration stored with a feature layer definition.
+/// Drives the v1 <c>extrusionInfo</c> contract surfaced through the
+/// GeoServices FeatureServer layer metadata response and consumed by
+/// downstream 3D Tiles generation.
+/// </summary>
+public sealed record LayerExtrusionInfo
+{
+    /// <summary>
+    /// Name of the numeric field that drives extrusion height.
+    /// Required and must reference a numeric field on the layer.
+    /// </summary>
+    public string HeightField { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional field name for base (bottom) elevation. When null, the
+    /// base elevation is the layer geometry footprint.
+    /// </summary>
+    public string? BaseHeightField { get; init; }
+
+    /// <summary>
+    /// Vertical unit for height and base values.
+    /// </summary>
+    public VerticalUnit Unit { get; init; } = VerticalUnit.Meters;
+
+    /// <summary>
+    /// Fallback height when the height field value is null. Must be &gt;= 0.
+    /// When null, no fallback is applied.
+    /// </summary>
+    public double? DefaultHeight { get; init; }
+
+    /// <summary>
+    /// Optional material or style hint passed through to 3D Tiles
+    /// generation (honua-server-842). Free-form string; not interpreted
+    /// by this server.
+    /// </summary>
+    public string? MaterialHint { get; init; }
+}
+
+/// <summary>
+/// Recognized vertical units for extrusion metadata.
+/// Serialized as lowercase strings on the wire ("meters", "feet",
+/// "usSurveyFeet"). Per-member <see cref="JsonStringEnumMemberNameAttribute"/>
+/// pins the wire form so it stays stable regardless of enum identifier
+/// changes.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<VerticalUnit>))]
+public enum VerticalUnit
+{
+    /// <summary>Metres (default).</summary>
+    [JsonStringEnumMemberName("meters")]
+    Meters,
+
+    /// <summary>International feet (0.3048 m).</summary>
+    [JsonStringEnumMemberName("feet")]
+    Feet,
+
+    /// <summary>US Survey feet (1200/3937 m).</summary>
+    [JsonStringEnumMemberName("usSurveyFeet")]
+    UsSurveyFeet
+}

--- a/src/Honua.Core/Features/Catalog/Domain/LayerExtrusionInfo.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/LayerExtrusionInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
-using System.Text.Json.Serialization;
-
 namespace Honua.Core.Features.Catalog.Domain;
 
 /// <summary>
@@ -26,9 +24,15 @@ public sealed record LayerExtrusionInfo
     public string? BaseHeightField { get; init; }
 
     /// <summary>
-    /// Vertical unit for height and base values.
+    /// Vertical unit for height and base values. Stored as the raw token
+    /// from catalog metadata so unknown values flow through to
+    /// <see cref="ExtrusionValidator"/> and surface as
+    /// <see cref="ExtrusionErrorCodes.UnitUnrecognized"/> rather than
+    /// throwing during catalog deserialization. Recognized values
+    /// (<see cref="VerticalUnits"/>) are matched case-insensitively;
+    /// null or whitespace defaults to meters.
     /// </summary>
-    public VerticalUnit Unit { get; init; } = VerticalUnit.Meters;
+    public string? Unit { get; init; }
 
     /// <summary>
     /// Fallback height when the height field value is null. Must be &gt;= 0.
@@ -45,24 +49,55 @@ public sealed record LayerExtrusionInfo
 }
 
 /// <summary>
-/// Recognized vertical units for extrusion metadata.
-/// Serialized as lowercase strings on the wire ("meters", "feet",
-/// "usSurveyFeet"). Per-member <see cref="JsonStringEnumMemberNameAttribute"/>
-/// pins the wire form so it stays stable regardless of enum identifier
-/// changes.
+/// Canonical wire tokens for vertical units recognized by the v1
+/// extrusion contract. The tokens are stable across releases and are
+/// emitted lowercase/camelCase regardless of the input casing.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter<VerticalUnit>))]
-public enum VerticalUnit
+public static class VerticalUnits
 {
     /// <summary>Metres (default).</summary>
-    [JsonStringEnumMemberName("meters")]
-    Meters,
+    public const string Meters = "meters";
 
     /// <summary>International feet (0.3048 m).</summary>
-    [JsonStringEnumMemberName("feet")]
-    Feet,
+    public const string Feet = "feet";
 
     /// <summary>US Survey feet (1200/3937 m).</summary>
-    [JsonStringEnumMemberName("usSurveyFeet")]
-    UsSurveyFeet
+    public const string UsSurveyFeet = "usSurveyFeet";
+
+    /// <summary>
+    /// Attempts to normalize a raw unit token to the canonical wire form.
+    /// Returns true and the canonical token for recognized values
+    /// (case-insensitive); returns true with <see cref="Meters"/> when the
+    /// input is null or whitespace; returns false for any other token.
+    /// </summary>
+    public static bool TryNormalize(string? rawUnit, out string normalized)
+    {
+        if (string.IsNullOrWhiteSpace(rawUnit))
+        {
+            normalized = Meters;
+            return true;
+        }
+
+        var trimmed = rawUnit.Trim();
+        if (string.Equals(trimmed, Meters, StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = Meters;
+            return true;
+        }
+
+        if (string.Equals(trimmed, Feet, StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = Feet;
+            return true;
+        }
+
+        if (string.Equals(trimmed, UsSurveyFeet, StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = UsSurveyFeet;
+            return true;
+        }
+
+        normalized = string.Empty;
+        return false;
+    }
 }

--- a/src/Honua.Core/Features/Metadata/Domain/LayerExtrusionMetadata.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/LayerExtrusionMetadata.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Domain;
+
+/// <summary>
+/// Unified extrusion metadata derived from
+/// <see cref="Honua.Core.Features.Catalog.Domain.LayerExtrusionInfo"/> and
+/// surfaced as a typed property on <see cref="LayerMetadata"/>. The wire
+/// representation uses a string for <see cref="Unit"/> so the metadata
+/// contract stays stable if new unit values are added later without
+/// forcing consumers to update enum definitions.
+/// </summary>
+public sealed record LayerExtrusionMetadata
+{
+    /// <summary>
+    /// Whether extrusion is enabled for this layer. Always true when this
+    /// record is present; the absence of <c>ExtrusionInfo</c> on
+    /// <see cref="LayerMetadata"/> represents a 2D-only layer.
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>
+    /// Name of the numeric field that drives extrusion height.
+    /// </summary>
+    public string HeightField { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional field name for base (bottom) elevation.
+    /// </summary>
+    public string? BaseHeightField { get; init; }
+
+    /// <summary>
+    /// Vertical unit for height and base values. Lowercase string on the
+    /// wire (e.g. "meters", "feet", "usSurveyFeet").
+    /// </summary>
+    public string Unit { get; init; } = "meters";
+
+    /// <summary>
+    /// Fallback height when the height field value is null. Null when no
+    /// fallback is configured.
+    /// </summary>
+    public double? DefaultHeight { get; init; }
+
+    /// <summary>
+    /// Optional material or style hint passed through to downstream
+    /// 3D Tiles generation.
+    /// </summary>
+    public string? MaterialHint { get; init; }
+}

--- a/src/Honua.Core/Features/Metadata/Domain/LayerMetadata.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/LayerMetadata.cs
@@ -45,6 +45,12 @@ public sealed record LayerMetadata
     public LayerTemporalInfo? TemporalInfo { get; init; }
 
     /// <summary>
+    /// Extrusion metadata for 3D-capable feature layers.
+    /// Null when no extrusion is configured (the layer is 2D-only).
+    /// </summary>
+    public LayerExtrusionMetadata? ExtrusionInfo { get; init; }
+
+    /// <summary>
     /// Styling and rendering information.
     /// </summary>
     public LayerStyleInfo? StyleInfo { get; init; }

--- a/src/Honua.Core/Features/Metadata/Services/UnifiedMetadataProvider.cs
+++ b/src/Honua.Core/Features/Metadata/Services/UnifiedMetadataProvider.cs
@@ -508,24 +508,25 @@ internal sealed class UnifiedMetadataProvider : IMetadataProvider
             TrackIdField = layer.Metadata.TimeInfo.TrackIdField
         } : null;
 
-    private static LayerExtrusionMetadata? BuildLayerExtrusionInfo(LayerDefinition layer) =>
-        layer.Metadata?.Extrusion is { } extrusion ? new LayerExtrusionMetadata
+    private static LayerExtrusionMetadata? BuildLayerExtrusionInfo(LayerDefinition layer)
+    {
+        if (layer.Metadata?.Extrusion is not { } extrusion)
+        {
+            return null;
+        }
+
+        VerticalUnits.TryNormalize(extrusion.Unit, out var unitWire);
+
+        return new LayerExtrusionMetadata
         {
             Enabled = true,
             HeightField = extrusion.HeightField,
             BaseHeightField = extrusion.BaseHeightField,
-            Unit = MapVerticalUnit(extrusion.Unit),
+            Unit = unitWire,
             DefaultHeight = extrusion.DefaultHeight,
             MaterialHint = extrusion.MaterialHint
-        } : null;
-
-    private static string MapVerticalUnit(VerticalUnit unit) => unit switch
-    {
-        VerticalUnit.Meters => "meters",
-        VerticalUnit.Feet => "feet",
-        VerticalUnit.UsSurveyFeet => "usSurveyFeet",
-        _ => "meters"
-    };
+        };
+    }
 
     private static LayerRelationshipInfo[] BuildLayerRelationships(LayerDefinition layer, ServiceDefinition service, MetadataProviderOptions options) =>
         layer.Relationships?.Select(r => new LayerRelationshipInfo

--- a/src/Honua.Core/Features/Metadata/Services/UnifiedMetadataProvider.cs
+++ b/src/Honua.Core/Features/Metadata/Services/UnifiedMetadataProvider.cs
@@ -251,6 +251,9 @@ internal sealed class UnifiedMetadataProvider : IMetadataProvider
         // Build temporal information
         var temporalInfo = BuildLayerTemporalInfo(layer);
 
+        // Build extrusion information for 3D-capable feature layers
+        var extrusionInfo = BuildLayerExtrusionInfo(layer);
+
         // Build style information
         LayerStyleInfo? styleInfo = null;
         if (options.IncludeDrawingInfo)
@@ -275,6 +278,7 @@ internal sealed class UnifiedMetadataProvider : IMetadataProvider
             Statistics = statistics,
             SpatialInfo = spatialInfo,
             TemporalInfo = temporalInfo,
+            ExtrusionInfo = extrusionInfo,
             StyleInfo = styleInfo,
             Relationships = relationships,
             Capabilities = capabilities,
@@ -503,6 +507,25 @@ internal sealed class UnifiedMetadataProvider : IMetadataProvider
             EndTimeField = layer.Metadata.TimeInfo.EndTimeField,
             TrackIdField = layer.Metadata.TimeInfo.TrackIdField
         } : null;
+
+    private static LayerExtrusionMetadata? BuildLayerExtrusionInfo(LayerDefinition layer) =>
+        layer.Metadata?.Extrusion is { } extrusion ? new LayerExtrusionMetadata
+        {
+            Enabled = true,
+            HeightField = extrusion.HeightField,
+            BaseHeightField = extrusion.BaseHeightField,
+            Unit = MapVerticalUnit(extrusion.Unit),
+            DefaultHeight = extrusion.DefaultHeight,
+            MaterialHint = extrusion.MaterialHint
+        } : null;
+
+    private static string MapVerticalUnit(VerticalUnit unit) => unit switch
+    {
+        VerticalUnit.Meters => "meters",
+        VerticalUnit.Feet => "feet",
+        VerticalUnit.UsSurveyFeet => "usSurveyFeet",
+        _ => "meters"
+    };
 
     private static LayerRelationshipInfo[] BuildLayerRelationships(LayerDefinition layer, ServiceDefinition service, MetadataProviderOptions options) =>
         layer.Relationships?.Select(r => new LayerRelationshipInfo

--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerEndpoints.cs
@@ -37,7 +37,8 @@ internal static partial class FeatureServerEndpoints
             .CacheOutput("LayerMetadata")
             .WithETag()
             .Produces<LayerResponse>(200, "application/json")
-            .Produces(404);
+            .Produces(404)
+            .Produces(StatusCodes.Status422UnprocessableEntity);
 
         var queryGet = endpoints.MapGet("/rest/services/{serviceId}/FeatureServer/{layerId:int}/query", HandleQueryFeaturesGet)
             .WithDisplayName("Query FeatureServer Features (GET)")

--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerMetadataHandlers.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerMetadataHandlers.cs
@@ -231,6 +231,18 @@ internal static partial class FeatureServerEndpoints
         {
             FeatureServerLog.LayerMetadataRequested(logger, serviceId, layer.Id);
 
+            if (layer.Metadata?.Extrusion is { } extrusion)
+            {
+                var extrusionErrors = ExtrusionValidator.Validate(extrusion, layer.Fields);
+                if (extrusionErrors.Count > 0)
+                {
+                    return StandardErrorHelpers.CreateUnprocessableEntity(
+                        context,
+                        "Layer extrusion configuration is invalid.",
+                        [.. extrusionErrors]);
+                }
+            }
+
             var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
             var supportsAttachmentUploads = HasAttachmentSurface(context.RequestServices);
             var timeInfo = await BuildTimeInfoAsync(layer, featureReader, cancellationToken).ConfigureAwait(false);
@@ -239,6 +251,7 @@ internal static partial class FeatureServerEndpoints
                 layer,
                 logger,
                 cancellationToken).ConfigureAwait(false);
+            var extrusionInfo = BuildExtrusionInfo(layer);
 
             LayerResponse response = MapLayerToResponse(
                 service,
@@ -246,6 +259,7 @@ internal static partial class FeatureServerEndpoints
                 limits,
                 timeInfo,
                 drawingInfo,
+                extrusionInfo,
                 supportsGeobufOutput: featureReader is IGeobufFeatureStore,
                 supportsAttachmentUploads: supportsAttachmentUploads);
 

--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerUtilities.cs
@@ -377,24 +377,18 @@ internal static partial class FeatureServerEndpoints
             return null;
         }
 
+        VerticalUnits.TryNormalize(extrusion.Unit, out var unitWire);
+
         return new FeatureServerExtrusionInfo
         {
             Enabled = true,
             HeightField = extrusion.HeightField,
             BaseHeightField = extrusion.BaseHeightField,
-            Unit = MapVerticalUnitWire(extrusion.Unit),
+            Unit = unitWire,
             DefaultHeight = extrusion.DefaultHeight,
             MaterialHint = extrusion.MaterialHint
         };
     }
-
-    private static string MapVerticalUnitWire(VerticalUnit unit) => unit switch
-    {
-        VerticalUnit.Meters => "meters",
-        VerticalUnit.Feet => "feet",
-        VerticalUnit.UsSurveyFeet => "usSurveyFeet",
-        _ => "meters"
-    };
 
     private static async Task<FeatureServerTimeInfo?> BuildTimeInfoAsync(
         LayerDefinition layer,

--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerUtilities.cs
@@ -289,6 +289,7 @@ internal static partial class FeatureServerEndpoints
         QueryLimits queryLimits,
         FeatureServerTimeInfo? timeInfo,
         JsonElement? drawingInfo,
+        FeatureServerExtrusionInfo? extrusionInfo,
         bool supportsGeobufOutput,
         bool supportsAttachmentUploads)
     {
@@ -317,6 +318,7 @@ internal static partial class FeatureServerEndpoints
             SpatialReference = layer.SpatialReference.ToSpatialReferenceInfo(),
             Extent = layer.Extent.HasValue ? layer.Extent.Value.ToExtentInfo() : null,
             TimeInfo = timeInfo,
+            ExtrusionInfo = extrusionInfo,
             Fields = [.. layer.Fields.Select(MapFieldInfo)],
             MaxRecordCount = queryLimits.MaxRecordCount,
             ObjectIdField = objectIdField,
@@ -367,6 +369,32 @@ internal static partial class FeatureServerEndpoints
             SupportsBatchEditing = supportsAdvancedQueries
         };
     }
+
+    private static FeatureServerExtrusionInfo? BuildExtrusionInfo(LayerDefinition layer)
+    {
+        if (layer.Metadata?.Extrusion is not { } extrusion)
+        {
+            return null;
+        }
+
+        return new FeatureServerExtrusionInfo
+        {
+            Enabled = true,
+            HeightField = extrusion.HeightField,
+            BaseHeightField = extrusion.BaseHeightField,
+            Unit = MapVerticalUnitWire(extrusion.Unit),
+            DefaultHeight = extrusion.DefaultHeight,
+            MaterialHint = extrusion.MaterialHint
+        };
+    }
+
+    private static string MapVerticalUnitWire(VerticalUnit unit) => unit switch
+    {
+        VerticalUnit.Meters => "meters",
+        VerticalUnit.Feet => "feet",
+        VerticalUnit.UsSurveyFeet => "usSurveyFeet",
+        _ => "meters"
+    };
 
     private static async Task<FeatureServerTimeInfo?> BuildTimeInfoAsync(
         LayerDefinition layer,

--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Models/FeatureServerExtrusionInfo.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Models/FeatureServerExtrusionInfo.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Protocols.GeoServices.FeatureServer.Models;
+
+/// <summary>
+/// Extrusion metadata for FeatureServer layers. Surfaced as the
+/// <c>extrusionInfo</c> property on the layer metadata response when a
+/// layer has 3D extrusion configured. Field-naming and null-handling
+/// match the existing FeatureServer model conventions: the parent
+/// <see cref="FeatureServerJsonContext"/> applies camelCase property
+/// names and omits null properties on serialization, which preserves
+/// byte-for-byte compatibility with 2D-only layers.
+/// </summary>
+public sealed class FeatureServerExtrusionInfo
+{
+    /// <summary>
+    /// Whether extrusion is enabled for this layer. Always true when
+    /// this object is present in the response.
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>
+    /// Name of the numeric field that drives extrusion height.
+    /// </summary>
+    public string HeightField { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional field name for base (bottom) elevation.
+    /// </summary>
+    public string? BaseHeightField { get; init; }
+
+    /// <summary>
+    /// Vertical unit for height and base values. Lowercase string on
+    /// the wire (e.g. "meters", "feet", "usSurveyFeet").
+    /// </summary>
+    public string Unit { get; init; } = "meters";
+
+    /// <summary>
+    /// Fallback height when the height field value is null.
+    /// </summary>
+    public double? DefaultHeight { get; init; }
+
+    /// <summary>
+    /// Optional material or style hint passed through to downstream
+    /// 3D Tiles generation.
+    /// </summary>
+    public string? MaterialHint { get; init; }
+}

--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Models/FeatureServerJsonContext.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Models/FeatureServerJsonContext.cs
@@ -21,6 +21,7 @@ namespace Honua.Server.Features.Protocols.GeoServices.FeatureServer.Models;
 [JsonSerializable(typeof(LayerRelationshipInfo[]))]
 [JsonSerializable(typeof(LayerInfo))]
 [JsonSerializable(typeof(FeatureServerTimeInfo))]
+[JsonSerializable(typeof(FeatureServerExtrusionInfo))]
 [JsonSerializable(typeof(SpatialReferenceInfo))]
 [JsonSerializable(typeof(GeoServicesSpatialReference))]
 [JsonSerializable(typeof(ExtentInfo))]

--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Models/LayerResponse.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Models/LayerResponse.cs
@@ -59,6 +59,13 @@ public sealed class LayerResponse
     public FeatureServerTimeInfo? TimeInfo { get; init; }
 
     /// <summary>
+    /// Extrusion metadata for 3D-capable layers. Absent from the response
+    /// when no extrusion is configured to preserve byte-for-byte
+    /// compatibility with 2D clients.
+    /// </summary>
+    public FeatureServerExtrusionInfo? ExtrusionInfo { get; init; }
+
+    /// <summary>
     /// Minimum scale for layer visibility
     /// </summary>
     public double? MinScale { get; init; }

--- a/tests/dotnet/Honua.Core.Tests/Features/Catalog/ExtrusionValidatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Catalog/ExtrusionValidatorTests.cs
@@ -36,7 +36,7 @@ public sealed class ExtrusionValidatorTests
         {
             HeightField = "height_m",
             BaseHeightField = "base_m",
-            Unit = VerticalUnit.Meters,
+            Unit = VerticalUnits.Meters,
             DefaultHeight = 3.0
         };
 
@@ -52,7 +52,7 @@ public sealed class ExtrusionValidatorTests
         var extrusion = new LayerExtrusionInfo
         {
             HeightField = "levels",
-            Unit = VerticalUnit.Meters
+            Unit = VerticalUnits.Meters
         };
 
         var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
@@ -218,12 +218,12 @@ public sealed class ExtrusionValidatorTests
 
     [UnitTest]
     [Operation(Operations.Metadata)]
-    public void Validate_UnitOutOfRange_ReportsUnitUnrecognized()
+    public void Validate_UnknownUnit_ReportsUnitUnrecognized()
     {
         var extrusion = new LayerExtrusionInfo
         {
             HeightField = "height_m",
-            Unit = (VerticalUnit)int.MaxValue
+            Unit = "yards"
         };
 
         var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
@@ -235,7 +235,7 @@ public sealed class ExtrusionValidatorTests
     [Operation(Operations.Metadata)]
     public void Validate_AllRecognizedUnits_AreAccepted()
     {
-        foreach (var unit in Enum.GetValues<VerticalUnit>())
+        foreach (var unit in new[] { VerticalUnits.Meters, VerticalUnits.Feet, VerticalUnits.UsSurveyFeet })
         {
             var extrusion = new LayerExtrusionInfo
             {
@@ -251,6 +251,39 @@ public sealed class ExtrusionValidatorTests
 
     [UnitTest]
     [Operation(Operations.Metadata)]
+    public void Validate_RecognizedUnit_IsCaseInsensitive()
+    {
+        foreach (var unit in new[] { "METERS", "Feet", "USSURVEYFEET" })
+        {
+            var extrusion = new LayerExtrusionInfo
+            {
+                HeightField = "height_m",
+                Unit = unit
+            };
+
+            var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+            errors.Should().NotContain(ExtrusionErrorCodes.UnitUnrecognized,
+                $"unit '{unit}' should be recognized case-insensitively");
+        }
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_NullUnit_DefaultsToMetersWithNoError()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "height_m",
+            Unit = null
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().NotContain(ExtrusionErrorCodes.UnitUnrecognized);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
     public void Validate_MultipleViolations_ReportsAllErrors()
     {
         var extrusion = new LayerExtrusionInfo
@@ -258,7 +291,7 @@ public sealed class ExtrusionValidatorTests
             HeightField = "name",
             BaseHeightField = "active",
             DefaultHeight = -2.0,
-            Unit = (VerticalUnit)999
+            Unit = "yards"
         };
 
         var errors = ExtrusionValidator.Validate(extrusion, _layerFields);

--- a/tests/dotnet/Honua.Core.Tests/Features/Catalog/ExtrusionValidatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Catalog/ExtrusionValidatorTests.cs
@@ -1,0 +1,271 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Core.Tests.Features.Catalog;
+
+/// <summary>
+/// Unit tests for <see cref="ExtrusionValidator"/>. Confirms that every
+/// validation branch reports the expected stable error code from
+/// <see cref="ExtrusionErrorCodes"/>.
+/// </summary>
+[Protocol(Protocols.GeoservicesCatalog)]
+public sealed class ExtrusionValidatorTests
+{
+    private static readonly FieldDefinition[] _layerFields =
+    [
+        new("objectid", FieldType.Integer, Nullable: false),
+        new("name", FieldType.String, Length: 64),
+        new("height_m", FieldType.Double),
+        new("base_m", FieldType.Float),
+        new("levels", FieldType.Integer),
+        new("levels_64", FieldType.BigInteger),
+        new("active", FieldType.Boolean),
+        new("shape", FieldType.Geometry, Nullable: false)
+    ];
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_ValidConfig_ReturnsNoErrors()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "height_m",
+            BaseHeightField = "base_m",
+            Unit = VerticalUnit.Meters,
+            DefaultHeight = 3.0
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_HeightFieldOnly_NoBaseField_IsValid()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "levels",
+            Unit = VerticalUnit.Meters
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_HeightFieldEmpty_ReportsHeightFieldMissing()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = string.Empty
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().Contain(ExtrusionErrorCodes.HeightFieldMissing);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_HeightFieldWhitespace_ReportsHeightFieldMissing()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "   "
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().Contain(ExtrusionErrorCodes.HeightFieldMissing);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_HeightFieldNotPresent_ReportsHeightFieldNotFound()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "nonexistent"
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().Contain(ExtrusionErrorCodes.HeightFieldNotFound);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_HeightFieldNonNumeric_ReportsHeightFieldTypeInvalid()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "name"
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().Contain(ExtrusionErrorCodes.HeightFieldTypeInvalid);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_HeightFieldGeometry_ReportsHeightFieldTypeInvalid()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "shape"
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().Contain(ExtrusionErrorCodes.HeightFieldTypeInvalid);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_HeightFieldName_IsCaseInsensitive()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "HEIGHT_M"
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_BaseHeightFieldNotPresent_ReportsBaseFieldNotFound()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "height_m",
+            BaseHeightField = "nonexistent"
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().Contain(ExtrusionErrorCodes.BaseFieldNotFound);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_BaseHeightFieldNonNumeric_ReportsBaseFieldTypeInvalid()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "height_m",
+            BaseHeightField = "active"
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().Contain(ExtrusionErrorCodes.BaseFieldTypeInvalid);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_NumericFieldTypes_AreAllAccepted()
+    {
+        foreach (var fieldName in new[] { "height_m", "base_m", "levels", "levels_64" })
+        {
+            var extrusion = new LayerExtrusionInfo { HeightField = fieldName };
+            var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+            errors.Should().BeEmpty($"field '{fieldName}' is numeric and should be accepted");
+        }
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_NegativeDefaultHeight_ReportsNegativeDefaultHeight()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "height_m",
+            DefaultHeight = -1.5
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().Contain(ExtrusionErrorCodes.NegativeDefaultHeight);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_ZeroDefaultHeight_IsValid()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "height_m",
+            DefaultHeight = 0.0
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().NotContain(ExtrusionErrorCodes.NegativeDefaultHeight);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_UnitOutOfRange_ReportsUnitUnrecognized()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "height_m",
+            Unit = (VerticalUnit)int.MaxValue
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().Contain(ExtrusionErrorCodes.UnitUnrecognized);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_AllRecognizedUnits_AreAccepted()
+    {
+        foreach (var unit in Enum.GetValues<VerticalUnit>())
+        {
+            var extrusion = new LayerExtrusionInfo
+            {
+                HeightField = "height_m",
+                Unit = unit
+            };
+
+            var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+            errors.Should().NotContain(ExtrusionErrorCodes.UnitUnrecognized,
+                $"unit {unit} should be recognized");
+        }
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Validate_MultipleViolations_ReportsAllErrors()
+    {
+        var extrusion = new LayerExtrusionInfo
+        {
+            HeightField = "name",
+            BaseHeightField = "active",
+            DefaultHeight = -2.0,
+            Unit = (VerticalUnit)999
+        };
+
+        var errors = ExtrusionValidator.Validate(extrusion, _layerFields);
+
+        errors.Should().Contain(ExtrusionErrorCodes.HeightFieldTypeInvalid);
+        errors.Should().Contain(ExtrusionErrorCodes.BaseFieldTypeInvalid);
+        errors.Should().Contain(ExtrusionErrorCodes.NegativeDefaultHeight);
+        errors.Should().Contain(ExtrusionErrorCodes.UnitUnrecognized);
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Catalog/LayerExtrusionInfoSerializationTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Catalog/LayerExtrusionInfoSerializationTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Core.Tests.Features.Catalog;
+
+/// <summary>
+/// Serialization round-trip tests for <see cref="LayerExtrusionInfo"/>
+/// through the source-generated <see cref="CatalogJsonContext"/>. The
+/// AOT integration depends on these types being registered in the
+/// JSON context; without that registration, deserialization would
+/// silently produce null values in published builds.
+/// </summary>
+[Protocol(Protocols.GeoservicesCatalog)]
+public sealed class LayerExtrusionInfoSerializationTests
+{
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void RoundTrip_AllFields_PreservesValues()
+    {
+        var original = new LayerExtrusionInfo
+        {
+            HeightField = "height_m",
+            BaseHeightField = "base_m",
+            Unit = VerticalUnit.UsSurveyFeet,
+            DefaultHeight = 4.5,
+            MaterialHint = "concrete"
+        };
+
+        var json = JsonSerializer.Serialize(original, CatalogJsonContext.Default.LayerExtrusionInfo);
+        var roundTrip = JsonSerializer.Deserialize(json, CatalogJsonContext.Default.LayerExtrusionInfo);
+
+        roundTrip.Should().NotBeNull();
+        roundTrip!.Should().Be(original);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void Serialize_VerticalUnit_UsesCamelCaseStrings()
+    {
+        var meters = new LayerExtrusionInfo { HeightField = "h", Unit = VerticalUnit.Meters };
+        var feet = new LayerExtrusionInfo { HeightField = "h", Unit = VerticalUnit.Feet };
+        var usSurveyFeet = new LayerExtrusionInfo { HeightField = "h", Unit = VerticalUnit.UsSurveyFeet };
+
+        var metersJson = JsonSerializer.Serialize(meters, CatalogJsonContext.Default.LayerExtrusionInfo);
+        var feetJson = JsonSerializer.Serialize(feet, CatalogJsonContext.Default.LayerExtrusionInfo);
+        var usSurveyFeetJson = JsonSerializer.Serialize(usSurveyFeet, CatalogJsonContext.Default.LayerExtrusionInfo);
+
+        metersJson.Should().Contain("\"unit\":\"meters\"");
+        feetJson.Should().Contain("\"unit\":\"feet\"");
+        usSurveyFeetJson.Should().Contain("\"unit\":\"usSurveyFeet\"");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void CatalogMetadata_RoundTrip_PreservesExtrusion()
+    {
+        var original = new CatalogMetadata
+        {
+            Extrusion = new LayerExtrusionInfo
+            {
+                HeightField = "h",
+                Unit = VerticalUnit.Feet,
+                DefaultHeight = 0.0,
+                MaterialHint = "glass"
+            }
+        };
+
+        var json = JsonSerializer.Serialize(original, CatalogJsonContext.Default.CatalogMetadata);
+        var roundTrip = JsonSerializer.Deserialize(json, CatalogJsonContext.Default.CatalogMetadata);
+
+        roundTrip.Should().NotBeNull();
+        roundTrip!.Extrusion.Should().NotBeNull();
+        roundTrip.Extrusion.Should().Be(original.Extrusion);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void CatalogMetadata_DefaultValues_DeserializeAsNullExtrusion()
+    {
+        // A 2D-only catalog metadata payload (no extrusion property at all)
+        // must deserialize to a null Extrusion property — the missing
+        // property is the v1 contract's signal of "no 3D extrusion".
+        const string payload = """{ "accessPolicy": null }""";
+
+        var metadata = JsonSerializer.Deserialize(payload, CatalogJsonContext.Default.CatalogMetadata);
+
+        metadata.Should().NotBeNull();
+        metadata!.Extrusion.Should().BeNull();
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Catalog/LayerExtrusionInfoSerializationTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Catalog/LayerExtrusionInfoSerializationTests.cs
@@ -27,7 +27,7 @@ public sealed class LayerExtrusionInfoSerializationTests
         {
             HeightField = "height_m",
             BaseHeightField = "base_m",
-            Unit = VerticalUnit.UsSurveyFeet,
+            Unit = VerticalUnits.UsSurveyFeet,
             DefaultHeight = 4.5,
             MaterialHint = "concrete"
         };
@@ -41,11 +41,11 @@ public sealed class LayerExtrusionInfoSerializationTests
 
     [UnitTest]
     [Operation(Operations.Metadata)]
-    public void Serialize_VerticalUnit_UsesCamelCaseStrings()
+    public void Serialize_VerticalUnit_PreservesCanonicalTokens()
     {
-        var meters = new LayerExtrusionInfo { HeightField = "h", Unit = VerticalUnit.Meters };
-        var feet = new LayerExtrusionInfo { HeightField = "h", Unit = VerticalUnit.Feet };
-        var usSurveyFeet = new LayerExtrusionInfo { HeightField = "h", Unit = VerticalUnit.UsSurveyFeet };
+        var meters = new LayerExtrusionInfo { HeightField = "h", Unit = VerticalUnits.Meters };
+        var feet = new LayerExtrusionInfo { HeightField = "h", Unit = VerticalUnits.Feet };
+        var usSurveyFeet = new LayerExtrusionInfo { HeightField = "h", Unit = VerticalUnits.UsSurveyFeet };
 
         var metersJson = JsonSerializer.Serialize(meters, CatalogJsonContext.Default.LayerExtrusionInfo);
         var feetJson = JsonSerializer.Serialize(feet, CatalogJsonContext.Default.LayerExtrusionInfo);
@@ -58,6 +58,21 @@ public sealed class LayerExtrusionInfoSerializationTests
 
     [UnitTest]
     [Operation(Operations.Metadata)]
+    public void Deserialize_UnknownUnit_DoesNotThrow()
+    {
+        // Unknown unit tokens must round-trip into the catalog model so
+        // ExtrusionValidator can surface them as EXTRUSION_UNIT_UNRECOGNIZED
+        // rather than failing during catalog deserialization.
+        const string payload = """{"heightField":"h","unit":"yards"}""";
+
+        var deserialized = JsonSerializer.Deserialize(payload, CatalogJsonContext.Default.LayerExtrusionInfo);
+
+        deserialized.Should().NotBeNull();
+        deserialized!.Unit.Should().Be("yards");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
     public void CatalogMetadata_RoundTrip_PreservesExtrusion()
     {
         var original = new CatalogMetadata
@@ -65,7 +80,7 @@ public sealed class LayerExtrusionInfoSerializationTests
             Extrusion = new LayerExtrusionInfo
             {
                 HeightField = "h",
-                Unit = VerticalUnit.Feet,
+                Unit = VerticalUnits.Feet,
                 DefaultHeight = 0.0,
                 MaterialHint = "glass"
             }

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/GeoServices/FeatureServer/FeatureServerExtrusionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/GeoServices/FeatureServer/FeatureServerExtrusionTests.cs
@@ -1,0 +1,232 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
+
+/// <summary>
+/// Integration tests for v1 extruded 3D feature layer metadata output
+/// surfaced through the GeoServices FeatureServer layer metadata response.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.FeatureServer)]
+public sealed class FeatureServerExtrusionTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task LayerMetadata_NoExtrusionConfigured_OmitsExtrusionInfoFromResponse()
+    {
+        var client = _fixture.CreateClient();
+
+        var response = await client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+
+        document.RootElement.TryGetProperty("extrusionInfo", out _).Should().BeFalse(
+            "2D-only layers must not surface extrusionInfo in the FeatureServer response");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task LayerMetadata_WithExtrusionConfigured_SurfacesExtrusionInfo()
+    {
+        await SetLayerExtrusionMetadataAsync(new LayerExtrusionInfo
+        {
+            HeightField = "objectid",
+            Unit = VerticalUnit.Meters,
+            DefaultHeight = 3.0,
+            MaterialHint = "concrete"
+        });
+
+        var client = _fixture.CreateClient();
+
+        var response = await client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+
+        document.RootElement.TryGetProperty("extrusionInfo", out var extrusionInfo).Should().BeTrue();
+        extrusionInfo.GetProperty("enabled").GetBoolean().Should().BeTrue();
+        extrusionInfo.GetProperty("heightField").GetString().Should().Be("objectid");
+        extrusionInfo.GetProperty("unit").GetString().Should().Be("meters");
+        extrusionInfo.GetProperty("defaultHeight").GetDouble().Should().Be(3.0);
+        extrusionInfo.GetProperty("materialHint").GetString().Should().Be("concrete");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task LayerMetadata_WithBaseHeightField_SurfacesBaseHeightField()
+    {
+        await SetLayerExtrusionMetadataAsync(new LayerExtrusionInfo
+        {
+            HeightField = "objectid",
+            BaseHeightField = "objectid",
+            Unit = VerticalUnit.Feet
+        });
+
+        var client = _fixture.CreateClient();
+
+        var response = await client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+
+        var extrusionInfo = document.RootElement.GetProperty("extrusionInfo");
+        extrusionInfo.GetProperty("baseHeightField").GetString().Should().Be("objectid");
+        extrusionInfo.GetProperty("unit").GetString().Should().Be("feet");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task LayerMetadata_HeightFieldMissing_Returns422WithErrorCode()
+    {
+        await SetRawMetadataJsonAsync("""{"extrusion":{"unit":"meters"}}""");
+
+        var client = _fixture.CreateClient();
+
+        var response = await client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var payload = await response.Content.ReadAsStringAsync();
+        payload.Should().Contain(ExtrusionErrorCodes.HeightFieldMissing);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task LayerMetadata_HeightFieldNotFound_Returns422WithErrorCode()
+    {
+        await SetLayerExtrusionMetadataAsync(new LayerExtrusionInfo
+        {
+            HeightField = "ghost_field"
+        });
+
+        var client = _fixture.CreateClient();
+
+        var response = await client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var payload = await response.Content.ReadAsStringAsync();
+        payload.Should().Contain(ExtrusionErrorCodes.HeightFieldNotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task LayerMetadata_HeightFieldNonNumeric_Returns422WithErrorCode()
+    {
+        await SetLayerExtrusionMetadataAsync(new LayerExtrusionInfo
+        {
+            HeightField = "name"
+        });
+
+        var client = _fixture.CreateClient();
+
+        var response = await client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var payload = await response.Content.ReadAsStringAsync();
+        payload.Should().Contain(ExtrusionErrorCodes.HeightFieldTypeInvalid);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task LayerMetadata_NegativeDefaultHeight_Returns422WithErrorCode()
+    {
+        await SetLayerExtrusionMetadataAsync(new LayerExtrusionInfo
+        {
+            HeightField = "objectid",
+            DefaultHeight = -1.0
+        });
+
+        var client = _fixture.CreateClient();
+
+        var response = await client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var payload = await response.Content.ReadAsStringAsync();
+        payload.Should().Contain(ExtrusionErrorCodes.NegativeDefaultHeight);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task LayerQuery_WithExtrusionConfigured_DoesNotAffect2DResponse()
+    {
+        await SetLayerExtrusionMetadataAsync(new LayerExtrusionInfo
+        {
+            HeightField = "objectid",
+            Unit = VerticalUnit.Meters
+        });
+
+        var client = _fixture.CreateClient();
+
+        var response = await client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?where=1%3D1&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+
+        document.RootElement.TryGetProperty("features", out _).Should().BeTrue(
+            "2D feature query must remain unaffected when extrusion is configured");
+        document.RootElement.TryGetProperty("extrusionInfo", out _).Should().BeFalse(
+            "extrusionInfo must not leak into query payloads");
+    }
+
+    private async Task SetLayerExtrusionMetadataAsync(LayerExtrusionInfo extrusion)
+    {
+        var metadata = new CatalogMetadata { Extrusion = extrusion };
+        var json = JsonSerializer.Serialize(metadata, CatalogJsonContext.Default.CatalogMetadata);
+        await SetRawMetadataJsonAsync(json);
+    }
+
+    private async Task SetRawMetadataJsonAsync(string metadataJson)
+    {
+        var schema = _fixture.CurrentSchema
+            ?? throw new InvalidOperationException("Test schema must be initialized.");
+
+        await using var connection = await _fixture.Postgres.GetConnectionAsync(schema);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            UPDATE honua.layers
+            SET metadata = @metadata::jsonb
+            WHERE layer_id = @layerId;
+            """;
+        command.Parameters.AddWithValue("metadata", metadataJson);
+        command.Parameters.AddWithValue("layerId", WebAppFixture.TestLayerId);
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/GeoServices/FeatureServer/FeatureServerExtrusionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/GeoServices/FeatureServer/FeatureServerExtrusionTests.cs
@@ -51,7 +51,7 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
         await SetLayerExtrusionMetadataAsync(new LayerExtrusionInfo
         {
             HeightField = "objectid",
-            Unit = VerticalUnit.Meters,
+            Unit = VerticalUnits.Meters,
             DefaultHeight = 3.0,
             MaterialHint = "concrete"
         });
@@ -83,7 +83,7 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
         {
             HeightField = "objectid",
             BaseHeightField = "objectid",
-            Unit = VerticalUnit.Feet
+            Unit = VerticalUnits.Feet
         });
 
         var client = _fixture.CreateClient();
@@ -161,6 +161,26 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Metadata)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task LayerMetadata_UnknownUnit_Returns422WithErrorCode()
+    {
+        // Unknown unit tokens in raw catalog metadata must surface through
+        // the validator as EXTRUSION_UNIT_UNRECOGNIZED rather than throw
+        // during catalog deserialization.
+        await SetRawMetadataJsonAsync("""{"extrusion":{"heightField":"objectid","unit":"yards"}}""");
+
+        var client = _fixture.CreateClient();
+
+        var response = await client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var payload = await response.Content.ReadAsStringAsync();
+        payload.Should().Contain(ExtrusionErrorCodes.UnitUnrecognized);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
     public async Task LayerMetadata_NegativeDefaultHeight_Returns422WithErrorCode()
     {
         await SetLayerExtrusionMetadataAsync(new LayerExtrusionInfo
@@ -187,7 +207,7 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
         await SetLayerExtrusionMetadataAsync(new LayerExtrusionInfo
         {
             HeightField = "objectid",
-            Unit = VerticalUnit.Meters
+            Unit = VerticalUnits.Meters
         });
 
         var client = _fixture.CreateClient();


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #841
## Summary

- Invalid extrusion config returns shared problem details with stable codes — five `*_Returns422WithErrorCode` integration tests now passing, covering `HeightFieldMissing`, `HeightFieldNotFound`, `HeightFieldTypeInvalid`, `NegativeDefaultHeight`, and the new `UnitUnrecognized`.
- Determinism preserved — `LayerExtrusionMetadata` mapping in `UnifiedMetadataProvider` and `FeatureServerExtrusionInfo` mapping in `FeatureServerUtilities` both pass through `VerticalUnits.TryNormalize`'s canonical token.
- AOT-safe — no reflection-based converters; raw string round-trips through the source-generated `CatalogJsonContext`; new `Deserialize_UnknownUnit_DoesNotThrow` test exercises the AOT path.
- Endpoint metadata advertises the new 422 — verified via the `.Produces(StatusCodes.Status422UnprocessableEntity)` chain on the layer metadata registration.
## Changes Made

- Invalid extrusion config returns shared problem details with stable codes — five `*_Returns422WithErrorCode` integration tests now passing, covering `HeightFieldMissing`, `HeightFieldNotFound`, `HeightFieldTypeInvalid`, `NegativeDefaultHeight`, and the new `UnitUnrecognized`.
- Determinism preserved — `LayerExtrusionMetadata` mapping in `UnifiedMetadataProvider` and `FeatureServerExtrusionInfo` mapping in `FeatureServerUtilities` both pass through `VerticalUnits.TryNormalize`'s canonical token.
- AOT-safe — no reflection-based converters; raw string round-trips through the source-generated `CatalogJsonContext`; new `Deserialize_UnknownUnit_DoesNotThrow` test exercises the AOT path.
- Endpoint metadata advertises the new 422 — verified via the `.Produces(StatusCodes.Status422UnprocessableEntity)` chain on the layer metadata registration.
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/ci/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
