### PR TITLE
feat: add migration manifest and parity evidence artifacts (#651, #652)

### DIFF
--- a/docs/gis/tutorials/geoserver-migration-guide.md
+++ b/docs/gis/tutorials/geoserver-migration-guide.md
@@ -4,7 +4,7 @@ Migrate from GeoServer to Honua Server, covering endpoint equivalence, inventory
 
 ## Overview
 
-Honua provides GeoServer migration tooling for discovery, compatibility classification, and dry-run import validation. The migration scanner is discovery-only: it returns a deterministic planning artifact before any connection, service, layer, or style changes are applied. GeoServer import remains a separate dry-run workflow, and style conversion still requires manual follow-up. After migration, clients that consumed GeoServer WFS/WMS/WMTS endpoints can connect to Honua's equivalent OGC and GeoServices REST endpoints.
+Honua provides GeoServer migration tooling for discovery, compatibility classification, and dry-run import validation. The migration scanner is discovery-only: it returns a deterministic planning artifact before any connection, service, layer, or style changes are applied. GeoServer import remains a separate dry-run workflow, and style conversion still requires manual follow-up. Use the shared [Migration Toolkit](../../operator/migration-toolkit.md) workflow for manifest translation, parity evidence, and cutover readiness after discovery. After migration, clients that consumed GeoServer WFS/WMS/WMTS endpoints can connect to Honua's equivalent OGC and GeoServices REST endpoints.
 
 ## Endpoint Equivalence Mapping
 

--- a/docs/operator/README.md
+++ b/docs/operator/README.md
@@ -27,6 +27,7 @@ Deploy, configure, monitor, and manage Honua Server.
 ## Server Management
 
 - [Control Plane API](CONTROL_PLANE_API.md) — Admin REST API for connections, layers, services, and migration inventory scans
+- [Migration Toolkit](migration-toolkit.md) — Inventory, manifest, parity evidence, and cutover readiness artifact workflow
 - [ArcGIS Inventory Discovery](arcgis-inventory-discovery.md) — Deterministic FeatureServer/MapServer inventory artifact, JSON export, and compatibility codes
 - [GeoServer Migration Guide](../gis/tutorials/geoserver-migration-guide.md) — Discovery-only scanner workflow, compatibility review, and dry-run import planning
 - [Tile Operations](tile-operations-runbook.md) — Vector tile seeding, warming, invalidation, archive

--- a/docs/operator/arcgis-inventory-discovery.md
+++ b/docs/operator/arcgis-inventory-discovery.md
@@ -7,7 +7,9 @@ downstream automation can review before any data is migrated.
 
 This document describes what the discovery slice does, how to invoke it, what
 the artifact contains, and how the slice fits into the larger migration
-workflow.
+workflow. After discovery, continue with the shared
+[Migration Toolkit](migration-toolkit.md) manifest, parity evidence, and
+cutover-readiness workflow.
 
 ## Non-goals for this slice
 

--- a/docs/operator/examples/migration-cutover-readiness-template.json
+++ b/docs/operator/examples/migration-cutover-readiness-template.json
@@ -1,0 +1,52 @@
+{
+  "items": [
+    {
+      "id": "inventory-confirmed",
+      "state": "unknown",
+      "evidence": [
+        "TODO: link to reviewed source inventory artifact"
+      ],
+      "owner": "TODO"
+    },
+    {
+      "id": "manifest-reviewed",
+      "state": "unknown",
+      "evidence": [
+        "TODO: link to reviewed migration manifest artifact"
+      ],
+      "owner": "TODO"
+    },
+    {
+      "id": "parity-report-reviewed",
+      "state": "unknown",
+      "evidence": [
+        "TODO: link to reviewed parity evidence pack"
+      ],
+      "owner": "TODO"
+    },
+    {
+      "id": "known-gaps-accepted",
+      "state": "unknown",
+      "evidence": [
+        "TODO: link to accepted fail/unknown gap list or set state to not-applicable only after the evidence pack has no fail or unknown items"
+      ],
+      "owner": "TODO"
+    },
+    {
+      "id": "rollback-plan-documented",
+      "state": "unknown",
+      "evidence": [
+        "TODO: link to rollback plan or runbook section"
+      ],
+      "owner": "TODO"
+    },
+    {
+      "id": "traffic-switch-planned",
+      "state": "unknown",
+      "evidence": [
+        "TODO: link to DNS, load-balancer, or client endpoint change plan"
+      ],
+      "owner": "TODO"
+    }
+  ]
+}

--- a/docs/operator/migration-pilot-cutover-checklist.md
+++ b/docs/operator/migration-pilot-cutover-checklist.md
@@ -1,0 +1,61 @@
+# Migration Pilot And Cutover Checklist
+
+Use this checklist after source discovery and manifest translation, before
+moving production traffic to Honua. Keep a completed copy with the migration
+inventory, manifest, parity evidence pack, and readiness attestation JSON.
+
+## Inputs
+
+- Source inventory artifact:
+- Migration manifest artifact:
+- Parity evidence pack:
+- Readiness attestation JSON:
+- Source owner:
+- Honua operator:
+- Planned pilot date:
+- Planned cutover date:
+
+## Readiness Checks
+
+| ID | State | Evidence | Owner |
+|---|---|---|---|
+| `inventory-confirmed` | `unknown` | Source owner reviewed inventory scope, auth posture, completeness warnings, and missing artifacts. | |
+| `manifest-reviewed` | `unknown` | Target resource actions, style actions, manual-review items, and unsupported items were reviewed. | |
+| `parity-report-reviewed` | `unknown` | Capability, style, and data parity sections were reviewed after pilot migration. | |
+| `known-gaps-accepted` | `unknown` | Every `fail` or `unknown` evidence item has an accepted remediation, waiver, or deferral. | |
+| `rollback-plan-documented` | `unknown` | Rollback steps, data restore point, DNS/load-balancer reversion, and owner escalation path are documented. | |
+| `traffic-switch-planned` | `unknown` | DNS, load-balancer, API client, tile client, and cache-warming changes are scheduled. | |
+
+Allowed states are `pass`, `fail`, `unknown`, and `not-applicable`. Do not
+mark an item `pass` until the evidence column points to a concrete artifact,
+ticket, dashboard, runbook, or signed approval.
+
+## Pilot Review
+
+- Confirm the pilot used the same inventory and manifest artifacts under
+  review.
+- Confirm styles were imported, recreated, or waived according to
+  `styleActions`.
+- Confirm unsupported items were excluded intentionally or moved to a
+  separate migration path.
+- Confirm client endpoint changes were tested against Honua equivalents.
+- Confirm generated parity evidence was rerun after any remediation.
+
+## Cutover Review
+
+- Confirm the latest parity evidence pack has no unaccepted `fail` items.
+- Confirm unresolved `unknown` items are either remediated or explicitly
+  accepted by the source owner.
+- Confirm rollback timing, owners, and restore points are current.
+- Confirm production credentials and secret references are in place.
+- Confirm monitoring, alerting, and on-call coverage are active for cutover.
+- Confirm the post-cutover validation window and decision owner.
+
+## Signoff
+
+| Role | Name | Date | Decision |
+|---|---|---|---|
+| Source owner | | | |
+| Honua operator | | | |
+| Application owner | | | |
+| Incident lead | | | |

--- a/docs/operator/migration-toolkit.md
+++ b/docs/operator/migration-toolkit.md
@@ -1,0 +1,111 @@
+# Migration Toolkit
+
+The migration toolkit is the operator workflow for moving GIS services into
+Honua without treating discovery as proof of cutover readiness. It uses a
+deterministic artifact chain:
+
+1. `MigrationSourceInventoryArtifact` captures what the source advertised.
+2. `MigrationManifestArtifact` translates that inventory into target Honua
+   intent and explicit manual-review or unsupported items.
+3. `MigrationParityEvidenceArtifact` summarizes capability, style, data, and
+   cutover-readiness evidence.
+
+These artifacts are stable intermediate contracts for the migration epic
+(honua-server#646). The manifest slice is tracked by honua-server#651, and
+the parity and evidence-pack slice is tracked by honua-server#652.
+
+## Artifact Flow
+
+Run the source scanner first. GeoServer REST and ArcGIS GeoServices REST
+scans produce the same top-level source inventory contract, so downstream
+review tooling can work against one artifact shape.
+
+Translate the reviewed inventory into a manifest before planning a pilot.
+The manifest does not claim that unsupported source items are migrated:
+incompatible resources are excluded from `targetResources` and emitted under
+`unsupportedItems`; partially compatible resources are emitted with the
+`manual-review` action and a matching `manualReviewItems` entry.
+
+Generate parity evidence after the manifest has been produced. A missing
+manifest leaves data parity `unknown`; it is never treated as a pass.
+
+## State Values
+
+Every parity and readiness item uses one of these state values:
+
+| State | Meaning |
+|---|---|
+| `pass` | Evidence is present and satisfies the check. |
+| `fail` | Evidence is present and shows the check failed. |
+| `unknown` | Evidence is missing or not yet reviewed. |
+| `not-applicable` | The check does not apply to this migration. |
+
+Overall state aggregation is conservative: any `fail` makes the evidence
+pack fail; otherwise any `unknown` keeps the evidence pack unknown. Missing
+operator attestations therefore block cutover readiness until they are
+recorded explicitly.
+
+## Manifest Review
+
+Use the manifest as the technical planning contract before pilot migration:
+
+- Review `targetResources` for target service and resource names.
+- Review `styleActions` before importing or recreating styles.
+- Resolve every `manualReviewItems` entry or record a waiver.
+- Remove or route around every `unsupportedItems` entry before cutover.
+
+The manifest carries copied field, capability, style, dependency, and spatial
+reference identifiers from the inventory. It does not mutate server catalog
+state by itself.
+
+## Parity Evidence
+
+The parity evidence pack groups generated checks into:
+
+- `capability`: source capabilities and unsupported source behaviors.
+- `style`: source style/renderer portability.
+- `data`: manifest target evidence for each migratable source resource.
+- `cutoverReadiness`: operator attestations required before traffic moves.
+
+Operator attestations are supplied separately as
+`MigrationReadinessAttestation` JSON. Use
+[migration-cutover-readiness-template.json](examples/migration-cutover-readiness-template.json)
+as the starting point and keep items `unknown` until evidence exists.
+
+## Pilot And Cutover
+
+Use the Markdown checklist in
+[Migration Pilot And Cutover Checklist](migration-pilot-cutover-checklist.md)
+for human review, and keep the JSON readiness attestation with the migration
+artifacts so automated checks can consume it later.
+
+The generated readiness checklist contains these stable item IDs:
+
+| ID | Purpose |
+|---|---|
+| `inventory-confirmed` | Source inventory has been reviewed with the source owner. |
+| `manifest-reviewed` | Target manifest actions and gaps have been reviewed. |
+| `parity-report-reviewed` | The generated evidence pack has been reviewed. |
+| `known-gaps-accepted` | Fail or unknown items have explicit approval or waiver. |
+| `rollback-plan-documented` | Rollback or traffic restoration plan is documented. |
+| `traffic-switch-planned` | DNS, load-balancer, or client endpoint change is scheduled. |
+
+## Admin And SDK Follow-Up
+
+The server contracts in this slice are the stabilized handoff point for
+admin UI and SDK work tracked by honua-server#880. Downstream UX should use
+the artifact contracts above instead of inventing source-specific manifest
+or readiness shapes.
+
+## Non-Goals
+
+This slice does not perform live source mutation, Honua catalog publishing,
+data copying, traffic switching, admin UI implementation, SDK release work,
+or managed cutover orchestration. Those remain separate implementation
+tickets under the migration epic.
+
+## Related Docs
+
+- [GeoServer to Honua Migration Guide](../gis/tutorials/geoserver-migration-guide.md)
+- [ArcGIS Migration Inventory Discovery](arcgis-inventory-discovery.md)
+- [SLD Migration Reference](sld-migration.md)

--- a/src/Honua.Core/Features/Import/Domain/MigrationManifestArtifact.cs
+++ b/src/Honua.Core/Features/Import/Domain/MigrationManifestArtifact.cs
@@ -1,0 +1,253 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Deterministic intermediate artifact that translates source inventory into
+/// target Honua migration intent.
+/// </summary>
+public sealed record MigrationManifestArtifact
+{
+    /// <summary>
+    /// Stable artifact kind identifier.
+    /// </summary>
+    public string ArtifactKind { get; init; } = "honua.migration.manifest";
+
+    /// <summary>
+    /// Artifact schema version.
+    /// </summary>
+    public string ArtifactVersion { get; init; } = "1.0";
+
+    /// <summary>
+    /// Source inventory artifact kind this manifest was translated from.
+    /// </summary>
+    public string SourceArtifactKind { get; init; } = "honua.migration.source-inventory";
+
+    /// <summary>
+    /// Source inventory artifact version this manifest was translated from.
+    /// </summary>
+    public string SourceArtifactVersion { get; init; } = "1.0";
+
+    /// <summary>
+    /// Source kind identifier such as <c>geoserver-rest</c> or <c>arcgis-geoservices-rest</c>.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Identity and version information for the scanned source.
+    /// </summary>
+    public required MigrationSourceIdentity Source { get; init; }
+
+    /// <summary>
+    /// Deterministic translation summary.
+    /// </summary>
+    public required MigrationManifestSummary Summary { get; init; }
+
+    /// <summary>
+    /// Target resources that can be published or staged from the source inventory.
+    /// </summary>
+    public MigrationManifestTargetResource[] TargetResources { get; init; } = [];
+
+    /// <summary>
+    /// Target style actions. Unsupported styles are listed here as manual-review
+    /// actions instead of being claimed as migrated.
+    /// </summary>
+    public MigrationManifestStyleAction[] StyleActions { get; init; } = [];
+
+    /// <summary>
+    /// Items that require operator review before migration can proceed.
+    /// </summary>
+    public MigrationManifestReviewItem[] ManualReviewItems { get; init; } = [];
+
+    /// <summary>
+    /// Items that cannot be translated into target Honua intent by this slice.
+    /// </summary>
+    public MigrationManifestReviewItem[] UnsupportedItems { get; init; } = [];
+}
+
+/// <summary>
+/// Aggregate counts for a migration manifest artifact.
+/// </summary>
+public sealed record MigrationManifestSummary
+{
+    /// <summary>
+    /// Number of source resources considered for translation.
+    /// </summary>
+    public int SourceResourceCount { get; init; }
+
+    /// <summary>
+    /// Number of target resources emitted into the manifest.
+    /// </summary>
+    public int TargetResourceCount { get; init; }
+
+    /// <summary>
+    /// Number of style actions emitted into the manifest.
+    /// </summary>
+    public int StyleActionCount { get; init; }
+
+    /// <summary>
+    /// Number of source items requiring manual review.
+    /// </summary>
+    public int ManualReviewCount { get; init; }
+
+    /// <summary>
+    /// Number of source items that are unsupported for deterministic translation.
+    /// </summary>
+    public int UnsupportedCount { get; init; }
+}
+
+/// <summary>
+/// Target resource intent translated from one source inventory resource.
+/// </summary>
+public sealed record MigrationManifestTargetResource
+{
+    /// <summary>
+    /// Source inventory resource identifier.
+    /// </summary>
+    public required string SourceResourceId { get; init; }
+
+    /// <summary>
+    /// Source inventory resource kind.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Target migration action such as <c>publish</c> or <c>manual-review</c>.
+    /// </summary>
+    public required string Action { get; init; }
+
+    /// <summary>
+    /// Target service name suggested for this resource.
+    /// </summary>
+    public required string TargetServiceName { get; init; }
+
+    /// <summary>
+    /// Target resource name suggested for this resource.
+    /// </summary>
+    public required string TargetResourceName { get; init; }
+
+    /// <summary>
+    /// Geometry type copied from the inventory when available.
+    /// </summary>
+    public string? GeometryType { get; init; }
+
+    /// <summary>
+    /// Field schema copied from the source inventory.
+    /// </summary>
+    public MigrationInventoryField[] Fields { get; init; } = [];
+
+    /// <summary>
+    /// Source capabilities copied into the manifest for operator review.
+    /// </summary>
+    public string[] Capabilities { get; init; } = [];
+
+    /// <summary>
+    /// Source spatial references copied into the manifest for operator review.
+    /// </summary>
+    public MigrationSpatialReferenceInfo[] SpatialReferences { get; init; } = [];
+
+    /// <summary>
+    /// Related style identifiers from the source inventory.
+    /// </summary>
+    public string[] StyleIds { get; init; } = [];
+
+    /// <summary>
+    /// Related external dependency identifiers from the source inventory.
+    /// </summary>
+    public string[] ExternalDependencyIds { get; init; } = [];
+
+    /// <summary>
+    /// Compatibility assessment that justified the target action.
+    /// </summary>
+    public required MigrationCompatibilityAssessment Compatibility { get; init; }
+}
+
+/// <summary>
+/// Target style action translated from a source style or renderer.
+/// </summary>
+public sealed record MigrationManifestStyleAction
+{
+    /// <summary>
+    /// Source style identifier.
+    /// </summary>
+    public required string SourceStyleId { get; init; }
+
+    /// <summary>
+    /// Target action such as <c>import</c> or <c>manual-review</c>.
+    /// </summary>
+    public required string Action { get; init; }
+
+    /// <summary>
+    /// Source style format.
+    /// </summary>
+    public string? Format { get; init; }
+
+    /// <summary>
+    /// Related source resource identifiers.
+    /// </summary>
+    public string[] ResourceIds { get; init; } = [];
+
+    /// <summary>
+    /// External dependencies that must be resolved before style migration.
+    /// </summary>
+    public string[] ExternalDependencyIds { get; init; } = [];
+
+    /// <summary>
+    /// Compatibility assessment that justified the target action.
+    /// </summary>
+    public required MigrationCompatibilityAssessment Compatibility { get; init; }
+}
+
+/// <summary>
+/// Review or unsupported item emitted during manifest translation.
+/// </summary>
+public sealed record MigrationManifestReviewItem
+{
+    /// <summary>
+    /// Source artifact identifier for the item.
+    /// </summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>
+    /// Source item kind.
+    /// </summary>
+    public required string Kind { get; init; }
+
+    /// <summary>
+    /// Stable machine-readable code.
+    /// </summary>
+    public required string Code { get; init; }
+
+    /// <summary>
+    /// Review severity such as <c>manual-review</c> or <c>unsupported</c>.
+    /// </summary>
+    public required string Severity { get; init; }
+
+    /// <summary>
+    /// Human-readable reason.
+    /// </summary>
+    public required string Reason { get; init; }
+
+    /// <summary>
+    /// Operator remediation guidance.
+    /// </summary>
+    public string[] ManualSteps { get; init; } = [];
+
+    /// <summary>
+    /// Warnings copied from the source compatibility assessment.
+    /// </summary>
+    public string[] Warnings { get; init; } = [];
+}
+
+/// <summary>
+/// Options for translating source inventory into a target migration manifest.
+/// </summary>
+public sealed record MigrationManifestTranslationOptions
+{
+    /// <summary>
+    /// Target service name to use for translated resources. When omitted, the
+    /// source display name is normalized into a deterministic service name.
+    /// </summary>
+    public string? TargetServiceName { get; init; }
+}

--- a/src/Honua.Core/Features/Import/Domain/MigrationParityEvidenceArtifact.cs
+++ b/src/Honua.Core/Features/Import/Domain/MigrationParityEvidenceArtifact.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Stable state values used by migration parity and cutover-readiness artifacts.
+/// </summary>
+public static class MigrationEvidenceStates
+{
+    /// <summary>Evidence is present and satisfies the check.</summary>
+    public const string Pass = "pass";
+
+    /// <summary>Evidence is present and shows the check failed.</summary>
+    public const string Fail = "fail";
+
+    /// <summary>Evidence is missing or not yet reviewed.</summary>
+    public const string Unknown = "unknown";
+
+    /// <summary>The check is not applicable to this migration.</summary>
+    public const string NotApplicable = "not-applicable";
+}
+
+/// <summary>
+/// Deterministic technical signoff artifact for a migration pilot or cutover review.
+/// </summary>
+public sealed record MigrationParityEvidenceArtifact
+{
+    /// <summary>
+    /// Stable artifact kind identifier.
+    /// </summary>
+    public string ArtifactKind { get; init; } = "honua.migration.parity-evidence-pack";
+
+    /// <summary>
+    /// Artifact schema version.
+    /// </summary>
+    public string ArtifactVersion { get; init; } = "1.0";
+
+    /// <summary>
+    /// Source kind identifier such as <c>geoserver-rest</c> or <c>arcgis-geoservices-rest</c>.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Identity and version information for the scanned source.
+    /// </summary>
+    public required MigrationSourceIdentity Source { get; init; }
+
+    /// <summary>
+    /// Overall parity state across capability, style, data, and readiness sections.
+    /// </summary>
+    public required string OverallState { get; init; }
+
+    /// <summary>
+    /// Human-readable summary for signoff reviewers.
+    /// </summary>
+    public required string Summary { get; init; }
+
+    /// <summary>
+    /// Whether a migration manifest was available as evidence input.
+    /// </summary>
+    public bool ManifestAvailable { get; init; }
+
+    /// <summary>
+    /// Evidence sections grouped by review category.
+    /// </summary>
+    public MigrationParityEvidenceSection[] Sections { get; init; } = [];
+
+    /// <summary>
+    /// Cutover-readiness checklist and aggregate state.
+    /// </summary>
+    public required MigrationCutoverReadinessSummary CutoverReadiness { get; init; }
+}
+
+/// <summary>
+/// Group of parity evidence items for one review category.
+/// </summary>
+public sealed record MigrationParityEvidenceSection
+{
+    /// <summary>
+    /// Stable section identifier.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Section display title.
+    /// </summary>
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Aggregate state for the section.
+    /// </summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// Evidence items in deterministic order.
+    /// </summary>
+    public MigrationParityEvidenceItem[] Items { get; init; } = [];
+}
+
+/// <summary>
+/// Individual evidence item inside a parity section.
+/// </summary>
+public sealed record MigrationParityEvidenceItem
+{
+    /// <summary>
+    /// Stable item identifier.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Item state: <c>pass</c>, <c>fail</c>, <c>unknown</c>, or <c>not-applicable</c>.
+    /// </summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// Short item summary.
+    /// </summary>
+    public required string Summary { get; init; }
+
+    /// <summary>
+    /// Evidence text supporting the assigned state.
+    /// </summary>
+    public string[] Evidence { get; init; } = [];
+
+    /// <summary>
+    /// Remediation guidance for fail or unknown states.
+    /// </summary>
+    public string[] Remediation { get; init; } = [];
+
+    /// <summary>
+    /// Related manifest or inventory identifiers.
+    /// </summary>
+    public string[] RelatedIds { get; init; } = [];
+}
+
+/// <summary>
+/// Cutover-readiness checklist and aggregate state.
+/// </summary>
+public sealed record MigrationCutoverReadinessSummary
+{
+    /// <summary>
+    /// Aggregate readiness state.
+    /// </summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// Checklist items in deterministic order.
+    /// </summary>
+    public MigrationCutoverReadinessItem[] Items { get; init; } = [];
+}
+
+/// <summary>
+/// Individual cutover-readiness checklist item.
+/// </summary>
+public sealed record MigrationCutoverReadinessItem
+{
+    /// <summary>
+    /// Stable checklist item identifier.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Checklist item title.
+    /// </summary>
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Item state: <c>pass</c>, <c>fail</c>, <c>unknown</c>, or <c>not-applicable</c>.
+    /// </summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// Evidence supplied by the operator or generated by the report.
+    /// </summary>
+    public string[] Evidence { get; init; } = [];
+
+    /// <summary>
+    /// Remediation guidance for fail or unknown states.
+    /// </summary>
+    public string[] Remediation { get; init; } = [];
+
+    /// <summary>
+    /// Optional owner responsible for closing the item.
+    /// </summary>
+    public string? Owner { get; init; }
+}
+
+/// <summary>
+/// Operator-supplied readiness attestations. Missing items remain unknown.
+/// </summary>
+public sealed record MigrationReadinessAttestation
+{
+    /// <summary>
+    /// Checklist item attestations.
+    /// </summary>
+    public MigrationReadinessAttestationItem[] Items { get; init; } = [];
+}
+
+/// <summary>
+/// Operator-supplied state for one readiness checklist item.
+/// </summary>
+public sealed record MigrationReadinessAttestationItem
+{
+    /// <summary>
+    /// Stable checklist item identifier.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Attested state.
+    /// </summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// Evidence supporting the attested state.
+    /// </summary>
+    public string[] Evidence { get; init; } = [];
+
+    /// <summary>
+    /// Optional owner responsible for the item.
+    /// </summary>
+    public string? Owner { get; init; }
+}

--- a/src/Honua.Core/Features/Import/Services/MigrationManifestTranslator.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationManifestTranslator.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.RegularExpressions;
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Translates source inventory artifacts into deterministic migration manifests.
+/// </summary>
+public static partial class MigrationManifestTranslator
+{
+    /// <summary>
+    /// Translate source inventory into a target manifest artifact.
+    /// </summary>
+    /// <param name="inventory">Source inventory artifact.</param>
+    /// <param name="options">Optional target naming options.</param>
+    /// <returns>Deterministic manifest artifact.</returns>
+    public static MigrationManifestArtifact Translate(
+        MigrationSourceInventoryArtifact inventory,
+        MigrationManifestTranslationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(inventory);
+
+        var targetServiceName = NormalizeName(
+            options?.TargetServiceName ?? inventory.Source.DisplayName,
+            fallback: "migration-service");
+        var targetResources = new List<MigrationManifestTargetResource>();
+        var styleActions = new List<MigrationManifestStyleAction>();
+        var manualReviewItems = new List<MigrationManifestReviewItem>();
+        var unsupportedItems = new List<MigrationManifestReviewItem>();
+
+        foreach (var resource in inventory.Resources.OrderBy(static item => item.Id, StringComparer.Ordinal))
+        {
+            AddReviewItems(
+                inventory.SourceKind,
+                resource.Id,
+                resource.Kind,
+                resource.Compatibility,
+                manualReviewItems,
+                unsupportedItems);
+
+            if (IsIncompatible(resource.Compatibility.Level))
+            {
+                continue;
+            }
+
+            targetResources.Add(new MigrationManifestTargetResource
+            {
+                SourceResourceId = resource.Id,
+                SourceKind = resource.Kind,
+                Action = IsPartial(resource.Compatibility.Level) ? "manual-review" : "publish",
+                TargetServiceName = targetServiceName,
+                TargetResourceName = NormalizeName(resource.Name, fallback: resource.Id),
+                GeometryType = resource.GeometryType,
+                Fields = resource.Fields.OrderBy(static item => item.Name, StringComparer.Ordinal).ToArray(),
+                Capabilities = Order(resource.Capabilities),
+                SpatialReferences = resource.SpatialReferences
+                    .OrderBy(static item => item.Role, StringComparer.Ordinal)
+                    .ThenBy(static item => item.SourceValue, StringComparer.Ordinal)
+                    .ToArray(),
+                StyleIds = Order(resource.StyleIds),
+                ExternalDependencyIds = Order(resource.ExternalDependencyIds),
+                Compatibility = resource.Compatibility
+            });
+        }
+
+        foreach (var style in inventory.Styles.OrderBy(static item => item.Id, StringComparer.Ordinal))
+        {
+            AddReviewItems(
+                inventory.SourceKind,
+                style.Id,
+                style.Kind,
+                style.Compatibility,
+                manualReviewItems,
+                unsupportedItems);
+
+            styleActions.Add(new MigrationManifestStyleAction
+            {
+                SourceStyleId = style.Id,
+                Action = IsCompatible(style.Compatibility.Level) ? "import" : "manual-review",
+                Format = style.Format,
+                ResourceIds = Order(style.ResourceIds),
+                ExternalDependencyIds = Order(style.ExternalDependencyIds),
+                Compatibility = style.Compatibility
+            });
+        }
+
+        foreach (var dependency in inventory.ExternalDependencies.OrderBy(static item => item.Id, StringComparer.Ordinal))
+        {
+            AddReviewItems(
+                inventory.SourceKind,
+                dependency.Id,
+                dependency.Kind,
+                dependency.Compatibility,
+                manualReviewItems,
+                unsupportedItems);
+        }
+
+        return new MigrationManifestArtifact
+        {
+            SourceArtifactKind = inventory.ArtifactKind,
+            SourceArtifactVersion = inventory.ArtifactVersion,
+            SourceKind = inventory.SourceKind,
+            Source = inventory.Source,
+            Summary = new MigrationManifestSummary
+            {
+                SourceResourceCount = inventory.Resources.Length,
+                TargetResourceCount = targetResources.Count,
+                StyleActionCount = styleActions.Count,
+                ManualReviewCount = manualReviewItems.Count,
+                UnsupportedCount = unsupportedItems.Count
+            },
+            TargetResources = targetResources.ToArray(),
+            StyleActions = styleActions.ToArray(),
+            ManualReviewItems = manualReviewItems
+                .OrderBy(static item => item.SourceId, StringComparer.Ordinal)
+                .ThenBy(static item => item.Code, StringComparer.Ordinal)
+                .ToArray(),
+            UnsupportedItems = unsupportedItems
+                .OrderBy(static item => item.SourceId, StringComparer.Ordinal)
+                .ThenBy(static item => item.Code, StringComparer.Ordinal)
+                .ToArray()
+        };
+    }
+
+    private static void AddReviewItems(
+        string sourceKind,
+        string sourceId,
+        string kind,
+        MigrationCompatibilityAssessment compatibility,
+        List<MigrationManifestReviewItem> manualReviewItems,
+        List<MigrationManifestReviewItem> unsupportedItems)
+    {
+        if (IsCompatible(compatibility.Level))
+        {
+            return;
+        }
+
+        var reviewItem = new MigrationManifestReviewItem
+        {
+            SourceId = sourceId,
+            Kind = kind,
+            Code = compatibility.Code ?? BuildFallbackCode(sourceKind, kind, compatibility.Level),
+            Severity = IsIncompatible(compatibility.Level) ? "unsupported" : "manual-review",
+            Reason = compatibility.Reason,
+            ManualSteps = Order(compatibility.ManualSteps),
+            Warnings = Order(compatibility.Warnings)
+        };
+
+        if (IsIncompatible(compatibility.Level))
+        {
+            unsupportedItems.Add(reviewItem);
+        }
+        else
+        {
+            manualReviewItems.Add(reviewItem);
+        }
+    }
+
+    private static string BuildFallbackCode(string sourceKind, string kind, string level)
+        => $"{ToCodePart(sourceKind)}_{ToCodePart(kind)}_{ToCodePart(level)}";
+
+    private static string ToCodePart(string value)
+        => CodeUnsafeCharacters().Replace(value.Trim(), "_").Trim('_').ToUpperInvariant();
+
+    private static string NormalizeName(string value, string fallback)
+    {
+        var normalized = NameUnsafeCharacters()
+            .Replace(value.Trim(), "-")
+            .Trim('-')
+            .ToLowerInvariant();
+
+        return string.IsNullOrWhiteSpace(normalized)
+            ? fallback
+            : normalized.Length <= 64 ? normalized : normalized[..64].TrimEnd('-');
+    }
+
+    private static string[] Order(IEnumerable<string> values)
+        => values
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static value => value, StringComparer.Ordinal)
+            .ToArray();
+
+    private static bool IsCompatible(string? level)
+        => string.Equals(level, "compatible", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsPartial(string? level)
+        => string.Equals(level, "partial", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsIncompatible(string? level)
+        => string.Equals(level, "incompatible", StringComparison.OrdinalIgnoreCase);
+
+    [GeneratedRegex("[^A-Za-z0-9]+")]
+    private static partial Regex CodeUnsafeCharacters();
+
+    [GeneratedRegex("[^A-Za-z0-9_-]+")]
+    private static partial Regex NameUnsafeCharacters();
+}

--- a/src/Honua.Core/Features/Import/Services/MigrationParityEvidenceGenerator.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationParityEvidenceGenerator.cs
@@ -1,0 +1,389 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Builds deterministic migration parity and cutover-readiness evidence packs.
+/// </summary>
+public static class MigrationParityEvidenceGenerator
+{
+    private static readonly MigrationCutoverReadinessItemDefinition[] ReadinessChecklist =
+    [
+        new("inventory-confirmed", "Inventory artifact reviewed"),
+        new("manifest-reviewed", "Migration manifest reviewed"),
+        new("parity-report-reviewed", "Parity evidence reviewed"),
+        new("known-gaps-accepted", "Known gaps accepted"),
+        new("rollback-plan-documented", "Rollback plan documented"),
+        new("traffic-switch-planned", "DNS or load-balancer change planned")
+    ];
+
+    /// <summary>
+    /// Generate a parity evidence pack from deterministic migration artifacts.
+    /// Missing readiness attestations remain <c>unknown</c>.
+    /// </summary>
+    /// <param name="inventory">Source inventory artifact.</param>
+    /// <param name="manifest">Optional migration manifest artifact.</param>
+    /// <param name="attestation">Optional operator-supplied readiness evidence.</param>
+    /// <returns>Deterministic parity evidence artifact.</returns>
+    public static MigrationParityEvidenceArtifact Generate(
+        MigrationSourceInventoryArtifact inventory,
+        MigrationManifestArtifact? manifest = null,
+        MigrationReadinessAttestation? attestation = null)
+    {
+        ArgumentNullException.ThrowIfNull(inventory);
+
+        var sections = new[]
+        {
+            BuildCapabilitySection(inventory),
+            BuildStyleSection(inventory),
+            BuildDataSection(inventory, manifest)
+        };
+        var readiness = BuildReadiness(inventory, manifest, sections, attestation);
+        var overallState = AggregateState(sections.Select(section => section.State).Append(readiness.State));
+
+        return new MigrationParityEvidenceArtifact
+        {
+            SourceKind = inventory.SourceKind,
+            Source = inventory.Source,
+            OverallState = overallState,
+            Summary = BuildSummary(overallState, sections, readiness),
+            ManifestAvailable = manifest != null,
+            Sections = sections,
+            CutoverReadiness = readiness
+        };
+    }
+
+    private static MigrationParityEvidenceSection BuildCapabilitySection(MigrationSourceInventoryArtifact inventory)
+    {
+        var items = inventory.Resources
+            .OrderBy(static resource => resource.Id, StringComparer.Ordinal)
+            .Select(resource =>
+            {
+                if (IsIncompatible(resource.Compatibility.Level))
+                {
+                    return CreateItem(
+                        $"capability:{resource.Id}",
+                        MigrationEvidenceStates.Fail,
+                        $"{resource.Id} has unsupported source capability.",
+                        [resource.Compatibility.Reason],
+                        resource.Compatibility.ManualSteps,
+                        [resource.Id]);
+                }
+
+                if (resource.Capabilities.Length == 0)
+                {
+                    return CreateItem(
+                        $"capability:{resource.Id}",
+                        MigrationEvidenceStates.Unknown,
+                        $"{resource.Id} has no advertised capability evidence.",
+                        ["The source inventory did not expose protocol capability flags for this resource."],
+                        ["Verify endpoint availability during the pilot parity run."],
+                        [resource.Id]);
+                }
+
+                return CreateItem(
+                    $"capability:{resource.Id}",
+                    MigrationEvidenceStates.Pass,
+                    $"{resource.Id} advertised capabilities were captured.",
+                    [$"capabilities: {string.Join(", ", resource.Capabilities.OrderBy(static value => value, StringComparer.Ordinal))}"],
+                    [],
+                    [resource.Id]);
+            })
+            .ToArray();
+
+        if (items.Length == 0)
+        {
+            items =
+            [
+                CreateItem(
+                    "capability:none",
+                    MigrationEvidenceStates.Unknown,
+                    "No source resources were available for capability comparison.",
+                    ["The source inventory contained no resources."],
+                    ["Rerun discovery or confirm the source is intentionally empty."],
+                    [])
+            ];
+        }
+
+        return CreateSection("capability", "Capability parity", items);
+    }
+
+    private static MigrationParityEvidenceSection BuildStyleSection(MigrationSourceInventoryArtifact inventory)
+    {
+        if (inventory.Styles.Length == 0)
+        {
+            return CreateSection(
+                "style",
+                "Style parity",
+                [
+                    CreateItem(
+                        "style:none",
+                        MigrationEvidenceStates.NotApplicable,
+                        "No source styles were discovered.",
+                        ["The source inventory contained no styles or renderers."],
+                        [],
+                        [])
+                ]);
+        }
+
+        var items = inventory.Styles
+            .OrderBy(static style => style.Id, StringComparer.Ordinal)
+            .Select(style =>
+            {
+                var state = ToEvidenceState(style.Compatibility.Level);
+                var remediation = state == MigrationEvidenceStates.Pass
+                    ? []
+                    : style.Compatibility.ManualSteps.Length > 0
+                        ? style.Compatibility.ManualSteps
+                        : ["Recreate or import the style and rerun parity review."];
+
+                return CreateItem(
+                    $"style:{style.Id}",
+                    state,
+                    $"{style.Id} style compatibility is {style.Compatibility.Level}.",
+                    [style.Compatibility.Reason],
+                    remediation,
+                    [style.Id, .. style.ResourceIds.OrderBy(static value => value, StringComparer.Ordinal)]);
+            })
+            .ToArray();
+
+        return CreateSection("style", "Style parity", items);
+    }
+
+    private static MigrationParityEvidenceSection BuildDataSection(
+        MigrationSourceInventoryArtifact inventory,
+        MigrationManifestArtifact? manifest)
+    {
+        var manifestResourceIds = manifest?.TargetResources
+            .Select(resource => resource.SourceResourceId)
+            .ToHashSet(StringComparer.Ordinal) ?? [];
+
+        var items = inventory.Resources
+            .OrderBy(static resource => resource.Id, StringComparer.Ordinal)
+            .Select(resource =>
+            {
+                if (IsIncompatible(resource.Compatibility.Level))
+                {
+                    return CreateItem(
+                        $"data:{resource.Id}",
+                        MigrationEvidenceStates.Fail,
+                        $"{resource.Id} is not represented as a migratable target resource.",
+                        [resource.Compatibility.Reason],
+                        resource.Compatibility.ManualSteps,
+                        [resource.Id]);
+                }
+
+                if (manifest == null || !manifestResourceIds.Contains(resource.Id))
+                {
+                    return CreateItem(
+                        $"data:{resource.Id}",
+                        MigrationEvidenceStates.Unknown,
+                        $"{resource.Id} has no manifest target evidence.",
+                        ["A migration manifest was not available or did not include this resource."],
+                        ["Generate and review the migration manifest before pilot cutover."],
+                        [resource.Id]);
+                }
+
+                var state = IsPartial(resource.Compatibility.Level)
+                    ? MigrationEvidenceStates.Unknown
+                    : MigrationEvidenceStates.Pass;
+                var remediation = state == MigrationEvidenceStates.Pass
+                    ? []
+                    : resource.Compatibility.ManualSteps.Length > 0
+                        ? resource.Compatibility.ManualSteps
+                        : ["Complete manual review and rerun the evidence pack."];
+
+                return CreateItem(
+                    $"data:{resource.Id}",
+                    state,
+                    $"{resource.Id} has manifest target evidence.",
+                    [$"target: {manifest.TargetResources.First(target => target.SourceResourceId == resource.Id).TargetResourceName}"],
+                    remediation,
+                    [resource.Id]);
+            })
+            .ToArray();
+
+        if (items.Length == 0)
+        {
+            items =
+            [
+                CreateItem(
+                    "data:none",
+                    MigrationEvidenceStates.Unknown,
+                    "No source resources were available for data parity.",
+                    ["The source inventory contained no resources."],
+                    ["Rerun discovery or confirm the source is intentionally empty."],
+                    [])
+            ];
+        }
+
+        return CreateSection("data", "Data parity", items);
+    }
+
+    private static MigrationCutoverReadinessSummary BuildReadiness(
+        MigrationSourceInventoryArtifact inventory,
+        MigrationManifestArtifact? manifest,
+        IReadOnlyList<MigrationParityEvidenceSection> sections,
+        MigrationReadinessAttestation? attestation)
+    {
+        var attested = attestation?.Items.ToDictionary(item => item.Id, StringComparer.Ordinal) ?? [];
+        var hasGaps = sections.SelectMany(section => section.Items)
+            .Any(item => item.State is MigrationEvidenceStates.Fail or MigrationEvidenceStates.Unknown);
+
+        var items = ReadinessChecklist
+            .Select(definition =>
+            {
+                if (attested.TryGetValue(definition.Id, out var item))
+                {
+                    return new MigrationCutoverReadinessItem
+                    {
+                        Id = definition.Id,
+                        Title = definition.Title,
+                        State = NormalizeState(item.State),
+                        Evidence = Order(item.Evidence),
+                        Remediation = [],
+                        Owner = item.Owner
+                    };
+                }
+
+                return definition.Id switch
+                {
+                    "known-gaps-accepted" when !hasGaps => new MigrationCutoverReadinessItem
+                    {
+                        Id = definition.Id,
+                        Title = definition.Title,
+                        State = MigrationEvidenceStates.NotApplicable,
+                        Evidence = ["No fail or unknown parity evidence items were generated."],
+                        Remediation = []
+                    },
+                    "inventory-confirmed" when string.Equals(inventory.ScanCompleteness.Status, "failed", StringComparison.OrdinalIgnoreCase) =>
+                        Unknown(definition, "Inventory scan failed and has not been reviewed.", "Rerun discovery or document an approved waiver."),
+                    "manifest-reviewed" when manifest == null =>
+                        Unknown(definition, "No migration manifest was supplied.", "Generate and review the migration manifest."),
+                    _ => Unknown(definition, "No operator attestation was supplied.", "Record pass, fail, or not-applicable evidence before cutover.")
+                };
+            })
+            .ToArray();
+
+        return new MigrationCutoverReadinessSummary
+        {
+            State = AggregateState(items.Select(item => item.State)),
+            Items = items
+        };
+    }
+
+    private static MigrationCutoverReadinessItem Unknown(
+        MigrationCutoverReadinessItemDefinition definition,
+        string evidence,
+        string remediation)
+        => new()
+        {
+            Id = definition.Id,
+            Title = definition.Title,
+            State = MigrationEvidenceStates.Unknown,
+            Evidence = [evidence],
+            Remediation = [remediation]
+        };
+
+    private static MigrationParityEvidenceSection CreateSection(
+        string id,
+        string title,
+        MigrationParityEvidenceItem[] items)
+        => new()
+        {
+            Id = id,
+            Title = title,
+            State = AggregateState(items.Select(item => item.State)),
+            Items = items
+        };
+
+    private static MigrationParityEvidenceItem CreateItem(
+        string id,
+        string state,
+        string summary,
+        IEnumerable<string> evidence,
+        IEnumerable<string> remediation,
+        IEnumerable<string> relatedIds)
+        => new()
+        {
+            Id = id,
+            State = NormalizeState(state),
+            Summary = summary,
+            Evidence = Order(evidence),
+            Remediation = Order(remediation),
+            RelatedIds = Order(relatedIds)
+        };
+
+    private static string BuildSummary(
+        string overallState,
+        IReadOnlyList<MigrationParityEvidenceSection> sections,
+        MigrationCutoverReadinessSummary readiness)
+    {
+        var failCount = sections.SelectMany(section => section.Items).Count(item => item.State == MigrationEvidenceStates.Fail) +
+            readiness.Items.Count(item => item.State == MigrationEvidenceStates.Fail);
+        var unknownCount = sections.SelectMany(section => section.Items).Count(item => item.State == MigrationEvidenceStates.Unknown) +
+            readiness.Items.Count(item => item.State == MigrationEvidenceStates.Unknown);
+
+        return overallState switch
+        {
+            MigrationEvidenceStates.Pass => "All generated parity and readiness checks passed.",
+            MigrationEvidenceStates.Fail => $"Evidence pack has {failCount} failed item(s) and {unknownCount} unknown item(s).",
+            _ => $"Evidence pack has {unknownCount} unknown item(s) requiring operator review."
+        };
+    }
+
+    private static string ToEvidenceState(string level)
+    {
+        if (IsIncompatible(level))
+        {
+            return MigrationEvidenceStates.Fail;
+        }
+
+        return IsPartial(level) ? MigrationEvidenceStates.Unknown : MigrationEvidenceStates.Pass;
+    }
+
+    private static string AggregateState(IEnumerable<string> states)
+    {
+        var materialized = states.Select(NormalizeState).ToArray();
+        if (materialized.Any(static state => state == MigrationEvidenceStates.Fail))
+        {
+            return MigrationEvidenceStates.Fail;
+        }
+
+        if (materialized.Any(static state => state == MigrationEvidenceStates.Unknown))
+        {
+            return MigrationEvidenceStates.Unknown;
+        }
+
+        return MigrationEvidenceStates.Pass;
+    }
+
+    private static string NormalizeState(string state)
+        => state switch
+        {
+            MigrationEvidenceStates.Pass => MigrationEvidenceStates.Pass,
+            MigrationEvidenceStates.Fail => MigrationEvidenceStates.Fail,
+            MigrationEvidenceStates.Unknown => MigrationEvidenceStates.Unknown,
+            MigrationEvidenceStates.NotApplicable => MigrationEvidenceStates.NotApplicable,
+            _ => MigrationEvidenceStates.Unknown
+        };
+
+    private static string[] Order(IEnumerable<string> values)
+        => values
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static value => value, StringComparer.Ordinal)
+            .ToArray();
+
+    private static bool IsPartial(string? level)
+        => string.Equals(level, "partial", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsIncompatible(string? level)
+        => string.Equals(level, "incompatible", StringComparison.OrdinalIgnoreCase);
+
+    private sealed record MigrationCutoverReadinessItemDefinition(string Id, string Title);
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationManifestTranslatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationManifestTranslatorTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+
+namespace Honua.Core.Tests.Features.Import;
+
+public sealed class MigrationManifestTranslatorTests
+{
+    [Fact]
+    public void Translate_WithUnsupportedResource_DoesNotEmitTargetAndRecordsUnsupported()
+    {
+        var inventory = CreateInventory(
+            resources:
+            [
+                CreateResource("workspace:roads", "Roads Layer", "compatible", "Schema can be mapped.", capabilities: ["Query", "Extract"]),
+                CreateResource(
+                    "workspace:coverage",
+                    "Raster Coverage",
+                    "incompatible",
+                    "Coverage layers are not translated by the feature manifest slice.",
+                    code: "GEOSERVER_UNSUPPORTED_COVERAGE",
+                    manualSteps: ["Publish through a raster migration path."])
+            ],
+            styles:
+            [
+                CreateStyle(
+                    "workspace:roads-style",
+                    "partial",
+                    "External graphic requires manual review.",
+                    code: "GEOSERVER_EXTERNAL_GRAPHIC")
+            ]);
+
+        var manifest = MigrationManifestTranslator.Translate(inventory, new MigrationManifestTranslationOptions
+        {
+            TargetServiceName = "Pilot Migration"
+        });
+
+        manifest.TargetResources.Should().ContainSingle(resource => resource.SourceResourceId == "workspace:roads")
+            .Which.Should().Match<MigrationManifestTargetResource>(resource =>
+                resource.Action == "publish" &&
+                resource.TargetServiceName == "pilot-migration" &&
+                resource.TargetResourceName == "roads-layer");
+        manifest.TargetResources.Should().NotContain(resource => resource.SourceResourceId == "workspace:coverage");
+        manifest.UnsupportedItems.Should().ContainSingle(item => item.SourceId == "workspace:coverage")
+            .Which.Should().Match<MigrationManifestReviewItem>(item =>
+                item.Code == "GEOSERVER_UNSUPPORTED_COVERAGE" &&
+                item.Severity == "unsupported" &&
+                item.ManualSteps.SequenceEqual(new[] { "Publish through a raster migration path." }));
+        manifest.StyleActions.Should().ContainSingle(action => action.SourceStyleId == "workspace:roads-style")
+            .Which.Action.Should().Be("manual-review");
+        manifest.ManualReviewItems.Should().ContainSingle(item => item.SourceId == "workspace:roads-style")
+            .Which.Code.Should().Be("GEOSERVER_EXTERNAL_GRAPHIC");
+        manifest.Summary.Should().BeEquivalentTo(new MigrationManifestSummary
+        {
+            SourceResourceCount = 2,
+            TargetResourceCount = 1,
+            StyleActionCount = 1,
+            ManualReviewCount = 1,
+            UnsupportedCount = 1
+        });
+    }
+
+    [Fact]
+    public void Translate_WithPartialResource_EmitsManualReviewTargetAndReviewItem()
+    {
+        var inventory = CreateInventory(
+            resources:
+            [
+                CreateResource(
+                    "service:parcels",
+                    "Parcels",
+                    "partial",
+                    "Coded-value domains require review.",
+                    manualSteps: ["Review field domains before publishing."])
+            ]);
+
+        var manifest = MigrationManifestTranslator.Translate(inventory);
+
+        manifest.TargetResources.Should().ContainSingle()
+            .Which.Should().Match<MigrationManifestTargetResource>(resource =>
+                resource.SourceResourceId == "service:parcels" &&
+                resource.Action == "manual-review" &&
+                resource.TargetServiceName == "migration-source" &&
+                resource.TargetResourceName == "parcels");
+        manifest.ManualReviewItems.Should().ContainSingle()
+            .Which.Should().Match<MigrationManifestReviewItem>(item =>
+                item.SourceId == "service:parcels" &&
+                item.Code == "GEOSERVER_REST_LAYER_PARTIAL" &&
+                item.Severity == "manual-review");
+        manifest.UnsupportedItems.Should().BeEmpty();
+    }
+
+    private static MigrationSourceInventoryArtifact CreateInventory(
+        MigrationInventoryResource[] resources,
+        MigrationInventoryStyle[]? styles = null,
+        MigrationExternalDependency[]? dependencies = null)
+    {
+        var containers = new[]
+        {
+            new MigrationInventoryContainer
+            {
+                Id = "workspace",
+                Kind = "workspace",
+                Name = "workspace",
+                Compatibility = Compatible("Workspace can be represented.")
+            }
+        };
+
+        var styleItems = styles ?? [];
+        var dependencyItems = dependencies ?? [];
+
+        return new MigrationSourceInventoryArtifact
+        {
+            SourceKind = "geoserver-rest",
+            Source = new MigrationSourceIdentity
+            {
+                DisplayName = "Migration Source",
+                BaseUrl = "https://geoserver.example.test/geoserver",
+                Product = "GeoServer",
+                Version = "2.26.0"
+            },
+            AuthPosture = new MigrationInventoryAuthPosture
+            {
+                Mode = "basic",
+                CredentialsSupplied = true,
+                AccessConfirmed = true
+            },
+            ScanCompleteness = new MigrationInventoryCompleteness
+            {
+                Status = "complete"
+            },
+            Summary = new MigrationInventorySummary
+            {
+                ContainerCount = containers.Length,
+                ResourceCount = resources.Length,
+                StyleCount = styleItems.Length,
+                ExternalDependencyCount = dependencyItems.Length,
+                CompatibleCount = resources.Count(resource => resource.Compatibility.Level == "compatible") +
+                    styleItems.Count(style => style.Compatibility.Level == "compatible") +
+                    dependencyItems.Count(dependency => dependency.Compatibility.Level == "compatible") +
+                    containers.Length,
+                PartiallyCompatibleCount = resources.Count(resource => resource.Compatibility.Level == "partial") +
+                    styleItems.Count(style => style.Compatibility.Level == "partial") +
+                    dependencyItems.Count(dependency => dependency.Compatibility.Level == "partial"),
+                IncompatibleCount = resources.Count(resource => resource.Compatibility.Level == "incompatible") +
+                    styleItems.Count(style => style.Compatibility.Level == "incompatible") +
+                    dependencyItems.Count(dependency => dependency.Compatibility.Level == "incompatible")
+            },
+            OverallCompatibility = Compatible("Fixture compatibility is computed per item."),
+            Containers = containers,
+            Resources = resources,
+            Styles = styleItems,
+            ExternalDependencies = dependencyItems
+        };
+    }
+
+    private static MigrationInventoryResource CreateResource(
+        string id,
+        string name,
+        string level,
+        string reason,
+        string? code = null,
+        string[]? capabilities = null,
+        string[]? manualSteps = null)
+        => new()
+        {
+            Id = id,
+            ContainerId = "workspace",
+            Kind = "layer",
+            Name = name,
+            GeometryType = "Point",
+            Capabilities = capabilities ?? ["Query"],
+            Fields =
+            [
+                new MigrationInventoryField
+                {
+                    Name = "name",
+                    FieldType = "string",
+                    Nullable = true
+                }
+            ],
+            Compatibility = Assessment(level, reason, code, manualSteps)
+        };
+
+    private static MigrationInventoryStyle CreateStyle(
+        string id,
+        string level,
+        string reason,
+        string? code = null,
+        string[]? manualSteps = null)
+        => new()
+        {
+            Id = id,
+            ContainerId = "workspace",
+            Kind = "style",
+            Name = id,
+            Format = "sld",
+            ResourceIds = ["workspace:roads"],
+            Compatibility = Assessment(level, reason, code, manualSteps)
+        };
+
+    private static MigrationCompatibilityAssessment Compatible(string reason)
+        => Assessment("compatible", reason);
+
+    private static MigrationCompatibilityAssessment Assessment(
+        string level,
+        string reason,
+        string? code = null,
+        string[]? manualSteps = null)
+        => new()
+        {
+            Level = level,
+            Code = code,
+            Reason = reason,
+            ManualSteps = manualSteps ?? []
+        };
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationParityEvidenceGeneratorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationParityEvidenceGeneratorTests.cs
@@ -1,0 +1,220 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+
+namespace Honua.Core.Tests.Features.Import;
+
+public sealed class MigrationParityEvidenceGeneratorTests
+{
+    [Fact]
+    public void Generate_WithoutReadinessAttestation_LeavesChecklistUnknown()
+    {
+        var inventory = CreateInventory(
+            resources:
+            [
+                CreateResource("workspace:roads", "Roads", "compatible", "Schema can be mapped."),
+                CreateResource(
+                    "workspace:parcels",
+                    "Parcels",
+                    "partial",
+                    "Field domains require manual review.",
+                    manualSteps: ["Confirm domain mapping."])
+            ],
+            styles:
+            [
+                CreateStyle("workspace:roads-style", "partial", "External graphic requires manual review.")
+            ]);
+        var manifest = MigrationManifestTranslator.Translate(inventory);
+
+        var evidence = MigrationParityEvidenceGenerator.Generate(inventory, manifest);
+
+        evidence.ManifestAvailable.Should().BeTrue();
+        evidence.OverallState.Should().Be(MigrationEvidenceStates.Unknown);
+        evidence.Sections.Should().ContainSingle(section => section.Id == "style")
+            .Which.State.Should().Be(MigrationEvidenceStates.Unknown);
+        evidence.Sections.Should().ContainSingle(section => section.Id == "data")
+            .Which.Items.Should().ContainSingle(item => item.Id == "data:workspace:parcels")
+            .Which.Should().Match<MigrationParityEvidenceItem>(item =>
+                item.State == MigrationEvidenceStates.Unknown &&
+                item.Remediation.SequenceEqual(new[] { "Confirm domain mapping." }));
+        evidence.CutoverReadiness.Items.Should().OnlyContain(item =>
+            item.Id == "known-gaps-accepted" || item.State == MigrationEvidenceStates.Unknown);
+    }
+
+    [Fact]
+    public void Generate_WithPassingAttestationAndNoGaps_ReturnsPass()
+    {
+        var inventory = CreateInventory(
+            resources:
+            [
+                CreateResource("workspace:roads", "Roads", "compatible", "Schema can be mapped.")
+            ],
+            styles:
+            [
+                CreateStyle("workspace:roads-style", "compatible", "Style can be imported.")
+            ]);
+        var manifest = MigrationManifestTranslator.Translate(inventory);
+
+        var evidence = MigrationParityEvidenceGenerator.Generate(inventory, manifest, CreatePassingAttestation());
+
+        evidence.OverallState.Should().Be(MigrationEvidenceStates.Pass);
+        evidence.Sections.Should().OnlyContain(section => section.State == MigrationEvidenceStates.Pass);
+        evidence.CutoverReadiness.State.Should().Be(MigrationEvidenceStates.Pass);
+        evidence.CutoverReadiness.Items.Should().OnlyContain(item =>
+            item.State == MigrationEvidenceStates.Pass || item.State == MigrationEvidenceStates.NotApplicable);
+        evidence.CutoverReadiness.Items.Should().ContainSingle(item => item.Id == "known-gaps-accepted")
+            .Which.State.Should().Be(MigrationEvidenceStates.NotApplicable);
+    }
+
+    [Fact]
+    public void Generate_WithoutManifest_DoesNotInferDataSuccess()
+    {
+        var inventory = CreateInventory(
+            resources:
+            [
+                CreateResource("workspace:roads", "Roads", "compatible", "Schema can be mapped.")
+            ]);
+
+        var evidence = MigrationParityEvidenceGenerator.Generate(inventory);
+
+        evidence.ManifestAvailable.Should().BeFalse();
+        evidence.OverallState.Should().Be(MigrationEvidenceStates.Unknown);
+        evidence.Sections.Should().ContainSingle(section => section.Id == "data")
+            .Which.Should().Match<MigrationParityEvidenceSection>(section =>
+                section.State == MigrationEvidenceStates.Unknown &&
+                section.Items.Single().State == MigrationEvidenceStates.Unknown);
+        evidence.CutoverReadiness.Items.Should().ContainSingle(item => item.Id == "manifest-reviewed")
+            .Which.Should().Match<MigrationCutoverReadinessItem>(item =>
+                item.State == MigrationEvidenceStates.Unknown &&
+                item.Remediation.SequenceEqual(new[] { "Generate and review the migration manifest." }));
+    }
+
+    private static MigrationReadinessAttestation CreatePassingAttestation()
+        => new()
+        {
+            Items =
+            [
+                Attest("inventory-confirmed"),
+                Attest("manifest-reviewed"),
+                Attest("parity-report-reviewed"),
+                Attest("rollback-plan-documented"),
+                Attest("traffic-switch-planned")
+            ]
+        };
+
+    private static MigrationReadinessAttestationItem Attest(string id)
+        => new()
+        {
+            Id = id,
+            State = MigrationEvidenceStates.Pass,
+            Evidence = [$"{id} evidence accepted."],
+            Owner = "platform"
+        };
+
+    private static MigrationSourceInventoryArtifact CreateInventory(
+        MigrationInventoryResource[] resources,
+        MigrationInventoryStyle[]? styles = null)
+    {
+        var containers = new[]
+        {
+            new MigrationInventoryContainer
+            {
+                Id = "workspace",
+                Kind = "workspace",
+                Name = "workspace",
+                Compatibility = Compatible("Workspace can be represented.")
+            }
+        };
+        var styleItems = styles ?? [];
+
+        return new MigrationSourceInventoryArtifact
+        {
+            SourceKind = "geoserver-rest",
+            Source = new MigrationSourceIdentity
+            {
+                DisplayName = "Migration Source",
+                BaseUrl = "https://geoserver.example.test/geoserver",
+                Product = "GeoServer",
+                Version = "2.26.0"
+            },
+            AuthPosture = new MigrationInventoryAuthPosture
+            {
+                Mode = "basic",
+                CredentialsSupplied = true,
+                AccessConfirmed = true
+            },
+            ScanCompleteness = new MigrationInventoryCompleteness
+            {
+                Status = "complete"
+            },
+            Summary = new MigrationInventorySummary
+            {
+                ContainerCount = containers.Length,
+                ResourceCount = resources.Length,
+                StyleCount = styleItems.Length,
+                CompatibleCount = resources.Count(resource => resource.Compatibility.Level == "compatible") +
+                    styleItems.Count(style => style.Compatibility.Level == "compatible") +
+                    containers.Length,
+                PartiallyCompatibleCount = resources.Count(resource => resource.Compatibility.Level == "partial") +
+                    styleItems.Count(style => style.Compatibility.Level == "partial"),
+                IncompatibleCount = resources.Count(resource => resource.Compatibility.Level == "incompatible") +
+                    styleItems.Count(style => style.Compatibility.Level == "incompatible")
+            },
+            OverallCompatibility = Compatible("Fixture compatibility is computed per item."),
+            Containers = containers,
+            Resources = resources,
+            Styles = styleItems
+        };
+    }
+
+    private static MigrationInventoryResource CreateResource(
+        string id,
+        string name,
+        string level,
+        string reason,
+        string[]? manualSteps = null)
+        => new()
+        {
+            Id = id,
+            ContainerId = "workspace",
+            Kind = "layer",
+            Name = name,
+            GeometryType = "Point",
+            Capabilities = ["Query", "Extract"],
+            Fields =
+            [
+                new MigrationInventoryField
+                {
+                    Name = "name",
+                    FieldType = "string",
+                    Nullable = true
+                }
+            ],
+            Compatibility = Assessment(level, reason, manualSteps)
+        };
+
+    private static MigrationInventoryStyle CreateStyle(string id, string level, string reason)
+        => new()
+        {
+            Id = id,
+            ContainerId = "workspace",
+            Kind = "style",
+            Name = id,
+            Format = "sld",
+            ResourceIds = ["workspace:roads"],
+            Compatibility = Assessment(level, reason)
+        };
+
+    private static MigrationCompatibilityAssessment Compatible(string reason)
+        => Assessment("compatible", reason);
+
+    private static MigrationCompatibilityAssessment Assessment(string level, string reason, string[]? manualSteps = null)
+        => new()
+        {
+            Level = level,
+            Reason = reason,
+            ManualSteps = manualSteps ?? []
+        };
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #651
Closes #652
Refs #646, #879, #880

## Summary
Adds the stable Core migration manifest and parity evidence contracts for the #646 migration toolkit workstream, plus operator readiness docs/templates for pilot and cutover review.

## Changes Made
- Added `MigrationManifestArtifact` contracts and a deterministic translator from source inventory into target resource, style, manual-review, and unsupported-item intent.
- Added `MigrationParityEvidenceArtifact` contracts and a generator for capability, style, data, and cutover-readiness evidence with explicit `pass`, `fail`, `unknown`, and `not-applicable` states.
- Added Core tests covering unsupported-resource handling, partial-resource review, missing-manifest unknowns, missing readiness attestations, and passing readiness attestations.
- Added operator migration toolkit docs, a pilot/cutover checklist, a JSON readiness attestation template, and links from existing GeoServer/ArcGIS migration docs.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Validation run locally:
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --no-restore --filter "FullyQualifiedName~Migration" --configuration Release --logger "console;verbosity=minimal"`
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --no-restore --configuration Release --logger "console;verbosity=minimal"`
- `dotnet format Honua.sln --verbosity minimal`
- `dotnet format Honua.sln --verify-no-changes --verbosity minimal`
- `git diff --cached --check`
- `jq . docs/operator/examples/migration-cutover-readiness-template.json >/dev/null`

Pre-PR script note: `bash scripts/ci/pre-pr-check.sh` was started locally. It passed restore, build, format verification, Core tests, Load tests, and Postgres tests; I stopped the first local Server shard after more than 20 minutes with no result line. GitHub PR gates are the completion record for the Server shards on this PR.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` through the successful local stages listed above; GitHub PR gates are completing the Server shard coverage.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
