### PR TITLE
feat: Add typed catalog group and saved source descriptor contracts (#869)

### DIFF
--- a/docs/developer/SDK_COMPATIBILITY_METADATA.md
+++ b/docs/developer/SDK_COMPATIBILITY_METADATA.md
@@ -14,6 +14,17 @@ Example response fragment:
 {
   "success": true,
   "data": {
+    "resourceKinds": [
+      "Service",
+      "Layer",
+      "Relationship",
+      "Style",
+      "Connection",
+      "MapTemplate",
+      "Theme",
+      "Group",
+      "SourceDescriptor"
+    ],
     "compatibility": {
       "serverVersion": "1.2.3",
       "releaseChannel": "stable",
@@ -52,6 +63,37 @@ Example response fragment:
 4. Prefer the newest `metadataSchemas` entry where `deprecated` is `false`.
 5. Use `features` for coarse branches such as manifest workflows instead of probing endpoints.
 6. Treat `releaseChannel` as rollout metadata and `serverVersion` as a minimum-version floor within the same major, not as the full feature contract.
+
+## Catalog Metadata Kinds
+
+`data.resourceKinds` advertises the metadata-resource kinds available through the generic CRUD surface. For catalog clients, `Group` and `SourceDescriptor` are first-class `honua.io/v1alpha1` kinds:
+
+- `Group`: use `metadata.name` and `metadata.namespace` as the group identity. `spec.description` is optional display text.
+- `SourceDescriptor`: store the SDK source descriptor in `spec.sourceDescriptor`. The descriptor must include non-empty `id` and `protocol` strings. Optional `locator`, `capabilities`, `schema`, and `attribution` fields follow `Honua.Sdk.Abstractions.Features.SourceDescriptor`.
+
+Example `SourceDescriptor` metadata resource:
+
+```json
+{
+  "apiVersion": "honua.io/v1alpha1",
+  "kind": "SourceDescriptor",
+  "metadata": {
+    "name": "parks-source",
+    "namespace": "default"
+  },
+  "spec": {
+    "sourceDescriptor": {
+      "id": "parks-source",
+      "protocol": "geoservices-feature-service",
+      "locator": {
+        "serviceId": "parks",
+        "layerId": 0
+      },
+      "capabilities": ["Query"]
+    }
+  }
+}
+```
 
 ## Minimum Version Check Rule
 

--- a/docs/operator/CONTROL_PLANE_API.md
+++ b/docs/operator/CONTROL_PLANE_API.md
@@ -453,6 +453,12 @@ The public `GET /api/styles/{layerId}.json` endpoint accepts an optional `?theme
 | `/api/v1/admin/metadata/layers/{layerId}/style/export-sld` | GET | Export the stored MapLibre style as an `application/xml` SLD 1.0 document. Diagnostic count surfaces in the `X-Sld-Diagnostic-Count` response header. |
 | `/api/styles/{layerId}.json` | GET | Public MapLibre style fetch with optional `?theme=default\|dark\|colorblind-safe\|print` deterministic transform; output cache varies per theme. |
 
+`Group` and `SourceDescriptor` are stable `honua.io/v1alpha1` metadata resource kinds on the generic CRUD surface. SDKs can list them with `GET /api/v1/admin/metadata/resources?kind=Group` and `GET /api/v1/admin/metadata/resources?kind=SourceDescriptor` instead of probing undocumented catalog endpoints.
+
+`Group` resources use `metadata.name` and `metadata.namespace` as the stable group identity. `spec.description` is optional and should contain the human-readable group summary when present.
+
+`SourceDescriptor` resources must store the SDK descriptor in `spec.sourceDescriptor`. The descriptor object must include non-empty `id` and `protocol` strings aligned with `Honua.Sdk.Abstractions.Features.SourceDescriptor`; optional `locator`, `capabilities`, `schema`, and `attribution` fields follow the SDK shape.
+
 ### **SDK Compatibility Handshake**
 
 SDKs should call `GET /api/v1/admin/capabilities` once per authenticated session and cache the `data.compatibility` object.

--- a/src/Honua.Core/Features/Metadata/Domain/MetadataResourceKinds.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/MetadataResourceKinds.cs
@@ -44,6 +44,16 @@ public static class MetadataResourceKinds
     public const string Theme = "Theme";
 
     /// <summary>
+    /// Catalog group resource kind.
+    /// </summary>
+    public const string Group = "Group";
+
+    /// <summary>
+    /// Saved SDK source descriptor resource kind.
+    /// </summary>
+    public const string SourceDescriptor = "SourceDescriptor";
+
+    /// <summary>
     /// All supported resource kinds.
     /// </summary>
     public static readonly IReadOnlyList<string> All =
@@ -54,6 +64,8 @@ public static class MetadataResourceKinds
         Style,
         Connection,
         MapTemplate,
-        Theme
+        Theme,
+        Group,
+        SourceDescriptor
     ];
 }

--- a/src/Honua.Core/Features/Metadata/Schema/MetadataSchemaRegistry.cs
+++ b/src/Honua.Core/Features/Metadata/Schema/MetadataSchemaRegistry.cs
@@ -117,6 +117,12 @@ public sealed class MetadataSchemaRegistry : IMetadataSchemaRegistry
             }
         }
 
+        if (errors.Count == 0 &&
+            string.Equals(schema.Kind, MetadataResourceKinds.SourceDescriptor, StringComparison.OrdinalIgnoreCase))
+        {
+            ValidateSourceDescriptorSpec(resource.Spec, errors);
+        }
+
         if (errors.Count > 0)
         {
             return new MetadataSchemaValidationResult(false, null, errors, wasUpConverted);
@@ -220,6 +226,18 @@ public sealed class MetadataSchemaRegistry : IMetadataSchemaRegistry
                 Kind = MetadataResourceKinds.Theme,
                 Description = "Theme metadata resource",
                 RequiredSpecFields = new[] { "name" }
+            },
+            new ResourceSchemaDefinition
+            {
+                ApiVersion = CurrentVersion,
+                Kind = MetadataResourceKinds.Group,
+                Description = "Catalog group metadata resource"
+            },
+            new ResourceSchemaDefinition
+            {
+                ApiVersion = CurrentVersion,
+                Kind = MetadataResourceKinds.SourceDescriptor,
+                Description = "Saved SDK source descriptor metadata resource"
             }
         };
 
@@ -233,6 +251,65 @@ public sealed class MetadataSchemaRegistry : IMetadataSchemaRegistry
         }
 
         return registry;
+    }
+
+    private static void ValidateSourceDescriptorSpec(JsonElement spec, List<string> errors)
+    {
+        if (!spec.TryGetProperty("sourceDescriptor", out var descriptor))
+        {
+            errors.Add("spec.sourceDescriptor is required.");
+            return;
+        }
+
+        if (descriptor.ValueKind != JsonValueKind.Object)
+        {
+            errors.Add("spec.sourceDescriptor must be a JSON object.");
+            return;
+        }
+
+        ValidateRequiredString(descriptor, "id", "spec.sourceDescriptor.id", errors);
+        ValidateRequiredString(descriptor, "protocol", "spec.sourceDescriptor.protocol", errors);
+
+        if (descriptor.TryGetProperty("locator", out var locator) &&
+            locator.ValueKind != JsonValueKind.Object)
+        {
+            errors.Add("spec.sourceDescriptor.locator must be a JSON object.");
+        }
+
+        if (descriptor.TryGetProperty("capabilities", out var capabilities))
+        {
+            if (capabilities.ValueKind != JsonValueKind.Array)
+            {
+                errors.Add("spec.sourceDescriptor.capabilities must be a JSON array.");
+            }
+            else
+            {
+                foreach (var capability in capabilities.EnumerateArray())
+                {
+                    if (capability.ValueKind != JsonValueKind.String)
+                    {
+                        errors.Add("spec.sourceDescriptor.capabilities entries must be strings.");
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (descriptor.TryGetProperty("schema", out var sourceSchema) &&
+            sourceSchema.ValueKind != JsonValueKind.Object)
+        {
+            errors.Add("spec.sourceDescriptor.schema must be a JSON object.");
+        }
+    }
+
+    private static void ValidateRequiredString(JsonElement element, string propertyName, string path, List<string> errors)
+    {
+        if (!element.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind != JsonValueKind.String ||
+            string.IsNullOrWhiteSpace(property.GetString()))
+        {
+            errors.Add($"{path} is required.");
+        }
     }
 
     private sealed class ApiKindComparer : IEqualityComparer<(string ApiVersion, string Kind)>

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/MetadataSchemaRegistryPackagingTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/MetadataSchemaRegistryPackagingTests.cs
@@ -34,6 +34,20 @@ public sealed class MetadataSchemaRegistryPackagingTests
 
     [UnitTest]
     [Operation(Operations.Query)]
+    public void MetadataResourceKinds_All_ContainsGroup()
+    {
+        MetadataResourceKinds.All.Should().Contain("Group");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void MetadataResourceKinds_All_ContainsSourceDescriptor()
+    {
+        MetadataResourceKinds.All.Should().Contain("SourceDescriptor");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
     public void ValidateAndUpgrade_MapTemplate_WithRequiredFields_Succeeds()
     {
         var resource = CreateResource("MapTemplate", """{"name":"Base Topo","category":"basemap"}""");
@@ -94,6 +108,90 @@ public sealed class MetadataSchemaRegistryPackagingTests
 
     [UnitTest]
     [Operation(Operations.Query)]
+    public void ValidateAndUpgrade_Group_WithEmptySpec_Succeeds()
+    {
+        var resource = CreateResource("Group", """{}""");
+
+        var result = _registry.ValidateAndUpgrade(resource);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void ValidateAndUpgrade_SourceDescriptor_WithRequiredFields_Succeeds()
+    {
+        var resource = CreateResource(
+            "SourceDescriptor",
+            """
+            {
+              "sourceDescriptor": {
+                "id": "parks-source",
+                "protocol": "geoservices-feature-service",
+                "locator": {
+                  "serviceId": "parks",
+                  "layerId": 0
+                },
+                "capabilities": ["Query"]
+              }
+            }
+            """);
+
+        var result = _registry.ValidateAndUpgrade(resource);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void ValidateAndUpgrade_SourceDescriptor_MissingProtocol_Fails()
+    {
+        var resource = CreateResource(
+            "SourceDescriptor",
+            """
+            {
+              "sourceDescriptor": {
+                "id": "parks-source",
+                "locator": {
+                  "serviceId": "parks",
+                  "layerId": 0
+                }
+              }
+            }
+            """);
+
+        var result = _registry.ValidateAndUpgrade(resource);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("spec.sourceDescriptor.protocol"));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void ValidateAndUpgrade_SourceDescriptor_NonStringCapability_Fails()
+    {
+        var resource = CreateResource(
+            "SourceDescriptor",
+            """
+            {
+              "sourceDescriptor": {
+                "id": "parks-source",
+                "protocol": "geoservices-feature-service",
+                "capabilities": ["Query", 42]
+              }
+            }
+            """);
+
+        var result = _registry.ValidateAndUpgrade(resource);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("capabilities entries"));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
     public void ValidateAndUpgrade_Style_StillValidates()
     {
         var resource = CreateResource("Style", """{"layerId":"layer-1","style":{"type":"fill"}}""");
@@ -128,6 +226,24 @@ public sealed class MetadataSchemaRegistryPackagingTests
     public void GetSupportedApiVersions_Theme_ReturnsCurrentVersion()
     {
         var versions = _registry.GetSupportedApiVersions("Theme");
+
+        versions.Should().ContainSingle().Which.Should().Be(MetadataSchemaRegistry.CurrentVersion);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void GetSupportedApiVersions_Group_ReturnsCurrentVersion()
+    {
+        var versions = _registry.GetSupportedApiVersions("Group");
+
+        versions.Should().ContainSingle().Which.Should().Be(MetadataSchemaRegistry.CurrentVersion);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void GetSupportedApiVersions_SourceDescriptor_ReturnsCurrentVersion()
+    {
+        var versions = _registry.GetSupportedApiVersions("SourceDescriptor");
 
         versions.Should().ContainSingle().Which.Should().Be(MetadataSchemaRegistry.CurrentVersion);
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataResourceEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataResourceEndpointsTests.cs
@@ -21,6 +21,9 @@ namespace Honua.Server.Tests.Features.Admin;
 [Collection("Database")]
 public sealed class MetadataResourceEndpointsTests : IAsyncLifetime
 {
+    private static readonly string[] _queryCapabilities = ["Query"];
+    private static readonly string[] _queryEditingCapabilities = ["Query", "Editing"];
+
     private readonly WebAppFixture _fixture = new();
 
     public Task InitializeAsync() => _fixture.InitializeAsync();
@@ -66,6 +69,8 @@ public sealed class MetadataResourceEndpointsTests : IAsyncLifetime
         apiResponse!.Success.Should().BeTrue();
         apiResponse.Data.Should().NotBeNull();
         apiResponse.Data!.ResourceKinds.Should().Contain(MetadataResourceKinds.Layer);
+        apiResponse.Data.ResourceKinds.Should().Contain(MetadataResourceKinds.Group);
+        apiResponse.Data.ResourceKinds.Should().Contain(MetadataResourceKinds.SourceDescriptor);
         apiResponse.Data.MetadataApiVersions.Should().Contain(MetadataSchemaRegistry.CurrentVersion);
         apiResponse.Data.Compatibility.ServerVersion.Should().NotBeNullOrWhiteSpace();
         apiResponse.Data.Compatibility.ReleaseChannel.Should().NotBeNullOrWhiteSpace();
@@ -288,6 +293,138 @@ public sealed class MetadataResourceEndpointsTests : IAsyncLifetime
         deleteResponse.Be200Ok();
     }
 
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("POST /api/v1/admin/metadata/resources")]
+    [Endpoint("GET /api/v1/admin/metadata/resources")]
+    [Endpoint("GET /api/v1/admin/metadata/resources/{kind}/{namespace}/{name}")]
+    [Endpoint("PUT /api/v1/admin/metadata/resources/{kind}/{namespace}/{name}")]
+    public async Task MetadataResourceCrud_WithCatalogGroupAndSourceDescriptor_RoundTrips()
+    {
+        var client = _fixture.CreateAdminClient();
+        var group = CreateGroupResource();
+        var sourceDescriptor = CreateSourceDescriptorResource();
+
+        var createGroupResponse = await client.PostAsync(
+            "/api/v1/admin/metadata/resources",
+            JsonContent.Create(group, MetadataResourceJsonContext.Default.MetadataResource));
+        createGroupResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.Created);
+
+        var createSourceDescriptorResponse = await client.PostAsync(
+            "/api/v1/admin/metadata/resources",
+            JsonContent.Create(sourceDescriptor, MetadataResourceJsonContext.Default.MetadataResource));
+        createSourceDescriptorResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.Created);
+
+        var listGroupsResponse = await client.GetAsync("/api/v1/admin/metadata/resources?kind=Group&namespace=default");
+        listGroupsResponse.Be200Ok();
+        var groupsPayload = await listGroupsResponse.Content.ReadAsStringAsync();
+        var groups = JsonSerializer.Deserialize(
+            groupsPayload,
+            MetadataResourceJsonContext.Default.ApiResponseMetadataResourceArray);
+        groups.Should().NotBeNull();
+        groups!.Data.Should().Contain(resource =>
+            resource.Kind == MetadataResourceKinds.Group &&
+            resource.Metadata != null &&
+            resource.Metadata.Name == group.Metadata!.Name);
+
+        var getGroupResponse = await client.GetAsync($"/api/v1/admin/metadata/resources/Group/default/{group.Metadata!.Name}");
+        getGroupResponse.Be200Ok();
+        var groupEtag = getGroupResponse.Headers.ETag?.ToString();
+        groupEtag.Should().NotBeNullOrEmpty();
+
+        var updatedGroup = CreateGroupResource(
+            group.Metadata!.Name,
+            JsonSerializer.SerializeToElement(new
+            {
+                description = "Updated field operations catalog group"
+            }));
+        var updateGroupRequest = new HttpRequestMessage(
+            HttpMethod.Put,
+            $"/api/v1/admin/metadata/resources/Group/default/{group.Metadata!.Name}")
+        {
+            Content = JsonContent.Create(updatedGroup, MetadataResourceJsonContext.Default.MetadataResource)
+        };
+        updateGroupRequest.Headers.TryAddWithoutValidation("If-Match", groupEtag);
+
+        var updateGroupResponse = await client.SendAsync(updateGroupRequest);
+        updateGroupResponse.Be200Ok();
+
+        var getSourceDescriptorResponse = await client.GetAsync(
+            $"/api/v1/admin/metadata/resources/SourceDescriptor/default/{sourceDescriptor.Metadata!.Name}");
+        getSourceDescriptorResponse.Be200Ok();
+        var sourceDescriptorEtag = getSourceDescriptorResponse.Headers.ETag?.ToString();
+        sourceDescriptorEtag.Should().NotBeNullOrEmpty();
+        var sourceDescriptorPayload = await getSourceDescriptorResponse.Content.ReadAsStringAsync();
+        var sourceDescriptorResource = JsonSerializer.Deserialize(
+            sourceDescriptorPayload,
+            MetadataResourceJsonContext.Default.ApiResponseMetadataResource);
+        sourceDescriptorResource.Should().NotBeNull();
+        sourceDescriptorResource!.Data!.Spec
+            .GetProperty("sourceDescriptor")
+            .GetProperty("protocol")
+            .GetString()
+            .Should()
+            .Be("geoservices-feature-service");
+
+        var updatedSourceDescriptor = CreateSourceDescriptorResource(
+            sourceDescriptor.Metadata!.Name,
+            JsonSerializer.SerializeToElement(new
+            {
+                sourceDescriptor = new
+                {
+                    id = "parks-source",
+                    protocol = "geoservices-feature-service",
+                    locator = new { serviceId = "parks", layerId = 0 },
+                    capabilities = _queryEditingCapabilities,
+                    attribution = "City GIS"
+                }
+            }));
+        var updateSourceDescriptorRequest = new HttpRequestMessage(
+            HttpMethod.Put,
+            $"/api/v1/admin/metadata/resources/SourceDescriptor/default/{sourceDescriptor.Metadata!.Name}")
+        {
+            Content = JsonContent.Create(updatedSourceDescriptor, MetadataResourceJsonContext.Default.MetadataResource)
+        };
+        updateSourceDescriptorRequest.Headers.TryAddWithoutValidation("If-Match", sourceDescriptorEtag);
+
+        var updateSourceDescriptorResponse = await client.SendAsync(updateSourceDescriptorRequest);
+        updateSourceDescriptorResponse.Be200Ok();
+
+        var listSourceDescriptorsResponse = await client.GetAsync("/api/v1/admin/metadata/resources?kind=SourceDescriptor&namespace=default");
+        listSourceDescriptorsResponse.Be200Ok();
+        var sourceDescriptorsPayload = await listSourceDescriptorsResponse.Content.ReadAsStringAsync();
+        var sourceDescriptors = JsonSerializer.Deserialize(
+            sourceDescriptorsPayload,
+            MetadataResourceJsonContext.Default.ApiResponseMetadataResourceArray);
+        sourceDescriptors.Should().NotBeNull();
+        sourceDescriptors!.Data.Should().Contain(resource =>
+            resource.Kind == MetadataResourceKinds.SourceDescriptor &&
+            resource.Metadata != null &&
+            resource.Metadata.Name == sourceDescriptor.Metadata!.Name);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("POST /api/v1/admin/metadata/resources")]
+    public async Task CreateMetadataResource_WithInvalidSourceDescriptor_ReturnsBadRequest()
+    {
+        var client = _fixture.CreateAdminClient();
+        var resource = CreateSourceDescriptorResource(
+            spec: JsonSerializer.SerializeToElement(new
+            {
+                sourceDescriptor = new
+                {
+                    id = "broken-source"
+                }
+            }));
+
+        var response = await client.PostAsync(
+            "/api/v1/admin/metadata/resources",
+            JsonContent.Create(resource, MetadataResourceJsonContext.Default.MetadataResource));
+
+        response.HaveStatusCode(System.Net.HttpStatusCode.BadRequest);
+    }
+
     private static MetadataResource CreateLayerResource(
         string? name = null,
         JsonElement? spec = null,
@@ -306,6 +443,58 @@ public sealed class MetadataResourceEndpointsTests : IAsyncLifetime
         {
             ApiVersion = apiVersion ?? MetadataSchemaRegistry.CurrentVersion,
             Kind = MetadataResourceKinds.Layer,
+            Metadata = new ResourceMetadata
+            {
+                Name = resourceName,
+                Namespace = "default"
+            },
+            Spec = resourceSpec
+        };
+    }
+
+    private static MetadataResource CreateGroupResource(
+        string? name = null,
+        JsonElement? spec = null)
+    {
+        var resourceName = name ?? $"group-{Guid.NewGuid():N}";
+        var resourceSpec = spec ?? JsonSerializer.SerializeToElement(new
+        {
+            description = "Field operations catalog group"
+        });
+
+        return new MetadataResource
+        {
+            ApiVersion = MetadataSchemaRegistry.CurrentVersion,
+            Kind = MetadataResourceKinds.Group,
+            Metadata = new ResourceMetadata
+            {
+                Name = resourceName,
+                Namespace = "default"
+            },
+            Spec = resourceSpec
+        };
+    }
+
+    private static MetadataResource CreateSourceDescriptorResource(
+        string? name = null,
+        JsonElement? spec = null)
+    {
+        var resourceName = name ?? $"source-{Guid.NewGuid():N}";
+        var resourceSpec = spec ?? JsonSerializer.SerializeToElement(new
+        {
+            sourceDescriptor = new
+            {
+                id = "parks-source",
+                protocol = "geoservices-feature-service",
+                locator = new { serviceId = "parks", layerId = 0 },
+                capabilities = _queryCapabilities
+            }
+        });
+
+        return new MetadataResource
+        {
+            ApiVersion = MetadataSchemaRegistry.CurrentVersion,
+            Kind = MetadataResourceKinds.SourceDescriptor,
             Metadata = new ResourceMetadata
             {
                 Name = resourceName,


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #869
## Summary

Added `Group` and `SourceDescriptor` as supported `honua.io/v1alpha1` metadata resource kinds in `Honua.Core`, registered them in the schema registry, and added SourceDescriptor validation for canonical `spec.sourceDescriptor` payloads.
## Changes Made

- Added `Group` and `SourceDescriptor` as supported `honua.io/v1alpha1` metadata resource kinds in `Honua.Core`, registered them in the schema registry, and added SourceDescriptor validation for canonical `spec.sourceDescriptor` payloads.
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/ci/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
