### PR TITLE
fix: align mobile offline fixture seed with server schema

### DIFF
--- a/docs/developer/mobile-offline-demo-fixture.md
+++ b/docs/developer/mobile-offline-demo-fixture.md
@@ -14,7 +14,7 @@ This fixture gives mobile and SDK agents a deterministic Honua server dataset fo
 - Package id: `mobile-offline-field-ops-v1`
 - Extent: `[-158.1250, 21.2600, -157.7000, 21.5200]`
 
-The service metadata stores a provisional offline manifest under `metadata.demoFixture.offlinePackageManifest`. The layer metadata stores form/schema hints under `metadata.form` and per-layer offline hints under `metadata.offline`.
+The service metadata stores a provisional offline manifest under `metadata.demoFixture.offlinePackageManifest`. The layer metadata stores form/schema hints under `metadata.form` and per-layer offline hints under `metadata.offline`. The fixture is intentionally public and sets `accessPolicy.allowAnonymousWrite=true` so disconnected edit, replica, and conflict harnesses can run against local and staging demo stacks without cloud-only credentials.
 
 ## Local Run
 
@@ -50,7 +50,7 @@ Apply the conflict delta only after the mobile harness has downloaded the baseli
 psql "$HONUA_DATABASE_URL" -v ON_ERROR_STOP=1 -f tests/seed/mobile-offline-demo-conflict-delta.sql
 ```
 
-Rerunning the baseline seed resets the fixture. The seed deletes only `mobile_offline_demo`, layers `68910`/`68920`, and the fixture-owned feature IDs before reinserting the baseline state.
+Rerunning the baseline seed resets the fixture. The seed deletes only `mobile_offline_demo`, layers `68910`/`68920`, and the fixture-owned feature IDs before reinserting the baseline state. It also applies idempotent catalog-column compatibility DDL for older demo images before inserting rows, aligning them with the canonical provider-binding columns used by current migrations.
 
 ## API Smoke Paths
 

--- a/tests/dotnet/Honua.Server.Tests/DatabaseMigrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/DatabaseMigrationTests.cs
@@ -148,6 +148,90 @@ public sealed class DatabaseMigrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task DbUpMigrations_MobileOfflineDemoSeed_AppliesToCanonicalSchema()
+    {
+        // Arrange
+        var connectionStringBuilder = new Npgsql.NpgsqlConnectionStringBuilder(_connectionString)
+        {
+            SearchPath = $"{_schemaName},public"
+        };
+
+        var upgrader = DeployChanges.To
+            .PostgresqlDatabase(connectionStringBuilder.ToString(), _schemaName)
+            .JournalToPostgresqlTable(_schemaName, "schema_versions")
+            .WithScriptsEmbeddedInAssembly(Assembly.GetAssembly(typeof(Program))!)
+            .WithTransaction()
+            .Build();
+
+        var migrationResult = upgrader.PerformUpgrade();
+        migrationResult.Successful.Should().BeTrue($"migrations should complete successfully. Error: {migrationResult.Error}");
+
+        var baselineSeedPath = ResolveRepositoryPath("tests/seed/mobile-offline-demo-v1.sql");
+        var conflictSeedPath = ResolveRepositoryPath("tests/seed/mobile-offline-demo-conflict-delta.sql");
+
+        await using var connection = await _postgres.GetConnectionAsync(_schemaName);
+
+        // Act
+        await ExecuteSqlFileAsync(connection, baselineSeedPath);
+        await ExecuteSqlFileAsync(connection, conflictSeedPath);
+
+        // Assert
+        await using var countCmd = connection.CreateCommand();
+        countCmd.CommandText = """
+            SELECT COUNT(*)
+            FROM features
+            WHERE layer_id IN (68910, 68920)
+            """;
+        var featureCount = (long)(await countCmd.ExecuteScalarAsync())!;
+        featureCount.Should().Be(5, "mobile offline baseline should seed the deterministic edit and context records");
+
+        await using var conflictCmd = connection.CreateCommand();
+        conflictCmd.CommandText = """
+            SELECT attributes ->> 'sync_version'
+            FROM features
+            WHERE layer_id = 68910
+              AND objectid = 6891002
+            """;
+        var syncVersion = (string?)await conflictCmd.ExecuteScalarAsync();
+        syncVersion.Should().Be("2", "conflict delta should advance the deterministic server-side conflict target");
+
+        await using var serviceCmd = connection.CreateCommand();
+        serviceCmd.CommandText = """
+            SELECT COUNT(*)
+            FROM honua.services s
+            JOIN honua.service_layers sl ON sl.service_name = s.service_name
+            JOIN honua.layers l ON l.layer_id = sl.layer_id
+            WHERE s.service_name = 'mobile_offline_demo'
+              AND l.layer_id IN (68910, 68920)
+            """;
+        var serviceLayerCount = (long)(await serviceCmd.ExecuteScalarAsync())!;
+        serviceLayerCount.Should().Be(2, "fixture service should expose both mobile offline layers");
+
+        await using var accessPolicyCmd = connection.CreateCommand();
+        accessPolicyCmd.CommandText = """
+            SELECT metadata #>> '{accessPolicy,allowAnonymousWrite}'
+            FROM honua.services
+            WHERE service_name = 'mobile_offline_demo'
+            """;
+        var allowAnonymousWrite = (string?)await accessPolicyCmd.ExecuteScalarAsync();
+        allowAnonymousWrite.Should().Be("true", "fixture writes and replica sync should not require cloud-only credentials");
+
+        await using var storageCmd = connection.CreateCommand();
+        storageCmd.CommandText = """
+            SELECT COUNT(*)
+            FROM honua.layers
+            WHERE layer_id IN (68910, 68920)
+              AND table_schema = 'public'
+              AND table_name = 'features'
+              AND primary_key_column = 'objectid'
+              AND geometry_column = 'geometry'
+              AND storage_srid = 4326
+            """;
+        var storageBindingCount = (long)(await storageCmd.ExecuteScalarAsync())!;
+        storageBindingCount.Should().Be(2, "fixture layers should declare provider-ready storage bindings");
+    }
+
+    [Fact]
     public async Task DbUpMigrations_WithInvalidConnectionString_FailsGracefully()
     {
         // Arrange
@@ -164,5 +248,28 @@ public sealed class DatabaseMigrationTests : IAsyncLifetime
         // Assert
         result.Successful.Should().BeFalse("migration should fail with invalid connection");
         result.Error.Should().NotBeNull("error details should be provided");
+    }
+
+    private static string ResolveRepositoryPath(string relativePath)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Honua.sln")))
+            {
+                return Path.Combine(directory.FullName, relativePath);
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException($"Unable to locate repository root for {relativePath}.");
+    }
+
+    private static async Task ExecuteSqlFileAsync(Npgsql.NpgsqlConnection connection, string path)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = await File.ReadAllTextAsync(path);
+        await command.ExecuteNonQueryAsync();
     }
 }

--- a/tests/seed/mobile-offline-demo-v1.sql
+++ b/tests/seed/mobile-offline-demo-v1.sql
@@ -7,6 +7,33 @@
 
 BEGIN;
 
+ALTER TABLE IF EXISTS honua.services
+    ADD COLUMN IF NOT EXISTS metadata JSONB;
+
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS table_schema TEXT NOT NULL DEFAULT current_schema();
+
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS primary_key_column TEXT NOT NULL DEFAULT 'objectid';
+
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS geometry_column TEXT DEFAULT 'geometry';
+
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS storage_srid INT;
+
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS temporal_column TEXT;
+
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS storage_options JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS metadata JSONB;
+
+ALTER TABLE IF EXISTS honua.layers
+    ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
 DELETE FROM honua.service_layers
 WHERE service_name = 'mobile_offline_demo';
 
@@ -27,7 +54,6 @@ INSERT INTO honua.services (
     service_name,
     description,
     srid,
-    max_record_count,
     supported_formats,
     capabilities,
     service_extent,
@@ -37,12 +63,11 @@ VALUES (
     'mobile_offline_demo',
     'Deterministic SDK-backed mobile offline field operations fixture',
     4326,
-    100,
     ARRAY['JSON', 'GeoJSON'],
     ARRAY['Query', 'Extract', 'Create', 'Update', 'Delete', 'Sync'],
     ST_MakeEnvelope(-158.1250, 21.2600, -157.7000, 21.5200, 4326),
     jsonb_build_object(
-        'accessPolicy', jsonb_build_object('allowAnonymous', true),
+        'accessPolicy', jsonb_build_object('allowAnonymous', true, 'allowAnonymousWrite', true),
         'demoFixture', jsonb_build_object(
             'id', 'mobile-offline-field-ops-v1',
             'issue', 'honua-server#895',
@@ -99,6 +124,7 @@ INSERT INTO honua.layers (
     table_name,
     primary_key_column,
     geometry_column,
+    storage_srid,
     temporal_column,
     geometry_type,
     srid,
@@ -116,6 +142,7 @@ VALUES
         'features',
         'objectid',
         'geometry',
+        4326,
         'inspection_date',
         'Point',
         4326,
@@ -156,6 +183,7 @@ VALUES
         'features',
         'objectid',
         'geometry',
+        4326,
         NULL,
         'Polygon',
         4326,


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #895

## Summary
Aligns the SDK-backed mobile offline demo fixture with the canonical Honua Server schema and older demo images so the seed can be provisioned reliably for mobile live-image/offline package testing.

## Changes Made
- Removed the obsolete `honua.services.max_record_count` fixture insert.
- Added idempotent catalog-column compatibility DDL and explicit layer storage bindings for provider-ready schema alignment.
- Marked the demo service write-capable for public fixture workflows and documented the provisioning/reset behavior.
- Added a migration-backed regression test that applies the baseline fixture and conflict delta.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Verification Notes
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~DatabaseMigrationTests.DbUpMigrations_MobileOfflineDemoSeed_AppliesToCanonicalSchema" --logger "console;verbosity=minimal"`
- `scripts/ci/pre-pr-check.sh`
- Mobile live-image probe: fixture seed now applies to `honuaio/honua-server:latest`; remaining failures are broader live-image contract gaps outside this fixture seed (old-image write auth/response shape, attachments, replica response shape, scenes, gRPC transport, routing).
