### PR TITLE
fix: expose serverGen on createReplica

### DIFF
--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -278,6 +278,7 @@ internal static partial class FeatureServerEndpoints
             ReplicaId = replicaId,
             ReplicaName = replicaName,
             SyncModel = syncModel,
+            ServerGen = currentGen,
             Layers = layerIds.Select(id => new ReplicaLayerInfo
             {
                 Id = id,

--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Models/ReplicationModels.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Models/ReplicationModels.cs
@@ -77,6 +77,12 @@ public sealed class CreateReplicaResponse
     public string? SyncModel { get; set; }
 
     /// <summary>
+    /// Current server generation number at creation time.
+    /// </summary>
+    [JsonPropertyName("serverGen")]
+    public long ServerGen { get; set; }
+
+    /// <summary>
     /// Layers included in the replica.
     /// </summary>
     [JsonPropertyName("layers")]

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/GeoServices/FeatureServer/FeatureServerReplicationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/GeoServices/FeatureServer/FeatureServerReplicationTests.cs
@@ -85,6 +85,13 @@ public sealed class FeatureServerReplicationTests : IAsyncLifetime
         root.TryGetProperty("syncModel", out var syncModel).Should().BeTrue();
         syncModel.GetString().Should().Be("perReplica");
 
+        root.TryGetProperty("serverGen", out var serverGen).Should().BeTrue();
+        serverGen.GetInt64().Should().BeGreaterThanOrEqualTo(0);
+
+        root.TryGetProperty("layers", out var layers).Should().BeTrue();
+        var layer = layers.EnumerateArray().Single(item => item.GetProperty("id").GetInt32() == 0);
+        layer.GetProperty("serverGen").GetInt64().Should().Be(serverGen.GetInt64());
+
         root.TryGetProperty("creationDate", out var creationDate).Should().BeTrue();
         creationDate.GetInt64().Should().BeGreaterThan(0);
     }


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #926

## Summary
Adds the top-level `serverGen` field to FeatureServer `createReplica` responses so mobile and SDK replica clients can read the same generation alias exposed by `extractChanges` and `synchronizeReplica`.

## Changes Made
- Added `serverGen` to `CreateReplicaResponse`.
- Populated `serverGen` from the current change-tracking generation used for per-layer replica metadata.
- Extended the FeatureServer replication integration test to assert top-level and per-layer generations match.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Focused local validation:
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~FeatureServerReplicationTests" --logger "console;verbosity=minimal"` passed: 18/18.
- `git diff --check` passed.

Full local validation note:
- `scripts/ci/pre-pr-check.sh` was run locally. It passed restore, Release build, `dotnet format --verify-no-changes`, `Honua.Core.Tests`, `Honua.LoadTests`, and `Honua.Postgres.Tests`, then timed out in the existing `Core` server shard after the configured 20-minute shard timeout. GitHub PR CI is carrying the full gate result.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh`; local run reached the existing Core shard timeout as noted above, with GitHub CI carrying the full gate result
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review