### PR TITLE
fix: expose native gRPC h2c in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,11 @@ LABEL security.non-root="true" \
       org.opencontainers.image.licenses="Elastic-2.0"
 
 ENV ASPNETCORE_ENVIRONMENT=Production \
-    ASPNETCORE_URLS=http://+:8080 \
+    ASPNETCORE_HTTP_PORTS= \
+    Kestrel__Endpoints__Http__Url=http://+:8080 \
+    Kestrel__Endpoints__Http__Protocols=Http1 \
+    Kestrel__Endpoints__Grpc__Url=http://+:8081 \
+    Kestrel__Endpoints__Grpc__Protocols=Http2 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     DOTNET_EnableDiagnostics=0
@@ -151,6 +155,6 @@ ENV ASPNETCORE_ENVIRONMENT=Production \
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
     CMD wget -q -T 5 -O /dev/null http://localhost:8080/healthz/live || exit 1
 
-EXPOSE 8080/tcp
+EXPOSE 8080/tcp 8081/tcp
 
 ENTRYPOINT ["dotnet", "Honua.Server.dll"]

--- a/README.md
+++ b/README.md
@@ -27,16 +27,20 @@ docker compose up -d
 curl http://localhost:8080/healthz/ready
 ```
 
-PostGIS starts automatically. Migrations run on first boot. The server is at `http://localhost:8080`.
+PostGIS starts automatically. Migrations run on first boot. HTTP/1 REST and gRPC-Web are at
+`http://localhost:8080`; native h2c gRPC for SDK/mobile clients is at `http://localhost:8081`.
 
 **Pre-built image** (bring your own PostGIS):
 
 ```bash
-docker run -p 8080:8080 \
+docker run -p 8080:8080 -p 8081:8081 \
   -e ConnectionStrings__DefaultConnection="Host=host.docker.internal;Database=honua;Username=postgres;Password=postgres" \
   -e HONUA_ADMIN_PASSWORD="change-me" \
   honuaio/honua-server:latest
 ```
+
+For `honua-mobile` live image tests against a pre-started server, set
+`HONUA_MOBILE_LIVE_SERVER_GRPC_URL=http://localhost:8081`.
 
 **Kubernetes**:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
         HONUA_INCLUDE_STAC_OPS_DEMO: "true"
     ports:
       - "${HONUA_HTTP_PORT:-8080}:8080"
+      - "${HONUA_GRPC_PORT:-8081}:8081"
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ConnectionStrings__DefaultConnection: "Host=postgres;Database=honua_dev;Username=honua_user;Password=honua_password"
@@ -47,7 +48,10 @@ services:
       FileStorage__AwsS3__SecretAccessKey: "${HONUA_S3_SECRET_ACCESS_KEY:-}"
       Security__ConnectionEncryption__MasterKey: "${HONUA_CONNECTION_ENCRYPTION_MASTER_KEY:-}"
       Security__ConnectionEncryption__Salt: "${HONUA_CONNECTION_ENCRYPTION_SALT:-}"
-      ASPNETCORE_URLS: "http://+:8080"
+      Kestrel__Endpoints__Http__Url: "http://+:8080"
+      Kestrel__Endpoints__Http__Protocols: "Http1"
+      Kestrel__Endpoints__Grpc__Url: "http://+:8081"
+      Kestrel__Endpoints__Grpc__Protocols: "Http2"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/Dockerfile.aot
+++ b/docker/Dockerfile.aot
@@ -122,7 +122,11 @@ LABEL security.non-root="true" \
 
 # Security: Minimal environment variables
 ENV ASPNETCORE_ENVIRONMENT=Production \
-    ASPNETCORE_URLS=http://+:8080 \
+    ASPNETCORE_HTTP_PORTS= \
+    Kestrel__Endpoints__Http__Url=http://+:8080 \
+    Kestrel__Endpoints__Http__Protocols=Http1 \
+    Kestrel__Endpoints__Grpc__Url=http://+:8081 \
+    Kestrel__Endpoints__Grpc__Protocols=Http2 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     DOTNET_EnableDiagnostics=0
@@ -132,7 +136,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
     CMD wget -q -T 5 -O /dev/null http://localhost:8080/healthz/live || exit 1
 
 # Security: Explicit port exposure
-EXPOSE 8080/tcp
+EXPOSE 8080/tcp 8081/tcp
 
 # Security: Use exec form and explicit binary path
 ENTRYPOINT ["/app/Honua.Server"]

--- a/docs/developer/mobile-offline-demo-fixture.md
+++ b/docs/developer/mobile-offline-demo-fixture.md
@@ -30,10 +30,15 @@ scripts/demos/run-mobile-offline-demo.sh conflict-after-download
 
 The conflict scenario pauses after the baseline seed is applied. Download the offline package or create the replica from the mobile harness, then press Enter. The script applies `mobile-offline-demo-conflict-delta.sql`, which advances feature `6891002` from `sync_version = 1` to `sync_version = 2`.
 
+The local demo maps REST/gRPC-Web to `http://localhost:18081` and native h2c gRPC to
+`http://localhost:18082`. When running `honua-mobile` live tests against this demo, set
+`HONUA_MOBILE_LIVE_SERVER_BASE_URL=http://localhost:18081` and
+`HONUA_MOBILE_LIVE_SERVER_GRPC_URL=http://localhost:18082`.
+
 Cleanup uses the same isolated docker-compose pattern as the STAC ops demo:
 
 ```bash
-COMPOSE_PROJECT_NAME=honua-mobile-offline-demo HONUA_HTTP_PORT=18081 POSTGRES_PORT=55433 docker compose -f docker-compose.yml --project-directory . down --remove-orphans --volumes
+COMPOSE_PROJECT_NAME=honua-mobile-offline-demo HONUA_HTTP_PORT=18081 HONUA_GRPC_PORT=18082 POSTGRES_PORT=55433 docker compose -f docker-compose.yml --project-directory . down --remove-orphans --volumes
 ```
 
 ## Cloud Or Staging Provisioning

--- a/docs/operator/DEPLOYMENT_SCENARIOS.md
+++ b/docs/operator/DEPLOYMENT_SCENARIOS.md
@@ -23,7 +23,7 @@ Use these quick signals:
 services:
   honua:
     image: honuaio/honua-server:latest
-    ports: ["8080:8080"]
+    ports: ["8080:8080", "8081:8081"]
     environment:
       - ConnectionStrings__DefaultConnection=Host=postgres;Database=honua;Username=honua;Password=honua_password
     depends_on: [postgres]
@@ -44,6 +44,7 @@ curl http://localhost:8080/healthz/ready
 
 **Notes:**
 - Use local volumes for data.
+- Port `8080` is HTTP/1 REST and gRPC-Web; port `8081` is native h2c gRPC for SDK/mobile clients.
 - No HA or backup automation in this setup.
 
 ---

--- a/docs/operator/docker-compose.md
+++ b/docs/operator/docker-compose.md
@@ -22,6 +22,11 @@ Container layout is intentional:
 docker compose up -d
 ```
 
+The compose stack publishes two Honua ports:
+
+- `HONUA_HTTP_PORT` maps to container `8080` for HTTP/1 REST, browser traffic, health checks, and gRPC-Web.
+- `HONUA_GRPC_PORT` maps to container `8081` for native cleartext HTTP/2 gRPC (h2c). Use this URL for SDK/mobile clients that do not use gRPC-Web.
+
 The default local database credentials are:
 
 - database: `honua_dev`
@@ -52,6 +57,12 @@ docker compose --profile minio up -d
 
 ```bash
 curl http://localhost:8080/healthz/live
+```
+
+For `honua-mobile` live tests against this stack, set:
+
+```bash
+HONUA_MOBILE_LIVE_SERVER_GRPC_URL=http://localhost:${HONUA_GRPC_PORT:-8081}
 ```
 
 ## Shutdown

--- a/scripts/demos/run-mobile-offline-demo.sh
+++ b/scripts/demos/run-mobile-offline-demo.sh
@@ -31,11 +31,13 @@ fi
 
 export COMPOSE_PROJECT_NAME="${HONUA_MOBILE_OFFLINE_DEMO_PROJECT:-honua-mobile-offline-demo}"
 export HONUA_HTTP_PORT="${HONUA_MOBILE_OFFLINE_DEMO_HTTP_PORT:-18081}"
+export HONUA_GRPC_PORT="${HONUA_MOBILE_OFFLINE_DEMO_GRPC_PORT:-18082}"
 export POSTGRES_PORT="${HONUA_MOBILE_OFFLINE_DEMO_POSTGRES_PORT:-55433}"
 export HONUA_CONNECTION_ENCRYPTION_MASTER_KEY="${HONUA_CONNECTION_ENCRYPTION_MASTER_KEY:-mobile-offline-demo-master-key-32c}"
 export HONUA_CONNECTION_ENCRYPTION_SALT="${HONUA_CONNECTION_ENCRYPTION_SALT:-bW9iaWxlLW9mZmxpbmUtZGVtby1zYWx0LTAwMQ==}"
 
 readonly BASE_URL="http://localhost:${HONUA_HTTP_PORT}"
+readonly GRPC_URL="http://localhost:${HONUA_GRPC_PORT}"
 readonly READY_URL="${BASE_URL}/healthz/ready"
 readonly SERVICE_URL="${BASE_URL}/rest/services/mobile_offline_demo/FeatureServer?f=json"
 readonly LAYER_URL="${BASE_URL}/rest/services/mobile_offline_demo/FeatureServer/68910?f=json"
@@ -115,6 +117,7 @@ Scenario: ${SCENARIO}
 Service metadata: ${SERVICE_URL}
 Editable layer metadata: ${LAYER_URL}
 Editable layer query: ${QUERY_URL}
+Native gRPC endpoint: ${GRPC_URL}
 Create replica path: ${BASE_URL}/rest/services/mobile_offline_demo/FeatureServer/createReplica
 
 Expected signals:
@@ -122,5 +125,5 @@ Expected signals:
 - conflict-after-download: objectid 6891002 advances to sync_version = 2 after the client captures the baseline package.
 
 Cleanup:
-COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} HONUA_HTTP_PORT=${HONUA_HTTP_PORT} POSTGRES_PORT=${POSTGRES_PORT} docker compose -f "${COMPOSE_FILE}" --project-directory "${ROOT_DIR}" down --remove-orphans --volumes
+COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} HONUA_HTTP_PORT=${HONUA_HTTP_PORT} HONUA_GRPC_PORT=${HONUA_GRPC_PORT} POSTGRES_PORT=${POSTGRES_PORT} docker compose -f "${COMPOSE_FILE}" --project-directory "${ROOT_DIR}" down --remove-orphans --volumes
 EOF

--- a/scripts/demos/run-stac-ops-demo.sh
+++ b/scripts/demos/run-stac-ops-demo.sh
@@ -31,6 +31,7 @@ fi
 
 export COMPOSE_PROJECT_NAME="${HONUA_STAC_DEMO_PROJECT:-honua-stac-demo}"
 export HONUA_HTTP_PORT="${HONUA_STAC_DEMO_HTTP_PORT:-18080}"
+export HONUA_GRPC_PORT="${HONUA_STAC_DEMO_GRPC_PORT:-18083}"
 export POSTGRES_PORT="${HONUA_STAC_DEMO_POSTGRES_PORT:-55432}"
 export HONUA_CONNECTION_ENCRYPTION_MASTER_KEY="${HONUA_CONNECTION_ENCRYPTION_MASTER_KEY:-stac-ops-demo-master-key-with-32-chars}"
 export HONUA_CONNECTION_ENCRYPTION_SALT="${HONUA_CONNECTION_ENCRYPTION_SALT:-c3RhYy1vcHMtZGVtby1zYWx0LXN0YWJsZS0wMDE=}"
@@ -113,5 +114,5 @@ Expected signals:
 - stale-cache: baseline signals plus discovery freshness and temporal-drift warnings for cached collection metadata versus live item timestamps.
 
 Cleanup:
-COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} HONUA_HTTP_PORT=${HONUA_HTTP_PORT} POSTGRES_PORT=${POSTGRES_PORT} docker compose -f "${COMPOSE_FILE}" --project-directory "${ROOT_DIR}" down --remove-orphans --volumes
+COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} HONUA_HTTP_PORT=${HONUA_HTTP_PORT} HONUA_GRPC_PORT=${HONUA_GRPC_PORT} POSTGRES_PORT=${POSTGRES_PORT} docker compose -f "${COMPOSE_FILE}" --project-directory "${ROOT_DIR}" down --remove-orphans --volumes
 EOF

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Hosting/ContainerGrpcTransportConfigurationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Hosting/ContainerGrpcTransportConfigurationTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Tests.Infrastructure.Hosting;
+
+public sealed class ContainerGrpcTransportConfigurationTests
+{
+    [Theory]
+    [InlineData("Dockerfile")]
+    [InlineData("docker/Dockerfile.aot")]
+    public void Dockerfile_DefinesDedicatedNativeGrpcH2cEndpoint(string relativePath)
+    {
+        var dockerfile = ReadRepoFile(relativePath);
+
+        Assert.Contains("Kestrel__Endpoints__Http__Url=http://+:8080", dockerfile, StringComparison.Ordinal);
+        Assert.Contains("Kestrel__Endpoints__Http__Protocols=Http1", dockerfile, StringComparison.Ordinal);
+        Assert.Contains("Kestrel__Endpoints__Grpc__Url=http://+:8081", dockerfile, StringComparison.Ordinal);
+        Assert.Contains("Kestrel__Endpoints__Grpc__Protocols=Http2", dockerfile, StringComparison.Ordinal);
+        Assert.Contains("EXPOSE 8080/tcp 8081/tcp", dockerfile, StringComparison.Ordinal);
+        Assert.DoesNotContain("ASPNETCORE_URLS=http://+:8080", dockerfile, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComposeFile_MapsNativeGrpcPortToHttp2Endpoint()
+    {
+        var compose = ReadRepoFile("docker-compose.yml");
+
+        Assert.Contains("\"${HONUA_HTTP_PORT:-8080}:8080\"", compose, StringComparison.Ordinal);
+        Assert.Contains("\"${HONUA_GRPC_PORT:-8081}:8081\"", compose, StringComparison.Ordinal);
+        Assert.Contains("Kestrel__Endpoints__Http__Protocols: \"Http1\"", compose, StringComparison.Ordinal);
+        Assert.Contains("Kestrel__Endpoints__Grpc__Protocols: \"Http2\"", compose, StringComparison.Ordinal);
+        Assert.DoesNotContain("ASPNETCORE_URLS", compose, StringComparison.Ordinal);
+    }
+
+    private static string ReadRepoFile(string relativePath)
+        => File.ReadAllText(Path.Combine(FindRepositoryRoot(), relativePath));
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Honua.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root from test output directory.");
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #925

## Summary
Publishes a dedicated native h2c gRPC endpoint for the Docker image and compose stack so mobile live-image tests can use native gRPC without conflicting with the HTTP/1 REST/gRPC-Web port.

## Changes Made
- Configured Docker image defaults with HTTP/1 on `8080` and HTTP/2 h2c gRPC on `8081`.
- Published `HONUA_GRPC_PORT` in docker compose and demo scripts.
- Documented `HONUA_MOBILE_LIVE_SERVER_GRPC_URL=http://localhost:8081` for mobile live-image tests.
- Added regression tests for container gRPC transport configuration.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Focused local validation:
- `docker compose config` passed.
- `dotnet format Honua.sln --include tests/dotnet/Honua.Server.Tests/Infrastructure/Hosting/ContainerGrpcTransportConfigurationTests.cs` completed.
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~ContainerGrpcTransportConfigurationTests|FullyQualifiedName~GrpcServiceCollectionExtensionsTests"` passed: 10/10.
- `git diff --check` passed.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [x] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Focused validation was run instead of full local `scripts/ci/pre-pr-check.sh`; GitHub CI carries the full PR gate
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review