### PR TITLE
fix: unblock nightly container builds

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -93,6 +93,7 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="SkiaSharp" Version="3.119.2" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
+    <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="StackExchange.Redis" Version="2.12.14" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
     <PackageVersion Include="Testcontainers.MySql" Version="4.11.0" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY Honua.sln Directory.Build.props Directory.Packages.props NuGet.config .edit
 COPY scripts/docker/restore-dotnet-with-github-packages.sh scripts/docker/
 COPY src/Honua.Core/*.csproj src/Honua.Core/
 COPY src/Honua.DuckDB/*.csproj src/Honua.DuckDB/
+COPY src/Honua.MySql/*.csproj src/Honua.MySql/
 COPY src/Honua.Postgres/*.csproj src/Honua.Postgres/
 COPY src/Honua.SqlServer/*.csproj src/Honua.SqlServer/
 COPY src/Honua.ServiceDefaults/*.csproj src/Honua.ServiceDefaults/

--- a/docker/Dockerfile.aot
+++ b/docker/Dockerfile.aot
@@ -27,9 +27,12 @@ RUN apk add --no-cache \
 COPY Honua.sln Directory.Build.props Directory.Packages.props NuGet.config .editorconfig ./
 COPY scripts/docker/restore-dotnet-with-github-packages.sh scripts/docker/
 COPY src/Honua.Core/*.csproj src/Honua.Core/
+COPY src/Honua.DuckDB/*.csproj src/Honua.DuckDB/
+COPY src/Honua.MySql/*.csproj src/Honua.MySql/
 COPY src/Honua.Postgres/*.csproj src/Honua.Postgres/
 COPY src/Honua.ServiceDefaults/*.csproj src/Honua.ServiceDefaults/
 COPY src/Honua.Server/*.csproj src/Honua.Server/
+COPY src/Honua.SqlServer/*.csproj src/Honua.SqlServer/
 
 ARG TARGETARCH
 

--- a/src/Honua.Core/Honua.Core.csproj
+++ b/src/Honua.Core/Honua.Core.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="NetTopologySuite" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON" />
     <PackageReference Include="Parquet.Net" />
+    <PackageReference Include="Snappier" />
 
     <!-- Geocoding provider dependencies -->
     <PackageReference Include="AWSSDK.LocationService" />

--- a/tests/dotnet/Honua.TestKit/Honua.TestKit.csproj
+++ b/tests/dotnet/Honua.TestKit/Honua.TestKit.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="NBomber" />
     <PackageReference Include="Parquet.Net" />
+    <PackageReference Include="Snappier" />
     <PackageReference Include="NBomber.Http" />
     <PackageReference Include="Newtonsoft.Json.Schema" />
     <PackageReference Include="Testcontainers.PostgreSql" />


### PR DESCRIPTION
## Summary
- copy every server provider project file into the JIT and AOT Docker restore layers
- pin patched Snappier 1.3.1 where Parquet.Net is directly consumed so NuGet audit no longer fails restores
- keeps #932 open until a published nightly image is available and validated by the mobile live suite

Related to #932

## Changes Made
- Updated Dockerfile and docker/Dockerfile.aot project-file copy lists to match Honua.Server project references.
- Added central Snappier 1.3.1 package version and direct references in Honua.Core and Honua.TestKit, the projects that directly reference Parquet.Net.

## Breaking Changes
None.

## Gate Impact
- [x] Docker/container build
- [x] Release/publish plumbing
- [x] Dependency/security audit

## Testing
- [x] scripts/ci/pre-pr-check.sh equivalent completed for this targeted CI/container fix: local restore, diff check, GeoParquet tests, and container restore/build attempt.
- [x] git diff --check
- [x] dotnet restore Honua.sln
- [x] dotnet test tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj --filter "FullyQualifiedName~GeoParquet" --logger "console;verbosity=normal" (28 passed)
- [x] dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~GeoParquet" --logger "console;verbosity=normal" (35 passed)
- [x] docker build -f docker/Dockerfile.aot --secret id=github_actor,env=GITHUB_ACTOR --secret id=github_token,env=GITHUB_TOKEN -t honua-server:aot-restore-check . (passed before the Snappier pin; rerun now blocked locally by gh token missing read:packages)
- [x] docker build -f Dockerfile --secret id=github_actor,env=GITHUB_ACTOR --secret id=github_token,env=GITHUB_TOKEN -t honua-server:jit-restore-check . (confirmed MySQL project copy and Snappier audit blocker are gone; local run then failed on gh token missing read:packages for github-honua feed)
