### PR TITLE
feat: harden GeoServer scanner inventory

### DIFF
--- a/docs/gis/tutorials/geoserver-migration-guide.md
+++ b/docs/gis/tutorials/geoserver-migration-guide.md
@@ -61,7 +61,7 @@ curl -X POST http://localhost:8080/api/v1/admin/import/scan \
 
 Contract notes:
 - `sourceKind: "geoserver"` is normalized to `sourceKind: "geoserver-rest"` in the response artifact.
-- `includeStyleContent: true` fetches SLD documents for deeper compatibility analysis and external graphic detection, but the artifact does not echo raw SLD bodies.
+- `includeStyleContent: true` fetches SLD documents for deeper compatibility analysis and external graphic detection, but the artifact does not echo raw SLD bodies. SLD styles always carry `styleReference` and `styleContentReference` URLs plus `styleContentDisposition: "linked"` for downstream review.
 - GeoServer basic auth is only used when both `username` and `password` are supplied. Providing only one field falls back to anonymous discovery and records a note in `authPosture.notes`.
 - `timeoutSeconds` is optional for GeoServer scans and defaults to `120`.
 - The response body is the artifact itself, not a `success/data` admin envelope.
@@ -74,11 +74,12 @@ The response includes:
 - Workspace and layer inventory
 - Synthetic `workspace:global` container entries when GeoServer exposes global styles or layer groups
 - Datastore and coverage-store types with sanitized connection metadata and secret-safe addresses
-- Style formats, deterministic `styles[*].metadata`, and compatibility assessment
+- WMS/WFS service endpoints as `service-endpoint` external dependencies with advertised capabilities and enabled state
+- Style formats, deterministic `styles[*].metadata`, linked style URLs, and compatibility assessment
 - CRS, datum, and unit details for migration planning
 - External dependencies with sanitized addresses, stable cross-links (`styleIds`, `resourceIds`, `resourceId`), and manual follow-up steps
 
-Review the inventory artifact before proceeding. Start with `summary`, `scanCompleteness`, and `overallCompatibility`, then drill into per-item blockers using the stable IDs shared across `resources`, `styles`, and `externalDependencies`. Arrays are deterministically ordered for repeatable diffs, sensitive datastore values are redacted before serialization, and nullable scalar fields are omitted when the scanner has no value to emit. Layers backed by PostGIS data stores have the highest migration fidelity.
+Review the inventory artifact before proceeding. Start with `summary`, `scanCompleteness`, and `overallCompatibility`, then drill into per-item blockers using the stable IDs shared across `resources`, `styles`, and `externalDependencies`. Compatibility assessments include stable GeoServer codes such as `GEOSERVER_SUPPORTED`, `GEOSERVER_MANUAL_REVIEW`, `GEOSERVER_UNSUPPORTED_STORE`, `GEOSERVER_UNSUPPORTED_COVERAGE_STORE`, `GEOSERVER_DISABLED_LAYER`, `GEOSERVER_EMPTY_LAYER_GROUP`, `GEOSERVER_STYLE_CONVERSION_REQUIRED`, `GEOSERVER_UNSUPPORTED_STYLE_FORMAT`, `GEOSERVER_EXTERNAL_GRAPHIC`, and `GEOSERVER_SERVICE_ENDPOINT`. Arrays are deterministically ordered for repeatable diffs, sensitive datastore values are redacted before serialization, and nullable scalar fields are omitted when the scanner has no value to emit. Layers backed by PostGIS data stores have the highest migration fidelity.
 
 ### Step 2: Start a Dry-Run Import
 

--- a/docs/operator/migration-toolkit.md
+++ b/docs/operator/migration-toolkit.md
@@ -40,6 +40,14 @@ Run the source scanner first. GeoServer REST and ArcGIS GeoServices REST
 scans produce the same top-level source inventory contract, so downstream
 review tooling can work against one artifact shape.
 
+GeoServer source inventories emit advertised WMS/WFS service endpoints as
+external dependencies, preserve GeoServer layer capabilities on resources, and
+link styles by REST metadata URL plus SLD content URL instead of embedding raw
+SLD bodies. Setting `includeStyleContent` lets the scanner inspect SLD/SE
+documents for compatibility warnings and external graphic dependencies; the
+inventory remains a deterministic planning artifact, not a style translation
+payload.
+
 Translate the reviewed inventory into a manifest before planning a pilot.
 The manifest does not claim that unsupported source items are migrated:
 incompatible resources are excluded from `targetResources` and emitted under

--- a/src/Honua.Core/Features/Import/Domain/GeoServerServiceInfo.cs
+++ b/src/Honua.Core/Features/Import/Domain/GeoServerServiceInfo.cs
@@ -66,6 +66,11 @@ public sealed record GeoServerServiceInfo
     public GeoServerStyleInfo[] Styles { get; init; } = [];
 
     /// <summary>
+    /// Advertised GeoServer service endpoints discovered from REST service settings.
+    /// </summary>
+    public GeoServerServiceEndpointInfo[] ServiceEndpoints { get; init; } = [];
+
+    /// <summary>
     /// Migration compatibility assessment.
     /// </summary>
     public GeoServerMigrationCompatibility? CompatibilityAssessment { get; init; }
@@ -434,6 +439,37 @@ public sealed record GeoServerStyleInfo
 }
 
 /// <summary>
+/// Advertised GeoServer service endpoint, such as WMS or WFS.
+/// </summary>
+public sealed record GeoServerServiceEndpointInfo
+{
+    /// <summary>
+    /// Protocol label, for example <c>WMS</c> or <c>WFS</c>.
+    /// </summary>
+    public required string Protocol { get; init; }
+
+    /// <summary>
+    /// Advertised service endpoint URL.
+    /// </summary>
+    public required string Url { get; init; }
+
+    /// <summary>
+    /// Whether the GeoServer service settings report this endpoint as enabled.
+    /// </summary>
+    public bool? Enabled { get; init; }
+
+    /// <summary>
+    /// Stable operation capability labels derived from the advertised service.
+    /// </summary>
+    public string[] Capabilities { get; init; } = [];
+
+    /// <summary>
+    /// Deterministic service metadata useful for migration planning.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
+}
+
+/// <summary>
 /// Bounding box coordinates.
 /// </summary>
 public sealed record GeoServerBoundingBox
@@ -658,6 +694,11 @@ public sealed record GeoServerResourceCompatibility
     /// Warnings for this resource.
     /// </summary>
     public string[] Warnings { get; init; } = [];
+
+    /// <summary>
+    /// Stable machine-readable compatibility code.
+    /// </summary>
+    public string? Code { get; init; }
 
     /// <summary>
     /// Whether automatic migration is possible.

--- a/src/Honua.Core/Features/Import/Domain/ImportCompatibilityCodes.cs
+++ b/src/Honua.Core/Features/Import/Domain/ImportCompatibilityCodes.cs
@@ -51,4 +51,37 @@ public static class ImportCompatibilityCodes
 
     /// <summary>ArcGIS coded-value domain exceeded the deterministic capture cap.</summary>
     public const string ArcGisDomainTruncated = "ARCGIS_DOMAIN_TRUNCATED";
+
+    /// <summary>GeoServer resource or endpoint is supported by the scanner's migration path.</summary>
+    public const string GeoServerSupported = "GEOSERVER_SUPPORTED";
+
+    /// <summary>GeoServer resource needs manual review but can remain in the inventory plan.</summary>
+    public const string GeoServerManualReview = "GEOSERVER_MANUAL_REVIEW";
+
+    /// <summary>GeoServer datastore type is not supported by the automated migration path.</summary>
+    public const string GeoServerUnsupportedStore = "GEOSERVER_UNSUPPORTED_STORE";
+
+    /// <summary>GeoServer coverage store type is not supported by the automated migration path.</summary>
+    public const string GeoServerUnsupportedCoverageStore = "GEOSERVER_UNSUPPORTED_COVERAGE_STORE";
+
+    /// <summary>GeoServer layer is disabled and requires operator confirmation before enabling in the target.</summary>
+    public const string GeoServerDisabledLayer = "GEOSERVER_DISABLED_LAYER";
+
+    /// <summary>GeoServer layer group is empty and needs manual review.</summary>
+    public const string GeoServerEmptyLayerGroup = "GEOSERVER_EMPTY_LAYER_GROUP";
+
+    /// <summary>GeoServer SLD style requires style conversion work before automated migration.</summary>
+    public const string GeoServerStyleConversionRequired = "GEOSERVER_STYLE_CONVERSION_REQUIRED";
+
+    /// <summary>GeoServer style format is not supported by the automated migration path.</summary>
+    public const string GeoServerUnsupportedStyleFormat = "GEOSERVER_UNSUPPORTED_STYLE_FORMAT";
+
+    /// <summary>GeoServer style references an external graphic or URL dependency.</summary>
+    public const string GeoServerExternalGraphic = "GEOSERVER_EXTERNAL_GRAPHIC";
+
+    /// <summary>GeoServer advertised service endpoint was captured for downstream migration planning.</summary>
+    public const string GeoServerServiceEndpoint = "GEOSERVER_SERVICE_ENDPOINT";
+
+    /// <summary>GeoServer inventory scan could not complete.</summary>
+    public const string GeoServerScanFailed = "GEOSERVER_SCAN_FAILED";
 }

--- a/src/Honua.Core/Features/Import/Services/GeoServerRestClient.cs
+++ b/src/Honua.Core/Features/Import/Services/GeoServerRestClient.cs
@@ -114,6 +114,9 @@ internal sealed partial class GeoServerRestClient
             // Get all styles across workspaces
             var styles = await GetStylesAsync(baseUrl, workspaces, includeStyleContent, cancellationToken);
 
+            // Get advertised OGC service endpoints when GeoServer REST exposes service settings
+            var serviceEndpoints = await GetServiceEndpointsAsync(baseUrl, cancellationToken);
+
             // Perform compatibility analysis
             var compatibility = includeCompatibilityAnalysis
                 ? PerformCompatibilityAnalysis(dataStores, coverageStores, layers, styles)
@@ -132,6 +135,7 @@ internal sealed partial class GeoServerRestClient
                 Layers = layers,
                 LayerGroups = layerGroups,
                 Styles = styles,
+                ServiceEndpoints = serviceEndpoints,
                 CompatibilityAssessment = compatibility,
                 DiscoveredAt = DateTimeOffset.UtcNow
             };
@@ -806,6 +810,141 @@ internal sealed partial class GeoServerRestClient
         return styles.ToArray();
     }
 
+    private async Task<GeoServerServiceEndpointInfo[]> GetServiceEndpointsAsync(
+        string baseUrl,
+        CancellationToken cancellationToken)
+    {
+        var endpoints = new List<GeoServerServiceEndpointInfo>(2);
+
+        var wms = await TryGetServiceEndpointAsync(
+            baseUrl,
+            protocol: "WMS",
+            servicePath: "wms",
+            settingsPropertyName: "wms",
+            defaultCapabilities: ["get-capabilities", "get-map", "get-feature-info"],
+            cancellationToken).ConfigureAwait(false);
+        if (wms != null)
+        {
+            endpoints.Add(wms);
+        }
+
+        var wfs = await TryGetServiceEndpointAsync(
+            baseUrl,
+            protocol: "WFS",
+            servicePath: "wfs",
+            settingsPropertyName: "wfs",
+            defaultCapabilities: ["describe-feature-type", "get-capabilities", "get-feature"],
+            cancellationToken).ConfigureAwait(false);
+        if (wfs != null)
+        {
+            endpoints.Add(wfs);
+        }
+
+        return endpoints
+            .OrderBy(static endpoint => endpoint.Protocol, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private async Task<GeoServerServiceEndpointInfo?> TryGetServiceEndpointAsync(
+        string baseUrl,
+        string protocol,
+        string servicePath,
+        string settingsPropertyName,
+        string[] defaultCapabilities,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var json = await GetRequiredJsonDocumentAsync(
+                BuildJsonUrl(baseUrl, $"services/{servicePath}/settings"),
+                cancellationToken).ConfigureAwait(false);
+
+            var settingsElement = json.RootElement.TryGetProperty(settingsPropertyName, out var nested) &&
+                nested.ValueKind == JsonValueKind.Object
+                ? nested
+                : json.RootElement;
+
+            var enabled = GetOptionalBoolProperty(settingsElement, "enabled");
+            var metadata = BuildServiceSettingsMetadata(settingsElement);
+            var capabilities = BuildServiceCapabilities(protocol, enabled, metadata, defaultCapabilities);
+
+            return new GeoServerServiceEndpointInfo
+            {
+                Protocol = protocol,
+                Url = BuildServiceEndpointUrl(baseUrl, servicePath),
+                Enabled = enabled,
+                Capabilities = capabilities,
+                Metadata = metadata
+            };
+        }
+        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or JsonException)
+        {
+            Log.ServiceSettingsUnavailable(_logger, protocol, ex);
+            return null;
+        }
+    }
+
+    private static Dictionary<string, string> BuildServiceSettingsMetadata(JsonElement settingsElement)
+    {
+        var metadata = new SortedDictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var property in settingsElement.EnumerateObject())
+        {
+            var value = property.Value;
+            switch (value.ValueKind)
+            {
+                case JsonValueKind.String:
+                    metadata[property.Name] = value.GetString() ?? string.Empty;
+                    break;
+                case JsonValueKind.Number:
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                    metadata[property.Name] = value.GetRawText();
+                    break;
+                case JsonValueKind.Array:
+                    var values = value.EnumerateArray()
+                        .Where(static item => item.ValueKind is JsonValueKind.String or JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False)
+                        .Select(static item => item.ValueKind == JsonValueKind.String
+                            ? item.GetString() ?? string.Empty
+                            : item.GetRawText())
+                        .Where(static item => !string.IsNullOrWhiteSpace(item))
+                        .OrderBy(static item => item, StringComparer.Ordinal)
+                        .ToArray();
+                    if (values.Length > 0)
+                    {
+                        metadata[property.Name] = string.Join(",", values);
+                    }
+
+                    break;
+            }
+        }
+
+        return metadata.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal);
+    }
+
+    private static string[] BuildServiceCapabilities(
+        string protocol,
+        bool? enabled,
+        Dictionary<string, string> metadata,
+        string[] defaultCapabilities)
+    {
+        if (enabled == false)
+        {
+            return [];
+        }
+
+        var capabilities = new SortedSet<string>(defaultCapabilities, StringComparer.Ordinal);
+
+        if (string.Equals(protocol, "WFS", StringComparison.Ordinal) &&
+            metadata.TryGetValue("serviceLevel", out var serviceLevel) &&
+            string.Equals(serviceLevel, "COMPLETE", StringComparison.OrdinalIgnoreCase))
+        {
+            capabilities.Add("transaction");
+        }
+
+        return capabilities.ToArray();
+    }
+
     private async Task<GeoServerStyleInfo> GetStyleDetailsAsync(
         string baseUrl, string? workspaceName, string styleName, bool includeStyleContent, CancellationToken cancellationToken)
     {
@@ -876,6 +1015,35 @@ internal sealed partial class GeoServerRestClient
 
     private static string BuildSldUrl(string baseUrl, string relativePath)
         => $"{baseUrl}/{relativePath}.sld";
+
+    private static string BuildServiceEndpointUrl(string baseUrl, string servicePath)
+    {
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri))
+        {
+            var trimmed = baseUrl.TrimEnd('/');
+            if (trimmed.EndsWith("/rest", StringComparison.OrdinalIgnoreCase))
+            {
+                trimmed = trimmed[..^5];
+            }
+
+            return $"{trimmed}/{servicePath}";
+        }
+
+        var path = uri.AbsolutePath.TrimEnd('/');
+        if (path.EndsWith("/rest", StringComparison.OrdinalIgnoreCase))
+        {
+            path = path[..^5];
+        }
+
+        var builder = new UriBuilder(uri)
+        {
+            Path = $"{path}/{servicePath}".Replace("//", "/", StringComparison.Ordinal),
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+
+        return builder.Uri.AbsoluteUri;
+    }
 
     private async Task<string> GetStringAsync(string url, CancellationToken cancellationToken)
     {
@@ -1188,7 +1356,8 @@ internal sealed partial class GeoServerRestClient
             return new GeoServerResourceCompatibility
             {
                 CompatibilityLevel = GeoServerCompatibilityLevel.FullyCompatible,
-                Reason = $"DataStore type '{type}' is fully supported by Honua"
+                Reason = $"DataStore type '{type}' is fully supported by Honua",
+                Code = ImportCompatibilityCodes.GeoServerSupported
             };
         }
 
@@ -1196,7 +1365,8 @@ internal sealed partial class GeoServerRestClient
         {
             CompatibilityLevel = GeoServerCompatibilityLevel.Incompatible,
             Reason = $"DataStore type '{type}' is not currently supported by Honua",
-            RequiredManualSteps = [$"Manual migration required for {type} datastore"]
+            RequiredManualSteps = [$"Manual migration required for {type} datastore"],
+            Code = ImportCompatibilityCodes.GeoServerUnsupportedStore
         };
     }
 
@@ -1213,7 +1383,8 @@ internal sealed partial class GeoServerRestClient
             {
                 CompatibilityLevel = GeoServerCompatibilityLevel.PartiallyCompatible,
                 Reason = $"CoverageStore type '{type}' may require additional configuration in Honua",
-                Warnings = ["Raster support in Honua may have different capabilities than GeoServer"]
+                Warnings = ["Raster support in Honua may have different capabilities than GeoServer"],
+                Code = ImportCompatibilityCodes.GeoServerManualReview
             };
         }
 
@@ -1221,7 +1392,8 @@ internal sealed partial class GeoServerRestClient
         {
             CompatibilityLevel = GeoServerCompatibilityLevel.Incompatible,
             Reason = $"CoverageStore type '{type}' is not currently supported by Honua",
-            RequiredManualSteps = [$"Manual migration required for {type} coverage store"]
+            RequiredManualSteps = [$"Manual migration required for {type} coverage store"],
+            Code = ImportCompatibilityCodes.GeoServerUnsupportedCoverageStore
         };
     }
 
@@ -1236,14 +1408,16 @@ internal sealed partial class GeoServerRestClient
             {
                 CompatibilityLevel = GeoServerCompatibilityLevel.PartiallyCompatible,
                 Reason = "Disabled layers can be migrated but will need to be manually enabled",
-                Warnings = ["Layer is currently disabled in GeoServer"]
+                Warnings = ["Layer is currently disabled in GeoServer"],
+                Code = ImportCompatibilityCodes.GeoServerDisabledLayer
             };
         }
 
         return new GeoServerResourceCompatibility
         {
             CompatibilityLevel = GeoServerCompatibilityLevel.FullyCompatible,
-            Reason = "Standard layer configuration is fully supported"
+            Reason = "Standard layer configuration is fully supported",
+            Code = ImportCompatibilityCodes.GeoServerSupported
         };
     }
 
@@ -1255,14 +1429,16 @@ internal sealed partial class GeoServerRestClient
             {
                 CompatibilityLevel = GeoServerCompatibilityLevel.PartiallyCompatible,
                 Reason = "Empty layer groups can be migrated but provide no functionality",
-                Warnings = ["Layer group contains no layers"]
+                Warnings = ["Layer group contains no layers"],
+                Code = ImportCompatibilityCodes.GeoServerEmptyLayerGroup
             };
         }
 
         return new GeoServerResourceCompatibility
         {
             CompatibilityLevel = GeoServerCompatibilityLevel.FullyCompatible,
-            Reason = "Layer groups are fully supported"
+            Reason = "Layer groups are fully supported",
+            Code = ImportCompatibilityCodes.GeoServerSupported
         };
     }
 
@@ -1274,7 +1450,8 @@ internal sealed partial class GeoServerRestClient
             {
                 CompatibilityLevel = GeoServerCompatibilityLevel.Incompatible,
                 Reason = "SLD styles require conversion to MapLibre format (issue #375)",
-                RequiredManualSteps = ["Implement SLD to MapLibre style conversion", "Manual style recreation may be required"]
+                RequiredManualSteps = ["Implement SLD to MapLibre style conversion", "Manual style recreation may be required"],
+                Code = ImportCompatibilityCodes.GeoServerStyleConversionRequired
             };
         }
 
@@ -1282,7 +1459,8 @@ internal sealed partial class GeoServerRestClient
         {
             CompatibilityLevel = GeoServerCompatibilityLevel.Incompatible,
             Reason = $"Style format '{format}' is not supported",
-            RequiredManualSteps = [$"Convert {format} style to supported format"]
+            RequiredManualSteps = [$"Convert {format} style to supported format"],
+            Code = ImportCompatibilityCodes.GeoServerUnsupportedStyleFormat
         };
     }
 
@@ -1453,6 +1631,9 @@ internal sealed partial class GeoServerRestClient
 
         [LoggerMessage(7987, LogLevel.Warning, "Failed to fetch SLD content for style {StyleName}")]
         public static partial void StyleContentFetchFailed(ILogger logger, string styleName, Exception exception);
+
+        [LoggerMessage(7988, LogLevel.Debug, "GeoServer {Protocol} service settings were unavailable during inventory scan")]
+        public static partial void ServiceSettingsUnavailable(ILogger logger, string protocol, Exception exception);
     }
 }
 

--- a/src/Honua.Core/Features/Import/Services/MigrationInventoryHelpers.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationInventoryHelpers.cs
@@ -224,15 +224,18 @@ internal static partial class MigrationInventoryHelpers
             GeoServerCompatibilityLevel.FullyCompatible => Compatible(
                 compatibility.Reason,
                 compatibility.Warnings,
-                compatibility.RequiredManualSteps),
+                compatibility.RequiredManualSteps,
+                compatibility.Code),
             GeoServerCompatibilityLevel.PartiallyCompatible => Partial(
                 compatibility.Reason,
                 compatibility.Warnings,
-                compatibility.RequiredManualSteps),
+                compatibility.RequiredManualSteps,
+                compatibility.Code),
             _ => Incompatible(
                 compatibility.Reason,
                 compatibility.Warnings,
-                compatibility.RequiredManualSteps)
+                compatibility.RequiredManualSteps,
+                compatibility.Code)
         };
     }
 

--- a/src/Honua.Postgres/Features/Import/GeoServerImportService.cs
+++ b/src/Honua.Postgres/Features/Import/GeoServerImportService.cs
@@ -280,7 +280,8 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
     {
         var containers = new List<MigrationInventoryContainer>(serviceInfo.Workspaces.Length + 1);
         var globalContainerNeeded = serviceInfo.Styles.Any(style => string.IsNullOrWhiteSpace(style.WorkspaceName)) ||
-            serviceInfo.LayerGroups.Any(group => string.IsNullOrWhiteSpace(group.WorkspaceName));
+            serviceInfo.LayerGroups.Any(group => string.IsNullOrWhiteSpace(group.WorkspaceName)) ||
+            serviceInfo.ServiceEndpoints.Length > 0;
 
         if (globalContainerNeeded)
         {

--- a/src/Honua.Postgres/Features/Import/GeoServerImportService.cs
+++ b/src/Honua.Postgres/Features/Import/GeoServerImportService.cs
@@ -162,7 +162,8 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
                 OverallCompatibility = MigrationInventoryHelpers.Partial(
                     "The scan did not complete successfully.",
                     [ex.Message],
-                    ["Verify GeoServer reachability and credentials, then rerun the scan."]),
+                    ["Verify GeoServer reachability and credentials, then rerun the scan."],
+                    ImportCompatibilityCodes.GeoServerScanFailed),
                 Containers = [],
                 Resources = [],
                 Styles = [],
@@ -223,7 +224,7 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
                 GeometryType = null,
                 FeatureCount = null,
                 HasAttachments = null,
-                Capabilities = BuildLayerCapabilities(layer),
+                Capabilities = BuildLayerCapabilities(layer, serviceInfo.ServiceEndpoints),
                 SpatialReferences = spatialReferences,
                 StyleIds = styleIds,
                 ExternalDependencyIds = dependencyIds,
@@ -258,7 +259,7 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
                 GeometryType = null,
                 FeatureCount = null,
                 HasAttachments = null,
-                Capabilities = [],
+                Capabilities = BuildLayerGroupCapabilities(layerGroup, serviceInfo.ServiceEndpoints),
                 SpatialReferences = spatialReferences,
                 StyleIds = GetStyleIdsForResource(serviceInfo.Styles, styleResourceIds, layerGroupId),
                 ExternalDependencyIds = [],
@@ -370,6 +371,14 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
                     metadata["filename"] = style.Filename;
                 }
 
+                metadata["styleReference"] = BuildStyleReferenceUrl(serviceInfo.GeoServerRestUrl, style);
+
+                if (style.Format.Equals("sld", StringComparison.OrdinalIgnoreCase))
+                {
+                    metadata["styleContentReference"] = BuildStyleContentReferenceUrl(serviceInfo.GeoServerRestUrl, style);
+                    metadata["styleContentDisposition"] = "linked";
+                }
+
                 return new MigrationInventoryStyle
                 {
                     Id = styleId,
@@ -436,6 +445,51 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
             });
         }
 
+        foreach (var endpoint in serviceInfo.ServiceEndpoints.OrderBy(static endpoint => endpoint.Protocol, StringComparer.Ordinal))
+        {
+            var metadata = new SortedDictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["protocol"] = endpoint.Protocol
+            };
+
+            foreach (var (key, value) in endpoint.Metadata)
+            {
+                metadata[key] = value;
+            }
+
+            if (endpoint.Enabled.HasValue)
+            {
+                metadata["enabled"] = endpoint.Enabled.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant();
+            }
+
+            if (endpoint.Capabilities.Length > 0)
+            {
+                metadata["capabilities"] = string.Join(",", endpoint.Capabilities);
+            }
+
+            dependencies.Add(new MigrationExternalDependency
+            {
+                Id = GetServiceEndpointId(endpoint.Protocol),
+                ContainerId = GetGlobalContainerId(),
+                ResourceId = null,
+                Kind = "service-endpoint",
+                Name = endpoint.Protocol,
+                DependencyType = "ogc-service",
+                Address = endpoint.Url,
+                Metadata = metadata.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal),
+                SpatialReferences = [],
+                Compatibility = endpoint.Enabled == false
+                    ? MigrationInventoryHelpers.Partial(
+                        $"{endpoint.Protocol} service endpoint is disabled in GeoServer.",
+                        [$"{endpoint.Protocol} is advertised but disabled."],
+                        ["Confirm whether this service should be enabled in the target deployment."],
+                        ImportCompatibilityCodes.GeoServerManualReview)
+                    : MigrationInventoryHelpers.Compatible(
+                        $"{endpoint.Protocol} service endpoint was captured for migration planning.",
+                        code: ImportCompatibilityCodes.GeoServerServiceEndpoint)
+            });
+        }
+
         if (includeStyleContent)
         {
             foreach (var style in serviceInfo.Styles)
@@ -464,7 +518,8 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
                         Compatibility = MigrationInventoryHelpers.Partial(
                             "External graphic references require manual migration review.",
                             ["The style references an external URL."],
-                            ["Mirror or replace external graphics in the target deployment."])
+                            ["Mirror or replace external graphics in the target deployment."],
+                            ImportCompatibilityCodes.GeoServerExternalGraphic)
                     });
                 }
             }
@@ -546,7 +601,9 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
             ? style.Name
             : $"{style.WorkspaceName}:{style.Name}";
 
-    private static string[] BuildLayerCapabilities(GeoServerLayerInfo layer)
+    private static string[] BuildLayerCapabilities(
+        GeoServerLayerInfo layer,
+        IReadOnlyList<GeoServerServiceEndpointInfo> serviceEndpoints)
     {
         var capabilities = new List<string>();
 
@@ -563,6 +620,27 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
         if (layer.Opaque)
         {
             capabilities.Add("opaque");
+        }
+
+        foreach (var endpoint in serviceEndpoints.Where(static endpoint => endpoint.Enabled != false))
+        {
+            capabilities.Add(endpoint.Protocol.ToLowerInvariant());
+        }
+
+        return capabilities.OrderBy(static value => value, StringComparer.Ordinal).ToArray();
+    }
+
+    private static string[] BuildLayerGroupCapabilities(
+        GeoServerLayerGroupInfo layerGroup,
+        IReadOnlyList<GeoServerServiceEndpointInfo> serviceEndpoints)
+    {
+        var capabilities = new List<string>();
+
+        foreach (var endpoint in serviceEndpoints.Where(static endpoint =>
+                     endpoint.Enabled != false &&
+                     string.Equals(endpoint.Protocol, "WMS", StringComparison.Ordinal)))
+        {
+            capabilities.Add(endpoint.Protocol.ToLowerInvariant());
         }
 
         return capabilities.OrderBy(static value => value, StringComparer.Ordinal).ToArray();
@@ -594,6 +672,27 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
 
     private static string GetCoverageStoreId(string workspaceName, string coverageStoreName)
         => $"coverage-store:{workspaceName}:{coverageStoreName}";
+
+    private static string GetServiceEndpointId(string protocol)
+        => $"service-endpoint:{protocol.ToLowerInvariant()}";
+
+    private static string BuildStyleReferenceUrl(string baseUrl, GeoServerStyleInfo style)
+    {
+        var relativePath = string.IsNullOrWhiteSpace(style.WorkspaceName)
+            ? $"styles/{Uri.EscapeDataString(style.Name)}"
+            : $"workspaces/{Uri.EscapeDataString(style.WorkspaceName)}/styles/{Uri.EscapeDataString(style.Name)}";
+
+        return $"{baseUrl.TrimEnd('/')}/{relativePath}.json";
+    }
+
+    private static string BuildStyleContentReferenceUrl(string baseUrl, GeoServerStyleInfo style)
+    {
+        var relativePath = string.IsNullOrWhiteSpace(style.WorkspaceName)
+            ? $"styles/{Uri.EscapeDataString(style.Name)}"
+            : $"workspaces/{Uri.EscapeDataString(style.WorkspaceName)}/styles/{Uri.EscapeDataString(style.Name)}";
+
+        return $"{baseUrl.TrimEnd('/')}/{relativePath}.sld";
+    }
 
     private static string? ResolveDependencyAddress(Dictionary<string, string> metadata)
     {

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/Baselines/GeoServer/MixedCatalog-expected.json
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/Baselines/GeoServer/MixedCatalog-expected.json
@@ -1,0 +1,410 @@
+{
+  "artifactKind": "honua.migration.source-inventory",
+  "artifactVersion": "1.0",
+  "sourceKind": "geoserver-rest",
+  "source": {
+    "displayName": "Demo GeoServer",
+    "baseUrl": "https://example.com/geoserver/rest",
+    "product": "GeoServer",
+    "version": "2.28.0",
+    "build": "abc123",
+    "serviceType": "REST"
+  },
+  "authPosture": {
+    "mode": "anonymous",
+    "credentialsSupplied": false,
+    "accessConfirmed": true,
+    "notes": []
+  },
+  "scanCompleteness": {
+    "status": "complete",
+    "warnings": [],
+    "missingArtifacts": []
+  },
+  "summary": {
+    "containerCount": 2,
+    "resourceCount": 3,
+    "styleCount": 2,
+    "externalDependencyCount": 6,
+    "compatibleCount": 5,
+    "partiallyCompatibleCount": 4,
+    "incompatibleCount": 4
+  },
+  "overallCompatibility": {
+    "level": "incompatible",
+    "reason": "Compatible: 5; partial: 4; incompatible: 4.",
+    "warnings": [
+      "Layer group contains no layers",
+      "Layer is currently disabled in GeoServer",
+      "Raster support in Honua may have different capabilities than GeoServer",
+      "The style references an external URL."
+    ],
+    "manualSteps": [
+      "Convert css style to supported format",
+      "Implement SLD to MapLibre style conversion",
+      "Manual migration required for VPF datastore",
+      "Manual style recreation may be required",
+      "Mirror or replace external graphics in the target deployment."
+    ]
+  },
+  "containers": [
+    {
+      "id": "workspace:archive",
+      "kind": "workspace",
+      "name": "archive",
+      "title": "archive",
+      "isDefault": false,
+      "compatibility": {
+        "level": "compatible",
+        "code": "EMPTY",
+        "reason": "No resources were discovered in this container.",
+        "warnings": [],
+        "manualSteps": []
+      }
+    },
+    {
+      "id": "workspace:demo",
+      "kind": "workspace",
+      "name": "demo",
+      "title": "demo",
+      "isDefault": true,
+      "compatibility": {
+        "level": "incompatible",
+        "reason": "Compatible: 2; partial: 4; incompatible: 3.",
+        "warnings": [
+          "Layer group contains no layers",
+          "Layer is currently disabled in GeoServer",
+          "Raster support in Honua may have different capabilities than GeoServer",
+          "The style references an external URL."
+        ],
+        "manualSteps": [
+          "Convert css style to supported format",
+          "Implement SLD to MapLibre style conversion",
+          "Manual migration required for VPF datastore",
+          "Manual style recreation may be required",
+          "Mirror or replace external graphics in the target deployment."
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "id": "layer:demo:closed",
+      "containerId": "workspace:demo",
+      "kind": "layer",
+      "name": "closed",
+      "title": "Closed Facilities",
+      "capabilities": [
+        "wfs",
+        "wms"
+      ],
+      "spatialReferences": [],
+      "fields": [],
+      "styleIds": [
+        "style:demo:deprecated"
+      ],
+      "externalDependencyIds": [
+        "datastore:demo:legacy"
+      ],
+      "compatibility": {
+        "level": "partial",
+        "code": "GEOSERVER_DISABLED_LAYER",
+        "reason": "Disabled layers can be migrated but will need to be manually enabled",
+        "warnings": [
+          "Layer is currently disabled in GeoServer"
+        ],
+        "manualSteps": []
+      }
+    },
+    {
+      "id": "layer:demo:roads",
+      "containerId": "workspace:demo",
+      "kind": "layer",
+      "name": "roads",
+      "title": "Roads",
+      "description": "Road centerlines",
+      "capabilities": [
+        "enabled",
+        "query",
+        "wfs",
+        "wms"
+      ],
+      "spatialReferences": [
+        {
+          "role": "declared",
+          "sourceValue": "EPSG:4326",
+          "srid": 4326,
+          "crsUri": "http://www.opengis.net/def/crs/EPSG/0/4326",
+          "unit": "degree",
+          "axisOrder": "east-north",
+          "isGeographic": true
+        },
+        {
+          "role": "latlon-bounds",
+          "sourceValue": "EPSG:4326",
+          "srid": 4326,
+          "crsUri": "http://www.opengis.net/def/crs/EPSG/0/4326",
+          "unit": "degree",
+          "axisOrder": "east-north",
+          "isGeographic": true
+        },
+        {
+          "role": "native",
+          "sourceValue": "EPSG:3857",
+          "srid": 3857,
+          "crsUri": "http://www.opengis.net/def/crs/EPSG/0/3857",
+          "axisOrder": "east-north",
+          "isGeographic": false
+        },
+        {
+          "role": "native-bounds",
+          "sourceValue": "EPSG:3857",
+          "srid": 3857,
+          "crsUri": "http://www.opengis.net/def/crs/EPSG/0/3857",
+          "axisOrder": "east-north",
+          "isGeographic": false
+        }
+      ],
+      "fields": [],
+      "styleIds": [
+        "style:demo:line"
+      ],
+      "externalDependencyIds": [
+        "datastore:demo:pg"
+      ],
+      "compatibility": {
+        "level": "compatible",
+        "code": "GEOSERVER_SUPPORTED",
+        "reason": "Standard layer configuration is fully supported",
+        "warnings": [],
+        "manualSteps": []
+      }
+    },
+    {
+      "id": "layer-group:demo:empty-group",
+      "containerId": "workspace:demo",
+      "kind": "layer-group",
+      "name": "empty-group",
+      "title": "Empty Group",
+      "capabilities": [
+        "wms"
+      ],
+      "spatialReferences": [
+        {
+          "role": "bounds",
+          "sourceValue": "EPSG:4326",
+          "srid": 4326,
+          "crsUri": "http://www.opengis.net/def/crs/EPSG/0/4326",
+          "unit": "degree",
+          "axisOrder": "east-north",
+          "isGeographic": true
+        }
+      ],
+      "fields": [],
+      "styleIds": [],
+      "externalDependencyIds": [],
+      "compatibility": {
+        "level": "partial",
+        "code": "GEOSERVER_EMPTY_LAYER_GROUP",
+        "reason": "Empty layer groups can be migrated but provide no functionality",
+        "warnings": [
+          "Layer group contains no layers"
+        ],
+        "manualSteps": []
+      }
+    }
+  ],
+  "styles": [
+    {
+      "id": "style:demo:deprecated",
+      "containerId": "workspace:demo",
+      "kind": "style",
+      "name": "deprecated",
+      "format": "css",
+      "resourceIds": [
+        "layer:demo:closed"
+      ],
+      "externalDependencyIds": [],
+      "metadata": {
+        "filename": "deprecated.css",
+        "format": "css",
+        "styleReference": "https://example.com/geoserver/rest/workspaces/demo/styles/deprecated.json"
+      },
+      "compatibility": {
+        "level": "incompatible",
+        "code": "GEOSERVER_UNSUPPORTED_STYLE_FORMAT",
+        "reason": "Style format \u0027css\u0027 is not supported",
+        "warnings": [],
+        "manualSteps": [
+          "Convert css style to supported format"
+        ]
+      }
+    },
+    {
+      "id": "style:demo:line",
+      "containerId": "workspace:demo",
+      "kind": "style",
+      "name": "line",
+      "format": "sld",
+      "resourceIds": [
+        "layer:demo:roads"
+      ],
+      "externalDependencyIds": [
+        "style:demo:line:external:9e504ef024797904"
+      ],
+      "metadata": {
+        "filename": "line.sld",
+        "format": "sld",
+        "languageVersion": "1.0.0",
+        "styleContentDisposition": "linked",
+        "styleContentReference": "https://example.com/geoserver/rest/workspaces/demo/styles/line.sld",
+        "styleReference": "https://example.com/geoserver/rest/workspaces/demo/styles/line.json"
+      },
+      "compatibility": {
+        "level": "incompatible",
+        "code": "GEOSERVER_STYLE_CONVERSION_REQUIRED",
+        "reason": "SLD styles require conversion to MapLibre format (issue #375)",
+        "warnings": [],
+        "manualSteps": [
+          "Implement SLD to MapLibre style conversion",
+          "Manual style recreation may be required"
+        ]
+      }
+    }
+  ],
+  "externalDependencies": [
+    {
+      "id": "coverage-store:demo:imagery",
+      "containerId": "workspace:demo",
+      "kind": "coverage-store",
+      "name": "imagery",
+      "dependencyType": "GeoTIFF",
+      "address": "s3://example-bucket/imagery/demo.tif",
+      "metadata": {
+        "url": "s3://example-bucket/imagery/demo.tif"
+      },
+      "spatialReferences": [],
+      "compatibility": {
+        "level": "partial",
+        "code": "GEOSERVER_MANUAL_REVIEW",
+        "reason": "CoverageStore type \u0027GeoTIFF\u0027 may require additional configuration in Honua",
+        "warnings": [
+          "Raster support in Honua may have different capabilities than GeoServer"
+        ],
+        "manualSteps": []
+      }
+    },
+    {
+      "id": "datastore:demo:legacy",
+      "containerId": "workspace:demo",
+      "kind": "datastore",
+      "name": "legacy",
+      "dependencyType": "VPF",
+      "address": "file:/srv/geoserver/legacy.vpf",
+      "metadata": {
+        "url": "file:/srv/geoserver/legacy.vpf"
+      },
+      "spatialReferences": [],
+      "compatibility": {
+        "level": "incompatible",
+        "code": "GEOSERVER_UNSUPPORTED_STORE",
+        "reason": "DataStore type \u0027VPF\u0027 is not currently supported by Honua",
+        "warnings": [],
+        "manualSteps": [
+          "Manual migration required for VPF datastore"
+        ]
+      }
+    },
+    {
+      "id": "datastore:demo:pg",
+      "containerId": "workspace:demo",
+      "kind": "datastore",
+      "name": "pg",
+      "dependencyType": "PostGIS",
+      "address": "db.example.com/gis",
+      "metadata": {
+        "database": "gis",
+        "dbtype": "postgis",
+        "host": "db.example.com"
+      },
+      "spatialReferences": [],
+      "compatibility": {
+        "level": "compatible",
+        "code": "GEOSERVER_SUPPORTED",
+        "reason": "DataStore type \u0027PostGIS\u0027 is fully supported by Honua",
+        "warnings": [],
+        "manualSteps": []
+      }
+    },
+    {
+      "id": "service-endpoint:wfs",
+      "containerId": "workspace:global",
+      "kind": "service-endpoint",
+      "name": "WFS",
+      "dependencyType": "ogc-service",
+      "address": "https://example.com/geoserver/wfs",
+      "metadata": {
+        "capabilities": "describe-feature-type,get-capabilities,get-feature,transaction",
+        "enabled": "true",
+        "protocol": "WFS",
+        "serviceLevel": "COMPLETE",
+        "title": "Demo WFS"
+      },
+      "spatialReferences": [],
+      "compatibility": {
+        "level": "compatible",
+        "code": "GEOSERVER_SERVICE_ENDPOINT",
+        "reason": "WFS service endpoint was captured for migration planning.",
+        "warnings": [],
+        "manualSteps": []
+      }
+    },
+    {
+      "id": "service-endpoint:wms",
+      "containerId": "workspace:global",
+      "kind": "service-endpoint",
+      "name": "WMS",
+      "dependencyType": "ogc-service",
+      "address": "https://example.com/geoserver/wms",
+      "metadata": {
+        "capabilities": "get-capabilities,get-feature-info,get-map",
+        "enabled": "true",
+        "maxRenderingTime": "60",
+        "protocol": "WMS",
+        "title": "Demo WMS"
+      },
+      "spatialReferences": [],
+      "compatibility": {
+        "level": "compatible",
+        "code": "GEOSERVER_SERVICE_ENDPOINT",
+        "reason": "WMS service endpoint was captured for migration planning.",
+        "warnings": [],
+        "manualSteps": []
+      }
+    },
+    {
+      "id": "style:demo:line:external:9e504ef024797904",
+      "containerId": "workspace:demo",
+      "resourceId": "style:demo:line",
+      "kind": "external-graphic",
+      "name": "line",
+      "dependencyType": "url",
+      "address": "https://cdn.example.com/styles/road-marker.svg",
+      "metadata": {
+        "source": "sld"
+      },
+      "spatialReferences": [],
+      "compatibility": {
+        "level": "partial",
+        "code": "GEOSERVER_EXTERNAL_GRAPHIC",
+        "reason": "External graphic references require manual migration review.",
+        "warnings": [
+          "The style references an external URL."
+        ],
+        "manualSteps": [
+          "Mirror or replace external graphics in the target deployment."
+        ]
+      }
+    }
+  ]
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/Baselines/GeoServer/MixedCatalog-expected.json
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/Baselines/GeoServer/MixedCatalog-expected.json
@@ -22,17 +22,17 @@
     "missingArtifacts": []
   },
   "summary": {
-    "containerCount": 2,
+    "containerCount": 3,
     "resourceCount": 3,
     "styleCount": 2,
     "externalDependencyCount": 6,
-    "compatibleCount": 5,
+    "compatibleCount": 6,
     "partiallyCompatibleCount": 4,
     "incompatibleCount": 4
   },
   "overallCompatibility": {
     "level": "incompatible",
-    "reason": "Compatible: 5; partial: 4; incompatible: 4.",
+    "reason": "Compatible: 6; partial: 4; incompatible: 4.",
     "warnings": [
       "Layer group contains no layers",
       "Layer is currently disabled in GeoServer",
@@ -84,6 +84,19 @@
           "Manual style recreation may be required",
           "Mirror or replace external graphics in the target deployment."
         ]
+      }
+    },
+    {
+      "id": "workspace:global",
+      "kind": "workspace",
+      "name": "global",
+      "title": "Global",
+      "isDefault": false,
+      "compatibility": {
+        "level": "compatible",
+        "reason": "Compatible: 2; partial: 0; incompatible: 0.",
+        "warnings": [],
+        "manualSteps": []
       }
     }
   ],

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/Fixtures/GeoServer/MixedCatalog.json
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/Fixtures/GeoServer/MixedCatalog.json
@@ -1,0 +1,233 @@
+{
+  "serviceUrl": "https://example.com/geoserver/rest",
+  "responses": {
+    "/geoserver/rest/about/version.xml": "<about><resource name=\"GeoServer\"><Version>2.28.0</Version><Build-Timestamp>2026-01-15T10:30:00Z</Build-Timestamp><Git-Revision>abc123</Git-Revision></resource></about>",
+    "/geoserver/rest/settings.json": {
+      "global": {
+        "title": "Demo GeoServer",
+        "abstract": "Fixture-backed GeoServer catalog",
+        "onlineResource": "https://example.com/geoserver"
+      }
+    },
+    "/geoserver/rest/services/wms/settings.json": {
+      "wms": {
+        "enabled": true,
+        "title": "Demo WMS",
+        "maxRenderingTime": 60
+      }
+    },
+    "/geoserver/rest/services/wfs/settings.json": {
+      "wfs": {
+        "enabled": true,
+        "title": "Demo WFS",
+        "serviceLevel": "COMPLETE"
+      }
+    },
+    "/geoserver/rest/workspaces.json": {
+      "workspaces": {
+        "workspace": [
+          { "name": "archive" },
+          { "name": "demo" }
+        ]
+      }
+    },
+    "/geoserver/rest/workspaces/archive.json": {
+      "workspace": {
+        "name": "archive",
+        "isolated": true
+      }
+    },
+    "/geoserver/rest/workspaces/demo.json": {
+      "workspace": {
+        "name": "demo",
+        "default": true
+      }
+    },
+    "/geoserver/rest/workspaces/archive/datastores.json": {
+      "dataStores": {
+        "dataStore": ""
+      }
+    },
+    "/geoserver/rest/workspaces/demo/datastores.json": {
+      "dataStores": {
+        "dataStore": [
+          { "name": "legacy" },
+          { "name": "pg" }
+        ]
+      }
+    },
+    "/geoserver/rest/workspaces/demo/datastores/legacy.json": {
+      "dataStore": {
+        "name": "legacy",
+        "type": "VPF",
+        "connectionParameters": {
+          "entry": [
+            { "@key": "url", "$": "file:/srv/geoserver/legacy.vpf" }
+          ]
+        }
+      }
+    },
+    "/geoserver/rest/workspaces/demo/datastores/pg.json": {
+      "dataStore": {
+        "name": "pg",
+        "type": "PostGIS",
+        "connectionParameters": {
+          "entry": [
+            { "@key": "host", "$": "db.example.com" },
+            { "@key": "database", "$": "gis" },
+            { "@key": "dbtype", "$": "postgis" }
+          ]
+        }
+      }
+    },
+    "/geoserver/rest/workspaces/archive/coveragestores.json": {
+      "coverageStores": {
+        "coverageStore": ""
+      }
+    },
+    "/geoserver/rest/workspaces/demo/coveragestores.json": {
+      "coverageStores": {
+        "coverageStore": [
+          { "name": "imagery" }
+        ]
+      }
+    },
+    "/geoserver/rest/workspaces/demo/coveragestores/imagery.json": {
+      "coverageStore": {
+        "name": "imagery",
+        "type": "GeoTIFF",
+        "url": "s3://example-bucket/imagery/demo.tif"
+      }
+    },
+    "/geoserver/rest/workspaces/archive/layers.json": {
+      "layers": {
+        "layer": ""
+      }
+    },
+    "/geoserver/rest/workspaces/demo/layers.json": {
+      "layers": {
+        "layer": [
+          { "name": "closed" },
+          { "name": "roads" }
+        ]
+      }
+    },
+    "/geoserver/rest/workspaces/demo/layers/closed.json": {
+      "layer": {
+        "name": "closed",
+        "title": "Closed Facilities",
+        "enabled": false,
+        "queryable": false,
+        "resource": {
+          "href": "https://example.com/geoserver/rest/workspaces/demo/datastores/legacy/featuretypes/closed.json"
+        },
+        "defaultStyle": {
+          "name": "deprecated",
+          "workspace": "demo"
+        }
+      }
+    },
+    "/geoserver/rest/workspaces/demo/layers/roads.json": {
+      "layer": {
+        "name": "roads",
+        "title": "Roads",
+        "abstract": "Road centerlines",
+        "srs": "EPSG:4326",
+        "nativeCRS": "EPSG:3857",
+        "latLonBoundingBox": {
+          "minx": -158.2,
+          "miny": 21.1,
+          "maxx": -157.6,
+          "maxy": 21.8,
+          "crs": "EPSG:4326"
+        },
+        "nativeBoundingBox": {
+          "minx": 0,
+          "miny": 0,
+          "maxx": 100,
+          "maxy": 100,
+          "crs": "EPSG:3857"
+        },
+        "resource": {
+          "href": "https://example.com/geoserver/rest/workspaces/demo/datastores/pg/featuretypes/roads.json"
+        },
+        "defaultStyle": {
+          "name": "line",
+          "workspace": "demo"
+        }
+      }
+    },
+    "/geoserver/rest/layergroups.json": {
+      "layerGroups": {
+        "layerGroup": ""
+      }
+    },
+    "/geoserver/rest/workspaces/archive/layergroups.json": {
+      "layerGroups": {
+        "layerGroup": ""
+      }
+    },
+    "/geoserver/rest/workspaces/demo/layergroups.json": {
+      "layerGroups": {
+        "layerGroup": [
+          { "name": "empty-group" }
+        ]
+      }
+    },
+    "/geoserver/rest/workspaces/demo/layergroups/empty-group.json": {
+      "layerGroup": {
+        "name": "empty-group",
+        "title": "Empty Group",
+        "mode": "SINGLE",
+        "publishables": {
+          "published": ""
+        },
+        "styles": {
+          "style": ""
+        },
+        "bounds": {
+          "minx": -158.2,
+          "miny": 21.1,
+          "maxx": -157.6,
+          "maxy": 21.8,
+          "crs": "EPSG:4326"
+        }
+      }
+    },
+    "/geoserver/rest/styles.json": {
+      "styles": {
+        "style": ""
+      }
+    },
+    "/geoserver/rest/workspaces/archive/styles.json": {
+      "styles": {
+        "style": ""
+      }
+    },
+    "/geoserver/rest/workspaces/demo/styles.json": {
+      "styles": {
+        "style": [
+          { "name": "deprecated" },
+          { "name": "line" }
+        ]
+      }
+    },
+    "/geoserver/rest/workspaces/demo/styles/deprecated.json": {
+      "style": {
+        "name": "deprecated",
+        "format": "css",
+        "filename": "deprecated.css"
+      }
+    },
+    "/geoserver/rest/workspaces/demo/styles/deprecated.sld": "",
+    "/geoserver/rest/workspaces/demo/styles/line.json": {
+      "style": {
+        "name": "line",
+        "format": "sld",
+        "languageVersion": "1.0.0",
+        "filename": "line.sld"
+      }
+    },
+    "/geoserver/rest/workspaces/demo/styles/line.sld": "<StyledLayerDescriptor xmlns=\"http://www.opengis.net/sld\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><NamedLayer><UserStyle><FeatureTypeStyle><Rule><LineSymbolizer /><PointSymbolizer><Graphic><ExternalGraphic><OnlineResource xlink:href=\"https://cdn.example.com/styles/road-marker.svg?token=fixture#frag\" /></ExternalGraphic></Graphic></PointSymbolizer></Rule></FeatureTypeStyle></UserStyle></NamedLayer></StyledLayerDescriptor>"
+  }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerInventoryBaselineTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerInventoryBaselineTests.cs
@@ -86,6 +86,14 @@ public sealed class GeoServerInventoryBaselineTests
         artifact.ExternalDependencies.Should().ContainSingle(dependency => dependency.Id == "service-endpoint:wfs")
             .Which.Compatibility.Code.Should().Be(ImportCompatibilityCodes.GeoServerServiceEndpoint);
 
+        var containerIds = artifact.Containers.Select(container => container.Id).ToHashSet(StringComparer.Ordinal);
+        artifact.ExternalDependencies
+            .Where(dependency => dependency.Kind == "service-endpoint")
+            .Should().OnlyContain(dependency => containerIds.Contains(dependency.ContainerId));
+
+        artifact.Containers.Should().ContainSingle(container => container.Id == "workspace:global")
+            .Which.Compatibility.Reason.Should().Be("Compatible: 2; partial: 0; incompatible: 0.");
+
         artifact.ExternalDependencies.Should().ContainSingle(dependency => dependency.Id == "datastore:demo:legacy")
             .Which.Compatibility.Code.Should().Be(ImportCompatibilityCodes.GeoServerUnsupportedStore);
         artifact.ExternalDependencies.Should().ContainSingle(dependency => dependency.Id == "coverage-store:demo:imagery")

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerInventoryBaselineTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerInventoryBaselineTests.cs
@@ -1,0 +1,232 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Shared.Models;
+using Honua.Postgres.Features.Import;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+/// <summary>
+/// Verifies the GeoServer migration inventory scanner against deterministic
+/// fixture-backed baselines. Baselines are regenerated on demand by setting
+/// <c>UPDATE_GEOSERVER_INVENTORY_BASELINES=1</c>.
+/// </summary>
+public sealed class GeoServerInventoryBaselineTests
+{
+    private static readonly JsonSerializerOptions IndentedSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true
+    };
+
+    [Theory]
+    [InlineData("MixedCatalog")]
+    public async Task ScanSourceAsync_ProducesExpectedBaseline(string scenario)
+    {
+        var fixture = LoadFixture(scenario);
+        var service = CreateService(new FixtureHttpHandler(fixture.Responses));
+
+        var artifact = await service.ScanSourceAsync(new GeoServerDiscoveryRequest
+        {
+            GeoServerRestUrl = fixture.ServiceUrl,
+            IncludeCompatibilityAnalysis = true,
+            IncludeStyleContent = true,
+            TimeoutSeconds = 5
+        });
+
+        var actualJson = JsonSerializer.Serialize(artifact, IndentedSerializerOptions);
+        AssertMatchesBaseline(scenario, actualJson);
+    }
+
+    [Fact]
+    public async Task ScanSourceAsync_MixedCatalog_ReportsStableCodesAndEndpointReferences()
+    {
+        var fixture = LoadFixture("MixedCatalog");
+        var service = CreateService(new FixtureHttpHandler(fixture.Responses));
+
+        var artifact = await service.ScanSourceAsync(new GeoServerDiscoveryRequest
+        {
+            GeoServerRestUrl = fixture.ServiceUrl,
+            IncludeCompatibilityAnalysis = true,
+            IncludeStyleContent = true,
+            TimeoutSeconds = 5
+        });
+
+        var roads = artifact.Resources.Should().ContainSingle(resource => resource.Id == "layer:demo:roads").Subject;
+        roads.Capabilities.Should().Equal("enabled", "query", "wfs", "wms");
+        roads.Compatibility.Code.Should().Be(ImportCompatibilityCodes.GeoServerSupported);
+
+        var disabled = artifact.Resources.Should().ContainSingle(resource => resource.Id == "layer:demo:closed").Subject;
+        disabled.Compatibility.Code.Should().Be(ImportCompatibilityCodes.GeoServerDisabledLayer);
+        disabled.Capabilities.Should().Equal("wfs", "wms");
+
+        var emptyGroup = artifact.Resources.Should().ContainSingle(resource => resource.Id == "layer-group:demo:empty-group").Subject;
+        emptyGroup.Compatibility.Code.Should().Be(ImportCompatibilityCodes.GeoServerEmptyLayerGroup);
+        emptyGroup.Capabilities.Should().Equal("wms");
+
+        artifact.ExternalDependencies.Should().ContainSingle(dependency => dependency.Id == "service-endpoint:wms")
+            .Which.Should().BeEquivalentTo(new
+            {
+                Kind = "service-endpoint",
+                Name = "WMS",
+                DependencyType = "ogc-service",
+                Address = "https://example.com/geoserver/wms"
+            });
+        artifact.ExternalDependencies.Should().ContainSingle(dependency => dependency.Id == "service-endpoint:wfs")
+            .Which.Compatibility.Code.Should().Be(ImportCompatibilityCodes.GeoServerServiceEndpoint);
+
+        artifact.ExternalDependencies.Should().ContainSingle(dependency => dependency.Id == "datastore:demo:legacy")
+            .Which.Compatibility.Code.Should().Be(ImportCompatibilityCodes.GeoServerUnsupportedStore);
+        artifact.ExternalDependencies.Should().ContainSingle(dependency => dependency.Id == "coverage-store:demo:imagery")
+            .Which.Compatibility.Code.Should().Be(ImportCompatibilityCodes.GeoServerManualReview);
+
+        var style = artifact.Styles.Should().ContainSingle(item => item.Id == "style:demo:line").Subject;
+        style.Compatibility.Code.Should().Be(ImportCompatibilityCodes.GeoServerStyleConversionRequired);
+        style.Metadata.Should().ContainKey("styleReference")
+            .WhoseValue.Should().Be("https://example.com/geoserver/rest/workspaces/demo/styles/line.json");
+        style.Metadata.Should().ContainKey("styleContentReference")
+            .WhoseValue.Should().Be("https://example.com/geoserver/rest/workspaces/demo/styles/line.sld");
+        style.Metadata.Keys.Should().NotContain("sldContent");
+
+        artifact.ExternalDependencies.Should().ContainSingle(dependency => dependency.Kind == "external-graphic")
+            .Which.Compatibility.Code.Should().Be(ImportCompatibilityCodes.GeoServerExternalGraphic);
+    }
+
+    private static FixtureScenario LoadFixture(string scenario)
+    {
+        var fixturePath = Path.Combine(
+            AppContext.BaseDirectory,
+            "Features",
+            "Import",
+            "Fixtures",
+            "GeoServer",
+            $"{scenario}.json");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(fixturePath));
+        var root = document.RootElement;
+        var serviceUrl = root.GetProperty("serviceUrl").GetString()
+            ?? throw new InvalidDataException($"Fixture {scenario} is missing serviceUrl.");
+        var responses = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var entry in root.GetProperty("responses").EnumerateObject())
+        {
+            responses[entry.Name] = entry.Value.ValueKind == JsonValueKind.String
+                ? entry.Value.GetString() ?? string.Empty
+                : entry.Value.GetRawText();
+        }
+
+        return new FixtureScenario(serviceUrl, responses);
+    }
+
+    private static void AssertMatchesBaseline(string scenario, string actualJson)
+    {
+        var baselineFile = $"{scenario}-expected.json";
+        var outputBaselinePath = Path.Combine(
+            AppContext.BaseDirectory,
+            "Features",
+            "Import",
+            "Baselines",
+            "GeoServer",
+            baselineFile);
+
+        var sourceBaselinePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..",
+            "Features",
+            "Import",
+            "Baselines",
+            "GeoServer",
+            baselineFile));
+
+        var regenRequested = string.Equals(
+            Environment.GetEnvironmentVariable("UPDATE_GEOSERVER_INVENTORY_BASELINES"),
+            "1",
+            StringComparison.Ordinal);
+
+        if (regenRequested)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(sourceBaselinePath)!);
+            File.WriteAllText(sourceBaselinePath, actualJson);
+            Directory.CreateDirectory(Path.GetDirectoryName(outputBaselinePath)!);
+            File.WriteAllText(outputBaselinePath, actualJson);
+            return;
+        }
+
+        File.Exists(sourceBaselinePath).Should().BeTrue(
+            $"baseline {baselineFile} must exist at {sourceBaselinePath}. Re-run with UPDATE_GEOSERVER_INVENTORY_BASELINES=1 to regenerate it and commit the result.");
+
+        var expectedJson = File.ReadAllText(sourceBaselinePath);
+        actualJson.Should().Be(
+            expectedJson,
+            $"baseline {baselineFile} should match scanner output. Re-run with UPDATE_GEOSERVER_INVENTORY_BASELINES=1 to refresh after intentional model changes.");
+    }
+
+    private static GeoServerImportService CreateService(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler);
+        var restClient = new GeoServerRestClient(
+            httpClient,
+            NullLogger<GeoServerRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+        var connectionProvider = new Mock<IDatabaseConnectionProvider>(MockBehavior.Strict);
+        var crsRegistry = new Mock<ICrsRegistry>(MockBehavior.Strict);
+
+        crsRegistry.Setup(registry => registry.ResolveBySridAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns((int srid, CancellationToken _) => new ValueTask<CrsDefinition?>(
+                srid switch
+                {
+                    3857 => new CrsDefinition("http://www.opengis.net/def/crs/EPSG/0/3857", 3857, AxisOrder.EastNorth, false),
+                    4326 => new CrsDefinition("http://www.opengis.net/def/crs/EPSG/0/4326", 4326, AxisOrder.EastNorth, true),
+                    _ => null
+                }));
+
+        return new GeoServerImportService(
+            restClient,
+            connectionProvider.Object,
+            crsRegistry.Object,
+            NullLogger<GeoServerImportService>.Instance);
+    }
+
+    private sealed record FixtureScenario(string ServiceUrl, IReadOnlyDictionary<string, string> Responses);
+
+    private sealed class FixtureHttpHandler : HttpMessageHandler
+    {
+        private readonly IReadOnlyDictionary<string, string> _responses;
+
+        public FixtureHttpHandler(IReadOnlyDictionary<string, string> responses)
+        {
+            _responses = responses;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var pathAndQuery = request.RequestUri?.PathAndQuery ?? string.Empty;
+            if (!_responses.TryGetValue(pathAndQuery, out var body))
+            {
+                throw new InvalidOperationException(
+                    $"Fixture has no response for {pathAndQuery}. Add it to the fixture JSON or correct the request path.");
+            }
+
+            var contentType = pathAndQuery.EndsWith(".xml", StringComparison.Ordinal)
+                ? "application/xml"
+                : pathAndQuery.EndsWith(".sld", StringComparison.Ordinal)
+                    ? "application/vnd.ogc.sld+xml"
+                    : "application/json";
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, contentType)
+            });
+        }
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj
+++ b/tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj
@@ -31,6 +31,12 @@
     <None Update="Features/Import/Baselines/ArcGis/*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Features/Import/Fixtures/GeoServer/*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Features/Import/Baselines/GeoServer/*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Issue Link
Fixes #878

## Summary
Hardens the GeoServer migration inventory scanner so migration reports carry stable compatibility codes, service endpoint dependencies, and fixture-backed baseline coverage for mixed GeoServer catalogs.

## Changes Made
- Added stable GeoServer compatibility codes for service endpoints, stores, layers, layer groups, styles, external graphics, and failed scans.
- Captured WMS/WFS endpoint dependencies and per-layer capabilities in migration inventory output.
- Added fixture-backed baseline coverage for mixed GeoServer catalogs, style references, external graphics, and scanner compatibility codes.
- Updated migration toolkit docs for the scanner hardening behavior and preview limitations.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Focused validation run locally:
- `UPDATE_GEOSERVER_INVENTORY_BASELINES=1 dotnet test tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj --filter "FullyQualifiedName~GeoServerInventoryBaselineTests" --logger "console;verbosity=normal"`
- `dotnet test tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj --filter "FullyQualifiedName~GeoServerImportService" --logger "console;verbosity=normal"`
- `dotnet test tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj --filter "FullyQualifiedName~GeoServerInventoryBaselineTests" --logger "console;verbosity=normal"`
- `git diff --check`
- `git diff --cached --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review