### PR TITLE
chore(release): record JS SDK CI release evidence

### DIFF
--- a/release/honua-2026-05-preview.json
+++ b/release/honua-2026-05-preview.json
@@ -36,7 +36,7 @@
       "Source-build workflow evidence is not release-candidate-image evidence unless the evidence record names the image digest tested."
     ]
   },
-  "observedAt": "2026-05-06T20:30:08Z",
+  "observedAt": "2026-05-07T09:41:25Z",
   "releaseGates": [
     {
       "id": "server-sdk-compatibility",
@@ -147,26 +147,19 @@
       "id": "sdk-js-trunk-ci",
       "owningRepo": "honua-io/honua-sdk-js",
       "requirement": "Trunk SDK CI is green.",
-      "evidenceState": "blocked",
+      "evidenceState": "passed",
       "latestEvidence": {
-        "runUrl": "https://github.com/honua-io/honua-sdk-js/actions/runs/25459278308",
+        "runUrl": "https://github.com/honua-io/honua-sdk-js/actions/runs/25487920652",
         "workflow": "SDK CI",
         "status": "completed",
-        "conclusion": "failure",
-        "headSha": "9e7d8ba14702186769f668d9d0e9cb54e9b82b7f",
-        "createdAt": "2026-05-06T20:27:57Z",
-        "updatedAt": "2026-05-06T20:29:11Z",
+        "conclusion": "success",
+        "headSha": "e8a46dd06b432088be3840a453716703d92a6a1d",
+        "createdAt": "2026-05-07T09:35:10Z",
+        "updatedAt": "2026-05-07T09:41:25Z",
         "source": "gh run list -R honua-io/honua-sdk-js --branch trunk --limit 10"
       },
       "waiver": null,
-      "blockers": [
-        {
-          "repo": "honua-io/honua-sdk-js",
-          "number": 132,
-          "url": "https://github.com/honua-io/honua-sdk-js/issues/132",
-          "reason": "Trunk SDK CI is failing; tracked by the bounded SDK JS release blocker."
-        }
-      ]
+      "blockers": []
     },
     {
       "id": "sdk-js-quickstart-staging",
@@ -174,13 +167,13 @@
       "requirement": "Quickstart staging is green.",
       "evidenceState": "passed",
       "latestEvidence": {
-        "runUrl": "https://github.com/honua-io/honua-sdk-js/actions/runs/25459278260",
+        "runUrl": "https://github.com/honua-io/honua-sdk-js/actions/runs/25487920662",
         "workflow": "Quickstart Staging",
         "status": "completed",
         "conclusion": "success",
-        "headSha": "9e7d8ba14702186769f668d9d0e9cb54e9b82b7f",
-        "createdAt": "2026-05-06T20:27:57Z",
-        "updatedAt": "2026-05-06T20:28:15Z",
+        "headSha": "e8a46dd06b432088be3840a453716703d92a6a1d",
+        "createdAt": "2026-05-07T09:35:10Z",
+        "updatedAt": "2026-05-07T09:35:22Z",
         "source": "gh run list -R honua-io/honua-sdk-js --branch trunk --limit 10"
       },
       "waiver": null,


### PR DESCRIPTION
## Issue Link
Related to #876
Related to honua-io/honua-sdk-js#132

## Summary
Updates the 2026-05 preview release manifest with current JS SDK release evidence after trunk recovered.

## Changes Made
- Mark `sdk-js-trunk-ci` as passed with SDK CI run https://github.com/honua-io/honua-sdk-js/actions/runs/25487920652.
- Refresh `sdk-js-quickstart-staging` with Quickstart Staging run https://github.com/honua-io/honua-sdk-js/actions/runs/25487920662.
- Advance the manifest `observedAt` timestamp to the successful SDK CI evidence time.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Manual validation: `jq empty release/honua-2026-05-preview.json`.

## Gate Impact
- [ ] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] `scripts/ci/pre-pr-check.sh` not run: manifest-only release evidence update; local JSON validation and PR CI cover this change
- [x] Commit messages follow conventional format: `chore(release): record JS SDK CI release evidence`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [x] If protocol/auth behavior changed: not applicable
- [x] If breaking admin/control-plane API changes: not applicable
- [x] If breaking gRPC/proto wire changes: not applicable