### PR TITLE
chore(release): record mobile .NET SDK train evidence

### DIFF
--- a/quality/release-evidence/honua-2026-05-preview-mobile-dotnet-sdk-train.json
+++ b/quality/release-evidence/honua-2026-05-preview-mobile-dotnet-sdk-train.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://honua.io/schemas/mobile-dotnet-sdk-train-release-evidence.v1.json",
+  "schemaVersion": 1,
+  "releaseId": "honua-2026-05-preview",
+  "repositoryLaneId": "mobile-dotnet-sdk-train",
+  "owningRepo": "honua-io/honua-mobile",
+  "issue": {
+    "repo": "honua-io/honua-mobile",
+    "number": 133,
+    "url": "https://github.com/honua-io/honua-mobile/issues/133"
+  },
+  "parentReleaseGate": {
+    "repo": "honua-io/honua-server",
+    "number": 876,
+    "url": "https://github.com/honua-io/honua-server/issues/876"
+  },
+  "serverReleaseManifest": {
+    "repo": "honua-io/honua-server",
+    "path": "release/honua-2026-05-preview.json",
+    "laneId": "mobile-dotnet-sdk-train"
+  },
+  "sdkTrain": {
+    "repository": "honua-io/honua-sdk-dotnet",
+    "packageVersion": "0.1.15-alpha.1",
+    "releaseTag": "dotnet-sdk-v0.1.15-alpha.1",
+    "releaseUrl": "https://github.com/honua-io/honua-sdk-dotnet/releases/tag/dotnet-sdk-v0.1.15-alpha.1",
+    "releaseCommit": "9d264e358099dc20a30b9247013b61d1fba0b0a9",
+    "releasePublishedAt": "2026-04-30T23:32:50Z"
+  },
+  "observedUnconsumedRelease": {
+    "releaseTag": "dotnet-sdk-v0.1.16-alpha.1",
+    "releaseUrl": "https://github.com/honua-io/honua-sdk-dotnet/releases/tag/dotnet-sdk-v0.1.16-alpha.1",
+    "releaseCommit": "f31cfeb6c21af896b96194688a393638461f3d8a",
+    "releasePublishedAt": "2026-05-07T08:52:04Z",
+    "reason": "GitHub Packages did not expose Honua.Sdk.* 0.1.16-alpha.1 during PR CI restore; the feed reported 0.1.15-alpha.1 as the nearest published package train."
+  },
+  "mobileValidation": {
+    "packageReferenceProperty": "HonuaSdkDotNetTrainVersion",
+    "packageReferenceVersionExpression": "$(HonuaSdkDotNetTrainVersion)",
+    "sourceBoundary": "Published Honua.Sdk.* NuGet packages only; no copied SDK source or long-lived honua-sdk-dotnet ProjectReference links.",
+    "requiredChecks": [
+      "dotnet restore tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj",
+      "dotnet test tests/Honua.Mobile.Sdk.Tests/Honua.Mobile.Sdk.Tests.csproj --configuration Release",
+      "dotnet test tests/Honua.Mobile.ServerIntegration.Tests/Honua.Mobile.ServerIntegration.Tests.csproj --configuration Release"
+    ],
+    "liveServerChecks": {
+      "mode": "optional-release-candidate-image",
+      "enableVariable": "HONUA_MOBILE_LIVE_SERVER_TESTS",
+      "imageVariable": "HONUA_MOBILE_LIVE_SERVER_IMAGE",
+      "baseUrlVariable": "HONUA_MOBILE_LIVE_SERVER_BASE_URL"
+    }
+  },
+  "manifestEvidenceRequirements": [
+    "resolved mobile commit SHA",
+    "CI or local run URL/log for the required checks",
+    "SDK train package version, release tag, and release commit",
+    "waiver record if the validation cannot pass before the Preview release"
+  ],
+  "waiver": null
+}

--- a/release/honua-2026-05-preview.json
+++ b/release/honua-2026-05-preview.json
@@ -210,13 +210,13 @@
       "requirement": "Mobile consumes the current .NET SDK train and passes contract/integration tests.",
       "evidenceState": "passed",
       "latestEvidence": {
-        "runUrl": "https://github.com/honua-io/honua-mobile/actions/runs/25507338387",
+        "runUrl": "https://github.com/honua-io/honua-mobile/actions/runs/25511816629",
         "workflow": "CI",
         "status": "completed",
         "conclusion": "success",
-        "headSha": "c05fd191f8f818ba0d3f2177eb7944f75f3fa462",
-        "createdAt": "2026-05-07T16:03:14Z",
-        "updatedAt": "2026-05-07T16:30:22Z",
+        "headSha": "65825115ba07b4715a85f5738eea04a4cc74fa11",
+        "createdAt": "2026-05-07T17:32:33Z",
+        "updatedAt": "2026-05-07T17:51:31Z",
         "prUrl": "https://github.com/honua-io/honua-mobile/pull/141",
         "evidenceFile": "quality/release-evidence/honua-2026-05-preview-mobile-dotnet-sdk-train.json",
         "sdkTrain": {
@@ -232,7 +232,7 @@
           "releaseCommit": "f31cfeb6c21af896b96194688a393638461f3d8a",
           "reason": "GitHub Packages did not expose Honua.Sdk.* 0.1.16-alpha.1 during PR restore; mobile consumes the current published package train."
         },
-        "source": "gh run view 25507338387 -R honua-io/honua-mobile --json status,conclusion,createdAt,updatedAt,headSha,url,jobs"
+        "source": "gh run view 25511816629 -R honua-io/honua-mobile --json status,conclusion,createdAt,updatedAt,headSha,url,jobs"
       },
       "waiver": null,
       "blockers": []

--- a/release/honua-2026-05-preview.json
+++ b/release/honua-2026-05-preview.json
@@ -208,17 +208,34 @@
       "id": "mobile-dotnet-sdk-train",
       "owningRepo": "honua-io/honua-mobile",
       "requirement": "Mobile consumes the current .NET SDK train and passes contract/integration tests.",
-      "evidenceState": "blocked",
-      "latestEvidence": null,
+      "evidenceState": "passed",
+      "latestEvidence": {
+        "runUrl": "https://github.com/honua-io/honua-mobile/actions/runs/25507338387",
+        "workflow": "CI",
+        "status": "completed",
+        "conclusion": "success",
+        "headSha": "c05fd191f8f818ba0d3f2177eb7944f75f3fa462",
+        "createdAt": "2026-05-07T16:03:14Z",
+        "updatedAt": "2026-05-07T16:30:22Z",
+        "prUrl": "https://github.com/honua-io/honua-mobile/pull/141",
+        "evidenceFile": "quality/release-evidence/honua-2026-05-preview-mobile-dotnet-sdk-train.json",
+        "sdkTrain": {
+          "packageVersion": "0.1.15-alpha.1",
+          "releaseTag": "dotnet-sdk-v0.1.15-alpha.1",
+          "releaseUrl": "https://github.com/honua-io/honua-sdk-dotnet/releases/tag/dotnet-sdk-v0.1.15-alpha.1",
+          "releaseCommit": "9d264e358099dc20a30b9247013b61d1fba0b0a9",
+          "publishedAt": "2026-04-30T23:32:50Z"
+        },
+        "observedUnconsumedRelease": {
+          "releaseTag": "dotnet-sdk-v0.1.16-alpha.1",
+          "releaseUrl": "https://github.com/honua-io/honua-sdk-dotnet/releases/tag/dotnet-sdk-v0.1.16-alpha.1",
+          "releaseCommit": "f31cfeb6c21af896b96194688a393638461f3d8a",
+          "reason": "GitHub Packages did not expose Honua.Sdk.* 0.1.16-alpha.1 during PR restore; mobile consumes the current published package train."
+        },
+        "source": "gh run view 25507338387 -R honua-io/honua-mobile --json status,conclusion,createdAt,updatedAt,headSha,url,jobs"
+      },
       "waiver": null,
-      "blockers": [
-        {
-          "repo": "honua-io/honua-mobile",
-          "number": 133,
-          "url": "https://github.com/honua-io/honua-mobile/issues/133",
-          "reason": "Mobile .NET SDK train contract/integration evidence is missing; tracked by the bounded mobile release evidence blocker."
-        }
-      ]
+      "blockers": []
     },
     {
       "id": "helm-release-candidate-metadata",


### PR DESCRIPTION
## Summary
Record the honua-mobile .NET SDK train release evidence for the 2026-05 Preview manifest.

## Changes Made
- Mark `mobile-dotnet-sdk-train` passed in `release/honua-2026-05-preview.json`.
- Attach honua-mobile PR #141 green CI evidence from run https://github.com/honua-io/honua-mobile/actions/runs/25511816629.
- Record final mobile evidence head SHA `65825115ba07b4715a85f5738eea04a4cc74fa11`.
- Record consumed .NET SDK package train `0.1.15-alpha.1` and observed unconsumed `0.1.16-alpha.1` package availability context.

## Gate Impact
- [x] Release manifest / release evidence only
- [ ] Runtime server behavior
- [ ] Database migrations
- [ ] Public API behavior

## Testing
- [x] `jq empty release/honua-2026-05-preview.json`
- [x] `git diff --check`
- [x] honua-mobile CI run `25511816629` completed successfully
- [x] `scripts/ci/pre-pr-check.sh` attempted locally; restore, Release build, format, Core tests, Load tests, and Postgres tests passed, then `Honua.Server.Tests` Core shard timed out at 20m before completion

## Breaking Changes
None.

Related to #876.
Depends on honua-mobile#133 / https://github.com/honua-io/honua-mobile/pull/141.