### PR TITLE
test: add AI builder spatial query contract fixture

### DIFF
--- a/docs/developer/MCP_SERVER.md
+++ b/docs/developer/MCP_SERVER.md
@@ -780,6 +780,7 @@ method as the `target` and `authenticated = false`.
 ### Source
 
 - Vertical slice: `src/Honua.Server/Features/Protocols/Mcp/`
+- AI builder fixture contract: `docs/developer/ai-builder-contract-fixtures.md`
 - Tools: `src/Honua.Server/Features/Protocols/Mcp/Tools/`
 - Resources: `src/Honua.Server/Features/Protocols/Mcp/Resources/`
 - Reporting feature (builder, renderers, narrative provider, templates):

--- a/docs/developer/ai-builder-contract-fixtures.md
+++ b/docs/developer/ai-builder-contract-fixtures.md
@@ -1,0 +1,42 @@
+# AI Builder Contract Fixtures
+
+`tests/fixtures/ai-builder/spatial-query-contract-v1.json` is the deterministic
+server-side contract fixture for the AI app builder and spatial query demo. It
+does not call a live model and does not authorize raw SQL generation. The fixture
+locks the structured response shapes that SDK and MCP clients can replay while
+the broader app-builder runtime continues to land behind the existing NL query,
+spec, plan/apply, package, and MCP surfaces.
+
+The fixture covers:
+
+- NL prompt to structured `filterPlan`, `specDraft`, and `appDraft` state.
+- Metadata discovery for source selection, schema preview, field labels/domains,
+  geometry columns, CRS, and spatial predicate capability states.
+- Clarification candidates for ambiguous sources, units, and operations.
+- Plan DAGs, warnings, cache keys, reproducibility warnings, job status, and
+  artifact references.
+- Packageable `MapPackage` and `AppPackage` artifact references using the MCP
+  resource URI patterns.
+- Starter templates for `map-only`, `map-plus-table`, `map-plus-chart`,
+  `filtered-map`, and `linked-dashboard`.
+- Required fixture outcomes: success, ambiguity, unsupported capability,
+  auth/RBAC denied, oversized estimate, cache hit, and apply failure.
+
+The narrow regression suite is
+`Honua.Core.Tests.Features.AiBuilder.AiBuilderContractFixtureTests`. It verifies
+that the fixture remains complete enough for honua-sdk-js app-builder smoke tests
+to render reviewable drafts and recovery states without hidden model state.
+
+MCP clients should pair fixture artifacts with these existing inspection routes:
+
+- `honua_ground_candidates` and `honua_clarify_intent` for grounding and
+  clarification envelopes.
+- `honua_validate_plan`, `honua_dry_run_plan`, and `honua_execute_plan` for
+  plan validation, dry-run estimates, and job submission.
+- `honua://jobs/{jobId}`, `honua://jobs/{jobId}/results`,
+  `honua://map-packages/{packageId}`, and
+  `honua://app-packages/{packageId}` for inspection.
+
+This slice is intentionally fixture-driven. Live model-backed planning,
+cloud-deployed SDK compatibility runs, and broader runtime endpoint coverage
+remain follow-up work for the parent platform ticket.

--- a/tests/dotnet/Honua.Core.Tests/Features/AiBuilder/AiBuilderContractFixtureTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/AiBuilder/AiBuilderContractFixtureTests.cs
@@ -40,10 +40,16 @@ public sealed class AiBuilderContractFixtureTests
         using var document = await LoadFixtureAsync();
         var discovery = document.RootElement.GetProperty("capabilityDiscovery");
 
-        var source = discovery.GetProperty("sources").EnumerateArray().First();
-        source.GetProperty("fields").GetArrayLength().Should().BeGreaterThan(0);
-        source.GetProperty("geometryColumn").GetString().Should().NotBeNullOrWhiteSpace();
-        source.GetProperty("crs").GetString().Should().StartWith("EPSG:");
+        var sourceIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var source in discovery.GetProperty("sources").EnumerateArray())
+        {
+            var sourceId = source.GetProperty("sourceId").GetString();
+            sourceId.Should().NotBeNullOrWhiteSpace();
+            sourceIds.Add(sourceId!).Should().BeTrue();
+            source.GetProperty("fields").GetArrayLength().Should().BeGreaterThan(0);
+            source.GetProperty("geometryColumn").GetString().Should().NotBeNullOrWhiteSpace();
+            source.GetProperty("crs").GetString().Should().StartWith("EPSG:");
+        }
 
         var predicates = discovery.GetProperty("spatialQueryCapabilities")
             .EnumerateArray()
@@ -113,13 +119,30 @@ public sealed class AiBuilderContractFixtureTests
     {
         using var document = await LoadFixtureAsync();
 
+        var discoveredSources = document.RootElement.GetProperty("capabilityDiscovery")
+            .GetProperty("sources")
+            .EnumerateArray()
+            .Select(source => source.GetProperty("sourceId").GetString())
+            .OfType<string>()
+            .Where(sourceId => !string.IsNullOrWhiteSpace(sourceId))
+            .ToHashSet(StringComparer.Ordinal);
+
         var ambiguity = FindScenario(document.RootElement, "ambiguity-source-and-unit");
         ambiguity.GetProperty("draft").GetProperty("status").GetString().Should().Be("clarification_required");
-        var candidateKinds = ambiguity.GetProperty("clarification").GetProperty("candidates")
+        var candidates = ambiguity.GetProperty("clarification").GetProperty("candidates")
             .EnumerateArray()
+            .ToArray();
+        var candidateKinds = candidates
             .Select(candidate => candidate.GetProperty("kind").GetString())
             .ToHashSet(StringComparer.Ordinal);
         candidateKinds.Should().Contain(["source", "unit", "operation"]);
+        var sourceOptions = candidates
+            .Single(candidate => candidate.GetProperty("kind").GetString() == "source")
+            .GetProperty("options")
+            .EnumerateArray()
+            .Select(option => option.GetString()!)
+            .ToArray();
+        sourceOptions.Should().OnlyContain(sourceId => discoveredSources.Contains(sourceId));
 
         var unsupported = FindScenario(document.RootElement, "unsupported-spatial-join");
         unsupported.GetProperty("capabilityState").GetProperty("state").GetString().Should().Be("unsupported");

--- a/tests/dotnet/Honua.Core.Tests/Features/AiBuilder/AiBuilderContractFixtureTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/AiBuilder/AiBuilderContractFixtureTests.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+
+namespace Honua.Core.Tests.Features.AiBuilder;
+
+public sealed class AiBuilderContractFixtureTests
+{
+    private const string FixtureVersion = "honua.ai_builder.spatial_query.v1";
+
+    [Fact]
+    public async Task SpatialQueryFixture_CoversRequiredOutcomeCases()
+    {
+        using var document = await LoadFixtureAsync();
+        var root = document.RootElement;
+
+        root.GetProperty("contractVersion").GetString().Should().Be(FixtureVersion);
+        root.GetProperty("fixtureProfile").GetString().Should().Be("deterministic-no-model");
+
+        var cases = root.GetProperty("scenarios")
+            .EnumerateArray()
+            .Select(scenario => scenario.GetProperty("case").GetString())
+            .ToHashSet(StringComparer.Ordinal);
+
+        cases.Should().BeEquivalentTo(
+            "success",
+            "ambiguity",
+            "unsupported",
+            "auth-denied",
+            "oversized",
+            "cache-hit",
+            "apply-failure");
+    }
+
+    [Fact]
+    public async Task CapabilityDiscovery_AdvertisesMetadataPredicatesTemplatesAndMcpInspection()
+    {
+        using var document = await LoadFixtureAsync();
+        var discovery = document.RootElement.GetProperty("capabilityDiscovery");
+
+        var source = discovery.GetProperty("sources").EnumerateArray().First();
+        source.GetProperty("fields").GetArrayLength().Should().BeGreaterThan(0);
+        source.GetProperty("geometryColumn").GetString().Should().NotBeNullOrWhiteSpace();
+        source.GetProperty("crs").GetString().Should().StartWith("EPSG:");
+
+        var predicates = discovery.GetProperty("spatialQueryCapabilities")
+            .EnumerateArray()
+            .ToDictionary(
+                item => item.GetProperty("name").GetString()!,
+                item => item.GetProperty("state").GetString()!,
+                StringComparer.Ordinal);
+
+        predicates.Should().ContainKeys(
+            "bbox",
+            "intersects",
+            "contains",
+            "within",
+            "withinDistance",
+            "attributeFilter",
+            "groupingAggregation",
+            "spatialJoin");
+        predicates.Values.Should().OnlyContain(state =>
+            state == "supported" || state == "degraded" || state == "unsupported");
+
+        var templates = discovery.GetProperty("starterOutputTemplates")
+            .EnumerateArray()
+            .Select(template => template.GetProperty("templateId").GetString())
+            .ToHashSet(StringComparer.Ordinal);
+
+        templates.Should().BeEquivalentTo(
+            "map-only",
+            "map-plus-table",
+            "map-plus-chart",
+            "filtered-map",
+            "linked-dashboard");
+
+        var mcp = discovery.GetProperty("mcpInspection");
+        mcp.GetProperty("tools").EnumerateArray().Select(tool => tool.GetString())
+            .Should().Contain(["honua_ground_candidates", "honua_clarify_intent", "honua_execute_plan"]);
+        mcp.GetProperty("resources").EnumerateArray().Select(resource => resource.GetString())
+            .Should().Contain(["honua://jobs/{jobId}/results", "honua://map-packages/{packageId}", "honua://app-packages/{packageId}"]);
+    }
+
+    [Fact]
+    public async Task SuccessAndCacheHitScenarios_SurfaceDraftPlanWarningsCacheAndPackageArtifacts()
+    {
+        using var document = await LoadFixtureAsync();
+
+        var success = FindScenario(document.RootElement, "success-linked-dashboard");
+        success.GetProperty("draft").GetProperty("filterPlan").GetProperty("clauses").GetArrayLength().Should().BeGreaterThan(0);
+        success.GetProperty("draft").GetProperty("specDraft").GetProperty("grammarVersion").GetString().Should().Be("v1.0");
+        success.GetProperty("draft").GetProperty("appDraft").GetProperty("targetSdk").GetString().Should().Be("honua-sdk-js");
+
+        var plan = success.GetProperty("plan");
+        plan.GetProperty("dag").GetArrayLength().Should().BeGreaterThan(1);
+        plan.GetProperty("warnings").EnumerateArray()
+            .Should().Contain(warning => warning.GetProperty("code").GetString() == "mutable_source_cache_warning");
+        plan.GetProperty("cache").GetProperty("hit").GetBoolean().Should().BeFalse();
+
+        AssertPackageArtifacts(success.GetProperty("apply"));
+
+        var cacheHit = FindScenario(document.RootElement, "cache-hit-reused-packages");
+        cacheHit.GetProperty("plan").GetProperty("cache").GetProperty("hit").GetBoolean().Should().BeTrue();
+        cacheHit.GetProperty("plan").GetProperty("warnings").EnumerateArray()
+            .Should().Contain(warning => warning.GetProperty("code").GetString() == "cache_hit");
+        AssertPackageArtifacts(cacheHit.GetProperty("apply"));
+    }
+
+    [Fact]
+    public async Task FailureAndClarificationScenarios_UseStructuredRecoverableShapes()
+    {
+        using var document = await LoadFixtureAsync();
+
+        var ambiguity = FindScenario(document.RootElement, "ambiguity-source-and-unit");
+        ambiguity.GetProperty("draft").GetProperty("status").GetString().Should().Be("clarification_required");
+        var candidateKinds = ambiguity.GetProperty("clarification").GetProperty("candidates")
+            .EnumerateArray()
+            .Select(candidate => candidate.GetProperty("kind").GetString())
+            .ToHashSet(StringComparer.Ordinal);
+        candidateKinds.Should().Contain(["source", "unit", "operation"]);
+
+        var unsupported = FindScenario(document.RootElement, "unsupported-spatial-join");
+        unsupported.GetProperty("capabilityState").GetProperty("state").GetString().Should().Be("unsupported");
+        unsupported.GetProperty("warnings").EnumerateArray()
+            .Should().Contain(warning => warning.GetProperty("code").GetString() == "unsupported_capability");
+
+        var authDenied = FindScenario(document.RootElement, "auth-denied-private-source");
+        authDenied.GetProperty("error").GetProperty("code").GetString().Should().Be("auth_denied");
+        authDenied.GetProperty("error").TryGetProperty("policyRef", out _).Should().BeTrue();
+
+        var oversized = FindScenario(document.RootElement, "oversized-estimate");
+        oversized.GetProperty("plan").GetProperty("status").GetString().Should().Be("rejected");
+        oversized.GetProperty("plan").GetProperty("estimate").GetProperty("featureCount").GetInt64()
+            .Should().BeGreaterThan(oversized.GetProperty("plan").GetProperty("estimate").GetProperty("limit").GetInt64());
+
+        var applyFailure = FindScenario(document.RootElement, "apply-failure-package-step");
+        applyFailure.GetProperty("apply").GetProperty("status").GetString().Should().Be("failed");
+        applyFailure.GetProperty("apply").GetProperty("job").GetProperty("resourceUri").GetString()
+            .Should().StartWith("honua://jobs/");
+        applyFailure.GetProperty("apply").GetProperty("warnings").EnumerateArray()
+            .Should().Contain(warning => warning.GetProperty("code").GetString() == "artifact_write_failed");
+    }
+
+    private static void AssertPackageArtifacts(JsonElement apply)
+    {
+        apply.GetProperty("status").GetString().Should().Be("succeeded");
+        var artifacts = apply.GetProperty("artifacts").EnumerateArray().ToList();
+
+        artifacts.Should().Contain(artifact =>
+            artifact.GetProperty("kind").GetString() == "MapPackage"
+            && artifact.GetProperty("format").GetString() == "honua_map_package.v1"
+            && artifact.GetProperty("resourceUri").GetString()!.StartsWith("honua://map-packages/", StringComparison.Ordinal)
+            && artifact.GetProperty("packageable").GetBoolean());
+
+        artifacts.Should().Contain(artifact =>
+            artifact.GetProperty("kind").GetString() == "AppPackage"
+            && artifact.GetProperty("format").GetString() == "honua_app_package.v1"
+            && artifact.GetProperty("resourceUri").GetString()!.StartsWith("honua://app-packages/", StringComparison.Ordinal)
+            && artifact.GetProperty("packageable").GetBoolean());
+    }
+
+    private static JsonElement FindScenario(JsonElement root, string id) =>
+        root.GetProperty("scenarios")
+            .EnumerateArray()
+            .Single(scenario => scenario.GetProperty("id").GetString() == id);
+
+    private static async Task<JsonDocument> LoadFixtureAsync()
+    {
+        await using var stream = File.OpenRead(ResolveRepoPath(
+            Path.Combine("tests", "fixtures", "ai-builder", "spatial-query-contract-v1.json")));
+
+        return await JsonDocument.ParseAsync(stream);
+    }
+
+    private static string ResolveRepoPath(string relativePath)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, relativePath);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException($"Unable to locate '{relativePath}' from '{AppContext.BaseDirectory}'.");
+    }
+}

--- a/tests/fixtures/ai-builder/spatial-query-contract-v1.json
+++ b/tests/fixtures/ai-builder/spatial-query-contract-v1.json
@@ -1,0 +1,439 @@
+{
+  "contractVersion": "honua.ai_builder.spatial_query.v1",
+  "fixtureProfile": "deterministic-no-model",
+  "description": "Fixture-only platform contract for NL spatial query to draft, plan, apply, package, and MCP inspection flows.",
+  "capabilityDiscovery": {
+    "sources": [
+      {
+        "sourceId": "catalog:layer:critical_facilities",
+        "label": "Critical Facilities",
+        "geometryColumn": "geom",
+        "geometryType": "Point",
+        "crs": "EPSG:4326",
+        "fields": [
+          {
+            "name": "facility_type",
+            "label": "Facility type",
+            "type": "string",
+            "domain": [
+              "hospital",
+              "shelter",
+              "school"
+            ]
+          },
+          {
+            "name": "status",
+            "label": "Operational status",
+            "type": "string",
+            "domain": [
+              "open",
+              "limited",
+              "closed"
+            ]
+          },
+          {
+            "name": "capacity",
+            "label": "Capacity",
+            "type": "integer"
+          }
+        ]
+      },
+      {
+        "sourceId": "catalog:layer:flood_zones",
+        "label": "Flood Zones",
+        "geometryColumn": "geom",
+        "geometryType": "Polygon",
+        "crs": "EPSG:4326",
+        "fields": [
+          {
+            "name": "zone",
+            "label": "Flood zone",
+            "type": "string",
+            "domain": [
+              "A",
+              "AE",
+              "VE"
+            ]
+          }
+        ]
+      }
+    ],
+    "spatialQueryCapabilities": [
+      {
+        "name": "bbox",
+        "state": "supported"
+      },
+      {
+        "name": "intersects",
+        "state": "supported"
+      },
+      {
+        "name": "contains",
+        "state": "supported"
+      },
+      {
+        "name": "within",
+        "state": "supported"
+      },
+      {
+        "name": "withinDistance",
+        "state": "supported"
+      },
+      {
+        "name": "attributeFilter",
+        "state": "supported"
+      },
+      {
+        "name": "groupingAggregation",
+        "state": "supported"
+      },
+      {
+        "name": "spatialJoin",
+        "state": "degraded",
+        "reason": "Available only for point-in-polygon joins on fixture layers."
+      }
+    ],
+    "starterOutputTemplates": [
+      {
+        "templateId": "map-only",
+        "outputs": [
+          "mapPackage"
+        ]
+      },
+      {
+        "templateId": "map-plus-table",
+        "outputs": [
+          "mapPackage",
+          "table"
+        ]
+      },
+      {
+        "templateId": "map-plus-chart",
+        "outputs": [
+          "mapPackage",
+          "chart"
+        ]
+      },
+      {
+        "templateId": "filtered-map",
+        "outputs": [
+          "mapPackage",
+          "filterPanel"
+        ]
+      },
+      {
+        "templateId": "linked-dashboard",
+        "outputs": [
+          "appPackage",
+          "mapPackage",
+          "table",
+          "chart",
+          "details"
+        ]
+      }
+    ],
+    "mcpInspection": {
+      "tools": [
+        "honua_ground_candidates",
+        "honua_clarify_intent",
+        "honua_validate_plan",
+        "honua_dry_run_plan",
+        "honua_execute_plan"
+      ],
+      "resources": [
+        "honua://catalog/processes",
+        "honua://jobs/{jobId}",
+        "honua://jobs/{jobId}/results",
+        "honua://map-packages/{packageId}",
+        "honua://app-packages/{packageId}",
+        "honua://published-services/{serviceId}",
+        "honua://deployments/{deploymentId}"
+      ]
+    }
+  },
+  "scenarios": [
+    {
+      "id": "success-linked-dashboard",
+      "case": "success",
+      "prompt": "Show open hospitals within 1 km of flood zones as a linked map, table, and chart.",
+      "draft": {
+        "status": "ready",
+        "filterPlan": {
+          "combinator": "and",
+          "clauses": [
+            {
+              "type": "comparison",
+              "comparison": {
+                "property": "facility_type",
+                "operator": "eq",
+                "value": "hospital"
+              }
+            },
+            {
+              "type": "comparison",
+              "comparison": {
+                "property": "status",
+                "operator": "eq",
+                "value": "open"
+              }
+            },
+            {
+              "type": "spatial",
+              "spatial": {
+                "operator": "dwithin",
+                "targetSource": "catalog:layer:flood_zones",
+                "distance": 1000,
+                "distanceUnit": "meters"
+              }
+            }
+          ]
+        },
+        "specDraft": {
+          "grammarVersion": "v1.0",
+          "sourceIds": [
+            "facilities",
+            "flood_zones"
+          ],
+          "computeIds": [
+            "near_flood_zones"
+          ],
+          "outputIds": [
+            "dashboard"
+          ]
+        },
+        "appDraft": {
+          "templateId": "linked-dashboard",
+          "targetSdk": "honua-sdk-js",
+          "views": [
+            "map",
+            "table",
+            "chart",
+            "details"
+          ]
+        }
+      },
+      "plan": {
+        "status": "planned",
+        "planId": "plan-success-linked-dashboard",
+        "dag": [
+          {
+            "nodeId": "query-open-hospitals",
+            "kind": "queryFeatures"
+          },
+          {
+            "nodeId": "distance-filter",
+            "kind": "geoprocess",
+            "processId": "geometry.withinDistance",
+            "dependsOn": [
+              "query-open-hospitals"
+            ]
+          },
+          {
+            "nodeId": "compose-packages",
+            "kind": "export",
+            "dependsOn": [
+              "distance-filter"
+            ]
+          }
+        ],
+        "warnings": [
+          {
+            "code": "mutable_source_cache_warning",
+            "message": "Source catalog:layer:critical_facilities can change; artifacts are reproducible only against the recorded snapshot token."
+          }
+        ],
+        "cache": {
+          "key": "sha256:fixture-success-linked-dashboard",
+          "hit": false,
+          "reproducibility": "snapshot-token-required"
+        }
+      },
+      "apply": {
+        "status": "succeeded",
+        "job": {
+          "jobId": "job-success-linked-dashboard",
+          "status": "succeeded",
+          "resourceUri": "honua://jobs/job-success-linked-dashboard"
+        },
+        "artifacts": [
+          {
+            "artifactId": "map-pkg-success",
+            "kind": "MapPackage",
+            "format": "honua_map_package.v1",
+            "resourceUri": "honua://map-packages/map-pkg-success",
+            "packageable": true
+          },
+          {
+            "artifactId": "app-pkg-success",
+            "kind": "AppPackage",
+            "format": "honua_app_package.v1",
+            "resourceUri": "honua://app-packages/app-pkg-success",
+            "packageable": true
+          }
+        ]
+      }
+    },
+    {
+      "id": "ambiguity-source-and-unit",
+      "case": "ambiguity",
+      "prompt": "Find shelters near flood zones.",
+      "draft": {
+        "status": "clarification_required"
+      },
+      "clarification": {
+        "candidates": [
+          {
+            "kind": "source",
+            "field": "dataset.selection",
+            "reason": "ambiguous_source",
+            "options": [
+              "catalog:layer:critical_facilities",
+              "catalog:layer:emergency_shelters"
+            ]
+          },
+          {
+            "kind": "unit",
+            "field": "distance",
+            "reason": "missing_distance",
+            "options": [
+              "500 meters",
+              "1 kilometer",
+              "5 kilometers"
+            ]
+          },
+          {
+            "kind": "operation",
+            "field": "spatialPredicate",
+            "reason": "ambiguous_operation",
+            "options": [
+              "withinDistance",
+              "intersects"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "unsupported-spatial-join",
+      "case": "unsupported",
+      "prompt": "Join every road segment to every flood polygon it crosses and summarize by route.",
+      "draft": {
+        "status": "unsupported"
+      },
+      "capabilityState": {
+        "name": "spatialJoin",
+        "state": "unsupported",
+        "reason": "Line-on-polygon spatial joins are outside this fixture profile."
+      },
+      "warnings": [
+        {
+          "code": "unsupported_capability",
+          "capability": "spatialJoin"
+        }
+      ]
+    },
+    {
+      "id": "auth-denied-private-source",
+      "case": "auth-denied",
+      "prompt": "Show restricted emergency command centers near flood zones.",
+      "error": {
+        "code": "auth_denied",
+        "requiresReauthentication": false,
+        "policyRef": "rbac:source:restricted_command_centers"
+      }
+    },
+    {
+      "id": "oversized-estimate",
+      "case": "oversized",
+      "prompt": "Buffer every parcel in the county by 20 km and build a dashboard.",
+      "plan": {
+        "status": "rejected",
+        "estimate": {
+          "featureCount": 12000000,
+          "limit": 1000000,
+          "unit": "features"
+        },
+        "warnings": [
+          {
+            "code": "estimate_limit_exceeded",
+            "message": "Estimated feature count exceeds the fixture apply limit."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cache-hit-reused-packages",
+      "case": "cache-hit",
+      "prompt": "Show open hospitals within 1 km of flood zones as a linked map, table, and chart.",
+      "plan": {
+        "status": "planned",
+        "cache": {
+          "key": "sha256:fixture-success-linked-dashboard",
+          "hit": true,
+          "reproducibility": "snapshot-token-required"
+        },
+        "warnings": [
+          {
+            "code": "cache_hit",
+            "message": "Plan reused artifacts from the recorded fixture cache key."
+          }
+        ]
+      },
+      "apply": {
+        "status": "succeeded",
+        "artifacts": [
+          {
+            "artifactId": "map-pkg-success",
+            "kind": "MapPackage",
+            "format": "honua_map_package.v1",
+            "resourceUri": "honua://map-packages/map-pkg-success",
+            "packageable": true
+          },
+          {
+            "artifactId": "app-pkg-success",
+            "kind": "AppPackage",
+            "format": "honua_app_package.v1",
+            "resourceUri": "honua://app-packages/app-pkg-success",
+            "packageable": true
+          }
+        ]
+      }
+    },
+    {
+      "id": "apply-failure-package-step",
+      "case": "apply-failure",
+      "prompt": "Create a linked dashboard for open hospitals near flood zones.",
+      "plan": {
+        "status": "planned",
+        "planId": "plan-apply-failure-package-step",
+        "dag": [
+          {
+            "nodeId": "query-open-hospitals",
+            "kind": "queryFeatures"
+          },
+          {
+            "nodeId": "compose-packages",
+            "kind": "export",
+            "dependsOn": [
+              "query-open-hospitals"
+            ]
+          }
+        ]
+      },
+      "apply": {
+        "status": "failed",
+        "job": {
+          "jobId": "job-apply-failure-package-step",
+          "status": "failed",
+          "resourceUri": "honua://jobs/job-apply-failure-package-step"
+        },
+        "warnings": [
+          {
+            "code": "artifact_write_failed",
+            "retryable": true
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/ai-builder/spatial-query-contract-v1.json
+++ b/tests/fixtures/ai-builder/spatial-query-contract-v1.json
@@ -39,6 +39,35 @@
         ]
       },
       {
+        "sourceId": "catalog:layer:emergency_shelters",
+        "label": "Emergency Shelters",
+        "geometryColumn": "geom",
+        "geometryType": "Point",
+        "crs": "EPSG:4326",
+        "fields": [
+          {
+            "name": "shelter_name",
+            "label": "Shelter name",
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "label": "Operational status",
+            "type": "string",
+            "domain": [
+              "open",
+              "limited",
+              "closed"
+            ]
+          },
+          {
+            "name": "capacity",
+            "label": "Capacity",
+            "type": "integer"
+          }
+        ]
+      },
+      {
         "sourceId": "catalog:layer:flood_zones",
         "label": "Flood Zones",
         "geometryColumn": "geom",


### PR DESCRIPTION
## Summary

Related to #892.

Adds a bounded, fixture-driven server contract slice for the AI app builder / spatial query demo. This intentionally does not attempt the full platform epic or live model-backed runtime.

## Changes Made

- Added deterministic `honua.ai_builder.spatial_query.v1` fixture data for NL prompt -> structured draft -> plan -> apply/package/MCP inspection flows.
- Covered required fixture outcomes: success, ambiguity, unsupported capability, auth/RBAC denied, oversized estimate, cache hit, and apply failure.
- Locked metadata/capability discovery for source selection, schema preview, field/domain labels, geometry column, CRS, spatial predicate states, starter output templates, and MCP tools/resources.
- Verified plan/apply warnings, cache/reproducibility metadata, job resource URIs, and packageable MapPackage/AppPackage artifact references.
- Documented the fixture and linked it from MCP server docs.

## Gate Impact

- [x] Tests
- [x] Documentation
- [ ] API surface
- [ ] Database migrations
- [ ] Runtime configuration

## Testing

- [x] `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --filter FullyQualifiedName~AiBuilderContractFixtureTests --no-restore`
- [x] `scripts/ci/pre-pr-check.sh` attempted locally; Core shard hit the 20m script timeout under load. Equivalent GitHub Core shard passed in 19m39, and full PR CI is green through the aggregate test suite.

## Breaking Changes

None.

## Not Full Closure

This is a partial PR for #892. Remaining work includes live endpoint/eval wiring for the SDK sample, cloud-deployed honua-sdk-js compatibility smoke, and broader runtime coverage beyond deterministic fixture replay.