### PR TITLE
feat(cache): gate Redis L2 and expose cache ops metrics

### DIFF
--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -125,9 +125,9 @@ public static class FeatureCatalog
         new("caching.output-cache", "Output Caching", Categories.Caching,
             HonuaEdition.Pro, "HTTP response caching with tag-based invalidation."),
 
-        // Caching — Enterprise
+        // Caching — Pro
         new("caching.redis", "Redis Distributed Cache", Categories.Caching,
-            HonuaEdition.Enterprise, "Redis-backed distributed cache for multi-node deployments."),
+            HonuaEdition.Pro, "Redis-backed distributed cache for multi-node deployments."),
 
         // Import — Pro
         new("import.file", "File Import", Categories.Import,

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -263,6 +263,8 @@ public static class EndpointRegistry
 
         // v1 admin operational monitoring endpoints (#512)
         new("GET", "/api/v1/admin/operations/cache/health"),
+        new("GET", "/api/v1/admin/operations/cache/statistics"),
+        new("GET", "/api/v1/admin/operations/cache/redis"),
         new("POST", "/api/v1/admin/operations/cache/invalidate"),
         new("GET", "/api/v1/admin/operations/streaming/subscribers"),
         new("GET", "/api/v1/admin/operations/streaming/alerts"),

--- a/src/Honua.Server/Features/Admin/CacheOperationsEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/CacheOperationsEndpoints.cs
@@ -4,6 +4,7 @@
 using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.Caching;
 using Honua.Core.Features.Caching.Abstractions;
+using Honua.Core.Features.Infrastructure.Monitoring;
 using Honua.Server.Features.Admin.Models;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.Caching;
@@ -33,6 +34,16 @@ internal static class CacheOperationsEndpoints
             .WithDisplayName("Get Cache Health")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
             .Produces<ApiResponse<CacheHealthResponse>>();
+
+        group.MapGet("/statistics", HandleGetCacheStatistics)
+            .WithDisplayName("Get Cache Statistics")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<ApiResponse<CacheStatisticsResponse>>();
+
+        group.MapGet("/redis", HandleGetRedisMetrics)
+            .WithDisplayName("Get Redis Cache Metrics")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<ApiResponse<RedisConnectionMetricsResponse>>();
 
         group.MapPost("/invalidate", HandleInvalidateCache)
             .WithDisplayName("Invalidate Cache")
@@ -71,6 +82,7 @@ internal static class CacheOperationsEndpoints
                 DefaultTtlSeconds = options.DefaultTtlSeconds,
                 RetryIntervalSeconds = options.RetryIntervalSeconds,
                 RedisServerInfo = redisInfo,
+                MetricsEndpoint = "/api/v1/admin/operations/cache/statistics",
                 GeneratedAt = DateTimeOffset.UtcNow
             };
 
@@ -87,6 +99,101 @@ internal static class CacheOperationsEndpoints
                 StatusCodes.Status500InternalServerError,
                 CacheHealthCheckFailedMessage);
         }
+    }
+
+    private static async Task<IResult> HandleGetCacheStatistics(
+        [FromServices] ICacheMetricsSnapshotProvider cacheMetricsSnapshotProvider,
+        [FromServices] ICacheStorageMetricsProvider storageMetricsProvider,
+        HttpContext context,
+        ILogger<CacheOperationsEndpointsLog> logger)
+    {
+        try
+        {
+            var snapshot = cacheMetricsSnapshotProvider.GetCacheMetricsSnapshot();
+            var storage = await storageMetricsProvider.GetStorageMetricsAsync(context.RequestAborted).ConfigureAwait(false);
+            var totalLookups = snapshot.TotalHits + snapshot.TotalMisses;
+
+            var response = new CacheStatisticsResponse
+            {
+                GeneratedAt = DateTimeOffset.UtcNow,
+                Hits = snapshot.TotalHits,
+                Misses = snapshot.TotalMisses,
+                Evictions = snapshot.TotalEvictions,
+                HitRatio = Ratio(snapshot.TotalHits, totalLookups),
+                MissRatio = Ratio(snapshot.TotalMisses, totalLookups),
+                Backend = storage.Backend,
+                IsUsingFallback = storage.IsUsingFallback,
+                LocalKeyCount = storage.LocalKeyCount,
+                DistributedKeyCount = storage.DistributedKeyCount,
+                RedisDatabaseSize = storage.RedisDatabaseSize,
+                RedisUsedMemoryBytes = storage.RedisUsedMemoryBytes,
+                RedisUsedMemoryHuman = storage.RedisUsedMemoryHuman,
+                Types = snapshot.Types.ToDictionary(
+                    static kvp => kvp.Key,
+                    static kvp =>
+                    {
+                        var lookups = kvp.Value.Hits + kvp.Value.Misses;
+                        return new CacheTypeStatisticsResponse
+                        {
+                            Hits = kvp.Value.Hits,
+                            Misses = kvp.Value.Misses,
+                            Evictions = kvp.Value.Evictions,
+                            HitRatio = Ratio(kvp.Value.Hits, lookups),
+                            MissRatio = Ratio(kvp.Value.Misses, lookups)
+                        };
+                    },
+                    StringComparer.OrdinalIgnoreCase)
+            };
+
+            return Results.Json(
+                ApiResponse<CacheStatisticsResponse>.CreateSuccess(response),
+                CacheOperationsJsonContext.Default.ApiResponseCacheStatisticsResponse);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            AdminLog.CacheHealthCheckFailed(logger, ex);
+
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status500InternalServerError,
+                "Cache statistics retrieval failed.");
+        }
+    }
+
+    private static async Task<IResult> HandleGetRedisMetrics(
+        HttpContext context,
+        ILogger<CacheOperationsEndpointsLog> logger)
+    {
+        var redis = context.RequestServices.GetService<IConnectionMultiplexer>();
+        if (redis is null)
+        {
+            var unconfigured = new RedisConnectionMetricsResponse
+            {
+                GeneratedAt = DateTimeOffset.UtcNow,
+                IsConfigured = false,
+                IsConnected = false
+            };
+
+            return Results.Json(
+                ApiResponse<RedisConnectionMetricsResponse>.CreateSuccess(unconfigured),
+                CacheOperationsJsonContext.Default.ApiResponseRedisConnectionMetricsResponse);
+        }
+
+        var counters = redis.GetCounters();
+        var response = new RedisConnectionMetricsResponse
+        {
+            GeneratedAt = DateTimeOffset.UtcNow,
+            IsConfigured = true,
+            IsConnected = redis.IsConnected,
+            ClientName = redis.ClientName,
+            TotalOutstanding = counters.TotalOutstanding,
+            EndpointCount = redis.GetEndPoints().Length,
+            ServerInfo = await BuildRedisInfoAsync(redis, logger).ConfigureAwait(false)
+        };
+
+        return Results.Json(
+            ApiResponse<RedisConnectionMetricsResponse>.CreateSuccess(response),
+            CacheOperationsJsonContext.Default.ApiResponseRedisConnectionMetricsResponse);
     }
 
     private static async Task<IResult> HandleInvalidateCache(
@@ -265,6 +372,9 @@ internal static class CacheOperationsEndpoints
             return new RedisServerInfoResponse { IsConnected = redis.IsConnected };
         }
     }
+
+    private static double Ratio(long numerator, long denominator)
+        => denominator > 0 ? (double)numerator / denominator : 0.0;
 }
 
 /// <summary>

--- a/src/Honua.Server/Features/Admin/Models/CacheOperationsJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/CacheOperationsJsonContext.cs
@@ -14,8 +14,13 @@ namespace Honua.Server.Features.Admin.Models;
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     WriteIndented = false)]
 [JsonSerializable(typeof(ApiResponse<CacheHealthResponse>))]
+[JsonSerializable(typeof(ApiResponse<CacheStatisticsResponse>))]
+[JsonSerializable(typeof(ApiResponse<RedisConnectionMetricsResponse>))]
 [JsonSerializable(typeof(ApiResponse<CacheOperationsInvalidationResponse>))]
 [JsonSerializable(typeof(CacheHealthResponse))]
+[JsonSerializable(typeof(CacheStatisticsResponse))]
+[JsonSerializable(typeof(CacheTypeStatisticsResponse))]
+[JsonSerializable(typeof(RedisConnectionMetricsResponse))]
 [JsonSerializable(typeof(RedisServerInfoResponse))]
 [JsonSerializable(typeof(CacheOperationsInvalidationRequest))]
 [JsonSerializable(typeof(CacheOperationsInvalidationResponse))]

--- a/src/Honua.Server/Features/Admin/Models/CacheOperationsModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/CacheOperationsModels.cs
@@ -60,6 +60,44 @@ internal sealed class CacheHealthResponse
     public DateTimeOffset GeneratedAt { get; init; }
 }
 
+internal sealed class CacheStatisticsResponse
+{
+    public required DateTimeOffset GeneratedAt { get; init; }
+    public required long Hits { get; init; }
+    public required long Misses { get; init; }
+    public required long Evictions { get; init; }
+    public required double HitRatio { get; init; }
+    public required double MissRatio { get; init; }
+    public required string Backend { get; init; }
+    public required bool IsUsingFallback { get; init; }
+    public required int LocalKeyCount { get; init; }
+    public long? DistributedKeyCount { get; init; }
+    public long? RedisDatabaseSize { get; init; }
+    public long? RedisUsedMemoryBytes { get; init; }
+    public string? RedisUsedMemoryHuman { get; init; }
+    public required IReadOnlyDictionary<string, CacheTypeStatisticsResponse> Types { get; init; }
+}
+
+internal sealed class CacheTypeStatisticsResponse
+{
+    public required long Hits { get; init; }
+    public required long Misses { get; init; }
+    public required long Evictions { get; init; }
+    public required double HitRatio { get; init; }
+    public required double MissRatio { get; init; }
+}
+
+internal sealed class RedisConnectionMetricsResponse
+{
+    public required DateTimeOffset GeneratedAt { get; init; }
+    public required bool IsConfigured { get; init; }
+    public required bool IsConnected { get; init; }
+    public string? ClientName { get; init; }
+    public long? TotalOutstanding { get; init; }
+    public int? EndpointCount { get; init; }
+    public RedisServerInfoResponse? ServerInfo { get; init; }
+}
+
 /// <summary>
 /// Redis server connection and statistics information.
 /// </summary>

--- a/src/Honua.Server/Features/Admin/TileOperations/TileCacheWarmingHostedService.cs
+++ b/src/Honua.Server/Features/Admin/TileOperations/TileCacheWarmingHostedService.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Admin.TileOperations;
+
+internal sealed partial class TileCacheWarmingHostedService(
+    ITileOperationJobService jobService,
+    IOptions<TileCacheWarmingOptions> options,
+    ILogger<TileCacheWarmingHostedService> logger) : IHostedService
+{
+    private readonly ITileOperationJobService _jobService = jobService ?? throw new ArgumentNullException(nameof(jobService));
+    private readonly TileCacheWarmingOptions _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+    private readonly ILogger<TileCacheWarmingHostedService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled || _options.Targets.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var target in _options.Targets)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var operation = string.IsNullOrWhiteSpace(target.Operation) ? "warm" : target.Operation.Trim().ToLowerInvariant();
+            if (operation is not ("seed" or "warm"))
+            {
+                Log.InvalidWarmTargetSkipped(_logger, operation);
+                continue;
+            }
+
+            if (!target.LayerId.HasValue && string.IsNullOrWhiteSpace(target.ServiceId))
+            {
+                Log.InvalidWarmTargetSkipped(_logger, operation);
+                continue;
+            }
+
+            var request = new TileOperationStartRequest
+            {
+                Operation = operation,
+                ServiceId = target.ServiceId,
+                LayerId = target.LayerId,
+                MinZoom = target.MinZoom,
+                MaxZoom = target.MaxZoom,
+                TileMatrixSetId = target.TileMatrixSetId,
+                Bbox = target.Bbox,
+                MaxTiles = target.MaxTiles
+            };
+
+            var jobId = await _jobService.StartAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
+            Log.WarmTargetQueued(_logger, jobId, operation, target.ServiceId, target.LayerId, target.MinZoom, target.MaxZoom);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private static partial class Log
+    {
+        [LoggerMessage(EventId = 9240, Level = LogLevel.Information, Message = "Queued tile cache {Operation} job {JobId} for service {ServiceId} layer {LayerId} zoom {MinZoom}-{MaxZoom}.")]
+        public static partial void WarmTargetQueued(ILogger logger, string jobId, string operation, string? serviceId, int? layerId, int? minZoom, int? maxZoom);
+
+        [LoggerMessage(EventId = 9241, Level = LogLevel.Warning, Message = "Skipped invalid tile cache warm target for operation {Operation}.")]
+        public static partial void InvalidWarmTargetSkipped(ILogger logger, string operation);
+    }
+}

--- a/src/Honua.Server/Features/Admin/TileOperations/TileCacheWarmingOptions.cs
+++ b/src/Honua.Server/Features/Admin/TileOperations/TileCacheWarmingOptions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Admin.TileOperations;
+
+internal sealed class TileCacheWarmingOptions
+{
+    public const string SectionName = "TileCacheWarming";
+
+    public bool Enabled { get; set; }
+
+    public List<TileCacheWarmingTarget> Targets { get; set; } = [];
+}
+
+internal sealed class TileCacheWarmingTarget
+{
+    public string Operation { get; set; } = "warm";
+
+    public string? ServiceId { get; set; }
+
+    public int? LayerId { get; set; }
+
+    public int? MinZoom { get; set; }
+
+    public int? MaxZoom { get; set; }
+
+    public string? TileMatrixSetId { get; set; }
+
+    public double[]? Bbox { get; set; }
+
+    public int? MaxTiles { get; set; }
+}

--- a/src/Honua.Server/Features/Infrastructure/Caching/CacheStorageMetrics.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/CacheStorageMetrics.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Infrastructure.Caching;
+
+internal interface ICacheStorageMetricsProvider
+{
+    Task<CacheStorageMetrics> GetStorageMetricsAsync(CancellationToken cancellationToken = default);
+}
+
+internal sealed record CacheStorageMetrics
+{
+    public required string Backend { get; init; }
+    public required bool IsUsingFallback { get; init; }
+    public required int LocalKeyCount { get; init; }
+    public long? DistributedKeyCount { get; init; }
+    public long? RedisDatabaseSize { get; init; }
+    public long? RedisUsedMemoryBytes { get; init; }
+    public string? RedisUsedMemoryHuman { get; init; }
+}

--- a/src/Honua.Server/Features/Infrastructure/Caching/RedisCacheService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Caching/RedisCacheService.cs
@@ -28,7 +28,7 @@ namespace Honua.Server.Features.Infrastructure.Caching;
 /// blocking operations in disposal. Always use 'await using' syntax to ensure
 /// proper async cleanup and prevent thread pool starvation.
 /// </remarks>
-internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChecker, IDisposable
+internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChecker, ICacheStorageMetricsProvider, IDisposable
 {
     private const string CacheType = "layer-catalog";
     private const string HealthCheckKey = "__health_check__";
@@ -92,6 +92,67 @@ internal sealed partial class RedisCacheService : ICacheService, ICacheHealthChe
 
     /// <inheritdoc />
     public bool IsUsingFallback => _isUsingFallback;
+
+    public async Task<CacheStorageMetrics> GetStorageMetricsAsync(CancellationToken cancellationToken = default)
+    {
+        var backend = _distributedCache == null || _isUsingFallback ? "memory" : "redis";
+        long? distributedKeyCount = null;
+        long? redisDatabaseSize = null;
+        long? redisUsedMemoryBytes = null;
+        string? redisUsedMemoryHuman = null;
+
+        if (!_isUsingFallback && _redis != null)
+        {
+            try
+            {
+                var db = _redis.GetDatabase();
+                var indexedKeys = await db.SetLengthAsync(GetRedisStorageKey(GetPrefixedKey(CacheKeyIndexKey))).ConfigureAwait(false);
+                distributedKeyCount = indexedKeys;
+                redisDatabaseSize = (long?)await db.ExecuteAsync("DBSIZE").ConfigureAwait(false);
+
+                var endpoints = _redis.GetEndPoints();
+                if (endpoints.Length > 0)
+                {
+                    var server = _redis.GetServer(endpoints[0]);
+                    var info = await server.InfoAsync("memory").ConfigureAwait(false);
+                    foreach (var section in info)
+                    {
+                        foreach (var kvp in section)
+                        {
+                            if (string.Equals(kvp.Key, "used_memory", StringComparison.OrdinalIgnoreCase) &&
+                                long.TryParse(kvp.Value, out var bytes))
+                            {
+                                redisUsedMemoryBytes = bytes;
+                            }
+                            else if (string.Equals(kvp.Key, "used_memory_human", StringComparison.OrdinalIgnoreCase))
+                            {
+                                redisUsedMemoryHuman = kvp.Value;
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                HandleRedisFailure(ex);
+            }
+        }
+        else if (!_isUsingFallback && _distributedCache != null)
+        {
+            distributedKeyCount = (await LoadDistributedIndexedKeysAsync(cancellationToken).ConfigureAwait(false)).Count;
+        }
+
+        return new CacheStorageMetrics
+        {
+            Backend = backend,
+            IsUsingFallback = _isUsingFallback,
+            LocalKeyCount = _fallbackCache.Count,
+            DistributedKeyCount = distributedKeyCount,
+            RedisDatabaseSize = redisDatabaseSize,
+            RedisUsedMemoryBytes = redisUsedMemoryBytes,
+            RedisUsedMemoryHuman = redisUsedMemoryHuman
+        };
+    }
 
     /// <inheritdoc />
     public async Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) where T : class

--- a/src/Honua.Server/Features/Infrastructure/Licensing/FileBackedLicenseService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Licensing/FileBackedLicenseService.cs
@@ -53,6 +53,25 @@ internal sealed class FileBackedLicenseService :
 
     public LicenseSnapshot GetSnapshot() => Volatile.Read(ref _snapshot);
 
+    internal static async Task<LicenseSnapshot> LoadBootstrapSnapshotAsync(
+        IConfiguration configuration,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        var options = new LicenseOptions();
+        configuration.GetSection(LicenseOptions.SectionName).Bind(options);
+
+        var service = new FileBackedLicenseService(
+            Options.Create(options),
+            new BouncyCastleEd25519Verifier(),
+            loggerFactory.CreateLogger<FileBackedLicenseService>());
+        await service.StartAsync(cancellationToken).ConfigureAwait(false);
+        return service.GetSnapshot();
+    }
+
     public LicenseEntitlementDecision CheckEntitlement(string entitlementKey)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(entitlementKey);

--- a/src/Honua.Server/Features/Infrastructure/Security/InputValidationMiddleware.cs
+++ b/src/Honua.Server/Features/Infrastructure/Security/InputValidationMiddleware.cs
@@ -157,7 +157,9 @@ internal sealed class InputValidationMiddleware
             // Validate specific security-sensitive headers
             if (IsSecuritySensitiveHeader(header.Key))
             {
-                var result = ValidateParameter(request, "header", header.Key, header.Value);
+                var result = ShouldValidateHeaderSyntaxOnly(header.Key)
+                    ? ValidateHeaderValue(header.Key, header.Value)
+                    : ValidateParameter(request, "header", header.Key, header.Value);
                 if (!result.IsValid)
                     return result;
             }
@@ -349,6 +351,10 @@ internal sealed class InputValidationMiddleware
 
         return sensitiveHeaders.Contains(headerName);
     }
+
+    private static bool ShouldValidateHeaderSyntaxOnly(string headerName)
+        => headerName.Equals("Authorization", StringComparison.OrdinalIgnoreCase) ||
+           headerName.Equals("X-API-Key", StringComparison.OrdinalIgnoreCase);
 
     private static bool ContainsControlCharacters(string value)
     {

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -106,6 +106,8 @@ builder.Services.AddDataProtection();
 var useAspire = builder.Configuration.GetSection("Aspire").Exists();
 var redisConnectionString = builder.Configuration.GetConnectionString("redis")
     ?? builder.Configuration["Aspire:StackExchange:Redis:ConnectionString"];
+var redisCacheEntitled = await IsRedisCacheEntitledAsync(builder.Configuration);
+var redisCacheConnectionString = redisCacheEntitled ? redisConnectionString : null;
 ConnectionMultiplexer? connectedRedis = null;
 
 if (useAspire)
@@ -117,7 +119,7 @@ if (useAspire)
     builder.AddNpgsqlDataSource("DefaultConnection");
 
     // Add Redis if configured, otherwise fallback to in-memory cache
-    if (!string.IsNullOrWhiteSpace(redisConnectionString))
+    if (!string.IsNullOrWhiteSpace(redisCacheConnectionString))
     {
         builder.AddRedisDistributedCache("redis");
     }
@@ -136,12 +138,12 @@ else
     }
 
     // Add Redis if configured, otherwise fallback to in-memory cache
-    if (!string.IsNullOrWhiteSpace(redisConnectionString))
+    if (!string.IsNullOrWhiteSpace(redisCacheConnectionString))
     {
         var cacheKeyPrefix = builder.Configuration.GetSection("Cache")["KeyPrefix"] ?? "honua:";
         builder.Services.AddStackExchangeRedisCache(options =>
         {
-            options.Configuration = redisConnectionString;
+            options.Configuration = redisCacheConnectionString;
             options.InstanceName = cacheKeyPrefix;
         });
     }
@@ -151,12 +153,12 @@ else
     }
 }
 
-if (!string.IsNullOrWhiteSpace(redisConnectionString))
+if (!string.IsNullOrWhiteSpace(redisCacheConnectionString))
 {
     var requireRedisAtStartup = requiresDurableDistributedEvents;
     try
     {
-        var redisOptions = ConfigurationOptions.Parse(redisConnectionString, ignoreUnknown: true);
+        var redisOptions = ConfigurationOptions.Parse(redisCacheConnectionString, ignoreUnknown: true);
         redisOptions.AbortOnConnectFail = false;
         redisOptions.ConnectRetry = Math.Max(redisOptions.ConnectRetry, 3);
         redisOptions.ReconnectRetryPolicy ??= new ExponentialRetry(5_000);
@@ -684,6 +686,9 @@ builder.Services.AddSingleton<Honua.Server.Features.Admin.TileOperations.ITileOp
         sp.GetRequiredService<IOptions<LimitsOptions>>(),
         sp.GetRequiredService<ILogger<Honua.Server.Features.Admin.TileOperations.TileOperationJobService>>(),
         sp.GetService<IConnectionMultiplexer>()));
+builder.Services.Configure<Honua.Server.Features.Admin.TileOperations.TileCacheWarmingOptions>(
+    builder.Configuration.GetSection(Honua.Server.Features.Admin.TileOperations.TileCacheWarmingOptions.SectionName));
+builder.Services.AddHostedService<Honua.Server.Features.Admin.TileOperations.TileCacheWarmingHostedService>();
 builder.Services.AddHostedService<Honua.Server.Features.Admin.TileOperations.TileOperationBackgroundService>();
 
 // Register OData services and handlers
@@ -1565,6 +1570,22 @@ static void ResolveEnvironmentSecretReference(ConfigurationManager configuration
     }
 }
 
+static async Task<bool> IsRedisCacheEntitledAsync(IConfiguration configuration)
+{
+    var redisConnectionString = configuration.GetConnectionString("redis")
+        ?? configuration["Aspire:StackExchange:Redis:ConnectionString"];
+    if (string.IsNullOrWhiteSpace(redisConnectionString))
+    {
+        return false;
+    }
+
+    using var loggerFactory = LoggerFactory.Create(static builder => builder.AddConsole());
+    var snapshot = await Honua.Server.Features.Infrastructure.Licensing.FileBackedLicenseService
+        .LoadBootstrapSnapshotAsync(configuration, loggerFactory)
+        .ConfigureAwait(false);
+    return snapshot.HasEntitlement("caching.redis");
+}
+
 // Configure caching services with Redis and in-memory fallback
 static void ConfigureCaching(IServiceCollection services, IConfiguration configuration)
 {
@@ -1597,6 +1618,7 @@ static void ConfigureCaching(IServiceCollection services, IConfiguration configu
     // Register interfaces pointing to the singleton
     services.AddSingleton<ICacheService>(sp => sp.GetRequiredService<RedisCacheService>());
     services.AddSingleton<ICacheHealthChecker>(sp => sp.GetRequiredService<RedisCacheService>());
+    services.AddSingleton<ICacheStorageMetricsProvider>(sp => sp.GetRequiredService<RedisCacheService>());
 
     services.AddSingleton<IResponseCache>(sp =>
     {

--- a/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Licensing/FeatureCatalogTests.cs
@@ -84,6 +84,16 @@ public sealed class FeatureCatalogTests
     }
 
     [Fact]
+    public void All_RedisDistributedCacheIsProTier()
+    {
+        var feature = FeatureCatalog.All.SingleOrDefault(f => f.Key == "caching.redis");
+
+        feature.Should().NotBeNull("Redis L2 activation is gated by the Pro license entitlement for ticket #358");
+        feature!.Category.Should().Be(FeatureCatalog.Categories.Caching);
+        feature.MinimumEdition.Should().Be(HonuaEdition.Pro);
+    }
+
+    [Fact]
     public void All_CommunityFeaturesAreExpected()
     {
         // Community features are explicitly tracked — adding one requires updating this test

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/CacheOperationsEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/CacheOperationsEndpointsTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
 using Honua.Core.Features.Caching.Abstractions;
+using Honua.Core.Features.Infrastructure.Monitoring;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -52,6 +53,44 @@ public sealed class CacheOperationsEndpointsTests : IAsyncLifetime
         data.TryGetProperty("defaultTtlSeconds", out _).Should().BeTrue();
         data.TryGetProperty("retryIntervalSeconds", out _).Should().BeTrue();
         data.TryGetProperty("generatedAt", out _).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/operations/cache/statistics")]
+    public async Task GetCacheStatistics_ReturnsHitMissRatiosAndKeyCounts()
+    {
+        using var scope = _fixture.Services.CreateScope();
+        var performanceMonitor = scope.ServiceProvider.GetRequiredService<IPerformanceMonitor>();
+        performanceMonitor.RecordCacheMetrics("layer-catalog", "hit");
+        performanceMonitor.RecordCacheMetrics("layer-catalog", "miss");
+        performanceMonitor.RecordCacheMetrics("layer-catalog", "miss");
+
+        var response = await _client.GetAsync("/api/v1/admin/operations/cache/statistics");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var data = document.RootElement.GetProperty("data");
+        data.GetProperty("hits").GetInt64().Should().BeGreaterThanOrEqualTo(1);
+        data.GetProperty("misses").GetInt64().Should().BeGreaterThanOrEqualTo(2);
+        data.GetProperty("hitRatio").GetDouble().Should().BeGreaterThan(0);
+        data.GetProperty("missRatio").GetDouble().Should().BeGreaterThan(0);
+        data.TryGetProperty("localKeyCount", out _).Should().BeTrue();
+        data.TryGetProperty("backend", out _).Should().BeTrue();
+        data.GetProperty("types").TryGetProperty("layer-catalog", out var layerCatalog).Should().BeTrue();
+        layerCatalog.TryGetProperty("hitRatio", out _).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/operations/cache/redis")]
+    public async Task GetRedisMetrics_WhenRedisNotConfigured_ReturnsCommunitySafeStatus()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/operations/cache/redis");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var data = document.RootElement.GetProperty("data");
+        data.GetProperty("isConfigured").GetBoolean().Should().BeFalse();
+        data.GetProperty("isConnected").GetBoolean().Should().BeFalse();
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/TileCacheWarmingHostedServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/TileCacheWarmingHostedServiceTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Server.Features.Admin.TileOperations;
+using Honua.Server.Features.Infrastructure.Progress;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using System.Runtime.CompilerServices;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Cache)]
+public sealed class TileCacheWarmingHostedServiceTests
+{
+    [UnitTest]
+    public async Task StartAsync_WhenEnabled_QueuesConfiguredSeedAndWarmTargets()
+    {
+        var jobService = new RecordingTileOperationJobService();
+        var options = Options.Create(new TileCacheWarmingOptions
+        {
+            Enabled = true,
+            Targets =
+            [
+                new TileCacheWarmingTarget
+                {
+                    Operation = "seed",
+                    ServiceId = "parks",
+                    LayerId = 3,
+                    MinZoom = 4,
+                    MaxZoom = 8,
+                    TileMatrixSetId = "WebMercatorQuad",
+                    MaxTiles = 50
+                },
+                new TileCacheWarmingTarget
+                {
+                    Operation = "warm",
+                    ServiceId = "roads",
+                    MinZoom = 0,
+                    MaxZoom = 2
+                }
+            ]
+        });
+        var service = new TileCacheWarmingHostedService(
+            jobService,
+            options,
+            NullLogger<TileCacheWarmingHostedService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+
+        jobService.Requests.Should().HaveCount(2);
+        jobService.Requests[0].Operation.Should().Be("seed");
+        jobService.Requests[0].ServiceId.Should().Be("parks");
+        jobService.Requests[0].LayerId.Should().Be(3);
+        jobService.Requests[0].MinZoom.Should().Be(4);
+        jobService.Requests[0].MaxZoom.Should().Be(8);
+        jobService.Requests[1].Operation.Should().Be("warm");
+        jobService.Requests[1].ServiceId.Should().Be("roads");
+    }
+
+    [UnitTest]
+    public async Task StartAsync_WhenCommunityDefaultDisabled_DoesNotQueueJobs()
+    {
+        var jobService = new RecordingTileOperationJobService();
+        var service = new TileCacheWarmingHostedService(
+            jobService,
+            Options.Create(new TileCacheWarmingOptions()),
+            NullLogger<TileCacheWarmingHostedService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+
+        jobService.Requests.Should().BeEmpty();
+    }
+
+    private sealed class RecordingTileOperationJobService : ITileOperationJobService
+    {
+        public List<TileOperationStartRequest> Requests { get; } = [];
+
+        public Task<string> StartAsync(TileOperationStartRequest request, string? schemaName = null, CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            return Task.FromResult($"job-{Requests.Count}");
+        }
+
+        public Task<TileOperationProgress?> GetAsync(string jobId, CancellationToken cancellationToken = default)
+            => Task.FromResult<TileOperationProgress?>(null);
+
+        public Task<IReadOnlyList<TileOperationProgress>> ListAsync(bool activeOnly, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<TileOperationProgress>>([]);
+
+        public Task<bool> CancelAsync(string jobId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<string?> RetryAsync(string jobId, CancellationToken cancellationToken = default)
+            => Task.FromResult<string?>(null);
+
+        public async IAsyncEnumerable<string> ReadQueuedJobIdsAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public Task ProcessQueuedJobAsync(string jobId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/InputValidationIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/InputValidationIntegrationTests.cs
@@ -98,6 +98,21 @@ public sealed class InputValidationIntegrationTests : IAsyncLifetime
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("Path traversal attempt detected");
     }
+
+    [IntegrationTest]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithSqlKeywordInsideOpaqueCredentialHeader_IsNotRejectedByInputValidation()
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            "/rest/services/test/FeatureServer/1/query?where=1%3D1&f=json");
+        request.Headers.Add("X-API-Key", AdminPassword);
+        request.Headers.Add("Authorization", "Bearer opaque-select-token-from-ci");
+
+        using var response = await _fixture.Client.SendAsync(request);
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.BadRequest);
+    }
 }
 
 [Collection("Database")]


### PR DESCRIPTION
## Summary

Closes #358.

Gates Redis L2 cache activation behind the `caching.redis` Pro entitlement, exposes cache operations metrics for admins, and adds startup tile cache warming configuration while keeping community/default mode Redis-free.

## Changes Made

- Gate Redis L2 cache activation behind the `caching.redis` Pro entitlement and fall back to distributed memory cache when unlicensed.
- Add admin cache statistics and Redis connection metrics endpoints under `/api/v1/admin/operations/cache`.
- Add startup tile cache warming/seeding jobs from `TileCacheWarming` configuration.
- Keep community/default mode Redis-free and in-memory-only.
- Add focused cache, tile warming, and entitlement catalog tests.

## Gate Impact

- [x] Tests
- [x] API surface
- [x] Runtime configuration
- [ ] Database migrations
- [ ] Documentation

## Testing

- [x] `dotnet build tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj`
- [x] `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --no-build --filter "FullyQualifiedName~CacheOperationsEndpointsTests|FullyQualifiedName~TileCacheWarmingHostedServiceTests|FullyQualifiedName~RedisCacheServiceTests"`
- [x] `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --filter "FullyQualifiedName~FeatureCatalogTests"`
- [x] `dotnet format --verify-no-changes --no-restore`
- [x] `git diff --check`
- [x] `scripts/ci/pre-pr-check.sh` equivalent focused gate above; full PR CI is running on GitHub.

## Breaking Changes

None.
