### PR TITLE
fix: close STAC validator hypermedia gaps

### DIFF
--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -651,6 +651,8 @@ public static class EndpointRegistry
 
         // STAC (SpatioTemporal Asset Catalog)
         new("GET", "/stac"),
+        new("GET", "/stac/conformance"),
+        new("GET", "/stac/openapi.json"),
         new("GET", "/stac/collections"),
         new("GET", "/stac/collections/{collectionId}"),
         new("GET", "/stac/collections/{collectionId}/items"),

--- a/src/Honua.Server/Features/Protocols/Stac/CatalogEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Stac/CatalogEndpoints.cs
@@ -7,6 +7,7 @@ using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Server.Features.Infrastructure.Caching;
 using Honua.Server.Features.Infrastructure.Helpers;
 using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Protocols.Ogc.Api.Features;
 using Honua.Server.Features.Protocols.Ogc.Common;
 using Honua.Server.Features.Protocols.Stac.Models;
 using Honua.Server.Features.Protocols.Stac.Services;
@@ -33,6 +34,26 @@ internal static class CatalogEndpoints
             .CacheOutput("StacCatalog")
             .WithETag()
             .Produces<StacCatalog>(200, MediaTypes.Json)
+            .Produces(404);
+
+        endpoints.MapGet("/stac/conformance", HandleGetConformance)
+            .WithDisplayName("STAC Conformance")
+            .WithName("StacConformance")
+            .WithSummary("Get the STAC API conformance declaration")
+            .WithDescription("Returns the conformance classes implemented by the STAC API surface")
+            .WithTags("STAC")
+            .CacheOutput("StacCatalog")
+            .Produces<ConformanceDeclaration>(200, MediaTypes.Json)
+            .Produces(404);
+
+        endpoints.MapGet("/stac/openapi.json", HandleGetOpenApiSpec)
+            .WithDisplayName("STAC OpenAPI Specification")
+            .WithName("StacOpenApiSpec")
+            .WithSummary("Get OpenAPI 3.0 specification for STAC API")
+            .WithDescription("The OpenAPI specification describes the STAC API endpoints.")
+            .WithTags("STAC")
+            .CacheOutput("StacCatalog")
+            .Produces<object>(200, MediaTypes.OpenApi)
             .Produces(404);
 
         return endpoints;
@@ -82,9 +103,25 @@ internal static class CatalogEndpoints
                 type: MediaTypes.Json,
                 title: "STAC Catalog"));
 
-            // Do not advertise the OGC API Features OpenAPI document as the STAC
-            // service description. Until STAC has a dedicated API definition, omit
-            // this relation rather than publishing a misleading link.
+            // API definition and documentation.
+            links.Add(Link.Create(
+                href: $"{stacBase}/openapi.json",
+                rel: RelationTypes.ServiceDesc,
+                type: MediaTypes.OpenApi,
+                title: "STAC API definition"));
+
+            links.Add(Link.Create(
+                href: "https://api.stacspec.org/v1.0.0/",
+                rel: RelationTypes.ServiceDoc,
+                type: MediaTypes.Html,
+                title: "STAC API documentation"));
+
+            // Conformance
+            links.Add(Link.Create(
+                href: $"{stacBase}/conformance",
+                rel: RelationTypes.Conformance,
+                type: MediaTypes.Json,
+                title: "Conformance declaration"));
 
             // Collections
             links.Add(Link.Create(
@@ -116,14 +153,7 @@ internal static class CatalogEndpoints
                 Id = StacConstants.CatalogId,
                 Title = "Honua STAC Catalog",
                 Description = "SpatioTemporal Asset Catalog for Honua geospatial data discovery",
-                ConformsTo = ImmutableArray.Create(
-                    StacConstants.Conformance.Core,
-                    StacConstants.Conformance.ItemSearch,
-                    StacConstants.Conformance.OgcApiFeatures,
-                    StacConstants.Conformance.Collections,
-                    StacConstants.Conformance.FieldsExtension,
-                    StacConstants.Conformance.SortExtension,
-                    StacConstants.Conformance.FilterExtension),
+                ConformsTo = GetConformanceClasses(),
                 Links = links.ToImmutable()
             };
 
@@ -145,4 +175,185 @@ internal static class CatalogEndpoints
                 context, "An error occurred while retrieving the STAC catalog.");
         }
     }
+
+    private static IResult HandleGetConformance(HttpContext context)
+    {
+        var validationError = OgcCommonUtilities.ValidateQueryParameters(
+            context.Request, StacConstants.AllowedQueryParameters.Catalog);
+        if (validationError is not null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, validationError.Value ?? "Invalid query parameters.");
+        }
+
+        var baseUrl = BaseUrlResolver.GetBaseUrl(context);
+        var stacBase = $"{baseUrl}/stac";
+        var conformance = new ConformanceDeclaration
+        {
+            ConformsTo = GetConformanceClasses(),
+            Links = ImmutableArray.Create(
+                Link.Create(
+                    href: $"{stacBase}/conformance",
+                    rel: RelationTypes.Self,
+                    type: MediaTypes.Json,
+                    title: "Conformance declaration"),
+                Link.Create(
+                    href: stacBase,
+                    rel: StacConstants.StacRelations.Root,
+                    type: MediaTypes.Json,
+                    title: "STAC Catalog"))
+        };
+
+        return Results.Json(conformance, OgcJsonContext.Default.ConformanceDeclaration, MediaTypes.Json);
+    }
+
+    private static IResult HandleGetOpenApiSpec(HttpContext context)
+    {
+        var validationError = OgcCommonUtilities.ValidateQueryParameters(
+            context.Request, StacConstants.AllowedQueryParameters.Catalog);
+        if (validationError is not null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, validationError.Value ?? "Invalid query parameters.");
+        }
+
+        var openApi = """
+            {
+              "openapi": "3.0.3",
+              "info": {
+                "title": "Honua STAC API",
+                "description": "STAC API surface for Honua geospatial discovery.",
+                "version": "1.0.0"
+              },
+              "paths": {
+                "/stac": {
+                  "get": {
+                    "summary": "STAC root catalog",
+                    "responses": {
+                      "200": {
+                        "description": "STAC Catalog"
+                      }
+                    }
+                  }
+                },
+                "/stac/conformance": {
+                  "get": {
+                    "summary": "STAC conformance declaration",
+                    "responses": {
+                      "200": {
+                        "description": "Conformance declaration"
+                      }
+                    }
+                  }
+                },
+                "/stac/collections": {
+                  "get": {
+                    "summary": "STAC collections",
+                    "responses": {
+                      "200": {
+                        "description": "STAC Collections response"
+                      }
+                    }
+                  }
+                },
+                "/stac/collections/{collectionId}": {
+                  "get": {
+                    "summary": "STAC collection",
+                    "parameters": [
+                      {
+                        "name": "collectionId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "responses": {
+                      "200": {
+                        "description": "STAC Collection"
+                      }
+                    }
+                  }
+                },
+                "/stac/collections/{collectionId}/items": {
+                  "get": {
+                    "summary": "STAC collection items",
+                    "parameters": [
+                      {
+                        "name": "collectionId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "responses": {
+                      "200": {
+                        "description": "STAC ItemCollection"
+                      }
+                    }
+                  }
+                },
+                "/stac/collections/{collectionId}/items/{itemId}": {
+                  "get": {
+                    "summary": "STAC item",
+                    "parameters": [
+                      {
+                        "name": "collectionId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "name": "itemId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "responses": {
+                      "200": {
+                        "description": "STAC Item"
+                      }
+                    }
+                  }
+                },
+                "/stac/search": {
+                  "get": {
+                    "summary": "STAC item search",
+                    "responses": {
+                      "200": {
+                        "description": "STAC ItemCollection"
+                      }
+                    }
+                  },
+                  "post": {
+                    "summary": "STAC item search",
+                    "responses": {
+                      "200": {
+                        "description": "STAC ItemCollection"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        return Results.Content(openApi, MediaTypes.OpenApi);
+    }
+
+    private static ImmutableArray<string> GetConformanceClasses()
+        => ImmutableArray.Create(
+            StacConstants.Conformance.Core,
+            StacConstants.Conformance.ItemSearch,
+            StacConstants.Conformance.OgcApiFeatures,
+            StacConstants.Conformance.Collections,
+            StacConstants.Conformance.FieldsExtension,
+            StacConstants.Conformance.SortExtension,
+            StacConstants.Conformance.FilterExtension);
 }

--- a/src/Honua.Server/Features/Protocols/Stac/ItemEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Stac/ItemEndpoints.cs
@@ -135,9 +135,10 @@ internal static class ItemEndpoints
 
             var stacBase = $"{baseUrl}/stac";
             var itemsPath = $"{stacBase}/collections/{collectionId}/items";
+            var requestedItemsUrl = $"{baseUrl}{context.Request.Path}{context.Request.QueryString}";
             var linksBuilder = ImmutableArray.CreateBuilder<Link>();
             linksBuilder.Add(Link.Create(
-                href: $"{itemsPath}?{BuildItemsFilterQuery(effectiveLimit, effectiveOffset, bbox, datetime)}",
+                href: requestedItemsUrl,
                 rel: RelationTypes.Self,
                 type: MediaTypes.GeoJson,
                 title: "Items"));

--- a/src/Honua.Server/Features/Protocols/Stac/Services/StacMappingService.cs
+++ b/src/Honua.Server/Features/Protocols/Stac/Services/StacMappingService.cs
@@ -170,6 +170,11 @@ internal sealed class StacMappingService
                 type: MediaTypes.Json,
                 title: layer.Name),
             Link.Create(
+                href: $"{stacBase}/collections/{collectionId}",
+                rel: StacConstants.StacRelations.Parent,
+                type: MediaTypes.Json,
+                title: layer.Name),
+            Link.Create(
                 href: stacBase,
                 rel: StacConstants.StacRelations.Root,
                 type: MediaTypes.Json,

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -949,6 +949,19 @@ ConfigurationLog.ConfigurationValidationSucceeded(app.Logger);
 // Add security headers middleware (first in pipeline for all requests)
 app.UseSecurityHeaders();
 
+// Some standards validators and older HTTP clients send only `Accept-Encoding: *`.
+// Prefer gzip/deflate for that wildcard so the response remains broadly decodable.
+app.Use(async (context, next) =>
+{
+    if (context.Request.Headers.AcceptEncoding.Count == 1 &&
+        string.Equals(context.Request.Headers.AcceptEncoding[0], "*", StringComparison.Ordinal))
+    {
+        context.Request.Headers.AcceptEncoding = "gzip, deflate";
+    }
+
+    await next(context);
+});
+
 // Add response compression middleware (early in pipeline)
 app.UseResponseCompression();
 app.UseWebSockets();

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Stac/StacCatalogTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Stac/StacCatalogTests.cs
@@ -111,7 +111,7 @@ public sealed class StacCatalogTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.StacCatalog)]
     [Endpoint("GET /stac")]
-    public async Task GetCatalog_DoesNotAdvertiseOgcFeaturesOpenApiAsServiceDescription()
+    public async Task GetCatalog_AdvertisesValidatorRequiredHypermediaLinks()
     {
         var response = await _fixture.Client.GetAsync("/stac");
 
@@ -120,14 +120,59 @@ public sealed class StacCatalogTests : IAsyncLifetime
         var content = await response.Content.ReadAsStringAsync();
         var json = JsonDocument.Parse(content);
 
-        var serviceDescLinks = json.RootElement.GetProperty("links")
+        var links = json.RootElement.GetProperty("links")
             .EnumerateArray()
-            .Where(link => string.Equals(
-                link.GetProperty("rel").GetString(),
-                "service-desc",
-                StringComparison.Ordinal))
             .ToArray();
 
-        serviceDescLinks.Should().BeEmpty();
+        links.Should().Contain(link =>
+            link.GetProperty("rel").GetString() == "service-desc" &&
+            link.GetProperty("href").GetString()!.EndsWith("/stac/openapi.json", StringComparison.Ordinal));
+        links.Should().Contain(link =>
+            link.GetProperty("rel").GetString() == "service-doc");
+        links.Should().Contain(link =>
+            link.GetProperty("rel").GetString() == "conformance" &&
+            link.GetProperty("href").GetString()!.EndsWith("/stac/conformance", StringComparison.Ordinal));
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.StacCatalog)]
+    [Endpoint("GET /stac/conformance")]
+    public async Task GetConformance_ReturnsStacConformanceClasses()
+    {
+        var response = await _fixture.Client.GetAsync("/stac/conformance");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        var conformsTo = json.RootElement.GetProperty("conformsTo")
+            .EnumerateArray()
+            .Select(e => e.GetString()!)
+            .ToList();
+
+        conformsTo.Should().Contain("https://api.stacspec.org/v1.0.0/core");
+        conformsTo.Should().Contain("https://api.stacspec.org/v1.0.0/ogcapi-features");
+        json.RootElement.GetProperty("links")
+            .EnumerateArray()
+            .Should()
+            .Contain(link => link.GetProperty("rel").GetString() == "self");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.StacCatalog)]
+    [Endpoint("GET /stac/openapi.json")]
+    public async Task GetOpenApiSpec_ReturnsStacApiDescription()
+    {
+        var response = await _fixture.Client.GetAsync("/stac/openapi.json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+
+        json.RootElement.GetProperty("openapi").GetString().Should().StartWith("3.");
+        json.RootElement.GetProperty("paths").TryGetProperty("/stac", out _).Should().BeTrue();
+        json.RootElement.GetProperty("paths").TryGetProperty("/stac/search", out _).Should().BeTrue();
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Stac/StacItemsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Stac/StacItemsTests.cs
@@ -69,6 +69,10 @@ public sealed class StacItemsTests : IAsyncLifetime
             item.GetProperty("stac_version").GetString().Should().Be("1.0.0");
             item.GetProperty("properties").ValueKind.Should().Be(JsonValueKind.Object);
             item.GetProperty("links").EnumerateArray().Should().NotBeEmpty();
+            item.GetProperty("links")
+                .EnumerateArray()
+                .Should()
+                .Contain(link => link.GetProperty("rel").GetString() == "parent");
 
             // STAC requires "datetime" in properties (may be null)
             item.GetProperty("properties").TryGetProperty("datetime", out _).Should().BeTrue();
@@ -108,6 +112,28 @@ public sealed class StacItemsTests : IAsyncLifetime
             .Select(static element => element.GetString())
             .Should()
             .BeEquivalentTo(ExpectedItemExtensions);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /stac/collections/{collectionId}/items")]
+    public async Task GetItems_SelfLinkMatchesRequestedUrl()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var requestPath = $"/stac/collections/{collectionId}/items?limit=2";
+        var response = await _fixture.Client.GetAsync(requestPath);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+        var selfLink = json.RootElement.GetProperty("links")
+            .EnumerateArray()
+            .First(link => link.GetProperty("rel").GetString() == "self");
+
+        selfLink.GetProperty("href").GetString()
+            .Should()
+            .Be(response.RequestMessage!.RequestUri!.ToString());
     }
 
     [IntegrationTest]
@@ -301,6 +327,12 @@ public sealed class StacItemsTests : IAsyncLifetime
         json.RootElement.GetProperty("id").GetString().Should().Be(featureId.ToString(System.Globalization.CultureInfo.InvariantCulture));
         json.RootElement.GetProperty("collection").GetString().Should().Be(collectionId);
         json.RootElement.GetProperty("links").EnumerateArray().Should().NotBeEmpty();
+        json.RootElement.GetProperty("links")
+            .EnumerateArray()
+            .Should()
+            .Contain(link =>
+                link.GetProperty("rel").GetString() == "parent" &&
+                link.GetProperty("href").GetString()!.EndsWith($"/stac/collections/{collectionId}", StringComparison.Ordinal));
 
         // Should have cross-protocol asset links
         json.RootElement.GetProperty("assets").GetProperty("geojson")


### PR DESCRIPTION
## Issue Link
Fixes #956

## Summary

Closes the STAC API validator `core` and `features` hypermedia gaps found while adding the external validator lane in #949. The STAC landing page now advertises validator-required service description, service documentation, and conformance links; item collection and item documents expose the links the validator traverses; and wildcard-only compression negotiation stays decodable for validator/PySTAC traversal.

## Changes Made

- Added `/stac/conformance` and `/stac/openapi.json` endpoints.
- Added `service-desc`, `service-doc`, and `conformance` links to the STAC landing page.
- Reused one conformance class list for the landing page and conformance declaration.
- Made collection-items `self` links match the requested URL and added STAC item `parent` links.
- Rewrote wildcard-only `Accept-Encoding: *` requests to `gzip, deflate` before response compression so `requests`/PySTAC validator traversal receives decodable STAC JSON.
- Added focused .NET integration assertions for the new STAC links and endpoint responses.

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validated locally with:

- `dotnet build src/Honua.Server/Honua.Server.csproj --configuration Debug --no-restore /p:TreatWarningsAsErrors=true`
- `timeout 240s dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~StacCatalogTests|FullyQualifiedName~StacItemsTests" --no-restore --logger "console;verbosity=minimal"`
- manual `stac-api-validator==0.6.8` run against a live seeded `/stac` fixture for `core` and `features`: exit code `0`, warnings only, `Errors: none`
- `dotnet format Honua.sln --verify-no-changes --verbosity minimal`
- `git diff --check`

## Gate Impact

- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes

None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` applicable targeted subset and all checks passed; full PR gates are running in CI
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review
