### PR TITLE
feat(collaboration): add saved-map session seam

### DIFF
--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "updatedUtc": "2026-05-08T00:00:00Z",
+  "updatedUtc": "2026-05-12T00:00:00Z",
   "surfaces": [
     {
       "surfaceId": "platform-http",
@@ -64,6 +64,36 @@
           "ownerRepo": "honua-server",
           "status": "implemented",
           "linkedTicket": "honua-server#963",
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
+      "surfaceId": "saved-map-collaboration",
+      "displayName": "Saved-map collaboration session API",
+      "surfaceKind": "http-route-family",
+      "protocol": "Portal Collaboration HTTP",
+      "canonicalIdentifier": "/api/v1/saved-maps/{mapId}/collaboration/sessions/join",
+      "parentSurfaceId": null,
+      "endpointPrefixes": [],
+      "endpointExactMatches": [
+        "/api/v1/saved-maps/{mapId}/collaboration/sessions/join"
+      ],
+      "endpointContains": [],
+      "operationKeys": [],
+      "proofs": [
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "EndpointRegistry coverage plus saved-map collaboration session endpoint tests",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/EndpointRegistry.cs",
+            "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/Collaboration/Sessions/CollaborationSessionEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "honua-server#971",
           "versionCaptureRule": null
         }
       ]

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -392,6 +392,9 @@ public static class EndpointRegistry
         new("GET", "/terrain/{datasetId}/tile.json"),
         new("GET", "/terrain/{datasetId}/{z}/{x}/{y}.png"),
 
+        // Saved-map collaboration session seam.
+        new("POST", "/api/v1/saved-maps/{mapId}/collaboration/sessions/join"),
+
         // Public SDK-compatible scene discovery (#923).
         new("GET", "/api/scenes"),
         new("GET", "/api/scenes/{sceneId}"),

--- a/src/Honua.Server/Features/Collaboration/CollaborationEndpoints.cs
+++ b/src/Honua.Server/Features/Collaboration/CollaborationEndpoints.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Server.Features.Collaboration.Sessions;
+
+namespace Honua.Server.Features.Collaboration;
+
+internal static class CollaborationEndpoints
+{
+    public static void MapCollaborationEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapCollaborationSessionEndpoints();
+    }
+}

--- a/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionEndpoints.cs
+++ b/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionEndpoints.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Server.Features.Infrastructure.Helpers;
+using Honua.Server.Features.Infrastructure.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Collaboration.Sessions;
+
+internal static class CollaborationSessionEndpoints
+{
+    public static void MapCollaborationSessionEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/saved-maps/{mapId}/collaboration/sessions")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Saved Maps", "Collaboration");
+
+        group.MapPost("/join", HandleJoin)
+            .WithDisplayName("Join Saved Map Collaboration Session")
+            .WithMetadata(new HttpMethodMetadata([HttpMethods.Post]))
+            .Produces<ApiResponse<CollaborationJoinResponse>>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+    }
+
+    private static async Task<IResult> HandleJoin(
+        string mapId,
+        [FromBody] CollaborationJoinRequest request,
+        [FromServices] InMemoryCollaborationSessionService sessions,
+        HttpContext context)
+    {
+        var result = await sessions.JoinAsync(
+                mapId,
+                request,
+                context.User,
+                context.RequestAborted)
+            .ConfigureAwait(false);
+
+        if (result.Response is not null)
+        {
+            return Results.Json(
+                ApiResponse<CollaborationJoinResponse>.CreateSuccess(result.Response),
+                CollaborationSessionJsonContext.Default.ApiResponseCollaborationJoinResponse);
+        }
+
+        return result.Authorization.Status switch
+        {
+            SavedMapCollaborationAuthorizationStatus.RequiresAuthentication =>
+                StandardErrorHelpers.CreateUnauthorized(
+                    context,
+                    result.Authorization.Detail ?? "Authentication is required to join this collaboration session."),
+            SavedMapCollaborationAuthorizationStatus.Forbidden =>
+                StandardErrorHelpers.CreateForbidden(
+                    context,
+                    result.Authorization.Detail ?? "You are not allowed to join this collaboration session."),
+            _ => StandardErrorHelpers.CreateForbidden(
+                context,
+                "You are not allowed to join this collaboration session.")
+        };
+    }
+}

--- a/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionJsonContext.cs
+++ b/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionJsonContext.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Server.Features.Infrastructure.Models;
+
+namespace Honua.Server.Features.Collaboration.Sessions;
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(CollaborationJoinRequest))]
+[JsonSerializable(typeof(CollaborationJoinResponse))]
+[JsonSerializable(typeof(CollaborationParticipantPresence))]
+[JsonSerializable(typeof(CollaborationParticipantPresence[]))]
+[JsonSerializable(typeof(CollaborationSessionSnapshot))]
+[JsonSerializable(typeof(CollaborationEventEnvelope))]
+[JsonSerializable(typeof(CollaborationEventEnvelope[]))]
+[JsonSerializable(typeof(CollaborationCursor))]
+[JsonSerializable(typeof(CollaborationSelection))]
+[JsonSerializable(typeof(CollaborationFollowState))]
+[JsonSerializable(typeof(ApiResponse<CollaborationJoinResponse>))]
+internal sealed partial class CollaborationSessionJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionModels.cs
+++ b/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionModels.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+
+namespace Honua.Server.Features.Collaboration.Sessions;
+
+internal static class CollaborationSessionEventTypes
+{
+    public const string ParticipantJoined = "participant.joined";
+    public const string ParticipantHeartbeat = "participant.heartbeat";
+    public const string ParticipantLeft = "participant.left";
+    public const string CursorUpdated = "cursor.updated";
+    public const string SelectionUpdated = "selection.updated";
+    public const string FollowUpdated = "follow.updated";
+    public const string FollowCleared = "follow.cleared";
+    public const string Snapshot = "snapshot";
+}
+
+internal sealed record CollaborationJoinRequest
+{
+    public string? DisplayName { get; init; }
+
+    public string? ClientInstanceId { get; init; }
+}
+
+internal sealed record CollaborationCursor
+{
+    public required double Longitude { get; init; }
+
+    public required double Latitude { get; init; }
+
+    public double? Zoom { get; init; }
+
+    public double? ScreenX { get; init; }
+
+    public double? ScreenY { get; init; }
+}
+
+internal sealed record CollaborationSelection
+{
+    public string? LayerId { get; init; }
+
+    public string[] FeatureIds { get; init; } = [];
+}
+
+internal sealed record CollaborationFollowState
+{
+    public Guid? FollowingSessionId { get; init; }
+
+    public bool IsFollowing => FollowingSessionId.HasValue;
+}
+
+internal sealed record CollaborationParticipantPresence
+{
+    public required Guid SessionId { get; init; }
+
+    public required string ParticipantId { get; init; }
+
+    public required string DisplayName { get; init; }
+
+    public string? UserId { get; init; }
+
+    public string? ClientInstanceId { get; init; }
+
+    public required DateTimeOffset JoinedAt { get; init; }
+
+    public required DateTimeOffset LastSeenAt { get; init; }
+
+    public CollaborationCursor? Cursor { get; init; }
+
+    public CollaborationSelection? Selection { get; init; }
+
+    public CollaborationFollowState Follow { get; init; } = new();
+}
+
+internal sealed record CollaborationSessionSnapshot
+{
+    public required string MapId { get; init; }
+
+    public CollaborationParticipantPresence[] Participants { get; init; } = [];
+
+    public required DateTimeOffset GeneratedAt { get; init; }
+}
+
+internal sealed record CollaborationEventEnvelope
+{
+    public required string Type { get; init; }
+
+    public required Guid EventId { get; init; }
+
+    public required string MapId { get; init; }
+
+    public Guid? SessionId { get; init; }
+
+    public string? ActorParticipantId { get; init; }
+
+    public required DateTimeOffset Timestamp { get; init; }
+
+    public CollaborationParticipantPresence? Participant { get; init; }
+
+    public CollaborationCursor? Cursor { get; init; }
+
+    public CollaborationSelection? Selection { get; init; }
+
+    public CollaborationFollowState? Follow { get; init; }
+
+    public CollaborationSessionSnapshot? Snapshot { get; init; }
+}
+
+internal sealed record CollaborationJoinResponse
+{
+    public required Guid SessionId { get; init; }
+
+    public required CollaborationParticipantPresence Participant { get; init; }
+
+    public required CollaborationSessionSnapshot Snapshot { get; init; }
+}
+
+internal sealed record CollaborationFanOutResult
+{
+    public required CollaborationEventEnvelope Event { get; init; }
+
+    public required int DeliveredCount { get; init; }
+}
+
+internal enum SavedMapCollaborationAuthorizationStatus
+{
+    Authorized,
+    RequiresAuthentication,
+    Forbidden
+}
+
+internal sealed record SavedMapCollaborationAuthorizationResult
+{
+    private SavedMapCollaborationAuthorizationResult(
+        SavedMapCollaborationAuthorizationStatus status,
+        string? detail)
+    {
+        Status = status;
+        Detail = detail;
+    }
+
+    public SavedMapCollaborationAuthorizationStatus Status { get; }
+
+    public string? Detail { get; }
+
+    public bool Authorized => Status == SavedMapCollaborationAuthorizationStatus.Authorized;
+
+    public static SavedMapCollaborationAuthorizationResult Allow() =>
+        new(SavedMapCollaborationAuthorizationStatus.Authorized, detail: null);
+
+    public static SavedMapCollaborationAuthorizationResult RequireAuthentication(string detail) =>
+        new(SavedMapCollaborationAuthorizationStatus.RequiresAuthentication, detail);
+
+    public static SavedMapCollaborationAuthorizationResult Forbid(string detail) =>
+        new(SavedMapCollaborationAuthorizationStatus.Forbidden, detail);
+}
+
+internal sealed record CollaborationJoinResult
+{
+    public required SavedMapCollaborationAuthorizationResult Authorization { get; init; }
+
+    public CollaborationJoinResponse? Response { get; init; }
+}
+
+internal interface ISavedMapCollaborationAuthorizer
+{
+    ValueTask<SavedMapCollaborationAuthorizationResult> AuthorizeJoinAsync(
+        string mapId,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken);
+}
+
+internal interface ICollaborationSessionClock
+{
+    DateTimeOffset UtcNow { get; }
+}

--- a/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionServices.cs
+++ b/src/Honua.Server/Features/Collaboration/Sessions/CollaborationSessionServices.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Features.Collaboration.Sessions;
+
+internal static class CollaborationSessionServices
+{
+    public static IServiceCollection AddCollaborationSessionTransport(this IServiceCollection services)
+    {
+        services.TryAddSingleton<ICollaborationSessionClock, SystemCollaborationSessionClock>();
+        services.TryAddSingleton<ISavedMapCollaborationAuthorizer, FailClosedSavedMapCollaborationAuthorizer>();
+        services.TryAddSingleton<InMemoryCollaborationSessionService>();
+        return services;
+    }
+}
+
+internal sealed class SystemCollaborationSessionClock : ICollaborationSessionClock
+{
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// Placeholder saved-map capability gate. Until durable saved-map ACLs land, the
+/// collaboration transport denies joins by default so tests and future features must
+/// explicitly provide the real authorizer or a narrow fixture authorizer.
+/// </summary>
+internal sealed class FailClosedSavedMapCollaborationAuthorizer : ISavedMapCollaborationAuthorizer
+{
+    public ValueTask<SavedMapCollaborationAuthorizationResult> AuthorizeJoinAsync(
+        string mapId,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(mapId);
+        ArgumentNullException.ThrowIfNull(principal);
+
+        return principal.Identity?.IsAuthenticated == true
+            ? ValueTask.FromResult(SavedMapCollaborationAuthorizationResult.Forbid(
+                "Saved-map collaboration authorization is not configured."))
+            : ValueTask.FromResult(SavedMapCollaborationAuthorizationResult.RequireAuthentication(
+                "Authentication is required to join a saved-map collaboration session."));
+    }
+}

--- a/src/Honua.Server/Features/Collaboration/Sessions/InMemoryCollaborationSessionService.cs
+++ b/src/Honua.Server/Features/Collaboration/Sessions/InMemoryCollaborationSessionService.cs
@@ -1,0 +1,459 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Security.Claims;
+
+namespace Honua.Server.Features.Collaboration.Sessions;
+
+internal sealed class InMemoryCollaborationSessionService
+{
+    private readonly ConcurrentDictionary<string, MapChannel> _channels = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<Guid, string> _sessionMapIndex = new();
+    private readonly ISavedMapCollaborationAuthorizer _authorizer;
+    private readonly ICollaborationSessionClock _clock;
+
+    public InMemoryCollaborationSessionService(
+        ISavedMapCollaborationAuthorizer authorizer,
+        ICollaborationSessionClock clock)
+    {
+        _authorizer = authorizer ?? throw new ArgumentNullException(nameof(authorizer));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public async ValueTask<CollaborationJoinResult> JoinAsync(
+        string mapId,
+        CollaborationJoinRequest request,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(mapId);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(principal);
+
+        var authorization = await _authorizer.AuthorizeJoinAsync(mapId, principal, cancellationToken).ConfigureAwait(false);
+        if (!authorization.Authorized)
+        {
+            return new CollaborationJoinResult { Authorization = authorization };
+        }
+
+        var now = _clock.UtcNow;
+        var sessionId = Guid.NewGuid();
+        var userId = ResolveUserId(principal);
+        var participant = new CollaborationParticipantPresence
+        {
+            SessionId = sessionId,
+            ParticipantId = sessionId.ToString("N"),
+            DisplayName = ResolveDisplayName(request, principal, sessionId),
+            UserId = userId,
+            ClientInstanceId = NormalizeOptional(request.ClientInstanceId),
+            JoinedAt = now,
+            LastSeenAt = now
+        };
+
+        var channel = _channels.GetOrAdd(mapId, static id => new MapChannel(id));
+        CollaborationSessionSnapshot snapshot;
+        lock (channel.Sync)
+        {
+            channel.Participants.Add(sessionId, new ParticipantState(participant));
+            _sessionMapIndex[sessionId] = mapId;
+
+            var joined = CreateEvent(
+                CollaborationSessionEventTypes.ParticipantJoined,
+                mapId,
+                participant,
+                now) with
+            { Participant = participant };
+            FanOutLocked(channel, joined, excludeSessionId: sessionId);
+            snapshot = CreateSnapshotLocked(channel, now);
+        }
+
+        return new CollaborationJoinResult
+        {
+            Authorization = authorization,
+            Response = new CollaborationJoinResponse
+            {
+                SessionId = sessionId,
+                Participant = participant,
+                Snapshot = snapshot
+            }
+        };
+    }
+
+    public CollaborationSessionSnapshot GetSnapshot(string mapId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(mapId);
+        var now = _clock.UtcNow;
+        var channel = _channels.GetOrAdd(mapId, static id => new MapChannel(id));
+        lock (channel.Sync)
+        {
+            return CreateSnapshotLocked(channel, now);
+        }
+    }
+
+    public CollaborationFanOutResult Heartbeat(Guid sessionId)
+    {
+        return UpdateParticipant(
+            sessionId,
+            CollaborationSessionEventTypes.ParticipantHeartbeat,
+            static (presence, now) => presence with { LastSeenAt = now },
+            static (ev, _) => ev);
+    }
+
+    public CollaborationFanOutResult UpdateCursor(Guid sessionId, CollaborationCursor cursor)
+    {
+        ArgumentNullException.ThrowIfNull(cursor);
+        return UpdateParticipant(
+            sessionId,
+            CollaborationSessionEventTypes.CursorUpdated,
+            (presence, now) => presence with { LastSeenAt = now, Cursor = cursor },
+            (ev, _) => ev with { Cursor = cursor });
+    }
+
+    public CollaborationFanOutResult UpdateSelection(Guid sessionId, CollaborationSelection selection)
+    {
+        ArgumentNullException.ThrowIfNull(selection);
+        return UpdateParticipant(
+            sessionId,
+            CollaborationSessionEventTypes.SelectionUpdated,
+            (presence, now) => presence with { LastSeenAt = now, Selection = selection },
+            (ev, _) => ev with { Selection = selection });
+    }
+
+    public CollaborationFanOutResult Follow(Guid sessionId, Guid targetSessionId)
+    {
+        if (!TryResolveSession(sessionId, out var mapId, out var channel))
+        {
+            throw new KeyNotFoundException($"Collaboration session '{sessionId}' was not found.");
+        }
+
+        lock (channel.Sync)
+        {
+            if (!channel.Participants.TryGetValue(sessionId, out var state))
+            {
+                throw new KeyNotFoundException($"Collaboration session '{sessionId}' was not found.");
+            }
+
+            if (!channel.Participants.ContainsKey(targetSessionId))
+            {
+                throw new KeyNotFoundException(
+                    $"Collaboration follow target '{targetSessionId}' was not found in map '{mapId}'.");
+            }
+
+            var now = _clock.UtcNow;
+            var updatedPresence = state.Presence with
+            {
+                LastSeenAt = now,
+                Follow = new CollaborationFollowState { FollowingSessionId = targetSessionId }
+            };
+            state.Presence = updatedPresence;
+
+            var ev = CreateEvent(
+                CollaborationSessionEventTypes.FollowUpdated,
+                mapId,
+                updatedPresence,
+                now) with
+            {
+                Participant = updatedPresence,
+                Follow = updatedPresence.Follow
+            };
+            var delivered = FanOutLocked(channel, ev, excludeSessionId: sessionId);
+            return new CollaborationFanOutResult { Event = ev, DeliveredCount = delivered };
+        }
+    }
+
+    public CollaborationFanOutResult Unfollow(Guid sessionId)
+    {
+        return UpdateParticipant(
+            sessionId,
+            CollaborationSessionEventTypes.FollowCleared,
+            static (presence, now) => presence with
+            {
+                LastSeenAt = now,
+                Follow = new CollaborationFollowState()
+            },
+            static (ev, presence) => ev with { Follow = presence.Follow });
+    }
+
+    public bool Leave(Guid sessionId, string? reason = null)
+    {
+        if (!TryResolveSession(sessionId, out var mapId, out var channel))
+        {
+            return false;
+        }
+
+        lock (channel.Sync)
+        {
+            if (!channel.Participants.Remove(sessionId, out var state))
+            {
+                _sessionMapIndex.TryRemove(sessionId, out _);
+                return false;
+            }
+
+            _sessionMapIndex.TryRemove(sessionId, out _);
+            ClearFollowsTargetingLocked(channel, mapId, sessionId, _clock.UtcNow);
+            var left = CreateEvent(
+                CollaborationSessionEventTypes.ParticipantLeft,
+                mapId,
+                state.Presence,
+                _clock.UtcNow) with
+            { Participant = state.Presence };
+            FanOutLocked(channel, left, excludeSessionId: sessionId);
+            RemoveChannelIfEmpty(mapId, channel);
+            return true;
+        }
+    }
+
+    public int PruneStaleParticipants(TimeSpan maxIdle)
+    {
+        if (maxIdle <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxIdle), "Stale participant timeout must be positive.");
+        }
+
+        var now = _clock.UtcNow;
+        var removed = 0;
+        foreach (var (mapId, channel) in _channels)
+        {
+            lock (channel.Sync)
+            {
+                var stale = channel.Participants
+                    .Where(kvp => now - kvp.Value.Presence.LastSeenAt > maxIdle)
+                    .Select(kvp => kvp.Key)
+                    .ToArray();
+
+                foreach (var sessionId in stale)
+                {
+                    if (!channel.Participants.Remove(sessionId, out var state))
+                    {
+                        continue;
+                    }
+
+                    _sessionMapIndex.TryRemove(sessionId, out _);
+                    removed++;
+                    ClearFollowsTargetingLocked(channel, mapId, sessionId, now);
+
+                    var left = CreateEvent(
+                        CollaborationSessionEventTypes.ParticipantLeft,
+                        mapId,
+                        state.Presence,
+                        now) with
+                    { Participant = state.Presence };
+                    FanOutLocked(channel, left, excludeSessionId: sessionId);
+                }
+
+                RemoveChannelIfEmpty(mapId, channel);
+            }
+        }
+
+        return removed;
+    }
+
+    public CollaborationEventEnvelope[] DrainEvents(Guid sessionId)
+    {
+        if (!TryResolveSession(sessionId, out _, out var channel))
+        {
+            return [];
+        }
+
+        lock (channel.Sync)
+        {
+            if (!channel.Participants.TryGetValue(sessionId, out var state))
+            {
+                return [];
+            }
+
+            var events = state.Outbox.ToArray();
+            state.Outbox.Clear();
+            return events;
+        }
+    }
+
+    private CollaborationFanOutResult UpdateParticipant(
+        Guid sessionId,
+        string eventType,
+        Func<CollaborationParticipantPresence, DateTimeOffset, CollaborationParticipantPresence> update,
+        Func<CollaborationEventEnvelope, CollaborationParticipantPresence, CollaborationEventEnvelope> enrich)
+    {
+        if (!TryResolveSession(sessionId, out var mapId, out var channel))
+        {
+            throw new KeyNotFoundException($"Collaboration session '{sessionId}' was not found.");
+        }
+
+        lock (channel.Sync)
+        {
+            if (!channel.Participants.TryGetValue(sessionId, out var state))
+            {
+                throw new KeyNotFoundException($"Collaboration session '{sessionId}' was not found.");
+            }
+
+            var now = _clock.UtcNow;
+            var updatedPresence = update(state.Presence, now);
+            state.Presence = updatedPresence;
+
+            var ev = enrich(
+                CreateEvent(eventType, mapId, updatedPresence, now) with { Participant = updatedPresence },
+                updatedPresence);
+            var delivered = FanOutLocked(channel, ev, excludeSessionId: sessionId);
+            return new CollaborationFanOutResult { Event = ev, DeliveredCount = delivered };
+        }
+    }
+
+    private bool TryResolveSession(Guid sessionId, out string mapId, out MapChannel channel)
+    {
+        mapId = string.Empty;
+        channel = null!;
+        return _sessionMapIndex.TryGetValue(sessionId, out mapId!) &&
+            _channels.TryGetValue(mapId, out channel!);
+    }
+
+    private static int FanOutLocked(MapChannel channel, CollaborationEventEnvelope ev, Guid excludeSessionId)
+    {
+        var delivered = 0;
+        foreach (var (sessionId, state) in channel.Participants)
+        {
+            if (sessionId == excludeSessionId)
+            {
+                continue;
+            }
+
+            state.Outbox.Enqueue(ev);
+            delivered++;
+        }
+
+        return delivered;
+    }
+
+    private static int ClearFollowsTargetingLocked(
+        MapChannel channel,
+        string mapId,
+        Guid targetSessionId,
+        DateTimeOffset now)
+    {
+        var cleared = 0;
+        foreach (var state in channel.Participants.Values)
+        {
+            if (state.Presence.Follow.FollowingSessionId != targetSessionId)
+            {
+                continue;
+            }
+
+            var updatedPresence = state.Presence with
+            {
+                LastSeenAt = now,
+                Follow = new CollaborationFollowState()
+            };
+            state.Presence = updatedPresence;
+            var ev = CreateEvent(
+                CollaborationSessionEventTypes.FollowCleared,
+                mapId,
+                updatedPresence,
+                now) with
+            {
+                Participant = updatedPresence,
+                Follow = updatedPresence.Follow
+            };
+            FanOutLocked(channel, ev, excludeSessionId: Guid.Empty);
+            cleared++;
+        }
+
+        return cleared;
+    }
+
+    private static CollaborationSessionSnapshot CreateSnapshotLocked(MapChannel channel, DateTimeOffset now)
+    {
+        return new CollaborationSessionSnapshot
+        {
+            MapId = channel.MapId,
+            Participants = channel.Participants.Values
+                .Select(static state => state.Presence)
+                .OrderBy(static presence => presence.JoinedAt)
+                .ThenBy(static presence => presence.ParticipantId, StringComparer.Ordinal)
+                .ToArray(),
+            GeneratedAt = now
+        };
+    }
+
+    private static CollaborationEventEnvelope CreateEvent(
+        string type,
+        string mapId,
+        CollaborationParticipantPresence participant,
+        DateTimeOffset now)
+    {
+        return new CollaborationEventEnvelope
+        {
+            Type = type,
+            EventId = Guid.NewGuid(),
+            MapId = mapId,
+            SessionId = participant.SessionId,
+            ActorParticipantId = participant.ParticipantId,
+            Timestamp = now
+        };
+    }
+
+    private void RemoveChannelIfEmpty(string mapId, MapChannel channel)
+    {
+        if (channel.Participants.Count == 0)
+        {
+            _channels.TryRemove(new KeyValuePair<string, MapChannel>(mapId, channel));
+        }
+    }
+
+    private static string ResolveDisplayName(
+        CollaborationJoinRequest request,
+        ClaimsPrincipal principal,
+        Guid sessionId)
+    {
+        var requested = NormalizeOptional(request.DisplayName);
+        if (requested is not null)
+        {
+            return requested;
+        }
+
+        var name = NormalizeOptional(principal.FindFirstValue(ClaimTypes.Name));
+        if (name is not null)
+        {
+            return name;
+        }
+
+        return $"participant-{sessionId:N}"[..44];
+    }
+
+    private static string? ResolveUserId(ClaimsPrincipal principal)
+    {
+        return NormalizeOptional(principal.FindFirstValue(ClaimTypes.NameIdentifier)) ??
+            NormalizeOptional(principal.FindFirstValue("sub")) ??
+            NormalizeOptional(principal.FindFirstValue(ClaimTypes.Name));
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private sealed class MapChannel
+    {
+        public MapChannel(string mapId)
+        {
+            MapId = mapId;
+        }
+
+        public string MapId { get; }
+
+        public object Sync { get; } = new();
+
+        public Dictionary<Guid, ParticipantState> Participants { get; } = new();
+    }
+
+    private sealed class ParticipantState
+    {
+        public ParticipantState(CollaborationParticipantPresence presence)
+        {
+            Presence = presence;
+        }
+
+        public CollaborationParticipantPresence Presence { get; set; }
+
+        public Queue<CollaborationEventEnvelope> Outbox { get; } = new();
+    }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -27,6 +27,7 @@ using Honua.Server.Features.Admin;
 using Honua.Server.Features.Admin.Services;
 using Honua.Server.Features.Admin.TileOperations;
 using Honua.Server.Features.CloudDemo;
+using Honua.Server.Features.Collaboration;
 using Honua.Server.Features.Collaboration.Sessions;
 using Honua.Server.Features.Export;
 using Honua.Server.Features.PrintingTools;
@@ -1215,7 +1216,7 @@ app.MapExportEndpoints();
 // Configure unified operations progress endpoints
 app.MapOperationsProgressEndpoints();
 app.MapFeatureChangeEventsEndpoints();
-app.MapCollaborationSessionEndpoints();
+app.MapCollaborationEndpoints();
 app.MapMobileExceptionIngestionEndpoints();
 app.MapFieldCollectionSyncEndpoints();
 app.MapTileOperationsEndpoints();

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -27,6 +27,7 @@ using Honua.Server.Features.Admin;
 using Honua.Server.Features.Admin.Services;
 using Honua.Server.Features.Admin.TileOperations;
 using Honua.Server.Features.CloudDemo;
+using Honua.Server.Features.Collaboration.Sessions;
 using Honua.Server.Features.Export;
 using Honua.Server.Features.PrintingTools;
 using Honua.Server.Features.Infrastructure.ControlPlane;
@@ -658,6 +659,7 @@ builder.Services.AddHostedService(sp =>
         sp.GetRequiredService<IHttpClientFactory>(),
         sp.GetRequiredService<IOptions<Honua.Server.Features.Infrastructure.Events.FeatureChangeWebhookOptions>>(),
         sp.GetRequiredService<ILogger<Honua.Server.Features.Infrastructure.Events.FeatureChangeWebhookDispatcher>>()));
+builder.Services.AddCollaborationSessionTransport();
 
 // Register manifest drift webhook dispatcher (#515)
 builder.Services.AddSingleton<IValidateOptions<Honua.Server.Features.Admin.ManifestDriftWebhookOptions>, Honua.Server.Features.Admin.ManifestDriftWebhookOptionsValidator>();
@@ -850,6 +852,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Protocols.Stac.StacJsonContext.Default,
         Honua.Server.Features.Protocols.Cog.CogJsonContext.Default,
         Honua.Server.Features.Protocols.SpatialAnalytics.Models.SpatialAnalyticsJsonContext.Default,
+        Honua.Server.Features.Collaboration.Sessions.CollaborationSessionJsonContext.Default,
         Honua.Core.Features.Authorization.Domain.OperatorAuthorizationJsonContext.Default,
         Honua.Server.Features.Protocols.Ogc.Api.Processes.OgcProcessesJsonContext.Default);
 });
@@ -1212,6 +1215,7 @@ app.MapExportEndpoints();
 // Configure unified operations progress endpoints
 app.MapOperationsProgressEndpoints();
 app.MapFeatureChangeEventsEndpoints();
+app.MapCollaborationSessionEndpoints();
 app.MapMobileExceptionIngestionEndpoints();
 app.MapFieldCollectionSyncEndpoints();
 app.MapTileOperationsEndpoints();

--- a/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
@@ -21,6 +21,7 @@ public sealed class VerticalSliceIsolationTests
         "Admin",
         "Alerts",
         "CloudDemo",
+        "Collaboration",
         "Geocoding",
         "Geoprocessing",
         "Grounding",

--- a/tests/dotnet/Honua.Server.Tests/Features/Collaboration/Sessions/CollaborationSessionEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Collaboration/Sessions/CollaborationSessionEndpointsTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Server.Features.Collaboration.Sessions;
+using Honua.TestKit.Attributes;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Tests.Features.Collaboration.Sessions;
+
+[Protocol(Honua.TestKit.Constants.Protocols.Streaming)]
+[Operation(Honua.TestKit.Constants.Operations.Streaming)]
+public sealed class CollaborationSessionEndpointsTests
+{
+    private const string AdminPassword = "collaboration-session-test-key";
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/saved-maps/{mapId}/collaboration/sessions/join")]
+    public async Task Join_WithAuthorizedSavedMapCapability_ReturnsSessionSnapshot()
+    {
+        using var factory = CreateFactory(allowJoin: true);
+        using var client = CreateClient(factory);
+        using var response = await client.PostAsync(
+            "/api/v1/saved-maps/saved-map:ops/collaboration/sessions/join",
+            JsonBody(new CollaborationJoinRequest { DisplayName = "Ada", ClientInstanceId = "browser-1" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var data = document.RootElement.GetProperty("data");
+        data.GetProperty("participant").GetProperty("displayName").GetString().Should().Be("Ada");
+        data.GetProperty("snapshot").GetProperty("mapId").GetString().Should().Be("saved-map:ops");
+        data.GetProperty("snapshot").GetProperty("participants").GetArrayLength().Should().Be(1);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/saved-maps/{mapId}/collaboration/sessions/join")]
+    public async Task Join_WithoutSavedMapCapability_ReturnsUnauthorized()
+    {
+        using var factory = CreateFactory(allowJoin: false);
+        using var client = factory.CreateClient();
+        using var response = await client.PostAsync(
+            "/api/v1/saved-maps/saved-map:ops/collaboration/sessions/join",
+            JsonBody(new CollaborationJoinRequest { DisplayName = "Ada" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory(bool allowJoin)
+    {
+        return new TestWebApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, configBuilder) =>
+                {
+                    configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["HONUA_DEV_AUTH"] = "false",
+                        ["HONUA_ADMIN_PASSWORD"] = AdminPassword
+                    });
+                });
+
+                if (allowJoin)
+                {
+                    builder.ConfigureTestServices(services =>
+                    {
+                        services.RemoveAll<ISavedMapCollaborationAuthorizer>();
+                        services.AddSingleton<ISavedMapCollaborationAuthorizer, AllowSavedMapCollaborationAuthorizer>();
+                    });
+                }
+            });
+    }
+
+    private static HttpClient CreateClient(WebApplicationFactory<Program> factory)
+    {
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", AdminPassword);
+        return client;
+    }
+
+    private static StringContent JsonBody(CollaborationJoinRequest request)
+    {
+        var json = JsonSerializer.Serialize(
+            request,
+            CollaborationSessionJsonContext.Default.CollaborationJoinRequest);
+        return new StringContent(json, Encoding.UTF8, "application/json");
+    }
+
+    private sealed class AllowSavedMapCollaborationAuthorizer : ISavedMapCollaborationAuthorizer
+    {
+        public ValueTask<SavedMapCollaborationAuthorizationResult> AuthorizeJoinAsync(
+            string mapId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken) =>
+            ValueTask.FromResult(SavedMapCollaborationAuthorizationResult.Allow());
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Collaboration/Sessions/InMemoryCollaborationSessionServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Collaboration/Sessions/InMemoryCollaborationSessionServiceTests.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Server.Features.Collaboration.Sessions;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Collaboration.Sessions;
+
+public sealed class InMemoryCollaborationSessionServiceTests
+{
+    [UnitTest]
+    public async Task JoinAsync_WithAuthorizedUser_ReturnsMapSnapshot()
+    {
+        var clock = new FakeCollaborationClock(FixedUtcNow());
+        var service = CreateService(clock);
+
+        var result = await service.JoinAsync(
+            "saved-map:ops",
+            new CollaborationJoinRequest { DisplayName = "Ada" },
+            Principal("user-1", "Ada"));
+
+        result.Authorization.Authorized.Should().BeTrue();
+        result.Response.Should().NotBeNull();
+        result.Response!.Snapshot.MapId.Should().Be("saved-map:ops");
+        result.Response.Snapshot.Participants.Should().ContainSingle();
+        result.Response.Participant.DisplayName.Should().Be("Ada");
+        result.Response.Participant.UserId.Should().Be("user-1");
+    }
+
+    [UnitTest]
+    public async Task UpdateCursor_SameMapParticipants_FansOutOnlyWithinMap()
+    {
+        var clock = new FakeCollaborationClock(FixedUtcNow());
+        var service = CreateService(clock);
+        var alice = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Alice" }, Principal("alice"))).Response!;
+        var bob = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Bob" }, Principal("bob"))).Response!;
+        var cara = (await service.JoinAsync("map-b", new CollaborationJoinRequest { DisplayName = "Cara" }, Principal("cara"))).Response!;
+        _ = service.DrainEvents(alice.SessionId);
+        _ = service.DrainEvents(bob.SessionId);
+        _ = service.DrainEvents(cara.SessionId);
+
+        var fanOut = service.UpdateCursor(
+            alice.SessionId,
+            new CollaborationCursor { Longitude = -157.8583, Latitude = 21.3069, Zoom = 12 });
+
+        fanOut.DeliveredCount.Should().Be(1);
+        service.DrainEvents(alice.SessionId).Should().BeEmpty();
+        var bobEvents = service.DrainEvents(bob.SessionId);
+        bobEvents.Should().ContainSingle();
+        bobEvents[0].Type.Should().Be(CollaborationSessionEventTypes.CursorUpdated);
+        bobEvents[0].Cursor!.Longitude.Should().Be(-157.8583);
+        service.DrainEvents(cara.SessionId).Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public async Task FollowAndUnfollow_SameMapParticipant_FansOutStateChanges()
+    {
+        var clock = new FakeCollaborationClock(FixedUtcNow());
+        var service = CreateService(clock);
+        var leader = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Leader" }, Principal("leader"))).Response!;
+        var follower = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Follower" }, Principal("follower"))).Response!;
+        _ = service.DrainEvents(leader.SessionId);
+        _ = service.DrainEvents(follower.SessionId);
+
+        service.Follow(follower.SessionId, leader.SessionId);
+
+        var followEvents = service.DrainEvents(leader.SessionId);
+        followEvents.Should().ContainSingle();
+        followEvents[0].Type.Should().Be(CollaborationSessionEventTypes.FollowUpdated);
+        followEvents[0].Follow!.FollowingSessionId.Should().Be(leader.SessionId);
+
+        service.Unfollow(follower.SessionId);
+
+        var unfollowEvents = service.DrainEvents(leader.SessionId);
+        unfollowEvents.Should().ContainSingle();
+        unfollowEvents[0].Type.Should().Be(CollaborationSessionEventTypes.FollowCleared);
+        unfollowEvents[0].Follow!.IsFollowing.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task Follow_TargetFromDifferentMap_FailsWithoutFanOut()
+    {
+        var clock = new FakeCollaborationClock(FixedUtcNow());
+        var service = CreateService(clock);
+        var follower = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Follower" }, Principal("follower"))).Response!;
+        var otherMapLeader = (await service.JoinAsync("map-b", new CollaborationJoinRequest { DisplayName = "Leader" }, Principal("leader"))).Response!;
+        _ = service.DrainEvents(follower.SessionId);
+        _ = service.DrainEvents(otherMapLeader.SessionId);
+
+        var act = () => service.Follow(follower.SessionId, otherMapLeader.SessionId);
+
+        act.Should().Throw<KeyNotFoundException>();
+        service.GetSnapshot("map-a").Participants.Single().Follow.IsFollowing.Should().BeFalse();
+        service.DrainEvents(follower.SessionId).Should().BeEmpty();
+        service.DrainEvents(otherMapLeader.SessionId).Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public async Task Leave_JoinedParticipant_RemovesPresenceAndFansOutLeave()
+    {
+        var clock = new FakeCollaborationClock(FixedUtcNow());
+        var service = CreateService(clock);
+        var alice = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Alice" }, Principal("alice"))).Response!;
+        var bob = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Bob" }, Principal("bob"))).Response!;
+        _ = service.DrainEvents(alice.SessionId);
+        _ = service.DrainEvents(bob.SessionId);
+
+        service.Leave(bob.SessionId).Should().BeTrue();
+
+        service.GetSnapshot("map-a").Participants.Should().ContainSingle(p => p.SessionId == alice.SessionId);
+        service.DrainEvents(alice.SessionId).Should().ContainSingle(e =>
+            e.Type == CollaborationSessionEventTypes.ParticipantLeft &&
+            e.SessionId == bob.SessionId);
+        service.DrainEvents(bob.SessionId).Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public async Task Leave_FollowedParticipant_ClearsFollowerState()
+    {
+        var clock = new FakeCollaborationClock(FixedUtcNow());
+        var service = CreateService(clock);
+        var leader = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Leader" }, Principal("leader"))).Response!;
+        var follower = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Follower" }, Principal("follower"))).Response!;
+        service.Follow(follower.SessionId, leader.SessionId);
+        _ = service.DrainEvents(leader.SessionId);
+        _ = service.DrainEvents(follower.SessionId);
+
+        service.Leave(leader.SessionId).Should().BeTrue();
+
+        service.GetSnapshot("map-a").Participants.Single().Follow.IsFollowing.Should().BeFalse();
+        service.DrainEvents(follower.SessionId).Should().Contain(e =>
+            e.Type == CollaborationSessionEventTypes.FollowCleared &&
+            e.SessionId == follower.SessionId);
+    }
+
+    [UnitTest]
+    public async Task PruneStaleParticipants_RemovesOnlyExpiredHeartbeatSessions()
+    {
+        var clock = new FakeCollaborationClock(FixedUtcNow());
+        var service = CreateService(clock);
+        var active = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Active" }, Principal("active"))).Response!;
+        var stale = (await service.JoinAsync("map-a", new CollaborationJoinRequest { DisplayName = "Stale" }, Principal("stale"))).Response!;
+        _ = service.DrainEvents(active.SessionId);
+        _ = service.DrainEvents(stale.SessionId);
+
+        clock.Advance(TimeSpan.FromMinutes(10));
+        service.Heartbeat(active.SessionId);
+        clock.Advance(TimeSpan.FromMinutes(1));
+
+        var removed = service.PruneStaleParticipants(TimeSpan.FromMinutes(5));
+
+        removed.Should().Be(1);
+        var snapshot = service.GetSnapshot("map-a");
+        snapshot.Participants.Should().ContainSingle(p => p.SessionId == active.SessionId);
+        snapshot.Participants.Should().NotContain(p => p.SessionId == stale.SessionId);
+        service.DrainEvents(active.SessionId).Should().ContainSingle(e =>
+            e.Type == CollaborationSessionEventTypes.ParticipantLeft &&
+            e.SessionId == stale.SessionId);
+    }
+
+    [UnitTest]
+    public async Task JoinAsync_WithoutSavedMapAuthorizer_FailsClosed()
+    {
+        var service = new InMemoryCollaborationSessionService(
+            new FailClosedSavedMapCollaborationAuthorizer(),
+            new FakeCollaborationClock(FixedUtcNow()));
+
+        var result = await service.JoinAsync(
+            "saved-map:ops",
+            new CollaborationJoinRequest { DisplayName = "Nope" },
+            new ClaimsPrincipal(new ClaimsIdentity()));
+
+        result.Response.Should().BeNull();
+        result.Authorization.Status.Should().Be(SavedMapCollaborationAuthorizationStatus.RequiresAuthentication);
+    }
+
+    private static InMemoryCollaborationSessionService CreateService(FakeCollaborationClock clock) =>
+        new(new AllowSavedMapCollaborationAuthorizer(), clock);
+
+    private static DateTimeOffset FixedUtcNow() =>
+        new(2026, 5, 12, 0, 0, 0, TimeSpan.Zero);
+
+    private static ClaimsPrincipal Principal(string userId, string? name = null)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId)
+        };
+
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            claims.Add(new Claim(ClaimTypes.Name, name));
+        }
+
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "Test"));
+    }
+
+    private sealed class FakeCollaborationClock : ICollaborationSessionClock
+    {
+        public FakeCollaborationClock(DateTimeOffset utcNow)
+        {
+            UtcNow = utcNow;
+        }
+
+        public DateTimeOffset UtcNow { get; private set; }
+
+        public void Advance(TimeSpan value)
+        {
+            UtcNow += value;
+        }
+    }
+
+    private sealed class AllowSavedMapCollaborationAuthorizer : ISavedMapCollaborationAuthorizer
+    {
+        public ValueTask<SavedMapCollaborationAuthorizationResult> AuthorizeJoinAsync(
+            string mapId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken) =>
+            ValueTask.FromResult(SavedMapCollaborationAuthorizationResult.Allow());
+    }
+}


### PR DESCRIPTION
## Issue Link
Related to #971

## Summary
Adds the first server-side saved-map collaboration session seam for active users in the same map. This is a narrow foundation for #971, not the full production transport.

## Changes Made
- Added fail-closed saved-map collaboration authorization seam and service registration.
- Added an in-memory map-scoped session service for join, heartbeat, cursor, selection, follow/unfollow, leave, stale cleanup, snapshots, and participant outboxes.
- Added a minimal `POST /api/v1/saved-maps/{mapId}/collaboration/sessions/join` endpoint with source-generated JSON context.
- Registered Collaboration as a server feature vertical slice for architecture tests.
- Added unit/integration tests for authorization, same-map fan-out, follow cleanup, stale cleanup, leave cleanup, and join response shape.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Targeted validation run locally:
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~Collaboration.Sessions" --no-restore` passed: 10/10
- `dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj --filter "FullyQualifiedName~VerticalSliceIsolationTests" --no-restore` passed: 5/5
- `dotnet format Honua.sln --no-restore --verify-no-changes --include ...collaboration session files...` passed
- `git diff --check` passed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

Adds an internal endpoint/session contract seam. Production transport docs and SDK adapter mapping remain follow-up work.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Targeted validation passed; full `scripts/ci/pre-pr-check.sh` was not run locally for this draft backlog slice
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
