### PR TITLE
feat(collaboration): add feature lock seam

### DIFF
--- a/src/Honua.Core/Features/Collaboration/FeatureLocks/FeatureLockContracts.cs
+++ b/src/Honua.Core/Features/Collaboration/FeatureLocks/FeatureLockContracts.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Collaboration.FeatureLocks;
+
+public readonly record struct FeatureRef(
+    string ServiceName,
+    int LayerId,
+    string FeatureId);
+
+public sealed record LockHolder(
+    string HolderId,
+    string? DisplayName = null,
+    string? SessionId = null,
+    string? TenantId = null);
+
+public sealed record FeatureLockLease(
+    string LockId,
+    FeatureRef Feature,
+    LockHolder Holder,
+    DateTimeOffset AcquiredAt,
+    DateTimeOffset ExpiresAt,
+    DateTimeOffset? RenewedAt = null);
+
+public readonly record struct FeatureLockAccessContext(
+    bool IsAuthorized,
+    bool CanWrite)
+{
+    public static FeatureLockAccessContext AuthorizedWrite => new(IsAuthorized: true, CanWrite: true);
+
+    public static FeatureLockAccessContext Unauthorized => new(IsAuthorized: false, CanWrite: false);
+
+    public static FeatureLockAccessContext ReadOnly => new(IsAuthorized: true, CanWrite: false);
+}
+
+public sealed record FeatureLockHeldError(
+    string Code,
+    string Message,
+    FeatureRef Feature,
+    LockHolder Holder,
+    DateTimeOffset ExpiresAt)
+{
+    public static FeatureLockHeldError FromLease(FeatureLockLease lease)
+        => new(
+            "feature-lock-held",
+            "The feature is locked by another editor.",
+            lease.Feature,
+            lease.Holder,
+            lease.ExpiresAt);
+}
+
+public sealed record FeatureEditConflictResponse(
+    string Code,
+    string Reason,
+    string Message,
+    string Operation,
+    FeatureRef Feature,
+    FeatureLockHeldError? Lock,
+    DateTimeOffset OccurredAt)
+{
+    public static FeatureEditConflictResponse FromLockHeld(
+        string operation,
+        FeatureLockHeldError lockError,
+        DateTimeOffset occurredAt)
+        => new(
+            "edit-conflict",
+            lockError.Code,
+            "The edit cannot be applied because the target feature is locked.",
+            operation,
+            lockError.Feature,
+            lockError,
+            occurredAt);
+}
+
+public enum FeatureLockClaimStatus
+{
+    Claimed,
+    Renewed,
+    HeldByOther,
+    Denied
+}
+
+public sealed record FeatureLockClaimResponse(
+    FeatureLockClaimStatus Status,
+    FeatureLockLease? Lease = null,
+    FeatureLockHeldError? Error = null,
+    string? DenialReason = null)
+{
+    public bool IsSuccess => Status is FeatureLockClaimStatus.Claimed or FeatureLockClaimStatus.Renewed;
+}
+
+public enum FeatureLockRenewStatus
+{
+    Renewed,
+    NotFound,
+    HeldByOther,
+    Denied
+}
+
+public sealed record FeatureLockRenewResponse(
+    FeatureLockRenewStatus Status,
+    FeatureLockLease? Lease = null,
+    FeatureLockHeldError? Error = null,
+    string? DenialReason = null)
+{
+    public bool IsSuccess => Status == FeatureLockRenewStatus.Renewed;
+}
+
+public enum FeatureLockReleaseStatus
+{
+    Released,
+    NotFound,
+    HeldByOther,
+    Denied
+}
+
+public sealed record FeatureLockReleaseResponse(
+    FeatureLockReleaseStatus Status,
+    FeatureRef Feature,
+    FeatureLockLease? ReleasedLease = null,
+    FeatureLockHeldError? Error = null,
+    string? DenialReason = null)
+{
+    public bool IsSuccess => Status == FeatureLockReleaseStatus.Released;
+}

--- a/src/Honua.Core/Features/Collaboration/FeatureLocks/IFeatureLockService.cs
+++ b/src/Honua.Core/Features/Collaboration/FeatureLocks/IFeatureLockService.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Collaboration.FeatureLocks;
+
+public interface IFeatureLockService
+{
+    ValueTask<FeatureLockClaimResponse> ClaimAsync(
+        FeatureRef feature,
+        LockHolder holder,
+        TimeSpan leaseDuration,
+        FeatureLockAccessContext access,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<FeatureLockRenewResponse> RenewAsync(
+        FeatureRef feature,
+        LockHolder holder,
+        TimeSpan leaseDuration,
+        FeatureLockAccessContext access,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<FeatureLockReleaseResponse> ReleaseAsync(
+        FeatureRef feature,
+        LockHolder holder,
+        FeatureLockAccessContext access,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<FeatureLockLease?> GetActiveLeaseAsync(
+        FeatureRef feature,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<int> PruneExpiredAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Collaboration/FeatureLocks/InMemoryFeatureLockService.cs
+++ b/src/Honua.Core/Features/Collaboration/FeatureLocks/InMemoryFeatureLockService.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+
+namespace Honua.Core.Features.Collaboration.FeatureLocks;
+
+public sealed class InMemoryFeatureLockService : IFeatureLockService
+{
+    private const string DeniedReason = "Feature lock mutation requires authorized write access.";
+
+    private readonly ConcurrentDictionary<FeatureRef, FeatureLockLease> _leases = new();
+    private readonly object _gate = new();
+    private readonly TimeProvider _timeProvider;
+
+    public InMemoryFeatureLockService(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public ValueTask<FeatureLockClaimResponse> ClaimAsync(
+        FeatureRef feature,
+        LockHolder holder,
+        TimeSpan leaseDuration,
+        FeatureLockAccessContext access,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(feature.ServiceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(feature.FeatureId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(holder.HolderId);
+        ValidateLeaseDuration(leaseDuration);
+
+        if (!HasWriteAccess(access))
+        {
+            return ValueTask.FromResult(new FeatureLockClaimResponse(FeatureLockClaimStatus.Denied, DenialReason: DeniedReason));
+        }
+
+        lock (_gate)
+        {
+            var now = _timeProvider.GetUtcNow();
+            PruneExpiredCore(now);
+
+            if (_leases.TryGetValue(feature, out var existing))
+            {
+                if (IsSameHolder(existing.Holder, holder))
+                {
+                    var renewed = RenewLease(existing, holder, leaseDuration, now);
+                    _leases[feature] = renewed;
+                    return ValueTask.FromResult(new FeatureLockClaimResponse(FeatureLockClaimStatus.Renewed, Lease: renewed));
+                }
+
+                return ValueTask.FromResult(new FeatureLockClaimResponse(
+                    FeatureLockClaimStatus.HeldByOther,
+                    Error: FeatureLockHeldError.FromLease(existing)));
+            }
+
+            var lease = new FeatureLockLease(
+                Guid.NewGuid().ToString("N"),
+                feature,
+                holder,
+                now,
+                now.Add(leaseDuration));
+            _leases[feature] = lease;
+
+            return ValueTask.FromResult(new FeatureLockClaimResponse(FeatureLockClaimStatus.Claimed, Lease: lease));
+        }
+    }
+
+    public ValueTask<FeatureLockRenewResponse> RenewAsync(
+        FeatureRef feature,
+        LockHolder holder,
+        TimeSpan leaseDuration,
+        FeatureLockAccessContext access,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(feature.ServiceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(feature.FeatureId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(holder.HolderId);
+        ValidateLeaseDuration(leaseDuration);
+
+        if (!HasWriteAccess(access))
+        {
+            return ValueTask.FromResult(new FeatureLockRenewResponse(FeatureLockRenewStatus.Denied, DenialReason: DeniedReason));
+        }
+
+        lock (_gate)
+        {
+            var now = _timeProvider.GetUtcNow();
+            PruneExpiredCore(now);
+
+            if (!_leases.TryGetValue(feature, out var existing))
+            {
+                return ValueTask.FromResult(new FeatureLockRenewResponse(FeatureLockRenewStatus.NotFound));
+            }
+
+            if (!IsSameHolder(existing.Holder, holder))
+            {
+                return ValueTask.FromResult(new FeatureLockRenewResponse(
+                    FeatureLockRenewStatus.HeldByOther,
+                    Error: FeatureLockHeldError.FromLease(existing)));
+            }
+
+            var renewed = RenewLease(existing, holder, leaseDuration, now);
+            _leases[feature] = renewed;
+            return ValueTask.FromResult(new FeatureLockRenewResponse(FeatureLockRenewStatus.Renewed, Lease: renewed));
+        }
+    }
+
+    public ValueTask<FeatureLockReleaseResponse> ReleaseAsync(
+        FeatureRef feature,
+        LockHolder holder,
+        FeatureLockAccessContext access,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(feature.ServiceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(feature.FeatureId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(holder.HolderId);
+
+        if (!HasWriteAccess(access))
+        {
+            return ValueTask.FromResult(new FeatureLockReleaseResponse(
+                FeatureLockReleaseStatus.Denied,
+                feature,
+                DenialReason: DeniedReason));
+        }
+
+        lock (_gate)
+        {
+            var now = _timeProvider.GetUtcNow();
+            PruneExpiredCore(now);
+
+            if (!_leases.TryGetValue(feature, out var existing))
+            {
+                return ValueTask.FromResult(new FeatureLockReleaseResponse(FeatureLockReleaseStatus.NotFound, feature));
+            }
+
+            if (!IsSameHolder(existing.Holder, holder))
+            {
+                return ValueTask.FromResult(new FeatureLockReleaseResponse(
+                    FeatureLockReleaseStatus.HeldByOther,
+                    feature,
+                    Error: FeatureLockHeldError.FromLease(existing)));
+            }
+
+            _leases.TryRemove(feature, out _);
+            return ValueTask.FromResult(new FeatureLockReleaseResponse(
+                FeatureLockReleaseStatus.Released,
+                feature,
+                ReleasedLease: existing));
+        }
+    }
+
+    public ValueTask<FeatureLockLease?> GetActiveLeaseAsync(
+        FeatureRef feature,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(feature.ServiceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(feature.FeatureId);
+
+        lock (_gate)
+        {
+            var now = _timeProvider.GetUtcNow();
+            PruneExpiredCore(now);
+
+            return ValueTask.FromResult(_leases.TryGetValue(feature, out var lease) ? lease : null);
+        }
+    }
+
+    public ValueTask<int> PruneExpiredAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            return ValueTask.FromResult(PruneExpiredCore(_timeProvider.GetUtcNow()));
+        }
+    }
+
+    private int PruneExpiredCore(DateTimeOffset now)
+    {
+        var removed = 0;
+
+        foreach (var (feature, lease) in _leases)
+        {
+            if (lease.ExpiresAt > now)
+            {
+                continue;
+            }
+
+            if (_leases.TryRemove(feature, out _))
+            {
+                removed++;
+            }
+        }
+
+        return removed;
+    }
+
+    private static FeatureLockLease RenewLease(
+        FeatureLockLease existing,
+        LockHolder holder,
+        TimeSpan leaseDuration,
+        DateTimeOffset now)
+        => existing with
+        {
+            Holder = holder,
+            RenewedAt = now,
+            ExpiresAt = now.Add(leaseDuration)
+        };
+
+    private static bool HasWriteAccess(FeatureLockAccessContext access)
+        => access.IsAuthorized && access.CanWrite;
+
+    private static bool IsSameHolder(LockHolder existing, LockHolder candidate)
+    {
+        if (!string.Equals(existing.HolderId, candidate.HolderId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(existing.SessionId) || !string.IsNullOrWhiteSpace(candidate.SessionId))
+        {
+            return string.Equals(existing.SessionId, candidate.SessionId, StringComparison.Ordinal);
+        }
+
+        if (!string.IsNullOrWhiteSpace(existing.TenantId) || !string.IsNullOrWhiteSpace(candidate.TenantId))
+        {
+            return string.Equals(existing.TenantId, candidate.TenantId, StringComparison.Ordinal);
+        }
+
+        return true;
+    }
+
+    private static void ValidateLeaseDuration(TimeSpan leaseDuration)
+    {
+        if (leaseDuration <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(leaseDuration), leaseDuration, "Lease duration must be greater than zero.");
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Collaboration/FeatureLocks/InMemoryFeatureLockServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Collaboration/FeatureLocks/InMemoryFeatureLockServiceTests.cs
@@ -1,0 +1,213 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Collaboration.FeatureLocks;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Collaboration.FeatureLocks;
+
+[Protocol(TestProtocols.Infrastructure)]
+public sealed class InMemoryFeatureLockServiceTests
+{
+    private static readonly FeatureRef Feature = new("parcels", 7, "42");
+    private static readonly LockHolder Alice = new("alice", "Alice Editor", "session-a", "tenant-1");
+    private static readonly LockHolder Bob = new("bob", "Bob Editor", "session-b", "tenant-1");
+    private static readonly TimeSpan LeaseDuration = TimeSpan.FromMinutes(2);
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    public async Task ClaimAsync_AuthorizedWriteAccess_ClaimsLease()
+    {
+        var clock = new MutableTimeProvider(Instant());
+        var service = new InMemoryFeatureLockService(clock);
+
+        var result = await service.ClaimAsync(Feature, Alice, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+
+        result.Status.Should().Be(FeatureLockClaimStatus.Claimed);
+        result.IsSuccess.Should().BeTrue();
+        result.Lease.Should().NotBeNull();
+        result.Lease!.Feature.Should().Be(Feature);
+        result.Lease.Holder.Should().Be(Alice);
+        result.Lease.AcquiredAt.Should().Be(clock.GetUtcNow());
+        result.Lease.ExpiresAt.Should().Be(clock.GetUtcNow().Add(LeaseDuration));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Security)]
+    public async Task ClaimAsync_UnauthorizedOrReadOnlyAccess_DeniesFailClosed()
+    {
+        var service = new InMemoryFeatureLockService(new MutableTimeProvider(Instant()));
+
+        var unauthorized = await service.ClaimAsync(Feature, Alice, LeaseDuration, FeatureLockAccessContext.Unauthorized);
+        var readOnly = await service.ClaimAsync(Feature, Alice, LeaseDuration, FeatureLockAccessContext.ReadOnly);
+
+        unauthorized.Status.Should().Be(FeatureLockClaimStatus.Denied);
+        unauthorized.IsSuccess.Should().BeFalse();
+        readOnly.Status.Should().Be(FeatureLockClaimStatus.Denied);
+        readOnly.IsSuccess.Should().BeFalse();
+        (await service.GetActiveLeaseAsync(Feature)).Should().BeNull();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    public async Task ClaimAsync_ActiveLeaseByDifferentHolder_ReturnsLockHeldMetadata()
+    {
+        var service = new InMemoryFeatureLockService(new MutableTimeProvider(Instant()));
+        var first = await service.ClaimAsync(Feature, Alice, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+
+        var second = await service.ClaimAsync(Feature, Bob, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+
+        second.Status.Should().Be(FeatureLockClaimStatus.HeldByOther);
+        second.IsSuccess.Should().BeFalse();
+        second.Error.Should().NotBeNull();
+        second.Error!.Code.Should().Be("feature-lock-held");
+        second.Error.Feature.Should().Be(Feature);
+        second.Error.Holder.Should().Be(Alice);
+        second.Error.ExpiresAt.Should().Be(first.Lease!.ExpiresAt);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    public async Task ClaimAsync_ActiveLeaseBySameHolder_RenewsLease()
+    {
+        var clock = new MutableTimeProvider(Instant());
+        var service = new InMemoryFeatureLockService(clock);
+        var first = await service.ClaimAsync(Feature, Alice, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+        clock.Advance(TimeSpan.FromSeconds(30));
+
+        var second = await service.ClaimAsync(Feature, Alice, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+
+        second.Status.Should().Be(FeatureLockClaimStatus.Renewed);
+        second.Lease!.LockId.Should().Be(first.Lease!.LockId);
+        second.Lease.RenewedAt.Should().Be(clock.GetUtcNow());
+        second.Lease.ExpiresAt.Should().Be(clock.GetUtcNow().Add(LeaseDuration));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    public async Task ClaimAsync_SameHolderDifferentSession_ReturnsLockHeld()
+    {
+        var service = new InMemoryFeatureLockService(new MutableTimeProvider(Instant()));
+        var sameUserOtherSession = Alice with { SessionId = "session-a-other" };
+        await service.ClaimAsync(Feature, Alice, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+
+        var result = await service.ClaimAsync(
+            Feature,
+            sameUserOtherSession,
+            LeaseDuration,
+            FeatureLockAccessContext.AuthorizedWrite);
+
+        result.Status.Should().Be(FeatureLockClaimStatus.HeldByOther);
+        result.Error!.Holder.Should().Be(Alice);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    public async Task RenewAsync_SameHolder_ExtendsLease()
+    {
+        var clock = new MutableTimeProvider(Instant());
+        var service = new InMemoryFeatureLockService(clock);
+        var claim = await service.ClaimAsync(Feature, Alice, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+        clock.Advance(TimeSpan.FromMinutes(1));
+
+        var renew = await service.RenewAsync(Feature, Alice, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+
+        renew.Status.Should().Be(FeatureLockRenewStatus.Renewed);
+        renew.IsSuccess.Should().BeTrue();
+        renew.Lease!.LockId.Should().Be(claim.Lease!.LockId);
+        renew.Lease.ExpiresAt.Should().Be(clock.GetUtcNow().Add(LeaseDuration));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    public async Task ReleaseAsync_SameHolder_ReleasesLease()
+    {
+        var service = new InMemoryFeatureLockService(new MutableTimeProvider(Instant()));
+        var claim = await service.ClaimAsync(Feature, Alice, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+
+        var release = await service.ReleaseAsync(Feature, Alice, FeatureLockAccessContext.AuthorizedWrite);
+
+        release.Status.Should().Be(FeatureLockReleaseStatus.Released);
+        release.IsSuccess.Should().BeTrue();
+        release.ReleasedLease.Should().Be(claim.Lease);
+        (await service.GetActiveLeaseAsync(Feature)).Should().BeNull();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    public async Task ClaimAsync_ExpiredLease_PrunesAndAllowsNewHolder()
+    {
+        var clock = new MutableTimeProvider(Instant());
+        var service = new InMemoryFeatureLockService(clock);
+        await service.ClaimAsync(Feature, Alice, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+        clock.Advance(LeaseDuration.Add(TimeSpan.FromTicks(1)));
+
+        var result = await service.ClaimAsync(Feature, Bob, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+
+        result.Status.Should().Be(FeatureLockClaimStatus.Claimed);
+        result.Lease!.Holder.Should().Be(Bob);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    public async Task PruneExpiredAsync_RemovesExpiredLeases()
+    {
+        var clock = new MutableTimeProvider(Instant());
+        var service = new InMemoryFeatureLockService(clock);
+        await service.ClaimAsync(Feature, Alice, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+        clock.Advance(LeaseDuration.Add(TimeSpan.FromTicks(1)));
+
+        var removed = await service.PruneExpiredAsync();
+
+        removed.Should().Be(1);
+        (await service.GetActiveLeaseAsync(Feature)).Should().BeNull();
+    }
+
+    [UnitTest]
+    [Operation(Operations.ErrorHandling)]
+    public async Task FeatureEditConflictResponse_FromLockHeld_HasStableShape()
+    {
+        var clock = new MutableTimeProvider(Instant());
+        var service = new InMemoryFeatureLockService(clock);
+        await service.ClaimAsync(Feature, Alice, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+        var held = await service.ClaimAsync(Feature, Bob, LeaseDuration, FeatureLockAccessContext.AuthorizedWrite);
+
+        var conflict = FeatureEditConflictResponse.FromLockHeld("replace", held.Error!, clock.GetUtcNow());
+
+        conflict.Code.Should().Be("edit-conflict");
+        conflict.Reason.Should().Be("feature-lock-held");
+        conflict.Operation.Should().Be("replace");
+        conflict.Feature.Should().Be(Feature);
+        conflict.Lock.Should().NotBeNull();
+        conflict.Lock!.Holder.DisplayName.Should().Be("Alice Editor");
+
+        var json = JsonSerializer.Serialize(conflict);
+        using var document = JsonDocument.Parse(json);
+        document.RootElement.GetProperty("Code").GetString().Should().Be("edit-conflict");
+        document.RootElement.GetProperty("Reason").GetString().Should().Be("feature-lock-held");
+        document.RootElement.GetProperty("Lock").GetProperty("Holder").GetProperty("HolderId").GetString().Should().Be("alice");
+    }
+
+    private static DateTimeOffset Instant()
+        => new(2026, 5, 11, 10, 0, 0, TimeSpan.Zero);
+
+    private sealed class MutableTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow;
+
+        public MutableTimeProvider(DateTimeOffset utcNow)
+        {
+            _utcNow = utcNow;
+        }
+
+        public override DateTimeOffset GetUtcNow()
+            => _utcNow;
+
+        public void Advance(TimeSpan value)
+        {
+            _utcNow = _utcNow.Add(value);
+        }
+    }
+}


### PR DESCRIPTION
## Issue Link
Related to #973

## Summary
Adds a protocol-neutral Core feature-lock service seam for collaborative feature editing, including session-aware lock ownership and typed conflict metadata.

## Changes Made
- Added feature references, holders, leases, access decisions, typed lock-held errors, and edit conflict envelopes.
- Added `IFeatureLockService` plus an in-memory claim/renew/release/lookup/prune implementation.
- Made lock ownership session-aware so the same user in a different collaboration session cannot silently renew or release a lock.
- Added focused tests for claims, fail-closed access, concurrent claims, same-session renewals, different-session conflicts, release, expiry, pruning, and stable conflict JSON shape.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Targeted validation run locally:
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter FullyQualifiedName~InMemoryFeatureLockServiceTests --no-restore` passed: 10/10
- `dotnet build src/Honua.Core/Honua.Core.csproj --no-restore` passed per worker validation
- `dotnet format Honua.sln --no-restore --verify-no-changes --include ...feature lock files...` passed
- `git diff --check` passed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

Adds Core collaboration contracts only. Endpoint/channel docs and provider edit integration remain follow-up work.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Targeted validation passed; full `scripts/ci/pre-pr-check.sh` was not run locally for this draft backlog slice
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
