### PR TITLE
feat(admin): add operator UI server dependencies

### DIFF
--- a/docs/contributor/test-seed-data.md
+++ b/docs/contributor/test-seed-data.md
@@ -79,6 +79,7 @@ runner.apply(postgis.get_connection(schema), schema=schema, profile="core")
 | `tests/seed/client-compat-v1.sql` | Versioned client compatibility certification seed snapshot; canonical source for desktop/BI smoke evidence, Docker real-client interop GDAL/PyQGIS lanes, and the Python STAC client compatibility lane | `windows-client-compat-nightly.yml`, `client-interop-nightly.yml` (`gdal`, `pyqgis`), `tests/python/stac_client` |
 | `tests/seed/mobile-offline-demo-v1.sql` | Deterministic SDK-backed mobile offline field-operations fixture with service/layer/form metadata, provisional offline manifest metadata, baseline edit records, and safe reset semantics | Manual local/staging/cloud provisioning for honua-server#895; see [Mobile Offline Demo Fixture](../developer/mobile-offline-demo-fixture.md) |
 | `tests/seed/mobile-offline-demo-conflict-delta.sql` | Advances the mobile offline conflict target from `sync_version = 1` to `sync_version = 2` after package download | Manual/mobile harness conflict scenario for honua-server#895 |
+| `tests/seed/admin-sample-feature-server.yaml` | Local admin UI sample FeatureServer fixture (`admin_sample`, layer `3000`) with Oahu point features, extents, fields, and renderer metadata | Manual/local PostGIS bootstrap after `base-schema.sql` or a migrated database |
 | `tests/seed/mcp.yaml` | MCP certification data (second service, polygon layer, deterministic features) | CI `mcp-certification` and `mcp-llm-smoke` jobs |
 | `tests/seed/browser-compat.yaml` | Browser compatibility service with point/line/polygon layers (IDs 2000–2002) and seeded features in the San Francisco area; anonymous access | CI `maplibre-compat` job (via `setup-honua-server` action) |
 | `tests/seed/apply-yaml-seed.sh` | Extracts SQL from a YAML seed file with a top-level `sql:` key and applies via `psql` | CI `mcp-certification`, `mcp-llm-smoke`, and `maplibre-compat` jobs |
@@ -88,6 +89,15 @@ runner.apply(postgis.get_connection(schema), schema=schema, profile="core")
 `client-compat-v1.sql` is intentionally a versioned snapshot instead of an alias to the moving CI base seed. When the client compatibility workflow needs a different dataset, add a new snapshot (`client-compat-v2.sql`) rather than rewriting `v1`.
 
 The current snapshot seeds anonymous access for service `test_service`, layer/collection `0`, and layer title `Test Layer` so the Windows client compatibility transcripts and manual follow-through remain repeatable. It also enables `postgis_raster` and creates the raster metadata tables expected by raster-aware startup paths in the Docker client-interop stack; the browser-specific service and layers are applied separately from `tests/seed/browser-compat.yaml`.
+
+For a local admin UI sample service, apply the base schema and the admin sample fixture:
+
+```bash
+psql -f tests/seed/base-schema.sql
+bash tests/seed/apply-yaml-seed.sh tests/seed/admin-sample-feature-server.yaml
+```
+
+That creates `admin_sample` with layer `3000`, so the UI can preview `/rest/services/admin_sample/FeatureServer/3000/query?f=geojson&where=1%3D1` without relying on fake client-side rows.
 
 ## Profiles in CI
 

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
@@ -222,7 +222,22 @@ internal sealed partial class PostgreSqlLayerPublishingService(
 
         await InsertFieldsAsync(connection, transaction, layerId, fields, cancellationToken);
 
+        var materializedCount = await MaterializeLayerFeaturesAsync(
+            connection,
+            transaction,
+            layerId,
+            schema,
+            table,
+            geometryColumn,
+            srid,
+            selectedColumns,
+            cancellationToken);
+        Log.LayerMaterialized(_logger, layerId, materializedCount);
+
+        await UpdateLayerExtentAsync(connection, transaction, layerId, srid, cancellationToken);
+
         await EnsureServiceLayerAsync(connection, transaction, serviceName, layerId, cancellationToken);
+        await UpdateServiceExtentAsync(connection, transaction, serviceName, cancellationToken);
 
         await transaction.CommitAsync(cancellationToken);
 
@@ -623,6 +638,177 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
+    private static async Task<int> MaterializeLayerFeaturesAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        int layerId,
+        string schema,
+        string table,
+        string geometryColumn,
+        int srid,
+        IReadOnlyList<ColumnInfo> attributeColumns,
+        CancellationToken cancellationToken)
+    {
+        // TODO(honua-server#974): replace this one-time snapshot with the settled
+        // publish refresh/CDC path once source-of-truth policy is finalized.
+        var sourceTable = $"{QuoteIdentifier(schema)}.{QuoteIdentifier(table)}";
+        var sourceGeometry = $"src.{QuoteIdentifier(geometryColumn)}";
+        var canonicalGeometry = BuildCanonicalGeometryExpression(sourceGeometry);
+        var attributesExpression = BuildAttributesExpression(attributeColumns);
+
+        var sql = $"""
+            WITH inserted AS (
+                INSERT INTO features (layer_id, geometry, attributes)
+                SELECT
+                    @layerId,
+                    {canonicalGeometry},
+                    {attributesExpression}
+                FROM {sourceTable} AS src
+                RETURNING 1
+            )
+            SELECT COUNT(*)::int
+            FROM inserted;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("@layerId", layerId);
+        command.Parameters.AddWithValue("@srid", srid);
+
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result is int count
+            ? count
+            : Convert.ToInt32(result, CultureInfo.InvariantCulture);
+    }
+
+    private static async Task UpdateLayerExtentAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        int layerId,
+        int srid,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            WITH layer_geometries AS (
+                SELECT
+                    CASE
+                        WHEN geometry IS NULL THEN NULL
+                        WHEN COALESCE(NULLIF(ST_SRID(geometry), 0), @srid) = 4326
+                            THEN ST_SetSRID(geometry, 4326)
+                        ELSE ST_Transform(
+                            ST_SetSRID(geometry, COALESCE(NULLIF(ST_SRID(geometry), 0), @srid)),
+                            4326)
+                    END AS geom
+                FROM features
+                WHERE layer_id = @layerId
+                  AND geometry IS NOT NULL
+            ),
+            extent_box AS (
+                SELECT ST_Extent(geom) AS box
+                FROM layer_geometries
+            ),
+            computed_extent AS (
+                SELECT
+                    CASE
+                        WHEN box IS NULL THEN NULL
+                        ELSE ST_MakeEnvelope(
+                            ST_XMin(box),
+                            ST_YMin(box),
+                            ST_XMax(box),
+                            ST_YMax(box),
+                            4326)
+                    END AS extent
+                FROM extent_box
+            )
+            UPDATE honua.layers AS layer
+            SET extent = computed_extent.extent
+            FROM computed_extent
+            WHERE layer.layer_id = @layerId;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("@layerId", layerId);
+        command.Parameters.AddWithValue("@srid", srid);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static async Task UpdateServiceExtentAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string serviceName,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            WITH extent_box AS (
+                SELECT ST_Extent(l.extent) AS box
+                FROM honua.service_layers sl
+                INNER JOIN honua.layers l
+                    ON l.layer_id = sl.layer_id
+                WHERE sl.service_name = @serviceName
+                  AND l.enabled = TRUE
+                  AND l.extent IS NOT NULL
+            ),
+            computed_extent AS (
+                SELECT
+                    CASE
+                        WHEN box IS NULL THEN NULL
+                        ELSE ST_MakeEnvelope(
+                            ST_XMin(box),
+                            ST_YMin(box),
+                            ST_XMax(box),
+                            ST_YMax(box),
+                            4326)
+                    END AS extent
+                FROM extent_box
+            )
+            UPDATE honua.services AS service
+            SET service_extent = computed_extent.extent,
+                updated_at = NOW()
+            FROM computed_extent
+            WHERE service.service_name = @serviceName;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("@serviceName", serviceName);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static string BuildCanonicalGeometryExpression(string sourceGeometry)
+    {
+        return $"""
+            CASE
+                WHEN {sourceGeometry} IS NULL THEN NULL
+                WHEN ST_SRID({sourceGeometry}::geometry) = 0
+                    THEN ST_SetSRID({sourceGeometry}::geometry, @srid)
+                WHEN ST_SRID({sourceGeometry}::geometry) = @srid
+                    THEN {sourceGeometry}::geometry
+                ELSE ST_Transform({sourceGeometry}::geometry, @srid)
+            END
+            """;
+    }
+
+    private static string BuildAttributesExpression(IReadOnlyList<ColumnInfo> attributeColumns)
+    {
+        if (attributeColumns.Count == 0)
+        {
+            return "'{}'::jsonb";
+        }
+
+        var parts = new List<string>(attributeColumns.Count * 2);
+        foreach (var column in attributeColumns)
+        {
+            parts.Add(QuoteLiteral(column.Name));
+            parts.Add($"src.{QuoteIdentifier(column.Name)}");
+        }
+
+        return $"jsonb_build_object({string.Join(", ", parts)})";
+    }
+
+    private static string QuoteIdentifier(string identifier)
+        => "\"" + identifier.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
+
+    private static string QuoteLiteral(string literal)
+        => "'" + literal.Replace("'", "''", StringComparison.Ordinal) + "'";
+
     private static async Task InsertFieldsAsync(
         NpgsqlConnection connection,
         NpgsqlTransaction transaction,
@@ -857,6 +1043,12 @@ internal sealed partial class PostgreSqlLayerPublishingService(
             Level = LogLevel.Error,
             Message = "Failed to discover tables for layer publishing")]
         public static partial void TableDiscoveryFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(
+            EventId = 8202,
+            Level = LogLevel.Information,
+            Message = "Materialized {FeatureCount} features for published layer {LayerId}")]
+        public static partial void LayerMaterialized(ILogger logger, int layerId, int featureCount);
     }
 
     private sealed record LayerFieldInsert(

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -162,6 +162,7 @@ public static class EndpointRegistry
         new("DELETE", "/api/v1/admin/metadata/resources/{kind}/{namespace}/{name}"),
         new("GET", "/api/v1/admin/metadata/layers/{layerId}/style"),
         new("PUT", "/api/v1/admin/metadata/layers/{layerId}/style"),
+        new("GET", "/api/v1/admin/metadata/layers/{layerId}/validation"),
         new("POST", "/api/v1/admin/metadata/layers/{layerId}/style/import-sld"),
         new("GET", "/api/v1/admin/metadata/layers/{layerId}/style/export-sld"),
         new("POST", "/api/v1/admin/metadata/layers/{layerId}/suggest-style"),

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -72,6 +72,7 @@ public static class EndpointRegistry
         new("PATCH", "/api/v1/admin/connections/{id}/tables"),
         new("GET", "/api/v1/admin/connections/tables"),
         new("GET", "/api/v1/admin/connections/{*path}"),
+        new("POST", "/api/v1/admin/external-services/discover"),
         new("GET", "/api/v1/admin/connections/{id}/layers"),
         new("POST", "/api/v1/admin/connections/{id}/layers"),
         new("PUT", "/api/v1/admin/connections/{id}/layers/{layerId}/enabled"),

--- a/src/Honua.Server/Features/Admin/AdminLayerValidationEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AdminLayerValidationEndpoints.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Validation.Abstractions;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Admin.Services;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Admin endpoints for validating layer storage metadata.
+/// </summary>
+internal static class AdminLayerValidationEndpoints
+{
+    /// <summary>
+    /// Maps layer validation endpoints to the admin metadata API group.
+    /// </summary>
+    public static void MapAdminLayerValidationEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/metadata/layers")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Metadata", "Validation")
+            .RequireAdminAuthorization();
+
+        _ = group.MapGet("/{layerId:int}/validation", HandleGetLayerValidation)
+            .WithName("GetAdminLayerValidation")
+            .WithSummary("Validate layer metadata against its backing storage")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+    }
+
+    private static async Task<IResult> HandleGetLayerValidation(
+        int layerId,
+        HttpContext context,
+        [FromServices] IResourceValidator resourceValidator,
+        [FromServices] ILayerValidationService validationService,
+        CancellationToken cancellationToken)
+    {
+        var layerResult = await resourceValidator.ValidateLayerAsync(layerId, cancellationToken).ConfigureAwait(false);
+        if (!layerResult.IsValid || layerResult.Resource == null)
+        {
+            var statusCode = layerResult.ErrorCode == ResourceValidationError.InvalidIdentifier
+                ? StatusCodes.Status400BadRequest
+                : StatusCodes.Status404NotFound;
+            var message = layerResult.ErrorMessage ?? $"Layer {layerId} not found.";
+            return ProblemDetailsHelpers.CreateAdminProblem(context, statusCode, message);
+        }
+
+        var validation = await validationService.ValidateLayerAsync(layerId, cancellationToken).ConfigureAwait(false);
+        if (validation == null)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status404NotFound,
+                $"Layer {layerId} not found.");
+        }
+
+        var payload = ApiResponse<LayerValidationResponse>.CreateSuccess(validation);
+        return Results.Json(payload, LayerValidationJsonContext.Default.ApiResponseLayerValidationResponse);
+    }
+}

--- a/src/Honua.Server/Features/Admin/AdminRealtimeHub.cs
+++ b/src/Honua.Server/Features/Admin/AdminRealtimeHub.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Monitoring;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Honua.Server.Features.Admin;
+
+internal static class AdminRealtimeHubExtensions
+{
+    public static IServiceCollection AddAdminRealtime(this IServiceCollection services)
+    {
+        services
+            .AddSignalR()
+            .AddJsonProtocol(options =>
+            {
+                options.PayloadSerializerOptions.TypeInfoResolverChain.Insert(
+                    0,
+                    AdminRealtimeJsonContext.Default);
+            });
+
+        return services;
+    }
+
+    public static IEndpointConventionBuilder MapAdminRealtimeHub(this IEndpointRouteBuilder endpoints)
+        => endpoints.MapHub<AdminHub>("/hubs/admin")
+            .WithDisplayName("Admin realtime hub")
+            .RequireAdminAuthorization();
+}
+
+internal sealed class AdminHub(
+    IHostEnvironment environment,
+    MigrationState migrationState) : Hub
+{
+    private const string StatusChangedEventName = "AdminStatusChanged";
+
+    public override async Task OnConnectedAsync()
+    {
+        await Clients.Caller.SendAsync(
+            StatusChangedEventName,
+            CreateStatus(),
+            Context.ConnectionAborted).ConfigureAwait(false);
+
+        await base.OnConnectedAsync().ConfigureAwait(false);
+    }
+
+    public Task<AdminRealtimeStatus> GetStatus()
+        => Task.FromResult(CreateStatus());
+
+    private AdminRealtimeStatus CreateStatus()
+        => new(
+            Status: migrationState.IsFailed ? "degraded" : "online",
+            InstanceId: Environment.MachineName,
+            EnvironmentName: environment.EnvironmentName,
+            MigrationStatus: GetMigrationStatusLabel(migrationState.Status),
+            MigrationReady: migrationState.IsReady,
+            GeneratedAt: DateTimeOffset.UtcNow);
+
+    private static string GetMigrationStatusLabel(MigrationLifecycleStatus status)
+        => status switch
+        {
+            MigrationLifecycleStatus.Running => "running",
+            MigrationLifecycleStatus.Succeeded => "succeeded",
+            MigrationLifecycleStatus.Skipped => "skipped",
+            MigrationLifecycleStatus.Failed => "failed",
+            _ => "unknown"
+        };
+}
+
+internal sealed record AdminRealtimeStatus(
+    string Status,
+    string InstanceId,
+    string EnvironmentName,
+    string MigrationStatus,
+    bool MigrationReady,
+    DateTimeOffset GeneratedAt);
+
+[JsonSerializable(typeof(AdminRealtimeStatus))]
+internal sealed partial class AdminRealtimeJsonContext : JsonSerializerContext;

--- a/src/Honua.Server/Features/Admin/AdminServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Admin/AdminServiceCollectionExtensions.cs
@@ -23,6 +23,13 @@ public static class AdminServiceCollectionExtensions
     {
         services.TryAddSingleton<IConfigurationValidator, ConfigurationValidator>();
         services.TryAddSingleton<IConfigurationDiscovery>(sp => (ConfigurationValidator)sp.GetRequiredService<IConfigurationValidator>());
+        services.TryAddSingleton<IExternalServiceDiscoveryNetworkGuard, ExternalServiceDiscoveryNetworkGuard>();
+        services.TryAddScoped<IExternalServiceDiscoveryService, ExternalServiceDiscoveryService>();
+        services.AddHttpClient(ExternalServiceDiscoveryService.HttpClientName, client =>
+        {
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("HonuaServer/1.0");
+            client.Timeout = TimeSpan.FromMinutes(2);
+        });
 
         // Register configuration documentation service (existing)
         services.TryAddScoped<ConfigurationDocumentationService>();

--- a/src/Honua.Server/Features/Admin/AdminServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Admin/AdminServiceCollectionExtensions.cs
@@ -40,6 +40,8 @@ public static class AdminServiceCollectionExtensions
         // Register startup connectivity testing service
         services.TryAddScoped<StartupConnectivityTestService>();
 
+        services.TryAddScoped<ILayerValidationService, LayerValidationService>();
+
         return services;
     }
 }

--- a/src/Honua.Server/Features/Admin/ExternalServiceDiscoveryEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/ExternalServiceDiscoveryEndpoints.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Admin.Services;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Models;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Admin endpoints for external service discovery.
+/// </summary>
+internal static class ExternalServiceDiscoveryEndpoints
+{
+    public static void MapExternalServiceDiscoveryEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/external-services")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "External Services")
+            .RequireAdminAuthorization();
+
+        _ = group.MapMethods("/discover", [HttpMethods.Post], HandleDiscover)
+            .WithDisplayName("Discover External Service")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+    }
+
+    private static async Task HandleDiscover(HttpContext context)
+    {
+        ExternalServiceDiscoveryRequest? request;
+        try
+        {
+            request = await context.Request.ReadFromJsonAsync(
+                    ExternalServiceDiscoveryJsonContext.Default.ExternalServiceDiscoveryRequest,
+                    context.RequestAborted)
+                .ConfigureAwait(false);
+        }
+        catch (JsonException)
+        {
+            await ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status400BadRequest,
+                    "Invalid request body")
+                .ExecuteAsync(context);
+            return;
+        }
+
+        if (request is null)
+        {
+            await ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status400BadRequest,
+                    "Request body is required")
+                .ExecuteAsync(context);
+            return;
+        }
+
+        try
+        {
+            var service = context.RequestServices.GetRequiredService<IExternalServiceDiscoveryService>();
+            var response = await service.DiscoverAsync(request, context.RequestAborted).ConfigureAwait(false);
+
+            context.Response.StatusCode = StatusCodes.Status200OK;
+            context.Response.ContentType = "application/json; charset=utf-8";
+            await JsonSerializer.SerializeAsync(
+                    context.Response.Body,
+                    response,
+                    ExternalServiceDiscoveryJsonContext.Default.ExternalServiceDiscoveryResponse,
+                    context.RequestAborted)
+                .ConfigureAwait(false);
+        }
+        catch (ExternalServiceDiscoveryRequestException ex)
+        {
+            await ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status400BadRequest,
+                    ex.Message)
+                .ExecuteAsync(context);
+        }
+        catch (HttpRequestException)
+        {
+            await ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status502BadGateway,
+                    "External service discovery failed",
+                    "The external service could not be reached or returned an unsupported response.")
+                .ExecuteAsync(context);
+        }
+        catch (ExternalServiceDiscoveryRemoteException ex)
+        {
+            await ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status502BadGateway,
+                    "External service discovery failed",
+                    ex.Message)
+                .ExecuteAsync(context);
+        }
+        catch (OperationCanceledException) when (!context.RequestAborted.IsCancellationRequested)
+        {
+            await ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status502BadGateway,
+                    "External service discovery timed out")
+                .ExecuteAsync(context);
+        }
+    }
+}

--- a/src/Honua.Server/Features/Admin/Models/ExternalServiceDiscoveryJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/ExternalServiceDiscoveryJsonContext.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// JSON source generation metadata for external service discovery.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(ExternalServiceDiscoveryRequest))]
+[JsonSerializable(typeof(ExternalServiceDiscoveryResponse))]
+[JsonSerializable(typeof(ExternalServiceLayerCandidate))]
+[JsonSerializable(typeof(ExternalServiceLayerCandidate[]))]
+[JsonSerializable(typeof(ExternalServiceExtent))]
+[JsonSerializable(typeof(ExternalServiceField))]
+[JsonSerializable(typeof(ExternalServiceField[]))]
+[JsonSerializable(typeof(ArcGisServiceDocument))]
+[JsonSerializable(typeof(ArcGisLayerDocument))]
+[JsonSerializable(typeof(ArcGisCountDocument))]
+internal sealed partial class ExternalServiceDiscoveryJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Admin/Models/ExternalServiceDiscoveryModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/ExternalServiceDiscoveryModels.cs
@@ -1,0 +1,312 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Request to discover externally hosted service/layer candidates.
+/// </summary>
+internal sealed record ExternalServiceDiscoveryRequest
+{
+    /// <summary>
+    /// URL to the external service root.
+    /// </summary>
+    public string? Url { get; init; }
+
+    /// <summary>
+    /// Compatibility alias for import-oriented callers that already send serviceUrl.
+    /// </summary>
+    public string? ServiceUrl { get; init; }
+
+    /// <summary>
+    /// Optional per-request timeout in seconds.
+    /// </summary>
+    public int? TimeoutSeconds { get; init; }
+}
+
+/// <summary>
+/// Response containing discovered external service candidates.
+/// </summary>
+internal sealed record ExternalServiceDiscoveryResponse
+{
+    /// <summary>
+    /// Original URL supplied by the caller.
+    /// </summary>
+    public required string SourceUrl { get; init; }
+
+    /// <summary>
+    /// Normalized service-root URL used for discovery.
+    /// </summary>
+    public required string NormalizedUrl { get; init; }
+
+    /// <summary>
+    /// Stable source kind for downstream import planning.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// External service type such as FeatureServer or MapServer.
+    /// </summary>
+    public required string ServiceType { get; init; }
+
+    /// <summary>
+    /// Display name reported by the service, or derived from the URL.
+    /// </summary>
+    public required string ServiceName { get; init; }
+
+    /// <summary>
+    /// Optional service description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Service-level SRID if the service reports one.
+    /// </summary>
+    public int? Srid { get; init; }
+
+    /// <summary>
+    /// Discovered layer/table candidates.
+    /// </summary>
+    public ExternalServiceLayerCandidate[] Candidates { get; init; } = [];
+
+    /// <summary>
+    /// Non-fatal discovery warnings.
+    /// </summary>
+    public string[] Warnings { get; init; } = [];
+}
+
+/// <summary>
+/// Discovered layer/table candidate from an external service.
+/// </summary>
+internal sealed record ExternalServiceLayerCandidate
+{
+    /// <summary>
+    /// Source kind inherited from the external service.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// External service display name.
+    /// </summary>
+    public required string ServiceName { get; init; }
+
+    /// <summary>
+    /// External service root URL.
+    /// </summary>
+    public required string ServiceUrl { get; init; }
+
+    /// <summary>
+    /// Numeric layer id when the source exposes one.
+    /// </summary>
+    public int? LayerId { get; init; }
+
+    /// <summary>
+    /// Layer or table name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Layer or table description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// ArcGIS layer type such as Feature Layer or Table.
+    /// </summary>
+    public string? LayerType { get; init; }
+
+    /// <summary>
+    /// Geometry type if available.
+    /// </summary>
+    public string? GeometryType { get; init; }
+
+    /// <summary>
+    /// Candidate SRID if available.
+    /// </summary>
+    public int? Srid { get; init; }
+
+    /// <summary>
+    /// Candidate extent if available.
+    /// </summary>
+    public ExternalServiceExtent? Extent { get; init; }
+
+    /// <summary>
+    /// Attribute fields reported by the source.
+    /// </summary>
+    public ExternalServiceField[] Fields { get; init; } = [];
+
+    /// <summary>
+    /// Feature count if the source exposes it cheaply.
+    /// </summary>
+    public int? FeatureCount { get; init; }
+}
+
+/// <summary>
+/// External service extent.
+/// </summary>
+internal sealed record ExternalServiceExtent
+{
+    public double XMin { get; init; }
+
+    public double YMin { get; init; }
+
+    public double XMax { get; init; }
+
+    public double YMax { get; init; }
+
+    public int? Srid { get; init; }
+}
+
+/// <summary>
+/// External service field metadata.
+/// </summary>
+internal sealed record ExternalServiceField
+{
+    public required string Name { get; init; }
+
+    public string? Type { get; init; }
+
+    public string? Alias { get; init; }
+
+    public int? Length { get; init; }
+
+    public bool? Nullable { get; init; }
+}
+
+internal sealed record ArcGisServiceDocument
+{
+    [JsonPropertyName("serviceDescription")]
+    public string? ServiceDescription { get; init; }
+
+    [JsonPropertyName("mapName")]
+    public string? MapName { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("spatialReference")]
+    public ArcGisSpatialReferenceDocument? SpatialReference { get; init; }
+
+    [JsonPropertyName("layers")]
+    public ArcGisLayerReferenceDocument[]? Layers { get; init; }
+
+    [JsonPropertyName("tables")]
+    public ArcGisLayerReferenceDocument[]? Tables { get; init; }
+
+    [JsonPropertyName("error")]
+    public ArcGisErrorDocument? Error { get; init; }
+}
+
+internal sealed record ArcGisLayerReferenceDocument
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+}
+
+internal sealed record ArcGisLayerDocument
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    [JsonPropertyName("geometryType")]
+    public string? GeometryType { get; init; }
+
+    [JsonPropertyName("extent")]
+    public ArcGisExtentDocument? Extent { get; init; }
+
+    [JsonPropertyName("fields")]
+    public ArcGisFieldDocument[]? Fields { get; init; }
+
+    [JsonPropertyName("count")]
+    public int? Count { get; init; }
+
+    [JsonPropertyName("featureCount")]
+    public int? FeatureCount { get; init; }
+
+    [JsonPropertyName("error")]
+    public ArcGisErrorDocument? Error { get; init; }
+}
+
+internal sealed record ArcGisCountDocument
+{
+    [JsonPropertyName("count")]
+    public int? Count { get; init; }
+
+    [JsonPropertyName("error")]
+    public ArcGisErrorDocument? Error { get; init; }
+}
+
+internal sealed record ArcGisExtentDocument
+{
+    [JsonPropertyName("xmin")]
+    public double XMin { get; init; }
+
+    [JsonPropertyName("ymin")]
+    public double YMin { get; init; }
+
+    [JsonPropertyName("xmax")]
+    public double XMax { get; init; }
+
+    [JsonPropertyName("ymax")]
+    public double YMax { get; init; }
+
+    [JsonPropertyName("spatialReference")]
+    public ArcGisSpatialReferenceDocument? SpatialReference { get; init; }
+}
+
+internal sealed record ArcGisSpatialReferenceDocument
+{
+    [JsonPropertyName("wkid")]
+    public int? Wkid { get; init; }
+
+    [JsonPropertyName("latestWkid")]
+    public int? LatestWkid { get; init; }
+}
+
+internal sealed record ArcGisFieldDocument
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    [JsonPropertyName("alias")]
+    public string? Alias { get; init; }
+
+    [JsonPropertyName("length")]
+    public int? Length { get; init; }
+
+    [JsonPropertyName("nullable")]
+    public bool? Nullable { get; init; }
+}
+
+internal sealed record ArcGisErrorDocument
+{
+    [JsonPropertyName("code")]
+    public int Code { get; init; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; init; }
+
+    [JsonPropertyName("details")]
+    public JsonElement? Details { get; init; }
+}

--- a/src/Honua.Server/Features/Admin/Models/LayerValidationJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/LayerValidationJsonContext.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Server.Features.Infrastructure.Models;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// JSON source generation context for layer validation admin APIs.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(LayerValidationResponse))]
+[JsonSerializable(typeof(LayerValidationCheck))]
+[JsonSerializable(typeof(LayerValidationCheck[]))]
+[JsonSerializable(typeof(ApiResponse<LayerValidationResponse>))]
+[JsonSerializable(typeof(ApiResponse<object>))]
+internal sealed partial class LayerValidationJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Admin/Models/LayerValidationModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/LayerValidationModels.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Validation response for a persisted layer and its backing storage.
+/// </summary>
+internal sealed record LayerValidationResponse
+{
+    public int LayerId { get; init; }
+
+    public required string LayerName { get; init; }
+
+    public required string Status { get; init; }
+
+    public bool IsValid { get; init; }
+
+    public string? StorageSchema { get; init; }
+
+    public string? StorageTable { get; init; }
+
+    public DateTimeOffset CheckedAt { get; init; }
+
+    public LayerValidationCheck[] Checks { get; init; } = [];
+}
+
+/// <summary>
+/// Individual validation check result.
+/// </summary>
+internal sealed record LayerValidationCheck
+{
+    public required string Code { get; init; }
+
+    public required string Severity { get; init; }
+
+    public required string Message { get; init; }
+
+    public string? Expected { get; init; }
+
+    public string? Actual { get; init; }
+}

--- a/src/Honua.Server/Features/Admin/Services/ExternalServiceDiscoveryService.cs
+++ b/src/Honua.Server/Features/Admin/Services/ExternalServiceDiscoveryService.cs
@@ -1,0 +1,394 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Import;
+
+namespace Honua.Server.Features.Admin.Services;
+
+internal sealed partial class ExternalServiceDiscoveryService(
+    IHttpClientFactory httpClientFactory,
+    IExternalServiceDiscoveryNetworkGuard networkGuard,
+    ILogger<ExternalServiceDiscoveryService> logger) : IExternalServiceDiscoveryService
+{
+    internal const string HttpClientName = "external-service-discovery";
+    private const int DefaultTimeoutSeconds = 30;
+    private const int MaximumTimeoutSeconds = 120;
+
+    public async Task<ExternalServiceDiscoveryResponse> DiscoverAsync(
+        ExternalServiceDiscoveryRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var sourceUrl = request.Url ?? request.ServiceUrl;
+        if (string.IsNullOrWhiteSpace(sourceUrl))
+        {
+            throw new ExternalServiceDiscoveryRequestException("Url is required.");
+        }
+
+        var normalizedUri = await NormalizeAndValidateAsync(sourceUrl, cancellationToken).ConfigureAwait(false);
+        var serviceType = GetServiceType(normalizedUri);
+
+        if (serviceType is null)
+        {
+            // TODO honua-server#977: add OGC API Features landing/collections discovery here.
+            throw new ExternalServiceDiscoveryRequestException(
+                "Only ArcGIS REST FeatureServer and MapServer service root URLs are supported. OGC API Features discovery is tracked by honua-server#977.");
+        }
+
+        return await DiscoverArcGisAsync(
+                sourceUrl,
+                normalizedUri,
+                serviceType,
+                ClampTimeout(request.TimeoutSeconds),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<ExternalServiceDiscoveryResponse> DiscoverArcGisAsync(
+        string sourceUrl,
+        Uri serviceUri,
+        string serviceType,
+        int timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        var sourceKind = serviceType.Equals("FeatureServer", StringComparison.OrdinalIgnoreCase)
+            ? "arcgis-feature-server"
+            : "arcgis-map-server";
+
+        var serviceDocument = await GetJsonAsync(
+                BuildServiceInfoUri(serviceUri),
+                ExternalServiceDiscoveryJsonContext.Default.ArcGisServiceDocument,
+                timeoutSeconds,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (serviceDocument.Error is not null)
+        {
+            throw new ExternalServiceDiscoveryRemoteException("ArcGIS service returned an error during discovery.");
+        }
+
+        var serviceName = FirstNonWhiteSpace(
+            serviceDocument.ServiceDescription,
+            serviceDocument.MapName,
+            serviceDocument.Name,
+            ExtractServiceName(serviceUri));
+
+        var warnings = new List<string>();
+        var candidates = new List<ExternalServiceLayerCandidate>();
+        var references = EnumerateLayerReferences(serviceDocument);
+
+        foreach (var reference in references)
+        {
+            try
+            {
+                var layer = await GetJsonAsync(
+                        BuildLayerInfoUri(serviceUri, reference.Id),
+                        ExternalServiceDiscoveryJsonContext.Default.ArcGisLayerDocument,
+                        timeoutSeconds,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (layer.Error is not null)
+                {
+                    warnings.Add($"Layer {reference.Id} metadata returned an ArcGIS error and was skipped.");
+                    continue;
+                }
+
+                var featureCount = layer.FeatureCount ?? layer.Count;
+                if (featureCount is null)
+                {
+                    featureCount = await TryGetFeatureCountAsync(serviceUri, reference.Id, timeoutSeconds, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                candidates.Add(MapCandidate(
+                    serviceUri,
+                    sourceKind,
+                    serviceName,
+                    serviceDocument.SpatialReference,
+                    reference,
+                    layer,
+                    featureCount));
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)
+            {
+                Log.LayerMetadataFailed(logger, reference.Id, ex);
+                warnings.Add($"Layer {reference.Id} metadata could not be read.");
+                candidates.Add(CreateReferenceOnlyCandidate(
+                    serviceUri,
+                    sourceKind,
+                    serviceName,
+                    serviceDocument.SpatialReference,
+                    reference));
+            }
+        }
+
+        var normalizedUrl = serviceUri.ToString();
+        Log.ServiceDiscovered(logger, normalizedUrl, candidates.Count);
+
+        return new ExternalServiceDiscoveryResponse
+        {
+            SourceUrl = sourceUrl,
+            NormalizedUrl = normalizedUrl,
+            SourceKind = sourceKind,
+            ServiceType = serviceType,
+            ServiceName = serviceName,
+            Description = serviceDocument.Description,
+            Srid = GetSrid(serviceDocument.SpatialReference),
+            Candidates = candidates.ToArray(),
+            Warnings = warnings.ToArray()
+        };
+    }
+
+    private async Task<Uri> NormalizeAndValidateAsync(string sourceUrl, CancellationToken cancellationToken)
+    {
+        if (!Uri.TryCreate(sourceUrl, UriKind.Absolute, out var uri) ||
+            uri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new ExternalServiceDiscoveryRequestException("Url must be a valid HTTPS URL.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(uri.UserInfo))
+        {
+            throw new ExternalServiceDiscoveryRequestException("Url must not include embedded credentials.");
+        }
+
+        if (await networkGuard.IsDisallowedAsync(uri, cancellationToken).ConfigureAwait(false))
+        {
+            throw new ExternalServiceDiscoveryRequestException(
+                "Url resolves to a private, loopback, or unresolvable network address, which is not allowed.");
+        }
+
+        var builder = new UriBuilder(uri)
+        {
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+
+        var normalized = builder.Uri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        return new Uri(normalized, UriKind.Absolute);
+    }
+
+    private async Task<T> GetJsonAsync<T>(
+        Uri uri,
+        System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> jsonTypeInfo,
+        int timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        var client = httpClientFactory.CreateClient(HttpClientName);
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+
+        var result = await client.GetFromJsonAsync(uri, jsonTypeInfo, timeoutCts.Token).ConfigureAwait(false);
+        return result ?? throw new InvalidOperationException("External service returned an empty JSON response.");
+    }
+
+    private async Task<int?> TryGetFeatureCountAsync(
+        Uri serviceUri,
+        int layerId,
+        int timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var count = await GetJsonAsync(
+                    BuildLayerCountUri(serviceUri, layerId),
+                    ExternalServiceDiscoveryJsonContext.Default.ArcGisCountDocument,
+                    timeoutSeconds,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            return count.Error is null ? count.Count : null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)
+        {
+            Log.FeatureCountFailed(logger, layerId, ex);
+            return null;
+        }
+    }
+
+    private static IEnumerable<ArcGisLayerReferenceDocument> EnumerateLayerReferences(ArcGisServiceDocument serviceDocument)
+    {
+        foreach (var layer in serviceDocument.Layers ?? [])
+        {
+            yield return layer;
+        }
+
+        foreach (var table in serviceDocument.Tables ?? [])
+        {
+            yield return table;
+        }
+    }
+
+    private static ExternalServiceLayerCandidate MapCandidate(
+        Uri serviceUri,
+        string sourceKind,
+        string serviceName,
+        ArcGisSpatialReferenceDocument? serviceSpatialReference,
+        ArcGisLayerReferenceDocument reference,
+        ArcGisLayerDocument layer,
+        int? featureCount)
+    {
+        var extent = MapExtent(layer.Extent);
+        return new ExternalServiceLayerCandidate
+        {
+            SourceKind = sourceKind,
+            ServiceName = serviceName,
+            ServiceUrl = serviceUri.ToString(),
+            LayerId = layer.Id,
+            Name = FirstNonWhiteSpace(layer.Name, reference.Name, $"Layer {reference.Id}"),
+            Description = layer.Description,
+            LayerType = layer.Type,
+            GeometryType = layer.GeometryType,
+            Srid = extent?.Srid ?? GetSrid(serviceSpatialReference),
+            Extent = extent,
+            Fields = MapFields(layer.Fields),
+            FeatureCount = featureCount
+        };
+    }
+
+    private static ExternalServiceLayerCandidate CreateReferenceOnlyCandidate(
+        Uri serviceUri,
+        string sourceKind,
+        string serviceName,
+        ArcGisSpatialReferenceDocument? serviceSpatialReference,
+        ArcGisLayerReferenceDocument reference)
+        => new()
+        {
+            SourceKind = sourceKind,
+            ServiceName = serviceName,
+            ServiceUrl = serviceUri.ToString(),
+            LayerId = reference.Id,
+            Name = FirstNonWhiteSpace(reference.Name, $"Layer {reference.Id}"),
+            Srid = GetSrid(serviceSpatialReference)
+        };
+
+    private static ExternalServiceExtent? MapExtent(ArcGisExtentDocument? extent)
+        => extent is null
+            ? null
+            : new ExternalServiceExtent
+            {
+                XMin = extent.XMin,
+                YMin = extent.YMin,
+                XMax = extent.XMax,
+                YMax = extent.YMax,
+                Srid = GetSrid(extent.SpatialReference)
+            };
+
+    private static ExternalServiceField[] MapFields(ArcGisFieldDocument[]? fields)
+        => fields is null
+            ? []
+            : fields
+                .Where(field => !string.IsNullOrWhiteSpace(field.Name))
+                .Select(field => new ExternalServiceField
+                {
+                    Name = field.Name!,
+                    Type = field.Type,
+                    Alias = field.Alias,
+                    Length = field.Length,
+                    Nullable = field.Nullable
+                })
+                .ToArray();
+
+    private static Uri BuildServiceInfoUri(Uri serviceUri)
+        => new($"{serviceUri}?f=json", UriKind.Absolute);
+
+    private static Uri BuildLayerInfoUri(Uri serviceUri, int layerId)
+        => new($"{serviceUri}/{layerId}?f=json", UriKind.Absolute);
+
+    private static Uri BuildLayerCountUri(Uri serviceUri, int layerId)
+        => new($"{serviceUri}/{layerId}/query?where=1%3D1&returnCountOnly=true&f=json", UriKind.Absolute);
+
+    private static string? GetServiceType(Uri serviceUri)
+    {
+        var segments = serviceUri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0)
+        {
+            return null;
+        }
+
+        var lastSegment = segments[^1];
+        if (lastSegment.Equals("FeatureServer", StringComparison.OrdinalIgnoreCase))
+        {
+            return "FeatureServer";
+        }
+
+        return lastSegment.Equals("MapServer", StringComparison.OrdinalIgnoreCase)
+            ? "MapServer"
+            : null;
+    }
+
+    private static string ExtractServiceName(Uri serviceUri)
+    {
+        var segments = serviceUri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = segments.Length - 1; i >= 0; i--)
+        {
+            if (segments[i].Equals("FeatureServer", StringComparison.OrdinalIgnoreCase) ||
+                segments[i].Equals("MapServer", StringComparison.OrdinalIgnoreCase))
+            {
+                return i > 0 ? Uri.UnescapeDataString(segments[i - 1]) : "External Service";
+            }
+        }
+
+        return segments.Length > 0 ? Uri.UnescapeDataString(segments[^1]) : "External Service";
+    }
+
+    private static int? GetSrid(ArcGisSpatialReferenceDocument? spatialReference)
+        => spatialReference?.LatestWkid ?? spatialReference?.Wkid;
+
+    private static int ClampTimeout(int? timeoutSeconds)
+        => Math.Clamp(timeoutSeconds ?? DefaultTimeoutSeconds, 1, MaximumTimeoutSeconds);
+
+    private static string FirstNonWhiteSpace(params string?[] values)
+        => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value)) ?? "External Service";
+
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 4180,
+            Level = LogLevel.Information,
+            Message = "Discovered external service {ServiceUrl} with {CandidateCount} candidates")]
+        public static partial void ServiceDiscovered(ILogger logger, string serviceUrl, int candidateCount);
+
+        [LoggerMessage(
+            EventId = 4181,
+            Level = LogLevel.Debug,
+            Message = "Failed to read external service layer {LayerId} metadata")]
+        public static partial void LayerMetadataFailed(ILogger logger, int layerId, Exception exception);
+
+        [LoggerMessage(
+            EventId = 4182,
+            Level = LogLevel.Debug,
+            Message = "Failed to read external service layer {LayerId} feature count")]
+        public static partial void FeatureCountFailed(ILogger logger, int layerId, Exception exception);
+    }
+}
+
+internal sealed class ExternalServiceDiscoveryRequestException(string message) : Exception(message)
+{
+}
+
+internal sealed class ExternalServiceDiscoveryRemoteException(string message) : Exception(message)
+{
+}
+
+internal sealed class ExternalServiceDiscoveryNetworkGuard : IExternalServiceDiscoveryNetworkGuard
+{
+    public Task<bool> IsDisallowedAsync(Uri uri, CancellationToken cancellationToken = default)
+        => NetworkAddressValidator.IsDisallowedAddressAsync(uri, ResolveHostAddressesAsync, cancellationToken);
+
+    private static Task<IPAddress[]> ResolveHostAddressesAsync(string host, CancellationToken cancellationToken)
+        => Dns.GetHostAddressesAsync(host, cancellationToken);
+}

--- a/src/Honua.Server/Features/Admin/Services/IExternalServiceDiscoveryService.cs
+++ b/src/Honua.Server/Features/Admin/Services/IExternalServiceDiscoveryService.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Server.Features.Admin.Models;
+
+namespace Honua.Server.Features.Admin.Services;
+
+internal interface IExternalServiceDiscoveryService
+{
+    Task<ExternalServiceDiscoveryResponse> DiscoverAsync(
+        ExternalServiceDiscoveryRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+internal interface IExternalServiceDiscoveryNetworkGuard
+{
+    Task<bool> IsDisallowedAsync(Uri uri, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Server/Features/Admin/Services/ILayerValidationService.cs
+++ b/src/Honua.Server/Features/Admin/Services/ILayerValidationService.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Server.Features.Admin.Models;
+
+namespace Honua.Server.Features.Admin.Services;
+
+internal interface ILayerValidationService
+{
+    Task<LayerValidationResponse?> ValidateLayerAsync(
+        int layerId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Server/Features/Admin/Services/LayerValidationService.cs
+++ b/src/Honua.Server/Features/Admin/Services/LayerValidationService.cs
@@ -1,0 +1,315 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Admin.Abstractions;
+using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Server.Features.Admin.Models;
+
+namespace Honua.Server.Features.Admin.Services;
+
+internal sealed class LayerValidationService(
+    ILayerCatalog catalog,
+    ITableDiscoveryService tableDiscoveryService,
+    IDatabaseConnectionProvider connectionProvider) : ILayerValidationService
+{
+    private const string SeverityPass = "pass";
+    private const string SeverityWarning = "warning";
+    private const string SeverityError = "error";
+
+    public async Task<LayerValidationResponse?> ValidateLayerAsync(
+        int layerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (layerId < 0)
+        {
+            return null;
+        }
+
+        var layer = await catalog.GetLayerAsync(layerId, cancellationToken).ConfigureAwait(false);
+        if (layer == null)
+        {
+            return null;
+        }
+
+        var checks = new List<LayerValidationCheck>
+        {
+            Pass("catalog-layer", $"Layer {layerId} exists in the catalog.")
+        };
+
+        var storageMapping = layer.StorageMapping;
+        if (storageMapping == null)
+        {
+            checks.Add(Error(
+                "storage-mapping",
+                "Layer does not define a physical storage mapping."));
+
+            return BuildResponse(layer, null, checks);
+        }
+
+        var storageErrors = storageMapping.Validate();
+        if (storageErrors.Count > 0)
+        {
+            foreach (var error in storageErrors)
+            {
+                checks.Add(Error("storage-mapping", error));
+            }
+
+            return BuildResponse(layer, storageMapping, checks);
+        }
+
+        checks.Add(Pass(
+            "storage-mapping",
+            $"Layer is mapped to '{storageMapping.QualifiedName}'."));
+
+        await using var connection = await connectionProvider
+            .OpenConnectionAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var tables = await tableDiscoveryService
+            .DiscoverPostGisTablesAsync(connection, cancellationToken)
+            .ConfigureAwait(false);
+
+        var table = FindTable(tables, storageMapping);
+        if (table == null)
+        {
+            checks.Add(Error(
+                "storage-table",
+                "Mapped storage table was not found or no longer exposes a geometry column.",
+                storageMapping.QualifiedName,
+                null));
+
+            return BuildResponse(layer, storageMapping, checks);
+        }
+
+        checks.Add(Pass(
+            "storage-table",
+            $"Mapped storage table '{table.Schema}.{table.Table}' is discoverable."));
+
+        ValidatePrimaryKey(storageMapping, table, checks);
+        ValidateGeometry(layer, storageMapping, table, checks);
+        ValidateSrid(layer, storageMapping, table, checks);
+        ValidateDeclaredFields(layer, table, checks);
+
+        return BuildResponse(layer, storageMapping, checks);
+    }
+
+    private static TableInfo? FindTable(
+        IReadOnlyCollection<TableInfo> tables,
+        LayerStorageMapping storageMapping)
+    {
+        if (!string.IsNullOrWhiteSpace(storageMapping.SchemaName))
+        {
+            return tables.FirstOrDefault(table =>
+                table.Schema.Equals(storageMapping.SchemaName, StringComparison.OrdinalIgnoreCase) &&
+                table.Table.Equals(storageMapping.TableName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return tables.FirstOrDefault(table =>
+            table.Table.Equals(storageMapping.TableName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static void ValidatePrimaryKey(
+        LayerStorageMapping storageMapping,
+        TableInfo table,
+        List<LayerValidationCheck> checks)
+    {
+        var primaryKeyColumn = FindColumn(table, storageMapping.PrimaryKeyColumn);
+        if (primaryKeyColumn == null)
+        {
+            checks.Add(Error(
+                "primary-key-column",
+                "Mapped primary key column is missing from the storage table.",
+                storageMapping.PrimaryKeyColumn,
+                null));
+            return;
+        }
+
+        checks.Add(Pass(
+            "primary-key-column",
+            $"Primary key column '{primaryKeyColumn.Name}' exists."));
+    }
+
+    private static void ValidateGeometry(
+        LayerDefinition layer,
+        LayerStorageMapping storageMapping,
+        TableInfo table,
+        List<LayerValidationCheck> checks)
+    {
+        if (!layer.HasGeometry)
+        {
+            checks.Add(Pass("geometry-column", "Layer is non-spatial."));
+            return;
+        }
+
+        var expectedGeometryColumn = storageMapping.GeometryColumn;
+        if (string.IsNullOrWhiteSpace(expectedGeometryColumn))
+        {
+            checks.Add(Error(
+                "geometry-column",
+                "Layer is spatial but does not define a mapped geometry column."));
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(table.GeometryColumn))
+        {
+            checks.Add(Error(
+                "geometry-column",
+                "Storage table no longer exposes a geometry column.",
+                expectedGeometryColumn,
+                null));
+            return;
+        }
+
+        if (!table.GeometryColumn.Equals(expectedGeometryColumn, StringComparison.OrdinalIgnoreCase))
+        {
+            checks.Add(Error(
+                "geometry-column",
+                "Storage table geometry column does not match layer metadata.",
+                expectedGeometryColumn,
+                table.GeometryColumn));
+            return;
+        }
+
+        checks.Add(Pass(
+            "geometry-column",
+            $"Geometry column '{table.GeometryColumn}' exists."));
+    }
+
+    private static void ValidateSrid(
+        LayerDefinition layer,
+        LayerStorageMapping storageMapping,
+        TableInfo table,
+        List<LayerValidationCheck> checks)
+    {
+        var expectedSrid = storageMapping.StorageSrid ?? layer.SpatialReference.Wkid;
+        var actualSrid = table.Srid;
+
+        if (expectedSrid <= 0)
+        {
+            checks.Add(Warning(
+                "storage-srid",
+                "Layer metadata does not define an expected storage SRID.",
+                null,
+                actualSrid?.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+            return;
+        }
+
+        if (actualSrid is null or <= 0)
+        {
+            checks.Add(Error(
+                "storage-srid",
+                "Storage table does not report a valid SRID.",
+                expectedSrid.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                actualSrid?.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+            return;
+        }
+
+        if (actualSrid.Value != expectedSrid)
+        {
+            checks.Add(Error(
+                "storage-srid",
+                "Storage table SRID does not match layer storage metadata.",
+                expectedSrid.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                actualSrid.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+            return;
+        }
+
+        checks.Add(Pass(
+            "storage-srid",
+            $"Storage SRID {actualSrid.Value} matches layer metadata."));
+    }
+
+    private static void ValidateDeclaredFields(
+        LayerDefinition layer,
+        TableInfo table,
+        List<LayerValidationCheck> checks)
+    {
+        foreach (var field in layer.AttributeFields)
+        {
+            if (FindColumn(table, field.Name) != null)
+            {
+                checks.Add(Pass(
+                    "declared-field",
+                    $"Declared field '{field.Name}' exists.",
+                    field.Name,
+                    field.Name));
+                continue;
+            }
+
+            checks.Add(Error(
+                "declared-field",
+                $"Declared field '{field.Name}' is missing from the storage table.",
+                field.Name,
+                null));
+        }
+    }
+
+    private static ColumnInfo? FindColumn(TableInfo table, string columnName)
+        => table.Columns.FirstOrDefault(column =>
+            column.Name.Equals(columnName, StringComparison.OrdinalIgnoreCase));
+
+    private static LayerValidationResponse BuildResponse(
+        LayerDefinition layer,
+        LayerStorageMapping? storageMapping,
+        IReadOnlyCollection<LayerValidationCheck> checks)
+    {
+        var hasErrors = checks.Any(check => check.Severity == SeverityError);
+        var hasWarnings = checks.Any(check => check.Severity == SeverityWarning);
+
+        return new LayerValidationResponse
+        {
+            LayerId = layer.Id,
+            LayerName = layer.Name,
+            IsValid = !hasErrors,
+            Status = hasErrors ? "invalid" : hasWarnings ? "warning" : "valid",
+            StorageSchema = storageMapping?.SchemaName,
+            StorageTable = storageMapping?.TableName,
+            CheckedAt = DateTimeOffset.UtcNow,
+            Checks = checks.ToArray()
+        };
+    }
+
+    private static LayerValidationCheck Pass(
+        string code,
+        string message,
+        string? expected = null,
+        string? actual = null)
+        => new()
+        {
+            Code = code,
+            Severity = SeverityPass,
+            Message = message,
+            Expected = expected,
+            Actual = actual
+        };
+
+    private static LayerValidationCheck Warning(
+        string code,
+        string message,
+        string? expected = null,
+        string? actual = null)
+        => new()
+        {
+            Code = code,
+            Severity = SeverityWarning,
+            Message = message,
+            Expected = expected,
+            Actual = actual
+        };
+
+    private static LayerValidationCheck Error(
+        string code,
+        string message,
+        string? expected = null,
+        string? actual = null)
+        => new()
+        {
+            Code = code,
+            Severity = SeverityError,
+            Message = message,
+            Expected = expected,
+            Actual = actual
+        };
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -503,6 +503,7 @@ builder.Services.AddValidationServices();
 
 // Register feature services (FeatureServer, OGC, OData, Observability)
 builder.Services.AddServerFeatures(builder.Configuration);
+builder.Services.AddAdminRealtime();
 if (!isTestEnvironment)
 {
     builder.Services.AddOrchestrationBackgroundServices();
@@ -1126,6 +1127,7 @@ app.MapAdminEndpoints();
 app.MapExternalServiceDiscoveryEndpoints();
 app.MapConfigurationDiscoveryEndpoints();
 app.MapAdminObservabilityEndpoints();
+app.MapAdminRealtimeHub();
 
 // Configure layer publishing endpoints
 app.MapLayerPublishingEndpoints();

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -831,6 +831,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Protocols.Scene.Models.PublicSceneDiscoveryJsonContext.Default,
         Honua.Server.Features.Admin.Models.RateLimitJsonContext.Default,
         Honua.Server.Features.Admin.Models.TableDiscoveryJsonContext.Default,
+        Honua.Server.Features.Admin.Models.ExternalServiceDiscoveryJsonContext.Default,
         Honua.Server.Features.Admin.Models.AdminAuthJsonContext.Default,
         Honua.Server.Features.Admin.Models.ConfigurationJsonContext.Default,
         Honua.Server.Features.Admin.Models.LicenseAdminJsonContext.Default,
@@ -1122,6 +1123,7 @@ app.MapMobileAuthEndpoints();
 
 // Configure admin endpoints
 app.MapAdminEndpoints();
+app.MapExternalServiceDiscoveryEndpoints();
 app.MapConfigurationDiscoveryEndpoints();
 app.MapAdminObservabilityEndpoints();
 

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -821,6 +821,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Admin.Models.ManifestApprovalJsonContext.Default,
         Honua.Server.Features.Admin.Models.GitOpsWatchJsonContext.Default,
         Honua.Server.Features.Admin.Models.LayerStyleJsonContext.Default,
+        Honua.Server.Features.Admin.Models.LayerValidationJsonContext.Default,
         Honua.Server.Features.Admin.Models.StyleSuggestionJsonContext.Default,
         Honua.Server.Features.Admin.Models.AlertAdminJsonContext.Default,
         Honua.Server.Features.Admin.Models.LicenseJsonContext.Default,
@@ -1144,6 +1145,7 @@ app.MapDeployControlEndpoints();
 
 // Configure admin layer style endpoints
 app.MapAdminLayerStyleEndpoints();
+app.MapAdminLayerValidationEndpoints();
 app.MapAdminStyleSuggestionEndpoints();
 app.MapAdminSldStyleEndpoints();
 

--- a/tests/dotnet/Honua.Server.Tests/Admin/AdminRealtimeHubTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Admin/AdminRealtimeHubTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace Honua.Server.Tests.Admin;
+
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Streaming)]
+public sealed class AdminRealtimeHubTests
+{
+    private const string AdminPassword = "admin-realtime-test-password";
+
+    [IntegrationTest]
+    [Endpoint("POST /hubs/admin/negotiate")]
+    public async Task AdminHubNegotiate_WithAdminApiKey_ReturnsConnectionInfo()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", AdminPassword);
+
+        using var content = new StringContent(string.Empty, Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("/hubs/admin/negotiate?negotiateVersion=1", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        document.RootElement.TryGetProperty("connectionToken", out var connectionToken).Should().BeTrue();
+        connectionToken.GetString().Should().NotBeNullOrWhiteSpace();
+        document.RootElement.TryGetProperty("availableTransports", out var transports).Should().BeTrue();
+        transports.GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /hubs/admin/negotiate")]
+    public async Task AdminHubNegotiate_WithoutAdminApiKey_ReturnsUnauthorized()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var content = new StringContent(string.Empty, Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("/hubs/admin/negotiate?negotiateVersion=1", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory()
+        => new TestWebApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+                builder.ConfigureAppConfiguration((_, configBuilder) =>
+                {
+                    configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["HONUA_ADMIN_PASSWORD"] = AdminPassword
+                    });
+                });
+            });
+}

--- a/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
@@ -195,6 +195,108 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.Create)]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task PublishLayer_MaterializesFeaturesAndExtentForFeatureServer()
+    {
+        var publishRequest = new PublishLayerRequest
+        {
+            Schema = _schema,
+            Table = _tableName,
+            LayerName = $"Layer {_tableName}",
+            Description = "Layer publish materialization integration test",
+            GeometryColumn = "geom",
+            GeometryType = "Point",
+            Srid = 4326,
+            PrimaryKey = "id",
+            Fields = new[] { "id", "name", "population" },
+            ServiceName = _serviceName,
+            Enabled = true
+        };
+
+        var publishResponse = await _client.PostAsync(
+            $"/api/v1/admin/connections/{_connectionId}/layers",
+            JsonContent.Create(publishRequest, options: _jsonOptions));
+
+        var publishPayload = await publishResponse.Content.ReadAsStringAsync();
+        publishResponse.StatusCode.Should().Be(HttpStatusCode.Created, $"response: {publishPayload}");
+        var publishApi = JsonSerializer.Deserialize<ApiResponse<PublishedLayerSummary>>(publishPayload, _jsonOptions);
+        publishApi.Should().NotBeNull();
+        publishApi!.Success.Should().BeTrue();
+        publishApi.Data.Should().NotBeNull();
+        _layerId = publishApi.Data!.LayerId;
+
+        await using (var connection = await _fixture.Postgres.GetConnectionAsync())
+        await using (var command = connection.CreateCommand())
+        {
+            command.CommandText = """
+                SELECT
+                    COUNT(*)::int,
+                    MIN(attributes->>'id'),
+                    MIN(attributes->>'name'),
+                    MIN((attributes->>'population')::int),
+                    ST_XMin(l.extent),
+                    ST_YMin(l.extent),
+                    ST_XMax(l.extent),
+                    ST_YMax(l.extent),
+                    ST_SRID(l.extent)
+                FROM features f
+                INNER JOIN honua.layers l
+                    ON l.layer_id = f.layer_id
+                WHERE f.layer_id = @layerId
+                GROUP BY l.extent;
+                """;
+            command.Parameters.AddWithValue("layerId", _layerId.Value);
+
+            await using var reader = await command.ExecuteReaderAsync();
+            (await reader.ReadAsync()).Should().BeTrue();
+            reader.GetInt32(0).Should().Be(1);
+            reader.GetString(1).Should().Be("1");
+            reader.GetString(2).Should().Be("Test Feature");
+            reader.GetInt32(3).Should().Be(100);
+            reader.GetDouble(4).Should().Be(1);
+            reader.GetDouble(5).Should().Be(1);
+            reader.GetDouble(6).Should().Be(1);
+            reader.GetDouble(7).Should().Be(1);
+            reader.GetInt32(8).Should().Be(4326);
+        }
+
+        using var featureClient = _fixture.CreateClient(client =>
+            client.DefaultRequestHeaders.Remove("X-Honua-Test-Schema"));
+
+        var queryResponse = await featureClient.GetAsync(
+            $"/rest/services/{_serviceName}/FeatureServer/{_layerId}/query?where=1%3D1&f=json");
+
+        queryResponse.Be200Ok();
+        var queryPayload = await queryResponse.Content.ReadAsStringAsync();
+        using (var queryDocument = JsonDocument.Parse(queryPayload))
+        {
+            var features = queryDocument.RootElement.GetProperty("features").EnumerateArray().ToArray();
+            features.Should().ContainSingle();
+            var attributes = features[0].GetProperty("attributes");
+            attributes.GetProperty("id").GetInt32().Should().Be(1);
+            attributes.GetProperty("name").GetString().Should().Be("Test Feature");
+            attributes.GetProperty("population").GetInt32().Should().Be(100);
+        }
+
+        var metadataResponse = await featureClient.GetAsync(
+            $"/rest/services/{_serviceName}/FeatureServer/{_layerId}");
+
+        metadataResponse.Be200Ok();
+        var metadataPayload = await metadataResponse.Content.ReadAsStringAsync();
+        using var metadataDocument = JsonDocument.Parse(metadataPayload);
+        var extent = metadataDocument.RootElement.GetProperty("extent");
+        extent.GetProperty("xmin").GetDouble().Should().Be(1);
+        extent.GetProperty("ymin").GetDouble().Should().Be(1);
+        extent.GetProperty("xmax").GetDouble().Should().Be(1);
+        extent.GetProperty("ymax").GetDouble().Should().Be(1);
+        extent.GetProperty("spatialReference").GetProperty("wkid").GetInt32().Should().Be(4326);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
     [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
     public async Task PublishLayer_PrimaryKeyNotInFields_ReturnsBadRequest()
     {
@@ -520,6 +622,7 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
         await using var connection = await _fixture.Postgres.GetConnectionAsync();
         await using var command = connection.CreateCommand();
         command.CommandText = """
+            DELETE FROM features WHERE layer_id = @layerId;
             DELETE FROM honua.layer_fields WHERE layer_id = @layerId;
             DELETE FROM honua.service_layers WHERE layer_id = @layerId;
             DELETE FROM honua.layers WHERE layer_id = @layerId;

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/ExternalServiceDiscoveryEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/ExternalServiceDiscoveryEndpointsTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Server.Features.Admin.Services;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Import)]
+public sealed class ExternalServiceDiscoveryEndpointsTests : IAsyncLifetime, IDisposable
+{
+    private const string AdminPassword = "external-service-discovery-admin-key";
+
+    private readonly ExternalServiceDiscoveryServiceTests.StubHttpClientFactory _httpClientFactory =
+        new(ExternalServiceDiscoveryServiceTests.ArcGisFeatureServerResponses());
+
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+    private bool _disposed;
+
+    public ExternalServiceDiscoveryEndpointsTests()
+    {
+        _fixture = new WebAppFixture()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+            })
+            .ReplaceService<IExternalServiceDiscoveryNetworkGuard>(
+                new ExternalServiceDiscoveryServiceTests.AllowingNetworkGuard())
+            .ReplaceService<IHttpClientFactory>(_httpClientFactory);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateClient(client => client.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+        Dispose();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _httpClientFactory.Dispose();
+        _disposed = true;
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/external-services/discover")]
+    public async Task DiscoverExternalService_WithArcGisFeatureServerFixture_ReturnsCandidates()
+    {
+        using var response = await _client.PostAsync(
+            "/api/v1/admin/external-services/discover",
+            JsonContent("""
+            {
+              "url": "https://services.example.test/arcgis/rest/services/Planning/FeatureServer"
+            }
+            """));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        json.RootElement.GetProperty("sourceKind").GetString().Should().Be("arcgis-feature-server");
+        json.RootElement.GetProperty("serviceName").GetString().Should().Be("Planning");
+
+        var candidate = json.RootElement.GetProperty("candidates")[0];
+        candidate.GetProperty("layerId").GetInt32().Should().Be(0);
+        candidate.GetProperty("name").GetString().Should().Be("Parcels");
+        candidate.GetProperty("geometryType").GetString().Should().Be("esriGeometryPolygon");
+        candidate.GetProperty("srid").GetInt32().Should().Be(4326);
+        candidate.GetProperty("featureCount").GetInt32().Should().Be(42);
+        candidate.GetProperty("fields").GetArrayLength().Should().Be(2);
+        candidate.GetProperty("extent").GetProperty("xMin").GetDouble().Should().Be(-158.3);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/external-services/discover")]
+    public async Task DiscoverExternalService_WithMissingUrl_ReturnsBadRequest()
+    {
+        using var response = await _client.PostAsync(
+            "/api/v1/admin/external-services/discover",
+            JsonContent("{}"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("Url is required");
+    }
+
+    private static StringContent JsonContent(string json)
+        => new(json, Encoding.UTF8, "application/json");
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/ExternalServiceDiscoveryServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/ExternalServiceDiscoveryServiceTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Admin.Services;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+public sealed class ExternalServiceDiscoveryServiceTests
+{
+    [UnitTest]
+    public async Task DiscoverAsync_WithArcGisFeatureServerFixture_ReturnsLayerCandidateMetadata()
+    {
+        using var factory = new StubHttpClientFactory(ArcGisFeatureServerResponses());
+        var service = new ExternalServiceDiscoveryService(
+            factory,
+            new AllowingNetworkGuard(),
+            NullLogger<ExternalServiceDiscoveryService>.Instance);
+
+        var response = await service.DiscoverAsync(new ExternalServiceDiscoveryRequest
+        {
+            Url = "https://services.example.test/arcgis/rest/services/Planning/FeatureServer",
+            TimeoutSeconds = 5
+        });
+
+        response.SourceKind.Should().Be("arcgis-feature-server");
+        response.ServiceType.Should().Be("FeatureServer");
+        response.ServiceName.Should().Be("Planning");
+        response.Srid.Should().Be(4326);
+        response.Candidates.Should().ContainSingle();
+
+        var candidate = response.Candidates[0];
+        candidate.LayerId.Should().Be(0);
+        candidate.Name.Should().Be("Parcels");
+        candidate.GeometryType.Should().Be("esriGeometryPolygon");
+        candidate.Srid.Should().Be(4326);
+        candidate.FeatureCount.Should().Be(42);
+        candidate.Extent.Should().BeEquivalentTo(new ExternalServiceExtent
+        {
+            XMin = -158.3,
+            YMin = 21.2,
+            XMax = -157.6,
+            YMax = 21.8,
+            Srid = 4326
+        });
+        candidate.Fields.Should().Contain(field => field.Name == "OBJECTID" && field.Type == "esriFieldTypeOID");
+        candidate.Fields.Should().Contain(field => field.Name == "zone" && field.Length == 16 && field.Nullable == true);
+
+        factory.RequestedUrls.Should().BeEquivalentTo([
+            "https://services.example.test/arcgis/rest/services/Planning/FeatureServer?f=json",
+            "https://services.example.test/arcgis/rest/services/Planning/FeatureServer/0?f=json",
+            "https://services.example.test/arcgis/rest/services/Planning/FeatureServer/0/query?where=1%3D1&returnCountOnly=true&f=json"
+        ], options => options.WithStrictOrdering());
+    }
+
+    [UnitTest]
+    public async Task DiscoverAsync_WithOgcApiFeaturesUrl_ReturnsExplicitBacklogError()
+    {
+        using var factory = new StubHttpClientFactory(new Dictionary<string, string>());
+        var service = new ExternalServiceDiscoveryService(
+            factory,
+            new AllowingNetworkGuard(),
+            NullLogger<ExternalServiceDiscoveryService>.Instance);
+
+        var act = async () => await service.DiscoverAsync(new ExternalServiceDiscoveryRequest
+        {
+            Url = "https://ogc.example.test/collections"
+        });
+
+        await act.Should().ThrowAsync<ExternalServiceDiscoveryRequestException>()
+            .WithMessage("*honua-server#977*");
+        factory.RequestedUrls.Should().BeEmpty();
+    }
+
+    internal static Dictionary<string, string> ArcGisFeatureServerResponses()
+        => new(StringComparer.Ordinal)
+        {
+            ["https://services.example.test/arcgis/rest/services/Planning/FeatureServer?f=json"] = """
+            {
+              "currentVersion": 11.2,
+              "serviceDescription": "Planning",
+              "description": "Planning service",
+              "spatialReference": { "wkid": 4326, "latestWkid": 4326 },
+              "layers": [
+                { "id": 0, "name": "Parcels" }
+              ]
+            }
+            """,
+            ["https://services.example.test/arcgis/rest/services/Planning/FeatureServer/0?f=json"] = """
+            {
+              "id": 0,
+              "name": "Parcels",
+              "type": "Feature Layer",
+              "geometryType": "esriGeometryPolygon",
+              "extent": {
+                "xmin": -158.3,
+                "ymin": 21.2,
+                "xmax": -157.6,
+                "ymax": 21.8,
+                "spatialReference": { "wkid": 4326 }
+              },
+              "fields": [
+                { "name": "OBJECTID", "type": "esriFieldTypeOID", "alias": "OBJECTID", "nullable": false },
+                { "name": "zone", "type": "esriFieldTypeString", "alias": "Zone", "length": 16, "nullable": true }
+              ]
+            }
+            """,
+            ["https://services.example.test/arcgis/rest/services/Planning/FeatureServer/0/query?where=1%3D1&returnCountOnly=true&f=json"] = """
+            {
+              "count": 42
+            }
+            """
+        };
+
+    internal sealed class AllowingNetworkGuard : IExternalServiceDiscoveryNetworkGuard
+    {
+        public Task<bool> IsDisallowedAsync(Uri uri, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+    }
+
+    internal sealed class StubHttpClientFactory : IHttpClientFactory, IDisposable
+    {
+        private readonly StubHttpMessageHandler _handler;
+        private readonly HttpClient _client;
+
+        public StubHttpClientFactory(IReadOnlyDictionary<string, string> responses)
+        {
+            _handler = new StubHttpMessageHandler(responses);
+            _client = new HttpClient(_handler);
+        }
+
+        public IReadOnlyList<string> RequestedUrls => _handler.RequestedUrls;
+
+        public HttpClient CreateClient(string name) => _client;
+
+        public void Dispose()
+        {
+            _client.Dispose();
+            _handler.Dispose();
+        }
+    }
+
+    private sealed class StubHttpMessageHandler(IReadOnlyDictionary<string, string> responses) : HttpMessageHandler
+    {
+        private readonly List<string> _requestedUrls = [];
+
+        public IReadOnlyList<string> RequestedUrls => _requestedUrls;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var requestUrl = request.RequestUri?.ToString() ?? string.Empty;
+            _requestedUrls.Add(requestUrl);
+
+            if (!responses.TryGetValue(requestUrl, out var body))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/LayerValidationEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/LayerValidationEndpointsTests.cs
@@ -1,0 +1,280 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+using Npgsql;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+/// <summary>
+/// Integration tests for admin layer storage validation endpoints.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+public sealed class LayerValidationEndpointsTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+    private HttpClient _client = null!;
+    private string _schema = string.Empty;
+    private string _tableName = string.Empty;
+    private string _serviceName = string.Empty;
+    private int? _layerId;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateAdminClient();
+        _schema = _fixture.CurrentSchema ?? throw new InvalidOperationException("Test schema was not initialized.");
+        _tableName = $"layer_validation_{Guid.NewGuid():N}";
+        _serviceName = $"svc_validation_{Guid.NewGuid():N}";
+
+        await CreateSpatialTableAsync();
+        await CreateLayerMetadataAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await CleanupLayerMetadataAsync();
+        await DropSpatialTableAsync();
+        await _fixture.DisposeAsync();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /api/v1/admin/metadata/layers/{layerId}/validation")]
+    public async Task GetLayerValidation_WithMatchingStorage_ReturnsValid()
+    {
+        var response = await _client.GetAsync($"/api/v1/admin/metadata/layers/{_layerId}/validation");
+
+        response.Be200Ok();
+        var apiResponse = await ReadValidationResponseAsync(response);
+
+        apiResponse.Success.Should().BeTrue();
+        apiResponse.Data.Should().NotBeNull();
+        apiResponse.Data!.IsValid.Should().BeTrue();
+        apiResponse.Data.Status.Should().Be("valid");
+        apiResponse.Data.StorageSchema.Should().Be(_schema);
+        apiResponse.Data.StorageTable.Should().Be(_tableName);
+        apiResponse.Data.Checks.Should().NotContain(check => check.Severity == "error");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /api/v1/admin/metadata/layers/{layerId}/validation")]
+    public async Task GetLayerValidation_WhenDeclaredColumnIsDropped_ReturnsInvalid()
+    {
+        await DropPopulationColumnAsync();
+
+        var response = await _client.GetAsync($"/api/v1/admin/metadata/layers/{_layerId}/validation");
+
+        response.Be200Ok();
+        var apiResponse = await ReadValidationResponseAsync(response);
+
+        apiResponse.Success.Should().BeTrue();
+        apiResponse.Data.Should().NotBeNull();
+        apiResponse.Data!.IsValid.Should().BeFalse();
+        apiResponse.Data.Status.Should().Be("invalid");
+        apiResponse.Data.Checks.Should().Contain(check =>
+            check.Code == "declared-field" &&
+            check.Severity == "error" &&
+            check.Expected == "population" &&
+            check.Actual == null);
+    }
+
+    private static async Task<ApiResponse<LayerValidationResponse>> ReadValidationResponseAsync(
+        HttpResponseMessage response)
+    {
+        var payload = await response.Content.ReadAsStringAsync();
+        var apiResponse = JsonSerializer.Deserialize(
+            payload,
+            LayerValidationJsonContext.Default.ApiResponseLayerValidationResponse);
+
+        apiResponse.Should().NotBeNull($"response payload was: {payload}");
+        return apiResponse!;
+    }
+
+    private async Task CreateSpatialTableAsync()
+    {
+        await using var connection = await _fixture.Postgres.GetConnectionAsync(_schema);
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            CREATE TABLE {QuoteIdentifier(_tableName)} (
+                id integer PRIMARY KEY,
+                name text NOT NULL,
+                population integer,
+                geom geometry(Point, 4326) NOT NULL
+            );
+
+            INSERT INTO {QuoteIdentifier(_tableName)} (id, name, population, geom)
+            VALUES
+                (1, 'Feature One', 100, ST_SetSRID(ST_Point(-157.8583, 21.3069), 4326)),
+                (2, 'Feature Two', 250, ST_SetSRID(ST_Point(-157.8167, 21.2970), 4326));
+            """;
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private async Task CreateLayerMetadataAsync()
+    {
+        await using var connection = await _fixture.Postgres.GetConnectionAsync(_schema);
+
+        await using (var sequenceCommand = connection.CreateCommand())
+        {
+            sequenceCommand.CommandText = """
+                SELECT setval(
+                    pg_get_serial_sequence('honua.layers', 'layer_id'),
+                    GREATEST((SELECT COALESCE(MAX(layer_id), 1) FROM honua.layers), 1),
+                    true);
+                """;
+            await sequenceCommand.ExecuteNonQueryAsync();
+        }
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO honua.services (
+                service_name,
+                description,
+                srid,
+                supported_formats,
+                capabilities,
+                service_extent
+            )
+            VALUES (
+                @serviceName,
+                'Layer validation endpoint test service',
+                4326,
+                ARRAY['JSON', 'GeoJSON'],
+                ARRAY['Query'],
+                ST_MakeEnvelope(-158.0, 21.0, -157.0, 22.0, 4326)
+            );
+
+            INSERT INTO honua.layers (
+                layer_name,
+                description,
+                table_schema,
+                table_name,
+                primary_key_column,
+                geometry_column,
+                storage_srid,
+                geometry_type,
+                srid,
+                extent,
+                default_visibility,
+                enabled
+            )
+            VALUES (
+                @layerName,
+                'Layer validation endpoint test layer',
+                @schema,
+                @tableName,
+                'id',
+                'geom',
+                4326,
+                'Point',
+                4326,
+                ST_MakeEnvelope(-158.0, 21.0, -157.0, 22.0, 4326),
+                true,
+                true
+            )
+            RETURNING layer_id;
+            """;
+        command.Parameters.AddWithValue("serviceName", _serviceName);
+        command.Parameters.AddWithValue("layerName", $"Layer {_tableName}");
+        command.Parameters.AddWithValue("schema", _schema);
+        command.Parameters.AddWithValue("tableName", _tableName);
+
+        var layerId = await command.ExecuteScalarAsync();
+        _layerId = Convert.ToInt32(layerId, CultureInfo.InvariantCulture);
+
+        await using var fieldsCommand = connection.CreateCommand();
+        fieldsCommand.CommandText = """
+            INSERT INTO honua.service_layers (service_name, layer_id, layer_order)
+            VALUES (@serviceName, @layerId, 0);
+
+            INSERT INTO honua.layer_fields (
+                layer_id,
+                field_name,
+                field_type,
+                field_order,
+                max_length,
+                nullable,
+                description
+            )
+            VALUES
+                (@layerId, 'id', 'Integer', 0, null, false, 'Identifier'),
+                (@layerId, 'name', 'String', 1, null, false, 'Name'),
+                (@layerId, 'population', 'Integer', 2, null, true, 'Population'),
+                (@layerId, 'geom', 'Geometry', 3, null, false, 'Geometry');
+            """;
+        fieldsCommand.Parameters.AddWithValue("serviceName", _serviceName);
+        fieldsCommand.Parameters.AddWithValue("layerId", _layerId.Value);
+
+        await fieldsCommand.ExecuteNonQueryAsync();
+    }
+
+    private async Task DropPopulationColumnAsync()
+    {
+        await using var connection = await _fixture.Postgres.GetConnectionAsync(_schema);
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"ALTER TABLE {QuoteIdentifier(_tableName)} DROP COLUMN population;";
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private async Task CleanupLayerMetadataAsync()
+    {
+        if (_layerId.HasValue)
+        {
+            await using var connection = await _fixture.Postgres.GetConnectionAsync(_schema);
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                DELETE FROM honua.layer_fields WHERE layer_id = @layerId;
+                DELETE FROM honua.service_layers WHERE layer_id = @layerId;
+                DELETE FROM honua.layers WHERE layer_id = @layerId;
+                """;
+            command.Parameters.AddWithValue("layerId", _layerId.Value);
+            await command.ExecuteNonQueryAsync();
+        }
+
+        if (!string.IsNullOrWhiteSpace(_serviceName))
+        {
+            await using var connection = await _fixture.Postgres.GetConnectionAsync(_schema);
+            await using var command = connection.CreateCommand();
+            command.CommandText = "DELETE FROM honua.services WHERE service_name = @serviceName;";
+            command.Parameters.AddWithValue("serviceName", _serviceName);
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+
+    private async Task DropSpatialTableAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_tableName))
+        {
+            return;
+        }
+
+        await using var connection = await _fixture.Postgres.GetConnectionAsync(_schema);
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"DROP TABLE IF EXISTS {QuoteIdentifier(_tableName)};";
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static string QuoteIdentifier(string identifier)
+    {
+        if (identifier.Any(static ch => !char.IsLetterOrDigit(ch) && ch != '_'))
+        {
+            throw new ArgumentException($"Invalid identifier '{identifier}'.", nameof(identifier));
+        }
+
+        return "\"" + identifier.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Seed/AdminSampleSeedFixtureTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Seed/AdminSampleSeedFixtureTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Seed;
+
+[Protocol(TestProtocols.FeatureServer)]
+[Operation(Operations.GetServiceInfo)]
+public sealed class AdminSampleSeedFixtureTests
+{
+    [IntegrationTest]
+    public void AdminSampleSeed_DeclaresPreviewableFeatureServerFixture()
+    {
+        var seed = File.ReadAllText(ResolveRepoFile("tests", "seed", "admin-sample-feature-server.yaml"));
+
+        seed.Should().Contain("/rest/services/admin_sample/FeatureServer?f=json");
+        seed.Should().Contain("/rest/services/admin_sample/FeatureServer/3000/query?f=geojson&where=1%3D1");
+        seed.Should().Contain("'admin_sample'");
+        seed.Should().Contain("3000");
+        seed.Should().Contain("ST_MakeEnvelope(-158.05, 21.25, -157.65, 21.45, 4326)");
+        seed.Should().Contain("Honolulu Operations Center");
+        seed.Should().Contain("Pearl City Sensor Gateway");
+        Regex.Count(seed, "ST_SetSRID\\(ST_MakePoint").Should().BeGreaterThanOrEqualTo(4);
+    }
+
+    private static string ResolveRepoFile(params string[] path)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "Honua.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.Should().NotBeNull("the test should run under the repository output tree");
+        return Path.Combine(new[] { directory!.FullName }.Concat(path).ToArray());
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Seed/AdminSampleSeedFixtureTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Seed/AdminSampleSeedFixtureTests.cs
@@ -13,6 +13,8 @@ namespace Honua.Server.Tests.Seed;
 public sealed class AdminSampleSeedFixtureTests
 {
     [IntegrationTest]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer")]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
     public void AdminSampleSeed_DeclaresPreviewableFeatureServerFixture()
     {
         var seed = File.ReadAllText(ResolveRepoFile("tests", "seed", "admin-sample-feature-server.yaml"));

--- a/tests/seed/admin-sample-feature-server.yaml
+++ b/tests/seed/admin-sample-feature-server.yaml
@@ -1,0 +1,206 @@
+version: 1
+sql:
+  # Local admin UI sample service. Apply after tests/seed/base-schema.sql or
+  # against a migrated local PostGIS database to expose:
+  #   /rest/services/admin_sample/FeatureServer?f=json
+  #   /rest/services/admin_sample/FeatureServer/3000/query?f=geojson&where=1%3D1
+  - |
+      INSERT INTO honua.services (
+          service_name,
+          description,
+          srid,
+          supported_formats,
+          capabilities,
+          service_extent,
+          metadata
+      )
+      VALUES (
+          'admin_sample',
+          'Local admin UI sample FeatureServer service with previewable Oahu operations data',
+          4326,
+          ARRAY['JSON', 'GeoJSON'],
+          ARRAY['Query', 'Extract'],
+          ST_MakeEnvelope(-158.05, 21.25, -157.65, 21.45, 4326),
+          jsonb_build_object(
+              'accessPolicy', jsonb_build_object('allowAnonymous', true),
+              'source', 'tests/seed/admin-sample-feature-server.yaml',
+              'owner', 'Honua local sample'
+          )
+      )
+      ON CONFLICT (service_name) DO UPDATE SET
+          description = EXCLUDED.description,
+          srid = EXCLUDED.srid,
+          supported_formats = EXCLUDED.supported_formats,
+          capabilities = EXCLUDED.capabilities,
+          service_extent = EXCLUDED.service_extent,
+          metadata = EXCLUDED.metadata,
+          updated_at = NOW();
+
+  - |
+      INSERT INTO honua.layers (
+          layer_id,
+          layer_name,
+          description,
+          table_schema,
+          table_name,
+          primary_key_column,
+          geometry_column,
+          geometry_type,
+          srid,
+          extent,
+          default_visibility,
+          enabled,
+          metadata,
+          geoservices_drawing_info
+      )
+      VALUES (
+          3000,
+          'Oahu Operations Sample',
+          'Previewable point layer for local admin UI service and layer metadata workflows',
+          current_schema(),
+          'features',
+          'objectid',
+          'geometry',
+          'Point',
+          4326,
+          ST_MakeEnvelope(-158.05, 21.25, -157.65, 21.45, 4326),
+          true,
+          true,
+          jsonb_build_object(
+              'accessPolicy', jsonb_build_object('allowAnonymous', true),
+              'displayField', 'name',
+              'source', 'tests/seed/admin-sample-feature-server.yaml'
+          ),
+          jsonb_build_object(
+              'renderer', jsonb_build_object(
+                  'type', 'simple',
+                  'symbol', jsonb_build_object(
+                      'type', 'esriSMS',
+                      'style', 'esriSMSCircle',
+                      'color', jsonb_build_array(44, 123, 229, 210),
+                      'size', 9,
+                      'outline', jsonb_build_object(
+                          'color', jsonb_build_array(255, 255, 255, 255),
+                          'width', 1
+                      )
+                  )
+              )
+          )
+      )
+      ON CONFLICT (layer_id) DO UPDATE SET
+          layer_name = EXCLUDED.layer_name,
+          description = EXCLUDED.description,
+          table_schema = EXCLUDED.table_schema,
+          table_name = EXCLUDED.table_name,
+          primary_key_column = EXCLUDED.primary_key_column,
+          geometry_column = EXCLUDED.geometry_column,
+          geometry_type = EXCLUDED.geometry_type,
+          srid = EXCLUDED.srid,
+          extent = EXCLUDED.extent,
+          default_visibility = EXCLUDED.default_visibility,
+          enabled = EXCLUDED.enabled,
+          metadata = EXCLUDED.metadata,
+          geoservices_drawing_info = EXCLUDED.geoservices_drawing_info;
+
+  - |
+      INSERT INTO honua.service_layers (service_name, layer_id, layer_order)
+      VALUES ('admin_sample', 3000, 0)
+      ON CONFLICT (service_name, layer_id) DO UPDATE SET
+          layer_order = EXCLUDED.layer_order;
+
+  - |
+      INSERT INTO honua.layer_fields (
+          layer_id,
+          field_name,
+          field_type,
+          field_order,
+          max_length,
+          nullable,
+          description
+      )
+      VALUES
+          (3000, 'objectid', 'Integer', 0, null, false, 'Object ID'),
+          (3000, 'name', 'String', 1, 255, false, 'Site or asset name'),
+          (3000, 'category', 'String', 2, 80, false, 'Operational category'),
+          (3000, 'status', 'String', 3, 32, false, 'Current operating status'),
+          (3000, 'priority', 'Integer', 4, null, true, 'Operator triage priority'),
+          (3000, 'owner', 'String', 5, 120, true, 'Responsible team'),
+          (3000, 'updated_at', 'DateTime', 6, null, true, 'Last sample update timestamp'),
+          (3000, 'shape', 'Geometry', 7, null, true, 'Geometry')
+      ON CONFLICT (layer_id, field_name) DO UPDATE SET
+          field_type = EXCLUDED.field_type,
+          field_order = EXCLUDED.field_order,
+          max_length = EXCLUDED.max_length,
+          nullable = EXCLUDED.nullable,
+          description = EXCLUDED.description;
+
+  - |
+      INSERT INTO features (objectid, layer_id, geometry, attributes)
+      VALUES
+          (
+              300001,
+              3000,
+              ST_SetSRID(ST_MakePoint(-157.8583, 21.3069), 4326),
+              jsonb_build_object(
+                  'objectid', 300001,
+                  'name', 'Honolulu Operations Center',
+                  'category', 'Operations',
+                  'status', 'online',
+                  'priority', 1,
+                  'owner', 'Platform Ops',
+                  'updated_at', '2026-05-01T18:00:00Z'
+              )
+          ),
+          (
+              300002,
+              3000,
+              ST_SetSRID(ST_MakePoint(-157.9225, 21.3187), 4326),
+              jsonb_build_object(
+                  'objectid', 300002,
+                  'name', 'Daniel K. Inouye Airport Feed',
+                  'category', 'Transportation',
+                  'status', 'degraded',
+                  'priority', 2,
+                  'owner', 'Field Integrations',
+                  'updated_at', '2026-05-01T18:15:00Z'
+              )
+          ),
+          (
+              300003,
+              3000,
+              ST_SetSRID(ST_MakePoint(-157.7394, 21.3972), 4326),
+              jsonb_build_object(
+                  'objectid', 300003,
+                  'name', 'Kailua Field Office',
+                  'category', 'Field Office',
+                  'status', 'online',
+                  'priority', 3,
+                  'owner', 'Customer Success',
+                  'updated_at', '2026-05-01T18:30:00Z'
+              )
+          ),
+          (
+              300004,
+              3000,
+              ST_SetSRID(ST_MakePoint(-158.0011, 21.3867), 4326),
+              jsonb_build_object(
+                  'objectid', 300004,
+                  'name', 'Pearl City Sensor Gateway',
+                  'category', 'Telemetry',
+                  'status', 'online',
+                  'priority', 2,
+                  'owner', 'Observability',
+                  'updated_at', '2026-05-01T18:45:00Z'
+              )
+          )
+      ON CONFLICT (objectid) DO UPDATE SET
+          layer_id = EXCLUDED.layer_id,
+          geometry = EXCLUDED.geometry,
+          attributes = EXCLUDED.attributes,
+          updated_at = NOW();
+
+  - |
+      SELECT setval(
+          pg_get_serial_sequence('features', 'objectid'),
+          (SELECT COALESCE(MAX(objectid), 0) FROM features)
+      );


### PR DESCRIPTION
## Issue Link

Related to #970
Related to #974
Related to #975
Related to #977
Related to #978
Related to #979

## Summary

This PR combines the server-side dependencies needed by the Honua admin/operator UI cleanup into one reviewable branch. It makes newly published layers queryable, gives the admin UI real server status and sample preview data, and exposes validation/discovery endpoints needed by the redesigned publishing and layer configuration flows.

## Changes Made

- Materialize published PostGIS layers into canonical feature storage so preview/query flows can see newly published layers immediately.
- Compute and persist layer/service extents during publish for catalog and preview zoom behavior.
- Add admin external service discovery for ArcGIS REST FeatureServer/MapServer service roots, with OGC discovery returning an explicit backlog response.
- Add an authenticated admin SignalR hub at `/hubs/admin` so the admin UI can connect to server status instead of showing offline/no OTLP placeholders.
- Add a local admin sample FeatureServer seed fixture (`admin_sample`, layer `3000`) for real preview data.
- Add admin layer storage validation at `GET /api/v1/admin/metadata/layers/{layerId}/validation` to detect schema drift such as missing declared columns, primary key mismatches, geometry column drift, and SRID mismatches.

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Focused validation:

- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~LayerPublishingIntegrationTests|FullyQualifiedName~ExternalServiceDiscovery|FullyQualifiedName~AdminRealtimeHubTests|FullyQualifiedName~AdminSampleSeedFixtureTests|FullyQualifiedName~LayerValidationEndpointsTests" -p:NuGetAudit=false`
- Result: passed, 20/20.
- `git diff --check origin/trunk`
- Result: clean.

Note: local test commands use `-p:NuGetAudit=false` because the repo currently treats the existing `Snappier 1.3.0` NU1903 advisory as a build error before tests run.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes

None.

---

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

Local `scripts/ci/pre-pr-check.sh` was attempted after the focused checks; the local shell path exited during restore without details even though direct `dotnet restore Honua.sln` succeeds. The PR gate is validating the same build/test path in CI.
