### PR TITLE
fix: source-backed layer publishing queries (#974)

### DIFF
--- a/src/Honua.Core/Features/Catalog/Domain/LayerStorageMapping.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/LayerStorageMapping.cs
@@ -29,10 +29,23 @@ public sealed record LayerStorageMapping(
     IReadOnlyDictionary<string, string>? ProviderOptions = null)
 {
     /// <summary>
+    /// Provider option key indicating that reads should be routed back to the source table.
+    /// </summary>
+    public const string SourceBackedOption = "sourceBacked";
+
+    /// <summary>
     /// Provider-specific extension values, normalized to an empty dictionary when unset.
     /// </summary>
     public IReadOnlyDictionary<string, string> ProviderOptions { get; init; } =
         ProviderOptions ?? new Dictionary<string, string>();
+
+    /// <summary>
+    /// Gets a value indicating whether the mapping should be read from the source provider.
+    /// </summary>
+    public bool IsSourceBacked =>
+        ProviderOptions.TryGetValue(SourceBackedOption, out var value)
+        && bool.TryParse(value, out var sourceBacked)
+        && sourceBacked;
 
     /// <summary>
     /// Gets the best available fully qualified storage name for diagnostics and capability reporting.

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
@@ -20,6 +20,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
     ILogger<PostgreSqlLayerPublishingService> logger) : ILayerPublishingService
 {
     private const string DefaultServiceName = "default";
+    private const string SourceBackedStorageOptionsJson = """{"sourceBacked":"true"}""";
     private static readonly string[] _defaultFormats = ["JSON", "GeoJSON"];
     private static readonly string[] _defaultCapabilities = ["Query", "Extract"];
 
@@ -46,13 +47,27 @@ internal sealed partial class PostgreSqlLayerPublishingService(
                 l.description,
                 l.table_schema,
                 l.table_name,
+                l.primary_key_column,
                 l.geometry_type,
                 l.srid,
-                l.enabled
+                l.enabled,
+                COUNT(f.field_name)::int AS field_count
             FROM honua.layers l
             INNER JOIN honua.service_layers sl
                 ON sl.layer_id = l.layer_id
+            LEFT JOIN honua.layer_fields f
+                ON f.layer_id = l.layer_id
             WHERE sl.service_name = @serviceName
+            GROUP BY
+                l.layer_id,
+                l.layer_name,
+                l.description,
+                l.table_schema,
+                l.table_name,
+                l.primary_key_column,
+                l.geometry_type,
+                l.srid,
+                l.enabled
             ORDER BY l.layer_id;
             """;
 
@@ -69,10 +84,11 @@ internal sealed partial class PostgreSqlLayerPublishingService(
                 Description = reader.IsDBNull(2) ? null : reader.GetString(2),
                 Schema = reader.GetString(3),
                 Table = reader.GetString(4),
-                GeometryType = reader.GetString(5),
-                Srid = reader.GetInt32(6),
-                Enabled = reader.GetBoolean(7),
-                FieldCount = 0,
+                PrimaryKey = reader.IsDBNull(5) ? null : reader.GetString(5),
+                GeometryType = reader.GetString(6),
+                Srid = reader.GetInt32(7),
+                Enabled = reader.GetBoolean(8),
+                FieldCount = reader.GetInt32(9),
                 ServiceName = normalizedService
             });
         }
@@ -195,6 +211,14 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
 
         await EnsureServiceAsync(connection, transaction, serviceName, srid, request.ConnectionId, cancellationToken);
+        var extent = await ReadLayerExtentAsync(
+            connection,
+            transaction,
+            schema,
+            table,
+            geometryColumn,
+            srid,
+            cancellationToken);
 
         var existingLayerId = await FindExistingLayerAsync(connection, transaction, schema, table, cancellationToken);
         if (existingLayerId.HasValue)
@@ -217,6 +241,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
             geometryColumn,
             geometryType,
             srid,
+            extent,
             request.Enabled,
             cancellationToken);
 
@@ -565,6 +590,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         string geometryColumn,
         string geometryType,
         int srid,
+        LayerExtentInsert? extent,
         bool enabled,
         CancellationToken cancellationToken)
     {
@@ -576,13 +602,32 @@ internal sealed partial class PostgreSqlLayerPublishingService(
                 table_name,
                 primary_key_column,
                 geometry_column,
+                storage_options,
                 storage_srid,
                 geometry_type,
                 srid,
+                extent,
                 default_visibility,
                 enabled
             )
-            VALUES (@name, @description, @schema, @table, @primaryKeyColumn, @geometryColumn, @srid, @geometryType, @srid, TRUE, @enabled)
+            VALUES (
+                @name,
+                @description,
+                @schema,
+                @table,
+                @primaryKeyColumn,
+                @geometryColumn,
+                @storageOptions,
+                @srid,
+                @geometryType,
+                @srid,
+                CASE
+                    WHEN @extentMinX IS NULL THEN NULL
+                    ELSE ST_MakeEnvelope(@extentMinX, @extentMinY, @extentMaxX, @extentMaxY, @srid)
+                END,
+                TRUE,
+                @enabled
+            )
             RETURNING layer_id;
             """;
 
@@ -593,8 +638,13 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         command.Parameters.AddWithValue("@table", table);
         command.Parameters.AddWithValue("@primaryKeyColumn", primaryKeyColumn);
         command.Parameters.AddWithValue("@geometryColumn", geometryColumn);
+        command.Parameters.Add("@storageOptions", NpgsqlDbType.Jsonb).Value = SourceBackedStorageOptionsJson;
         command.Parameters.AddWithValue("@geometryType", geometryType);
         command.Parameters.AddWithValue("@srid", srid);
+        command.Parameters.AddWithValue("@extentMinX", (object?)extent?.MinX ?? DBNull.Value);
+        command.Parameters.AddWithValue("@extentMinY", (object?)extent?.MinY ?? DBNull.Value);
+        command.Parameters.AddWithValue("@extentMaxX", (object?)extent?.MaxX ?? DBNull.Value);
+        command.Parameters.AddWithValue("@extentMaxY", (object?)extent?.MaxY ?? DBNull.Value);
         command.Parameters.AddWithValue("@enabled", enabled);
 
         var result = await command.ExecuteScalarAsync(cancellationToken);
@@ -606,6 +656,42 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         }
 
         return layerId;
+    }
+
+    private static async Task<LayerExtentInsert?> ReadLayerExtentAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string schema,
+        string table,
+        string geometryColumn,
+        int srid,
+        CancellationToken cancellationToken)
+    {
+        var qualifiedTable = $"{QuoteIdentifier(schema)}.{QuoteIdentifier(table)}";
+        var quotedGeometryColumn = QuoteIdentifier(geometryColumn);
+        var sql = $"""
+            SELECT ST_XMin(extent), ST_YMin(extent), ST_XMax(extent), ST_YMax(extent)
+            FROM (
+                SELECT ST_Extent({quotedGeometryColumn}::geometry) AS extent
+                FROM {qualifiedTable}
+                WHERE {quotedGeometryColumn} IS NOT NULL
+                  AND ST_SRID({quotedGeometryColumn}::geometry) IN (0, @srid)
+            ) AS extent_query;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("@srid", srid);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken) || reader.IsDBNull(0))
+        {
+            return null;
+        }
+
+        return new LayerExtentInsert(
+            reader.GetDouble(0),
+            reader.GetDouble(1),
+            reader.GetDouble(2),
+            reader.GetDouble(3));
     }
 
     private static async Task EnsureLayerSequenceAsync(
@@ -983,14 +1069,28 @@ internal sealed partial class PostgreSqlLayerPublishingService(
                 l.description,
                 l.table_schema,
                 l.table_name,
+                l.primary_key_column,
                 l.geometry_type,
                 l.srid,
-                l.enabled
+                l.enabled,
+                COUNT(f.field_name)::int AS field_count
             FROM honua.layers l
             INNER JOIN honua.service_layers sl
                 ON sl.layer_id = l.layer_id
+            LEFT JOIN honua.layer_fields f
+                ON f.layer_id = l.layer_id
             WHERE sl.service_name = @serviceName
-                AND l.layer_id = @layerId;
+                AND l.layer_id = @layerId
+            GROUP BY
+                l.layer_id,
+                l.layer_name,
+                l.description,
+                l.table_schema,
+                l.table_name,
+                l.primary_key_column,
+                l.geometry_type,
+                l.srid,
+                l.enabled;
             """;
 
         await using var command = new NpgsqlCommand(sql, connection, transaction);
@@ -1010,10 +1110,11 @@ internal sealed partial class PostgreSqlLayerPublishingService(
             Description = reader.IsDBNull(2) ? null : reader.GetString(2),
             Schema = reader.GetString(3),
             Table = reader.GetString(4),
-            GeometryType = reader.GetString(5),
-            Srid = reader.GetInt32(6),
-            Enabled = reader.GetBoolean(7),
-            FieldCount = 0,
+            PrimaryKey = reader.IsDBNull(5) ? null : reader.GetString(5),
+            GeometryType = reader.GetString(6),
+            Srid = reader.GetInt32(7),
+            Enabled = reader.GetBoolean(8),
+            FieldCount = reader.GetInt32(9),
             ServiceName = serviceName
         };
     }
@@ -1058,4 +1159,10 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         bool Nullable,
         string? Description,
         object? DefaultValue = null);
+
+    private sealed record LayerExtentInsert(
+        double MinX,
+        double MinY,
+        double MaxX,
+        double MaxY);
 }

--- a/src/Honua.Postgres/Features/FeatureStore/PostgresFeatureStore.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/PostgresFeatureStore.cs
@@ -10,8 +10,12 @@ using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Infrastructure.Monitoring;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Security.Abstractions;
 using Honua.Postgres.Features.FeatureStore.Services;
+using Microsoft.Extensions.ObjectPool;
 using CoreGeometryStorageType = Honua.Core.Features.FeatureStore.Abstractions.GeometryStorageType;
 
 namespace Honua.Postgres.Features.FeatureStore;
@@ -32,12 +36,15 @@ namespace Honua.Postgres.Features.FeatureStore;
 /// 'field = value', 'age > 18') and properly parameterizes all literal values while
 /// validating field names to prevent SQL injection attacks.</para>
 /// </remarks>
-internal sealed class PostgresFeatureStoreRefactored : IFeatureDataProvider, IFeatureReader, IRasterPointReader, IFeatureWriter, ITileProvider, IRelationshipStore, IGeoJsonFeatureStore, IGeobufFeatureStore, IFlatGeobufFeatureStore, IGmlFeatureStore, IKmlFeatureStore, IStreamingFeatureStore, IPagedFeatureReader, IPagedGeoJsonFeatureStore, IPagedRawGeoJsonFeatureStore, IPagedRawGeoServicesFeatureStore
+internal sealed class PostgresFeatureStoreRefactored : IFeatureDataProvider, IFeatureReader, IBindableFeatureDataProvider, IRasterPointReader, IFeatureWriter, ITileProvider, IRelationshipStore, IGeoJsonFeatureStore, IGeobufFeatureStore, IFlatGeobufFeatureStore, IGmlFeatureStore, IKmlFeatureStore, IStreamingFeatureStore, IPagedFeatureReader, IPagedGeoJsonFeatureStore, IPagedRawGeoJsonFeatureStore, IPagedRawGeoServicesFeatureStore
 {
     private readonly IFeatureQueryBuilder _queryBuilder;
     private readonly IFeatureDataAccess _dataAccess;
     private readonly IFeatureCacheManager _cacheManager;
     private readonly ILayerCatalog? _layerCatalog;
+    private readonly IDatabaseConnectionProvider? _connectionProvider;
+    private readonly ObjectPool<Dictionary<string, object?>>? _dictionaryPool;
+    private readonly IConnectionEncryptionService? _connectionEncryptionService;
 
     public PostgresFeatureStoreRefactored(
         IFeatureQueryBuilder queryBuilder,
@@ -52,11 +59,33 @@ internal sealed class PostgresFeatureStoreRefactored : IFeatureDataProvider, IFe
         IFeatureDataAccess dataAccess,
         IFeatureCacheManager cacheManager,
         ILayerCatalog? layerCatalog)
+        : this(
+            queryBuilder,
+            dataAccess,
+            cacheManager,
+            layerCatalog,
+            connectionProvider: null,
+            dictionaryPool: null,
+            connectionEncryptionService: null)
+    {
+    }
+
+    public PostgresFeatureStoreRefactored(
+        IFeatureQueryBuilder queryBuilder,
+        IFeatureDataAccess dataAccess,
+        IFeatureCacheManager cacheManager,
+        ILayerCatalog? layerCatalog,
+        IDatabaseConnectionProvider? connectionProvider,
+        ObjectPool<Dictionary<string, object?>>? dictionaryPool,
+        IConnectionEncryptionService? connectionEncryptionService)
     {
         _queryBuilder = queryBuilder ?? throw new ArgumentNullException(nameof(queryBuilder));
         _dataAccess = dataAccess ?? throw new ArgumentNullException(nameof(dataAccess));
         _cacheManager = cacheManager ?? throw new ArgumentNullException(nameof(cacheManager));
         _layerCatalog = layerCatalog;
+        _connectionProvider = connectionProvider;
+        _dictionaryPool = dictionaryPool;
+        _connectionEncryptionService = connectionEncryptionService;
     }
 
     public string ProviderName => DataProviderNames.Postgis;
@@ -66,6 +95,23 @@ internal sealed class PostgresFeatureStoreRefactored : IFeatureDataProvider, IFe
     public IFeatureReader Reader => this;
 
     public IFeatureWriter Writer => this;
+
+    public IFeatureReader CreateReaderForBinding(FeatureProviderBinding binding)
+    {
+        ArgumentNullException.ThrowIfNull(binding);
+
+        if (_connectionProvider == null || _dictionaryPool == null)
+        {
+            return this;
+        }
+
+        return new PostgresStorageMappedFeatureReader(
+            _connectionProvider,
+            _dictionaryPool,
+            binding.Layer,
+            binding.Connection,
+            _connectionEncryptionService);
+    }
 
     #region Core CRUD Operations
 

--- a/src/Honua.Postgres/Features/FeatureStore/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/ServiceCollectionExtensions.cs
@@ -3,9 +3,11 @@
 
 using System.Text;
 using Honua.Core.Configuration;
+using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Monitoring;
+using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.SpatialAnalytics.Abstractions;
 using Honua.Postgres.Features.FeatureStore.Services;
 using Honua.Postgres.Features.Infrastructure.Caching;
@@ -80,8 +82,16 @@ internal static class ServiceCollectionExtensions
             return new FeatureDataAccess(dependencies);
         });
 
-        // Register the main feature store implementation
-        services.AddScoped<PostgresFeatureStoreRefactored>();
+        // Register the main feature store implementation.
+        services.AddScoped<PostgresFeatureStoreRefactored>(provider =>
+            new PostgresFeatureStoreRefactored(
+                provider.GetRequiredService<IFeatureQueryBuilder>(),
+                provider.GetRequiredService<IFeatureDataAccess>(),
+                provider.GetRequiredService<IFeatureCacheManager>(),
+                provider.GetService<ILayerCatalog>(),
+                provider.GetRequiredService<IDatabaseConnectionProvider>(),
+                provider.GetRequiredService<ObjectPool<Dictionary<string, object?>>>(),
+                provider.GetService<IConnectionEncryptionService>()));
 
         // Register segregated interfaces
         services.AddScoped<IFeatureDataProvider>(provider => provider.GetRequiredService<PostgresFeatureStoreRefactored>());

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
@@ -1,0 +1,1016 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.Core.Features.Security.Domain;
+using Honua.Core.Features.Shared.Models;
+using Honua.Core.Queries.Filters;
+using Honua.Postgres.Features.Infrastructure;
+using Microsoft.Extensions.ObjectPool;
+using Npgsql;
+
+namespace Honua.Postgres.Features.FeatureStore.Services;
+
+/// <summary>
+/// Reads a provider-bound PostGIS table directly from the storage mapping persisted in the catalog.
+/// </summary>
+internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReader, IPagedFeatureReader, IStreamingFeatureStore
+{
+    private const string UnsupportedWhereClauseMessage =
+        "WHERE clause format not supported for source-backed PostGIS layers.";
+
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly ObjectPool<Dictionary<string, object?>> _dictionaryPool;
+    private readonly LayerDefinition _layer;
+    private readonly LayerStorageMapping _mapping;
+    private readonly DataConnection? _connection;
+    private readonly IConnectionEncryptionService? _connectionEncryptionService;
+    private readonly string _qualifiedTableName;
+    private readonly string _primaryKeyColumn;
+    private readonly string? _geometryColumn;
+
+    public PostgresStorageMappedFeatureReader(
+        IDatabaseConnectionProvider connectionProvider,
+        ObjectPool<Dictionary<string, object?>> dictionaryPool,
+        LayerDefinition layer,
+        DataConnection? connection,
+        IConnectionEncryptionService? connectionEncryptionService)
+    {
+        _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+        _dictionaryPool = dictionaryPool ?? throw new ArgumentNullException(nameof(dictionaryPool));
+        _layer = layer ?? throw new ArgumentNullException(nameof(layer));
+        _mapping = layer.StorageMapping
+            ?? throw new InvalidOperationException($"Layer '{layer.Name}' does not define a runtime storage mapping.");
+        _connection = connection;
+        _connectionEncryptionService = connectionEncryptionService;
+        _qualifiedTableName = QuoteQualifiedTableName(_mapping);
+        _primaryKeyColumn = ValidateAndQuoteIdentifier(_mapping.PrimaryKeyColumn);
+        _geometryColumn = string.IsNullOrWhiteSpace(_mapping.GeometryColumn)
+            ? null
+            : ValidateAndQuoteIdentifier(_mapping.GeometryColumn!);
+    }
+
+    public async Task<Feature?> GetAsync(int layerId, long featureId, CancellationToken cancellationToken = default)
+    {
+        var query = new FeatureQuery
+        {
+            ObjectIds = ImmutableArray.Create(featureId),
+            Limit = 1
+        };
+
+        var result = await QueryAsync(layerId, query, cancellationToken).ConfigureAwait(false);
+        return result.Items.Length == 0 ? null : result.Items[0];
+    }
+
+    public async Task<QueryResult<Feature>> QueryAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        if (IsNearestNeighborQuery(query))
+        {
+            var nearestItems = await ExecuteFeatureQueryAsync(query, probeLimit: false, cancellationToken).ConfigureAwait(false);
+            return nearestItems.Length == 0
+                ? QueryResult<Feature>.Empty()
+                : QueryResult<Feature>.Create(nearestItems.Length, nearestItems, hasMoreResults: false);
+        }
+
+        var totalCount = await CountAsync(layerId, query, cancellationToken).ConfigureAwait(false);
+        if (totalCount == 0)
+        {
+            return QueryResult<Feature>.Empty();
+        }
+
+        var items = await ExecuteFeatureQueryAsync(query, probeLimit: false, cancellationToken).ConfigureAwait(false);
+        var offset = query.Offset.GetValueOrDefault();
+        var hasMoreResults = offset + items.Length < totalCount;
+        return QueryResult<Feature>.Create(totalCount, items, hasMoreResults);
+    }
+
+    public Task<byte[]?> QueryFlatGeobufAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("FlatGeobuf output is not supported for source-backed PostGIS layers yet.");
+
+    public async Task<ImmutableArray<long>> QueryObjectIdsAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = new SqlBuilder();
+        sql.Append(CultureInfo.InvariantCulture, $"SELECT {_primaryKeyColumn}::bigint FROM {_qualifiedTableName}");
+        AppendFilter(sql, query);
+        AppendOrderBy(sql, query);
+        AppendPagination(sql, query);
+
+        var objectIds = ImmutableArray.CreateBuilder<long>();
+        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = CreateReadCommand(connection, sql);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            objectIds.Add(reader.GetInt64(0));
+        }
+
+        return objectIds.ToImmutable();
+    }
+
+    public async Task<long> CountAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = new SqlBuilder();
+        sql.Append(CultureInfo.InvariantCulture, $"SELECT COUNT(*)::bigint FROM {_qualifiedTableName}");
+        AppendFilter(sql, query);
+
+        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = CreateReadCommand(connection, sql);
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return Convert.ToInt64(result, CultureInfo.InvariantCulture);
+    }
+
+    public async Task<FeatureExtent?> GetExtentAsync(
+        int layerId,
+        FeatureQuery? query = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (_geometryColumn == null)
+        {
+            return null;
+        }
+
+        var effectiveQuery = query ?? new FeatureQuery();
+        var geometryExpression = BuildGeometryExpression(effectiveQuery);
+        var sql = new SqlBuilder();
+        sql.Append(CultureInfo.InvariantCulture, $"""
+            SELECT ST_XMin(extent), ST_YMin(extent), ST_XMax(extent), ST_YMax(extent)
+            FROM (
+                SELECT ST_Extent({geometryExpression}) AS extent
+                FROM {_qualifiedTableName}
+            """);
+        AppendFilter(sql, effectiveQuery, prefix: "WHERE");
+        sql.Append(CultureInfo.InvariantCulture, $"""
+
+                  {BuildWhereJoiner(sql)} {geometryExpression} IS NOT NULL
+            ) AS extent_query
+            """);
+
+        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = CreateReadCommand(connection, sql);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false) || reader.IsDBNull(0))
+        {
+            return null;
+        }
+
+        var srid = effectiveQuery.OutputSrid ?? _mapping.StorageSrid ?? _layer.SpatialReference.Wkid;
+        return FeatureExtent.Create(
+            reader.GetDouble(0),
+            reader.GetDouble(1),
+            reader.GetDouble(2),
+            reader.GetDouble(3),
+            srid);
+    }
+
+    public Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryStatisticsAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Statistics are not supported for source-backed PostGIS layers yet.");
+
+    public Task<TemporalExtentResult?> GetTemporalExtentAsync(
+        int layerId,
+        string fieldName,
+        FieldType fieldType,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Temporal extents are not supported for source-backed PostGIS layers yet.");
+
+    public async Task<EstimateResult> GetEstimatesAsync(int layerId, CancellationToken cancellationToken = default)
+    {
+        var countTask = CountAsync(layerId, new FeatureQuery(), cancellationToken);
+        var extentTask = GetExtentAsync(layerId, null, cancellationToken);
+        await Task.WhenAll(countTask, extentTask).ConfigureAwait(false);
+
+        return new EstimateResult
+        {
+            EstimatedCount = await countTask.ConfigureAwait(false),
+            Extent = await extentTask.ConfigureAwait(false)
+        };
+    }
+
+    public Task<QueryResult<Feature>> QueryTopFeaturesAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Top-feature queries are not supported for source-backed PostGIS layers yet.");
+
+    public Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryDateBinsAsync(
+        int layerId,
+        FeatureQuery query,
+        DateBinDefinition dateBin,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Date bins are not supported for source-backed PostGIS layers yet.");
+
+    public Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryBinsAsync(
+        int layerId,
+        FeatureQuery query,
+        BinDefinition binDefinition,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Bins are not supported for source-backed PostGIS layers yet.");
+
+    public Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryH3Async(
+        int layerId,
+        FeatureQuery query,
+        H3AggregationQuery h3Query,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("H3 queries are not supported for source-backed PostGIS layers yet.");
+
+    public async Task<PagedQueryResult<Feature>> QueryPageAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        if (!query.Limit.HasValue || query.Limit.Value == int.MaxValue)
+        {
+            var result = await QueryAsync(layerId, query, cancellationToken).ConfigureAwait(false);
+            return PagedQueryResult<Feature>.Create(result.Items, result.HasMoreResults, result.TotalCount);
+        }
+
+        var items = await ExecuteFeatureQueryAsync(query, probeLimit: true, cancellationToken).ConfigureAwait(false);
+        if (items.Length == 0)
+        {
+            return PagedQueryResult<Feature>.Empty();
+        }
+
+        var hasMoreResults = items.Length > query.Limit.Value;
+        if (hasMoreResults)
+        {
+            items = items.RemoveAt(items.Length - 1);
+        }
+
+        return PagedQueryResult<Feature>.Create(items, hasMoreResults);
+    }
+
+    public async IAsyncEnumerable<Feature> StreamFeaturesAsync(
+        int layerId,
+        FeatureQuery query,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var sql = BuildFeatureSelect(query, probeLimit: false);
+        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = CreateReadCommand(connection, sql);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            yield return ReadFeature(reader);
+        }
+    }
+
+    public async IAsyncEnumerable<IReadOnlyList<Feature>> StreamFeatureBatchesAsync(
+        int layerId,
+        FeatureQuery query,
+        int batchSize = 1000,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var batch = new List<Feature>(Math.Max(1, batchSize));
+        await foreach (var feature in StreamFeaturesAsync(layerId, query, cancellationToken)
+                           .WithCancellation(cancellationToken))
+        {
+            batch.Add(feature);
+            if (batch.Count >= batchSize)
+            {
+                yield return batch.ToArray();
+                batch.Clear();
+            }
+        }
+
+        if (batch.Count > 0)
+        {
+            yield return batch.ToArray();
+        }
+    }
+
+    public IAsyncEnumerable<GmlFeature> StreamGmlFeaturesAsync(
+        int layerId,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("GML streaming is not supported for source-backed PostGIS layers yet.");
+
+    private async Task<ImmutableArray<Feature>> ExecuteFeatureQueryAsync(
+        FeatureQuery query,
+        bool probeLimit,
+        CancellationToken cancellationToken)
+    {
+        var sql = BuildFeatureSelect(query, probeLimit);
+        var features = ImmutableArray.CreateBuilder<Feature>();
+
+        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = CreateReadCommand(connection, sql);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            features.Add(ReadFeature(reader));
+        }
+
+        return features.ToImmutable();
+    }
+
+    private SqlBuilder BuildFeatureSelect(FeatureQuery query, bool probeLimit)
+    {
+        var sql = new SqlBuilder();
+        var geometrySelect = _geometryColumn == null
+            ? "NULL"
+            : $"ST_AsBinary({BuildGeometryExpression(query)})";
+        var attributesSelect = BuildAttributesExpression(query);
+        var distanceSelect = BuildDistanceSelectExpression(query, sql);
+
+        sql.Append(CultureInfo.InvariantCulture, $"""
+            SELECT {_primaryKeyColumn}::bigint AS objectid,
+                   {geometrySelect} AS geometry,
+                   {attributesSelect} AS attributes{distanceSelect}
+            FROM {_qualifiedTableName}
+            """);
+        AppendFilter(sql, query);
+        AppendOrderBy(sql, query);
+        AppendPagination(sql, query, probeLimit);
+        return sql;
+    }
+
+    private string BuildGeometryExpression(FeatureQuery query)
+    {
+        if (_geometryColumn == null)
+        {
+            return "NULL";
+        }
+
+        var geometryExpression = $"{_geometryColumn}::geometry";
+        var storageSrid = _mapping.StorageSrid ?? _layer.SpatialReference.Wkid;
+        if (query.OutputSrid.HasValue && query.OutputSrid.Value != storageSrid)
+        {
+            geometryExpression = $"ST_Transform({geometryExpression}, {query.OutputSrid.Value})";
+        }
+
+        return geometryExpression;
+    }
+
+    private string BuildAttributesExpression(FeatureQuery query)
+    {
+        if (query.ExcludeAttributes)
+        {
+            return "NULL";
+        }
+
+        var fields = ResolveAttributeFields(query);
+        if (fields.Length == 0)
+        {
+            return "'{}'::jsonb::text";
+        }
+
+        var parts = new List<string>(fields.Length * 2);
+        foreach (var field in fields)
+        {
+            parts.Add($"'{EscapeSqlLiteral(field.Name)}'");
+            parts.Add(ValidateAndQuoteIdentifier(field.Name));
+        }
+
+        return $"jsonb_build_object({string.Join(", ", parts)})::text";
+    }
+
+    private FieldDefinition[] ResolveAttributeFields(FeatureQuery query)
+    {
+        var declaredFields = _layer.Fields
+            .Where(field => !field.IsGeometry && IsSafeIdentifier(field.Name))
+            .ToArray();
+
+        if (!query.OutFields.HasValue || query.OutFields.Value.IsDefault)
+        {
+            return declaredFields;
+        }
+
+        if (query.OutFields.Value.IsEmpty)
+        {
+            return [];
+        }
+
+        var requested = query.OutFields.Value.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return declaredFields
+            .Where(field => requested.Contains(field.Name))
+            .ToArray();
+    }
+
+    private void AppendFilter(SqlBuilder sql, FeatureQuery query, string prefix = "WHERE")
+    {
+        var conditions = new List<string>();
+
+        if (query.SqlFilter != null)
+        {
+            conditions.Add(ConvertSqlFilter(query.SqlFilter, sql));
+        }
+        else if (!string.IsNullOrWhiteSpace(query.Where))
+        {
+            conditions.Add(ParseWhereClause(query.Where!, sql));
+        }
+
+        if (query.ObjectIds.HasValue && !query.ObjectIds.Value.IsDefaultOrEmpty)
+        {
+            conditions.Add($"{_primaryKeyColumn} = ANY({sql.AddParameter(query.ObjectIds.Value.ToArray())})");
+        }
+
+        if (query.SpatialFilter.HasValue && _geometryColumn != null)
+        {
+            conditions.Add(BuildSpatialFilter(query.SpatialFilter.Value, sql));
+        }
+
+        if (conditions.Count == 0)
+        {
+            return;
+        }
+
+        sql.Append(CultureInfo.InvariantCulture, $" {prefix} ");
+        sql.Append(
+            CultureInfo.InvariantCulture,
+            string.Join(" AND ", conditions.Select(static condition => $"({condition})")));
+    }
+
+    private static string BuildWhereJoiner(SqlBuilder sql)
+        => sql.TextContainsWhere ? "AND" : "WHERE";
+
+    private string ConvertSqlFilter(SqlFragment sqlFilter, SqlBuilder sql)
+    {
+        var converted = SqlFilterParameterRegex().Replace(
+            sqlFilter.Sql,
+            match =>
+            {
+                var index = int.Parse(match.Groups["index"].Value, CultureInfo.InvariantCulture);
+                if ((uint)index >= (uint)sqlFilter.Parameters.Count)
+                {
+                    throw new ArgumentException(UnsupportedWhereClauseMessage);
+                }
+
+                return sql.AddParameter(sqlFilter.Parameters[index]);
+            });
+
+        return QuotedIdentifierRegex().Replace(
+            converted,
+            match =>
+            {
+                var identifier = match.Groups["identifier"].Value.Replace("\"\"", "\"", StringComparison.Ordinal);
+                return ResolveColumnExpression(identifier);
+            });
+    }
+
+    private string BuildSpatialFilter(SpatialFilter filter, SqlBuilder sql)
+    {
+        var geometryColumn = $"{_geometryColumn}::geometry";
+        if (filter.SpatialRelationship == SpatialRelationship.NearestNeighbor)
+        {
+            return $"{geometryColumn} IS NOT NULL";
+        }
+
+        var filterGeometry = BuildFilterGeometryExpression(filter, sql);
+
+        return filter.SpatialRelationship switch
+        {
+            SpatialRelationship.Within => $"ST_Within({geometryColumn}, {filterGeometry})",
+            SpatialRelationship.Contains => $"ST_Contains({geometryColumn}, {filterGeometry})",
+            SpatialRelationship.EnvelopeIntersects => $"{geometryColumn} && {filterGeometry}",
+            SpatialRelationship.Crosses => $"ST_Crosses({geometryColumn}, {filterGeometry})",
+            SpatialRelationship.Touches => $"ST_Touches({geometryColumn}, {filterGeometry})",
+            SpatialRelationship.Overlaps => $"ST_Overlaps({geometryColumn}, {filterGeometry})",
+            SpatialRelationship.Disjoint => $"ST_Disjoint({geometryColumn}, {filterGeometry})",
+            SpatialRelationship.Equals => $"ST_Equals({geometryColumn}, {filterGeometry})",
+            SpatialRelationship.WithinDistance => BuildDistancePredicate(geometryColumn, filterGeometry, filter, sql, beyond: false),
+            SpatialRelationship.BeyondDistance => BuildDistancePredicate(geometryColumn, filterGeometry, filter, sql, beyond: true),
+            _ => $"ST_Intersects({geometryColumn}, {filterGeometry})"
+        };
+    }
+
+    private string BuildFilterGeometryExpression(SpatialFilter filter, SqlBuilder sql)
+    {
+        if (filter.IsSimpleEnvelope &&
+            filter.EnvelopeMinX.HasValue &&
+            filter.EnvelopeMinY.HasValue &&
+            filter.EnvelopeMaxX.HasValue &&
+            filter.EnvelopeMaxY.HasValue)
+        {
+            var minX = sql.AddParameter(filter.EnvelopeMinX.Value);
+            var minY = sql.AddParameter(filter.EnvelopeMinY.Value);
+            var maxX = sql.AddParameter(filter.EnvelopeMaxX.Value);
+            var maxY = sql.AddParameter(filter.EnvelopeMaxY.Value);
+            var srid = filter.Srid ?? _mapping.StorageSrid ?? _layer.SpatialReference.Wkid;
+            var envelope = $"ST_MakeEnvelope({minX}, {minY}, {maxX}, {maxY}, {srid})";
+            return TransformFilterGeometryIfNeeded(envelope, srid);
+        }
+
+        var geometryParameter = sql.AddParameter(filter.Geometry);
+        var sourceSrid = filter.Srid ?? _mapping.StorageSrid ?? _layer.SpatialReference.Wkid;
+        var rawGeometry = $"ST_GeomFromEWKB({geometryParameter})";
+        var geometry = $"ST_SetSRID({rawGeometry}, COALESCE(NULLIF(ST_SRID({rawGeometry}), 0), {sourceSrid}))";
+        return TransformFilterGeometryIfNeeded(geometry, sourceSrid);
+    }
+
+    private string TransformFilterGeometryIfNeeded(string geometryExpression, int sourceSrid)
+    {
+        var targetSrid = _mapping.StorageSrid ?? _layer.SpatialReference.Wkid;
+        return sourceSrid == targetSrid
+            ? geometryExpression
+            : $"ST_Transform({geometryExpression}, {targetSrid})";
+    }
+
+    private static string BuildDistancePredicate(
+        string geometryColumn,
+        string filterGeometry,
+        SpatialFilter filter,
+        SqlBuilder sql,
+        bool beyond)
+    {
+        var distance = ConvertDistanceToMeters(filter.Distance ?? 0d, filter.DistanceUnit);
+        var operatorText = beyond ? ">" : "<=";
+        return $"ST_Distance({geometryColumn}::geography, {filterGeometry}::geography) {operatorText} {sql.AddParameter(distance)}";
+    }
+
+    private static double ConvertDistanceToMeters(double distance, DistanceUnit unit)
+        => unit switch
+        {
+            DistanceUnit.Feet => distance * 0.3048d,
+            DistanceUnit.Kilometers => distance * 1000d,
+            DistanceUnit.Miles => distance * 1609.344d,
+            _ => distance
+        };
+
+    private void AppendOrderBy(SqlBuilder sql, FeatureQuery query)
+    {
+        if (IsNearestNeighborQuery(query))
+        {
+            sql.Append(CultureInfo.InvariantCulture, $" ORDER BY {BuildNearestNeighborOrderExpression(query, sql)}");
+            return;
+        }
+
+        if (query.OrderBy.HasValue && !query.OrderBy.Value.IsDefaultOrEmpty)
+        {
+            var clauses = new List<string>();
+            foreach (var clause in query.OrderBy.Value)
+            {
+                var column = ResolveColumnExpression(clause.Field);
+                clauses.Add($"{column} {(clause.Ascending ? "ASC" : "DESC")}");
+            }
+
+            sql.Append(CultureInfo.InvariantCulture, $" ORDER BY {string.Join(", ", clauses)}");
+            return;
+        }
+
+        sql.Append(CultureInfo.InvariantCulture, $" ORDER BY {_primaryKeyColumn}");
+    }
+
+    private static void AppendPagination(SqlBuilder sql, FeatureQuery query, bool probeLimit = false)
+    {
+        var spatialFilter = query.SpatialFilter;
+        var isNearestNeighbor = spatialFilter.HasValue &&
+                                spatialFilter.Value.SpatialRelationship == SpatialRelationship.NearestNeighbor;
+        var nearestCount = isNearestNeighbor
+            ? spatialFilter.GetValueOrDefault().NearestCount
+            : null;
+        var limit = isNearestNeighbor
+            ? nearestCount ?? query.Limit
+            : query.Limit;
+
+        if (limit.HasValue)
+        {
+            var effectiveLimit = probeLimit && !isNearestNeighbor
+                ? checked(limit.Value + 1)
+                : limit.Value;
+            sql.Append(CultureInfo.InvariantCulture, $" LIMIT {sql.AddParameter(effectiveLimit)}");
+        }
+
+        if (query.Offset.HasValue)
+        {
+            sql.Append(CultureInfo.InvariantCulture, $" OFFSET {sql.AddParameter(query.Offset.Value)}");
+        }
+    }
+
+    private string ParseWhereClause(string whereClause, SqlBuilder sql)
+    {
+        var trimmed = whereClause.Trim();
+        if (TrueLiteralRegex().IsMatch(trimmed))
+        {
+            return "TRUE";
+        }
+
+        var expressions = SplitOnAnd(trimmed);
+        if (expressions.Count == 0)
+        {
+            throw new ArgumentException(UnsupportedWhereClauseMessage);
+        }
+
+        var parameterizedExpressions = new List<string>(expressions.Count);
+        foreach (var expression in expressions)
+        {
+            var part = expression.Trim();
+            var nullMatch = NullCheckRegex().Match(part);
+            if (nullMatch.Success)
+            {
+                var nullColumn = ResolveColumnExpression(nullMatch.Groups["field"].Value);
+                var notClause = string.IsNullOrWhiteSpace(nullMatch.Groups["not"].Value) ? string.Empty : "NOT ";
+                parameterizedExpressions.Add($"{nullColumn} IS {notClause}NULL");
+                continue;
+            }
+
+            var comparisonMatch = ComparisonRegex().Match(part);
+            if (!comparisonMatch.Success)
+            {
+                throw new ArgumentException(UnsupportedWhereClauseMessage);
+            }
+
+            var column = ResolveColumnExpression(comparisonMatch.Groups["field"].Value);
+            var normalizedOperator = NormalizeOperator(comparisonMatch.Groups["op"].Value);
+            var value = ParseValueToken(
+                comparisonMatch.Groups["value"].Value,
+                normalizedOperator.Contains("LIKE", StringComparison.OrdinalIgnoreCase));
+            parameterizedExpressions.Add($"{column} {normalizedOperator} {sql.AddParameter(value)}");
+        }
+
+        return string.Join(" AND ", parameterizedExpressions);
+    }
+
+    private string ResolveColumnExpression(string fieldName)
+    {
+        if (fieldName.Equals("objectid", StringComparison.OrdinalIgnoreCase) ||
+            fieldName.Equals("object_id", StringComparison.OrdinalIgnoreCase))
+        {
+            return _primaryKeyColumn;
+        }
+
+        var field = _layer.Fields.FirstOrDefault(candidate =>
+            candidate.Name.Equals(fieldName, StringComparison.OrdinalIgnoreCase));
+        if (field == null)
+        {
+            throw new ArgumentException($"Field '{fieldName}' was not found on layer '{_layer.Name}'.");
+        }
+
+        if (field.IsGeometry)
+        {
+            if (_geometryColumn == null)
+            {
+                throw new ArgumentException($"Layer '{_layer.Name}' does not define a geometry column.");
+            }
+
+            return _geometryColumn;
+        }
+
+        return ValidateAndQuoteIdentifier(field.Name);
+    }
+
+    private Feature ReadFeature(NpgsqlDataReader reader)
+    {
+        var id = reader.GetInt64(0);
+        var geometry = reader.IsDBNull(1) ? null : reader.GetFieldValue<byte[]>(1);
+        var attributesJson = reader.IsDBNull(2) ? null : reader.GetString(2);
+        var attributesDictionary = _dictionaryPool.Get();
+
+        try
+        {
+            var deserialized = string.IsNullOrWhiteSpace(attributesJson)
+                ? new Dictionary<string, object?>()
+                : JsonSerializer.Deserialize(
+                    attributesJson,
+                    FeatureAttributesJsonContext.Default.DictionaryStringObject) ?? new Dictionary<string, object?>();
+
+            foreach (var (key, value) in deserialized)
+            {
+                attributesDictionary[key] = value is JsonElement element
+                    ? JsonElementConverter.ConvertToScalar(element)
+                    : value;
+            }
+
+            attributesDictionary[FieldNames.ObjectId] = id;
+            if (reader.FieldCount > 3)
+            {
+                for (var i = 3; i < reader.FieldCount; i++)
+                {
+                    var fieldName = reader.GetName(i);
+                    if (fieldName.Equals(FeatureQueryEncoding.InternalDistanceColumn, StringComparison.OrdinalIgnoreCase))
+                    {
+                        attributesDictionary[FeatureQueryEncoding.PublicDistanceColumn] = reader.IsDBNull(i)
+                            ? null
+                            : reader.GetFieldValue<double>(i);
+                    }
+                }
+            }
+
+            return Feature.Create(id, geometry, attributesDictionary.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            attributesDictionary.Clear();
+            _dictionaryPool.Return(attributesDictionary);
+        }
+    }
+
+    private async Task<NpgsqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connectionString = await ResolveBoundConnectionStringAsync().ConfigureAwait(false);
+        if (connectionString == null)
+        {
+            return await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+
+    private async Task<string?> ResolveBoundConnectionStringAsync()
+    {
+        if (_connection == null)
+        {
+            return null;
+        }
+
+        if (!_connection.IsEncrypted && !string.IsNullOrWhiteSpace(_connection.ConnectionString))
+        {
+            return _connection.ConnectionString;
+        }
+
+        if (_connection.EncryptedConnectionString.Length > 0 && _connectionEncryptionService != null)
+        {
+            return await _connectionEncryptionService
+                .DecryptConnectionStringAsync(_connection.EncryptedConnectionString, _connection.EncryptionKeyVersion)
+                .ConfigureAwait(false);
+        }
+
+        return null;
+    }
+
+    private static NpgsqlCommand CreateReadCommand(NpgsqlConnection connection, SqlBuilder sql)
+    {
+        var command = PostgresSqlSafety.CreateReadCommand(connection, sql.ToString());
+        foreach (var parameter in sql.Parameters)
+        {
+            command.Parameters.AddWithValue(NormalizeParameterValue(parameter));
+        }
+
+        return command;
+    }
+
+    private static object NormalizeParameterValue(object? value)
+    {
+        return value switch
+        {
+            null => DBNull.Value,
+            DateTimeOffset dateTimeOffset => dateTimeOffset.ToUniversalTime(),
+            _ => value
+        };
+    }
+
+    private static string QuoteQualifiedTableName(LayerStorageMapping mapping)
+    {
+        var table = ValidateAndQuoteIdentifier(mapping.TableName);
+        if (string.IsNullOrWhiteSpace(mapping.SchemaName))
+        {
+            return table;
+        }
+
+        return $"{ValidateAndQuoteIdentifier(mapping.SchemaName!)}.{table}";
+    }
+
+    private static string ValidateAndQuoteIdentifier(string identifier)
+    {
+        var sanitized = identifier.Trim();
+        if (!IsSafeIdentifier(sanitized))
+        {
+            throw new InvalidOperationException($"Invalid PostGIS identifier '{identifier}'.");
+        }
+
+        return $"\"{sanitized}\"";
+    }
+
+    private static bool IsSafeIdentifier(string identifier)
+        => SchemaSearchPath.IsValidIdentifier(identifier);
+
+    private static string NormalizeOperator(string operatorValue)
+    {
+        return operatorValue.Trim().ToUpperInvariant() switch
+        {
+            "NOT LIKE" => "NOT LIKE",
+            "LIKE" => "LIKE",
+            ">=" => ">=",
+            "<=" => "<=",
+            "!=" => "!=",
+            "<>" => "!=",
+            "=" => "=",
+            ">" => ">",
+            "<" => "<",
+            _ => throw new ArgumentException(UnsupportedWhereClauseMessage)
+        };
+    }
+
+    private static object ParseValueToken(string valueToken, bool forceText)
+    {
+        if (valueToken.StartsWith('\'') && valueToken.EndsWith('\''))
+        {
+            return UnescapeSqlString(valueToken);
+        }
+
+        if (!forceText && decimal.TryParse(valueToken, NumberStyles.Float, CultureInfo.InvariantCulture, out var decimalValue))
+        {
+            return decimalValue;
+        }
+
+        return valueToken;
+    }
+
+    private static string UnescapeSqlString(string valueToken)
+    {
+        var content = valueToken[1..^1];
+        return content.Replace("''", "'", StringComparison.Ordinal);
+    }
+
+    private static string EscapeSqlLiteral(string value)
+        => value.Replace("'", "''", StringComparison.Ordinal);
+
+    private string BuildDistanceSelectExpression(FeatureQuery query, SqlBuilder sql)
+    {
+        var spatialFilter = query.SpatialFilter;
+        if (!spatialFilter.HasValue ||
+            spatialFilter.Value.SpatialRelationship != SpatialRelationship.NearestNeighbor ||
+            !spatialFilter.Value.ReturnDistance ||
+            _geometryColumn == null)
+        {
+            return string.Empty;
+        }
+
+        return $", {BuildNearestNeighborDistanceExpression(query, sql)} AS {FeatureQueryEncoding.InternalDistanceColumn}";
+    }
+
+    private string BuildNearestNeighborOrderExpression(FeatureQuery query, SqlBuilder sql)
+    {
+        if (_geometryColumn == null)
+        {
+            throw new ArgumentException($"Layer '{_layer.Name}' does not define a geometry column.");
+        }
+
+        var geometryColumn = $"{_geometryColumn}::geometry";
+        var filterGeometry = BuildFilterGeometryExpression(query.SpatialFilter!.Value, sql);
+        return ShouldUseGeodesicNearestNeighbor()
+            ? BuildGeodesicDistanceExpression(geometryColumn, filterGeometry)
+            : $"{geometryColumn} <-> {filterGeometry}";
+    }
+
+    private string BuildNearestNeighborDistanceExpression(FeatureQuery query, SqlBuilder sql)
+    {
+        var geometryColumn = $"{_geometryColumn}::geometry";
+        var filterGeometry = BuildFilterGeometryExpression(query.SpatialFilter!.Value, sql);
+        return ShouldUseGeodesicNearestNeighbor()
+            ? BuildGeodesicDistanceExpression(geometryColumn, filterGeometry)
+            : $"ST_Distance({geometryColumn}, {filterGeometry})";
+    }
+
+    private string BuildGeodesicDistanceExpression(string geometryColumn, string filterGeometry)
+    {
+        var storageSrid = _mapping.StorageSrid ?? _layer.SpatialReference.Wkid;
+        var geographyColumn = ToWgs84Geography(geometryColumn, storageSrid);
+        var geographyFilter = ToWgs84Geography(filterGeometry, storageSrid);
+        return $"ST_Distance({geographyColumn}, {geographyFilter})";
+    }
+
+    private bool ShouldUseGeodesicNearestNeighbor()
+    {
+        var storageSrid = _mapping.StorageSrid ?? _layer.SpatialReference.Wkid;
+        return IsLikelyGeographicSrid(storageSrid);
+    }
+
+    private static string ToWgs84Geography(string geometryExpression, int srid)
+        => srid == SpatialReference.WGS84.Wkid
+            ? $"{geometryExpression}::geography"
+            : $"ST_Transform({geometryExpression}, {SpatialReference.WGS84.Wkid})::geography";
+
+    private static bool IsLikelyGeographicSrid(int srid)
+        => srid == SpatialReference.WGS84.Wkid ||
+           srid == 4269 ||
+           srid == 4267 ||
+           srid is >= 4000 and <= 4999;
+
+    private static bool IsNearestNeighborQuery(FeatureQuery query)
+        => query.SpatialFilter.HasValue &&
+           query.SpatialFilter.Value.SpatialRelationship == SpatialRelationship.NearestNeighbor;
+
+    private static List<string> SplitOnAnd(string whereClause)
+    {
+        var parts = new List<string>();
+        var current = new StringBuilder();
+        var inQuotes = false;
+
+        for (var i = 0; i < whereClause.Length; i++)
+        {
+            var c = whereClause[i];
+            if (c == '\'')
+            {
+                inQuotes = !inQuotes;
+                current.Append(c);
+                continue;
+            }
+
+            if (!inQuotes && IsAndTokenAt(whereClause, i))
+            {
+                parts.Add(current.ToString());
+                current.Clear();
+                i += 2;
+                continue;
+            }
+
+            current.Append(c);
+        }
+
+        if (current.Length > 0)
+        {
+            parts.Add(current.ToString());
+        }
+
+        return parts;
+    }
+
+    private static bool IsAndTokenAt(string whereClause, int index)
+    {
+        if (index + 3 > whereClause.Length)
+        {
+            return false;
+        }
+
+        var candidate = whereClause.Substring(index, 3);
+        if (!candidate.Equals("AND", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var previous = index > 0 ? whereClause[index - 1] : ' ';
+        var next = index + 3 < whereClause.Length ? whereClause[index + 3] : ' ';
+        return !IsIdentifierChar(previous) && !IsIdentifierChar(next);
+    }
+
+    private static bool IsIdentifierChar(char value)
+        => char.IsLetterOrDigit(value) || value == '_';
+
+    [GeneratedRegex(
+        @"^(?<field>[a-zA-Z_][a-zA-Z0-9_]*)\s*(?<op>NOT\s+LIKE|LIKE|>=|<=|!=|<>|=|>|<)\s*(?<value>'(?:''|[^'])*'|-?\d+(?:\.\d+)?)$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex ComparisonRegex();
+
+    [GeneratedRegex(
+        @"^(?<field>[a-zA-Z_][a-zA-Z0-9_]*)\s+IS\s+(?<not>NOT\s+)?NULL$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex NullCheckRegex();
+
+    [GeneratedRegex(
+        @"^(?:1\s*=\s*1|TRUE)$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex TrueLiteralRegex();
+
+    [GeneratedRegex(
+        @"@p(?<index>\d+)",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex SqlFilterParameterRegex();
+
+    [GeneratedRegex(
+        @"""(?<identifier>(?:[^""]|"""")+)""",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex QuotedIdentifierRegex();
+
+    private sealed class SqlBuilder
+    {
+        private readonly StringBuilder _text = new();
+        private readonly List<object?> _parameters = [];
+
+        public IReadOnlyList<object?> Parameters => _parameters;
+
+        public bool TextContainsWhere => _text.ToString().Contains(" WHERE ", StringComparison.OrdinalIgnoreCase);
+
+        public void Append(string value) => _text.Append(value);
+
+        public void Append(IFormatProvider provider, string value)
+            => _text.Append(value);
+
+        public string AddParameter(object? value)
+        {
+            _parameters.Add(value);
+            return "$" + _parameters.Count.ToString(CultureInfo.InvariantCulture);
+        }
+
+        public override string ToString() => _text.ToString();
+    }
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@
 using System.Globalization;
 using Honua.Core.Features.Alerts.Abstractions;
 using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Admin.Abstractions;
 using Honua.Core.Features.AutoDocs;
 using Honua.Core.Features.Import;
@@ -86,6 +88,14 @@ internal static class ServiceCollectionExtensions
 
         // Register refactored feature store implementation
         services.AddRefactoredFeatureStore(configuration["Database:Schema"]);
+        services.TryAddScoped<IFeatureDataProviderRegistry>(serviceProvider =>
+            new FeatureDataProviderRegistry(serviceProvider.GetServices<IFeatureDataProvider>()));
+        services.TryAddScoped(serviceProvider =>
+            new FeatureProviderBindingResolver(
+                serviceProvider.GetRequiredService<ISecureConnectionRegistry>(),
+                serviceProvider.GetRequiredService<IFeatureDataProviderRegistry>(),
+                DataProviderNames.Postgis));
+        services.TryAddScoped<FeatureProviderQueryRouter>();
 
         // Register raster store implementation
         services.AddPostgresRasterStore(configuration["Database:Schema"]);

--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Services/FeatureServerQueryExecutor.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Services/FeatureServerQueryExecutor.cs
@@ -787,7 +787,7 @@ internal sealed class FeatureServerQueryExecutor
         FeatureProviderReadOperation operation,
         CancellationToken cancellationToken)
     {
-        if (_providerQueryRouter == null || (layer.StorageMapping == null && !service.ConnectionId.HasValue))
+        if (_providerQueryRouter == null || !ShouldRouteProviderReader(service, layer))
         {
             return _featureReader;
         }
@@ -796,6 +796,9 @@ internal sealed class FeatureServerQueryExecutor
             .ResolveReaderAsync(service, layer, operation, cancellationToken)
             .ConfigureAwait(false);
     }
+
+    private static bool ShouldRouteProviderReader(ServiceDefinition service, LayerDefinition layer)
+        => service.ConnectionId.HasValue || layer.StorageMapping?.IsSourceBacked == true;
 
     private static void EnableChunkedEncodingIfHttp1(HttpContext context)
     {

--- a/src/Honua.Server/Features/Protocols/Ogc/Api/Features/OgcFeaturesQueryDependencies.cs
+++ b/src/Honua.Server/Features/Protocols/Ogc/Api/Features/OgcFeaturesQueryDependencies.cs
@@ -3,6 +3,7 @@
 
 using Honua.Core.Features.Caching;
 using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Caching;
 using Honua.Core.Features.Query;
@@ -28,7 +29,8 @@ internal sealed class OgcFeaturesQueryDependencies
         IResponseCache responseCache,
         IETagService etagService,
         IOptions<CacheOptions> cacheOptions,
-        IOptions<OgcFeaturesOptions> ogcFeaturesOptions)
+        IOptions<OgcFeaturesOptions> ogcFeaturesOptions,
+        FeatureProviderQueryRouter? providerQueryRouter = null)
     {
         FeatureReader = featureReader ?? throw new ArgumentNullException(nameof(featureReader));
         StreamingFeatureStore = streamingFeatureStore ?? throw new ArgumentNullException(nameof(streamingFeatureStore));
@@ -43,6 +45,7 @@ internal sealed class OgcFeaturesQueryDependencies
         ETagService = etagService ?? throw new ArgumentNullException(nameof(etagService));
         CacheOptions = cacheOptions?.Value ?? throw new ArgumentNullException(nameof(cacheOptions));
         OgcFeaturesOptions = ogcFeaturesOptions?.Value ?? throw new ArgumentNullException(nameof(ogcFeaturesOptions));
+        ProviderQueryRouter = providerQueryRouter;
     }
 
     public IFeatureReader FeatureReader { get; }
@@ -58,4 +61,5 @@ internal sealed class OgcFeaturesQueryDependencies
     public IETagService ETagService { get; }
     public CacheOptions CacheOptions { get; }
     public OgcFeaturesOptions OgcFeaturesOptions { get; }
+    public FeatureProviderQueryRouter? ProviderQueryRouter { get; }
 }

--- a/src/Honua.Server/Features/Protocols/Ogc/Api/Features/OgcFeaturesQueryHandler.cs
+++ b/src/Honua.Server/Features/Protocols/Ogc/Api/Features/OgcFeaturesQueryHandler.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Caching;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Caching;
 using Honua.Core.Features.Query;
@@ -46,6 +47,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
     private readonly IETagService _etagService = dependencies.ETagService;
     private readonly CacheOptions _cacheOptions = dependencies.CacheOptions;
     private readonly OgcFeaturesOptions _ogcFeaturesOptions = dependencies.OgcFeaturesOptions;
+    private readonly FeatureProviderQueryRouter? _providerQueryRouter = dependencies.ProviderQueryRouter;
     private readonly ILogger<OgcFeaturesQueryHandler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private const int StreamingThreshold = 200;
     private const int StreamingFlushInterval = 128;
@@ -154,6 +156,18 @@ internal sealed partial class OgcFeaturesQueryHandler(
             }
 
             var query = _queryProcessor.ToFeatureQuery(unifiedQuery, layer);
+            var service = await LayerValidationHelpers.ResolvePrimaryServiceAsync(
+                context,
+                layerId,
+                ServiceProtocols.OgcFeatures,
+                cancellationToken).ConfigureAwait(false);
+            var featureReader = await ResolveReaderAsync(
+                service,
+                layer,
+                FeatureProviderReadOperation.Query,
+                cancellationToken).ConfigureAwait(false);
+            var resolvedStreamingFeatureStore = featureReader as IStreamingFeatureStore;
+            var streamingFeatureStore = resolvedStreamingFeatureStore ?? _streamingFeatureStore;
 
             var effectiveLimit = query.Limit ?? 0;
             var effectiveOffset = query.Offset ?? 0;
@@ -161,8 +175,11 @@ internal sealed partial class OgcFeaturesQueryHandler(
             var outputAxisOrder = unifiedQuery.OutputCrs?.AxisOrder ?? AxisOrder.EastNorth;
             var outputCrsUri = unifiedQuery.OutputCrs?.Uri ?? "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
 
-            var allowStreaming = string.Equals(outputFormat, MediaTypes.GeoJson, StringComparison.OrdinalIgnoreCase) ||
-                                 string.Equals(outputFormat, MediaTypes.Gml, StringComparison.OrdinalIgnoreCase);
+            var hasCompatibleStreamingStore = layer.StorageMapping == null || resolvedStreamingFeatureStore != null;
+            var allowStreaming = hasCompatibleStreamingStore &&
+                                 (string.Equals(outputFormat, MediaTypes.GeoJson, StringComparison.OrdinalIgnoreCase) ||
+                                 (string.Equals(outputFormat, MediaTypes.Gml, StringComparison.OrdinalIgnoreCase) &&
+                                  featureReader is IGmlFeatureStore));
             var omitExactNumberMatched = _ogcFeaturesOptions.NumberMatchedPolicy == OgcFeaturesNumberMatchedPolicy.OmitWhenExpensive;
             var useStreaming = allowStreaming &&
                                !omitExactNumberMatched &&
@@ -201,7 +218,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
 
             if (useStreaming)
             {
-                var totalCount = await _featureReader.CountAsync(layerId, query, cancellationToken);
+                var totalCount = await featureReader.CountAsync(layerId, query, cancellationToken);
 
                 // Avoid streaming for small result sets even when the requested limit is large.
                 if (totalCount > StreamingThreshold)
@@ -227,7 +244,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
                     if (string.Equals(outputFormat, MediaTypes.Gml, StringComparison.OrdinalIgnoreCase))
                     {
                         return new StreamingGmlItemsResult(
-                            _streamingFeatureStore,
+                            streamingFeatureStore,
                             layer,
                             query,
                             totalCount,
@@ -238,7 +255,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
                     }
 
                     return new StreamingItemsResult(
-                        _streamingFeatureStore,
+                        streamingFeatureStore,
                         layer,
                         query,
                         collectionId,
@@ -276,21 +293,21 @@ internal sealed partial class OgcFeaturesQueryHandler(
                                                 query.SpatialFilter?.IsSimpleEnvelope == true;
 
             if (canUseRawPointGeoJsonFastPath &&
-                _featureReader is IPagedRawGeoServicesFeatureStore rawPointFeatureStore)
+                featureReader is IPagedRawGeoServicesFeatureStore rawPointFeatureStore)
             {
                 pagedRawPointResult = await rawPointFeatureStore.QueryGeoServicesRawPointPageAsync(layerId, query, cancellationToken);
             }
             else if (canUseRawGeoJsonFastPath &&
-                _featureReader is IPagedRawGeoJsonFeatureStore rawGeoJsonFeatureStore)
+                featureReader is IPagedRawGeoJsonFeatureStore rawGeoJsonFeatureStore)
             {
                 pagedRawResult = await rawGeoJsonFeatureStore.QueryGeoJsonRawPageAsync(layerId, query, cancellationToken);
             }
             else if (string.Equals(outputFormat, MediaTypes.Gml, StringComparison.OrdinalIgnoreCase) &&
-                _featureReader is IGmlFeatureStore gmlFeatureStore)
+                featureReader is IGmlFeatureStore gmlFeatureStore)
             {
                 gmlResult = await gmlFeatureStore.QueryGmlAsync(layerId, query, cancellationToken);
             }
-            else if (omitExactNumberMatched && useNativeGeoJson && _featureReader is IPagedGeoJsonFeatureStore pagedGeoJsonFeatureStore)
+            else if (omitExactNumberMatched && useNativeGeoJson && featureReader is IPagedGeoJsonFeatureStore pagedGeoJsonFeatureStore)
             {
                 pagedEncodedResult = await pagedGeoJsonFeatureStore.QueryGeoJsonPageAsync(layerId, query, cancellationToken);
                 features = pagedEncodedResult.Value.Items
@@ -313,7 +330,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
                     })
                     .ToArray();
             }
-            else if (omitExactNumberMatched && _featureReader is IPagedFeatureReader pagedFeatureReader)
+            else if (omitExactNumberMatched && featureReader is IPagedFeatureReader pagedFeatureReader)
             {
                 pagedFeatureResult = await pagedFeatureReader.QueryPageAsync(layerId, query, cancellationToken);
                 features = pagedFeatureResult.Value.Items
@@ -336,7 +353,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
                     })
                     .ToArray();
             }
-            else if (useNativeGeoJson && _featureReader is IGeoJsonFeatureStore geoJsonFeatureStore)
+            else if (useNativeGeoJson && featureReader is IGeoJsonFeatureStore geoJsonFeatureStore)
             {
                 encodedResult = await geoJsonFeatureStore.QueryGeoJsonAsync(layerId, query, cancellationToken);
                 features = encodedResult.Value.Items
@@ -361,7 +378,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
             }
             else
             {
-                featureResult = await _featureReader.QueryAsync(layerId, query, cancellationToken);
+                featureResult = await featureReader.QueryAsync(layerId, query, cancellationToken);
                 features = featureResult.Value.Items
                     .Select(feature =>
                     {
@@ -560,9 +577,19 @@ internal sealed partial class OgcFeaturesQueryHandler(
             featureActivity?.SetTag(HonuaTelemetry.Tags.CollectionId, collectionId);
 
             OgcFeaturesLog.ItemRequested(_logger, collectionId, featureId);
+            var service = await LayerValidationHelpers.ResolvePrimaryServiceAsync(
+                context,
+                layerId,
+                ServiceProtocols.OgcFeatures,
+                cancellationToken).ConfigureAwait(false);
+            var featureReader = await ResolveReaderAsync(
+                service,
+                layer,
+                FeatureProviderReadOperation.Query,
+                cancellationToken).ConfigureAwait(false);
 
             var resolvedFeature = await OgcFeatureIdentifierResolver.ResolveAsync(
-                _featureReader,
+                featureReader,
                 _queryProcessor,
                 layer,
                 featureId,
@@ -635,7 +662,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
             context.Response.Headers["Content-Crs"] = FormatContentCrs(crsDefinition.Uri);
 
             if (string.Equals(outputFormat, MediaTypes.Gml, StringComparison.OrdinalIgnoreCase) &&
-                _featureReader is IGmlFeatureStore gmlFeatureStore)
+                featureReader is IGmlFeatureStore gmlFeatureStore)
             {
                 var gmlResult = await gmlFeatureStore.QueryGmlAsync(layerId, query, cancellationToken);
                 stopwatch.Stop();
@@ -651,7 +678,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
             }
 
             var responseFeature = await OgcFeaturesResponseHelpers.LoadFeatureForResponseAsync(
-                _featureReader,
+                featureReader,
                 layerId,
                 layer,
                 objectId,
@@ -856,6 +883,25 @@ internal sealed partial class OgcFeaturesQueryHandler(
     }
 
     private static string FormatContentCrs(string crsUri) => $"<{crsUri}>";
+
+    private async Task<IFeatureReader> ResolveReaderAsync(
+        ServiceDefinition? service,
+        LayerDefinition layer,
+        FeatureProviderReadOperation operation,
+        CancellationToken cancellationToken)
+    {
+        if (_providerQueryRouter == null || service == null || !ShouldRouteProviderReader(service, layer))
+        {
+            return _featureReader;
+        }
+
+        return await _providerQueryRouter
+            .ResolveReaderAsync(service, layer, operation, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static bool ShouldRouteProviderReader(ServiceDefinition service, LayerDefinition layer)
+        => service.ConnectionId.HasValue || layer.StorageMapping?.IsSourceBacked == true;
 
     internal static ReadOnlyMemory<byte> CreateRawFeatureCollectionPayload(
         ImmutableArray<RawGeoJsonFeature> features,

--- a/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
@@ -6,6 +6,9 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
 using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Security.Domain;
 using Honua.Server.Features.Admin.Models;
@@ -39,6 +42,7 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
     private HttpClient _client = null!;
     private string _schema = string.Empty;
     private Guid _connectionId;
+    private string _connectionName = string.Empty;
     private bool _connectionCreated;
     private string _tableName = string.Empty;
     private string _serviceName = string.Empty;
@@ -139,6 +143,235 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
         toggleApi!.Success.Should().BeTrue();
         toggleApi.Data.Should().NotBeNull();
         toggleApi.Data!.Enabled.Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items/{featureId}")]
+    public async Task PublishLayer_FeatureServerQuery_ReadsSourceBackedPostGisTable()
+    {
+        var publishRequest = new PublishLayerRequest
+        {
+            Schema = _schema,
+            Table = _tableName,
+            LayerName = $"Layer {_tableName}",
+            Description = "Layer publish FeatureServer query integration test",
+            GeometryColumn = "geom",
+            GeometryType = "Point",
+            Srid = 4326,
+            PrimaryKey = "id",
+            Fields = new[] { "id", "name", "population" },
+            ServiceName = _serviceName,
+            Enabled = true
+        };
+
+        var publishResponse = await _client.PostAsync(
+            $"/api/v1/admin/connections/{_connectionId}/layers",
+            JsonContent.Create(publishRequest, options: _jsonOptions));
+
+        var publishPayload = await publishResponse.Content.ReadAsStringAsync();
+        publishResponse.StatusCode.Should().Be(HttpStatusCode.Created, $"response: {publishPayload}");
+        var publishApi = JsonSerializer.Deserialize<ApiResponse<PublishedLayerSummary>>(publishPayload, _jsonOptions);
+        publishApi.Should().NotBeNull();
+        publishApi!.Data.Should().NotBeNull();
+        _layerId = publishApi.Data!.LayerId;
+
+        using (var scope = _fixture.Services.CreateScope())
+        {
+            var catalog = scope.ServiceProvider.GetRequiredService<ILayerCatalog>();
+            var service = await catalog.GetServiceAsync(_serviceName);
+            service.Should().NotBeNull();
+            service!.ConnectionId.Should().Be(_connectionId);
+            var layer = service.Layers.Single(layer => layer.Id == _layerId);
+            layer.StorageMapping.Should().NotBeNull();
+            layer.StorageMapping!.IsSourceBacked.Should().BeTrue();
+
+            var router = scope.ServiceProvider.GetRequiredService<FeatureProviderQueryRouter>();
+            var reader = await router.ResolveReaderAsync(
+                service,
+                layer,
+                FeatureProviderReadOperation.Query);
+            var directResult = await reader.QueryAsync(
+                _layerId.Value,
+                new FeatureQuery { Where = "1=1", Limit = 10, SpatialReferenceSrid = 4326 });
+
+            directResult.Items.Should().HaveCount(1);
+        }
+
+        var metadataResponse = await _client.GetAsync(
+            $"/rest/services/{_serviceName}/FeatureServer/{_layerId}?f=json");
+
+        metadataResponse.Be200Ok();
+        using (var metadata = JsonDocument.Parse(await metadataResponse.Content.ReadAsStringAsync()))
+        {
+            metadata.RootElement.TryGetProperty("extent", out var extent).Should().BeTrue();
+            extent.GetProperty("xmin").GetDouble().Should().Be(1d);
+            extent.GetProperty("ymin").GetDouble().Should().Be(1d);
+            extent.GetProperty("xmax").GetDouble().Should().Be(1d);
+            extent.GetProperty("ymax").GetDouble().Should().Be(1d);
+        }
+
+        var queryResponse = await _client.GetAsync(
+            $"/rest/services/{_serviceName}/FeatureServer/{_layerId}/query?f=json&where=1%3D1&outFields=*&returnGeometry=true&resultRecordCount=10");
+
+        var queryPayload = await queryResponse.Content.ReadAsStringAsync();
+        queryResponse.StatusCode.Should().Be(HttpStatusCode.OK, $"response: {queryPayload}");
+        using var queryDocument = JsonDocument.Parse(queryPayload);
+        var features = queryDocument.RootElement.GetProperty("features");
+        features.GetArrayLength().Should().Be(1);
+
+        var attributes = features[0].GetProperty("attributes");
+        attributes.GetProperty("id").GetInt64().Should().Be(1);
+        attributes.GetProperty("name").GetString().Should().Be("Test Feature");
+        attributes.GetProperty("population").GetInt32().Should().Be(100);
+
+        var geometry = features[0].GetProperty("geometry");
+        geometry.GetProperty("x").GetDouble().Should().Be(1d);
+        geometry.GetProperty("y").GetDouble().Should().Be(1d);
+
+        var ogcItemsResponse = await _client.GetAsync(
+            $"/ogc/features/collections/{_layerId}/items?f=json&limit=10");
+
+        var ogcItemsPayload = await ogcItemsResponse.Content.ReadAsStringAsync();
+        ogcItemsResponse.StatusCode.Should().Be(HttpStatusCode.OK, $"response: {ogcItemsPayload}");
+        using var ogcItemsDocument = JsonDocument.Parse(ogcItemsPayload);
+        var ogcFeatures = ogcItemsDocument.RootElement.GetProperty("features");
+        ogcFeatures.GetArrayLength().Should().Be(1);
+
+        var ogcFeature = ogcFeatures[0];
+        ogcFeature.GetProperty("id").GetInt64().Should().Be(1);
+        ogcFeature.GetProperty("properties").GetProperty("name").GetString().Should().Be("Test Feature");
+        ogcFeature.GetProperty("properties").GetProperty("population").GetInt32().Should().Be(100);
+        var coordinates = ogcFeature.GetProperty("geometry").GetProperty("coordinates");
+        coordinates[0].GetDouble().Should().Be(1d);
+        coordinates[1].GetDouble().Should().Be(1d);
+
+        var ogcItemResponse = await _client.GetAsync(
+            $"/ogc/features/collections/{_layerId}/items/1?f=json");
+
+        var ogcItemPayload = await ogcItemResponse.Content.ReadAsStringAsync();
+        ogcItemResponse.StatusCode.Should().Be(HttpStatusCode.OK, $"response: {ogcItemPayload}");
+        using var ogcItemDocument = JsonDocument.Parse(ogcItemPayload);
+        ogcItemDocument.RootElement.GetProperty("id").GetInt64().Should().Be(1);
+        ogcItemDocument.RootElement.GetProperty("properties").GetProperty("name").GetString().Should().Be("Test Feature");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task PublishLayer_ByConnectionName_RoutesStorageMappedFeatureServerQueries()
+    {
+        var publishRequest = new PublishLayerRequest
+        {
+            Schema = _schema,
+            Table = _tableName,
+            LayerName = $"Layer {_tableName}",
+            Description = "Layer publish connection-name routing integration test",
+            GeometryColumn = "geom",
+            GeometryType = "Point",
+            Srid = 4326,
+            PrimaryKey = "id",
+            Fields = new[] { "id", "name", "population" },
+            ServiceName = _serviceName,
+            Enabled = true
+        };
+
+        var publishResponse = await _client.PostAsync(
+            $"/api/v1/admin/connections/{_connectionName}/layers",
+            JsonContent.Create(publishRequest, options: _jsonOptions));
+
+        var publishPayload = await publishResponse.Content.ReadAsStringAsync();
+        publishResponse.StatusCode.Should().Be(HttpStatusCode.Created, $"response: {publishPayload}");
+        var publishApi = JsonSerializer.Deserialize<ApiResponse<PublishedLayerSummary>>(publishPayload, _jsonOptions);
+        publishApi.Should().NotBeNull();
+        publishApi!.Data.Should().NotBeNull();
+        _layerId = publishApi.Data!.LayerId;
+
+        using (var scope = _fixture.Services.CreateScope())
+        {
+            var catalog = scope.ServiceProvider.GetRequiredService<ILayerCatalog>();
+            var service = await catalog.GetServiceAsync(_serviceName);
+            service.Should().NotBeNull();
+            service!.ConnectionId.Should().BeNull();
+            var layer = service.Layers.Single(layer => layer.Id == _layerId);
+            layer.StorageMapping.Should().NotBeNull();
+            layer.StorageMapping!.IsSourceBacked.Should().BeTrue();
+        }
+
+        await InsertPostGisFeatureAsync("Name Routed Feature", 200, 2d, 2d);
+
+        var queryResponse = await _client.GetAsync(
+            $"/rest/services/{_serviceName}/FeatureServer/{_layerId}/query?f=json&where=1%3D1&outFields=name,population&returnGeometry=false&resultRecordCount=10");
+
+        var queryPayload = await queryResponse.Content.ReadAsStringAsync();
+        queryResponse.StatusCode.Should().Be(HttpStatusCode.OK, $"response: {queryPayload}");
+        using var queryDocument = JsonDocument.Parse(queryPayload);
+        var names = queryDocument.RootElement
+            .GetProperty("features")
+            .EnumerateArray()
+            .Select(feature => feature.GetProperty("attributes").GetProperty("name").GetString())
+            .ToArray();
+
+        names.Should().Contain("Test Feature");
+        names.Should().Contain("Name Routed Feature");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task PublishLayer_FeatureServerNearestNeighbor_OrdersSourceBackedRows()
+    {
+        await InsertPostGisFeatureAsync("Near Feature", 200, 1.01d, 1.01d);
+        await InsertPostGisFeatureAsync("Far Feature", 300, 10d, 10d);
+
+        var publishRequest = new PublishLayerRequest
+        {
+            Schema = _schema,
+            Table = _tableName,
+            LayerName = $"Layer {_tableName}",
+            Description = "Layer publish nearest-neighbor integration test",
+            GeometryColumn = "geom",
+            GeometryType = "Point",
+            Srid = 4326,
+            PrimaryKey = "id",
+            Fields = new[] { "id", "name", "population" },
+            ServiceName = _serviceName,
+            Enabled = true
+        };
+
+        var publishResponse = await _client.PostAsync(
+            $"/api/v1/admin/connections/{_connectionId}/layers",
+            JsonContent.Create(publishRequest, options: _jsonOptions));
+
+        var publishPayload = await publishResponse.Content.ReadAsStringAsync();
+        publishResponse.StatusCode.Should().Be(HttpStatusCode.Created, $"response: {publishPayload}");
+        var publishApi = JsonSerializer.Deserialize<ApiResponse<PublishedLayerSummary>>(publishPayload, _jsonOptions);
+        publishApi.Should().NotBeNull();
+        publishApi!.Data.Should().NotBeNull();
+        _layerId = publishApi.Data!.LayerId;
+
+        var pointGeometry = Uri.EscapeDataString(@"{""x"":1,""y"":1}");
+        var queryResponse = await _client.GetAsync(
+            $"/rest/services/{_serviceName}/FeatureServer/{_layerId}/query?f=json&geometry={pointGeometry}&nearestCount=2&returnDistance=true&outFields=*&returnGeometry=false");
+
+        var queryPayload = await queryResponse.Content.ReadAsStringAsync();
+        queryResponse.StatusCode.Should().Be(HttpStatusCode.OK, $"response: {queryPayload}");
+        using var queryDocument = JsonDocument.Parse(queryPayload);
+        var features = queryDocument.RootElement.GetProperty("features").EnumerateArray().ToArray();
+        features.Should().HaveCount(2);
+
+        var firstAttributes = features[0].GetProperty("attributes");
+        var secondAttributes = features[1].GetProperty("attributes");
+
+        firstAttributes.GetProperty("name").GetString().Should().Be("Test Feature");
+        secondAttributes.GetProperty("name").GetString().Should().Be("Near Feature");
+        firstAttributes.GetProperty("distance").GetDouble().Should().BeLessThanOrEqualTo(secondAttributes.GetProperty("distance").GetDouble());
     }
 
     [IntegrationTest]
@@ -434,6 +667,22 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
         await _fixture.Postgres.ExecuteAsync(sql);
     }
 
+    private async Task InsertPostGisFeatureAsync(string name, int population, double x, double y)
+    {
+        await using var connection = await _fixture.Postgres.GetConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            INSERT INTO public.{_tableName} (name, population, geom)
+            VALUES (@name, @population, ST_SetSRID(ST_Point(@x, @y), 4326));
+            """;
+        command.Parameters.AddWithValue("name", name);
+        command.Parameters.AddWithValue("population", population);
+        command.Parameters.AddWithValue("x", x);
+        command.Parameters.AddWithValue("y", y);
+
+        await command.ExecuteNonQueryAsync();
+    }
+
     private static async Task CreatePostGisTableAsync(string connectionString, string tableName)
     {
         await using var connection = new NpgsqlConnection(connectionString);
@@ -473,8 +722,10 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
         var sslRequired = builder.SslMode is Npgsql.SslMode.Require or Npgsql.SslMode.VerifyCA or Npgsql.SslMode.VerifyFull;
         var sslMode = Enum.Parse<CoreSslMode>(builder.SslMode.ToString(), true);
 
+        _connectionName = $"layer-publish-{Guid.NewGuid():N}";
+
         var connection = DataConnection.CreateWithEncryptedCredentials(
-            name: $"layer-publish-{Guid.NewGuid():N}",
+            name: _connectionName,
             host: builder.Host!,
             port: builder.Port,
             databaseName: builder.Database!,

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/GeoServices/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/GeoServices/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
@@ -6,6 +6,8 @@ using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Configuration;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.Services;
+using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Shared.Models;
 using Honua.Server.Features.Protocols.GeoServices.FeatureServer.Models;
 using Honua.Server.Features.Protocols.GeoServices.FeatureServer.Services;
@@ -22,6 +24,64 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.Servic
 
 public sealed class FeatureServerQueryExecutorTests
 {
+    [Fact]
+    public async Task CountAsync_WhenLayerMappingIsNotSourceBacked_UsesCanonicalFeatureReader()
+    {
+        var featureReader = Substitute.For<IFeatureReader>();
+        featureReader.CountAsync(7, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(3L);
+        var providerReader = Substitute.For<IFeatureReader>();
+        var router = CreateProviderRouter(providerReader);
+        var sut = CreateSut(featureReader, providerQueryRouter: router);
+        var layer = CreatePointLayer() with
+        {
+            StorageMapping = new LayerStorageMapping(
+                "features",
+                SchemaName: "honua",
+                PrimaryKeyColumn: FieldNames.ObjectId,
+                GeometryColumn: "geometry",
+                StorageSrid: 4326)
+        };
+        var service = new ServiceDefinition("maps", "Maps", [layer], SpatialReference.WGS84);
+
+        var count = await sut.CountAsync(service, layer, new FeatureQuery(), CancellationToken.None);
+
+        count.Should().Be(3L);
+        await providerReader.DidNotReceive()
+            .CountAsync(Arg.Any<int>(), Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CountAsync_WhenLayerMappingIsSourceBackedWithoutConnection_UsesProviderReader()
+    {
+        var featureReader = Substitute.For<IFeatureReader>();
+        var providerReader = Substitute.For<IFeatureReader>();
+        providerReader.CountAsync(7, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(5L);
+        var router = CreateProviderRouter(providerReader);
+        var sut = CreateSut(featureReader, providerQueryRouter: router);
+        var layer = CreatePointLayer() with
+        {
+            StorageMapping = new LayerStorageMapping(
+                "roads",
+                SchemaName: "public",
+                PrimaryKeyColumn: FieldNames.ObjectId,
+                GeometryColumn: "shape",
+                StorageSrid: 4326,
+                ProviderOptions: new Dictionary<string, string>
+                {
+                    [LayerStorageMapping.SourceBackedOption] = "true"
+                })
+        };
+        var service = new ServiceDefinition("maps", "Maps", [layer], SpatialReference.WGS84);
+
+        var count = await sut.CountAsync(service, layer, new FeatureQuery(), CancellationToken.None);
+
+        count.Should().Be(5L);
+        await featureReader.DidNotReceive()
+            .CountAsync(Arg.Any<int>(), Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task QueryWithValidationAsync_WhenReaderThrowsArgumentException_ThrowsInvalidOperationException()
     {
@@ -509,12 +569,27 @@ public sealed class FeatureServerQueryExecutorTests
 
     private static FeatureServerQueryExecutor CreateSut(
         IFeatureReader featureReader,
-        IStreamingFeatureStore? streamingStore = null)
+        IStreamingFeatureStore? streamingStore = null,
+        FeatureProviderQueryRouter? providerQueryRouter = null)
     {
         streamingStore ??= Substitute.For<IStreamingFeatureStore>();
         var formatter = new StreamingQueryFormatter(Options.Create(new LimitsOptions()));
 
-        return new FeatureServerQueryExecutor(featureReader, streamingStore, formatter);
+        return new FeatureServerQueryExecutor(featureReader, streamingStore, formatter, providerQueryRouter);
+    }
+
+    private static FeatureProviderQueryRouter CreateProviderRouter(IFeatureReader reader)
+    {
+        var provider = Substitute.For<IFeatureDataProvider>();
+        provider.ProviderName.Returns(DataProviderNames.Postgis);
+        provider.Capabilities.Returns(FeatureProviderCapabilities.ReadOnlyAnalytical);
+        provider.Reader.Returns(reader);
+
+        var resolver = new FeatureProviderBindingResolver(
+            Substitute.For<ISecureConnectionRegistry>(),
+            new FeatureDataProviderRegistry([provider]));
+
+        return new FeatureProviderQueryRouter(resolver);
     }
 
     private static LayerDefinition CreateLayer()


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #974

## Summary
Fixes source-backed PostGIS publishing queries so layers published from external mapped tables serve their live source data through FeatureServer and OGC API Features instead of falling back to the canonical feature table.

## Changes Made
- Added a Postgres storage-mapped feature reader that binds catalog mappings, secure data connections, and source table metadata into paged/query/read operations.
- Registered Postgres provider binding and routed source-backed FeatureServer and OGC reads through the provider-aware reader while preserving canonical layer behavior.
- Persisted publishing metadata including field counts, source primary keys, and source extents.
- Added integration coverage for published source-backed PostGIS FeatureServer queries.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract (not applicable; existing protocol contracts are preserved)
- [x] If breaking admin/control-plane API changes: updated migration guide (not applicable)
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review (not applicable)