### PR TITLE
feat(admin): validate tables before layer publish

### DIFF
--- a/src/Honua.Core/Features/Admin/Abstractions/ILayerPublishingService.cs
+++ b/src/Honua.Core/Features/Admin/Abstractions/ILayerPublishingService.cs
@@ -33,6 +33,17 @@ public interface ILayerPublishingService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Validate a PostGIS table before publishing it as a layer.
+    /// </summary>
+    /// <param name="connectionString">PostgreSQL connection string.</param>
+    /// <param name="request">Table publish validation request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<TablePublishValidationResult> ValidateTableForPublishAsync(
+        string connectionString,
+        TablePublishValidationRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Enable or disable a layer within a service.
     /// </summary>
     /// <param name="connectionString">PostgreSQL connection string.</param>

--- a/src/Honua.Core/Features/Admin/Domain/LayerPublishingModels.cs
+++ b/src/Honua.Core/Features/Admin/Domain/LayerPublishingModels.cs
@@ -70,6 +70,220 @@ public sealed class LayerPublishRequest
 }
 
 /// <summary>
+/// Request payload for validating a PostGIS table before publishing it as a layer.
+/// </summary>
+public sealed class TablePublishValidationRequest
+{
+    /// <summary>
+    /// Schema containing the source table.
+    /// </summary>
+    public required string Schema { get; init; }
+
+    /// <summary>
+    /// Source table name.
+    /// </summary>
+    public required string Table { get; init; }
+
+    /// <summary>
+    /// Optional layer display name.
+    /// </summary>
+    public string? LayerName { get; init; }
+
+    /// <summary>
+    /// Optional service name for projection compatibility checks.
+    /// </summary>
+    public string? ServiceName { get; init; }
+
+    /// <summary>
+    /// Requested target spatial reference identifier. When omitted, an existing service SRID or table SRID is used.
+    /// </summary>
+    public int? TargetSrid { get; init; }
+
+    /// <summary>
+    /// Requested geometry column name. When omitted, discovery metadata is used.
+    /// </summary>
+    public string? GeometryColumn { get; init; }
+
+    /// <summary>
+    /// Requested primary key column name. When omitted, the table primary key or common object id names are used.
+    /// </summary>
+    public string? PrimaryKey { get; init; }
+
+    /// <summary>
+    /// Selected attribute fields to publish. Empty means all discovered columns.
+    /// </summary>
+    public IReadOnlyList<string> Fields { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Structured result for validating a table before layer publishing.
+/// </summary>
+public sealed class TablePublishValidationResult
+{
+    /// <summary>
+    /// Whether validation passed without errors.
+    /// </summary>
+    public bool IsValid { get; init; }
+
+    /// <summary>
+    /// Validation status: valid, warning, or invalid.
+    /// </summary>
+    public required string Status { get; init; }
+
+    /// <summary>
+    /// Source schema.
+    /// </summary>
+    public required string Schema { get; init; }
+
+    /// <summary>
+    /// Source table.
+    /// </summary>
+    public required string Table { get; init; }
+
+    /// <summary>
+    /// Normalized service name used for compatibility checks.
+    /// </summary>
+    public required string ServiceName { get; init; }
+
+    /// <summary>
+    /// Optional layer display name.
+    /// </summary>
+    public string? LayerName { get; init; }
+
+    /// <summary>
+    /// Resolved geometry column.
+    /// </summary>
+    public string? GeometryColumn { get; init; }
+
+    /// <summary>
+    /// Resolved geometry type.
+    /// </summary>
+    public string? GeometryType { get; init; }
+
+    /// <summary>
+    /// Resolved primary key column.
+    /// </summary>
+    public string? PrimaryKey { get; init; }
+
+    /// <summary>
+    /// Source table SRID from discovery metadata.
+    /// </summary>
+    public int? SourceSrid { get; init; }
+
+    /// <summary>
+    /// Existing service SRID when the target service already exists.
+    /// </summary>
+    public int? ServiceSrid { get; init; }
+
+    /// <summary>
+    /// Target SRID the publish operation should use.
+    /// </summary>
+    public int? TargetSrid { get; init; }
+
+    /// <summary>
+    /// Estimated row count from discovery metadata.
+    /// </summary>
+    public long? EstimatedRows { get; init; }
+
+    /// <summary>
+    /// Actual source row count when it could be sampled.
+    /// </summary>
+    public long? FeatureCount { get; init; }
+
+    /// <summary>
+    /// Count of rows with NULL geometry.
+    /// </summary>
+    public long? NullGeometryCount { get; init; }
+
+    /// <summary>
+    /// Count of rows with invalid geometry.
+    /// </summary>
+    public long? InvalidGeometryCount { get; init; }
+
+    /// <summary>
+    /// Discovered field metadata.
+    /// </summary>
+    public TablePublishValidationField[] Fields { get; init; } = [];
+
+    /// <summary>
+    /// Individual validation checks.
+    /// </summary>
+    public TablePublishValidationCheck[] Checks { get; init; } = [];
+}
+
+/// <summary>
+/// Field metadata returned by table publish validation.
+/// </summary>
+public sealed class TablePublishValidationField
+{
+    /// <summary>
+    /// Source column name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Source database type.
+    /// </summary>
+    public required string DataType { get; init; }
+
+    /// <summary>
+    /// Honua field type inferred from the source type.
+    /// </summary>
+    public required string FieldType { get; init; }
+
+    /// <summary>
+    /// Whether the source column allows null values.
+    /// </summary>
+    public bool IsNullable { get; init; }
+
+    /// <summary>
+    /// Whether the source column is part of the table primary key.
+    /// </summary>
+    public bool IsPrimaryKey { get; init; }
+
+    /// <summary>
+    /// Whether this field is selected for publishing.
+    /// </summary>
+    public bool IsSelected { get; init; }
+
+    /// <summary>
+    /// Maximum length for character types.
+    /// </summary>
+    public int? MaxLength { get; init; }
+}
+
+/// <summary>
+/// Individual validation check for pre-publish table validation.
+/// </summary>
+public sealed class TablePublishValidationCheck
+{
+    /// <summary>
+    /// Stable machine-readable check code.
+    /// </summary>
+    public required string Code { get; init; }
+
+    /// <summary>
+    /// Severity: pass, warning, or error.
+    /// </summary>
+    public required string Severity { get; init; }
+
+    /// <summary>
+    /// Human-readable check result.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// Expected value when applicable.
+    /// </summary>
+    public string? Expected { get; init; }
+
+    /// <summary>
+    /// Actual value when applicable.
+    /// </summary>
+    public string? Actual { get; init; }
+}
+
+/// <summary>
 /// Summary information about a published layer.
 /// </summary>
 public sealed class PublishedLayerSummary

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
@@ -21,6 +21,9 @@ internal sealed partial class PostgreSqlLayerPublishingService(
 {
     private const string DefaultServiceName = "default";
     private const string SourceBackedStorageOptionsJson = """{"sourceBacked":"true"}""";
+    private const string SeverityPass = "pass";
+    private const string SeverityWarning = "warning";
+    private const string SeverityError = "error";
     private static readonly string[] _defaultFormats = ["JSON", "GeoJSON"];
     private static readonly string[] _defaultCapabilities = ["Query", "Extract"];
 
@@ -158,7 +161,9 @@ internal sealed partial class PostgreSqlLayerPublishingService(
 
         var geometryType = NormalizeGeometryType(geometryTypeRaw!);
 
-        var srid = request.Srid ?? tableInfo.Srid ?? 4326;
+        var serviceSrid = await ResolveExistingServiceSridAsync(connectionString, serviceName, cancellationToken)
+            .ConfigureAwait(false);
+        var srid = serviceSrid ?? request.Srid ?? tableInfo.Srid ?? 4326;
         if (srid <= 0)
         {
             srid = 4326;
@@ -280,6 +285,95 @@ internal sealed partial class PostgreSqlLayerPublishingService(
             Enabled = request.Enabled,
             ServiceName = serviceName
         };
+    }
+
+    public async Task<TablePublishValidationResult> ValidateTableForPublishAsync(
+        string connectionString,
+        TablePublishValidationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var schema = request.Schema?.Trim() ?? string.Empty;
+        var table = request.Table?.Trim() ?? string.Empty;
+        var serviceName = NormalizeServiceName(request.ServiceName);
+        var checks = new List<TablePublishValidationCheck>();
+
+        if (string.IsNullOrWhiteSpace(schema) || string.IsNullOrWhiteSpace(table))
+        {
+            checks.Add(Error("source-table", "Schema and table are required."));
+            return BuildValidationResult(request, serviceName, null, null, null, checks);
+        }
+
+        if (!IsSafeIdentifier(schema) || !IsSafeIdentifier(table))
+        {
+            checks.Add(Error("source-table", "Schema or table contains invalid characters.", null, $"{schema}.{table}"));
+            return BuildValidationResult(request, serviceName, null, null, null, checks);
+        }
+
+        checks.Add(Pass("source-table", $"Source table identifier '{schema}.{table}' is syntactically valid."));
+
+        var tableInfo = await ResolveTableInfoAsync(connectionString, schema, table, cancellationToken)
+            .ConfigureAwait(false);
+        if (tableInfo == null)
+        {
+            checks.Add(Error(
+                "source-table",
+                $"Table '{schema}.{table}' was not found or does not expose a discoverable geometry column.",
+                $"{schema}.{table}",
+                null));
+            return BuildValidationResult(request, serviceName, null, null, null, checks);
+        }
+
+        checks.Add(Pass("source-table", $"Table '{schema}.{table}' is discoverable."));
+
+        var selectedColumns = ResolveSelectedColumnsForValidation(tableInfo.Columns, request.Fields, checks);
+        if (selectedColumns.Count == 0)
+        {
+            checks.Add(Error("selected-fields", "No publishable fields were selected."));
+        }
+        else
+        {
+            checks.Add(Pass("selected-fields", $"{selectedColumns.Count} field(s) selected for publishing."));
+        }
+
+        var geometryColumn = ResolveGeometryColumnForValidation(tableInfo, request.GeometryColumn, checks);
+        var geometryType = ResolveGeometryTypeForValidation(tableInfo, checks);
+        var primaryKeyName = ResolvePrimaryKeyForValidation(tableInfo.Columns, selectedColumns, request.PrimaryKey, checks);
+        var serviceSrid = await ResolveExistingServiceSridAsync(connectionString, serviceName, cancellationToken)
+            .ConfigureAwait(false);
+        var targetSrid = ResolveTargetSridForValidation(tableInfo.Srid, serviceSrid, request.TargetSrid, checks);
+
+        GeometryHealth? geometryHealth = null;
+        if (!string.IsNullOrWhiteSpace(geometryColumn) &&
+            geometryColumn!.Equals(tableInfo.GeometryColumn, StringComparison.OrdinalIgnoreCase))
+        {
+            geometryHealth = await InspectGeometryHealthAsync(
+                    connectionString,
+                    schema,
+                    table,
+                    geometryColumn!,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            AddGeometryHealthChecks(geometryHealth, checks);
+        }
+
+        await AddExistingLayerCheckAsync(connectionString, schema, table, checks, cancellationToken)
+            .ConfigureAwait(false);
+
+        return BuildValidationResult(
+            request,
+            serviceName,
+            tableInfo,
+            new ResolvedPublishValidation(
+                geometryColumn,
+                geometryType,
+                primaryKeyName,
+                serviceSrid,
+                targetSrid),
+            geometryHealth,
+            checks);
     }
 
     public async Task<PublishedLayerSummary?> SetLayerEnabledAsync(
@@ -516,6 +610,330 @@ internal sealed partial class PostgreSqlLayerPublishingService(
             "text" => FieldType.String,
             _ => FieldType.String
         };
+    }
+
+    private static List<ColumnInfo> ResolveSelectedColumnsForValidation(
+        List<ColumnInfo> columns,
+        IReadOnlyList<string> selected,
+        List<TablePublishValidationCheck> checks)
+    {
+        if (selected == null || selected.Count == 0)
+        {
+            return columns;
+        }
+
+        var lookup = columns.ToDictionary(c => c.Name, StringComparer.OrdinalIgnoreCase);
+        var result = new List<ColumnInfo>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var field in selected)
+        {
+            if (string.IsNullOrWhiteSpace(field))
+            {
+                continue;
+            }
+
+            if (!lookup.TryGetValue(field.Trim(), out var column))
+            {
+                checks.Add(Error(
+                    "selected-field",
+                    $"Field '{field}' was not found on the source table.",
+                    field,
+                    null));
+                continue;
+            }
+
+            if (seen.Add(column.Name))
+            {
+                result.Add(column);
+            }
+        }
+
+        return result;
+    }
+
+    private static string? ResolveGeometryColumnForValidation(
+        TableInfo tableInfo,
+        string? requestedGeometryColumn,
+        List<TablePublishValidationCheck> checks)
+    {
+        var discoveredGeometryColumn = tableInfo.GeometryColumn;
+        var geometryColumn = string.IsNullOrWhiteSpace(requestedGeometryColumn)
+            ? discoveredGeometryColumn
+            : requestedGeometryColumn.Trim();
+
+        if (string.IsNullOrWhiteSpace(discoveredGeometryColumn))
+        {
+            checks.Add(Error("geometry-column", "Source table does not expose a geometry column."));
+            return geometryColumn;
+        }
+
+        if (string.IsNullOrWhiteSpace(geometryColumn))
+        {
+            checks.Add(Error("geometry-column", "Geometry column is required.", discoveredGeometryColumn, null));
+            return geometryColumn;
+        }
+
+        if (!geometryColumn.Equals(discoveredGeometryColumn, StringComparison.OrdinalIgnoreCase))
+        {
+            checks.Add(Error(
+                "geometry-column",
+                "Requested geometry column does not match the discovered PostGIS geometry column.",
+                discoveredGeometryColumn,
+                geometryColumn));
+            return geometryColumn;
+        }
+
+        checks.Add(Pass("geometry-column", $"Geometry column '{geometryColumn}' exists."));
+        return geometryColumn;
+    }
+
+    private static string? ResolveGeometryTypeForValidation(
+        TableInfo tableInfo,
+        List<TablePublishValidationCheck> checks)
+    {
+        if (string.IsNullOrWhiteSpace(tableInfo.GeometryType))
+        {
+            checks.Add(Error("geometry-type", "Source table does not report a geometry type."));
+            return null;
+        }
+
+        try
+        {
+            var normalized = NormalizeGeometryType(tableInfo.GeometryType);
+            checks.Add(Pass("geometry-type", $"Geometry type '{normalized}' is supported."));
+            return normalized;
+        }
+        catch (LayerPublishingException)
+        {
+            checks.Add(Error(
+                "geometry-type",
+                $"Geometry type '{tableInfo.GeometryType}' is not supported.",
+                null,
+                tableInfo.GeometryType));
+            return tableInfo.GeometryType;
+        }
+    }
+
+    private static string? ResolvePrimaryKeyForValidation(
+        List<ColumnInfo> columns,
+        List<ColumnInfo> selectedColumns,
+        string? requestedPrimaryKey,
+        List<TablePublishValidationCheck> checks)
+    {
+        var primaryKeyName = ResolvePrimaryKeyName(selectedColumns, requestedPrimaryKey);
+        if (string.IsNullOrWhiteSpace(primaryKeyName))
+        {
+            checks.Add(Error(
+                "primary-key",
+                "Primary key is required. Select an integer source column or choose an object id strategy."));
+            return null;
+        }
+
+        var primaryKeyColumn = selectedColumns.FirstOrDefault(col =>
+            string.Equals(col.Name, primaryKeyName, StringComparison.OrdinalIgnoreCase));
+        if (primaryKeyColumn == null)
+        {
+            var existsInTable = columns.Any(col =>
+                string.Equals(col.Name, primaryKeyName, StringComparison.OrdinalIgnoreCase));
+            checks.Add(Error(
+                "primary-key",
+                existsInTable
+                    ? $"Primary key field '{primaryKeyName}' must be included in selected fields."
+                    : $"Primary key field '{primaryKeyName}' was not found on the source table.",
+                primaryKeyName,
+                existsInTable ? "not selected" : null));
+            return primaryKeyName;
+        }
+
+        var primaryKeyType = MapPostgresType(primaryKeyColumn.DataType);
+        if (primaryKeyType is not FieldType.Integer and not FieldType.BigInteger)
+        {
+            checks.Add(Error(
+                "primary-key-type",
+                "Primary key must be an integer column.",
+                "Integer or BigInteger",
+                primaryKeyColumn.DataType));
+            return primaryKeyColumn.Name;
+        }
+
+        checks.Add(Pass("primary-key", $"Primary key column '{primaryKeyColumn.Name}' is publishable."));
+        return primaryKeyColumn.Name;
+    }
+
+    private static int? ResolveTargetSridForValidation(
+        int? tableSrid,
+        int? serviceSrid,
+        int? requestedTargetSrid,
+        List<TablePublishValidationCheck> checks)
+    {
+        if (tableSrid is null or <= 0)
+        {
+            checks.Add(Error(
+                "source-srid",
+                "Source table does not report a valid SRID.",
+                null,
+                tableSrid?.ToString(CultureInfo.InvariantCulture)));
+        }
+        else
+        {
+            checks.Add(Pass("source-srid", $"Source table SRID is {tableSrid.Value}."));
+        }
+
+        var targetSrid = serviceSrid ?? requestedTargetSrid ?? tableSrid;
+        if (targetSrid is null or <= 0)
+        {
+            checks.Add(Error(
+                "target-srid",
+                "Target SRID could not be resolved from the request, service, or source table."));
+            return targetSrid;
+        }
+
+        checks.Add(Pass("target-srid", $"Target SRID is {targetSrid.Value}."));
+
+        if (serviceSrid.HasValue && requestedTargetSrid.HasValue && requestedTargetSrid.Value != serviceSrid.Value)
+        {
+            checks.Add(Warning(
+                "service-srid-authoritative",
+                "Existing service projection overrides the requested target SRID.",
+                serviceSrid.Value.ToString(CultureInfo.InvariantCulture),
+                requestedTargetSrid.Value.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        if (tableSrid is > 0 && tableSrid.Value != targetSrid.Value)
+        {
+            checks.Add(Warning(
+                "source-srid-transform",
+                "Source geometries will be transformed to the target service projection during publish.",
+                targetSrid.Value.ToString(CultureInfo.InvariantCulture),
+                tableSrid.Value.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        return targetSrid;
+    }
+
+    private static void AddGeometryHealthChecks(
+        GeometryHealth? health,
+        List<TablePublishValidationCheck> checks)
+    {
+        if (health is not { } value)
+        {
+            checks.Add(Error("geometry-scan", "Geometry validation could not inspect the source table."));
+            return;
+        }
+
+        if (value.FeatureCount == 0)
+        {
+            checks.Add(Error("feature-count", "Source table is empty."));
+        }
+        else
+        {
+            checks.Add(Pass(
+                "feature-count",
+                $"Source table contains {value.FeatureCount.ToString(CultureInfo.InvariantCulture)} row(s)."));
+        }
+
+        if (value.NullGeometryCount > 0)
+        {
+            checks.Add(Warning(
+                "null-geometries",
+                "Some source rows have NULL geometry and will publish without geometry.",
+                "0",
+                value.NullGeometryCount.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        if (value.InvalidGeometryCount > 0)
+        {
+            checks.Add(Error(
+                "invalid-geometries",
+                "Source table contains invalid geometries.",
+                "0",
+                value.InvalidGeometryCount.ToString(CultureInfo.InvariantCulture)));
+        }
+        else
+        {
+            checks.Add(Pass("invalid-geometries", "No invalid geometries were found."));
+        }
+
+        if (value.DistinctGeometryTypeCount > 1)
+        {
+            checks.Add(Error(
+                "mixed-geometry",
+                "Source table contains mixed geometry types.",
+                "1",
+                value.DistinctGeometryTypeCount.ToString(CultureInfo.InvariantCulture)));
+        }
+        else if (value.DistinctGeometryTypeCount == 1)
+        {
+            checks.Add(Pass("mixed-geometry", "Source table uses a single geometry type."));
+        }
+
+        if (value.MinSrid.HasValue && value.MaxSrid.HasValue && value.MinSrid.Value != value.MaxSrid.Value)
+        {
+            checks.Add(Error(
+                "mixed-srid",
+                "Source table contains mixed geometry SRIDs.",
+                value.MinSrid.Value.ToString(CultureInfo.InvariantCulture),
+                value.MaxSrid.Value.ToString(CultureInfo.InvariantCulture)));
+        }
+    }
+
+    private static TablePublishValidationResult BuildValidationResult(
+        TablePublishValidationRequest request,
+        string serviceName,
+        TableInfo? tableInfo,
+        ResolvedPublishValidation? resolved,
+        GeometryHealth? geometryHealth,
+        IReadOnlyCollection<TablePublishValidationCheck> checks)
+    {
+        var hasErrors = checks.Any(check => check.Severity == SeverityError);
+        var hasWarnings = checks.Any(check => check.Severity == SeverityWarning);
+
+        return new TablePublishValidationResult
+        {
+            IsValid = !hasErrors,
+            Status = hasErrors ? "invalid" : hasWarnings ? "warning" : "valid",
+            Schema = request.Schema?.Trim() ?? string.Empty,
+            Table = request.Table?.Trim() ?? string.Empty,
+            ServiceName = serviceName,
+            LayerName = request.LayerName,
+            GeometryColumn = resolved?.GeometryColumn ?? request.GeometryColumn ?? tableInfo?.GeometryColumn,
+            GeometryType = resolved?.GeometryType ?? tableInfo?.GeometryType,
+            PrimaryKey = resolved?.PrimaryKey ?? request.PrimaryKey,
+            SourceSrid = tableInfo?.Srid,
+            ServiceSrid = resolved?.ServiceSrid,
+            TargetSrid = resolved?.TargetSrid,
+            EstimatedRows = tableInfo?.EstimatedRows,
+            FeatureCount = geometryHealth?.FeatureCount,
+            NullGeometryCount = geometryHealth?.NullGeometryCount,
+            InvalidGeometryCount = geometryHealth?.InvalidGeometryCount,
+            Fields = BuildValidationFields(tableInfo?.Columns ?? [], request.Fields),
+            Checks = checks.ToArray()
+        };
+    }
+
+    private static TablePublishValidationField[] BuildValidationFields(
+        List<ColumnInfo> columns,
+        IReadOnlyList<string> selected)
+    {
+        var selectedSet = selected == null || selected.Count == 0
+            ? null
+            : new HashSet<string>(
+                selected.Where(field => !string.IsNullOrWhiteSpace(field)).Select(field => field.Trim()),
+                StringComparer.OrdinalIgnoreCase);
+
+        return columns
+            .Select(column => new TablePublishValidationField
+            {
+                Name = column.Name,
+                DataType = column.DataType,
+                FieldType = MapPostgresType(column.DataType).ToString(),
+                IsNullable = column.IsNullable,
+                IsPrimaryKey = column.IsPrimaryKey,
+                IsSelected = selectedSet == null || selectedSet.Contains(column.Name),
+                MaxLength = column.MaxLength
+            })
+            .ToArray();
     }
 
     private static string NormalizeGeometryType(string raw)
@@ -895,6 +1313,183 @@ internal sealed partial class PostgreSqlLayerPublishingService(
     private static string QuoteLiteral(string literal)
         => "'" + literal.Replace("'", "''", StringComparison.Ordinal) + "'";
 
+    private static ColumnInfo? FindColumn(TableInfo tableInfo, string columnName)
+        => tableInfo.Columns.FirstOrDefault(column =>
+            column.Name.Equals(columnName, StringComparison.OrdinalIgnoreCase));
+
+    private static async Task<GeometryHealth?> InspectGeometryHealthAsync(
+        string connectionString,
+        string schema,
+        string table,
+        string geometryColumn,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        var sourceTable = $"{QuoteIdentifier(schema)}.{QuoteIdentifier(table)}";
+        var sourceGeometry = QuoteIdentifier(geometryColumn);
+        var sql = $"""
+            WITH source AS (
+                SELECT {sourceGeometry}::geometry AS geom
+                FROM {sourceTable}
+            )
+            SELECT
+                COUNT(*)::bigint,
+                COUNT(*) FILTER (WHERE geom IS NULL)::bigint,
+                COUNT(*) FILTER (WHERE geom IS NOT NULL AND NOT ST_IsValid(geom))::bigint,
+                COUNT(DISTINCT GeometryType(geom)) FILTER (WHERE geom IS NOT NULL)::int,
+                MIN(NULLIF(ST_SRID(geom), 0)) FILTER (WHERE geom IS NOT NULL)::int,
+                MAX(NULLIF(ST_SRID(geom), 0)) FILTER (WHERE geom IS NOT NULL)::int
+            FROM source;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return new GeometryHealth(
+            reader.GetInt64(0),
+            reader.GetInt64(1),
+            reader.GetInt64(2),
+            reader.IsDBNull(3) ? 0 : reader.GetInt32(3),
+            reader.IsDBNull(4) ? null : reader.GetInt32(4),
+            reader.IsDBNull(5) ? null : reader.GetInt32(5));
+    }
+
+    private static async Task<int?> ResolveExistingServiceSridAsync(
+        string connectionString,
+        string serviceName,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        if (!await HonuaTableExistsAsync(connection, "services", cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        const string sql = """
+            SELECT srid
+            FROM honua.services
+            WHERE service_name = @serviceName
+            LIMIT 1;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@serviceName", serviceName);
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return result == null || result == DBNull.Value
+            ? null
+            : Convert.ToInt32(result, CultureInfo.InvariantCulture);
+    }
+
+    private static async Task AddExistingLayerCheckAsync(
+        string connectionString,
+        string schema,
+        string table,
+        List<TablePublishValidationCheck> checks,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        if (!await HonuaTableExistsAsync(connection, "layers", cancellationToken).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        const string sql = """
+            SELECT layer_id
+            FROM honua.layers
+            WHERE table_schema = @schema
+              AND table_name = @table
+            LIMIT 1;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@schema", schema);
+        command.Parameters.AddWithValue("@table", table);
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        if (result == null || result == DBNull.Value)
+        {
+            checks.Add(Pass("layer-conflict", "No existing layer is mapped to this source table."));
+            return;
+        }
+
+        checks.Add(Error(
+            "layer-conflict",
+            "A layer already exists for this source table.",
+            null,
+            Convert.ToString(result, CultureInfo.InvariantCulture)));
+    }
+
+    private static async Task<bool> HonuaTableExistsAsync(
+        NpgsqlConnection connection,
+        string tableName,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = 'honua'
+                  AND table_name = @tableName
+            );
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@tableName", tableName);
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return result is bool exists && exists;
+    }
+
+    private static TablePublishValidationCheck Pass(
+        string code,
+        string message,
+        string? expected = null,
+        string? actual = null)
+        => new()
+        {
+            Code = code,
+            Severity = SeverityPass,
+            Message = message,
+            Expected = expected,
+            Actual = actual
+        };
+
+    private static TablePublishValidationCheck Warning(
+        string code,
+        string message,
+        string? expected = null,
+        string? actual = null)
+        => new()
+        {
+            Code = code,
+            Severity = SeverityWarning,
+            Message = message,
+            Expected = expected,
+            Actual = actual
+        };
+
+    private static TablePublishValidationCheck Error(
+        string code,
+        string message,
+        string? expected = null,
+        string? actual = null)
+        => new()
+        {
+            Code = code,
+            Severity = SeverityError,
+            Message = message,
+            Expected = expected,
+            Actual = actual
+        };
+
     private static async Task InsertFieldsAsync(
         NpgsqlConnection connection,
         NpgsqlTransaction transaction,
@@ -1165,4 +1760,19 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         double MinY,
         double MaxX,
         double MaxY);
+
+    private readonly record struct GeometryHealth(
+        long FeatureCount,
+        long NullGeometryCount,
+        long InvalidGeometryCount,
+        int DistinctGeometryTypeCount,
+        int? MinSrid,
+        int? MaxSrid);
+
+    private readonly record struct ResolvedPublishValidation(
+        string? GeometryColumn,
+        string? GeometryType,
+        string? PrimaryKey,
+        int? ServiceSrid,
+        int? TargetSrid);
 }

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -70,6 +70,7 @@ public static class EndpointRegistry
         new("PUT", "/api/v1/admin/connections/{id}/tables"),
         new("DELETE", "/api/v1/admin/connections/{id}/tables"),
         new("PATCH", "/api/v1/admin/connections/{id}/tables"),
+        new("POST", "/api/v1/admin/connections/{id}/tables/validate"),
         new("GET", "/api/v1/admin/connections/tables"),
         new("GET", "/api/v1/admin/connections/{*path}"),
         new("POST", "/api/v1/admin/external-services/discover"),

--- a/src/Honua.Server/Features/Admin/LayerPublishingEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/LayerPublishingEndpoints.cs
@@ -59,6 +59,21 @@ internal static class LayerPublishingEndpoints
         group.MapPut("/enabled", HandleSetServiceLayersEnabled)
             .WithDisplayName("Set Service Layers Enabled")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Put }));
+
+        var tableGroup = endpoints.MapGroup("/api/v{version:apiVersion}/admin/connections/{id}/tables")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Layers")
+            .RequireAdminAuthorization();
+
+        tableGroup.MapPost("/validate", HandleValidateTableForPublish)
+            .WithDisplayName("Validate Table For Layer Publishing")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
+            .Produces<ApiResponse<TablePublishValidationResult>>(StatusCodes.Status200OK)
+            .Produces<ApiResponse<object>>(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .Produces<ApiResponse<object>>(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
     }
 
     private static async Task<Results<Ok<ApiResponse<IReadOnlyList<PublishedLayerSummary>>>, NotFound<ApiResponse<object>>, BadRequest<ApiResponse<object>>, ProblemHttpResult, ForbidHttpResult>>
@@ -208,6 +223,80 @@ internal static class LayerPublishingEndpoints
             return TypedResults.Problem(
                 title: "Layer publish failed",
                 detail: "An internal error occurred while publishing the layer.",
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return TypedResults.Forbid();
+        }
+    }
+
+    private static async Task<IResult>
+        HandleValidateTableForPublish(
+            string id,
+            ValidateTablePublishRequest request,
+            [FromServices] ISecureConnectionResolver resolver,
+            [FromServices] ILayerPublishingService publishingService,
+            HttpContext context,
+            [FromServices] ILogger<LayerPublishingEndpointsLog> logger)
+    {
+        var validationResults = new List<ValidationResult>();
+        if (!Validator.TryValidateObject(request, new ValidationContext(request), validationResults, true))
+        {
+            var errors = string.Join(", ", validationResults.Select(r => r.ErrorMessage));
+            return TypedResults.BadRequest(ApiResponse<object>.Failure($"Validation failed: {errors}"));
+        }
+
+        try
+        {
+            var connectionString = await ResolveConnectionStringAsync(id, resolver, context.RequestAborted);
+            var validationRequest = new TablePublishValidationRequest
+            {
+                Schema = request.Schema,
+                Table = request.Table,
+                LayerName = request.LayerName,
+                ServiceName = request.ServiceName,
+                TargetSrid = request.TargetSrid,
+                GeometryColumn = request.GeometryColumn,
+                PrimaryKey = request.PrimaryKey,
+                Fields = request.Fields ?? Array.Empty<string>()
+            };
+
+            var result = await publishingService.ValidateTableForPublishAsync(
+                connectionString,
+                validationRequest,
+                context.RequestAborted);
+
+            return Results.Json(
+                ApiResponse<TablePublishValidationResult>.CreateSuccess(result),
+                LayerPublishingJsonContext.Default.ApiResponseTablePublishValidationResult);
+        }
+        catch (LayerPublishingException ex) when (ex.ErrorKind == LayerPublishingErrorKind.NotFound)
+        {
+            LayerPublishingLog.LayerPublishNotFound(logger, ex);
+            return TypedResults.NotFound(ApiResponse<object>.Failure(GetSafeLayerPublishingMessage(ex)));
+        }
+        catch (LayerPublishingException ex)
+        {
+            LayerPublishingLog.LayerPublishValidationFailed(logger, ex);
+            return TypedResults.BadRequest(ApiResponse<object>.Failure(GetSafeLayerPublishingMessage(ex)));
+        }
+        catch (ArgumentException ex)
+        {
+            LayerPublishingLog.LayerPublishInvalidRequest(logger, ex);
+            return TypedResults.BadRequest(ApiResponse<object>.Failure("Invalid request parameters."));
+        }
+        catch (ResourceNotFoundException ex)
+        {
+            LayerPublishingLog.LayerListConnectionNotFound(logger, ex);
+            return TypedResults.NotFound(ApiResponse<object>.Failure("The requested resource was not found."));
+        }
+        catch (InvalidOperationException ex)
+        {
+            LayerPublishingLog.LayerPublishInvalidOperation(logger, ex);
+            return TypedResults.Problem(
+                title: "Layer validation failed",
+                detail: "An internal error occurred while validating the layer.",
                 statusCode: StatusCodes.Status500InternalServerError);
         }
         catch (UnauthorizedAccessException)

--- a/src/Honua.Server/Features/Admin/Models/LayerPublishingJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/LayerPublishingJsonContext.cs
@@ -16,10 +16,17 @@ namespace Honua.Server.Features.Admin.Models;
     WriteIndented = false)]
 [JsonSerializable(typeof(ApiResponse<IReadOnlyList<PublishedLayerSummary>>))]
 [JsonSerializable(typeof(ApiResponse<PublishedLayerSummary>))]
+[JsonSerializable(typeof(ApiResponse<TablePublishValidationResult>))]
 [JsonSerializable(typeof(ApiResponse<object>))]
 [JsonSerializable(typeof(PublishLayerRequest))]
+[JsonSerializable(typeof(ValidateTablePublishRequest))]
 [JsonSerializable(typeof(LayerEnabledRequest))]
 [JsonSerializable(typeof(PublishedLayerSummary))]
+[JsonSerializable(typeof(TablePublishValidationResult))]
+[JsonSerializable(typeof(TablePublishValidationCheck))]
+[JsonSerializable(typeof(TablePublishValidationCheck[]))]
+[JsonSerializable(typeof(TablePublishValidationField))]
+[JsonSerializable(typeof(TablePublishValidationField[]))]
 internal sealed partial class LayerPublishingJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Server/Features/Admin/Models/LayerPublishingModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/LayerPublishingModels.cs
@@ -79,6 +79,61 @@ public sealed class PublishLayerRequest
 }
 
 /// <summary>
+/// Request payload for validating a selected table before publishing it as a layer.
+/// </summary>
+public sealed class ValidateTablePublishRequest
+{
+    /// <summary>
+    /// Schema containing the source table.
+    /// </summary>
+    [Required]
+    [StringLength(63, MinimumLength = 1)]
+    public required string Schema { get; init; }
+
+    /// <summary>
+    /// Source table name.
+    /// </summary>
+    [Required]
+    [StringLength(63, MinimumLength = 1)]
+    public required string Table { get; init; }
+
+    /// <summary>
+    /// Optional display name for the layer being prepared.
+    /// </summary>
+    [StringLength(128, MinimumLength = 1)]
+    public string? LayerName { get; init; }
+
+    /// <summary>
+    /// Optional target service name.
+    /// </summary>
+    [StringLength(64)]
+    public string? ServiceName { get; init; }
+
+    /// <summary>
+    /// Requested target spatial reference identifier.
+    /// </summary>
+    [Range(0, int.MaxValue)]
+    public int? TargetSrid { get; init; }
+
+    /// <summary>
+    /// Requested geometry column name.
+    /// </summary>
+    [StringLength(64)]
+    public string? GeometryColumn { get; init; }
+
+    /// <summary>
+    /// Requested primary key field name.
+    /// </summary>
+    [StringLength(64)]
+    public string? PrimaryKey { get; init; }
+
+    /// <summary>
+    /// Selected attribute fields to publish. Empty means include all.
+    /// </summary>
+    public IReadOnlyList<string> Fields { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>
 /// Request payload for enabling/disabling a layer.
 /// </summary>
 public sealed class LayerEnabledRequest

--- a/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
@@ -562,6 +562,105 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/tables/validate")]
+    public async Task ValidateTableForPublish_WithValidTable_ReturnsFieldMetadata()
+    {
+        var validationRequest = new ValidateTablePublishRequest
+        {
+            Schema = _schema,
+            Table = _tableName,
+            LayerName = $"Layer {_tableName}",
+            ServiceName = _serviceName,
+            TargetSrid = 4326,
+            GeometryColumn = "geom",
+            PrimaryKey = "id",
+            Fields = new[] { "id", "name", "population" }
+        };
+
+        var response = await _client.PostAsync(
+            $"/api/v1/admin/connections/{_connectionId}/tables/validate",
+            JsonContent.Create(validationRequest, options: _jsonOptions));
+
+        var payload = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, $"response: {payload}");
+        var api = JsonSerializer.Deserialize<ApiResponse<TablePublishValidationResult>>(payload, _jsonOptions);
+
+        api.Should().NotBeNull();
+        api!.Success.Should().BeTrue();
+        api.Data.Should().NotBeNull();
+        api.Data!.IsValid.Should().BeTrue();
+        api.Data.Status.Should().Be("valid");
+        api.Data.Schema.Should().Be(_schema);
+        api.Data.Table.Should().Be(_tableName);
+        api.Data.GeometryColumn.Should().Be("geom");
+        api.Data.PrimaryKey.Should().Be("id");
+        api.Data.SourceSrid.Should().Be(4326);
+        api.Data.TargetSrid.Should().Be(4326);
+        api.Data.FeatureCount.Should().Be(1);
+        api.Data.Fields.Should().Contain(field => field.Name == "id" && field.IsPrimaryKey && field.IsSelected);
+        api.Data.Fields.Should().OnlyContain(field => field.Name != "geom");
+        api.Data.Checks.Should().Contain(check => check.Code == "invalid-geometries" && check.Severity == "pass");
+        api.Data.Checks.Should().NotContain(check => check.Severity == "error");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/tables/validate")]
+    public async Task ValidateTableForPublish_WithTextPrimaryKey_ReturnsStructuredError()
+    {
+        var textPrimaryKeyTable = $"layer_textpk_{Guid.NewGuid():N}";
+
+        try
+        {
+            await _fixture.Postgres.ExecuteAsync($"""
+                CREATE TABLE public.{textPrimaryKeyTable} (
+                    code text PRIMARY KEY,
+                    name text NOT NULL,
+                    geom geometry(Point, 4326) NOT NULL
+                );
+
+                INSERT INTO public.{textPrimaryKeyTable} (code, name, geom)
+                VALUES ('A-1', 'Text key feature', ST_SetSRID(ST_Point(1, 1), 4326));
+                """);
+
+            var validationRequest = new ValidateTablePublishRequest
+            {
+                Schema = _schema,
+                Table = textPrimaryKeyTable,
+                LayerName = $"Layer {textPrimaryKeyTable}",
+                ServiceName = _serviceName,
+                TargetSrid = 4326,
+                GeometryColumn = "geom",
+                PrimaryKey = "code",
+                Fields = new[] { "code", "name" }
+            };
+
+            var response = await _client.PostAsync(
+                $"/api/v1/admin/connections/{_connectionId}/tables/validate",
+                JsonContent.Create(validationRequest, options: _jsonOptions));
+
+            var payload = await response.Content.ReadAsStringAsync();
+            response.StatusCode.Should().Be(HttpStatusCode.OK, $"response: {payload}");
+            var api = JsonSerializer.Deserialize<ApiResponse<TablePublishValidationResult>>(payload, _jsonOptions);
+
+            api.Should().NotBeNull();
+            api!.Success.Should().BeTrue();
+            api.Data.Should().NotBeNull();
+            api.Data!.IsValid.Should().BeFalse();
+            api.Data.Status.Should().Be("invalid");
+            api.Data.Checks.Should().Contain(check =>
+                check.Code == "primary-key-type" &&
+                check.Severity == "error" &&
+                check.Actual == "text");
+        }
+        finally
+        {
+            await _fixture.Postgres.ExecuteAsync($"DROP TABLE IF EXISTS public.{textPrimaryKeyTable};");
+        }
+    }
+
+    [IntegrationTest]
     [Operation(Operations.Create)]
     [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
     public async Task PublishLayer_WhenLayerTableIsEmpty_ReturnsCreated()

--- a/tests/dotnet/Honua.Server.Tests/TestWebApplicationFactory.cs
+++ b/tests/dotnet/Honua.Server.Tests/TestWebApplicationFactory.cs
@@ -286,6 +286,30 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
             throw new NotSupportedException("Layer publishing is not available in this test fixture.");
         }
 
+        public Task<TablePublishValidationResult> ValidateTableForPublishAsync(
+            string connectionString,
+            TablePublishValidationRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new TablePublishValidationResult
+            {
+                IsValid = false,
+                Status = "invalid",
+                Schema = request.Schema,
+                Table = request.Table,
+                ServiceName = request.ServiceName ?? "default",
+                Checks =
+                [
+                    new TablePublishValidationCheck
+                    {
+                        Code = "not-supported",
+                        Severity = "error",
+                        Message = "Layer publishing validation is not available in this test fixture."
+                    }
+                ]
+            });
+        }
+
         public Task<PublishedLayerSummary?> SetLayerEnabledAsync(
             string connectionString,
             int layerId,


### PR DESCRIPTION
## Summary
- Adds a pre-publish table validation contract for admin layer publishing.
- Exposes `POST /api/v1/admin/connections/{id}/tables/validate` for selected table validation before catalog rows are created.
- Makes existing service SRID authoritative when publishing into an existing service so source geometries are transformed to that projection.

## Changes Made
- Added structured table publish validation request/result/check/field DTOs.
- Added PostGIS validation for table existence, field selection, geometry column/type, source/target SRID, feature count, null/invalid geometries, mixed geometry/SRID, primary key type, and existing layer conflicts.
- Added admin endpoint wiring, source-generated JSON metadata, and EndpointRegistry tracking.
- Added integration coverage for valid table validation and unsupported text primary keys.

## Gate Impact
- [x] Admin/server API contract changed for layer publishing validation.
- [x] Server Tests/Admin & Infrastructure and publish-related paths affected.
- Supports honua-server#975 and unblocks admin pre-publish validation UI work.
- Follow-up remains for file-backed validation before publish/import; this PR is the selected database table slice.

## Testing
- [x] scripts/ci/pre-pr-check.sh equivalent scoped validation run locally; full PR gate is running in CI.
- [x] dotnet restore tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj
- [x] dotnet build tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --no-restore
- [x] dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --no-build --filter FullyQualifiedName~LayerPublishingIntegrationTests
- [x] dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --no-restore --filter FullyQualifiedName~EndpointRegistryDriftTests
- [x] dotnet format tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --verify-no-changes --no-restore

## Breaking Changes
- Extends ILayerPublishingService with table pre-publish validation; in-repo test fixtures were updated.

Related to #975
