### PR TITLE
feat(import): validate vector files before publish

### DIFF
--- a/src/Honua.Core/Features/Import/Domain/ImportResult.cs
+++ b/src/Honua.Core/Features/Import/Domain/ImportResult.cs
@@ -59,6 +59,16 @@ public sealed record ImportResult
     public string? ErrorMessage { get; init; }
 
     /// <summary>
+    /// Stable machine-readable error code if import failed.
+    /// </summary>
+    public string? ErrorCode { get; init; }
+
+    /// <summary>
+    /// Structured validation issues that blocked import before rows were created.
+    /// </summary>
+    public IReadOnlyList<ImportValidationIssue> ValidationErrors { get; init; } = [];
+
+    /// <summary>
     /// Import duration
     /// </summary>
     public TimeSpan Duration { get; init; }
@@ -97,14 +107,61 @@ public sealed record ImportResult
         SupportedFileFormat format,
         string errorMessage,
         TimeSpan duration = default,
-        IReadOnlyList<string>? warnings = null) =>
+        IReadOnlyList<string>? warnings = null,
+        string? errorCode = null,
+        IReadOnlyList<ImportValidationIssue>? validationErrors = null) =>
         new()
         {
             Success = false,
             TableName = tableName,
             Format = format,
             ErrorMessage = errorMessage,
+            ErrorCode = errorCode,
             Duration = duration,
-            Warnings = warnings ?? []
+            Warnings = warnings ?? [],
+            ValidationErrors = validationErrors ?? []
+        };
+}
+
+/// <summary>
+/// Stable import validation error codes surfaced in import failure responses.
+/// </summary>
+public static class ImportValidationErrorCodes
+{
+    public const string EmptyDataset = "import.empty_dataset";
+    public const string GeometryMissing = "import.geometry_missing";
+    public const string GeometryUnknownType = "import.geometry_unknown_type";
+    public const string GeometryInvalid = "import.geometry_invalid";
+    public const string InvalidGeoJson = "import.geojson_invalid";
+    public const string SourceSridRequired = "import.source_srid_required";
+    public const string SourceSridUnsupported = "import.source_srid_unsupported";
+    public const string TargetSridUnsupported = "import.target_srid_unsupported";
+    public const string ProjectionUnsupported = "import.projection_unsupported";
+}
+
+/// <summary>
+/// Machine-readable validation issue for file import failures.
+/// </summary>
+public sealed record ImportValidationIssue
+{
+    public required string Code { get; init; }
+
+    public required string Message { get; init; }
+
+    public int? FeatureIndex { get; init; }
+
+    public string? Field { get; init; }
+
+    public static ImportValidationIssue Create(
+        string code,
+        string message,
+        int? featureIndex = null,
+        string? field = null) =>
+        new()
+        {
+            Code = code,
+            Message = message,
+            FeatureIndex = featureIndex,
+            Field = field
         };
 }

--- a/src/Honua.Core/Features/Import/Services/StreamingGeoJsonReader.cs
+++ b/src/Honua.Core/Features/Import/Services/StreamingGeoJsonReader.cs
@@ -26,6 +26,11 @@ internal sealed record JsonProcessingState
     public bool IsComplete { get; init; }
 }
 
+internal sealed record GeoJsonValidationResult(int FeatureCount, IReadOnlyList<ImportValidationIssue> Issues)
+{
+    public bool IsValid => Issues.Count == 0;
+}
+
 /// <summary>
 /// Memory-efficient streaming GeoJSON reader that processes features incrementally.
 /// Uses Utf8JsonReader for low-allocation parsing without loading the entire file into memory.
@@ -34,6 +39,17 @@ internal sealed class StreamingGeoJsonReader
 {
     private readonly ImportLimits _limits;
     private readonly GeometryFactory _geometryFactory;
+    private const int MaxValidationIssues = 100;
+    private static readonly HashSet<string> _knownGeometryTypes = new(StringComparer.Ordinal)
+    {
+        "Point",
+        "MultiPoint",
+        "LineString",
+        "MultiLineString",
+        "Polygon",
+        "MultiPolygon",
+        "GeometryCollection"
+    };
 
     public StreamingGeoJsonReader(ImportLimits? limits = null)
     {
@@ -158,6 +174,90 @@ internal sealed class StreamingGeoJsonReader
                 MemoryPool.ReturnByteArray(leftoverBuffer, clearArray: false);
             }
         }
+    }
+
+    public async Task<GeoJsonValidationResult> ValidateAsync(
+        Stream stream,
+        CancellationToken cancellationToken = default)
+    {
+        var issues = new List<ImportValidationIssue>();
+        var featureCount = 0;
+
+        try
+        {
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+            }
+
+            using var document = await JsonDocument.ParseAsync(
+                stream,
+                new JsonDocumentOptions
+                {
+                    AllowTrailingCommas = true,
+                    CommentHandling = JsonCommentHandling.Skip
+                },
+                cancellationToken);
+
+            var root = document.RootElement;
+            if (!root.TryGetProperty("type", out var rootTypeElement) ||
+                !string.Equals(rootTypeElement.GetString(), "FeatureCollection", StringComparison.Ordinal))
+            {
+                issues.Add(ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.InvalidGeoJson,
+                    "GeoJSON root object must have type \"FeatureCollection\".",
+                    field: "type"));
+            }
+
+            if (!root.TryGetProperty("features", out var featuresElement) ||
+                featuresElement.ValueKind != JsonValueKind.Array)
+            {
+                issues.Add(ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.EmptyDataset,
+                    "GeoJSON FeatureCollection does not contain a features array.",
+                    field: "features"));
+            }
+            else
+            {
+                foreach (var featureElement in featuresElement.EnumerateArray())
+                {
+                    featureCount++;
+                    if (issues.Count < MaxValidationIssues)
+                    {
+                        issues.AddRange(ValidateFeature(featureElement, featureCount)
+                            .Take(MaxValidationIssues - issues.Count));
+                    }
+
+                    if (_limits.MaxFeaturesPerFile > 0 && featureCount >= _limits.MaxFeaturesPerFile)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (featureCount == 0 && issues.All(issue => issue.Code != ImportValidationErrorCodes.EmptyDataset))
+            {
+                issues.Add(ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.EmptyDataset,
+                    "GeoJSON FeatureCollection does not contain any features.",
+                    field: "features"));
+            }
+        }
+        catch (JsonException)
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.InvalidGeoJson,
+                "GeoJSON document is not valid JSON."));
+        }
+        finally
+        {
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+            }
+        }
+
+        return new GeoJsonValidationResult(featureCount, issues);
     }
 
     /// <summary>
@@ -286,6 +386,80 @@ internal sealed class StreamingGeoJsonReader
         return (features, reader.CurrentState, newProcessingState, lastConsumed);
     }
 
+    private List<ImportValidationIssue> ValidateFeature(JsonElement root, int featureIndex)
+    {
+        var issues = new List<ImportValidationIssue>(1);
+
+        if (!root.TryGetProperty("type", out var typeElement) ||
+            !string.Equals(typeElement.GetString(), "Feature", StringComparison.Ordinal))
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.InvalidGeoJson,
+                "GeoJSON features must have type \"Feature\".",
+                featureIndex,
+                "type"));
+            return issues;
+        }
+
+        if (!root.TryGetProperty("geometry", out var geometryElement) ||
+            geometryElement.ValueKind == JsonValueKind.Null)
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.GeometryMissing,
+                "GeoJSON feature is missing geometry.",
+                featureIndex,
+                "geometry"));
+            return issues;
+        }
+
+        if (geometryElement.ValueKind != JsonValueKind.Object)
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.GeometryInvalid,
+                "GeoJSON feature geometry must be an object.",
+                featureIndex,
+                "geometry"));
+            return issues;
+        }
+
+        if (!geometryElement.TryGetProperty("type", out var geometryTypeElement) ||
+            string.IsNullOrWhiteSpace(geometryTypeElement.GetString()))
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.GeometryMissing,
+                "GeoJSON feature geometry is missing a type.",
+                featureIndex,
+                "geometry.type"));
+            return issues;
+        }
+
+        var geometryType = geometryTypeElement.GetString()!;
+        if (!_knownGeometryTypes.Contains(geometryType))
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.GeometryUnknownType,
+                $"GeoJSON geometry type \"{geometryType}\" is not supported.",
+                featureIndex,
+                "geometry.type"));
+            return issues;
+        }
+
+        var geometry = ParseGeometry(geometryElement);
+        var validationError = geometry == null
+            ? "GeoJSON geometry coordinates are invalid or incomplete."
+            : ValidateParsedGeometry(geometry);
+        if (validationError != null)
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.GeometryInvalid,
+                validationError,
+                featureIndex,
+                "geometry"));
+        }
+
+        return issues;
+    }
+
     /// <summary>
     /// Parse a single GeoJSON feature from a byte span.
     /// </summary>
@@ -392,6 +566,69 @@ internal sealed class StreamingGeoJsonReader
         {
             return null;
         }
+    }
+
+    private string? ValidateParsedGeometry(NtsGeometry geometry)
+    {
+        if (geometry.IsEmpty)
+        {
+            return "GeoJSON geometry is empty.";
+        }
+
+        if (geometry.NumPoints > _limits.MaxVertices)
+        {
+            return $"Geometry vertex count ({geometry.NumPoints:N0}) exceeds maximum allowed ({_limits.MaxVertices:N0}).";
+        }
+
+        var ringCount = CountRings(geometry);
+        if (ringCount > _limits.MaxRings)
+        {
+            return $"Geometry ring count ({ringCount:N0}) exceeds maximum allowed ({_limits.MaxRings:N0}).";
+        }
+
+        if (!ValidateCoordinates(geometry))
+        {
+            return "Geometry contains invalid coordinates (NaN or Infinity).";
+        }
+
+        if (!geometry.IsValid)
+        {
+            return "Geometry topology is invalid.";
+        }
+
+        return null;
+    }
+
+    private static int CountRings(NtsGeometry geometry)
+    {
+        return geometry switch
+        {
+            Polygon polygon => 1 + polygon.NumInteriorRings,
+            MultiPolygon multiPolygon => multiPolygon.Geometries
+                .OfType<Polygon>()
+                .Sum(p => 1 + p.NumInteriorRings),
+            GeometryCollection collection => collection.Geometries.Sum(CountRings),
+            _ => 0
+        };
+    }
+
+    private static bool ValidateCoordinates(NtsGeometry geometry)
+    {
+        foreach (var coord in geometry.Coordinates)
+        {
+            if (double.IsNaN(coord.X) || double.IsInfinity(coord.X) ||
+                double.IsNaN(coord.Y) || double.IsInfinity(coord.Y))
+            {
+                return false;
+            }
+
+            if (!double.IsNaN(coord.Z) && double.IsInfinity(coord.Z))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private Point ParsePoint(JsonElement coords)

--- a/src/Honua.Postgres/Features/Import/StreamingFileImportService.cs
+++ b/src/Honua.Postgres/Features/Import/StreamingFileImportService.cs
@@ -440,13 +440,73 @@ internal sealed partial class StreamingFileImportService : IFileImportService
             if (!sourceSrid.HasValue)
             {
                 errorMessage = $"Source SRID is required for {format.Value} imports when CRS cannot be detected.";
+                var validationErrors = new[]
+                {
+                    ImportValidationIssue.Create(
+                        ImportValidationErrorCodes.SourceSridRequired,
+                        errorMessage,
+                        field: nameof(request.SourceSrid))
+                };
                 result = ImportResult.CreateFailure(
                     request.TableName,
                     format.Value,
                     errorMessage,
                     stopwatch.Elapsed,
-                    warnings);
+                    warnings,
+                    ImportValidationErrorCodes.SourceSridRequired,
+                    validationErrors);
                 return result;
+            }
+
+            var sridValidationErrors = await ValidateImportSridsAsync(
+                sourceSrid.Value,
+                request.TargetSrid,
+                cancellationToken);
+            if (sridValidationErrors.Count > 0)
+            {
+                errorMessage = sridValidationErrors[0].Message;
+                result = ImportResult.CreateFailure(
+                    request.TableName,
+                    format.Value,
+                    errorMessage,
+                    stopwatch.Elapsed,
+                    warnings,
+                    sridValidationErrors[0].Code,
+                    sridValidationErrors);
+                return result;
+            }
+
+            if (format.Value == SupportedFileFormat.GeoJson)
+            {
+                if (!fileStream.CanSeek)
+                {
+                    var seekableStream = await SpillToSeekableTempAsync(fileStream, cancellationToken);
+                    if (shouldDisposeStream)
+                    {
+                        await fileStream.DisposeAsync();
+                    }
+
+                    fileStream = seekableStream;
+                    shouldDisposeStream = true;
+                    totalBytes = seekableStream.Length;
+                    ImportLog.SpilledToTempFile(_logger, totalBytes.Value);
+                }
+
+                var geoJsonValidation = await _geoJsonReader.ValidateAsync(fileStream, cancellationToken);
+                if (!geoJsonValidation.IsValid)
+                {
+                    var issue = geoJsonValidation.Issues[0];
+                    errorMessage = issue.Message;
+                    result = ImportResult.CreateFailure(
+                        request.TableName,
+                        format.Value,
+                        errorMessage,
+                        stopwatch.Elapsed,
+                        warnings,
+                        issue.Code,
+                        geoJsonValidation.Issues);
+                    return result;
+                }
             }
 
             // Report initial progress
@@ -644,6 +704,11 @@ internal sealed partial class StreamingFileImportService : IFileImportService
                 continue;
             }
 
+            if (format != SupportedFileFormat.FileGdb && feature.Geometry != null)
+            {
+                feature.Geometry.SRID = sourceSrid;
+            }
+
             batch.Add(feature);
 
             // Process batch when full
@@ -779,6 +844,89 @@ internal sealed partial class StreamingFileImportService : IFileImportService
         if (failedCount > 0)
         {
             _performanceMonitor.RecordCounter("honua_import_failures_total", failedCount, tags);
+        }
+    }
+
+    private async Task<IReadOnlyList<ImportValidationIssue>> ValidateImportSridsAsync(
+        int sourceSrid,
+        int targetSrid,
+        CancellationToken cancellationToken)
+    {
+        if (sourceSrid <= 0)
+        {
+            return
+            [
+                ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.SourceSridUnsupported,
+                    $"Source SRID {sourceSrid} is not supported.",
+                    field: nameof(ImportRequest.SourceSrid))
+            ];
+        }
+
+        if (targetSrid <= 0)
+        {
+            return
+            [
+                ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.TargetSridUnsupported,
+                    $"Target SRID {targetSrid} is not supported.",
+                    field: nameof(ImportRequest.TargetSrid))
+            ];
+        }
+
+        if (!await _crsDetectionService.ValidateSridAsync(sourceSrid))
+        {
+            return
+            [
+                ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.SourceSridUnsupported,
+                    $"Source SRID {sourceSrid} is not registered in spatial_ref_sys.",
+                    field: nameof(ImportRequest.SourceSrid))
+            ];
+        }
+
+        if (!await _crsDetectionService.ValidateSridAsync(targetSrid))
+        {
+            return
+            [
+                ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.TargetSridUnsupported,
+                    $"Target SRID {targetSrid} is not registered in spatial_ref_sys.",
+                    field: nameof(ImportRequest.TargetSrid))
+            ];
+        }
+
+        if (sourceSrid != targetSrid && !await CanTransformAsync(sourceSrid, targetSrid, cancellationToken))
+        {
+            return
+            [
+                ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.ProjectionUnsupported,
+                    $"Source SRID {sourceSrid} cannot be transformed to target SRID {targetSrid}.",
+                    field: nameof(ImportRequest.TargetSrid))
+            ];
+        }
+
+        return [];
+    }
+
+    private async Task<bool> CanTransformAsync(int sourceSrid, int targetSrid, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await OpenConnectionAsync(cancellationToken);
+            await using var command = new NpgsqlCommand(
+                "SELECT ST_Transform(ST_SetSRID(ST_MakePoint(0, 0), @source_srid), @target_srid) IS NOT NULL",
+                connection);
+            command.Parameters.Add("source_srid", NpgsqlDbType.Integer).Value = sourceSrid;
+            command.Parameters.Add("target_srid", NpgsqlDbType.Integer).Value = targetSrid;
+
+            var result = await command.ExecuteScalarAsync(cancellationToken);
+            return result is bool transformed && transformed;
+        }
+        catch (PostgresException)
+        {
+            return false;
         }
     }
 

--- a/src/Honua.Server/Features/Import/ImportJsonContext.cs
+++ b/src/Honua.Server/Features/Import/ImportJsonContext.cs
@@ -21,6 +21,8 @@ namespace Honua.Server.Features.Import;
 [JsonSerializable(typeof(MigrationInventoryCodedValue[]))]
 [JsonSerializable(typeof(FilePreview))]
 [JsonSerializable(typeof(ImportResult))]
+[JsonSerializable(typeof(ImportValidationIssue))]
+[JsonSerializable(typeof(IReadOnlyList<ImportValidationIssue>))]
 [JsonSerializable(typeof(ImportProgress))]
 [JsonSerializable(typeof(ImportLimits))]
 [JsonSerializable(typeof(ImportStatus))]

--- a/tests/dotnet/Honua.Server.Tests/Import/StreamingImportTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/StreamingImportTests.cs
@@ -28,6 +28,7 @@ public class StreamingImportTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();
     private HttpClient _client = null!;
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     public async Task InitializeAsync()
     {
@@ -650,7 +651,7 @@ public class StreamingImportTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/import/upload")]
-    public async Task Import_InvalidGeoJson_HandlesErrorGracefully()
+    public async Task Import_InvalidGeoJson_ReturnsStructuredValidationAndDoesNotCreateTable()
     {
         // Arrange - Invalid GeoJSON with malformed geometry
         var geoJsonContent = """
@@ -683,10 +684,144 @@ public class StreamingImportTests : IAsyncLifetime
         // Act
         var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
 
-        // Assert - Should handle the error gracefully (either skip invalid features or fail with message)
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var responseContent = await response.Content.ReadAsStringAsync();
-        // The streaming parser should handle invalid features gracefully
-        (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.BadRequest).Should().BeTrue();
+        var result = DeserializeImportResult(responseContent);
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ImportValidationErrorCodes.GeometryUnknownType);
+        result.ValidationErrors.Should().ContainSingle(issue =>
+            issue.Code == ImportValidationErrorCodes.GeometryUnknownType &&
+            issue.FeatureIndex == 1 &&
+            issue.Field == "geometry.type");
+        (await ImportTableExistsAsync("invalid_test_table")).Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Import_GeoJsonMissingGeometry_ReturnsStructuredValidationAndDoesNotCreateTable()
+    {
+        var geoJsonContent = """
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": { "name": "No geometry" }
+                }
+            ]
+        }
+        """;
+
+        var content = new MultipartFormDataContent();
+        var fileContent = new StringContent(geoJsonContent, Encoding.UTF8, "application/json");
+        fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+        {
+            Name = "File",
+            FileName = "missing-geometry.geojson"
+        };
+        content.Add(fileContent);
+        content.Add(new StringContent("missing_geometry_table"), "TableName");
+        content.Add(new StringContent("true"), "OverwriteExisting");
+
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = DeserializeImportResult(await response.Content.ReadAsStringAsync());
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ImportValidationErrorCodes.GeometryMissing);
+        result.ValidationErrors.Should().ContainSingle(issue =>
+            issue.Code == ImportValidationErrorCodes.GeometryMissing &&
+            issue.FeatureIndex == 1 &&
+            issue.Field == "geometry");
+        (await ImportTableExistsAsync("missing_geometry_table")).Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Import_GeoJsonWithUnsupportedTargetSrid_ReturnsStructuredValidationAndDoesNotCreateTable()
+    {
+        var geoJsonContent = """
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [-122.4194, 37.7749]
+                    },
+                    "properties": { "name": "Valid" }
+                }
+            ]
+        }
+        """;
+
+        var content = new MultipartFormDataContent();
+        var fileContent = new StringContent(geoJsonContent, Encoding.UTF8, "application/json");
+        fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+        {
+            Name = "File",
+            FileName = "bad-target.geojson"
+        };
+        content.Add(fileContent);
+        content.Add(new StringContent("bad_target_srid_table"), "TableName");
+        content.Add(new StringContent("999999"), "TargetSrid");
+        content.Add(new StringContent("true"), "OverwriteExisting");
+
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = DeserializeImportResult(await response.Content.ReadAsStringAsync());
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ImportValidationErrorCodes.TargetSridUnsupported);
+        result.ValidationErrors.Should().ContainSingle(issue =>
+            issue.Code == ImportValidationErrorCodes.TargetSridUnsupported &&
+            issue.Field == nameof(ImportRequest.TargetSrid));
+        (await ImportTableExistsAsync("bad_target_srid_table")).Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Import_GeoJsonWithDifferentSourceAndTargetSrid_TransformsAtImport()
+    {
+        var geoJsonContent = """
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [111319.49079327357, 0]
+                    },
+                    "properties": { "name": "Web Mercator one degree east" }
+                }
+            ]
+        }
+        """;
+
+        var content = new MultipartFormDataContent();
+        var fileContent = new StringContent(geoJsonContent, Encoding.UTF8, "application/json");
+        fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+        {
+            Name = "File",
+            FileName = "mercator.geojson"
+        };
+        content.Add(fileContent);
+        content.Add(new StringContent("reprojected_geojson_table"), "TableName");
+        content.Add(new StringContent("3857"), "SourceSrid");
+        content.Add(new StringContent("4326"), "TargetSrid");
+        content.Add(new StringContent("true"), "OverwriteExisting");
+
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        response.BeSuccessful();
+        var result = DeserializeImportResult(await response.Content.ReadAsStringAsync());
+        result.Success.Should().BeTrue();
+        var (x, srid) = await ReadImportedPointAsync("reprojected_geojson_table");
+        x.Should().BeApproximately(1d, 0.000001d);
+        srid.Should().Be(4326);
     }
 
     [IntegrationTest]
@@ -751,7 +886,7 @@ public class StreamingImportTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/import/upload")]
-    public async Task Import_EmptyFeatureCollection_ReturnsError()
+    public async Task Import_EmptyFeatureCollection_ReturnsStructuredValidationAndDoesNotCreateTable()
     {
         // Arrange
         var geoJsonContent = """
@@ -776,8 +911,14 @@ public class StreamingImportTests : IAsyncLifetime
         var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
 
         // Assert
-        var responseContent = await response.Content.ReadAsStringAsync();
-        responseContent.Should().Contain("No features found");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = DeserializeImportResult(await response.Content.ReadAsStringAsync());
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ImportValidationErrorCodes.EmptyDataset);
+        result.ValidationErrors.Should().ContainSingle(issue =>
+            issue.Code == ImportValidationErrorCodes.EmptyDataset &&
+            issue.Field == "features");
+        (await ImportTableExistsAsync("empty_table")).Should().BeFalse();
     }
 
     private static byte[] BuildKmzArchive(string kmlContent)
@@ -812,4 +953,44 @@ public class StreamingImportTests : IAsyncLifetime
         response.BeSuccessful();
         return await response.Content.ReadAsStringAsync();
     }
+
+    private static ImportResult DeserializeImportResult(string responseContent)
+        => JsonSerializer.Deserialize<ImportResult>(responseContent, JsonOptions)
+           ?? throw new InvalidOperationException("Import response did not deserialize.");
+
+    private async Task<bool> ImportTableExistsAsync(string tableName)
+    {
+        var schema = _fixture.CurrentSchema ?? throw new InvalidOperationException("Schema was not initialized.");
+        await using var connection = await _fixture.Postgres.GetConnectionAsync(schema);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = @schema
+                  AND table_name = @table_name)
+            """;
+        command.Parameters.AddWithValue("schema", schema);
+        command.Parameters.AddWithValue("table_name", "imported_" + tableName);
+        var result = await command.ExecuteScalarAsync();
+        return result is bool exists && exists;
+    }
+
+    private async Task<(double X, int Srid)> ReadImportedPointAsync(string tableName)
+    {
+        var schema = _fixture.CurrentSchema ?? throw new InvalidOperationException("Schema was not initialized.");
+        await using var connection = await _fixture.Postgres.GetConnectionAsync(schema);
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT ST_X(geometry), ST_SRID(geometry) FROM {QuoteIdentifier("imported_" + tableName)} LIMIT 1";
+        await using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+        {
+            throw new InvalidOperationException("Imported point was not found.");
+        }
+
+        return (reader.GetDouble(0), reader.GetInt32(1));
+    }
+
+    private static string QuoteIdentifier(string identifier)
+        => "\"" + identifier.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
 }


### PR DESCRIPTION
## Summary
- Adds structured validation errors to file import results so admin/file publish flows can fail before layer rows are created.
- Validates GeoJSON uploads for empty datasets, missing geometry, unsupported geometry type, invalid coordinates/topology, and malformed FeatureCollection shape before table creation.
- Validates source/target SRIDs against `spatial_ref_sys` and checks PostGIS transform support before importing; valid differing SRIDs are transformed at import.

## Changes Made
- Added `ImportResult.ErrorCode` plus structured `ImportValidationIssue` entries and stable import validation error codes.
- Added GeoJSON preflight validation in `StreamingGeoJsonReader` and wired it into `StreamingFileImportService` before table creation.
- Added SRID validation/transform capability checks before file import materialization.
- Added import JSON source-generation metadata for validation issues.
- Added integration coverage for invalid GeoJSON geometry type, missing geometry, empty FeatureCollection, unsupported target SRID, and successful 3857-to-4326 reprojection.

## Gate Impact
- [x] Admin/server import API contract changed for structured file-validation failures.
- [x] Server Tests/Import affected.
- Stacked on honua-server#986 because both changes touch import progress/result surfaces. Merge #986 first, then retarget this PR to trunk.
- Related to #975.

## Testing
- [x] scripts/ci/pre-pr-check.sh equivalent scoped validation run locally; full PR gate is running in CI.
- [x] dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --no-restore --filter FullyQualifiedName~StreamingImportTests
- [x] dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --no-build --filter FullyQualifiedName~Import
- [x] dotnet format tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --verify-no-changes --no-restore

## Breaking Changes
- Extends `ImportResult` with optional structured validation fields. Existing clients can ignore the new JSON properties.

Follow-up: broader non-GeoJSON file preflight can reuse the same structured error contract as format-specific validators are promoted.
