### PR TITLE
feat(admin): validate layer publishing inputs

### DIFF
--- a/src/Honua.Core/Features/Admin/Abstractions/ILayerPublishingService.cs
+++ b/src/Honua.Core/Features/Admin/Abstractions/ILayerPublishingService.cs
@@ -33,6 +33,17 @@ public interface ILayerPublishingService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Validate a PostGIS table before publishing it as a layer.
+    /// </summary>
+    /// <param name="connectionString">PostgreSQL connection string.</param>
+    /// <param name="request">Table publish validation request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<TablePublishValidationResult> ValidateTableForPublishAsync(
+        string connectionString,
+        TablePublishValidationRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Enable or disable a layer within a service.
     /// </summary>
     /// <param name="connectionString">PostgreSQL connection string.</param>

--- a/src/Honua.Core/Features/Admin/Domain/LayerPublishingModels.cs
+++ b/src/Honua.Core/Features/Admin/Domain/LayerPublishingModels.cs
@@ -70,6 +70,220 @@ public sealed class LayerPublishRequest
 }
 
 /// <summary>
+/// Request payload for validating a PostGIS table before publishing it as a layer.
+/// </summary>
+public sealed class TablePublishValidationRequest
+{
+    /// <summary>
+    /// Schema containing the source table.
+    /// </summary>
+    public required string Schema { get; init; }
+
+    /// <summary>
+    /// Source table name.
+    /// </summary>
+    public required string Table { get; init; }
+
+    /// <summary>
+    /// Optional layer display name.
+    /// </summary>
+    public string? LayerName { get; init; }
+
+    /// <summary>
+    /// Optional service name for projection compatibility checks.
+    /// </summary>
+    public string? ServiceName { get; init; }
+
+    /// <summary>
+    /// Requested target spatial reference identifier. When omitted, an existing service SRID or table SRID is used.
+    /// </summary>
+    public int? TargetSrid { get; init; }
+
+    /// <summary>
+    /// Requested geometry column name. When omitted, discovery metadata is used.
+    /// </summary>
+    public string? GeometryColumn { get; init; }
+
+    /// <summary>
+    /// Requested primary key column name. When omitted, the table primary key or common object id names are used.
+    /// </summary>
+    public string? PrimaryKey { get; init; }
+
+    /// <summary>
+    /// Selected attribute fields to publish. Empty means all discovered columns.
+    /// </summary>
+    public IReadOnlyList<string> Fields { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Structured result for validating a table before layer publishing.
+/// </summary>
+public sealed class TablePublishValidationResult
+{
+    /// <summary>
+    /// Whether validation passed without errors.
+    /// </summary>
+    public bool IsValid { get; init; }
+
+    /// <summary>
+    /// Validation status: valid, warning, or invalid.
+    /// </summary>
+    public required string Status { get; init; }
+
+    /// <summary>
+    /// Source schema.
+    /// </summary>
+    public required string Schema { get; init; }
+
+    /// <summary>
+    /// Source table.
+    /// </summary>
+    public required string Table { get; init; }
+
+    /// <summary>
+    /// Normalized service name used for compatibility checks.
+    /// </summary>
+    public required string ServiceName { get; init; }
+
+    /// <summary>
+    /// Optional layer display name.
+    /// </summary>
+    public string? LayerName { get; init; }
+
+    /// <summary>
+    /// Resolved geometry column.
+    /// </summary>
+    public string? GeometryColumn { get; init; }
+
+    /// <summary>
+    /// Resolved geometry type.
+    /// </summary>
+    public string? GeometryType { get; init; }
+
+    /// <summary>
+    /// Resolved primary key column.
+    /// </summary>
+    public string? PrimaryKey { get; init; }
+
+    /// <summary>
+    /// Source table SRID from discovery metadata.
+    /// </summary>
+    public int? SourceSrid { get; init; }
+
+    /// <summary>
+    /// Existing service SRID when the target service already exists.
+    /// </summary>
+    public int? ServiceSrid { get; init; }
+
+    /// <summary>
+    /// Target SRID the publish operation should use.
+    /// </summary>
+    public int? TargetSrid { get; init; }
+
+    /// <summary>
+    /// Estimated row count from discovery metadata.
+    /// </summary>
+    public long? EstimatedRows { get; init; }
+
+    /// <summary>
+    /// Actual source row count when it could be sampled.
+    /// </summary>
+    public long? FeatureCount { get; init; }
+
+    /// <summary>
+    /// Count of rows with NULL geometry.
+    /// </summary>
+    public long? NullGeometryCount { get; init; }
+
+    /// <summary>
+    /// Count of rows with invalid geometry.
+    /// </summary>
+    public long? InvalidGeometryCount { get; init; }
+
+    /// <summary>
+    /// Discovered field metadata.
+    /// </summary>
+    public TablePublishValidationField[] Fields { get; init; } = [];
+
+    /// <summary>
+    /// Individual validation checks.
+    /// </summary>
+    public TablePublishValidationCheck[] Checks { get; init; } = [];
+}
+
+/// <summary>
+/// Field metadata returned by table publish validation.
+/// </summary>
+public sealed class TablePublishValidationField
+{
+    /// <summary>
+    /// Source column name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Source database type.
+    /// </summary>
+    public required string DataType { get; init; }
+
+    /// <summary>
+    /// Honua field type inferred from the source type.
+    /// </summary>
+    public required string FieldType { get; init; }
+
+    /// <summary>
+    /// Whether the source column allows null values.
+    /// </summary>
+    public bool IsNullable { get; init; }
+
+    /// <summary>
+    /// Whether the source column is part of the table primary key.
+    /// </summary>
+    public bool IsPrimaryKey { get; init; }
+
+    /// <summary>
+    /// Whether this field is selected for publishing.
+    /// </summary>
+    public bool IsSelected { get; init; }
+
+    /// <summary>
+    /// Maximum length for character types.
+    /// </summary>
+    public int? MaxLength { get; init; }
+}
+
+/// <summary>
+/// Individual validation check for pre-publish table validation.
+/// </summary>
+public sealed class TablePublishValidationCheck
+{
+    /// <summary>
+    /// Stable machine-readable check code.
+    /// </summary>
+    public required string Code { get; init; }
+
+    /// <summary>
+    /// Severity: pass, warning, or error.
+    /// </summary>
+    public required string Severity { get; init; }
+
+    /// <summary>
+    /// Human-readable check result.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// Expected value when applicable.
+    /// </summary>
+    public string? Expected { get; init; }
+
+    /// <summary>
+    /// Actual value when applicable.
+    /// </summary>
+    public string? Actual { get; init; }
+}
+
+/// <summary>
 /// Summary information about a published layer.
 /// </summary>
 public sealed class PublishedLayerSummary

--- a/src/Honua.Core/Features/Admin/Domain/LayerPublishingModels.cs
+++ b/src/Honua.Core/Features/Admin/Domain/LayerPublishingModels.cs
@@ -166,6 +166,11 @@ public sealed class TablePublishValidationResult
     public string? PrimaryKey { get; init; }
 
     /// <summary>
+    /// Object id strategy selected for layer publishing.
+    /// </summary>
+    public string ObjectIdStrategy { get; init; } = "unresolved";
+
+    /// <summary>
     /// Source table SRID from discovery metadata.
     /// </summary>
     public int? SourceSrid { get; init; }

--- a/src/Honua.Core/Features/Import/Domain/ImportResult.cs
+++ b/src/Honua.Core/Features/Import/Domain/ImportResult.cs
@@ -113,6 +113,7 @@ public static class ImportValidationErrorCodes
     public const string GeometryUnknownType = "import.geometry_unknown_type";
     public const string GeometryInvalid = "import.geometry_invalid";
     public const string InvalidGeoJson = "import.geojson_invalid";
+    public const string GeoJsonValidationTooLarge = "import.geojson_validation_too_large";
     public const string SourceSridRequired = "import.source_srid_required";
     public const string SourceSridUnsupported = "import.source_srid_unsupported";
     public const string TargetSridUnsupported = "import.target_srid_unsupported";

--- a/src/Honua.Core/Features/Import/Domain/ImportResult.cs
+++ b/src/Honua.Core/Features/Import/Domain/ImportResult.cs
@@ -39,6 +39,16 @@ public sealed record ImportResult
     public string? ErrorMessage { get; init; }
 
     /// <summary>
+    /// Stable machine-readable error code if import failed.
+    /// </summary>
+    public string? ErrorCode { get; init; }
+
+    /// <summary>
+    /// Structured validation issues that blocked import before rows were created.
+    /// </summary>
+    public IReadOnlyList<ImportValidationIssue> ValidationErrors { get; init; } = [];
+
+    /// <summary>
     /// Import duration
     /// </summary>
     public TimeSpan Duration { get; init; }
@@ -77,14 +87,61 @@ public sealed record ImportResult
         SupportedFileFormat format,
         string errorMessage,
         TimeSpan duration = default,
-        IReadOnlyList<string>? warnings = null) =>
+        IReadOnlyList<string>? warnings = null,
+        string? errorCode = null,
+        IReadOnlyList<ImportValidationIssue>? validationErrors = null) =>
         new()
         {
             Success = false,
             TableName = tableName,
             Format = format,
             ErrorMessage = errorMessage,
+            ErrorCode = errorCode,
             Duration = duration,
-            Warnings = warnings ?? []
+            Warnings = warnings ?? [],
+            ValidationErrors = validationErrors ?? []
+        };
+}
+
+/// <summary>
+/// Stable import validation error codes surfaced in import failure responses.
+/// </summary>
+public static class ImportValidationErrorCodes
+{
+    public const string EmptyDataset = "import.empty_dataset";
+    public const string GeometryMissing = "import.geometry_missing";
+    public const string GeometryUnknownType = "import.geometry_unknown_type";
+    public const string GeometryInvalid = "import.geometry_invalid";
+    public const string InvalidGeoJson = "import.geojson_invalid";
+    public const string SourceSridRequired = "import.source_srid_required";
+    public const string SourceSridUnsupported = "import.source_srid_unsupported";
+    public const string TargetSridUnsupported = "import.target_srid_unsupported";
+    public const string ProjectionUnsupported = "import.projection_unsupported";
+}
+
+/// <summary>
+/// Machine-readable validation issue for file import failures.
+/// </summary>
+public sealed record ImportValidationIssue
+{
+    public required string Code { get; init; }
+
+    public required string Message { get; init; }
+
+    public int? FeatureIndex { get; init; }
+
+    public string? Field { get; init; }
+
+    public static ImportValidationIssue Create(
+        string code,
+        string message,
+        int? featureIndex = null,
+        string? field = null) =>
+        new()
+        {
+            Code = code,
+            Message = message,
+            FeatureIndex = featureIndex,
+            Field = field
         };
 }

--- a/src/Honua.Core/Features/Import/Services/StreamingGeoJsonReader.cs
+++ b/src/Honua.Core/Features/Import/Services/StreamingGeoJsonReader.cs
@@ -26,6 +26,11 @@ internal sealed record JsonProcessingState
     public bool IsComplete { get; init; }
 }
 
+internal sealed record GeoJsonValidationResult(int FeatureCount, IReadOnlyList<ImportValidationIssue> Issues)
+{
+    public bool IsValid => Issues.Count == 0;
+}
+
 /// <summary>
 /// Memory-efficient streaming GeoJSON reader that processes features incrementally.
 /// Uses Utf8JsonReader for low-allocation parsing without loading the entire file into memory.
@@ -34,6 +39,17 @@ internal sealed class StreamingGeoJsonReader
 {
     private readonly ImportLimits _limits;
     private readonly GeometryFactory _geometryFactory;
+    private const int MaxValidationIssues = 100;
+    private static readonly HashSet<string> _knownGeometryTypes = new(StringComparer.Ordinal)
+    {
+        "Point",
+        "MultiPoint",
+        "LineString",
+        "MultiLineString",
+        "Polygon",
+        "MultiPolygon",
+        "GeometryCollection"
+    };
 
     public StreamingGeoJsonReader(ImportLimits? limits = null)
     {
@@ -158,6 +174,90 @@ internal sealed class StreamingGeoJsonReader
                 MemoryPool.ReturnByteArray(leftoverBuffer, clearArray: false);
             }
         }
+    }
+
+    public async Task<GeoJsonValidationResult> ValidateAsync(
+        Stream stream,
+        CancellationToken cancellationToken = default)
+    {
+        var issues = new List<ImportValidationIssue>();
+        var featureCount = 0;
+
+        try
+        {
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+            }
+
+            using var document = await JsonDocument.ParseAsync(
+                stream,
+                new JsonDocumentOptions
+                {
+                    AllowTrailingCommas = true,
+                    CommentHandling = JsonCommentHandling.Skip
+                },
+                cancellationToken);
+
+            var root = document.RootElement;
+            if (!root.TryGetProperty("type", out var rootTypeElement) ||
+                !string.Equals(rootTypeElement.GetString(), "FeatureCollection", StringComparison.Ordinal))
+            {
+                issues.Add(ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.InvalidGeoJson,
+                    "GeoJSON root object must have type \"FeatureCollection\".",
+                    field: "type"));
+            }
+
+            if (!root.TryGetProperty("features", out var featuresElement) ||
+                featuresElement.ValueKind != JsonValueKind.Array)
+            {
+                issues.Add(ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.EmptyDataset,
+                    "GeoJSON FeatureCollection does not contain a features array.",
+                    field: "features"));
+            }
+            else
+            {
+                foreach (var featureElement in featuresElement.EnumerateArray())
+                {
+                    featureCount++;
+                    if (issues.Count < MaxValidationIssues)
+                    {
+                        issues.AddRange(ValidateFeature(featureElement, featureCount)
+                            .Take(MaxValidationIssues - issues.Count));
+                    }
+
+                    if (_limits.MaxFeaturesPerFile > 0 && featureCount >= _limits.MaxFeaturesPerFile)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (featureCount == 0 && issues.All(issue => issue.Code != ImportValidationErrorCodes.EmptyDataset))
+            {
+                issues.Add(ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.EmptyDataset,
+                    "GeoJSON FeatureCollection does not contain any features.",
+                    field: "features"));
+            }
+        }
+        catch (JsonException)
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.InvalidGeoJson,
+                "GeoJSON document is not valid JSON."));
+        }
+        finally
+        {
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+            }
+        }
+
+        return new GeoJsonValidationResult(featureCount, issues);
     }
 
     /// <summary>
@@ -286,6 +386,80 @@ internal sealed class StreamingGeoJsonReader
         return (features, reader.CurrentState, newProcessingState, lastConsumed);
     }
 
+    private List<ImportValidationIssue> ValidateFeature(JsonElement root, int featureIndex)
+    {
+        var issues = new List<ImportValidationIssue>(1);
+
+        if (!root.TryGetProperty("type", out var typeElement) ||
+            !string.Equals(typeElement.GetString(), "Feature", StringComparison.Ordinal))
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.InvalidGeoJson,
+                "GeoJSON features must have type \"Feature\".",
+                featureIndex,
+                "type"));
+            return issues;
+        }
+
+        if (!root.TryGetProperty("geometry", out var geometryElement) ||
+            geometryElement.ValueKind == JsonValueKind.Null)
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.GeometryMissing,
+                "GeoJSON feature is missing geometry.",
+                featureIndex,
+                "geometry"));
+            return issues;
+        }
+
+        if (geometryElement.ValueKind != JsonValueKind.Object)
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.GeometryInvalid,
+                "GeoJSON feature geometry must be an object.",
+                featureIndex,
+                "geometry"));
+            return issues;
+        }
+
+        if (!geometryElement.TryGetProperty("type", out var geometryTypeElement) ||
+            string.IsNullOrWhiteSpace(geometryTypeElement.GetString()))
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.GeometryMissing,
+                "GeoJSON feature geometry is missing a type.",
+                featureIndex,
+                "geometry.type"));
+            return issues;
+        }
+
+        var geometryType = geometryTypeElement.GetString()!;
+        if (!_knownGeometryTypes.Contains(geometryType))
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.GeometryUnknownType,
+                $"GeoJSON geometry type \"{geometryType}\" is not supported.",
+                featureIndex,
+                "geometry.type"));
+            return issues;
+        }
+
+        var geometry = ParseGeometry(geometryElement);
+        var validationError = geometry == null
+            ? "GeoJSON geometry coordinates are invalid or incomplete."
+            : ValidateParsedGeometry(geometry);
+        if (validationError != null)
+        {
+            issues.Add(ImportValidationIssue.Create(
+                ImportValidationErrorCodes.GeometryInvalid,
+                validationError,
+                featureIndex,
+                "geometry"));
+        }
+
+        return issues;
+    }
+
     /// <summary>
     /// Parse a single GeoJSON feature from a byte span.
     /// </summary>
@@ -392,6 +566,69 @@ internal sealed class StreamingGeoJsonReader
         {
             return null;
         }
+    }
+
+    private string? ValidateParsedGeometry(NtsGeometry geometry)
+    {
+        if (geometry.IsEmpty)
+        {
+            return "GeoJSON geometry is empty.";
+        }
+
+        if (geometry.NumPoints > _limits.MaxVertices)
+        {
+            return $"Geometry vertex count ({geometry.NumPoints:N0}) exceeds maximum allowed ({_limits.MaxVertices:N0}).";
+        }
+
+        var ringCount = CountRings(geometry);
+        if (ringCount > _limits.MaxRings)
+        {
+            return $"Geometry ring count ({ringCount:N0}) exceeds maximum allowed ({_limits.MaxRings:N0}).";
+        }
+
+        if (!ValidateCoordinates(geometry))
+        {
+            return "Geometry contains invalid coordinates (NaN or Infinity).";
+        }
+
+        if (!geometry.IsValid)
+        {
+            return "Geometry topology is invalid.";
+        }
+
+        return null;
+    }
+
+    private static int CountRings(NtsGeometry geometry)
+    {
+        return geometry switch
+        {
+            Polygon polygon => 1 + polygon.NumInteriorRings,
+            MultiPolygon multiPolygon => multiPolygon.Geometries
+                .OfType<Polygon>()
+                .Sum(p => 1 + p.NumInteriorRings),
+            GeometryCollection collection => collection.Geometries.Sum(CountRings),
+            _ => 0
+        };
+    }
+
+    private static bool ValidateCoordinates(NtsGeometry geometry)
+    {
+        foreach (var coord in geometry.Coordinates)
+        {
+            if (double.IsNaN(coord.X) || double.IsInfinity(coord.X) ||
+                double.IsNaN(coord.Y) || double.IsInfinity(coord.Y))
+            {
+                return false;
+            }
+
+            if (!double.IsNaN(coord.Z) && double.IsInfinity(coord.Z))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private Point ParsePoint(JsonElement coords)

--- a/src/Honua.Core/Features/Import/Services/StreamingGeoJsonReader.cs
+++ b/src/Honua.Core/Features/Import/Services/StreamingGeoJsonReader.cs
@@ -188,6 +188,15 @@ internal sealed class StreamingGeoJsonReader
             if (stream.CanSeek)
             {
                 stream.Position = 0;
+                if (stream.Length > _limits.MaxMemoryBytes)
+                {
+                    issues.Add(ImportValidationIssue.Create(
+                        ImportValidationErrorCodes.GeoJsonValidationTooLarge,
+                        $"GeoJSON preflight validation is limited to {_limits.MaxMemoryBytes:N0} bytes.",
+                        field: "file"));
+
+                    return new GeoJsonValidationResult(featureCount, issues);
+                }
             }
 
             using var document = await JsonDocument.ParseAsync(

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
@@ -24,6 +24,10 @@ internal sealed partial class PostgreSqlLayerPublishingService(
     private const string SeverityPass = "pass";
     private const string SeverityWarning = "warning";
     private const string SeverityError = "error";
+    private const string LayerConflictCheckCode = "layer-conflict";
+    private const string SourceIntegerPrimaryKeyObjectIdStrategy = "source-integer-primary-key";
+    private const string UnsupportedSourcePrimaryKeyObjectIdStrategy = "unsupported-source-primary-key";
+    private const string UnresolvedObjectIdStrategy = "unresolved";
     private static readonly string[] _defaultFormats = ["JSON", "GeoJSON"];
     private static readonly string[] _defaultCapabilities = ["Query", "Extract"];
 
@@ -131,6 +135,23 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         }
 
         var serviceName = NormalizeServiceName(request.ServiceName);
+
+        var validation = await ValidateTableForPublishAsync(
+                connectionString,
+                new TablePublishValidationRequest
+                {
+                    Schema = schema,
+                    Table = table,
+                    LayerName = request.LayerName,
+                    ServiceName = serviceName,
+                    TargetSrid = request.Srid,
+                    GeometryColumn = request.GeometryColumn,
+                    PrimaryKey = request.PrimaryKey,
+                    Fields = request.Fields
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
+        ThrowIfPublishValidationFailed(validation);
 
         var tableInfo = await ResolveTableInfoAsync(connectionString, schema, table, cancellationToken)
             ?? throw new LayerPublishingException(
@@ -314,7 +335,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
 
         checks.Add(Pass("source-table", $"Source table identifier '{schema}.{table}' is syntactically valid."));
 
-        var tableInfo = await ResolveTableInfoAsync(connectionString, schema, table, cancellationToken)
+        var tableInfo = await ResolveTableInfoForValidationAsync(connectionString, schema, table, cancellationToken)
             .ConfigureAwait(false);
         if (tableInfo == null)
         {
@@ -473,6 +494,140 @@ internal sealed partial class PostgreSqlLayerPublishingService(
                 LayerPublishingErrorKind.Unknown,
                 "Failed to discover tables for publishing.");
         }
+    }
+
+    private async Task<TableInfo?> ResolveTableInfoForValidationAsync(
+        string connectionString,
+        string schema,
+        string table,
+        CancellationToken cancellationToken)
+    {
+        var discovered = await ResolveTableInfoAsync(connectionString, schema, table, cancellationToken)
+            .ConfigureAwait(false);
+        if (discovered != null)
+        {
+            return discovered;
+        }
+
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        if (!await TableExistsAsync(connection, schema, table, cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return new TableInfo
+        {
+            Schema = schema,
+            Table = table,
+            GeometryColumn = null,
+            GeometryType = null,
+            Srid = null,
+            EstimatedRows = await GetEstimatedRowCountAsync(connection, schema, table, cancellationToken)
+                .ConfigureAwait(false),
+            Columns = await GetTableColumnsAsync(connection, schema, table, cancellationToken)
+                .ConfigureAwait(false)
+        };
+    }
+
+    private static async Task<bool> TableExistsAsync(
+        NpgsqlConnection connection,
+        string schema,
+        string table,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = @schema
+                  AND table_name = @table
+                  AND table_type IN ('BASE TABLE', 'FOREIGN TABLE')
+            );
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@schema", schema);
+        command.Parameters.AddWithValue("@table", table);
+
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return result is bool exists && exists;
+    }
+
+    private static async Task<long?> GetEstimatedRowCountAsync(
+        NpgsqlConnection connection,
+        string schema,
+        string table,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT reltuples::bigint
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = @schema AND c.relname = @table;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@schema", schema);
+        command.Parameters.AddWithValue("@table", table);
+
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return result == null || result == DBNull.Value
+            ? null
+            : Convert.ToInt64(result, CultureInfo.InvariantCulture);
+    }
+
+    private static async Task<List<ColumnInfo>> GetTableColumnsAsync(
+        NpgsqlConnection connection,
+        string schema,
+        string table,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT
+                c.column_name,
+                c.data_type,
+                c.is_nullable,
+                c.character_maximum_length,
+                CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END as is_primary_key
+            FROM information_schema.columns c
+            LEFT JOIN (
+                SELECT a.attname as column_name
+                FROM pg_index i
+                JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+                JOIN pg_class cl ON cl.oid = i.indrelid
+                JOIN pg_namespace n ON n.oid = cl.relnamespace
+                WHERE i.indisprimary
+                  AND n.nspname = @schema
+                  AND cl.relname = @table
+            ) pk ON pk.column_name = c.column_name
+            WHERE c.table_schema = @schema
+              AND c.table_name = @table
+              AND c.data_type NOT IN ('geometry', 'geography')
+              AND c.udt_name NOT IN ('geometry', 'geography')
+            ORDER BY c.ordinal_position;
+            """;
+
+        var columns = new List<ColumnInfo>();
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@schema", schema);
+        command.Parameters.AddWithValue("@table", table);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            columns.Add(new ColumnInfo
+            {
+                Name = reader.GetString(0),
+                DataType = reader.GetString(1),
+                IsNullable = reader.GetString(2) == "YES",
+                MaxLength = reader.IsDBNull(3) ? null : reader.GetInt32(3),
+                IsPrimaryKey = reader.GetBoolean(4)
+            });
+        }
+
+        return columns;
     }
 
     private static List<ColumnInfo> ResolveSelectedColumns(
@@ -900,6 +1055,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
             GeometryColumn = resolved?.GeometryColumn ?? request.GeometryColumn ?? tableInfo?.GeometryColumn,
             GeometryType = resolved?.GeometryType ?? tableInfo?.GeometryType,
             PrimaryKey = resolved?.PrimaryKey ?? request.PrimaryKey,
+            ObjectIdStrategy = ResolveObjectIdStrategy(resolved?.PrimaryKey, checks),
             SourceSrid = tableInfo?.Srid,
             ServiceSrid = resolved?.ServiceSrid,
             TargetSrid = resolved?.TargetSrid,
@@ -910,6 +1066,54 @@ internal sealed partial class PostgreSqlLayerPublishingService(
             Fields = BuildValidationFields(tableInfo?.Columns ?? [], request.Fields),
             Checks = checks.ToArray()
         };
+    }
+
+    private static void ThrowIfPublishValidationFailed(TablePublishValidationResult validation)
+    {
+        var errors = validation.Checks
+            .Where(check => check.Severity == SeverityError)
+            .ToArray();
+        if (errors.Length == 0)
+        {
+            return;
+        }
+
+        var blockingError = errors.FirstOrDefault(check => check.Code != LayerConflictCheckCode);
+        if (blockingError != null)
+        {
+            throw new LayerPublishingException(
+                LayerPublishingErrorKind.Validation,
+                BuildPublishValidationFailureMessage(blockingError));
+        }
+
+        throw new LayerPublishingException(
+            LayerPublishingErrorKind.Conflict,
+            $"Layer already exists for table '{validation.Schema}.{validation.Table}'.");
+    }
+
+    private static string BuildPublishValidationFailureMessage(TablePublishValidationCheck check)
+        => $"Table validation failed ({check.Code}): {check.Message}";
+
+    private static string ResolveObjectIdStrategy(
+        string? primaryKey,
+        IReadOnlyCollection<TablePublishValidationCheck> checks)
+    {
+        var hasPrimaryKeyError = checks.Any(check =>
+            check.Severity == SeverityError &&
+            (check.Code == "primary-key" || check.Code == "primary-key-type"));
+        if (hasPrimaryKeyError)
+        {
+            return UnsupportedSourcePrimaryKeyObjectIdStrategy;
+        }
+
+        var hasPrimaryKeyPass = checks.Any(check =>
+            check.Severity == SeverityPass && check.Code == "primary-key");
+        if (!string.IsNullOrWhiteSpace(primaryKey) && hasPrimaryKeyPass)
+        {
+            return SourceIntegerPrimaryKeyObjectIdStrategy;
+        }
+
+        return UnresolvedObjectIdStrategy;
     }
 
     private static TablePublishValidationField[] BuildValidationFields(

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
@@ -21,6 +21,9 @@ internal sealed partial class PostgreSqlLayerPublishingService(
 {
     private const string DefaultServiceName = "default";
     private const string SourceBackedStorageOptionsJson = """{"sourceBacked":"true"}""";
+    private const string SeverityPass = "pass";
+    private const string SeverityWarning = "warning";
+    private const string SeverityError = "error";
     private static readonly string[] _defaultFormats = ["JSON", "GeoJSON"];
     private static readonly string[] _defaultCapabilities = ["Query", "Extract"];
 
@@ -158,7 +161,9 @@ internal sealed partial class PostgreSqlLayerPublishingService(
 
         var geometryType = NormalizeGeometryType(geometryTypeRaw!);
 
-        var srid = request.Srid ?? tableInfo.Srid ?? 4326;
+        var serviceSrid = await ResolveExistingServiceSridAsync(connectionString, serviceName, cancellationToken)
+            .ConfigureAwait(false);
+        var srid = serviceSrid ?? request.Srid ?? tableInfo.Srid ?? 4326;
         if (srid <= 0)
         {
             srid = 4326;
@@ -280,6 +285,95 @@ internal sealed partial class PostgreSqlLayerPublishingService(
             Enabled = request.Enabled,
             ServiceName = serviceName
         };
+    }
+
+    public async Task<TablePublishValidationResult> ValidateTableForPublishAsync(
+        string connectionString,
+        TablePublishValidationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var schema = request.Schema?.Trim() ?? string.Empty;
+        var table = request.Table?.Trim() ?? string.Empty;
+        var serviceName = NormalizeServiceName(request.ServiceName);
+        var checks = new List<TablePublishValidationCheck>();
+
+        if (string.IsNullOrWhiteSpace(schema) || string.IsNullOrWhiteSpace(table))
+        {
+            checks.Add(Error("source-table", "Schema and table are required."));
+            return BuildValidationResult(request, serviceName, null, null, null, checks);
+        }
+
+        if (!IsSafeIdentifier(schema) || !IsSafeIdentifier(table))
+        {
+            checks.Add(Error("source-table", "Schema or table contains invalid characters.", null, $"{schema}.{table}"));
+            return BuildValidationResult(request, serviceName, null, null, null, checks);
+        }
+
+        checks.Add(Pass("source-table", $"Source table identifier '{schema}.{table}' is syntactically valid."));
+
+        var tableInfo = await ResolveTableInfoAsync(connectionString, schema, table, cancellationToken)
+            .ConfigureAwait(false);
+        if (tableInfo == null)
+        {
+            checks.Add(Error(
+                "source-table",
+                $"Table '{schema}.{table}' was not found or does not expose a discoverable geometry column.",
+                $"{schema}.{table}",
+                null));
+            return BuildValidationResult(request, serviceName, null, null, null, checks);
+        }
+
+        checks.Add(Pass("source-table", $"Table '{schema}.{table}' is discoverable."));
+
+        var selectedColumns = ResolveSelectedColumnsForValidation(tableInfo.Columns, request.Fields, checks);
+        if (selectedColumns.Count == 0)
+        {
+            checks.Add(Error("selected-fields", "No publishable fields were selected."));
+        }
+        else
+        {
+            checks.Add(Pass("selected-fields", $"{selectedColumns.Count} field(s) selected for publishing."));
+        }
+
+        var geometryColumn = ResolveGeometryColumnForValidation(tableInfo, request.GeometryColumn, checks);
+        var geometryType = ResolveGeometryTypeForValidation(tableInfo, checks);
+        var primaryKeyName = ResolvePrimaryKeyForValidation(tableInfo.Columns, selectedColumns, request.PrimaryKey, checks);
+        var serviceSrid = await ResolveExistingServiceSridAsync(connectionString, serviceName, cancellationToken)
+            .ConfigureAwait(false);
+        var targetSrid = ResolveTargetSridForValidation(tableInfo.Srid, serviceSrid, request.TargetSrid, checks);
+
+        GeometryHealth? geometryHealth = null;
+        if (!string.IsNullOrWhiteSpace(geometryColumn) &&
+            geometryColumn!.Equals(tableInfo.GeometryColumn, StringComparison.OrdinalIgnoreCase))
+        {
+            geometryHealth = await InspectGeometryHealthAsync(
+                    connectionString,
+                    schema,
+                    table,
+                    geometryColumn!,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            AddGeometryHealthChecks(geometryHealth, checks);
+        }
+
+        await AddExistingLayerCheckAsync(connectionString, schema, table, checks, cancellationToken)
+            .ConfigureAwait(false);
+
+        return BuildValidationResult(
+            request,
+            serviceName,
+            tableInfo,
+            new ResolvedPublishValidation(
+                geometryColumn,
+                geometryType,
+                primaryKeyName,
+                serviceSrid,
+                targetSrid),
+            geometryHealth,
+            checks);
     }
 
     public async Task<PublishedLayerSummary?> SetLayerEnabledAsync(
@@ -516,6 +610,330 @@ internal sealed partial class PostgreSqlLayerPublishingService(
             "text" => FieldType.String,
             _ => FieldType.String
         };
+    }
+
+    private static List<ColumnInfo> ResolveSelectedColumnsForValidation(
+        List<ColumnInfo> columns,
+        IReadOnlyList<string> selected,
+        List<TablePublishValidationCheck> checks)
+    {
+        if (selected == null || selected.Count == 0)
+        {
+            return columns;
+        }
+
+        var lookup = columns.ToDictionary(c => c.Name, StringComparer.OrdinalIgnoreCase);
+        var result = new List<ColumnInfo>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var field in selected)
+        {
+            if (string.IsNullOrWhiteSpace(field))
+            {
+                continue;
+            }
+
+            if (!lookup.TryGetValue(field.Trim(), out var column))
+            {
+                checks.Add(Error(
+                    "selected-field",
+                    $"Field '{field}' was not found on the source table.",
+                    field,
+                    null));
+                continue;
+            }
+
+            if (seen.Add(column.Name))
+            {
+                result.Add(column);
+            }
+        }
+
+        return result;
+    }
+
+    private static string? ResolveGeometryColumnForValidation(
+        TableInfo tableInfo,
+        string? requestedGeometryColumn,
+        List<TablePublishValidationCheck> checks)
+    {
+        var discoveredGeometryColumn = tableInfo.GeometryColumn;
+        var geometryColumn = string.IsNullOrWhiteSpace(requestedGeometryColumn)
+            ? discoveredGeometryColumn
+            : requestedGeometryColumn.Trim();
+
+        if (string.IsNullOrWhiteSpace(discoveredGeometryColumn))
+        {
+            checks.Add(Error("geometry-column", "Source table does not expose a geometry column."));
+            return geometryColumn;
+        }
+
+        if (string.IsNullOrWhiteSpace(geometryColumn))
+        {
+            checks.Add(Error("geometry-column", "Geometry column is required.", discoveredGeometryColumn, null));
+            return geometryColumn;
+        }
+
+        if (!geometryColumn.Equals(discoveredGeometryColumn, StringComparison.OrdinalIgnoreCase))
+        {
+            checks.Add(Error(
+                "geometry-column",
+                "Requested geometry column does not match the discovered PostGIS geometry column.",
+                discoveredGeometryColumn,
+                geometryColumn));
+            return geometryColumn;
+        }
+
+        checks.Add(Pass("geometry-column", $"Geometry column '{geometryColumn}' exists."));
+        return geometryColumn;
+    }
+
+    private static string? ResolveGeometryTypeForValidation(
+        TableInfo tableInfo,
+        List<TablePublishValidationCheck> checks)
+    {
+        if (string.IsNullOrWhiteSpace(tableInfo.GeometryType))
+        {
+            checks.Add(Error("geometry-type", "Source table does not report a geometry type."));
+            return null;
+        }
+
+        try
+        {
+            var normalized = NormalizeGeometryType(tableInfo.GeometryType);
+            checks.Add(Pass("geometry-type", $"Geometry type '{normalized}' is supported."));
+            return normalized;
+        }
+        catch (LayerPublishingException)
+        {
+            checks.Add(Error(
+                "geometry-type",
+                $"Geometry type '{tableInfo.GeometryType}' is not supported.",
+                null,
+                tableInfo.GeometryType));
+            return tableInfo.GeometryType;
+        }
+    }
+
+    private static string? ResolvePrimaryKeyForValidation(
+        List<ColumnInfo> columns,
+        List<ColumnInfo> selectedColumns,
+        string? requestedPrimaryKey,
+        List<TablePublishValidationCheck> checks)
+    {
+        var primaryKeyName = ResolvePrimaryKeyName(selectedColumns, requestedPrimaryKey);
+        if (string.IsNullOrWhiteSpace(primaryKeyName))
+        {
+            checks.Add(Error(
+                "primary-key",
+                "Primary key is required. Select an integer source column or choose an object id strategy."));
+            return null;
+        }
+
+        var primaryKeyColumn = selectedColumns.FirstOrDefault(col =>
+            string.Equals(col.Name, primaryKeyName, StringComparison.OrdinalIgnoreCase));
+        if (primaryKeyColumn == null)
+        {
+            var existsInTable = columns.Any(col =>
+                string.Equals(col.Name, primaryKeyName, StringComparison.OrdinalIgnoreCase));
+            checks.Add(Error(
+                "primary-key",
+                existsInTable
+                    ? $"Primary key field '{primaryKeyName}' must be included in selected fields."
+                    : $"Primary key field '{primaryKeyName}' was not found on the source table.",
+                primaryKeyName,
+                existsInTable ? "not selected" : null));
+            return primaryKeyName;
+        }
+
+        var primaryKeyType = MapPostgresType(primaryKeyColumn.DataType);
+        if (primaryKeyType is not FieldType.Integer and not FieldType.BigInteger)
+        {
+            checks.Add(Error(
+                "primary-key-type",
+                "Primary key must be an integer column.",
+                "Integer or BigInteger",
+                primaryKeyColumn.DataType));
+            return primaryKeyColumn.Name;
+        }
+
+        checks.Add(Pass("primary-key", $"Primary key column '{primaryKeyColumn.Name}' is publishable."));
+        return primaryKeyColumn.Name;
+    }
+
+    private static int? ResolveTargetSridForValidation(
+        int? tableSrid,
+        int? serviceSrid,
+        int? requestedTargetSrid,
+        List<TablePublishValidationCheck> checks)
+    {
+        if (tableSrid is null or <= 0)
+        {
+            checks.Add(Error(
+                "source-srid",
+                "Source table does not report a valid SRID.",
+                null,
+                tableSrid?.ToString(CultureInfo.InvariantCulture)));
+        }
+        else
+        {
+            checks.Add(Pass("source-srid", $"Source table SRID is {tableSrid.Value}."));
+        }
+
+        var targetSrid = serviceSrid ?? requestedTargetSrid ?? tableSrid;
+        if (targetSrid is null or <= 0)
+        {
+            checks.Add(Error(
+                "target-srid",
+                "Target SRID could not be resolved from the request, service, or source table."));
+            return targetSrid;
+        }
+
+        checks.Add(Pass("target-srid", $"Target SRID is {targetSrid.Value}."));
+
+        if (serviceSrid.HasValue && requestedTargetSrid.HasValue && requestedTargetSrid.Value != serviceSrid.Value)
+        {
+            checks.Add(Warning(
+                "service-srid-authoritative",
+                "Existing service projection overrides the requested target SRID.",
+                serviceSrid.Value.ToString(CultureInfo.InvariantCulture),
+                requestedTargetSrid.Value.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        if (tableSrid is > 0 && tableSrid.Value != targetSrid.Value)
+        {
+            checks.Add(Warning(
+                "source-srid-transform",
+                "Source geometries will be transformed to the target service projection during publish.",
+                targetSrid.Value.ToString(CultureInfo.InvariantCulture),
+                tableSrid.Value.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        return targetSrid;
+    }
+
+    private static void AddGeometryHealthChecks(
+        GeometryHealth? health,
+        List<TablePublishValidationCheck> checks)
+    {
+        if (health is not { } value)
+        {
+            checks.Add(Error("geometry-scan", "Geometry validation could not inspect the source table."));
+            return;
+        }
+
+        if (value.FeatureCount == 0)
+        {
+            checks.Add(Error("feature-count", "Source table is empty."));
+        }
+        else
+        {
+            checks.Add(Pass(
+                "feature-count",
+                $"Source table contains {value.FeatureCount.ToString(CultureInfo.InvariantCulture)} row(s)."));
+        }
+
+        if (value.NullGeometryCount > 0)
+        {
+            checks.Add(Warning(
+                "null-geometries",
+                "Some source rows have NULL geometry and will publish without geometry.",
+                "0",
+                value.NullGeometryCount.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        if (value.InvalidGeometryCount > 0)
+        {
+            checks.Add(Error(
+                "invalid-geometries",
+                "Source table contains invalid geometries.",
+                "0",
+                value.InvalidGeometryCount.ToString(CultureInfo.InvariantCulture)));
+        }
+        else
+        {
+            checks.Add(Pass("invalid-geometries", "No invalid geometries were found."));
+        }
+
+        if (value.DistinctGeometryTypeCount > 1)
+        {
+            checks.Add(Error(
+                "mixed-geometry",
+                "Source table contains mixed geometry types.",
+                "1",
+                value.DistinctGeometryTypeCount.ToString(CultureInfo.InvariantCulture)));
+        }
+        else if (value.DistinctGeometryTypeCount == 1)
+        {
+            checks.Add(Pass("mixed-geometry", "Source table uses a single geometry type."));
+        }
+
+        if (value.MinSrid.HasValue && value.MaxSrid.HasValue && value.MinSrid.Value != value.MaxSrid.Value)
+        {
+            checks.Add(Error(
+                "mixed-srid",
+                "Source table contains mixed geometry SRIDs.",
+                value.MinSrid.Value.ToString(CultureInfo.InvariantCulture),
+                value.MaxSrid.Value.ToString(CultureInfo.InvariantCulture)));
+        }
+    }
+
+    private static TablePublishValidationResult BuildValidationResult(
+        TablePublishValidationRequest request,
+        string serviceName,
+        TableInfo? tableInfo,
+        ResolvedPublishValidation? resolved,
+        GeometryHealth? geometryHealth,
+        IReadOnlyCollection<TablePublishValidationCheck> checks)
+    {
+        var hasErrors = checks.Any(check => check.Severity == SeverityError);
+        var hasWarnings = checks.Any(check => check.Severity == SeverityWarning);
+
+        return new TablePublishValidationResult
+        {
+            IsValid = !hasErrors,
+            Status = hasErrors ? "invalid" : hasWarnings ? "warning" : "valid",
+            Schema = request.Schema?.Trim() ?? string.Empty,
+            Table = request.Table?.Trim() ?? string.Empty,
+            ServiceName = serviceName,
+            LayerName = request.LayerName,
+            GeometryColumn = resolved?.GeometryColumn ?? request.GeometryColumn ?? tableInfo?.GeometryColumn,
+            GeometryType = resolved?.GeometryType ?? tableInfo?.GeometryType,
+            PrimaryKey = resolved?.PrimaryKey ?? request.PrimaryKey,
+            SourceSrid = tableInfo?.Srid,
+            ServiceSrid = resolved?.ServiceSrid,
+            TargetSrid = resolved?.TargetSrid,
+            EstimatedRows = tableInfo?.EstimatedRows,
+            FeatureCount = geometryHealth?.FeatureCount,
+            NullGeometryCount = geometryHealth?.NullGeometryCount,
+            InvalidGeometryCount = geometryHealth?.InvalidGeometryCount,
+            Fields = BuildValidationFields(tableInfo?.Columns ?? [], request.Fields),
+            Checks = checks.ToArray()
+        };
+    }
+
+    private static TablePublishValidationField[] BuildValidationFields(
+        List<ColumnInfo> columns,
+        IReadOnlyList<string> selected)
+    {
+        var selectedSet = selected == null || selected.Count == 0
+            ? null
+            : new HashSet<string>(
+                selected.Where(field => !string.IsNullOrWhiteSpace(field)).Select(field => field.Trim()),
+                StringComparer.OrdinalIgnoreCase);
+
+        return columns
+            .Select(column => new TablePublishValidationField
+            {
+                Name = column.Name,
+                DataType = column.DataType,
+                FieldType = MapPostgresType(column.DataType).ToString(),
+                IsNullable = column.IsNullable,
+                IsPrimaryKey = column.IsPrimaryKey,
+                IsSelected = selectedSet == null || selectedSet.Contains(column.Name),
+                MaxLength = column.MaxLength
+            })
+            .ToArray();
     }
 
     private static string NormalizeGeometryType(string raw)
@@ -895,6 +1313,183 @@ internal sealed partial class PostgreSqlLayerPublishingService(
     private static string QuoteLiteral(string literal)
         => "'" + literal.Replace("'", "''", StringComparison.Ordinal) + "'";
 
+    private static ColumnInfo? FindColumn(TableInfo tableInfo, string columnName)
+        => tableInfo.Columns.FirstOrDefault(column =>
+            column.Name.Equals(columnName, StringComparison.OrdinalIgnoreCase));
+
+    private static async Task<GeometryHealth?> InspectGeometryHealthAsync(
+        string connectionString,
+        string schema,
+        string table,
+        string geometryColumn,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        var sourceTable = $"{QuoteIdentifier(schema)}.{QuoteIdentifier(table)}";
+        var sourceGeometry = QuoteIdentifier(geometryColumn);
+        var sql = $"""
+            WITH source AS (
+                SELECT {sourceGeometry}::geometry AS geom
+                FROM {sourceTable}
+            )
+            SELECT
+                COUNT(*)::bigint,
+                COUNT(*) FILTER (WHERE geom IS NULL)::bigint,
+                COUNT(*) FILTER (WHERE geom IS NOT NULL AND NOT ST_IsValid(geom))::bigint,
+                COUNT(DISTINCT GeometryType(geom)) FILTER (WHERE geom IS NOT NULL)::int,
+                MIN(NULLIF(ST_SRID(geom), 0)) FILTER (WHERE geom IS NOT NULL)::int,
+                MAX(NULLIF(ST_SRID(geom), 0)) FILTER (WHERE geom IS NOT NULL)::int
+            FROM source;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return new GeometryHealth(
+            reader.GetInt64(0),
+            reader.GetInt64(1),
+            reader.GetInt64(2),
+            reader.IsDBNull(3) ? 0 : reader.GetInt32(3),
+            reader.IsDBNull(4) ? null : reader.GetInt32(4),
+            reader.IsDBNull(5) ? null : reader.GetInt32(5));
+    }
+
+    private static async Task<int?> ResolveExistingServiceSridAsync(
+        string connectionString,
+        string serviceName,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        if (!await HonuaTableExistsAsync(connection, "services", cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        const string sql = """
+            SELECT srid
+            FROM honua.services
+            WHERE service_name = @serviceName
+            LIMIT 1;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@serviceName", serviceName);
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return result == null || result == DBNull.Value
+            ? null
+            : Convert.ToInt32(result, CultureInfo.InvariantCulture);
+    }
+
+    private static async Task AddExistingLayerCheckAsync(
+        string connectionString,
+        string schema,
+        string table,
+        List<TablePublishValidationCheck> checks,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        if (!await HonuaTableExistsAsync(connection, "layers", cancellationToken).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        const string sql = """
+            SELECT layer_id
+            FROM honua.layers
+            WHERE table_schema = @schema
+              AND table_name = @table
+            LIMIT 1;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@schema", schema);
+        command.Parameters.AddWithValue("@table", table);
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        if (result == null || result == DBNull.Value)
+        {
+            checks.Add(Pass("layer-conflict", "No existing layer is mapped to this source table."));
+            return;
+        }
+
+        checks.Add(Error(
+            "layer-conflict",
+            "A layer already exists for this source table.",
+            null,
+            Convert.ToString(result, CultureInfo.InvariantCulture)));
+    }
+
+    private static async Task<bool> HonuaTableExistsAsync(
+        NpgsqlConnection connection,
+        string tableName,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = 'honua'
+                  AND table_name = @tableName
+            );
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@tableName", tableName);
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return result is bool exists && exists;
+    }
+
+    private static TablePublishValidationCheck Pass(
+        string code,
+        string message,
+        string? expected = null,
+        string? actual = null)
+        => new()
+        {
+            Code = code,
+            Severity = SeverityPass,
+            Message = message,
+            Expected = expected,
+            Actual = actual
+        };
+
+    private static TablePublishValidationCheck Warning(
+        string code,
+        string message,
+        string? expected = null,
+        string? actual = null)
+        => new()
+        {
+            Code = code,
+            Severity = SeverityWarning,
+            Message = message,
+            Expected = expected,
+            Actual = actual
+        };
+
+    private static TablePublishValidationCheck Error(
+        string code,
+        string message,
+        string? expected = null,
+        string? actual = null)
+        => new()
+        {
+            Code = code,
+            Severity = SeverityError,
+            Message = message,
+            Expected = expected,
+            Actual = actual
+        };
+
     private static async Task InsertFieldsAsync(
         NpgsqlConnection connection,
         NpgsqlTransaction transaction,
@@ -1165,4 +1760,19 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         double MinY,
         double MaxX,
         double MaxY);
+
+    private readonly record struct GeometryHealth(
+        long FeatureCount,
+        long NullGeometryCount,
+        long InvalidGeometryCount,
+        int DistinctGeometryTypeCount,
+        int? MinSrid,
+        int? MaxSrid);
+
+    private readonly record struct ResolvedPublishValidation(
+        string? GeometryColumn,
+        string? GeometryType,
+        string? PrimaryKey,
+        int? ServiceSrid,
+        int? TargetSrid);
 }

--- a/src/Honua.Postgres/Features/Import/StreamingFileImportService.cs
+++ b/src/Honua.Postgres/Features/Import/StreamingFileImportService.cs
@@ -440,13 +440,73 @@ internal sealed partial class StreamingFileImportService : IFileImportService
             if (!sourceSrid.HasValue)
             {
                 errorMessage = $"Source SRID is required for {format.Value} imports when CRS cannot be detected.";
+                var validationErrors = new[]
+                {
+                    ImportValidationIssue.Create(
+                        ImportValidationErrorCodes.SourceSridRequired,
+                        errorMessage,
+                        field: nameof(request.SourceSrid))
+                };
                 result = ImportResult.CreateFailure(
                     request.TableName,
                     format.Value,
                     errorMessage,
                     stopwatch.Elapsed,
-                    warnings);
+                    warnings,
+                    ImportValidationErrorCodes.SourceSridRequired,
+                    validationErrors);
                 return result;
+            }
+
+            var sridValidationErrors = await ValidateImportSridsAsync(
+                sourceSrid.Value,
+                request.TargetSrid,
+                cancellationToken);
+            if (sridValidationErrors.Count > 0)
+            {
+                errorMessage = sridValidationErrors[0].Message;
+                result = ImportResult.CreateFailure(
+                    request.TableName,
+                    format.Value,
+                    errorMessage,
+                    stopwatch.Elapsed,
+                    warnings,
+                    sridValidationErrors[0].Code,
+                    sridValidationErrors);
+                return result;
+            }
+
+            if (format.Value == SupportedFileFormat.GeoJson)
+            {
+                if (!fileStream.CanSeek)
+                {
+                    var seekableStream = await SpillToSeekableTempAsync(fileStream, cancellationToken);
+                    if (shouldDisposeStream)
+                    {
+                        await fileStream.DisposeAsync();
+                    }
+
+                    fileStream = seekableStream;
+                    shouldDisposeStream = true;
+                    totalBytes = seekableStream.Length;
+                    ImportLog.SpilledToTempFile(_logger, totalBytes.Value);
+                }
+
+                var geoJsonValidation = await _geoJsonReader.ValidateAsync(fileStream, cancellationToken);
+                if (!geoJsonValidation.IsValid)
+                {
+                    var issue = geoJsonValidation.Issues[0];
+                    errorMessage = issue.Message;
+                    result = ImportResult.CreateFailure(
+                        request.TableName,
+                        format.Value,
+                        errorMessage,
+                        stopwatch.Elapsed,
+                        warnings,
+                        issue.Code,
+                        geoJsonValidation.Issues);
+                    return result;
+                }
             }
 
             // Report initial progress
@@ -639,6 +699,11 @@ internal sealed partial class StreamingFileImportService : IFileImportService
                 continue;
             }
 
+            if (format != SupportedFileFormat.FileGdb && feature.Geometry != null)
+            {
+                feature.Geometry.SRID = sourceSrid;
+            }
+
             batch.Add(feature);
 
             // Process batch when full
@@ -762,6 +827,89 @@ internal sealed partial class StreamingFileImportService : IFileImportService
         if (failedCount > 0)
         {
             _performanceMonitor.RecordCounter("honua_import_failures_total", failedCount, tags);
+        }
+    }
+
+    private async Task<IReadOnlyList<ImportValidationIssue>> ValidateImportSridsAsync(
+        int sourceSrid,
+        int targetSrid,
+        CancellationToken cancellationToken)
+    {
+        if (sourceSrid <= 0)
+        {
+            return
+            [
+                ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.SourceSridUnsupported,
+                    $"Source SRID {sourceSrid} is not supported.",
+                    field: nameof(ImportRequest.SourceSrid))
+            ];
+        }
+
+        if (targetSrid <= 0)
+        {
+            return
+            [
+                ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.TargetSridUnsupported,
+                    $"Target SRID {targetSrid} is not supported.",
+                    field: nameof(ImportRequest.TargetSrid))
+            ];
+        }
+
+        if (!await _crsDetectionService.ValidateSridAsync(sourceSrid))
+        {
+            return
+            [
+                ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.SourceSridUnsupported,
+                    $"Source SRID {sourceSrid} is not registered in spatial_ref_sys.",
+                    field: nameof(ImportRequest.SourceSrid))
+            ];
+        }
+
+        if (!await _crsDetectionService.ValidateSridAsync(targetSrid))
+        {
+            return
+            [
+                ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.TargetSridUnsupported,
+                    $"Target SRID {targetSrid} is not registered in spatial_ref_sys.",
+                    field: nameof(ImportRequest.TargetSrid))
+            ];
+        }
+
+        if (sourceSrid != targetSrid && !await CanTransformAsync(sourceSrid, targetSrid, cancellationToken))
+        {
+            return
+            [
+                ImportValidationIssue.Create(
+                    ImportValidationErrorCodes.ProjectionUnsupported,
+                    $"Source SRID {sourceSrid} cannot be transformed to target SRID {targetSrid}.",
+                    field: nameof(ImportRequest.TargetSrid))
+            ];
+        }
+
+        return [];
+    }
+
+    private async Task<bool> CanTransformAsync(int sourceSrid, int targetSrid, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await OpenConnectionAsync(cancellationToken);
+            await using var command = new NpgsqlCommand(
+                "SELECT ST_Transform(ST_SetSRID(ST_MakePoint(0, 0), @source_srid), @target_srid) IS NOT NULL",
+                connection);
+            command.Parameters.Add("source_srid", NpgsqlDbType.Integer).Value = sourceSrid;
+            command.Parameters.Add("target_srid", NpgsqlDbType.Integer).Value = targetSrid;
+
+            var result = await command.ExecuteScalarAsync(cancellationToken);
+            return result is bool transformed && transformed;
+        }
+        catch (PostgresException)
+        {
+            return false;
         }
     }
 

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -70,6 +70,7 @@ public static class EndpointRegistry
         new("PUT", "/api/v1/admin/connections/{id}/tables"),
         new("DELETE", "/api/v1/admin/connections/{id}/tables"),
         new("PATCH", "/api/v1/admin/connections/{id}/tables"),
+        new("POST", "/api/v1/admin/connections/{id}/tables/validate"),
         new("GET", "/api/v1/admin/connections/tables"),
         new("GET", "/api/v1/admin/connections/{*path}"),
         new("POST", "/api/v1/admin/external-services/discover"),

--- a/src/Honua.Server/Features/Admin/LayerPublishingEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/LayerPublishingEndpoints.cs
@@ -59,6 +59,21 @@ internal static class LayerPublishingEndpoints
         group.MapPut("/enabled", HandleSetServiceLayersEnabled)
             .WithDisplayName("Set Service Layers Enabled")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Put }));
+
+        var tableGroup = endpoints.MapGroup("/api/v{version:apiVersion}/admin/connections/{id}/tables")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Layers")
+            .RequireAdminAuthorization();
+
+        tableGroup.MapPost("/validate", HandleValidateTableForPublish)
+            .WithDisplayName("Validate Table For Layer Publishing")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
+            .Produces<ApiResponse<TablePublishValidationResult>>(StatusCodes.Status200OK)
+            .Produces<ApiResponse<object>>(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .Produces<ApiResponse<object>>(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
     }
 
     private static async Task<Results<Ok<ApiResponse<IReadOnlyList<PublishedLayerSummary>>>, NotFound<ApiResponse<object>>, BadRequest<ApiResponse<object>>, ProblemHttpResult, ForbidHttpResult>>
@@ -208,6 +223,80 @@ internal static class LayerPublishingEndpoints
             return TypedResults.Problem(
                 title: "Layer publish failed",
                 detail: "An internal error occurred while publishing the layer.",
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return TypedResults.Forbid();
+        }
+    }
+
+    private static async Task<IResult>
+        HandleValidateTableForPublish(
+            string id,
+            ValidateTablePublishRequest request,
+            [FromServices] ISecureConnectionResolver resolver,
+            [FromServices] ILayerPublishingService publishingService,
+            HttpContext context,
+            [FromServices] ILogger<LayerPublishingEndpointsLog> logger)
+    {
+        var validationResults = new List<ValidationResult>();
+        if (!Validator.TryValidateObject(request, new ValidationContext(request), validationResults, true))
+        {
+            var errors = string.Join(", ", validationResults.Select(r => r.ErrorMessage));
+            return TypedResults.BadRequest(ApiResponse<object>.Failure($"Validation failed: {errors}"));
+        }
+
+        try
+        {
+            var connectionString = await ResolveConnectionStringAsync(id, resolver, context.RequestAborted);
+            var validationRequest = new TablePublishValidationRequest
+            {
+                Schema = request.Schema,
+                Table = request.Table,
+                LayerName = request.LayerName,
+                ServiceName = request.ServiceName,
+                TargetSrid = request.TargetSrid,
+                GeometryColumn = request.GeometryColumn,
+                PrimaryKey = request.PrimaryKey,
+                Fields = request.Fields ?? Array.Empty<string>()
+            };
+
+            var result = await publishingService.ValidateTableForPublishAsync(
+                connectionString,
+                validationRequest,
+                context.RequestAborted);
+
+            return Results.Json(
+                ApiResponse<TablePublishValidationResult>.CreateSuccess(result),
+                LayerPublishingJsonContext.Default.ApiResponseTablePublishValidationResult);
+        }
+        catch (LayerPublishingException ex) when (ex.ErrorKind == LayerPublishingErrorKind.NotFound)
+        {
+            LayerPublishingLog.LayerPublishNotFound(logger, ex);
+            return TypedResults.NotFound(ApiResponse<object>.Failure(GetSafeLayerPublishingMessage(ex)));
+        }
+        catch (LayerPublishingException ex)
+        {
+            LayerPublishingLog.LayerPublishValidationFailed(logger, ex);
+            return TypedResults.BadRequest(ApiResponse<object>.Failure(GetSafeLayerPublishingMessage(ex)));
+        }
+        catch (ArgumentException ex)
+        {
+            LayerPublishingLog.LayerPublishInvalidRequest(logger, ex);
+            return TypedResults.BadRequest(ApiResponse<object>.Failure("Invalid request parameters."));
+        }
+        catch (ResourceNotFoundException ex)
+        {
+            LayerPublishingLog.LayerListConnectionNotFound(logger, ex);
+            return TypedResults.NotFound(ApiResponse<object>.Failure("The requested resource was not found."));
+        }
+        catch (InvalidOperationException ex)
+        {
+            LayerPublishingLog.LayerPublishInvalidOperation(logger, ex);
+            return TypedResults.Problem(
+                title: "Layer validation failed",
+                detail: "An internal error occurred while validating the layer.",
                 statusCode: StatusCodes.Status500InternalServerError);
         }
         catch (UnauthorizedAccessException)

--- a/src/Honua.Server/Features/Admin/Models/LayerPublishingJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/LayerPublishingJsonContext.cs
@@ -16,10 +16,17 @@ namespace Honua.Server.Features.Admin.Models;
     WriteIndented = false)]
 [JsonSerializable(typeof(ApiResponse<IReadOnlyList<PublishedLayerSummary>>))]
 [JsonSerializable(typeof(ApiResponse<PublishedLayerSummary>))]
+[JsonSerializable(typeof(ApiResponse<TablePublishValidationResult>))]
 [JsonSerializable(typeof(ApiResponse<object>))]
 [JsonSerializable(typeof(PublishLayerRequest))]
+[JsonSerializable(typeof(ValidateTablePublishRequest))]
 [JsonSerializable(typeof(LayerEnabledRequest))]
 [JsonSerializable(typeof(PublishedLayerSummary))]
+[JsonSerializable(typeof(TablePublishValidationResult))]
+[JsonSerializable(typeof(TablePublishValidationCheck))]
+[JsonSerializable(typeof(TablePublishValidationCheck[]))]
+[JsonSerializable(typeof(TablePublishValidationField))]
+[JsonSerializable(typeof(TablePublishValidationField[]))]
 internal sealed partial class LayerPublishingJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Server/Features/Admin/Models/LayerPublishingModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/LayerPublishingModels.cs
@@ -79,6 +79,61 @@ public sealed class PublishLayerRequest
 }
 
 /// <summary>
+/// Request payload for validating a selected table before publishing it as a layer.
+/// </summary>
+public sealed class ValidateTablePublishRequest
+{
+    /// <summary>
+    /// Schema containing the source table.
+    /// </summary>
+    [Required]
+    [StringLength(63, MinimumLength = 1)]
+    public required string Schema { get; init; }
+
+    /// <summary>
+    /// Source table name.
+    /// </summary>
+    [Required]
+    [StringLength(63, MinimumLength = 1)]
+    public required string Table { get; init; }
+
+    /// <summary>
+    /// Optional display name for the layer being prepared.
+    /// </summary>
+    [StringLength(128, MinimumLength = 1)]
+    public string? LayerName { get; init; }
+
+    /// <summary>
+    /// Optional target service name.
+    /// </summary>
+    [StringLength(64)]
+    public string? ServiceName { get; init; }
+
+    /// <summary>
+    /// Requested target spatial reference identifier.
+    /// </summary>
+    [Range(0, int.MaxValue)]
+    public int? TargetSrid { get; init; }
+
+    /// <summary>
+    /// Requested geometry column name.
+    /// </summary>
+    [StringLength(64)]
+    public string? GeometryColumn { get; init; }
+
+    /// <summary>
+    /// Requested primary key field name.
+    /// </summary>
+    [StringLength(64)]
+    public string? PrimaryKey { get; init; }
+
+    /// <summary>
+    /// Selected attribute fields to publish. Empty means include all.
+    /// </summary>
+    public IReadOnlyList<string> Fields { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>
 /// Request payload for enabling/disabling a layer.
 /// </summary>
 public sealed class LayerEnabledRequest

--- a/src/Honua.Server/Features/Import/ImportJsonContext.cs
+++ b/src/Honua.Server/Features/Import/ImportJsonContext.cs
@@ -21,6 +21,8 @@ namespace Honua.Server.Features.Import;
 [JsonSerializable(typeof(MigrationInventoryCodedValue[]))]
 [JsonSerializable(typeof(FilePreview))]
 [JsonSerializable(typeof(ImportResult))]
+[JsonSerializable(typeof(ImportValidationIssue))]
+[JsonSerializable(typeof(IReadOnlyList<ImportValidationIssue>))]
 [JsonSerializable(typeof(ImportProgress))]
 [JsonSerializable(typeof(ImportLimits))]
 [JsonSerializable(typeof(ImportStatus))]

--- a/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
@@ -562,6 +562,105 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/tables/validate")]
+    public async Task ValidateTableForPublish_WithValidTable_ReturnsFieldMetadata()
+    {
+        var validationRequest = new ValidateTablePublishRequest
+        {
+            Schema = _schema,
+            Table = _tableName,
+            LayerName = $"Layer {_tableName}",
+            ServiceName = _serviceName,
+            TargetSrid = 4326,
+            GeometryColumn = "geom",
+            PrimaryKey = "id",
+            Fields = new[] { "id", "name", "population" }
+        };
+
+        var response = await _client.PostAsync(
+            $"/api/v1/admin/connections/{_connectionId}/tables/validate",
+            JsonContent.Create(validationRequest, options: _jsonOptions));
+
+        var payload = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, $"response: {payload}");
+        var api = JsonSerializer.Deserialize<ApiResponse<TablePublishValidationResult>>(payload, _jsonOptions);
+
+        api.Should().NotBeNull();
+        api!.Success.Should().BeTrue();
+        api.Data.Should().NotBeNull();
+        api.Data!.IsValid.Should().BeTrue();
+        api.Data.Status.Should().Be("valid");
+        api.Data.Schema.Should().Be(_schema);
+        api.Data.Table.Should().Be(_tableName);
+        api.Data.GeometryColumn.Should().Be("geom");
+        api.Data.PrimaryKey.Should().Be("id");
+        api.Data.SourceSrid.Should().Be(4326);
+        api.Data.TargetSrid.Should().Be(4326);
+        api.Data.FeatureCount.Should().Be(1);
+        api.Data.Fields.Should().Contain(field => field.Name == "id" && field.IsPrimaryKey && field.IsSelected);
+        api.Data.Fields.Should().OnlyContain(field => field.Name != "geom");
+        api.Data.Checks.Should().Contain(check => check.Code == "invalid-geometries" && check.Severity == "pass");
+        api.Data.Checks.Should().NotContain(check => check.Severity == "error");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/tables/validate")]
+    public async Task ValidateTableForPublish_WithTextPrimaryKey_ReturnsStructuredError()
+    {
+        var textPrimaryKeyTable = $"layer_textpk_{Guid.NewGuid():N}";
+
+        try
+        {
+            await _fixture.Postgres.ExecuteAsync($"""
+                CREATE TABLE public.{textPrimaryKeyTable} (
+                    code text PRIMARY KEY,
+                    name text NOT NULL,
+                    geom geometry(Point, 4326) NOT NULL
+                );
+
+                INSERT INTO public.{textPrimaryKeyTable} (code, name, geom)
+                VALUES ('A-1', 'Text key feature', ST_SetSRID(ST_Point(1, 1), 4326));
+                """);
+
+            var validationRequest = new ValidateTablePublishRequest
+            {
+                Schema = _schema,
+                Table = textPrimaryKeyTable,
+                LayerName = $"Layer {textPrimaryKeyTable}",
+                ServiceName = _serviceName,
+                TargetSrid = 4326,
+                GeometryColumn = "geom",
+                PrimaryKey = "code",
+                Fields = new[] { "code", "name" }
+            };
+
+            var response = await _client.PostAsync(
+                $"/api/v1/admin/connections/{_connectionId}/tables/validate",
+                JsonContent.Create(validationRequest, options: _jsonOptions));
+
+            var payload = await response.Content.ReadAsStringAsync();
+            response.StatusCode.Should().Be(HttpStatusCode.OK, $"response: {payload}");
+            var api = JsonSerializer.Deserialize<ApiResponse<TablePublishValidationResult>>(payload, _jsonOptions);
+
+            api.Should().NotBeNull();
+            api!.Success.Should().BeTrue();
+            api.Data.Should().NotBeNull();
+            api.Data!.IsValid.Should().BeFalse();
+            api.Data.Status.Should().Be("invalid");
+            api.Data.Checks.Should().Contain(check =>
+                check.Code == "primary-key-type" &&
+                check.Severity == "error" &&
+                check.Actual == "text");
+        }
+        finally
+        {
+            await _fixture.Postgres.ExecuteAsync($"DROP TABLE IF EXISTS public.{textPrimaryKeyTable};");
+        }
+    }
+
+    [IntegrationTest]
     [Operation(Operations.Create)]
     [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
     public async Task PublishLayer_WhenLayerTableIsEmpty_ReturnsCreated()

--- a/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Admin/LayerPublishingIntegrationTests.cs
@@ -31,6 +31,7 @@ namespace Honua.Server.Tests.Admin;
 [Protocol(TestProtocols.Admin)]
 public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
 {
+    private static readonly string[] _idNameFields = ["id", "name"];
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -595,6 +596,7 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
         api.Data.Table.Should().Be(_tableName);
         api.Data.GeometryColumn.Should().Be("geom");
         api.Data.PrimaryKey.Should().Be("id");
+        api.Data.ObjectIdStrategy.Should().Be("source-integer-primary-key");
         api.Data.SourceSrid.Should().Be(4326);
         api.Data.TargetSrid.Should().Be(4326);
         api.Data.FeatureCount.Should().Be(1);
@@ -649,6 +651,7 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
             api.Data.Should().NotBeNull();
             api.Data!.IsValid.Should().BeFalse();
             api.Data.Status.Should().Be("invalid");
+            api.Data.ObjectIdStrategy.Should().Be("unsupported-source-primary-key");
             api.Data.Checks.Should().Contain(check =>
                 check.Code == "primary-key-type" &&
                 check.Severity == "error" &&
@@ -657,6 +660,275 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
         finally
         {
             await _fixture.Postgres.ExecuteAsync($"DROP TABLE IF EXISTS public.{textPrimaryKeyTable};");
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/tables/validate")]
+    public async Task ValidateTableForPublish_WithInvalidGeometry_ReturnsStructuredError()
+    {
+        var invalidGeometryTable = $"layer_invalidgeom_{Guid.NewGuid():N}";
+
+        try
+        {
+            await _fixture.Postgres.ExecuteAsync($"""
+                CREATE TABLE public.{invalidGeometryTable} (
+                    id integer PRIMARY KEY,
+                    name text NOT NULL,
+                    geom geometry(Polygon, 4326) NOT NULL
+                );
+
+                INSERT INTO public.{invalidGeometryTable} (id, name, geom)
+                VALUES (1, 'Invalid polygon', ST_GeomFromText('POLYGON((0 0, 1 1, 1 0, 0 1, 0 0))', 4326));
+                """);
+
+            var result = await ValidateTableForPublishAsync(new ValidateTablePublishRequest
+            {
+                Schema = _schema,
+                Table = invalidGeometryTable,
+                LayerName = $"Layer {invalidGeometryTable}",
+                ServiceName = _serviceName,
+                TargetSrid = 4326,
+                GeometryColumn = "geom",
+                PrimaryKey = "id",
+                Fields = _idNameFields
+            });
+
+            result.IsValid.Should().BeFalse();
+            result.Status.Should().Be("invalid");
+            result.InvalidGeometryCount.Should().Be(1);
+            result.Checks.Should().Contain(check =>
+                check.Code == "invalid-geometries" &&
+                check.Severity == "error" &&
+                check.Actual == "1");
+        }
+        finally
+        {
+            await _fixture.Postgres.ExecuteAsync($"DROP TABLE IF EXISTS public.{invalidGeometryTable};");
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
+    public async Task PublishLayer_WithInvalidGeometry_ReturnsBadRequestAndDoesNotCreateLayer()
+    {
+        var invalidGeometryTable = $"layer_publish_invalidgeom_{Guid.NewGuid():N}";
+
+        try
+        {
+            await _fixture.Postgres.ExecuteAsync($"""
+                CREATE TABLE public.{invalidGeometryTable} (
+                    id integer PRIMARY KEY,
+                    name text NOT NULL,
+                    geom geometry(Polygon, 4326) NOT NULL
+                );
+
+                INSERT INTO public.{invalidGeometryTable} (id, name, geom)
+                VALUES (1, 'Invalid polygon', ST_GeomFromText('POLYGON((0 0, 1 1, 1 0, 0 1, 0 0))', 4326));
+                """);
+
+            var publishRequest = new PublishLayerRequest
+            {
+                Schema = _schema,
+                Table = invalidGeometryTable,
+                LayerName = $"Layer {invalidGeometryTable}",
+                GeometryColumn = "geom",
+                GeometryType = "Polygon",
+                Srid = 4326,
+                PrimaryKey = "id",
+                Fields = _idNameFields,
+                ServiceName = _serviceName,
+                Enabled = true
+            };
+
+            var response = await _client.PostAsync(
+                $"/api/v1/admin/connections/{_connectionId}/layers",
+                JsonContent.Create(publishRequest, options: _jsonOptions));
+
+            var payload = await response.Content.ReadAsStringAsync();
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest, $"response: {payload}");
+            payload.Should().Contain("invalid geometries");
+            (await LayerMetadataExistsAsync(invalidGeometryTable)).Should().BeFalse();
+        }
+        finally
+        {
+            await _fixture.Postgres.ExecuteAsync($"DROP TABLE IF EXISTS public.{invalidGeometryTable};");
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/tables/validate")]
+    public async Task ValidateTableForPublish_WithTableWithoutGeometry_ReturnsGeometryColumnError()
+    {
+        var noGeometryTable = $"layer_nogeom_{Guid.NewGuid():N}";
+
+        try
+        {
+            await _fixture.Postgres.ExecuteAsync($"""
+                CREATE TABLE public.{noGeometryTable} (
+                    id integer PRIMARY KEY,
+                    name text NOT NULL
+                );
+
+                INSERT INTO public.{noGeometryTable} (id, name)
+                VALUES (1, 'No geometry');
+                """);
+
+            var result = await ValidateTableForPublishAsync(new ValidateTablePublishRequest
+            {
+                Schema = _schema,
+                Table = noGeometryTable,
+                LayerName = $"Layer {noGeometryTable}",
+                ServiceName = _serviceName,
+                TargetSrid = 4326,
+                GeometryColumn = "geom",
+                PrimaryKey = "id",
+                Fields = _idNameFields
+            });
+
+            result.IsValid.Should().BeFalse();
+            result.Fields.Should().Contain(field => field.Name == "id" && field.IsPrimaryKey);
+            result.Fields.Should().Contain(field => field.Name == "name");
+            result.Checks.Should().Contain(check => check.Code == "geometry-column" && check.Severity == "error");
+            result.Checks.Should().NotContain(check => check.Code == "source-table" && check.Severity == "error");
+        }
+        finally
+        {
+            await _fixture.Postgres.ExecuteAsync($"DROP TABLE IF EXISTS public.{noGeometryTable};");
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/tables/validate")]
+    public async Task ValidateTableForPublish_WithNon4326Srid_ReturnsTransformWarning()
+    {
+        var mercatorTable = $"layer_srid3857_{Guid.NewGuid():N}";
+
+        try
+        {
+            await _fixture.Postgres.ExecuteAsync($"""
+                CREATE TABLE public.{mercatorTable} (
+                    id integer PRIMARY KEY,
+                    name text NOT NULL,
+                    geom geometry(Point, 3857) NOT NULL
+                );
+
+                INSERT INTO public.{mercatorTable} (id, name, geom)
+                VALUES (1, 'Mercator point', ST_SetSRID(ST_Point(111319.49079327357, 0), 3857));
+                """);
+
+            var result = await ValidateTableForPublishAsync(new ValidateTablePublishRequest
+            {
+                Schema = _schema,
+                Table = mercatorTable,
+                LayerName = $"Layer {mercatorTable}",
+                ServiceName = _serviceName,
+                TargetSrid = 4326,
+                GeometryColumn = "geom",
+                PrimaryKey = "id",
+                Fields = _idNameFields
+            });
+
+            result.IsValid.Should().BeTrue();
+            result.Status.Should().Be("warning");
+            result.SourceSrid.Should().Be(3857);
+            result.TargetSrid.Should().Be(4326);
+            result.Checks.Should().Contain(check =>
+                check.Code == "source-srid-transform" &&
+                check.Severity == "warning" &&
+                check.Expected == "4326" &&
+                check.Actual == "3857");
+        }
+        finally
+        {
+            await _fixture.Postgres.ExecuteAsync($"DROP TABLE IF EXISTS public.{mercatorTable};");
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/tables/validate")]
+    public async Task ValidateTableForPublish_WithMixedGeometryAndSrid_ReturnsStructuredErrors()
+    {
+        var mixedTable = $"layer_mixedgeom_{Guid.NewGuid():N}";
+
+        try
+        {
+            await _fixture.Postgres.ExecuteAsync($"""
+                CREATE TABLE public.{mixedTable} (
+                    id integer PRIMARY KEY,
+                    name text NOT NULL,
+                    geom geometry(Geometry) NOT NULL
+                );
+
+                INSERT INTO public.{mixedTable} (id, name, geom)
+                VALUES
+                    (1, 'Point', ST_SetSRID(ST_Point(0, 0), 4326)),
+                    (2, 'Line', ST_SetSRID(ST_MakeLine(ST_Point(0, 0), ST_Point(1, 1)), 3857));
+                """);
+
+            var result = await ValidateTableForPublishAsync(new ValidateTablePublishRequest
+            {
+                Schema = _schema,
+                Table = mixedTable,
+                LayerName = $"Layer {mixedTable}",
+                ServiceName = _serviceName,
+                TargetSrid = 4326,
+                GeometryColumn = "geom",
+                PrimaryKey = "id",
+                Fields = _idNameFields
+            });
+
+            result.IsValid.Should().BeFalse();
+            result.Checks.Should().Contain(check => check.Code == "mixed-geometry" && check.Severity == "error");
+            result.Checks.Should().Contain(check => check.Code == "mixed-srid" && check.Severity == "error");
+        }
+        finally
+        {
+            await _fixture.Postgres.ExecuteAsync($"DROP TABLE IF EXISTS public.{mixedTable};");
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/tables/validate")]
+    public async Task ValidateTableForPublish_WithEmptyTable_ReturnsFeatureCountError()
+    {
+        var emptyTable = $"layer_empty_{Guid.NewGuid():N}";
+
+        try
+        {
+            await _fixture.Postgres.ExecuteAsync($"""
+                CREATE TABLE public.{emptyTable} (
+                    id integer PRIMARY KEY,
+                    name text NOT NULL,
+                    geom geometry(Point, 4326) NOT NULL
+                );
+                """);
+
+            var result = await ValidateTableForPublishAsync(new ValidateTablePublishRequest
+            {
+                Schema = _schema,
+                Table = emptyTable,
+                LayerName = $"Layer {emptyTable}",
+                ServiceName = _serviceName,
+                TargetSrid = 4326,
+                GeometryColumn = "geom",
+                PrimaryKey = "id",
+                Fields = _idNameFields
+            });
+
+            result.IsValid.Should().BeFalse();
+            result.FeatureCount.Should().Be(0);
+            result.Checks.Should().Contain(check => check.Code == "feature-count" && check.Severity == "error");
+        }
+        finally
+        {
+            await _fixture.Postgres.ExecuteAsync($"DROP TABLE IF EXISTS public.{emptyTable};");
         }
     }
 
@@ -747,6 +1019,40 @@ public sealed class LayerPublishingIntegrationTests : IAsyncLifetime
 
             await DropConnectionDatabaseAsync(externalDatabaseName);
         }
+    }
+
+    private async Task<TablePublishValidationResult> ValidateTableForPublishAsync(ValidateTablePublishRequest request)
+    {
+        var response = await _client.PostAsync(
+            $"/api/v1/admin/connections/{_connectionId}/tables/validate",
+            JsonContent.Create(request, options: _jsonOptions));
+
+        var payload = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, $"response: {payload}");
+        var api = JsonSerializer.Deserialize<ApiResponse<TablePublishValidationResult>>(payload, _jsonOptions);
+
+        api.Should().NotBeNull();
+        api!.Success.Should().BeTrue();
+        api.Data.Should().NotBeNull();
+        return api.Data!;
+    }
+
+    private async Task<bool> LayerMetadataExistsAsync(string tableName)
+    {
+        await using var connection = await _fixture.Postgres.GetConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT EXISTS (
+                SELECT 1
+                FROM honua.layers
+                WHERE table_schema = @schema AND table_name = @table
+            );
+            """;
+        command.Parameters.AddWithValue("schema", _schema);
+        command.Parameters.AddWithValue("table", tableName);
+
+        var result = await command.ExecuteScalarAsync();
+        return result is bool exists && exists;
     }
 
     private async Task CreatePostGisTableAsync()

--- a/tests/dotnet/Honua.Server.Tests/Import/StreamingImportTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/StreamingImportTests.cs
@@ -28,6 +28,7 @@ public class StreamingImportTests : IAsyncLifetime
 {
     private readonly WebAppFixture _fixture = new();
     private HttpClient _client = null!;
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     public async Task InitializeAsync()
     {
@@ -650,7 +651,7 @@ public class StreamingImportTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/import/upload")]
-    public async Task Import_InvalidGeoJson_HandlesErrorGracefully()
+    public async Task Import_InvalidGeoJson_ReturnsStructuredValidationAndDoesNotCreateTable()
     {
         // Arrange - Invalid GeoJSON with malformed geometry
         var geoJsonContent = """
@@ -683,10 +684,144 @@ public class StreamingImportTests : IAsyncLifetime
         // Act
         var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
 
-        // Assert - Should handle the error gracefully (either skip invalid features or fail with message)
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var responseContent = await response.Content.ReadAsStringAsync();
-        // The streaming parser should handle invalid features gracefully
-        (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.BadRequest).Should().BeTrue();
+        var result = DeserializeImportResult(responseContent);
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ImportValidationErrorCodes.GeometryUnknownType);
+        result.ValidationErrors.Should().ContainSingle(issue =>
+            issue.Code == ImportValidationErrorCodes.GeometryUnknownType &&
+            issue.FeatureIndex == 1 &&
+            issue.Field == "geometry.type");
+        (await ImportTableExistsAsync("invalid_test_table")).Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Import_GeoJsonMissingGeometry_ReturnsStructuredValidationAndDoesNotCreateTable()
+    {
+        var geoJsonContent = """
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": { "name": "No geometry" }
+                }
+            ]
+        }
+        """;
+
+        var content = new MultipartFormDataContent();
+        var fileContent = new StringContent(geoJsonContent, Encoding.UTF8, "application/json");
+        fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+        {
+            Name = "File",
+            FileName = "missing-geometry.geojson"
+        };
+        content.Add(fileContent);
+        content.Add(new StringContent("missing_geometry_table"), "TableName");
+        content.Add(new StringContent("true"), "OverwriteExisting");
+
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = DeserializeImportResult(await response.Content.ReadAsStringAsync());
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ImportValidationErrorCodes.GeometryMissing);
+        result.ValidationErrors.Should().ContainSingle(issue =>
+            issue.Code == ImportValidationErrorCodes.GeometryMissing &&
+            issue.FeatureIndex == 1 &&
+            issue.Field == "geometry");
+        (await ImportTableExistsAsync("missing_geometry_table")).Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Import_GeoJsonWithUnsupportedTargetSrid_ReturnsStructuredValidationAndDoesNotCreateTable()
+    {
+        var geoJsonContent = """
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [-122.4194, 37.7749]
+                    },
+                    "properties": { "name": "Valid" }
+                }
+            ]
+        }
+        """;
+
+        var content = new MultipartFormDataContent();
+        var fileContent = new StringContent(geoJsonContent, Encoding.UTF8, "application/json");
+        fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+        {
+            Name = "File",
+            FileName = "bad-target.geojson"
+        };
+        content.Add(fileContent);
+        content.Add(new StringContent("bad_target_srid_table"), "TableName");
+        content.Add(new StringContent("999999"), "TargetSrid");
+        content.Add(new StringContent("true"), "OverwriteExisting");
+
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = DeserializeImportResult(await response.Content.ReadAsStringAsync());
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ImportValidationErrorCodes.TargetSridUnsupported);
+        result.ValidationErrors.Should().ContainSingle(issue =>
+            issue.Code == ImportValidationErrorCodes.TargetSridUnsupported &&
+            issue.Field == nameof(ImportRequest.TargetSrid));
+        (await ImportTableExistsAsync("bad_target_srid_table")).Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Import_GeoJsonWithDifferentSourceAndTargetSrid_TransformsAtImport()
+    {
+        var geoJsonContent = """
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [111319.49079327357, 0]
+                    },
+                    "properties": { "name": "Web Mercator one degree east" }
+                }
+            ]
+        }
+        """;
+
+        var content = new MultipartFormDataContent();
+        var fileContent = new StringContent(geoJsonContent, Encoding.UTF8, "application/json");
+        fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+        {
+            Name = "File",
+            FileName = "mercator.geojson"
+        };
+        content.Add(fileContent);
+        content.Add(new StringContent("reprojected_geojson_table"), "TableName");
+        content.Add(new StringContent("3857"), "SourceSrid");
+        content.Add(new StringContent("4326"), "TargetSrid");
+        content.Add(new StringContent("true"), "OverwriteExisting");
+
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        response.BeSuccessful();
+        var result = DeserializeImportResult(await response.Content.ReadAsStringAsync());
+        result.Success.Should().BeTrue();
+        var (x, srid) = await ReadImportedPointAsync("reprojected_geojson_table");
+        x.Should().BeApproximately(1d, 0.000001d);
+        srid.Should().Be(4326);
     }
 
     [IntegrationTest]
@@ -751,7 +886,7 @@ public class StreamingImportTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/import/upload")]
-    public async Task Import_EmptyFeatureCollection_ReturnsError()
+    public async Task Import_EmptyFeatureCollection_ReturnsStructuredValidationAndDoesNotCreateTable()
     {
         // Arrange
         var geoJsonContent = """
@@ -776,8 +911,14 @@ public class StreamingImportTests : IAsyncLifetime
         var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
 
         // Assert
-        var responseContent = await response.Content.ReadAsStringAsync();
-        responseContent.Should().Contain("No features found");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = DeserializeImportResult(await response.Content.ReadAsStringAsync());
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ImportValidationErrorCodes.EmptyDataset);
+        result.ValidationErrors.Should().ContainSingle(issue =>
+            issue.Code == ImportValidationErrorCodes.EmptyDataset &&
+            issue.Field == "features");
+        (await ImportTableExistsAsync("empty_table")).Should().BeFalse();
     }
 
     private static byte[] BuildKmzArchive(string kmlContent)
@@ -812,4 +953,44 @@ public class StreamingImportTests : IAsyncLifetime
         response.BeSuccessful();
         return await response.Content.ReadAsStringAsync();
     }
+
+    private static ImportResult DeserializeImportResult(string responseContent)
+        => JsonSerializer.Deserialize<ImportResult>(responseContent, JsonOptions)
+           ?? throw new InvalidOperationException("Import response did not deserialize.");
+
+    private async Task<bool> ImportTableExistsAsync(string tableName)
+    {
+        var schema = _fixture.CurrentSchema ?? throw new InvalidOperationException("Schema was not initialized.");
+        await using var connection = await _fixture.Postgres.GetConnectionAsync(schema);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = @schema
+                  AND table_name = @table_name)
+            """;
+        command.Parameters.AddWithValue("schema", schema);
+        command.Parameters.AddWithValue("table_name", "imported_" + tableName);
+        var result = await command.ExecuteScalarAsync();
+        return result is bool exists && exists;
+    }
+
+    private async Task<(double X, int Srid)> ReadImportedPointAsync(string tableName)
+    {
+        var schema = _fixture.CurrentSchema ?? throw new InvalidOperationException("Schema was not initialized.");
+        await using var connection = await _fixture.Postgres.GetConnectionAsync(schema);
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT ST_X(geometry), ST_SRID(geometry) FROM {QuoteIdentifier("imported_" + tableName)} LIMIT 1";
+        await using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+        {
+            throw new InvalidOperationException("Imported point was not found.");
+        }
+
+        return (reader.GetDouble(0), reader.GetInt32(1));
+    }
+
+    private static string QuoteIdentifier(string identifier)
+        => "\"" + identifier.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
 }

--- a/tests/dotnet/Honua.Server.Tests/TestWebApplicationFactory.cs
+++ b/tests/dotnet/Honua.Server.Tests/TestWebApplicationFactory.cs
@@ -286,6 +286,30 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
             throw new NotSupportedException("Layer publishing is not available in this test fixture.");
         }
 
+        public Task<TablePublishValidationResult> ValidateTableForPublishAsync(
+            string connectionString,
+            TablePublishValidationRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new TablePublishValidationResult
+            {
+                IsValid = false,
+                Status = "invalid",
+                Schema = request.Schema,
+                Table = request.Table,
+                ServiceName = request.ServiceName ?? "default",
+                Checks =
+                [
+                    new TablePublishValidationCheck
+                    {
+                        Code = "not-supported",
+                        Severity = "error",
+                        Message = "Layer publishing validation is not available in this test fixture."
+                    }
+                ]
+            });
+        }
+
         public Task<PublishedLayerSummary?> SetLayerEnabledAsync(
             string connectionString,
             int layerId,


### PR DESCRIPTION
## Issue Link
Fixes #975

## Summary
Combines selected-table and GeoJSON file pre-publish validation into one server PR against `trunk`, while keeping the import progress work from #986 out of scope.

Supersedes #987 and #988.

## Changes Made
- Added selected-table pre-publish validation with structured checks, field metadata, object ID strategy reporting, geometry health checks, SRID/projection warnings, and fallback introspection for tables that exist without geometry columns.
- Gated `POST /admin/connections/{id}/layers` through the same validation path before layer metadata/features are inserted.
- Added structured GeoJSON upload validation issue codes and bounded GeoJSON preflight parsing by the configured import memory budget.
- Added integration coverage for valid table validation, invalid geometry, missing geometry column, non-4326 SRID, mixed geometry/SRID, empty table, non-integer primary key, duplicate publish gating, and GeoJSON upload validation paths.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Validation
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --configuration Release --filter "FullyQualifiedName~LayerPublishingIntegrationTests|FullyQualifiedName~StreamingImportTests|FullyQualifiedName~EndpointRegistryDriftTests"`
- `dotnet test tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj --configuration Release --filter "FullyQualifiedName~StreamingGeoJsonReaderTests"`
- `dotnet format Honua.sln --verify-no-changes --verbosity diagnostic`
- `scripts/ci/pre-pr-check.sh` was run locally; the Admin & Infrastructure shard reported a local geocoding startup validation blip in two tests, both passed on focused rerun, and the full GitHub PR gate is green.

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh`; local transient was rechecked and all GitHub PR checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
