### PR TITLE
docs: add SDK standards coverage matrix

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -69,6 +69,7 @@
 - [NVIDIA Construction Demo Fixture](demo/nvidia-construction.md)
 - [Scene Dataset Registry (Admin API)](admin-api/scene-dataset-registry.md)
 - [SDK Compatibility](developer/SDK_COMPATIBILITY_MATRIX.md)
+- [SDK Standards Coverage](developer/SDK_STANDARDS_COVERAGE.md)
 - [Mobile SDK Roadmap](developer/mobile-sdk-roadmap.md)
 - [FieldCollection Mobile Sync API](developer/fieldcollection-mobile-sync-api.md)
 - [MCP Server](developer/MCP_SERVER.md)

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -19,6 +19,7 @@ Build applications and integrations with Honua APIs and SDKs.
 ## SDKs
 
 - [SDK Compatibility Matrix](SDK_COMPATIBILITY_MATRIX.md) — Server/SDK version support
+- [SDK Standards Coverage](SDK_STANDARDS_COVERAGE.md) — Server-owned SDK coverage by language and protocol
 - [SDK Metadata Format](SDK_COMPATIBILITY_METADATA.md) — Compatibility metadata schema
 - [Mobile SDK Roadmap](mobile-sdk-roadmap.md) — Read / write / edit / sync / offline-cache cycle plan for `honua-mobile-sdk` (MAUI, iOS + Android)
 - [MCP Server](MCP_SERVER.md) — SDK-hosted discovery/query MCP package plus the server-owned operator surface for AI agents

--- a/docs/developer/SDK_COMPATIBILITY_MATRIX.md
+++ b/docs/developer/SDK_COMPATIBILITY_MATRIX.md
@@ -13,6 +13,7 @@ Use this page first when you need to:
 
 Use it together with:
 - [Machine-readable SDK compatibility version manifest](sdk-compatibility-versions.json)
+- [SDK Standards Coverage by Language](SDK_STANDARDS_COVERAGE.md)
 - [2026-05 Preview release-train manifest](../../release/honua-2026-05-preview.json)
 - [Control Plane API](../operator/CONTROL_PLANE_API.md)
 - [Control Plane Migration Guide](CONTROL_PLANE_MIGRATION_GUIDE.md)
@@ -27,6 +28,8 @@ Use it together with:
   catalog, and FeatureServer smoke paths, and .NET currently covers admin
   compatibility. It is not a comprehensive standards-conformance matrix for
   FeatureServer, OGC, OData, WMS, WMTS, or other protocol adapters.
+  Use [SDK Standards Coverage by Language](SDK_STANDARDS_COVERAGE.md) for
+  server-owned SDK coverage positioning by language and protocol.
 - Current admin API major in this repo: `v1`.
 - JavaScript/TypeScript, Python, and .NET SDK artifacts are generated from the
   same curated admin OpenAPI contract and should be treated as one versioned

--- a/docs/developer/SDK_STANDARDS_COVERAGE.md
+++ b/docs/developer/SDK_STANDARDS_COVERAGE.md
@@ -1,0 +1,111 @@
+# SDK Standards Coverage by Language
+
+This page is the server-owned SDK standards coverage ledger for
+[honua-server#994](https://github.com/honua-io/honua-server/issues/994). It is
+for website, release-note, and interoperability copy that needs to describe how
+first-party SDKs line up with Honua Server protocol surfaces.
+
+Use this page together with:
+
+- [Server + SDK Compatibility Matrix](SDK_COMPATIBILITY_MATRIX.md) for
+  server/SDK version support and live compatibility evidence
+- [Protocols Overview](../gis/STANDARDS_APIS.md) for server-side standards and
+  protocol adapter support
+- [Metadata and Catalog Parity Matrix](metadata-catalog-parity-matrix.md) for
+  metadata/catalog endpoint parity targets
+- [Mobile SDK Roadmap](mobile-sdk-roadmap.md) for MAUI/offline field workflows
+
+## Claim Rules
+
+- Server standards support means Honua Server exposes and governs the protocol
+  endpoint. It does not mean every first-party SDK has a language-native wrapper.
+- SDK coverage means there is a language-native convenience path or a tracked
+  first-party client target for that language. Standard HTTP/protocol access
+  remains available even when a language-specific wrapper is not claimed.
+- Marketing and site copy should say that Honua Server keeps standards
+  endpoints available while SDKs provide language-native paths for the surfaces
+  developers actually use in each environment.
+- Do not claim that every SDK supports every server standard.
+- Release-grade SDK claims must point to a pinned SDK line, release note, or
+  compatibility artifact. The `sdk-server-compatibility.yml` evidence records
+  the exact `protocol_surfaces_by_sdk` exercised for a server/SDK cell.
+
+## Status Labels
+
+| Label | Meaning |
+|---|---|
+| Supported convenience | First-party SDK path may be cited for a pinned SDK line when release notes or compatibility evidence cover that package. |
+| Targeted convenience | First-party SDK work is scoped or tracked, but it is not a shipping claim until the SDK repo releases it and evidence names it. |
+| Generic protocol | The server standard is available, but the language should use ordinary HTTP, generated OpenAPI/gRPC code, or ecosystem clients rather than a Honua-specific wrapper claim. |
+| Deferred | No first-party SDK client should be claimed until a concrete product workflow is linked. |
+
+## Evidence Boundary
+
+This page is positioning and backlog guidance, not release evidence by itself.
+The current server-owned SDK compatibility lane records these exercised surfaces:
+
+| SDK | Surfaces currently exercised by server compatibility evidence |
+|---|---|
+| JavaScript / TypeScript | `control-plane-admin`, `geoservices-catalog`, `feature-server`, `ogc-api-features` |
+| Python | `control-plane-admin`, `platform-http`, `geoservices-catalog`, `feature-server` |
+| .NET | `control-plane-admin` |
+
+Rows below can guide copy and SDK backlog decisions, but they become release
+claims only when the relevant SDK package, release note, or compatibility
+artifact names the surface.
+
+## Coverage Matrix
+
+| Server protocol surface | Server support | JavaScript / TypeScript SDK | Python SDK | .NET SDK |
+|---|---|---|---|---|
+| Admin/control-plane typed APIs (`/api/v1/admin`) | Supported server management API. | Supported convenience for web apps, app-builder flows, and automation. | Supported convenience for automation, ETL, and data operations. | Supported convenience for C# services, admin tooling, and automation. |
+| Geospatial gRPC (`geospatial.v1`) | Supported server protocol; protobuf ownership stays in `honua-io/geospatial-grpc`. | Generic protocol unless a web/gRPC-Web client is released for a concrete workflow. | Generic protocol unless a Python generated client is released for a concrete workflow. | Targeted convenience for C# services and automation. Do not claim feature gRPC interop until the .NET package path and live evidence match the server's `geospatial.v1` methods. |
+| GeoServices REST FeatureServer | Supported feature metadata, query, edit, attachment, and related-record surface. | Supported convenience for web/app service discovery, layer metadata, query, and edit workflows. | Supported convenience for analysis, ETL, AI/data, metadata, and feature query workflows. | Supported or targeted convenience where `Honua.Sdk.GeoServices` covers backend FeatureServer workflows. Cite only the operations released and evidenced for the pinned SDK line. |
+| GeoServices REST MapServer and ImageServer | Supported map, image, identify, legend, export, tile, and raster metadata surfaces. | Supported convenience for browser/web map display and raster/image workflows where released. | Supported convenience for analysis, ETL, validation, export, and raster/image workflows where released. | Backend-only target. No .NET map-display claim unless a .NET display component exists. Raster/image clients require a concrete backend workflow before implementation. |
+| OGC API Features | Supported standards feature API. | Supported convenience for web/app feature discovery, query, and map-source workflows. | Supported convenience for analysis, ETL, AI/data, and standards feature workflows. | Supported or targeted convenience through `Honua.Sdk.OgcFeatures` for services, automation, field, and offline workflows. No map-display claim by itself. |
+| OGC API Records | Planned server catalog surface; final route and query contract are tracked by [honua-server#952](https://github.com/honua-io/honua-server/issues/952). | Targeted convenience after the server contract is pinned. | Targeted convenience after the server contract is pinned. | Targeted convenience after the server contract is pinned. |
+| OGC API Maps, OGC API Tiles, MVT, TileJSON, and Terrain-RGB tiles | Supported rendered-map, tile, vector-tile, TileJSON, and terrain tile surfaces. | Supported convenience for browser map display and tile consumption where released. | Supported convenience for validation, cache inspection, data workflows, and ecosystem client integration where released. | Deferred for generic map-display parity. Only track backend raster/tile clients for named workflows such as static rendering, endpoint validation, tile cache audit/prewarm, secured proxying, thumbnails, or offline package generation. |
+| Classic OGC WFS | Supported standards feature service. | Supported convenience or generic standards-client path for web/app feature workflows where released. | Supported convenience for analysis, ETL, AI/data, and standards feature workflows where released. | Supported or targeted backend feature-interchange convenience where released and evidenced. |
+| Classic OGC WMS and WMTS | Supported standards map image and tile services. | Supported convenience for web map display and tile/image consumption where released. | Supported convenience for validation, rendering/export checks, and ecosystem client workflows where released. | Deferred for generic map-display parity. No WMS/WMTS .NET display claim without a .NET display component and release evidence. |
+| WCS and OGC API Coverages | Supported coverage/raster standards surfaces. | Generic protocol or targeted convenience for browser fetch/preview workflows where released. | Supported convenience for analysis, ETL, validation, and raster/coverage workflows where released. | Deferred unless a backend coverage workflow is linked, such as report rendering, thumbnail generation, validation, or offline package creation. |
+| STAC API | Supported catalog, collection, item, and search surface. | Supported convenience for catalog/search and app-builder workflows where released. | Supported convenience for analysis, ETL, AI/data, and asset catalog/search workflows where released. | Supported or targeted convenience for backend catalog/search workflows where released and evidenced. |
+| OData v4 | Supported BI/query/CRUD surface with spatial functions. | Supported convenience or generic OData client path where released. | Supported convenience for analysis, ETL, BI-adjacent, and data workflow clients where released. | Generic OData ecosystem client path by default; add Honua-specific convenience only for a concrete backend workflow. |
+| Process/job APIs (OGC API Processes, GeoServices GPServer, MCP, gRPC ProcessService) | Supported through the canonical process/job runtime where each adapter is implemented. | Supported convenience for MCP and app-builder/operator workflows where released. | Targeted convenience for AI/data and automation workflows where released. | Targeted convenience for C# service automation and typed gRPC process workflows where released and evidenced. |
+| Field/offline workflows | Server-owned sync and protocol contracts support mobile/offline clients. | Generic protocol unless a web/offline package explicitly covers the workflow. | Generic protocol unless an offline/data package explicitly covers the workflow. | Supported or targeted through the MAUI/offline roadmap and shared .NET SDK packages where released. |
+
+## Language Positioning
+
+JavaScript/TypeScript can be described as the web/app SDK lane: typed APIs,
+GeoServices, OGC API surfaces, WFS, WMS, WMTS, STAC, OData, tile, and map
+display support may be cited only for the surfaces present in the pinned SDK
+line.
+
+Python can be described as the analysis, ETL, AI, and data-workflow SDK lane:
+typed APIs, OGC API surfaces, WFS, WMS, WMTS, STAC, OData, raster/coverage, and
+related protocol clients may be cited only for the surfaces present in the
+pinned SDK line.
+
+.NET should be described as the C# services, automation, admin/control-plane,
+typed gRPC, FeatureServer, WFS, OGC API Features/Records, STAC, and
+field/offline workflow lane where those packages are released and evidenced.
+Do not claim .NET map-display support unless there is a .NET display component
+with its own product scope and evidence.
+
+## .NET Raster, Tile, and Map Display Gate
+
+.NET WMS, WMTS, OGC API Maps, OGC API Tiles, TileJSON, MVT, Terrain-RGB,
+ImageServer, WCS, and OGC API Coverages clients are not parity work for map
+display by default. Open or cite those clients only when the issue names a
+backend workflow such as:
+
+- static report rendering
+- endpoint validation or conformance probing
+- tile cache audit, prewarm, expiry, or quota checks
+- secured proxying
+- thumbnail or preview generation
+- offline package generation
+- backend export, ETL, or data-quality validation
+
+A .NET UI/display claim requires a separate .NET display component, such as a
+MAUI, WPF, Blazor, or partner map viewer, plus evidence that it consumes the
+specific protocol surface.


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #994

## Summary
Adds a server-owned SDK standards coverage matrix so site and SDK copy can distinguish server standards support from language-specific SDK convenience clients.

## Changes Made
- Added `docs/developer/SDK_STANDARDS_COVERAGE.md` with protocol coverage by JavaScript, Python, and .NET.
- Clarified .NET raster/tile/map-display non-goals and backend-only deferred use cases.
- Linked the new matrix from the developer docs index, docs summary, and SDK compatibility matrix.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- `git diff --check`
- `git diff --cached --check`
- Local documentation target check for linked repo-local docs

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Satisfied `scripts/ci/pre-pr-check.sh` coverage with scoped local validation and passing CI
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

