### PR TITLE
test: add admin sample geospatial seed

### DIFF
--- a/docs/contributor/test-seed-data.md
+++ b/docs/contributor/test-seed-data.md
@@ -79,7 +79,7 @@ runner.apply(postgis.get_connection(schema), schema=schema, profile="core")
 | `tests/seed/client-compat-v1.sql` | Versioned client compatibility certification seed snapshot; canonical source for desktop/BI smoke evidence, Docker real-client interop GDAL/PyQGIS lanes, and the Python STAC client compatibility lane | `windows-client-compat-nightly.yml`, `client-interop-nightly.yml` (`gdal`, `pyqgis`), `tests/python/stac_client` |
 | `tests/seed/mobile-offline-demo-v1.sql` | Deterministic SDK-backed mobile offline field-operations fixture with service/layer/form metadata, provisional offline manifest metadata, baseline edit records, and safe reset semantics | Manual local/staging/cloud provisioning for honua-server#895; see [Mobile Offline Demo Fixture](../developer/mobile-offline-demo-fixture.md) |
 | `tests/seed/mobile-offline-demo-conflict-delta.sql` | Advances the mobile offline conflict target from `sync_version = 1` to `sync_version = 2` after package download | Manual/mobile harness conflict scenario for honua-server#895 |
-| `tests/seed/admin-sample-feature-server.yaml` | Local admin UI sample FeatureServer fixture (`admin_sample`, layer `3000`) with Oahu point features, extents, fields, and renderer metadata | Manual/local PostGIS bootstrap after `base-schema.sql` or a migrated database |
+| `tests/seed/admin-sample-feature-server.yaml` | Local admin UI sample FeatureServer fixture (`admin_sample`, layers `3000`-`3002`) with Oahu point, projected line, and polygon features, extents, fields, and renderer metadata | Manual/local PostGIS bootstrap after `base-schema.sql` or a migrated database |
 | `tests/seed/mcp.yaml` | MCP certification data (second service, polygon layer, deterministic features) | CI `mcp-certification` and `mcp-llm-smoke` jobs |
 | `tests/seed/browser-compat.yaml` | Browser compatibility service with point/line/polygon layers (IDs 2000–2002) and seeded features in the San Francisco area; anonymous access | CI `maplibre-compat` job (via `setup-honua-server` action) |
 | `tests/seed/apply-yaml-seed.sh` | Extracts SQL from a YAML seed file with a top-level `sql:` key and applies via `psql` | CI `mcp-certification`, `mcp-llm-smoke`, and `maplibre-compat` jobs |
@@ -90,14 +90,37 @@ runner.apply(postgis.get_connection(schema), schema=schema, profile="core")
 
 The current snapshot seeds anonymous access for service `test_service`, layer/collection `0`, and layer title `Test Layer` so the Windows client compatibility transcripts and manual follow-through remain repeatable. It also enables `postgis_raster` and creates the raster metadata tables expected by raster-aware startup paths in the Docker client-interop stack; the browser-specific service and layers are applied separately from `tests/seed/browser-compat.yaml`.
 
-For a local admin UI sample service, apply the base schema and the admin sample fixture:
+For a local admin UI sample service, reset the shared test schema and apply the admin sample fixture:
+
+```bash
+bash scripts/dev/seed-admin-sample.sh
+```
+
+The script uses the same connection defaults as the other seed helpers:
+`PGHOST=localhost`, `PGPORT=5432`, `PGUSER=honua`, `PGPASSWORD=honua`,
+and `PGDATABASE=honua_test`. Override those environment variables for a
+different local database.
+
+To run the steps manually:
 
 ```bash
 psql -f tests/seed/base-schema.sql
 bash tests/seed/apply-yaml-seed.sh tests/seed/admin-sample-feature-server.yaml
 ```
 
-That creates `admin_sample` with layer `3000`, so the UI can preview `/rest/services/admin_sample/FeatureServer/3000/query?f=geojson&where=1%3D1` without relying on fake client-side rows.
+That creates `admin_sample` with point layer `3000`, projected line layer
+`3001`, and polygon layer `3002`, so the UI can preview these routes without
+fake client-side rows:
+
+```text
+/rest/services/admin_sample/FeatureServer/3000/query?f=geojson&where=1%3D1
+/rest/services/admin_sample/FeatureServer/3001/query?f=geojson&where=1%3D1
+/rest/services/admin_sample/FeatureServer/3002/query?f=geojson&where=1%3D1
+```
+
+The admin sample seed is deterministic and safe to re-run. It removes only the
+`admin_sample` service/layer bindings and the reserved sample object ids before
+reinserting known rows.
 
 ## Profiles in CI
 

--- a/scripts/dev/seed-admin-sample.sh
+++ b/scripts/dev/seed-admin-sample.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Reset the local test schema and seed the admin preview sample FeatureServer.
+#
+# Environment variables:
+#   PGPASSWORD, PGHOST (default localhost), PGPORT (default 5432),
+#   PGUSER (default honua), PGDATABASE (default honua_test)
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+export PGPASSWORD="${PGPASSWORD:-honua}"
+export PGHOST="${PGHOST:-localhost}"
+export PGPORT="${PGPORT:-5432}"
+export PGUSER="${PGUSER:-honua}"
+export PGDATABASE="${PGDATABASE:-honua_test}"
+
+psql \
+  -v ON_ERROR_STOP=1 \
+  -h "$PGHOST" \
+  -p "$PGPORT" \
+  -U "$PGUSER" \
+  -d "$PGDATABASE" \
+  -f "$ROOT_DIR/tests/seed/base-schema.sql"
+
+bash "$ROOT_DIR/tests/seed/apply-yaml-seed.sh" \
+  "$ROOT_DIR/tests/seed/admin-sample-feature-server.yaml"

--- a/tests/dotnet/Honua.Server.Tests/Seed/AdminSampleSeedFeatureServerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Seed/AdminSampleSeedFeatureServerTests.cs
@@ -1,0 +1,153 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+using Honua.TestKit.Seeding;
+
+namespace Honua.Server.Tests.Seed;
+
+[Collection("Database")]
+[Protocol(TestProtocols.FeatureServer)]
+public sealed class AdminSampleSeedFeatureServerTests : IAsyncLifetime
+{
+    private const string ServiceId = "admin_sample";
+    private const int SitesLayerId = 3000;
+    private const int RoutesLayerId = 3001;
+    private const int AreasLayerId = 3002;
+    private const double CoordinateTolerance = 0.0002;
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync()
+    {
+        _fixture.UseSeed(Path.Combine("tests", "seed", "server.yaml"));
+        await _fixture.InitializeAsync();
+
+        var schema = _fixture.CurrentSchema ?? throw new InvalidOperationException("Schema was not initialized.");
+        await _fixture.Postgres.ApplySeedAsync(
+            ResolveRepoFile("tests", "seed", "admin-sample-feature-server.yaml"),
+            schema);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetServiceInfo)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer")]
+    public async Task FeatureServerMetadata_WithAdminSampleSeed_ListsPreviewLayers()
+    {
+        var response = await _fixture.Client.GetAsync($"/rest/services/{ServiceId}/FeatureServer?f=json");
+
+        response.Be200Ok();
+        using var document = await ReadJsonDocumentAsync(response);
+
+        var layerIds = document.RootElement
+            .GetProperty("layers")
+            .EnumerateArray()
+            .Select(layer => layer.GetProperty("id").GetInt32())
+            .ToArray();
+
+        layerIds.Should().Contain([SitesLayerId, RoutesLayerId, AreasLayerId]);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query?returnCountOnly=true")]
+    public async Task FeatureServerCountQuery_WithAdminSampleSeed_ReturnsExpectedFeatureCounts()
+    {
+        await AssertCountAsync(SitesLayerId, 4);
+        await AssertCountAsync(RoutesLayerId, 3);
+        await AssertCountAsync(AreasLayerId, 2);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task FeatureServerGeoJsonQuery_WithProjectedAdminRoute_ReturnsWgs84Coordinates()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{ServiceId}/FeatureServer/{RoutesLayerId}/query" +
+            "?where=objectid%20%3D%20300101&outFields=objectid,name,status&f=geojson");
+
+        response.Be200Ok();
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/geo+json");
+        using var document = await ReadJsonDocumentAsync(response);
+
+        var features = document.RootElement.GetProperty("features");
+        features.GetArrayLength().Should().Be(1);
+
+        var geometry = features[0].GetProperty("geometry");
+        geometry.GetProperty("type").GetString().Should().Be("LineString");
+
+        var coordinates = geometry.GetProperty("coordinates");
+        coordinates[0][0].GetDouble().Should().BeApproximately(-157.8583, CoordinateTolerance);
+        coordinates[0][1].GetDouble().Should().BeApproximately(21.3069, CoordinateTolerance);
+        coordinates[2][0].GetDouble().Should().BeApproximately(-157.9225, CoordinateTolerance);
+        coordinates[2][1].GetDouble().Should().BeApproximately(21.3187, CoordinateTolerance);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query?returnExtentOnly=true")]
+    public async Task FeatureServerExtentQuery_WithAdminSampleSeed_ReturnsExpectedBounds()
+    {
+        await AssertExtentAsync(SitesLayerId, -158.0011, 21.3069, -157.7394, 21.3972);
+        await AssertExtentAsync(RoutesLayerId, -158.0011, 21.3069, -157.7394, 21.3972);
+        await AssertExtentAsync(AreasLayerId, -157.95, 21.29, -157.70, 21.43);
+    }
+
+    private async Task AssertCountAsync(int layerId, int expectedCount)
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{ServiceId}/FeatureServer/{layerId}/query?where=1%3D1&returnCountOnly=true&f=json");
+
+        response.Be200Ok();
+        using var document = await ReadJsonDocumentAsync(response);
+        document.RootElement.GetProperty("count").GetInt32().Should().Be(expectedCount);
+    }
+
+    private async Task AssertExtentAsync(
+        int layerId,
+        double expectedXmin,
+        double expectedYmin,
+        double expectedXmax,
+        double expectedYmax)
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{ServiceId}/FeatureServer/{layerId}/query?where=1%3D1&returnExtentOnly=true&outSR=4326&f=json");
+
+        response.Be200Ok();
+        using var document = await ReadJsonDocumentAsync(response);
+        var extent = document.RootElement.GetProperty("extent");
+        extent.GetProperty("xmin").GetDouble().Should().BeApproximately(expectedXmin, CoordinateTolerance);
+        extent.GetProperty("ymin").GetDouble().Should().BeApproximately(expectedYmin, CoordinateTolerance);
+        extent.GetProperty("xmax").GetDouble().Should().BeApproximately(expectedXmax, CoordinateTolerance);
+        extent.GetProperty("ymax").GetDouble().Should().BeApproximately(expectedYmax, CoordinateTolerance);
+        extent.GetProperty("spatialReference").GetProperty("wkid").GetInt32().Should().Be(4326);
+    }
+
+    private static async Task<JsonDocument> ReadJsonDocumentAsync(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonDocument.Parse(content);
+    }
+
+    private static string ResolveRepoFile(params string[] path)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "Honua.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.Should().NotBeNull("the test should run under the repository output tree");
+        return Path.Combine(new[] { directory!.FullName }.Concat(path).ToArray());
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Seed/AdminSampleSeedFixtureTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Seed/AdminSampleSeedFixtureTests.cs
@@ -21,12 +21,25 @@ public sealed class AdminSampleSeedFixtureTests
 
         seed.Should().Contain("/rest/services/admin_sample/FeatureServer?f=json");
         seed.Should().Contain("/rest/services/admin_sample/FeatureServer/3000/query?f=geojson&where=1%3D1");
+        seed.Should().Contain("/rest/services/admin_sample/FeatureServer/3001/query?f=geojson&where=1%3D1");
+        seed.Should().Contain("/rest/services/admin_sample/FeatureServer/3002/query?f=geojson&where=1%3D1");
         seed.Should().Contain("'admin_sample'");
         seed.Should().Contain("3000");
+        seed.Should().Contain("3001");
+        seed.Should().Contain("3002");
         seed.Should().Contain("ST_MakeEnvelope(-158.05, 21.25, -157.65, 21.45, 4326)");
+        seed.Should().Contain("Oahu Operations Sites");
+        seed.Should().Contain("Oahu Response Routes");
+        seed.Should().Contain("Oahu Service Areas");
         seed.Should().Contain("Honolulu Operations Center");
         seed.Should().Contain("Pearl City Sensor Gateway");
+        seed.Should().Contain("Town to Airport Response Route");
+        seed.Should().Contain("Urban Core Service Area");
+        seed.Should().Contain("storage_srid");
+        seed.Should().Contain("3857");
         Regex.Count(seed, "ST_SetSRID\\(ST_MakePoint").Should().BeGreaterThanOrEqualTo(4);
+        Regex.Count(seed, "ST_Transform\\(").Should().BeGreaterThanOrEqualTo(3);
+        Regex.Count(seed, "ST_GeomFromText\\('POLYGON").Should().BeGreaterThanOrEqualTo(2);
     }
 
     private static string ResolveRepoFile(params string[] path)

--- a/tests/seed/admin-sample-feature-server.yaml
+++ b/tests/seed/admin-sample-feature-server.yaml
@@ -4,6 +4,34 @@ sql:
   # against a migrated local PostGIS database to expose:
   #   /rest/services/admin_sample/FeatureServer?f=json
   #   /rest/services/admin_sample/FeatureServer/3000/query?f=geojson&where=1%3D1
+  #   /rest/services/admin_sample/FeatureServer/3001/query?f=geojson&where=1%3D1
+  #   /rest/services/admin_sample/FeatureServer/3002/query?f=geojson&where=1%3D1
+  - |
+      DELETE FROM features
+      WHERE layer_id IN (3000, 3001, 3002)
+         OR objectid IN (
+              300001, 300002, 300003, 300004,
+              300101, 300102, 300103,
+              300201, 300202
+          );
+
+  - |
+      DELETE FROM honua.service_layers
+      WHERE service_name = 'admin_sample'
+         OR layer_id IN (3000, 3001, 3002);
+
+  - |
+      DELETE FROM honua.layer_fields
+      WHERE layer_id IN (3000, 3001, 3002);
+
+  - |
+      DELETE FROM honua.layers
+      WHERE layer_id IN (3000, 3001, 3002);
+
+  - |
+      DELETE FROM honua.services
+      WHERE service_name = 'admin_sample';
+
   - |
       INSERT INTO honua.services (
           service_name,
@@ -24,17 +52,14 @@ sql:
           jsonb_build_object(
               'accessPolicy', jsonb_build_object('allowAnonymous', true),
               'source', 'tests/seed/admin-sample-feature-server.yaml',
-              'owner', 'Honua local sample'
+              'owner', 'Honua local sample',
+              'reservedObjectIds', jsonb_build_array(
+                  300001, 300002, 300003, 300004,
+                  300101, 300102, 300103,
+                  300201, 300202
+              )
           )
-      )
-      ON CONFLICT (service_name) DO UPDATE SET
-          description = EXCLUDED.description,
-          srid = EXCLUDED.srid,
-          supported_formats = EXCLUDED.supported_formats,
-          capabilities = EXCLUDED.capabilities,
-          service_extent = EXCLUDED.service_extent,
-          metadata = EXCLUDED.metadata,
-          updated_at = NOW();
+      );
 
   - |
       INSERT INTO honua.layers (
@@ -45,6 +70,7 @@ sql:
           table_name,
           primary_key_column,
           geometry_column,
+          storage_srid,
           geometry_type,
           srid,
           extent,
@@ -53,60 +79,128 @@ sql:
           metadata,
           geoservices_drawing_info
       )
-      VALUES (
-          3000,
-          'Oahu Operations Sample',
-          'Previewable point layer for local admin UI service and layer metadata workflows',
-          current_schema(),
-          'features',
-          'objectid',
-          'geometry',
-          'Point',
-          4326,
-          ST_MakeEnvelope(-158.05, 21.25, -157.65, 21.45, 4326),
-          true,
-          true,
-          jsonb_build_object(
-              'accessPolicy', jsonb_build_object('allowAnonymous', true),
-              'displayField', 'name',
-              'source', 'tests/seed/admin-sample-feature-server.yaml'
-          ),
-          jsonb_build_object(
-              'renderer', jsonb_build_object(
-                  'type', 'simple',
-                  'symbol', jsonb_build_object(
-                      'type', 'esriSMS',
-                      'style', 'esriSMSCircle',
-                      'color', jsonb_build_array(44, 123, 229, 210),
-                      'size', 9,
-                      'outline', jsonb_build_object(
-                          'color', jsonb_build_array(255, 255, 255, 255),
-                          'width', 1
+      VALUES
+          (
+              3000,
+              'Oahu Operations Sites',
+              'Previewable point layer for local admin UI service and layer metadata workflows',
+              current_schema(),
+              'features',
+              'objectid',
+              'geometry',
+              4326,
+              'Point',
+              4326,
+              ST_MakeEnvelope(-158.0011, 21.3069, -157.7394, 21.3972, 4326),
+              true,
+              true,
+              jsonb_build_object(
+                  'accessPolicy', jsonb_build_object('allowAnonymous', true),
+                  'displayField', 'name',
+                  'source', 'tests/seed/admin-sample-feature-server.yaml',
+                  'domains', jsonb_build_object(
+                      'category', jsonb_build_array('Operations', 'Transportation', 'Field Office', 'Telemetry'),
+                      'status', jsonb_build_array('online', 'degraded', 'planned', 'offline')
+                  )
+              ),
+              jsonb_build_object(
+                  'renderer', jsonb_build_object(
+                      'type', 'simple',
+                      'symbol', jsonb_build_object(
+                          'type', 'esriSMS',
+                          'style', 'esriSMSCircle',
+                          'color', jsonb_build_array(44, 123, 229, 210),
+                          'size', 9,
+                          'outline', jsonb_build_object(
+                              'color', jsonb_build_array(255, 255, 255, 255),
+                              'width', 1
+                          )
                       )
                   )
               )
-          )
-      )
-      ON CONFLICT (layer_id) DO UPDATE SET
-          layer_name = EXCLUDED.layer_name,
-          description = EXCLUDED.description,
-          table_schema = EXCLUDED.table_schema,
-          table_name = EXCLUDED.table_name,
-          primary_key_column = EXCLUDED.primary_key_column,
-          geometry_column = EXCLUDED.geometry_column,
-          geometry_type = EXCLUDED.geometry_type,
-          srid = EXCLUDED.srid,
-          extent = EXCLUDED.extent,
-          default_visibility = EXCLUDED.default_visibility,
-          enabled = EXCLUDED.enabled,
-          metadata = EXCLUDED.metadata,
-          geoservices_drawing_info = EXCLUDED.geoservices_drawing_info;
+          ),
+          (
+              3001,
+              'Oahu Response Routes',
+              'Projected Web Mercator line layer for validating preview reprojection behavior',
+              current_schema(),
+              'features',
+              'objectid',
+              'geometry',
+              3857,
+              'LineString',
+              3857,
+              ST_MakeEnvelope(-158.0011, 21.3069, -157.7394, 21.3972, 4326),
+              true,
+              true,
+              jsonb_build_object(
+                  'accessPolicy', jsonb_build_object('allowAnonymous', true),
+                  'displayField', 'name',
+                  'source', 'tests/seed/admin-sample-feature-server.yaml',
+                  'domains', jsonb_build_object(
+                      'category', jsonb_build_array('Primary Route', 'Connector', 'Evacuation'),
+                      'status', jsonb_build_array('online', 'degraded', 'planned', 'offline')
+                  )
+              ),
+              jsonb_build_object(
+                  'renderer', jsonb_build_object(
+                      'type', 'simple',
+                      'symbol', jsonb_build_object(
+                          'type', 'esriSLS',
+                          'style', 'esriSLSSolid',
+                          'color', jsonb_build_array(21, 132, 99, 220),
+                          'width', 3
+                      )
+                  )
+              )
+          ),
+          (
+              3002,
+              'Oahu Service Areas',
+              'Previewable polygon layer for local admin UI area rendering and extent smoke tests',
+              current_schema(),
+              'features',
+              'objectid',
+              'geometry',
+              4326,
+              'Polygon',
+              4326,
+              ST_MakeEnvelope(-157.95, 21.29, -157.70, 21.43, 4326),
+              true,
+              true,
+              jsonb_build_object(
+                  'accessPolicy', jsonb_build_object('allowAnonymous', true),
+                  'displayField', 'name',
+                  'source', 'tests/seed/admin-sample-feature-server.yaml',
+                  'domains', jsonb_build_object(
+                      'category', jsonb_build_array('Urban Core', 'Windward'),
+                      'status', jsonb_build_array('online', 'planned')
+                  )
+              ),
+              jsonb_build_object(
+                  'renderer', jsonb_build_object(
+                      'type', 'simple',
+                      'symbol', jsonb_build_object(
+                          'type', 'esriSFS',
+                          'style', 'esriSFSSolid',
+                          'color', jsonb_build_array(239, 168, 67, 85),
+                          'outline', jsonb_build_object(
+                              'type', 'esriSLS',
+                              'style', 'esriSLSSolid',
+                              'color', jsonb_build_array(196, 111, 34, 220),
+                              'width', 1.25
+                          )
+                      )
+                  )
+              )
+          );
 
   - |
       INSERT INTO honua.service_layers (service_name, layer_id, layer_order)
-      VALUES ('admin_sample', 3000, 0)
-      ON CONFLICT (service_name, layer_id) DO UPDATE SET
-          layer_order = EXCLUDED.layer_order;
+      VALUES
+          ('admin_sample', 3000, 0),
+          ('admin_sample', 3001, 1),
+          ('admin_sample', 3002, 2);
 
   - |
       INSERT INTO honua.layer_fields (
@@ -126,13 +220,23 @@ sql:
           (3000, 'priority', 'Integer', 4, null, true, 'Operator triage priority'),
           (3000, 'owner', 'String', 5, 120, true, 'Responsible team'),
           (3000, 'updated_at', 'DateTime', 6, null, true, 'Last sample update timestamp'),
-          (3000, 'shape', 'Geometry', 7, null, true, 'Geometry')
-      ON CONFLICT (layer_id, field_name) DO UPDATE SET
-          field_type = EXCLUDED.field_type,
-          field_order = EXCLUDED.field_order,
-          max_length = EXCLUDED.max_length,
-          nullable = EXCLUDED.nullable,
-          description = EXCLUDED.description;
+          (3000, 'shape', 'Geometry', 7, null, true, 'Geometry'),
+          (3001, 'objectid', 'Integer', 0, null, false, 'Object ID'),
+          (3001, 'name', 'String', 1, 255, false, 'Route name'),
+          (3001, 'category', 'String', 2, 80, false, 'Route category'),
+          (3001, 'status', 'String', 3, 32, false, 'Current route status'),
+          (3001, 'priority', 'Integer', 4, null, true, 'Operator triage priority'),
+          (3001, 'owner', 'String', 5, 120, true, 'Responsible team'),
+          (3001, 'updated_at', 'DateTime', 6, null, true, 'Last sample update timestamp'),
+          (3001, 'shape', 'Geometry', 7, null, true, 'Geometry'),
+          (3002, 'objectid', 'Integer', 0, null, false, 'Object ID'),
+          (3002, 'name', 'String', 1, 255, false, 'Area name'),
+          (3002, 'category', 'String', 2, 80, false, 'Area category'),
+          (3002, 'status', 'String', 3, 32, false, 'Current area status'),
+          (3002, 'priority', 'Integer', 4, null, true, 'Operator triage priority'),
+          (3002, 'owner', 'String', 5, 120, true, 'Responsible team'),
+          (3002, 'updated_at', 'DateTime', 6, null, true, 'Last sample update timestamp'),
+          (3002, 'shape', 'Geometry', 7, null, true, 'Geometry');
 
   - |
       INSERT INTO features (objectid, layer_id, geometry, attributes)
@@ -192,15 +296,102 @@ sql:
                   'owner', 'Observability',
                   'updated_at', '2026-05-01T18:45:00Z'
               )
-          )
-      ON CONFLICT (objectid) DO UPDATE SET
-          layer_id = EXCLUDED.layer_id,
-          geometry = EXCLUDED.geometry,
-          attributes = EXCLUDED.attributes,
-          updated_at = NOW();
+          ),
+          (
+              300101,
+              3001,
+              ST_Transform(
+                  ST_SetSRID(
+                      ST_GeomFromText('LINESTRING(-157.8583 21.3069, -157.8892 21.3189, -157.9225 21.3187)'),
+                      4326),
+                  3857),
+              jsonb_build_object(
+                  'objectid', 300101,
+                  'name', 'Town to Airport Response Route',
+                  'category', 'Primary Route',
+                  'status', 'online',
+                  'priority', 1,
+                  'owner', 'Field Integrations',
+                  'updated_at', '2026-05-01T19:00:00Z'
+              )
+          ),
+          (
+              300102,
+              3001,
+              ST_Transform(
+                  ST_SetSRID(
+                      ST_GeomFromText('LINESTRING(-157.9225 21.3187, -157.9650 21.3480, -158.0011 21.3867)'),
+                      4326),
+                  3857),
+              jsonb_build_object(
+                  'objectid', 300102,
+                  'name', 'Airport to Pearl City Connector',
+                  'category', 'Connector',
+                  'status', 'degraded',
+                  'priority', 2,
+                  'owner', 'Transportation Ops',
+                  'updated_at', '2026-05-01T19:15:00Z'
+              )
+          ),
+          (
+              300103,
+              3001,
+              ST_Transform(
+                  ST_SetSRID(
+                      ST_GeomFromText('LINESTRING(-157.8583 21.3069, -157.7950 21.3490, -157.7394 21.3972)'),
+                      4326),
+                  3857),
+              jsonb_build_object(
+                  'objectid', 300103,
+                  'name', 'Windward Field Connector',
+                  'category', 'Evacuation',
+                  'status', 'planned',
+                  'priority', 3,
+                  'owner', 'Customer Success',
+                  'updated_at', '2026-05-01T19:30:00Z'
+              )
+          ),
+          (
+              300201,
+              3002,
+              ST_SetSRID(
+                  ST_GeomFromText('POLYGON((-157.95 21.29, -157.83 21.29, -157.83 21.36, -157.95 21.36, -157.95 21.29))'),
+                  4326),
+              jsonb_build_object(
+                  'objectid', 300201,
+                  'name', 'Urban Core Service Area',
+                  'category', 'Urban Core',
+                  'status', 'online',
+                  'priority', 1,
+                  'owner', 'Platform Ops',
+                  'updated_at', '2026-05-01T20:00:00Z'
+              )
+          ),
+          (
+              300202,
+              3002,
+              ST_SetSRID(
+                  ST_GeomFromText('POLYGON((-157.78 21.36, -157.70 21.36, -157.70 21.43, -157.78 21.43, -157.78 21.36))'),
+                  4326),
+              jsonb_build_object(
+                  'objectid', 300202,
+                  'name', 'Windward Service Area',
+                  'category', 'Windward',
+                  'status', 'planned',
+                  'priority', 2,
+                  'owner', 'Customer Success',
+                  'updated_at', '2026-05-01T20:15:00Z'
+              )
+          );
 
   - |
       SELECT setval(
           pg_get_serial_sequence('features', 'objectid'),
           (SELECT COALESCE(MAX(objectid), 0) FROM features)
+      );
+
+  - |
+      SELECT setval(
+          pg_get_serial_sequence('honua.layers', 'layer_id'),
+          (SELECT COALESCE(MAX(layer_id), 0) FROM honua.layers)
       );


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #979

## Summary
Adds deterministic local sample geospatial seed data for admin publishing and preview smoke tests.

## Changes Made
- Extended `admin_sample` into deterministic point, projected line, and polygon FeatureServer layers.
- Added `scripts/dev/seed-admin-sample.sh` as a local reset/reseed helper.
- Documented reset/reseed commands and preview routes in contributor seed-data docs.
- Added FeatureServer integration coverage for seeded metadata, count, GeoJSON reprojection, and extent behavior.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- `python3` YAML parse for `tests/seed/admin-sample-feature-server.yaml`
- `bash -n scripts/dev/seed-admin-sample.sh`
- `dotnet format Honua.sln`
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter AdminSampleSeed`: 5 passed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

This slice uses deterministic seed SQL plus docs/tests, not admin API publishing. That keeps the scope separate from active admin/import branches.

---

## Pre-PR Checklist
- [x] Satisfied `scripts/ci/pre-pr-check.sh` coverage with scoped local validation and passing CI
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

