### PR TITLE
test: publish admin sample seed through API (#979)

### DIFF
--- a/docs/contributor/test-seed-data.md
+++ b/docs/contributor/test-seed-data.md
@@ -110,7 +110,10 @@ bash tests/seed/apply-yaml-seed.sh tests/seed/admin-sample-feature-server.yaml
 
 That creates `admin_sample` with point layer `3000`, projected line layer
 `3001`, and polygon layer `3002`, so the UI can preview these routes without
-fake client-side rows:
+fake client-side rows. The same seed also creates publishable source tables
+derived from the deterministic sample rows:
+`admin_sample_sites_source`, `admin_sample_routes_source`, and
+`admin_sample_areas_source`.
 
 ```text
 /rest/services/admin_sample/FeatureServer/3000/query?f=geojson&where=1%3D1
@@ -119,8 +122,13 @@ fake client-side rows:
 ```
 
 The admin sample seed is deterministic and safe to re-run. It removes only the
-`admin_sample` service/layer bindings and the reserved sample object ids before
-reinserting known rows.
+`admin_sample` service/layer bindings, the reserved sample object ids, and the
+derived admin sample source tables before reinserting known rows. To verify the
+same registration path used by the admin API, publish those source tables with
+`POST /api/v1/admin/connections/{id}/layers` using schema `public` for a manual
+local seed, geometry column `geometry`, primary key `objectid`, SRID `4326`, and
+the attribute fields `objectid`, `name`, `category`, `status`, `priority`,
+`owner`, and `updated_at`.
 
 ## Profiles in CI
 

--- a/tests/dotnet/Honua.Server.Tests/Seed/AdminSampleSeedFixtureTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Seed/AdminSampleSeedFixtureTests.cs
@@ -31,6 +31,9 @@ public sealed class AdminSampleSeedFixtureTests
         seed.Should().Contain("Oahu Operations Sites");
         seed.Should().Contain("Oahu Response Routes");
         seed.Should().Contain("Oahu Service Areas");
+        seed.Should().Contain("admin_sample_sites_source");
+        seed.Should().Contain("admin_sample_routes_source");
+        seed.Should().Contain("admin_sample_areas_source");
         seed.Should().Contain("Honolulu Operations Center");
         seed.Should().Contain("Pearl City Sensor Gateway");
         seed.Should().Contain("Town to Airport Response Route");

--- a/tests/dotnet/Honua.Server.Tests/Seed/AdminSampleSeedPublishThroughAdminApiTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Seed/AdminSampleSeedPublishThroughAdminApiTests.cs
@@ -1,0 +1,250 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Admin.Domain;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+using Honua.TestKit.Seeding;
+
+namespace Honua.Server.Tests.Seed;
+
+/// <summary>
+/// Verifies the admin sample seed can be registered through the layer publishing API.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Protocol(TestProtocols.FeatureServer)]
+public sealed class AdminSampleSeedPublishThroughAdminApiTests : IAsyncLifetime
+{
+    private const double CoordinateTolerance = 0.0002;
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly WebAppFixture _fixture = new();
+    private HttpClient _client = null!;
+    private string _schema = string.Empty;
+    private string _serviceName = string.Empty;
+
+    public async Task InitializeAsync()
+    {
+        _fixture.UseSeed(Path.Combine("tests", "seed", "server.yaml"));
+        await _fixture.InitializeAsync();
+
+        _client = _fixture.CreateAdminClient();
+        _schema = _fixture.CurrentSchema ?? throw new InvalidOperationException("Schema was not initialized.");
+        _serviceName = $"admin_sample_publish_{Guid.NewGuid().ToString("N")[..12]}";
+
+        await _fixture.Postgres.ApplySeedAsync(
+            ResolveRepoFile("tests", "seed", "admin-sample-feature-server.yaml"),
+            _schema);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await CleanupPublishedServiceAsync();
+        await _fixture.DisposeAsync();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/admin/connections/{id}/layers")]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query?returnCountOnly=true")]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query?returnExtentOnly=true")]
+    public async Task AdminSampleSourceTables_PublishThroughAdminApi_ReturnFeatureServerCountsAndExtents()
+    {
+        var connectionId = await _fixture.GetTestSecureConnectionIdAsync();
+        connectionId.Should().NotBeNull("the fixture should provision the test secure connection");
+
+        var samples = new[]
+        {
+            new SampleLayer(
+                "admin_sample_sites_source",
+                "Published Oahu Operations Sites",
+                "Point",
+                4,
+                -158.0011,
+                21.3069,
+                -157.7394,
+                21.3972),
+            new SampleLayer(
+                "admin_sample_routes_source",
+                "Published Oahu Response Routes",
+                "LineString",
+                3,
+                -158.0011,
+                21.3069,
+                -157.7394,
+                21.3972),
+            new SampleLayer(
+                "admin_sample_areas_source",
+                "Published Oahu Service Areas",
+                "Polygon",
+                2,
+                -157.95,
+                21.29,
+                -157.70,
+                21.43)
+        };
+
+        foreach (var sample in samples)
+        {
+            var published = await PublishLayerAsync(connectionId!.Value, sample);
+
+            published.Schema.Should().Be(_schema);
+            published.Table.Should().Be(sample.Table);
+            published.ServiceName.Should().Be(_serviceName);
+            published.GeometryType.Should().Be(sample.GeometryType);
+
+            await AssertCountAsync(published.LayerId, sample.ExpectedCount);
+            await AssertExtentAsync(
+                published.LayerId,
+                sample.ExpectedXmin,
+                sample.ExpectedYmin,
+                sample.ExpectedXmax,
+                sample.ExpectedYmax);
+        }
+    }
+
+    private async Task<PublishedLayerSummary> PublishLayerAsync(Guid connectionId, SampleLayer sample)
+    {
+        var request = new PublishLayerRequest
+        {
+            Schema = _schema,
+            Table = sample.Table,
+            LayerName = sample.LayerName,
+            Description = "Admin sample seed source table publish smoke test",
+            GeometryColumn = "geometry",
+            GeometryType = sample.GeometryType,
+            Srid = 4326,
+            PrimaryKey = "objectid",
+            Fields = ["objectid", "name", "category", "status", "priority", "owner", "updated_at"],
+            ServiceName = _serviceName,
+            Enabled = true
+        };
+
+        using var response = await _client.PostAsJsonAsync(
+            $"/api/v1/admin/connections/{connectionId}/layers",
+            request,
+            _jsonOptions);
+        var payload = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created, $"response: {payload}");
+        var api = JsonSerializer.Deserialize<ApiResponse<PublishedLayerSummary>>(payload, _jsonOptions);
+
+        api.Should().NotBeNull();
+        api!.Success.Should().BeTrue();
+        api.Data.Should().NotBeNull();
+        return api.Data!;
+    }
+
+    private async Task AssertCountAsync(int layerId, int expectedCount)
+    {
+        using var response = await _client.GetAsync(
+            $"/rest/services/{_serviceName}/FeatureServer/{layerId}/query?where=1%3D1&returnCountOnly=true&f=json");
+        var payload = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, $"response: {payload}");
+        using var document = JsonDocument.Parse(payload);
+        document.RootElement.GetProperty("count").GetInt32().Should().Be(expectedCount);
+    }
+
+    private async Task AssertExtentAsync(
+        int layerId,
+        double expectedXmin,
+        double expectedYmin,
+        double expectedXmax,
+        double expectedYmax)
+    {
+        using var response = await _client.GetAsync(
+            $"/rest/services/{_serviceName}/FeatureServer/{layerId}/query?where=1%3D1&returnExtentOnly=true&outSR=4326&f=json");
+        var payload = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, $"response: {payload}");
+        using var document = JsonDocument.Parse(payload);
+        var extent = document.RootElement.GetProperty("extent");
+
+        extent.ValueKind.Should().Be(JsonValueKind.Object);
+        extent.GetProperty("xmin").GetDouble().Should().BeApproximately(expectedXmin, CoordinateTolerance);
+        extent.GetProperty("ymin").GetDouble().Should().BeApproximately(expectedYmin, CoordinateTolerance);
+        extent.GetProperty("xmax").GetDouble().Should().BeApproximately(expectedXmax, CoordinateTolerance);
+        extent.GetProperty("ymax").GetDouble().Should().BeApproximately(expectedYmax, CoordinateTolerance);
+        extent.GetProperty("spatialReference").GetProperty("wkid").GetInt32().Should().Be(4326);
+    }
+
+    private async Task CleanupPublishedServiceAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_serviceName))
+        {
+            return;
+        }
+
+        await using var connection = await _fixture.Postgres.GetConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            DROP TABLE IF EXISTS admin_sample_publish_cleanup_layers;
+
+            CREATE TEMP TABLE admin_sample_publish_cleanup_layers (
+                layer_id integer PRIMARY KEY
+            );
+
+            INSERT INTO admin_sample_publish_cleanup_layers (layer_id)
+            SELECT layer_id
+            FROM honua.service_layers
+            WHERE service_name = @serviceName
+            ON CONFLICT DO NOTHING;
+
+            DELETE FROM features
+            WHERE layer_id IN (SELECT layer_id FROM admin_sample_publish_cleanup_layers);
+
+            DELETE FROM honua.layer_fields
+            WHERE layer_id IN (SELECT layer_id FROM admin_sample_publish_cleanup_layers);
+
+            DELETE FROM honua.service_layers
+            WHERE service_name = @serviceName;
+
+            DELETE FROM honua.layers
+            WHERE layer_id IN (SELECT layer_id FROM admin_sample_publish_cleanup_layers);
+
+            DELETE FROM honua.services
+            WHERE service_name = @serviceName;
+
+            DROP TABLE admin_sample_publish_cleanup_layers;
+            """;
+        command.Parameters.AddWithValue("serviceName", _serviceName);
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static string ResolveRepoFile(params string[] path)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "Honua.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.Should().NotBeNull("the test should run under the repository output tree");
+        return Path.Combine(new[] { directory!.FullName }.Concat(path).ToArray());
+    }
+
+    private sealed record SampleLayer(
+        string Table,
+        string LayerName,
+        string GeometryType,
+        int ExpectedCount,
+        double ExpectedXmin,
+        double ExpectedYmin,
+        double ExpectedXmax,
+        double ExpectedYmax);
+}

--- a/tests/seed/admin-sample-feature-server.yaml
+++ b/tests/seed/admin-sample-feature-server.yaml
@@ -7,6 +7,11 @@ sql:
   #   /rest/services/admin_sample/FeatureServer/3001/query?f=geojson&where=1%3D1
   #   /rest/services/admin_sample/FeatureServer/3002/query?f=geojson&where=1%3D1
   - |
+      DROP TABLE IF EXISTS admin_sample_sites_source;
+      DROP TABLE IF EXISTS admin_sample_routes_source;
+      DROP TABLE IF EXISTS admin_sample_areas_source;
+
+  - |
       DELETE FROM features
       WHERE layer_id IN (3000, 3001, 3002)
          OR objectid IN (
@@ -383,6 +388,111 @@ sql:
                   'updated_at', '2026-05-01T20:15:00Z'
               )
           );
+
+  - |
+      CREATE TABLE admin_sample_sites_source (
+          objectid integer PRIMARY KEY,
+          name text NOT NULL,
+          category text NOT NULL,
+          status text NOT NULL,
+          priority integer,
+          owner text,
+          updated_at timestamptz,
+          geometry geometry(Point, 4326) NOT NULL
+      );
+
+      INSERT INTO admin_sample_sites_source (
+          objectid,
+          name,
+          category,
+          status,
+          priority,
+          owner,
+          updated_at,
+          geometry
+      )
+      SELECT
+          objectid,
+          attributes->>'name',
+          attributes->>'category',
+          attributes->>'status',
+          (attributes->>'priority')::integer,
+          attributes->>'owner',
+          (attributes->>'updated_at')::timestamptz,
+          geometry::geometry(Point, 4326)
+      FROM features
+      WHERE layer_id = 3000
+      ORDER BY objectid;
+
+  - |
+      CREATE TABLE admin_sample_routes_source (
+          objectid integer PRIMARY KEY,
+          name text NOT NULL,
+          category text NOT NULL,
+          status text NOT NULL,
+          priority integer,
+          owner text,
+          updated_at timestamptz,
+          geometry geometry(LineString, 4326) NOT NULL
+      );
+
+      INSERT INTO admin_sample_routes_source (
+          objectid,
+          name,
+          category,
+          status,
+          priority,
+          owner,
+          updated_at,
+          geometry
+      )
+      SELECT
+          objectid,
+          attributes->>'name',
+          attributes->>'category',
+          attributes->>'status',
+          (attributes->>'priority')::integer,
+          attributes->>'owner',
+          (attributes->>'updated_at')::timestamptz,
+          ST_Transform(geometry, 4326)::geometry(LineString, 4326)
+      FROM features
+      WHERE layer_id = 3001
+      ORDER BY objectid;
+
+  - |
+      CREATE TABLE admin_sample_areas_source (
+          objectid integer PRIMARY KEY,
+          name text NOT NULL,
+          category text NOT NULL,
+          status text NOT NULL,
+          priority integer,
+          owner text,
+          updated_at timestamptz,
+          geometry geometry(Polygon, 4326) NOT NULL
+      );
+
+      INSERT INTO admin_sample_areas_source (
+          objectid,
+          name,
+          category,
+          status,
+          priority,
+          owner,
+          updated_at,
+          geometry
+      )
+      SELECT
+          objectid,
+          attributes->>'name',
+          attributes->>'category',
+          attributes->>'status',
+          (attributes->>'priority')::integer,
+          attributes->>'owner',
+          (attributes->>'updated_at')::timestamptz,
+          geometry::geometry(Polygon, 4326)
+      FROM features
+      WHERE layer_id = 3002
+      ORDER BY objectid;
 
   - |
       SELECT setval(


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #979

## Summary
Adds a focused admin API publish smoke test for the deterministic admin sample seed data so the seed now proves both direct FeatureServer preview rows and the server-side layer publishing path used by admin.

## Changes Made
- Create publishable sample source tables from the existing deterministic admin sample point, line, and polygon rows.
- Add an integration test that publishes those source tables through `POST /api/v1/admin/connections/{id}/layers`.
- Verify FeatureServer count and extent queries for the published sample layers.
- Document the source tables and manual publish parameters in contributor seed-data docs.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- `dotnet format Honua.sln`
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~Honua.Server.Tests.Seed.AdminSampleSeed"`: 6 passed
- `git diff --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent focused local validation; full script is intentionally not run for this test-only slice
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review
