### PR TITLE
fix(admin): enforce GitOps manifest path semantics (#992)

### DIFF
--- a/docs/developer/api-specs/admin-api.json
+++ b/docs/developer/api-specs/admin-api.json
@@ -5456,7 +5456,7 @@
           "manifestPath": {
             "type": "string",
             "default": "manifests/",
-            "description": "Relative path for manifest files within the repository"
+            "description": "Relative exact manifest file path or directory path. Directory paths resolve to honua-manifest.json first, then manifest.json; slashless paths without a file extension are normalized as directories. Glob patterns are not supported."
           },
           "pollIntervalSeconds": {
             "type": "integer",
@@ -5491,7 +5491,10 @@
           "configId": { "type": "string", "format": "uuid" },
           "repositoryUrl": { "type": "string" },
           "branch": { "type": "string" },
-          "manifestPath": { "type": "string" },
+          "manifestPath": {
+            "type": "string",
+            "description": "Configured relative exact manifest file path or directory path"
+          },
           "pollIntervalSeconds": { "type": "integer" },
           "approvalRequired": { "type": "boolean" },
           "pruneEnabled": { "type": "boolean" },

--- a/docs/operator/CONTROL_PLANE_API.md
+++ b/docs/operator/CONTROL_PLANE_API.md
@@ -789,7 +789,7 @@ Git repository watching is an **enterprise edition** feature. When enabled, the 
 |-------|------|---------|-------------|
 | `repositoryUrl` | string | — | Git repository URL (HTTPS, SSH, or git protocol) |
 | `branch` | string | `"main"` | Branch to watch |
-| `manifestPath` | string | `"manifests/"` | Relative path for manifest files |
+| `manifestPath` | string | `"manifests/"` | Relative exact manifest file path or directory path. Directory paths resolve to `honua-manifest.json`, then `manifest.json`; slashless paths without a file extension are normalized as directories. Glob patterns are rejected. |
 | `pollIntervalSeconds` | int | `60` | Poll interval (floored to server minimum) |
 | `approvalRequired` | bool | `false` | Queue changes for approval instead of auto-applying |
 | `pruneEnabled` | bool | `false` | Delete server resources absent from the repository manifest |

--- a/src/Honua.Core/Features/Metadata/Domain/GitOpsWatchModels.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/GitOpsWatchModels.cs
@@ -26,7 +26,9 @@ public sealed class GitOpsWatchConfig
     public string Branch { get; init; } = "main";
 
     /// <summary>
-    /// Glob pattern for manifest files within the repository.
+    /// Relative exact manifest file path or directory path within the repository. Directory paths resolve to
+    /// honua-manifest.json first, then manifest.json; slashless paths without a file extension are normalized as
+    /// directories. Glob patterns are not supported.
     /// </summary>
     public string ManifestPath { get; init; } = "manifests/";
 

--- a/src/Honua.Server/Features/Admin/AdminGitOpsWatchEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AdminGitOpsWatchEndpoints.cs
@@ -100,11 +100,10 @@ internal static class AdminGitOpsWatchEndpoints
             return;
         }
 
-        var manifestPath = string.IsNullOrWhiteSpace(request.ManifestPath) ? "manifests/" : request.ManifestPath;
-        if (!IsRelativePath(manifestPath))
+        if (!GitOpsWatchManifestPath.TryNormalize(request.ManifestPath, out var manifestPath, out var manifestPathError))
         {
             await AdminResponseWriter.WriteErrorAsync(context, StatusCodes.Status400BadRequest,
-                "Manifest path must be a relative path without '..' segments.");
+                manifestPathError ?? GitOpsWatchManifestPath.RelativePathErrorMessage);
             return;
         }
 
@@ -420,22 +419,4 @@ internal static class AdminGitOpsWatchEndpoints
         return repositoryUrl.IndexOf('/', atIndex + 1, colonIndex - atIndex - 1) < 0;
     }
 
-    /// <summary>
-    /// Validates that a path is relative and does not contain traversal sequences.
-    /// Prevents path traversal via absolute paths or '..' segments.
-    /// </summary>
-    internal static bool IsRelativePath(string path)
-    {
-        if (string.IsNullOrEmpty(path))
-        {
-            return false;
-        }
-
-        if (path.StartsWith('/') || path.StartsWith('\\') || path.Contains(".."))
-        {
-            return false;
-        }
-
-        return true;
-    }
 }

--- a/src/Honua.Server/Features/Admin/GitOpsWatchManifestPath.cs
+++ b/src/Honua.Server/Features/Admin/GitOpsWatchManifestPath.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Admin;
+
+internal static class GitOpsWatchManifestPath
+{
+    internal const string DefaultPath = "manifests/";
+    internal const string HonuaManifestFileName = "honua-manifest.json";
+    internal const string ManifestFileName = "manifest.json";
+    internal const string RelativePathErrorMessage =
+        "Manifest path must be a relative repository path without '.' or '..' segments.";
+    internal const string GlobUnsupportedErrorMessage =
+        "Manifest path glob patterns are not supported. Use an exact manifest file path or a directory containing honua-manifest.json or manifest.json.";
+
+    internal static bool TryNormalize(
+        string? path,
+        out string normalizedPath,
+        out string? errorMessage)
+    {
+        normalizedPath = string.IsNullOrWhiteSpace(path) ? DefaultPath : path.Trim();
+
+        if (!IsRelativeRepositoryPath(normalizedPath))
+        {
+            errorMessage = RelativePathErrorMessage;
+            return false;
+        }
+
+        if (ContainsGlobSyntax(normalizedPath))
+        {
+            errorMessage = GlobUnsupportedErrorMessage;
+            return false;
+        }
+
+        if (IsDirectoryIntent(normalizedPath) && !normalizedPath.EndsWith('/'))
+        {
+            normalizedPath += "/";
+        }
+
+        errorMessage = null;
+        return true;
+    }
+
+    internal static bool IsDirectoryIntent(string path)
+    {
+        if (path.EndsWith('/'))
+        {
+            return true;
+        }
+
+        var lastSegmentStart = path.LastIndexOf('/') + 1;
+        var lastSegment = path[lastSegmentStart..];
+        return !lastSegment.Contains('.');
+    }
+
+    internal static IReadOnlyList<string> BuildSparseCheckoutPatterns(string manifestPath)
+    {
+        var patterns = new List<string>();
+        if (!IsDirectoryIntent(manifestPath))
+        {
+            patterns.Add(manifestPath);
+        }
+
+        var directoryPath = manifestPath.TrimEnd('/');
+
+        if (!string.IsNullOrEmpty(directoryPath))
+        {
+            patterns.Add($"{directoryPath}/{HonuaManifestFileName}");
+            patterns.Add($"{directoryPath}/{ManifestFileName}");
+        }
+
+        return patterns.Distinct(StringComparer.Ordinal).ToArray();
+    }
+
+    private static bool IsRelativeRepositoryPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) ||
+            path.StartsWith('/') ||
+            path.StartsWith('\\') ||
+            path.Contains('\\'))
+        {
+            return false;
+        }
+
+        foreach (var c in path)
+        {
+            if (char.IsControl(c))
+            {
+                return false;
+            }
+        }
+
+        foreach (var segment in path.Split('/'))
+        {
+            if (segment is "." or "..")
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ContainsGlobSyntax(string path)
+    {
+        foreach (var c in path)
+        {
+            if (c is '*' or '?' or '[' or ']' or '{' or '}')
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Honua.Server/Features/Admin/GitOpsWatchService.cs
+++ b/src/Honua.Server/Features/Admin/GitOpsWatchService.cs
@@ -94,13 +94,22 @@ internal sealed partial class GitOpsWatchService : BackgroundService
 
         LogPollNewCommit(_logger, config.RepositoryUrl, latestCommit.Sha);
 
-        var fetchResult = await FetchManifestContentAsync(config, latestCommit.Sha, cancellationToken)
+        if (!GitOpsWatchManifestPath.TryNormalize(config.ManifestPath, out var manifestPath, out var manifestPathError))
+        {
+            var errorMessage = manifestPathError ?? GitOpsWatchManifestPath.RelativePathErrorMessage;
+            await RecordManifestPathFailureAsync(watchStore, config, latestCommit, errorMessage, cancellationToken)
+                .ConfigureAwait(false);
+            LogManifestPathRejected(_logger, config.RepositoryUrl, errorMessage);
+            return pollInterval;
+        }
+
+        var fetchResult = await FetchManifestContentAsync(config, manifestPath, latestCommit.Sha, cancellationToken)
             .ConfigureAwait(false);
 
         if (fetchResult == null)
         {
             // Leave the commit unobserved so transient fetch, path, or parse failures retry on the next poll.
-            LogManifestFetchFailed(_logger, config.RepositoryUrl, config.ManifestPath);
+            LogManifestFetchFailed(_logger, config.RepositoryUrl, manifestPath);
             return pollInterval;
         }
 
@@ -339,6 +348,40 @@ internal sealed partial class GitOpsWatchService : BackgroundService
         LogChangeApplied(_logger, commit.Sha, summary);
     }
 
+    private static async Task RecordManifestPathFailureAsync(
+        IGitOpsWatchStore watchStore,
+        GitOpsWatchConfig config,
+        GitCommitInfo commit,
+        string errorMessage,
+        CancellationToken cancellationToken)
+    {
+        var recentRecords = await watchStore.ListChangeRecordsAsync(10, 0, cancellationToken).ConfigureAwait(false);
+        if (recentRecords.Any(record =>
+                record.ConfigId == config.ConfigId &&
+                string.Equals(record.CommitSha, commit.Sha, StringComparison.Ordinal) &&
+                record.Status == GitOpsChangeStatus.Failed &&
+                string.Equals(record.ErrorMessage, errorMessage, StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        var changeRecord = new GitOpsChangeRecord
+        {
+            ChangeId = Guid.NewGuid(),
+            ConfigId = config.ConfigId,
+            CommitSha = commit.Sha,
+            CommitMessage = commit.Message,
+            CommitAuthor = commit.Author,
+            CommitTimestamp = commit.Timestamp,
+            ManifestAfter = CreateEmptyManifestElement(),
+            Status = GitOpsChangeStatus.Failed,
+            ErrorMessage = errorMessage,
+            DetectedAt = DateTimeOffset.UtcNow
+        };
+
+        await watchStore.CreateChangeRecordAsync(changeRecord, cancellationToken).ConfigureAwait(false);
+    }
+
     /// <summary>
     /// Fetches the latest commit information from the configured git repository
     /// using the git CLI.
@@ -387,6 +430,7 @@ internal sealed partial class GitOpsWatchService : BackgroundService
     /// </summary>
     private static async Task<ManifestFetchResult?> FetchManifestContentAsync(
         GitOpsWatchConfig config,
+        string manifestPath,
         string commitSha,
         CancellationToken cancellationToken)
     {
@@ -411,7 +455,7 @@ internal sealed partial class GitOpsWatchService : BackgroundService
             Directory.CreateDirectory(sparseCheckoutDir);
             await File.WriteAllTextAsync(
                 Path.Combine(sparseCheckoutDir, "sparse-checkout"),
-                config.ManifestPath + "\n",
+                string.Join("\n", GitOpsWatchManifestPath.BuildSparseCheckoutPatterns(manifestPath)) + "\n",
                 cancellationToken).ConfigureAwait(false);
 
             // Fetch only the specific commit
@@ -453,80 +497,17 @@ internal sealed partial class GitOpsWatchService : BackgroundService
                 }
             }
 
-            // Read manifest files and build a combined JSON array.
-            // Verify resolved paths stay within tempDir to prevent path traversal.
-            var manifestDir = Path.GetFullPath(Path.Combine(tempDir, config.ManifestPath.TrimEnd('/')));
-            if (!manifestDir.StartsWith(tempDir, StringComparison.Ordinal))
+            var manifestFile = ResolveManifestFile(tempDir, manifestPath);
+            if (manifestFile == null)
             {
                 return null;
             }
 
-            if (!Directory.Exists(manifestDir))
-            {
-                // Try as a single file path
-                var singleFile = Path.GetFullPath(Path.Combine(tempDir, config.ManifestPath));
-                if (!singleFile.StartsWith(tempDir, StringComparison.Ordinal))
-                {
-                    return null;
-                }
-
-                if (File.Exists(singleFile))
-                {
-                    var content = await File.ReadAllTextAsync(singleFile, cancellationToken).ConfigureAwait(false);
-                    using var doc = JsonDocument.Parse(content);
-                    return new ManifestFetchResult
-                    {
-                        ManifestContent = doc.RootElement.Clone(),
-                        CommitAuthor = commitAuthor,
-                        CommitMessage = commitMessage,
-                        CommitTimestamp = commitTimestamp
-                    };
-                }
-
-                return null;
-            }
-
-            var jsonFiles = Directory.GetFiles(manifestDir, "*.json", SearchOption.AllDirectories);
-            if (jsonFiles.Length == 0)
-            {
-                return null;
-            }
-
-            var resources = new List<JsonElement>();
-            foreach (var file in jsonFiles.OrderBy(f => f, StringComparer.OrdinalIgnoreCase))
-            {
-                var content = await File.ReadAllTextAsync(file, cancellationToken).ConfigureAwait(false);
-                using var doc = JsonDocument.Parse(content);
-                var root = doc.RootElement;
-
-                if (root.ValueKind == JsonValueKind.Array)
-                {
-                    foreach (var item in root.EnumerateArray())
-                    {
-                        resources.Add(item.Clone());
-                    }
-                }
-                else if (root.ValueKind == JsonValueKind.Object)
-                {
-                    // Check if it's a manifest wrapper with a "resources" array
-                    if (root.TryGetProperty("resources", out var resourcesArray) &&
-                        resourcesArray.ValueKind == JsonValueKind.Array)
-                    {
-                        foreach (var item in resourcesArray.EnumerateArray())
-                        {
-                            resources.Add(item.Clone());
-                        }
-                    }
-                    else
-                    {
-                        resources.Add(root.Clone());
-                    }
-                }
-            }
-
+            var content = await File.ReadAllTextAsync(manifestFile, cancellationToken).ConfigureAwait(false);
+            using var doc = JsonDocument.Parse(content);
             return new ManifestFetchResult
             {
-                ManifestContent = JsonSerializer.SerializeToElement(resources),
+                ManifestContent = doc.RootElement.Clone(),
                 CommitAuthor = commitAuthor,
                 CommitMessage = commitMessage,
                 CommitTimestamp = commitTimestamp
@@ -560,6 +541,62 @@ internal sealed partial class GitOpsWatchService : BackgroundService
         }
     }
 
+    private static string? ResolveManifestFile(string repositoryRoot, string manifestPath)
+    {
+        var exactPath = GetSafeRepositoryPath(repositoryRoot, manifestPath);
+        if (exactPath == null)
+        {
+            return null;
+        }
+
+        if (!GitOpsWatchManifestPath.IsDirectoryIntent(manifestPath) && IsRegularManifestFile(exactPath))
+        {
+            return exactPath;
+        }
+
+        if (!Directory.Exists(exactPath))
+        {
+            return null;
+        }
+
+        foreach (var fileName in new[] { GitOpsWatchManifestPath.HonuaManifestFileName, GitOpsWatchManifestPath.ManifestFileName })
+        {
+            var candidate = Path.GetFullPath(Path.Combine(exactPath, fileName));
+            if (IsWithinRepositoryRoot(repositoryRoot, candidate) && IsRegularManifestFile(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? GetSafeRepositoryPath(string repositoryRoot, string relativePath)
+    {
+        var fullPath = Path.GetFullPath(Path.Combine(repositoryRoot, relativePath));
+        return IsWithinRepositoryRoot(repositoryRoot, fullPath) ? fullPath : null;
+    }
+
+    private static bool IsWithinRepositoryRoot(string repositoryRoot, string fullPath)
+    {
+        var root = Path.GetFullPath(repositoryRoot).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) +
+                   Path.DirectorySeparatorChar;
+        var normalizedFullPath = Path.GetFullPath(fullPath);
+        return normalizedFullPath.StartsWith(root, StringComparison.Ordinal);
+    }
+
+    private static bool IsRegularManifestFile(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        var attributes = File.GetAttributes(path);
+        return !attributes.HasFlag(FileAttributes.Directory) &&
+               !attributes.HasFlag(FileAttributes.ReparsePoint);
+    }
+
     private static MetadataResource[]? DeserializeManifestResources(JsonElement manifestContent)
     {
         try
@@ -574,9 +611,22 @@ internal sealed partial class GitOpsWatchService : BackgroundService
             if (manifestContent.ValueKind == JsonValueKind.Object &&
                 manifestContent.TryGetProperty("resources", out var resourcesArray))
             {
+                if (resourcesArray.ValueKind != JsonValueKind.Array)
+                {
+                    return null;
+                }
+
                 return JsonSerializer.Deserialize(
                     resourcesArray.GetRawText(),
                     MetadataResourceJsonContext.Default.MetadataResourceArray);
+            }
+
+            if (manifestContent.ValueKind == JsonValueKind.Object)
+            {
+                var resource = JsonSerializer.Deserialize(
+                    manifestContent.GetRawText(),
+                    MetadataResourceJsonContext.Default.MetadataResource);
+                return resource == null ? null : [resource];
             }
 
             return null;
@@ -585,6 +635,12 @@ internal sealed partial class GitOpsWatchService : BackgroundService
         {
             return null;
         }
+    }
+
+    private static JsonElement CreateEmptyManifestElement()
+    {
+        using var document = JsonDocument.Parse("[]");
+        return document.RootElement.Clone();
     }
 
     private static async Task<GitProcessResult?> RunGitCommandAsync(
@@ -695,6 +751,9 @@ internal sealed partial class GitOpsWatchService : BackgroundService
 
     [LoggerMessage(EventId = 9406, Level = LogLevel.Warning, Message = "GitOps could not fetch manifest from {RepositoryUrl} at path {ManifestPath}.")]
     private static partial void LogManifestFetchFailed(ILogger logger, string repositoryUrl, string manifestPath);
+
+    [LoggerMessage(EventId = 9412, Level = LogLevel.Warning, Message = "GitOps manifest path rejected for {RepositoryUrl}: {Error}.")]
+    private static partial void LogManifestPathRejected(ILogger logger, string repositoryUrl, string error);
 
     [LoggerMessage(EventId = 9407, Level = LogLevel.Warning, Message = "GitOps manifest from {RepositoryUrl} contained no resources.")]
     private static partial void LogManifestEmpty(ILogger logger, string repositoryUrl);

--- a/src/Honua.Server/Features/Admin/Models/GitOpsWatchModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/GitOpsWatchModels.cs
@@ -45,7 +45,9 @@ public sealed class GitOpsWatchConfigRequest
     public string Branch { get; init; } = "main";
 
     /// <summary>
-    /// Path or glob pattern for manifest files within the repository.
+    /// Relative exact manifest file path or directory path within the repository. Directory paths resolve to
+    /// honua-manifest.json first, then manifest.json; slashless paths without a file extension are normalized as
+    /// directories. Glob patterns are not supported.
     /// </summary>
     [JsonPropertyName("manifestPath")]
     public string ManifestPath { get; init; } = "manifests/";
@@ -106,7 +108,7 @@ public sealed class GitOpsWatchConfigResponse
     public string Branch { get; init; } = string.Empty;
 
     /// <summary>
-    /// Manifest file path pattern.
+    /// Relative exact manifest file path or directory path.
     /// </summary>
     [JsonPropertyName("manifestPath")]
     public string ManifestPath { get; init; } = string.Empty;

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/GitOpsWatchEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/GitOpsWatchEndpointsTests.cs
@@ -636,6 +636,29 @@ public sealed class GitOpsWatchEndpointsTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Metadata)]
     [Endpoint("POST /api/v1/admin/gitops/watch")]
+    public async Task ConfigureWatch_ManifestPathGlob_Returns400()
+    {
+        var client = _fixture.CreateAdminClient();
+
+        var request = new GitOpsWatchConfigRequest
+        {
+            RepositoryUrl = "https://github.com/example/repo.git",
+            Branch = "main",
+            ManifestPath = "manifests/*.json"
+        };
+
+        var response = await client.PostAsync(
+            "/api/v1/admin/gitops/watch",
+            JsonContent.Create(request, GitOpsWatchJsonContext.Default.GitOpsWatchConfigRequest));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var payload = await response.Content.ReadAsStringAsync();
+        payload.Should().Contain("glob patterns are not supported");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("POST /api/v1/admin/gitops/watch")]
     public async Task ConfigureWatch_PruneEnabledRoundTrips()
     {
         var client = _fixture.CreateAdminClient();

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/GitOpsWatchServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/GitOpsWatchServiceTests.cs
@@ -33,7 +33,7 @@ public sealed class GitOpsWatchServiceTests : IDisposable
     [UnitTest]
     public async Task PollOnceAsync_MissingManifestPath_DoesNotMarkCommitObserved()
     {
-        var repoDir = await CreateLocalRepositoryAsync(includeManifest: false);
+        var repoDir = await CreateLocalRepositoryAsync();
         var latestCommit = await RunGitForOutputAsync(repoDir, "rev-parse", "HEAD");
         var watchStore = new TestGitOpsWatchStore(CreateConfig(repoDir, manifestPath: "missing/"));
 
@@ -49,11 +49,11 @@ public sealed class GitOpsWatchServiceTests : IDisposable
     }
 
     [UnitTest]
-    public async Task PollOnceAsync_ValidManifestPath_QueuesApprovalAndMarksCommitObserved()
+    public async Task PollOnceAsync_ExactManifestFile_QueuesApprovalAndMarksCommitObserved()
     {
-        var repoDir = await CreateLocalRepositoryAsync(includeManifest: true);
+        var repoDir = await CreateLocalRepositoryAsync(("manifests/group.json", ValidGroupManifest));
         var latestCommit = await RunGitForOutputAsync(repoDir, "rev-parse", "HEAD");
-        var watchStore = new TestGitOpsWatchStore(CreateConfig(repoDir, manifestPath: "manifests/"));
+        var watchStore = new TestGitOpsWatchStore(CreateConfig(repoDir, manifestPath: "manifests/group.json"));
         var pendingStore = new TestManifestPendingChangeStore();
 
         using var services = CreateServices(watchStore, pendingStore);
@@ -69,6 +69,107 @@ public sealed class GitOpsWatchServiceTests : IDisposable
         pendingStore.Changes.Should().ContainSingle();
         pendingStore.Changes[0].PendingId.Should().Be(watchStore.ChangeRecords[0].PendingApprovalId!.Value);
         pendingStore.Changes[0].ResourceCount.Should().Be(1);
+    }
+
+    [UnitTest]
+    public async Task PollOnceAsync_DirectoryManifestPath_UsesHonuaManifest()
+    {
+        var repoDir = await CreateLocalRepositoryAsync(("manifests/honua-manifest.json", ValidGroupManifest));
+        var latestCommit = await RunGitForOutputAsync(repoDir, "rev-parse", "HEAD");
+        var watchStore = new TestGitOpsWatchStore(CreateConfig(repoDir, manifestPath: "manifests/"));
+        var pendingStore = new TestManifestPendingChangeStore();
+
+        using var services = CreateServices(watchStore, pendingStore);
+        var service = CreateService(services);
+
+        await service.PollOnceAsync(CancellationToken.None);
+
+        watchStore.PollStateUpdateCount.Should().Be(1);
+        watchStore.CurrentConfig.LastKnownCommitSha.Should().Be(latestCommit);
+        watchStore.ChangeRecords.Should().ContainSingle();
+        watchStore.ChangeRecords[0].Status.Should().Be(GitOpsChangeStatus.PendingApproval);
+        pendingStore.Changes.Should().ContainSingle();
+        pendingStore.Changes[0].ResourceCount.Should().Be(1);
+    }
+
+    [UnitTest]
+    public async Task PollOnceAsync_DirectoryManifestPath_UsesManifestFallback()
+    {
+        var repoDir = await CreateLocalRepositoryAsync(("deploy/manifest.json", ValidGroupManifest));
+        var latestCommit = await RunGitForOutputAsync(repoDir, "rev-parse", "HEAD");
+        var watchStore = new TestGitOpsWatchStore(CreateConfig(repoDir, manifestPath: "deploy/"));
+        var pendingStore = new TestManifestPendingChangeStore();
+
+        using var services = CreateServices(watchStore, pendingStore);
+        var service = CreateService(services);
+
+        await service.PollOnceAsync(CancellationToken.None);
+
+        watchStore.PollStateUpdateCount.Should().Be(1);
+        watchStore.CurrentConfig.LastKnownCommitSha.Should().Be(latestCommit);
+        watchStore.ChangeRecords.Should().ContainSingle();
+        watchStore.ChangeRecords[0].Status.Should().Be(GitOpsChangeStatus.PendingApproval);
+        pendingStore.Changes.Should().ContainSingle();
+        pendingStore.Changes[0].ResourceCount.Should().Be(1);
+    }
+
+    [UnitTest]
+    public void BuildSparseCheckoutPatterns_SlashlessDirectoryPath_FetchesOnlyDefaultManifestFiles()
+    {
+        var normalized = GitOpsWatchManifestPath.TryNormalize(
+            "manifests",
+            out var manifestPath,
+            out var errorMessage);
+
+        normalized.Should().BeTrue();
+        errorMessage.Should().BeNull();
+        manifestPath.Should().Be("manifests/");
+
+        var patterns = GitOpsWatchManifestPath.BuildSparseCheckoutPatterns(manifestPath);
+
+        patterns.Should().Equal(
+            "manifests/honua-manifest.json",
+            "manifests/manifest.json");
+        patterns.Should().NotContain("manifests");
+    }
+
+    [UnitTest]
+    public async Task PollOnceAsync_DirectoryWithoutDefaultManifest_DoesNotMarkCommitObserved()
+    {
+        var repoDir = await CreateLocalRepositoryAsync(("manifests/group.json", ValidGroupManifest));
+        var latestCommit = await RunGitForOutputAsync(repoDir, "rev-parse", "HEAD");
+        var watchStore = new TestGitOpsWatchStore(CreateConfig(repoDir, manifestPath: "manifests/"));
+
+        using var services = CreateServices(watchStore);
+        var service = CreateService(services);
+
+        await service.PollOnceAsync(CancellationToken.None);
+
+        watchStore.PollStateUpdateCount.Should().Be(0);
+        watchStore.CurrentConfig.LastKnownCommitSha.Should().BeNull();
+        watchStore.ChangeRecords.Should().BeEmpty();
+        latestCommit.Should().HaveLength(40);
+    }
+
+    [UnitTest]
+    public async Task PollOnceAsync_GlobManifestPath_RecordsSafeFailureAndDoesNotMarkCommitObserved()
+    {
+        var repoDir = await CreateLocalRepositoryAsync(("manifests/honua-manifest.json", ValidGroupManifest));
+        var latestCommit = await RunGitForOutputAsync(repoDir, "rev-parse", "HEAD");
+        var watchStore = new TestGitOpsWatchStore(CreateConfig(repoDir, manifestPath: "manifests/*.json"));
+
+        using var services = CreateServices(watchStore);
+        var service = CreateService(services);
+
+        await service.PollOnceAsync(CancellationToken.None);
+
+        watchStore.PollStateUpdateCount.Should().Be(0);
+        watchStore.CurrentConfig.LastKnownCommitSha.Should().BeNull();
+        watchStore.ChangeRecords.Should().ContainSingle();
+        watchStore.ChangeRecords[0].CommitSha.Should().Be(latestCommit);
+        watchStore.ChangeRecords[0].Status.Should().Be(GitOpsChangeStatus.Failed);
+        watchStore.ChangeRecords[0].ErrorMessage.Should().Be(GitOpsWatchManifestPath.GlobUnsupportedErrorMessage);
+        watchStore.ChangeRecords[0].ErrorMessage.Should().NotContain(repoDir);
     }
 
     public void Dispose()
@@ -136,7 +237,7 @@ public sealed class GitOpsWatchServiceTests : IDisposable
         UpdatedAt = DateTimeOffset.UtcNow
     };
 
-    private async Task<string> CreateLocalRepositoryAsync(bool includeManifest)
+    private async Task<string> CreateLocalRepositoryAsync(params (string RelativePath, string Content)[] files)
     {
         var repoDir = Path.Combine(Path.GetTempPath(), $"honua-gitops-watch-{Guid.NewGuid():N}");
         Directory.CreateDirectory(repoDir);
@@ -147,11 +248,14 @@ public sealed class GitOpsWatchServiceTests : IDisposable
         await RunGitCheckedAsync(repoDir, "config", "user.name", "GitOps Test");
         await RunGitCheckedAsync(repoDir, "checkout", "-b", "main");
 
-        if (includeManifest)
+        if (files.Length > 0)
         {
-            var manifestDir = Path.Combine(repoDir, "manifests");
-            Directory.CreateDirectory(manifestDir);
-            await File.WriteAllTextAsync(Path.Combine(manifestDir, "group.json"), ValidGroupManifest);
+            foreach (var (relativePath, content) in files)
+            {
+                var filePath = Path.Combine(repoDir, relativePath);
+                Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+                await File.WriteAllTextAsync(filePath, content);
+            }
         }
         else
         {
@@ -159,7 +263,7 @@ public sealed class GitOpsWatchServiceTests : IDisposable
         }
 
         await RunGitCheckedAsync(repoDir, "add", ".");
-        await RunGitCheckedAsync(repoDir, "commit", "-m", includeManifest ? "add manifest" : "initial commit");
+        await RunGitCheckedAsync(repoDir, "commit", "-m", files.Length > 0 ? "add manifest" : "initial commit");
 
         return repoDir;
     }


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #992

## Summary
Clarifies and enforces GitOps Watch `manifestPath` behavior so operators get stable exact-file or directory semantics instead of ambiguous recursive path or glob handling.

## Changes Made
- Add shared manifest path normalization for GitOps Watch configuration and polling.
- Support exact manifest files and directory paths that resolve to `honua-manifest.json`, then `manifest.json`.
- Reject glob and traversal paths with safe API-visible errors that do not expose local filesystem details.
- Update admin API docs/OpenAPI descriptions and add endpoint plus local-git service tests for the finalized semantics.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- `dotnet format Honua.sln --no-restore --verbosity minimal`
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~GitOpsWatchServiceTests" --no-restore`: 6 passed
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~GitOpsWatchEndpointsTests|FullyQualifiedName~GitOpsWatchServiceTests" --no-restore`: 28 passed
- `git diff --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [x] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent focused local validation; full script is intentionally not run for this bounded GitOps slice
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review
