### PR TITLE
fix(admin): retry malformed GitOps manifests (#992)

### DIFF
--- a/src/Honua.Server/Features/Admin/GitOpsWatchService.cs
+++ b/src/Honua.Server/Features/Admin/GitOpsWatchService.cs
@@ -137,15 +137,15 @@ internal sealed partial class GitOpsWatchService : BackgroundService
 
         var manifest = fetchResult.ManifestContent;
 
-        if (config.ApprovalRequired)
-        {
-            await HandleApprovalRequiredAsync(scope, watchStore, config, latestCommit, manifest, previousManifest, now, cancellationToken)
+        var commitObserved = config.ApprovalRequired
+            ? await HandleApprovalRequiredAsync(scope, watchStore, config, latestCommit, manifest, previousManifest, now, cancellationToken)
+                .ConfigureAwait(false)
+            : await HandleAutoApplyAsync(scope, watchStore, config, latestCommit, manifest, previousManifest, now, cancellationToken)
                 .ConfigureAwait(false);
-        }
-        else
+
+        if (!commitObserved)
         {
-            await HandleAutoApplyAsync(scope, watchStore, config, latestCommit, manifest, previousManifest, now, cancellationToken)
-                .ConfigureAwait(false);
+            return pollInterval;
         }
 
         await watchStore.UpdatePollStateAsync(config.ConfigId, latestCommit.Sha, now, cancellationToken)
@@ -154,7 +154,7 @@ internal sealed partial class GitOpsWatchService : BackgroundService
         return pollInterval;
     }
 
-    private async Task HandleApprovalRequiredAsync(
+    private async Task<bool> HandleApprovalRequiredAsync(
         AsyncServiceScope scope,
         IGitOpsWatchStore watchStore,
         GitOpsWatchConfig config,
@@ -164,15 +164,22 @@ internal sealed partial class GitOpsWatchService : BackgroundService
         DateTimeOffset now,
         CancellationToken cancellationToken)
     {
-        var pendingStore = scope.ServiceProvider.GetRequiredService<IManifestPendingChangeStore>();
         var schemaRegistry = scope.ServiceProvider.GetRequiredService<IMetadataSchemaRegistry>();
 
         // Parse and validate resources from the manifest
         var resources = DeserializeManifestResources(manifestContent);
-        if (resources == null || resources.Length == 0)
+        if (resources == null)
+        {
+            await RecordManifestParseFailureAsync(watchStore, config, commit, manifestContent, now, cancellationToken)
+                .ConfigureAwait(false);
+            LogManifestParseFailed(_logger, config.RepositoryUrl);
+            return false;
+        }
+
+        if (resources.Length == 0)
         {
             LogManifestEmpty(_logger, config.RepositoryUrl);
-            return;
+            return true;
         }
 
         var (normalizedResources, validationError) = AdminMetadataEndpoints.ValidateAndNormalizeResources(resources!, schemaRegistry);
@@ -194,7 +201,7 @@ internal sealed partial class GitOpsWatchService : BackgroundService
             };
             await watchStore.CreateChangeRecordAsync(changeRecord, cancellationToken).ConfigureAwait(false);
             LogManifestValidationFailed(_logger, config.RepositoryUrl, validationError ?? "Unknown error");
-            return;
+            return true;
         }
 
         var snapshotJson = JsonSerializer.SerializeToElement(new ManifestApplyRequest
@@ -206,6 +213,7 @@ internal sealed partial class GitOpsWatchService : BackgroundService
 
         var manifestHash = AdminMetadataEndpoints.ComputeManifestHash(normalizedResources);
 
+        var pendingStore = scope.ServiceProvider.GetRequiredService<IManifestPendingChangeStore>();
         var approvalOptions = scope.ServiceProvider.GetRequiredService<IOptions<ManifestApprovalOptions>>();
         var expiresAt = approvalOptions.Value.DefaultTimeoutMinutes.HasValue
             ? now.AddMinutes(approvalOptions.Value.DefaultTimeoutMinutes.Value)
@@ -245,9 +253,10 @@ internal sealed partial class GitOpsWatchService : BackgroundService
         await watchStore.CreateChangeRecordAsync(changeRecord2, cancellationToken).ConfigureAwait(false);
 
         LogChangeQueuedForApproval(_logger, commit.Sha, pending.PendingId);
+        return true;
     }
 
-    private async Task HandleAutoApplyAsync(
+    private async Task<bool> HandleAutoApplyAsync(
         AsyncServiceScope scope,
         IGitOpsWatchStore watchStore,
         GitOpsWatchConfig config,
@@ -263,10 +272,18 @@ internal sealed partial class GitOpsWatchService : BackgroundService
         var versionStore = scope.ServiceProvider.GetRequiredService<IManifestVersionStore>();
 
         var resources = DeserializeManifestResources(manifestContent);
-        if (resources == null || resources.Length == 0)
+        if (resources == null)
+        {
+            await RecordManifestParseFailureAsync(watchStore, config, commit, manifestContent, now, cancellationToken)
+                .ConfigureAwait(false);
+            LogManifestParseFailed(_logger, config.RepositoryUrl);
+            return false;
+        }
+
+        if (resources.Length == 0)
         {
             LogManifestEmpty(_logger, config.RepositoryUrl);
-            return;
+            return true;
         }
 
         var (normalizedResources, validationError) = AdminMetadataEndpoints.ValidateAndNormalizeResources(resources!, schemaRegistry);
@@ -288,7 +305,7 @@ internal sealed partial class GitOpsWatchService : BackgroundService
             };
             await watchStore.CreateChangeRecordAsync(failedRecord, cancellationToken).ConfigureAwait(false);
             LogManifestValidationFailed(_logger, config.RepositoryUrl, validationError ?? "Unknown error");
-            return;
+            return true;
         }
 
         ManifestApplyResult applyResult;
@@ -322,7 +339,7 @@ internal sealed partial class GitOpsWatchService : BackgroundService
             };
             await watchStore.CreateChangeRecordAsync(failedRecord, cancellationToken).ConfigureAwait(false);
             LogApplyFailed(_logger, commit.Sha, ex);
-            return;
+            return true;
         }
 
         var summary = $"Created: {applyResult.Summary.Created}, Updated: {applyResult.Summary.Updated}, " +
@@ -346,6 +363,45 @@ internal sealed partial class GitOpsWatchService : BackgroundService
         await watchStore.CreateChangeRecordAsync(changeRecord, cancellationToken).ConfigureAwait(false);
 
         LogChangeApplied(_logger, commit.Sha, summary);
+        return true;
+    }
+
+    private static async Task RecordManifestParseFailureAsync(
+        IGitOpsWatchStore watchStore,
+        GitOpsWatchConfig config,
+        GitCommitInfo commit,
+        JsonElement manifestContent,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        const string errorMessage =
+            "Manifest parse failed: expected a metadata resource object, an array of metadata resources, or an object with a resources array.";
+
+        var recentRecords = await watchStore.ListChangeRecordsAsync(10, 0, cancellationToken).ConfigureAwait(false);
+        if (recentRecords.Any(record =>
+                record.ConfigId == config.ConfigId &&
+                string.Equals(record.CommitSha, commit.Sha, StringComparison.Ordinal) &&
+                record.Status == GitOpsChangeStatus.Failed &&
+                string.Equals(record.ErrorMessage, errorMessage, StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        var changeRecord = new GitOpsChangeRecord
+        {
+            ChangeId = Guid.NewGuid(),
+            ConfigId = config.ConfigId,
+            CommitSha = commit.Sha,
+            CommitMessage = commit.Message,
+            CommitAuthor = commit.Author,
+            CommitTimestamp = commit.Timestamp,
+            ManifestAfter = manifestContent,
+            Status = GitOpsChangeStatus.Failed,
+            ErrorMessage = errorMessage,
+            DetectedAt = now
+        };
+
+        await watchStore.CreateChangeRecordAsync(changeRecord, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task RecordManifestPathFailureAsync(
@@ -757,6 +813,9 @@ internal sealed partial class GitOpsWatchService : BackgroundService
 
     [LoggerMessage(EventId = 9407, Level = LogLevel.Warning, Message = "GitOps manifest from {RepositoryUrl} contained no resources.")]
     private static partial void LogManifestEmpty(ILogger logger, string repositoryUrl);
+
+    [LoggerMessage(EventId = 9413, Level = LogLevel.Warning, Message = "GitOps manifest from {RepositoryUrl} could not be parsed into metadata resources.")]
+    private static partial void LogManifestParseFailed(ILogger logger, string repositoryUrl);
 
     [LoggerMessage(EventId = 9408, Level = LogLevel.Warning, Message = "GitOps manifest validation failed for {RepositoryUrl}: {Error}.")]
     private static partial void LogManifestValidationFailed(ILogger logger, string repositoryUrl, string error);

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/GitOpsWatchServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/GitOpsWatchServiceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Diagnostics;
+using System.Text.Json;
 using FluentAssertions;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain;
@@ -170,6 +171,36 @@ public sealed class GitOpsWatchServiceTests : IDisposable
         watchStore.ChangeRecords[0].Status.Should().Be(GitOpsChangeStatus.Failed);
         watchStore.ChangeRecords[0].ErrorMessage.Should().Be(GitOpsWatchManifestPath.GlobUnsupportedErrorMessage);
         watchStore.ChangeRecords[0].ErrorMessage.Should().NotContain(repoDir);
+    }
+
+    [UnitTest]
+    public async Task PollOnceAsync_InvalidResourcesManifest_RecordsSafeFailureAndDoesNotMarkCommitObserved()
+    {
+        const string invalidManifest = """
+            {
+              "resources": {
+                "kind": "Group"
+              }
+            }
+            """;
+        var repoDir = await CreateLocalRepositoryAsync(("manifests/honua-manifest.json", invalidManifest));
+        var latestCommit = await RunGitForOutputAsync(repoDir, "rev-parse", "HEAD");
+        var watchStore = new TestGitOpsWatchStore(CreateConfig(repoDir, manifestPath: "manifests/"));
+
+        using var services = CreateServices(watchStore);
+        var service = CreateService(services);
+
+        await service.PollOnceAsync(CancellationToken.None);
+        await service.PollOnceAsync(CancellationToken.None);
+
+        watchStore.PollStateUpdateCount.Should().Be(0);
+        watchStore.CurrentConfig.LastKnownCommitSha.Should().BeNull();
+        watchStore.ChangeRecords.Should().ContainSingle();
+        watchStore.ChangeRecords[0].CommitSha.Should().Be(latestCommit);
+        watchStore.ChangeRecords[0].Status.Should().Be(GitOpsChangeStatus.Failed);
+        watchStore.ChangeRecords[0].ErrorMessage.Should().StartWith("Manifest parse failed:");
+        watchStore.ChangeRecords[0].ErrorMessage.Should().NotContain(repoDir);
+        watchStore.ChangeRecords[0].ManifestAfter.GetProperty("resources").ValueKind.Should().Be(JsonValueKind.Object);
     }
 
     public void Dispose()


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #992

## Summary
Keeps GitOps Watch from marking a commit observed when a manifest fetch succeeds but the JSON shape cannot be parsed into metadata resources. This preserves retry behavior for malformed post-fetch manifests instead of advancing `lastKnownCommitSha`.

## Changes Made
- Make GitOps Watch apply handlers report whether a commit should be marked observed.
- Record a safe, deduplicated parse failure for unsupported manifest resource shapes.
- Delay pending-approval store resolution until after resource parsing succeeds.
- Add regression coverage that polls the same malformed manifest twice and verifies the commit remains unobserved with one safe failed change record.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- `dotnet restore tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj`
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~GitOpsWatchServiceTests" --no-restore`: 8 passed
- `dotnet format Honua.sln --no-restore --verbosity minimal`
- `git diff --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [x] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent focused local validation for the changed GitOps Watch service slice
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review