### PR TITLE
feat(admin): discover OGC API Features services (#977)

### DIFF
--- a/src/Honua.Server/Features/Admin/Models/ExternalServiceDiscoveryJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/ExternalServiceDiscoveryJsonContext.cs
@@ -21,6 +21,8 @@ namespace Honua.Server.Features.Admin.Models;
 [JsonSerializable(typeof(ArcGisServiceDocument))]
 [JsonSerializable(typeof(ArcGisLayerDocument))]
 [JsonSerializable(typeof(ArcGisCountDocument))]
+[JsonSerializable(typeof(OgcLandingDocument))]
+[JsonSerializable(typeof(OgcCollectionsDocument))]
 internal sealed partial class ExternalServiceDiscoveryJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Server/Features/Admin/Models/ExternalServiceDiscoveryModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/ExternalServiceDiscoveryModels.cs
@@ -99,6 +99,11 @@ internal sealed record ExternalServiceLayerCandidate
     public required string ServiceUrl { get; init; }
 
     /// <summary>
+    /// Stable source identifier for the candidate when the source does not expose a numeric layer id.
+    /// </summary>
+    public string? ExternalId { get; init; }
+
+    /// <summary>
     /// Numeric layer id when the source exposes one.
     /// </summary>
     public int? LayerId { get; init; }
@@ -309,4 +314,88 @@ internal sealed record ArcGisErrorDocument
 
     [JsonPropertyName("details")]
     public JsonElement? Details { get; init; }
+}
+
+internal sealed record OgcLandingDocument
+{
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("links")]
+    public OgcLinkDocument[]? Links { get; init; }
+}
+
+internal sealed record OgcCollectionsDocument
+{
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("collections")]
+    public OgcCollectionDocument[]? Collections { get; init; }
+}
+
+internal sealed record OgcCollectionDocument
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("itemType")]
+    public string? ItemType { get; init; }
+
+    [JsonPropertyName("extent")]
+    public OgcExtentDocument? Extent { get; init; }
+
+    [JsonPropertyName("crs")]
+    public string[]? Crs { get; init; }
+
+    [JsonPropertyName("storageCrs")]
+    public string? StorageCrs { get; init; }
+
+    [JsonPropertyName("itemCount")]
+    public int? ItemCount { get; init; }
+
+    [JsonPropertyName("links")]
+    public OgcLinkDocument[]? Links { get; init; }
+}
+
+internal sealed record OgcExtentDocument
+{
+    [JsonPropertyName("spatial")]
+    public OgcSpatialExtentDocument? Spatial { get; init; }
+}
+
+internal sealed record OgcSpatialExtentDocument
+{
+    [JsonPropertyName("bbox")]
+    public double[][]? Bbox { get; init; }
+
+    [JsonPropertyName("crs")]
+    public string? Crs { get; init; }
+}
+
+internal sealed record OgcLinkDocument
+{
+    [JsonPropertyName("href")]
+    public string? Href { get; init; }
+
+    [JsonPropertyName("rel")]
+    public string? Rel { get; init; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
 }

--- a/src/Honua.Server/Features/Admin/Services/ExternalServiceDiscoveryService.cs
+++ b/src/Honua.Server/Features/Admin/Services/ExternalServiceDiscoveryService.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Net.Http.Json;
+using System.Globalization;
 using Honua.Server.Features.Admin.Models;
 using Honua.Server.Features.Import;
 
@@ -34,9 +35,12 @@ internal sealed partial class ExternalServiceDiscoveryService(
 
         if (serviceType is null)
         {
-            // TODO honua-server#977: add OGC API Features landing/collections discovery here.
-            throw new ExternalServiceDiscoveryRequestException(
-                "Only ArcGIS REST FeatureServer and MapServer service root URLs are supported. OGC API Features discovery is tracked by honua-server#977.");
+            return await DiscoverOgcApiFeaturesAsync(
+                    sourceUrl,
+                    normalizedUri,
+                    ClampTimeout(request.TimeoutSeconds),
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
 
         return await DiscoverArcGisAsync(
@@ -247,6 +251,7 @@ internal sealed partial class ExternalServiceDiscoveryService(
             SourceKind = sourceKind,
             ServiceName = serviceName,
             ServiceUrl = serviceUri.ToString(),
+            ExternalId = layer.Id.ToString(CultureInfo.InvariantCulture),
             LayerId = layer.Id,
             Name = FirstNonWhiteSpace(layer.Name, reference.Name, $"Layer {reference.Id}"),
             Description = layer.Description,
@@ -270,10 +275,212 @@ internal sealed partial class ExternalServiceDiscoveryService(
             SourceKind = sourceKind,
             ServiceName = serviceName,
             ServiceUrl = serviceUri.ToString(),
+            ExternalId = reference.Id.ToString(CultureInfo.InvariantCulture),
             LayerId = reference.Id,
             Name = FirstNonWhiteSpace(reference.Name, $"Layer {reference.Id}"),
             Srid = GetSrid(serviceSpatialReference)
         };
+
+    private async Task<ExternalServiceDiscoveryResponse> DiscoverOgcApiFeaturesAsync(
+        string sourceUrl,
+        Uri serviceUri,
+        int timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        var landingDocument = await TryGetOgcLandingAsync(serviceUri, timeoutSeconds, cancellationToken)
+            .ConfigureAwait(false);
+        var collectionsUri = ResolveOgcCollectionsUri(serviceUri, landingDocument);
+        var collectionsDocument = await GetJsonAsync(
+                collectionsUri,
+                ExternalServiceDiscoveryJsonContext.Default.OgcCollectionsDocument,
+                timeoutSeconds,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (collectionsDocument.Collections is null)
+        {
+            throw new ExternalServiceDiscoveryRemoteException(
+                "OGC API Features collections response did not include a collections array.");
+        }
+
+        var serviceName = FirstNonWhiteSpace(
+            landingDocument?.Title,
+            collectionsDocument.Title,
+            ExtractOgcServiceName(serviceUri));
+
+        var candidates = collectionsDocument.Collections
+            .Where(collection => !string.IsNullOrWhiteSpace(collection.Id))
+            .Select(collection => MapOgcCandidate(collection, serviceName, serviceUri, collectionsUri))
+            .ToArray();
+
+        string[] warnings = collectionsDocument.Collections.Length == candidates.Length
+            ? []
+            : new[] { "One or more OGC API Features collections without an id were skipped." };
+
+        var normalizedUrl = collectionsUri.ToString();
+        Log.ServiceDiscovered(logger, normalizedUrl, candidates.Length);
+
+        return new ExternalServiceDiscoveryResponse
+        {
+            SourceUrl = sourceUrl,
+            NormalizedUrl = normalizedUrl,
+            SourceKind = "ogc-api-features",
+            ServiceType = "OGC API Features",
+            ServiceName = serviceName,
+            Description = FirstNonWhiteSpaceOrNull(landingDocument?.Description, collectionsDocument.Description),
+            Srid = 4326,
+            Candidates = candidates,
+            Warnings = warnings
+        };
+    }
+
+    private async Task<OgcLandingDocument?> TryGetOgcLandingAsync(
+        Uri serviceUri,
+        int timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        if (IsOgcCollectionsUri(serviceUri))
+        {
+            return null;
+        }
+
+        try
+        {
+            return await GetJsonAsync(
+                    serviceUri,
+                    ExternalServiceDiscoveryJsonContext.Default.OgcLandingDocument,
+                    timeoutSeconds,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)
+        {
+            Log.OgcLandingPageFailed(logger, serviceUri, ex);
+            return null;
+        }
+    }
+
+    private static Uri ResolveOgcCollectionsUri(Uri serviceUri, OgcLandingDocument? landingDocument)
+    {
+        if (IsOgcCollectionsUri(serviceUri))
+        {
+            return serviceUri;
+        }
+
+        var linkedCollections = landingDocument?.Links?
+            .Where(static link =>
+                !string.IsNullOrWhiteSpace(link.Href) &&
+                (string.Equals(link.Rel, "data", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(link.Rel, "collections", StringComparison.OrdinalIgnoreCase)))
+            .Select(link => TryResolveSameOriginUri(serviceUri, link.Href!))
+            .FirstOrDefault(uri => uri is not null);
+
+        return linkedCollections ?? AppendPathSegment(serviceUri, "collections");
+    }
+
+    private static ExternalServiceLayerCandidate MapOgcCandidate(
+        OgcCollectionDocument collection,
+        string serviceName,
+        Uri serviceUri,
+        Uri collectionsUri)
+    {
+        var sourceUrl = ResolveOgcCollectionUri(collection, serviceUri, collectionsUri).ToString();
+        return new ExternalServiceLayerCandidate
+        {
+            SourceKind = "ogc-api-features",
+            ServiceName = serviceName,
+            ServiceUrl = sourceUrl,
+            ExternalId = collection.Id,
+            Name = FirstNonWhiteSpace(collection.Title, collection.Id, "Collection"),
+            Description = collection.Description,
+            LayerType = "collection",
+            GeometryType = collection.ItemType,
+            Srid = GetOgcSrid(collection),
+            Extent = MapOgcExtent(collection.Extent),
+            FeatureCount = collection.ItemCount
+        };
+    }
+
+    private static Uri ResolveOgcCollectionUri(
+        OgcCollectionDocument collection,
+        Uri serviceUri,
+        Uri collectionsUri)
+    {
+        var selfLink = collection.Links?
+            .Where(static link =>
+                !string.IsNullOrWhiteSpace(link.Href) &&
+                string.Equals(link.Rel, "self", StringComparison.OrdinalIgnoreCase))
+            .Select(link => TryResolveSameOriginUri(serviceUri, link.Href!))
+            .FirstOrDefault(uri => uri is not null);
+
+        if (selfLink is not null)
+        {
+            return selfLink;
+        }
+
+        return AppendPathSegment(collectionsUri, Uri.EscapeDataString(collection.Id ?? string.Empty));
+    }
+
+    private static ExternalServiceExtent? MapOgcExtent(OgcExtentDocument? extent)
+    {
+        var bbox = extent?.Spatial?.Bbox?.FirstOrDefault(static values => values.Length >= 4);
+        if (bbox is null)
+        {
+            return null;
+        }
+
+        return new ExternalServiceExtent
+        {
+            XMin = bbox[0],
+            YMin = bbox[1],
+            XMax = bbox[2],
+            YMax = bbox[3],
+            Srid = ParseOgcCrsSrid(extent?.Spatial?.Crs) ?? 4326
+        };
+    }
+
+    private static int? GetOgcSrid(OgcCollectionDocument collection)
+    {
+        if (ParseOgcCrsSrid(collection.StorageCrs) is { } storageSrid)
+        {
+            return storageSrid;
+        }
+
+        if (collection.Crs is not null)
+        {
+            foreach (var crs in collection.Crs)
+            {
+                if (ParseOgcCrsSrid(crs) is { } srid)
+                {
+                    return srid;
+                }
+            }
+        }
+
+        return ParseOgcCrsSrid(collection.Extent?.Spatial?.Crs) ?? 4326;
+    }
+
+    private static int? ParseOgcCrsSrid(string? crs)
+    {
+        if (string.IsNullOrWhiteSpace(crs))
+        {
+            return null;
+        }
+
+        if (crs.Contains("CRS84", StringComparison.OrdinalIgnoreCase))
+        {
+            return 4326;
+        }
+
+        var lastSegment = crs.Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
+        return int.TryParse(lastSegment, NumberStyles.Integer, CultureInfo.InvariantCulture, out var srid) && srid > 0
+            ? srid
+            : null;
+    }
 
     private static ExternalServiceExtent? MapExtent(ArcGisExtentDocument? extent)
         => extent is null
@@ -311,6 +518,47 @@ internal sealed partial class ExternalServiceDiscoveryService(
     private static Uri BuildLayerCountUri(Uri serviceUri, int layerId)
         => new($"{serviceUri}/{layerId}/query?where=1%3D1&returnCountOnly=true&f=json", UriKind.Absolute);
 
+    private static Uri AppendPathSegment(Uri baseUri, string segment)
+    {
+        var builder = new UriBuilder(baseUri)
+        {
+            Query = string.Empty,
+            Fragment = string.Empty,
+            Path = $"{baseUri.AbsolutePath.TrimEnd('/')}/{segment.TrimStart('/')}"
+        };
+
+        return builder.Uri;
+    }
+
+    private static bool IsOgcCollectionsUri(Uri uri)
+    {
+        var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length > 0 && segments[^1].Equals("collections", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Uri? TryResolveSameOriginUri(Uri baseUri, string href)
+    {
+        if (!Uri.TryCreate(baseUri, href, out var resolved))
+        {
+            return null;
+        }
+
+        if (!string.Equals(baseUri.Scheme, resolved.Scheme, StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(baseUri.Host, resolved.Host, StringComparison.OrdinalIgnoreCase) ||
+            baseUri.Port != resolved.Port)
+        {
+            return null;
+        }
+
+        var builder = new UriBuilder(resolved)
+        {
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+
+        return builder.Uri;
+    }
+
     private static string? GetServiceType(Uri serviceUri)
     {
         var segments = serviceUri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
@@ -345,6 +593,22 @@ internal sealed partial class ExternalServiceDiscoveryService(
         return segments.Length > 0 ? Uri.UnescapeDataString(segments[^1]) : "External Service";
     }
 
+    private static string ExtractOgcServiceName(Uri serviceUri)
+    {
+        var segments = serviceUri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0)
+        {
+            return serviceUri.Host;
+        }
+
+        if (segments[^1].Equals("collections", StringComparison.OrdinalIgnoreCase) && segments.Length > 1)
+        {
+            return Uri.UnescapeDataString(segments[^2]);
+        }
+
+        return Uri.UnescapeDataString(segments[^1]);
+    }
+
     private static int? GetSrid(ArcGisSpatialReferenceDocument? spatialReference)
         => spatialReference?.LatestWkid ?? spatialReference?.Wkid;
 
@@ -353,6 +617,9 @@ internal sealed partial class ExternalServiceDiscoveryService(
 
     private static string FirstNonWhiteSpace(params string?[] values)
         => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value)) ?? "External Service";
+
+    private static string? FirstNonWhiteSpaceOrNull(params string?[] values)
+        => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
 
     private static partial class Log
     {
@@ -373,6 +640,12 @@ internal sealed partial class ExternalServiceDiscoveryService(
             Level = LogLevel.Debug,
             Message = "Failed to read external service layer {LayerId} feature count")]
         public static partial void FeatureCountFailed(ILogger logger, int layerId, Exception exception);
+
+        [LoggerMessage(
+            EventId = 4183,
+            Level = LogLevel.Debug,
+            Message = "Failed to read OGC API Features landing page {ServiceUrl}")]
+        public static partial void OgcLandingPageFailed(ILogger logger, Uri serviceUrl, Exception exception);
     }
 }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/ExternalServiceDiscoveryEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/ExternalServiceDiscoveryEndpointsTests.cs
@@ -21,7 +21,7 @@ public sealed class ExternalServiceDiscoveryEndpointsTests : IAsyncLifetime, IDi
     private const string AdminPassword = "external-service-discovery-admin-key";
 
     private readonly ExternalServiceDiscoveryServiceTests.StubHttpClientFactory _httpClientFactory =
-        new(ExternalServiceDiscoveryServiceTests.ArcGisFeatureServerResponses());
+        new(ExternalServiceDiscoveryServiceTests.AllDiscoveryResponses());
 
     private readonly WebAppFixture _fixture;
     private HttpClient _client = null!;
@@ -90,6 +90,36 @@ public sealed class ExternalServiceDiscoveryEndpointsTests : IAsyncLifetime, IDi
         candidate.GetProperty("srid").GetInt32().Should().Be(4326);
         candidate.GetProperty("featureCount").GetInt32().Should().Be(42);
         candidate.GetProperty("fields").GetArrayLength().Should().Be(2);
+        candidate.GetProperty("extent").GetProperty("xMin").GetDouble().Should().Be(-158.3);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/external-services/discover")]
+    public async Task DiscoverExternalService_WithOgcApiFeaturesFixture_ReturnsCollectionCandidates()
+    {
+        using var response = await _client.PostAsync(
+            "/api/v1/admin/external-services/discover",
+            JsonContent("""
+            {
+              "url": "https://ogc.example.test/api"
+            }
+            """));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        json.RootElement.GetProperty("sourceKind").GetString().Should().Be("ogc-api-features");
+        json.RootElement.GetProperty("serviceType").GetString().Should().Be("OGC API Features");
+        json.RootElement.GetProperty("serviceName").GetString().Should().Be("Honolulu OGC");
+
+        var candidate = json.RootElement.GetProperty("candidates")[0];
+        candidate.GetProperty("externalId").GetString().Should().Be("zoning");
+        candidate.GetProperty("name").GetString().Should().Be("Zoning");
+        candidate.GetProperty("layerType").GetString().Should().Be("collection");
+        candidate.GetProperty("geometryType").GetString().Should().Be("feature");
+        candidate.GetProperty("srid").GetInt32().Should().Be(4326);
+        candidate.GetProperty("featureCount").GetInt32().Should().Be(7);
         candidate.GetProperty("extent").GetProperty("xMin").GetDouble().Should().Be(-158.3);
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/ExternalServiceDiscoveryServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/ExternalServiceDiscoveryServiceTests.cs
@@ -59,22 +59,60 @@ public sealed class ExternalServiceDiscoveryServiceTests
     }
 
     [UnitTest]
-    public async Task DiscoverAsync_WithOgcApiFeaturesUrl_ReturnsExplicitBacklogError()
+    public async Task DiscoverAsync_WithOgcApiFeaturesUrl_ReturnsCollectionCandidates()
     {
-        using var factory = new StubHttpClientFactory(new Dictionary<string, string>());
+        using var factory = new StubHttpClientFactory(OgcApiFeaturesResponses());
         var service = new ExternalServiceDiscoveryService(
             factory,
             new AllowingNetworkGuard(),
             NullLogger<ExternalServiceDiscoveryService>.Instance);
 
-        var act = async () => await service.DiscoverAsync(new ExternalServiceDiscoveryRequest
+        var response = await service.DiscoverAsync(new ExternalServiceDiscoveryRequest
         {
-            Url = "https://ogc.example.test/collections"
+            Url = "https://ogc.example.test/api",
+            TimeoutSeconds = 5
         });
 
-        await act.Should().ThrowAsync<ExternalServiceDiscoveryRequestException>()
-            .WithMessage("*honua-server#977*");
-        factory.RequestedUrls.Should().BeEmpty();
+        response.SourceKind.Should().Be("ogc-api-features");
+        response.ServiceType.Should().Be("OGC API Features");
+        response.ServiceName.Should().Be("Honolulu OGC");
+        response.NormalizedUrl.Should().Be("https://ogc.example.test/api/collections");
+        response.Srid.Should().Be(4326);
+        response.Candidates.Should().ContainSingle();
+
+        var candidate = response.Candidates[0];
+        candidate.LayerId.Should().BeNull();
+        candidate.ExternalId.Should().Be("zoning");
+        candidate.Name.Should().Be("Zoning");
+        candidate.LayerType.Should().Be("collection");
+        candidate.GeometryType.Should().Be("feature");
+        candidate.Srid.Should().Be(4326);
+        candidate.FeatureCount.Should().Be(7);
+        candidate.ServiceUrl.Should().Be("https://ogc.example.test/api/collections/zoning");
+        candidate.Extent.Should().BeEquivalentTo(new ExternalServiceExtent
+        {
+            XMin = -158.3,
+            YMin = 21.2,
+            XMax = -157.6,
+            YMax = 21.8,
+            Srid = 4326
+        });
+
+        factory.RequestedUrls.Should().BeEquivalentTo([
+            "https://ogc.example.test/api",
+            "https://ogc.example.test/api/collections"
+        ], options => options.WithStrictOrdering());
+    }
+
+    internal static Dictionary<string, string> AllDiscoveryResponses()
+    {
+        var responses = ArcGisFeatureServerResponses();
+        foreach (var (url, body) in OgcApiFeaturesResponses())
+        {
+            responses[url] = body;
+        }
+
+        return responses;
     }
 
     internal static Dictionary<string, string> ArcGisFeatureServerResponses()
@@ -113,6 +151,58 @@ public sealed class ExternalServiceDiscoveryServiceTests
             ["https://services.example.test/arcgis/rest/services/Planning/FeatureServer/0/query?where=1%3D1&returnCountOnly=true&f=json"] = """
             {
               "count": 42
+            }
+            """
+        };
+
+    internal static Dictionary<string, string> OgcApiFeaturesResponses()
+        => new(StringComparer.Ordinal)
+        {
+            ["https://ogc.example.test/api"] = """
+            {
+              "title": "Honolulu OGC",
+              "description": "OGC API Features fixture",
+              "links": [
+                {
+                  "href": "https://ogc.example.test/api/collections",
+                  "rel": "data",
+                  "type": "application/json",
+                  "title": "Collections"
+                }
+              ]
+            }
+            """,
+            ["https://ogc.example.test/api/collections"] = """
+            {
+              "title": "Honolulu Collections",
+              "collections": [
+                {
+                  "id": "zoning",
+                  "title": "Zoning",
+                  "description": "Zoning district polygons",
+                  "itemType": "feature",
+                  "storageCrs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                  "crs": [
+                    "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                  ],
+                  "itemCount": 7,
+                  "extent": {
+                    "spatial": {
+                      "bbox": [
+                        [-158.3, 21.2, -157.6, 21.8]
+                      ],
+                      "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                    }
+                  },
+                  "links": [
+                    {
+                      "href": "https://ogc.example.test/api/collections/zoning",
+                      "rel": "self",
+                      "type": "application/json"
+                    }
+                  ]
+                }
+              ]
             }
             """
         };


### PR DESCRIPTION
## Issue Link
Related to #977

## Summary
Adds OGC API Features landing and collections discovery to the existing external-service discovery endpoint so admin clients can list selectable collection candidates without screen-scraping external metadata.

This is a discovery-only slice of #977. Materialized import and live-reference registration remain broader follow-up work.

## Changes Made
- Detect non-ArcGIS service roots as OGC API Features candidates and read landing plus collections JSON.
- Return OGC collection candidates with stable external ids, collection URLs, CRS, extents, item counts, and source metadata.
- Add source-generated JSON metadata plus focused service and endpoint coverage for the OGC fixture path.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent focused local validation: `dotnet restore tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj`; `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~ExternalServiceDiscovery" --no-restore`; `dotnet format Honua.sln --no-restore --verbosity minimal`; `git diff --check`
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review