### PR TITLE
feat(admin): add layer field configuration (#976)

### DIFF
--- a/src/Honua.Core/Features/Admin/Abstractions/ILayerFieldConfigurationStore.cs
+++ b/src/Honua.Core/Features/Admin/Abstractions/ILayerFieldConfigurationStore.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Admin.Domain;
+
+namespace Honua.Core.Features.Admin.Abstractions;
+
+/// <summary>
+/// Persists operator-managed field display metadata for published layers.
+/// </summary>
+public interface ILayerFieldConfigurationStore
+{
+    /// <summary>
+    /// Gets persisted field configuration for a layer ordered by field order.
+    /// </summary>
+    /// <param name="layerId">Layer identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Persisted field configuration entries.</returns>
+    Task<IReadOnlyList<LayerFieldConfiguration>> GetFieldConfigurationsAsync(
+        int layerId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates aliases and domains for the supplied fields and returns the full layer configuration.
+    /// </summary>
+    /// <param name="layerId">Layer identifier.</param>
+    /// <param name="updates">Field configuration updates to apply.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Updated field configuration entries.</returns>
+    Task<IReadOnlyList<LayerFieldConfiguration>> UpdateFieldConfigurationsAsync(
+        int layerId,
+        IReadOnlyList<LayerFieldConfigurationUpdate> updates,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Admin/Domain/LayerFieldConfigurationModels.cs
+++ b/src/Honua.Core/Features/Admin/Domain/LayerFieldConfigurationModels.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Catalog.Domain;
+
+namespace Honua.Core.Features.Admin.Domain;
+
+/// <summary>
+/// Persisted operator-managed display metadata for a layer field.
+/// </summary>
+/// <param name="Name">Field name.</param>
+/// <param name="Alias">Optional field alias displayed by protocol metadata surfaces.</param>
+/// <param name="Domain">Optional coded-value domain for the field.</param>
+public sealed record LayerFieldConfiguration(
+    string Name,
+    string? Alias,
+    FieldDomainDefinition? Domain);
+
+/// <summary>
+/// Operator-managed display metadata update for a layer field.
+/// </summary>
+/// <param name="Name">Field name.</param>
+/// <param name="Alias">Optional field alias displayed by protocol metadata surfaces.</param>
+/// <param name="Domain">Optional coded-value domain for the field.</param>
+public sealed record LayerFieldConfigurationUpdate(
+    string Name,
+    string? Alias,
+    FieldDomainDefinition? Domain);

--- a/src/Honua.Core/Features/Catalog/Domain/CatalogJsonContext.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/CatalogJsonContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Text.Json.Serialization;
+using System.Text.Json;
 
 namespace Honua.Core.Features.Catalog.Domain;
 
@@ -16,6 +17,10 @@ namespace Honua.Core.Features.Catalog.Domain;
 [JsonSerializable(typeof(MapServerConfig))]
 [JsonSerializable(typeof(RasterMosaicSettings))]
 [JsonSerializable(typeof(StacCatalogMetadata))]
+[JsonSerializable(typeof(FieldDomainDefinition))]
+[JsonSerializable(typeof(DomainCodedValueDefinition))]
+[JsonSerializable(typeof(DomainCodedValueDefinition[]))]
+[JsonSerializable(typeof(JsonElement))]
 [JsonSerializable(typeof(Dictionary<string, string>))]
 public sealed partial class CatalogJsonContext : JsonSerializerContext
 {

--- a/src/Honua.Postgres/Features/Admin/PostgresLayerFieldConfigurationStore.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgresLayerFieldConfigurationStore.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Admin.Abstractions;
+using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Validation;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.Admin;
+
+/// <summary>
+/// PostgreSQL store for operator-managed layer field configuration.
+/// </summary>
+internal sealed class PostgresLayerFieldConfigurationStore : ILayerFieldConfigurationStore
+{
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly string _fieldsTable;
+
+    public PostgresLayerFieldConfigurationStore(IDatabaseConnectionProvider connectionProvider, string? schemaName = null)
+    {
+        _connectionProvider = connectionProvider.ThrowIfNull();
+        _fieldsTable = Infrastructure.SchemaSearchPath.QualifyTable("layer_fields", schemaName);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<LayerFieldConfiguration>> GetFieldConfigurationsAsync(
+        int layerId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        return await GetFieldConfigurationsAsync(connection, layerId, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<LayerFieldConfiguration>> UpdateFieldConfigurationsAsync(
+        int layerId,
+        IReadOnlyList<LayerFieldConfigurationUpdate> updates,
+        CancellationToken cancellationToken = default)
+    {
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        const string fieldNameParameter = "fieldName";
+        const string aliasParameter = "alias";
+        const string domainParameter = "domain";
+
+        string sql = $"""
+            UPDATE {_fieldsTable}
+            SET
+                description = @{aliasParameter},
+                domain = @{domainParameter}
+            WHERE layer_id = @layerId
+              AND field_name = @{fieldNameParameter}
+            """;
+
+        foreach (var update in updates)
+        {
+            await using var command = new NpgsqlCommand(sql, connection, transaction);
+            command.Parameters.AddWithValue("layerId", layerId);
+            command.Parameters.AddWithValue(fieldNameParameter, update.Name);
+            command.Parameters.AddWithValue(aliasParameter, (object?)NormalizeAlias(update.Alias) ?? DBNull.Value);
+            var domain = command.Parameters.Add(domainParameter, NpgsqlDbType.Jsonb);
+            domain.Value = update.Domain is null
+                ? DBNull.Value
+                : JsonSerializer.Serialize(update.Domain, CatalogJsonContext.Default.FieldDomainDefinition);
+
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var fields = await GetFieldConfigurationsAsync(connection, layerId, transaction, cancellationToken).ConfigureAwait(false);
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return fields;
+    }
+
+    private async Task<IReadOnlyList<LayerFieldConfiguration>> GetFieldConfigurationsAsync(
+        NpgsqlConnection connection,
+        int layerId,
+        CancellationToken cancellationToken)
+    {
+        return await GetFieldConfigurationsAsync(connection, layerId, transaction: null, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<LayerFieldConfiguration>> GetFieldConfigurationsAsync(
+        NpgsqlConnection connection,
+        int layerId,
+        NpgsqlTransaction? transaction,
+        CancellationToken cancellationToken)
+    {
+        string sql = $"""
+            SELECT field_name, description, domain
+            FROM {_fieldsTable}
+            WHERE layer_id = @layerId
+            ORDER BY field_order
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("layerId", layerId);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var fields = new List<LayerFieldConfiguration>();
+
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            string name = reader.GetString(reader.GetOrdinal("field_name"));
+            int aliasOrdinal = reader.GetOrdinal("description");
+            string? alias = reader.IsDBNull(aliasOrdinal) ? null : reader.GetString(aliasOrdinal);
+            int domainOrdinal = reader.GetOrdinal("domain");
+            FieldDomainDefinition? domain = reader.IsDBNull(domainOrdinal)
+                ? null
+                : JsonSerializer.Deserialize(
+                    reader.GetString(domainOrdinal),
+                    CatalogJsonContext.Default.FieldDomainDefinition);
+
+            fields.Add(new LayerFieldConfiguration(name, alias, domain));
+        }
+
+        return fields;
+    }
+
+    private static string? NormalizeAlias(string? alias)
+    {
+        var trimmed = alias?.Trim();
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
+}

--- a/src/Honua.Postgres/Features/Catalog/PostgresLayerCatalog.cs
+++ b/src/Honua.Postgres/Features/Catalog/PostgresLayerCatalog.cs
@@ -333,7 +333,8 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
                 f.max_length,
                 f.nullable,
                 f.default_value,
-                f.description
+                f.description,
+                f.domain
             FROM {_fieldsTable} f
             WHERE f.layer_id = @layerId
             ORDER BY f.field_order
@@ -367,7 +368,8 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
                 f.max_length,
                 f.nullable,
                 f.default_value,
-                f.description
+                f.description,
+                f.domain
             FROM {_fieldsTable} f
             WHERE f.layer_id = ANY(@layerIds)
             ORDER BY f.layer_id, f.field_order
@@ -666,8 +668,14 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
         object? defaultValue = reader.IsDBNull(defaultValueOrdinal) ? null : reader.GetValue(defaultValueOrdinal);
         int descriptionOrdinal = reader.GetOrdinal("description");
         string? description = reader.IsDBNull(descriptionOrdinal) ? null : reader.GetString(descriptionOrdinal);
+        int domainOrdinal = reader.GetOrdinal("domain");
+        FieldDomainDefinition? domain = reader.IsDBNull(domainOrdinal)
+            ? null
+            : JsonSerializer.Deserialize(
+                reader.GetString(domainOrdinal),
+                CatalogJsonContext.Default.FieldDomainDefinition);
 
-        return new FieldDefinition(fieldName, fieldType, maxLength, nullable, defaultValue, description);
+        return new FieldDefinition(fieldName, fieldType, maxLength, nullable, defaultValue, description, domain);
     }
 
     private static LayerDefinition PopulateLayerDetails(

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -130,6 +130,7 @@ internal static class ServiceCollectionExtensions
 
         // Register layer catalog implementation
         services.AddScoped<ILayerCatalog, PostgresLayerCatalog>();
+        services.AddScoped<ILayerFieldConfigurationStore, PostgresLayerFieldConfigurationStore>();
         services.AddScoped<IServiceMetadataUpdater, PostgresServiceMetadataUpdater>();
         services.AddScoped<ILayerMetadataUpdater, PostgresLayerMetadataUpdater>();
 

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -169,6 +169,8 @@ public static class EndpointRegistry
         new("DELETE", "/api/v1/admin/metadata/resources/{kind}/{namespace}/{name}"),
         new("GET", "/api/v1/admin/metadata/layers/{layerId}/style"),
         new("PUT", "/api/v1/admin/metadata/layers/{layerId}/style"),
+        new("GET", "/api/v1/admin/metadata/layers/{layerId}/fields"),
+        new("PUT", "/api/v1/admin/metadata/layers/{layerId}/fields"),
         new("GET", "/api/v1/admin/metadata/layers/{layerId}/validation"),
         new("POST", "/api/v1/admin/metadata/layers/{layerId}/style/import-sld"),
         new("GET", "/api/v1/admin/metadata/layers/{layerId}/style/export-sld"),

--- a/src/Honua.Server/Features/Admin/AdminLayerFieldConfigurationEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AdminLayerFieldConfigurationEndpoints.cs
@@ -1,0 +1,255 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Admin.Abstractions;
+using Honua.Core.Features.Admin.Domain;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Validation.Abstractions;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Caching;
+using Honua.Server.Features.Infrastructure.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Admin endpoints for persisted layer field configuration.
+/// </summary>
+internal static class AdminLayerFieldConfigurationEndpoints
+{
+    private const int MaxFieldAliasLength = 256;
+    private const int MaxDomainNameLength = 128;
+    private const int MaxDomainLabelLength = 256;
+    private const int MaxCodedValues = 512;
+
+    /// <summary>
+    /// Maps layer field configuration endpoints to the admin metadata API group.
+    /// </summary>
+    public static void MapAdminLayerFieldConfigurationEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/metadata/layers")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Metadata", "Fields")
+            .RequireAdminAuthorization();
+
+        _ = group.MapGet("/{layerId:int}/fields", HandleGetLayerFields)
+            .WithName("GetAdminLayerFields")
+            .WithSummary("Get persisted layer field configuration")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        _ = group.MapPut("/{layerId:int}/fields", HandleUpdateLayerFields)
+            .WithName("UpdateAdminLayerFields")
+            .WithSummary("Update persisted layer field aliases and coded-value domains")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Put }));
+    }
+
+    private static async Task<IResult> HandleGetLayerFields(
+        int layerId,
+        HttpContext context,
+        [FromServices] IResourceValidator resourceValidator,
+        [FromServices] ILayerFieldConfigurationStore fieldConfigurationStore,
+        CancellationToken cancellationToken)
+    {
+        var layerResult = await ValidateLayerAsync(layerId, context, resourceValidator, cancellationToken).ConfigureAwait(false);
+        if (layerResult.Problem != null || layerResult.Layer == null)
+        {
+            return layerResult.Problem!;
+        }
+
+        var configurations = await fieldConfigurationStore.GetFieldConfigurationsAsync(layerId, cancellationToken)
+            .ConfigureAwait(false);
+        var response = BuildResponse(layerResult.Layer, configurations);
+        return Results.Json(
+            ApiResponse<LayerFieldConfigurationResponse>.CreateSuccess(response),
+            LayerFieldConfigurationJsonContext.Default.ApiResponseLayerFieldConfigurationResponse);
+    }
+
+    private static async Task<IResult> HandleUpdateLayerFields(
+        int layerId,
+        LayerFieldConfigurationUpdateRequest request,
+        HttpContext context,
+        [FromServices] IResourceValidator resourceValidator,
+        [FromServices] ILayerFieldConfigurationStore fieldConfigurationStore,
+        [FromServices] OutputCacheInvalidationService cacheInvalidator,
+        CancellationToken cancellationToken)
+    {
+        var layerResult = await ValidateLayerAsync(layerId, context, resourceValidator, cancellationToken).ConfigureAwait(false);
+        if (layerResult.Problem != null || layerResult.Layer == null)
+        {
+            return layerResult.Problem!;
+        }
+
+        var validationError = ValidateRequest(layerResult.Layer, request);
+        if (validationError != null)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, validationError);
+        }
+
+        var updates = request.Fields
+            .Select(field => new LayerFieldConfigurationUpdate(
+                field.Name.Trim(),
+                NormalizeAlias(field.Alias),
+                field.Domain))
+            .ToArray();
+
+        var configurations = await fieldConfigurationStore.UpdateFieldConfigurationsAsync(
+                layerId,
+                updates,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        await cacheInvalidator.InvalidateServiceCatalogAsync(null, [layerId], cancellationToken).ConfigureAwait(false);
+
+        var response = BuildResponse(layerResult.Layer, configurations);
+        return Results.Json(
+            ApiResponse<LayerFieldConfigurationResponse>.CreateSuccess(response),
+            LayerFieldConfigurationJsonContext.Default.ApiResponseLayerFieldConfigurationResponse);
+    }
+
+    private static async Task<(LayerDefinition? Layer, IResult? Problem)> ValidateLayerAsync(
+        int layerId,
+        HttpContext context,
+        IResourceValidator resourceValidator,
+        CancellationToken cancellationToken)
+    {
+        var layerResult = await resourceValidator.ValidateLayerAsync(layerId, cancellationToken).ConfigureAwait(false);
+        if (!layerResult.IsValid || layerResult.Resource == null)
+        {
+            var statusCode = layerResult.ErrorCode == ResourceValidationError.InvalidIdentifier
+                ? StatusCodes.Status400BadRequest
+                : StatusCodes.Status404NotFound;
+            var message = layerResult.ErrorMessage ?? $"Layer {layerId} not found.";
+            return (null, ProblemDetailsHelpers.CreateAdminProblem(context, statusCode, message));
+        }
+
+        return (layerResult.Resource, null);
+    }
+
+    private static string? ValidateRequest(
+        LayerDefinition layer,
+        LayerFieldConfigurationUpdateRequest request)
+    {
+        if (request.Fields.Count == 0)
+        {
+            return "At least one field configuration update is required.";
+        }
+
+        var knownFields = layer.Fields.ToDictionary(field => field.Name, StringComparer.OrdinalIgnoreCase);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var field in request.Fields)
+        {
+            if (string.IsNullOrWhiteSpace(field.Name))
+            {
+                return "Field name is required.";
+            }
+
+            var fieldName = field.Name.Trim();
+            if (!knownFields.ContainsKey(fieldName))
+            {
+                return $"Field '{fieldName}' does not exist on layer {layer.Id}.";
+            }
+
+            if (!seen.Add(fieldName))
+            {
+                return $"Field '{fieldName}' is configured more than once.";
+            }
+
+            if (field.Alias?.Trim().Length > MaxFieldAliasLength)
+            {
+                return $"Alias for field '{fieldName}' must be {MaxFieldAliasLength} characters or fewer.";
+            }
+
+            var domainError = ValidateDomain(fieldName, field.Domain);
+            if (domainError != null)
+            {
+                return domainError;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? ValidateDomain(string fieldName, FieldDomainDefinition? domain)
+    {
+        if (domain == null)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(domain.Name) || domain.Name.Length > MaxDomainNameLength)
+        {
+            return $"Domain name for field '{fieldName}' must be 1 to {MaxDomainNameLength} characters.";
+        }
+
+        if (!string.Equals(domain.Type, "codedValue", StringComparison.OrdinalIgnoreCase))
+        {
+            return $"Domain for field '{fieldName}' must use type 'codedValue'.";
+        }
+
+        if (domain.CodedValues is not { Length: > 0 } codedValues)
+        {
+            return $"Domain for field '{fieldName}' must include at least one coded value.";
+        }
+
+        if (codedValues.Length > MaxCodedValues)
+        {
+            return $"Domain for field '{fieldName}' must include {MaxCodedValues} coded values or fewer.";
+        }
+
+        var seenCodes = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var codedValue in codedValues)
+        {
+            if (codedValue.Code == null)
+            {
+                return $"Domain code for field '{fieldName}' is required.";
+            }
+
+            if (string.IsNullOrWhiteSpace(codedValue.Name) || codedValue.Name.Length > MaxDomainLabelLength)
+            {
+                return $"Domain label for field '{fieldName}' must be 1 to {MaxDomainLabelLength} characters.";
+            }
+
+            if (!seenCodes.Add(codedValue.Code.ToString() ?? string.Empty))
+            {
+                return $"Domain code '{codedValue.Code}' for field '{fieldName}' is duplicated.";
+            }
+        }
+
+        return null;
+    }
+
+    private static LayerFieldConfigurationResponse BuildResponse(
+        LayerDefinition layer,
+        IReadOnlyList<LayerFieldConfiguration> configurations)
+    {
+        var configurationMap = configurations.ToDictionary(field => field.Name, StringComparer.OrdinalIgnoreCase);
+        var fields = layer.Fields
+            .Select(field =>
+            {
+                configurationMap.TryGetValue(field.Name, out var configuration);
+                return new LayerFieldConfigurationItem
+                {
+                    Name = field.Name,
+                    Type = field.Type.ToString(),
+                    Alias = configuration is null ? field.Description : configuration.Alias,
+                    Domain = configuration is null ? field.Domain : configuration.Domain
+                };
+            })
+            .ToArray();
+
+        return new LayerFieldConfigurationResponse
+        {
+            LayerId = layer.Id,
+            Fields = fields
+        };
+    }
+
+    private static string? NormalizeAlias(string? alias)
+    {
+        var trimmed = alias?.Trim();
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
+}

--- a/src/Honua.Server/Features/Admin/Models/LayerFieldConfigurationJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/LayerFieldConfigurationJsonContext.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Server.Features.Infrastructure.Models;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// JSON source generation context for layer field configuration admin APIs.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(LayerFieldConfigurationUpdateRequest))]
+[JsonSerializable(typeof(LayerFieldConfigurationUpdateItem))]
+[JsonSerializable(typeof(LayerFieldConfigurationResponse))]
+[JsonSerializable(typeof(LayerFieldConfigurationItem))]
+[JsonSerializable(typeof(ApiResponse<LayerFieldConfigurationResponse>))]
+[JsonSerializable(typeof(ApiResponse<object>))]
+[JsonSerializable(typeof(FieldDomainDefinition))]
+[JsonSerializable(typeof(DomainCodedValueDefinition))]
+[JsonSerializable(typeof(DomainCodedValueDefinition[]))]
+[JsonSerializable(typeof(JsonElement))]
+public sealed partial class LayerFieldConfigurationJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Admin/Models/LayerFieldConfigurationModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/LayerFieldConfigurationModels.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Catalog.Domain;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Request payload for updating persisted layer field configuration.
+/// </summary>
+public sealed class LayerFieldConfigurationUpdateRequest
+{
+    /// <summary>
+    /// Field configuration updates to apply. Omitted fields preserve their current configuration.
+    /// </summary>
+    public IReadOnlyList<LayerFieldConfigurationUpdateItem> Fields { get; init; } = Array.Empty<LayerFieldConfigurationUpdateItem>();
+}
+
+/// <summary>
+/// Field configuration update item.
+/// </summary>
+public sealed class LayerFieldConfigurationUpdateItem
+{
+    /// <summary>
+    /// Name of the persisted layer field to update.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Optional display alias for the field. Null or blank clears the alias.
+    /// </summary>
+    public string? Alias { get; init; }
+
+    /// <summary>
+    /// Optional coded-value domain for the field. Null clears the domain.
+    /// </summary>
+    public FieldDomainDefinition? Domain { get; init; }
+}
+
+/// <summary>
+/// Response payload for persisted layer field configuration.
+/// </summary>
+public sealed class LayerFieldConfigurationResponse
+{
+    /// <summary>
+    /// Layer identifier.
+    /// </summary>
+    public int LayerId { get; init; }
+
+    /// <summary>
+    /// Field configurations ordered by field order.
+    /// </summary>
+    public IReadOnlyList<LayerFieldConfigurationItem> Fields { get; init; } = Array.Empty<LayerFieldConfigurationItem>();
+}
+
+/// <summary>
+/// Persisted configuration for one layer field.
+/// </summary>
+public sealed class LayerFieldConfigurationItem
+{
+    /// <summary>
+    /// Field name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Field data type.
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Optional display alias for the field.
+    /// </summary>
+    public string? Alias { get; init; }
+
+    /// <summary>
+    /// Optional coded-value domain for the field.
+    /// </summary>
+    public FieldDomainDefinition? Domain { get; init; }
+}

--- a/src/Honua.Server/Migrations/001_CreateHonuaSchema.sql
+++ b/src/Honua.Server/Migrations/001_CreateHonuaSchema.sql
@@ -81,6 +81,7 @@ CREATE TABLE IF NOT EXISTS honua.layer_fields (
     nullable BOOLEAN NOT NULL DEFAULT TRUE,
     default_value TEXT,
     description TEXT,
+    domain JSONB,
     PRIMARY KEY (layer_id, field_name)
 );
 
@@ -121,4 +122,5 @@ COMMENT ON COLUMN honua.layers.storage_srid IS 'SRID/CRS used by the stored geom
 COMMENT ON COLUMN honua.layers.temporal_column IS 'Optional physical temporal column used by time-aware layers';
 COMMENT ON COLUMN honua.layers.storage_options IS 'Provider-specific storage binding options when neutral layer fields are not sufficient';
 COMMENT ON COLUMN honua.layer_fields.field_type IS 'Field data type: text, integer, double, boolean, date, timestamp';
+COMMENT ON COLUMN honua.layer_fields.domain IS 'Operator-managed field domain metadata such as coded-value domains';
 COMMENT ON COLUMN features.attributes IS 'Feature properties stored as JSONB for flexible schema';

--- a/src/Honua.Server/Migrations/026_AddLayerFieldDomains.sql
+++ b/src/Honua.Server/Migrations/026_AddLayerFieldDomains.sql
@@ -1,0 +1,18 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Persist operator-managed coded-value domain metadata for published fields.
+-- Field aliases continue to use honua.layer_fields.description, which already
+-- hydrates into FieldDefinition.DisplayName across protocol metadata surfaces.
+
+ALTER TABLE honua.layer_fields
+    ADD COLUMN IF NOT EXISTS domain JSONB;
+
+ALTER TABLE honua.layer_fields
+    DROP CONSTRAINT IF EXISTS layer_fields_domain_object_check;
+
+ALTER TABLE honua.layer_fields
+    ADD CONSTRAINT layer_fields_domain_object_check
+        CHECK (domain IS NULL OR jsonb_typeof(domain) = 'object');
+
+COMMENT ON COLUMN honua.layer_fields.domain IS 'Operator-managed field domain metadata such as coded-value domains';

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -823,6 +823,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Admin.Models.ManifestApprovalJsonContext.Default,
         Honua.Server.Features.Admin.Models.GitOpsWatchJsonContext.Default,
         Honua.Server.Features.Admin.Models.LayerStyleJsonContext.Default,
+        Honua.Server.Features.Admin.Models.LayerFieldConfigurationJsonContext.Default,
         Honua.Server.Features.Admin.Models.LayerValidationJsonContext.Default,
         Honua.Server.Features.Admin.Models.StyleSuggestionJsonContext.Default,
         Honua.Server.Features.Admin.Models.AlertAdminJsonContext.Default,
@@ -1149,6 +1150,7 @@ app.MapDeployControlEndpoints();
 
 // Configure admin layer style endpoints
 app.MapAdminLayerStyleEndpoints();
+app.MapAdminLayerFieldConfigurationEndpoints();
 app.MapAdminLayerValidationEndpoints();
 app.MapAdminStyleSuggestionEndpoints();
 app.MapAdminSldStyleEndpoints();

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminAuthorizationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminAuthorizationTests.cs
@@ -275,6 +275,22 @@ public sealed class AdminAuthorizationTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/metadata/layers/{layerId}/fields")]
+    public async Task GetLayerFields_WithoutAuth_Returns401()
+    {
+        var response = await _unauthenticatedClient.GetAsync("/api/v1/admin/metadata/layers/1/fields");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [IntegrationTest]
+    [Endpoint("PUT /api/v1/admin/metadata/layers/{layerId}/fields")]
+    public async Task PutLayerFields_WithoutAuth_Returns401()
+    {
+        var response = await _unauthenticatedClient.PutAsJsonAsync("/api/v1/admin/metadata/layers/1/fields", new { });
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
     // --- MetadataResourceEndpoints ---
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/LayerFieldConfigurationEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/LayerFieldConfigurationEndpointsTests.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+/// <summary>
+/// Integration tests for admin layer field configuration endpoints.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+public sealed class LayerFieldConfigurationEndpointsTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /api/v1/admin/metadata/layers/{layerId}/fields")]
+    [Endpoint("PUT /api/v1/admin/metadata/layers/{layerId}/fields")]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task UpdateLayerFields_WithAliasAndCodedValueDomain_PersistsAndHydratesCatalog()
+    {
+        var adminClient = _fixture.CreateAdminClient();
+        var anonymousClient = _fixture.CreateClient();
+        var request = new LayerFieldConfigurationUpdateRequest
+        {
+            Fields =
+            [
+                new LayerFieldConfigurationUpdateItem
+                {
+                    Name = "category",
+                    Alias = "Lifecycle category",
+                    Domain = new FieldDomainDefinition(
+                        "category-domain",
+                        "codedValue",
+                        [
+                            new DomainCodedValueDefinition("active", "Active"),
+                            new DomainCodedValueDefinition("retired", "Retired")
+                        ])
+                }
+            ]
+        };
+
+        var updateResponse = await adminClient.PutAsync(
+            $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/fields",
+            JsonContent.Create(request, LayerFieldConfigurationJsonContext.Default.LayerFieldConfigurationUpdateRequest));
+
+        updateResponse.Be200Ok();
+        var update = await ReadFieldConfigurationResponseAsync(updateResponse);
+        var category = update.Data!.Fields.Single(field => field.Name == "category");
+        category.Alias.Should().Be("Lifecycle category");
+        category.Domain.Should().NotBeNull();
+        category.Domain!.Name.Should().Be("category-domain");
+        category.Domain.CodedValues.Should().HaveCount(2);
+
+        var getResponse = await adminClient.GetAsync(
+            $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/fields");
+
+        getResponse.Be200Ok();
+        var get = await ReadFieldConfigurationResponseAsync(getResponse);
+        get.Data!.Fields.Single(field => field.Name == "category").Alias.Should().Be("Lifecycle category");
+        get.Data!.Fields.Single(field => field.Name == "category").Domain!.CodedValues![0].Name.Should().Be("Active");
+
+        var featureLayerResponse = await anonymousClient.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
+
+        featureLayerResponse.Be200Ok();
+        using var document = JsonDocument.Parse(await featureLayerResponse.Content.ReadAsStringAsync());
+        var fields = document.RootElement.GetProperty("fields").EnumerateArray();
+        var categoryField = fields.Single(field => field.GetProperty("name").GetString() == "category");
+        categoryField.GetProperty("alias").GetString().Should().Be("Lifecycle category");
+        var domain = categoryField.GetProperty("domain");
+        domain.GetProperty("name").GetString().Should().Be("category-domain");
+        domain.GetProperty("type").GetString().Should().Be("codedValue");
+        domain.GetProperty("codedValues").EnumerateArray()
+            .Select(value => value.GetProperty("name").GetString())
+            .Should()
+            .BeEquivalentTo("Active", "Retired");
+
+        var clearRequest = new LayerFieldConfigurationUpdateRequest
+        {
+            Fields =
+            [
+                new LayerFieldConfigurationUpdateItem
+                {
+                    Name = "category",
+                    Alias = " "
+                }
+            ]
+        };
+
+        var clearResponse = await adminClient.PutAsync(
+            $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/fields",
+            JsonContent.Create(clearRequest, LayerFieldConfigurationJsonContext.Default.LayerFieldConfigurationUpdateRequest));
+
+        clearResponse.Be200Ok();
+        var clear = await ReadFieldConfigurationResponseAsync(clearResponse);
+        var clearedCategory = clear.Data!.Fields.Single(field => field.Name == "category");
+        clearedCategory.Alias.Should().BeNull();
+        clearedCategory.Domain.Should().BeNull();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("PUT /api/v1/admin/metadata/layers/{layerId}/fields")]
+    public async Task UpdateLayerFields_WithUnknownField_ReturnsBadRequest()
+    {
+        var adminClient = _fixture.CreateAdminClient();
+        var request = new LayerFieldConfigurationUpdateRequest
+        {
+            Fields =
+            [
+                new LayerFieldConfigurationUpdateItem
+                {
+                    Name = "missing_field",
+                    Alias = "Missing"
+                }
+            ]
+        };
+
+        var response = await adminClient.PutAsync(
+            $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/fields",
+            JsonContent.Create(request, LayerFieldConfigurationJsonContext.Default.LayerFieldConfigurationUpdateRequest));
+
+        response.Be400BadRequest();
+    }
+
+    private static async Task<ApiResponse<LayerFieldConfigurationResponse>> ReadFieldConfigurationResponseAsync(
+        HttpResponseMessage response)
+    {
+        var payload = await response.Content.ReadAsStringAsync();
+        var apiResponse = JsonSerializer.Deserialize(
+            payload,
+            LayerFieldConfigurationJsonContext.Default.ApiResponseLayerFieldConfigurationResponse);
+
+        apiResponse.Should().NotBeNull($"response payload was: {payload}");
+        apiResponse!.Success.Should().BeTrue();
+        apiResponse.Data.Should().NotBeNull();
+        return apiResponse;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/PostgresLayerCatalogTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/PostgresLayerCatalogTests.cs
@@ -71,6 +71,7 @@ public class PostgresLayerCatalogTests : IAsyncLifetime
                 nullable boolean NOT NULL DEFAULT true,
                 default_value text,
                 description text,
+                domain jsonb,
                 PRIMARY KEY (layer_id, field_name)
             );
 

--- a/tests/python/shared/postgis.py
+++ b/tests/python/shared/postgis.py
@@ -403,9 +403,14 @@ class PostGISFixture:
                         nullable BOOLEAN NOT NULL DEFAULT TRUE,
                         default_value TEXT,
                         description TEXT,
+                        domain JSONB,
                         PRIMARY KEY (layer_id, field_name)
                     );
                     """
+                )
+                conn.execute(
+                    "ALTER TABLE IF EXISTS honua.layer_fields "
+                    "ADD COLUMN IF NOT EXISTS domain JSONB;"
                 )
 
                 conn.execute(

--- a/tests/seed/base-schema.sql
+++ b/tests/seed/base-schema.sql
@@ -123,6 +123,7 @@ CREATE TABLE IF NOT EXISTS honua.layer_fields (
     nullable BOOLEAN NOT NULL DEFAULT TRUE,
     default_value TEXT,
     description TEXT,
+    domain JSONB,
     PRIMARY KEY (layer_id, field_name)
 );
 

--- a/tests/seed/client-compat-v1.sql
+++ b/tests/seed/client-compat-v1.sql
@@ -111,6 +111,7 @@ CREATE TABLE IF NOT EXISTS honua.layer_fields (
     nullable BOOLEAN NOT NULL DEFAULT TRUE,
     default_value TEXT,
     description TEXT,
+    domain JSONB,
     PRIMARY KEY (layer_id, field_name)
 );
 

--- a/tests/seed/odata.yaml
+++ b/tests/seed/odata.yaml
@@ -69,6 +69,7 @@ sql:
           nullable BOOLEAN NOT NULL DEFAULT TRUE,
           default_value TEXT,
           description TEXT,
+          domain JSONB,
           PRIMARY KEY (layer_id, field_name)
       );
   - |

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -70,6 +70,7 @@ sql:
           nullable BOOLEAN NOT NULL DEFAULT TRUE,
           default_value TEXT,
           description TEXT,
+          domain JSONB,
           PRIMARY KEY (layer_id, field_name)
       );
   - |

--- a/tests/seed/spatial-reference.yaml
+++ b/tests/seed/spatial-reference.yaml
@@ -69,6 +69,7 @@ sql:
           nullable BOOLEAN NOT NULL DEFAULT TRUE,
           default_value TEXT,
           description TEXT,
+          domain JSONB,
           PRIMARY KEY (layer_id, field_name)
       );
   - |


### PR DESCRIPTION
## Issue Link
Related to #976

## Summary
Adds an admin metadata endpoint for operator-managed layer field configuration so published fields can carry aliases and manual coded-value domains through the shared catalog and protocol metadata surfaces.

This is a bounded #976 slice for persisted field aliases and coded-value domains. Permanent filters, hidden-field enforcement, SDK clients, and richer domain sources remain follow-up work.

## Changes Made
- Add GET/PUT `/api/v1/admin/metadata/layers/{layerId}/fields` with admin authorization and endpoint registry coverage.
- Persist field aliases in `honua.layer_fields.description` and coded-value domains in a new `honua.layer_fields.domain` JSONB column.
- Hydrate persisted domains through `PostgresLayerCatalog` so FeatureServer metadata emits the configured domain.
- Add source-generated JSON metadata plus endpoint, authorization, catalog, and architecture coverage.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [x] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent focused local validation: `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~LayerFieldConfigurationEndpointsTests|FullyQualifiedName~AdminAuthorizationTests" --no-restore`; `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~PostgresLayerCatalogTests" --no-restore`; `dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj --no-restore`; `dotnet format Honua.sln --no-restore --verbosity minimal`; `git diff --check`
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review