### PR TITLE
feat: discover WFS external services (#977)

### DIFF
--- a/src/Honua.Server/Features/Admin/Models/ExternalServiceDiscoveryModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/ExternalServiceDiscoveryModels.cs
@@ -114,6 +114,11 @@ internal sealed record ExternalServiceLayerCandidate
     public required string Name { get; init; }
 
     /// <summary>
+    /// Source display title when it differs from the stable source name.
+    /// </summary>
+    public string? Title { get; init; }
+
+    /// <summary>
     /// Layer or table description.
     /// </summary>
     public string? Description { get; init; }

--- a/src/Honua.Server/Features/Admin/Services/ExternalServiceDiscoveryService.cs
+++ b/src/Honua.Server/Features/Admin/Services/ExternalServiceDiscoveryService.cs
@@ -4,6 +4,8 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Globalization;
+using System.Xml;
+using System.Xml.Linq;
 using Honua.Server.Features.Admin.Models;
 using Honua.Server.Features.Import;
 
@@ -33,9 +35,20 @@ internal sealed partial class ExternalServiceDiscoveryService(
         var normalizedUri = await NormalizeAndValidateAsync(sourceUrl, cancellationToken).ConfigureAwait(false);
         var serviceType = GetServiceType(normalizedUri);
 
-        if (serviceType is null)
+        if (serviceType is not null)
         {
-            return await DiscoverOgcApiFeaturesAsync(
+            return await DiscoverArcGisAsync(
+                    sourceUrl,
+                    normalizedUri,
+                    serviceType,
+                    ClampTimeout(request.TimeoutSeconds),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (IsWfsDiscoveryRequest(sourceUrl, normalizedUri))
+        {
+            return await DiscoverWfsAsync(
                     sourceUrl,
                     normalizedUri,
                     ClampTimeout(request.TimeoutSeconds),
@@ -43,10 +56,9 @@ internal sealed partial class ExternalServiceDiscoveryService(
                 .ConfigureAwait(false);
         }
 
-        return await DiscoverArcGisAsync(
+        return await DiscoverOgcApiFeaturesAsync(
                 sourceUrl,
                 normalizedUri,
-                serviceType,
                 ClampTimeout(request.TimeoutSeconds),
                 cancellationToken)
             .ConfigureAwait(false);
@@ -334,6 +346,212 @@ internal sealed partial class ExternalServiceDiscoveryService(
         };
     }
 
+    private async Task<ExternalServiceDiscoveryResponse> DiscoverWfsAsync(
+        string sourceUrl,
+        Uri serviceUri,
+        int timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        var capabilitiesUri = BuildWfsGetCapabilitiesUri(serviceUri);
+        XDocument capabilitiesDocument;
+        try
+        {
+            capabilitiesDocument = await GetXmlAsync(capabilitiesUri, timeoutSeconds, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (XmlException)
+        {
+            throw new ExternalServiceDiscoveryRemoteException("WFS GetCapabilities response was not valid XML.");
+        }
+
+        var root = capabilitiesDocument.Root;
+        if (root is null)
+        {
+            throw new ExternalServiceDiscoveryRemoteException("WFS GetCapabilities response was empty.");
+        }
+
+        if (root.Name.LocalName.Equals("ExceptionReport", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ExternalServiceDiscoveryRemoteException("WFS service returned an error during discovery.");
+        }
+
+        if (!root.Name.LocalName.Equals("WFS_Capabilities", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ExternalServiceDiscoveryRemoteException("WFS GetCapabilities response was not recognized.");
+        }
+
+        var featureTypeList = DescendantsByLocalName(root, "FeatureTypeList").FirstOrDefault();
+        if (featureTypeList is null)
+        {
+            throw new ExternalServiceDiscoveryRemoteException(
+                "WFS GetCapabilities response did not include feature type metadata.");
+        }
+
+        var warnings = new List<string>();
+        var serviceName = FirstNonWhiteSpace(
+            GetWfsServiceMetadataValue(root, "Title"),
+            ExtractWfsServiceName(serviceUri));
+        var candidates = featureTypeList.Elements()
+            .Where(static element => element.Name.LocalName.Equals("FeatureType", StringComparison.OrdinalIgnoreCase))
+            .Select(featureType => MapWfsCandidate(featureType, serviceName, serviceUri, warnings))
+            .Where(static candidate => candidate is not null)
+            .Cast<ExternalServiceLayerCandidate>()
+            .ToArray();
+
+        if (candidates.Length == 0)
+        {
+            throw new ExternalServiceDiscoveryRemoteException(
+                "WFS GetCapabilities response did not include feature type candidates.");
+        }
+
+        var responseSrid = GetSharedSrid(candidates);
+        var normalizedUrl = capabilitiesUri.ToString();
+        Log.ServiceDiscovered(logger, normalizedUrl, candidates.Length);
+
+        return new ExternalServiceDiscoveryResponse
+        {
+            SourceUrl = sourceUrl,
+            NormalizedUrl = normalizedUrl,
+            SourceKind = "wfs",
+            ServiceType = BuildWfsServiceType(root),
+            ServiceName = serviceName,
+            Description = GetWfsServiceMetadataValue(root, "Abstract"),
+            Srid = responseSrid,
+            Candidates = candidates,
+            Warnings = warnings.ToArray()
+        };
+    }
+
+    private async Task<XDocument> GetXmlAsync(
+        Uri uri,
+        int timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        var client = httpClientFactory.CreateClient(HttpClientName);
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+
+        using var response = await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, timeoutCts.Token)
+            .ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException("External service returned a non-success response during discovery.");
+        }
+
+        using var stream = await response.Content.ReadAsStreamAsync(timeoutCts.Token).ConfigureAwait(false);
+        using var reader = XmlReader.Create(stream, CreateSecureXmlReaderSettings());
+        return await XDocument.LoadAsync(reader, LoadOptions.None, timeoutCts.Token).ConfigureAwait(false);
+    }
+
+    private static XmlReaderSettings CreateSecureXmlReaderSettings()
+        => new()
+        {
+            Async = true,
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = 2_000_000,
+            MaxCharactersFromEntities = 0
+        };
+
+    private static ExternalServiceLayerCandidate? MapWfsCandidate(
+        XElement featureType,
+        string serviceName,
+        Uri serviceUri,
+        List<string> warnings)
+    {
+        var featureName = FirstChildValue(featureType, "Name");
+        if (string.IsNullOrWhiteSpace(featureName))
+        {
+            warnings.Add("A WFS feature type without a name was skipped.");
+            return null;
+        }
+
+        var extent = MapWfsExtent(featureType);
+        return new ExternalServiceLayerCandidate
+        {
+            SourceKind = "wfs",
+            ServiceName = serviceName,
+            ServiceUrl = serviceUri.ToString(),
+            ExternalId = featureName,
+            Name = featureName,
+            Title = FirstNonWhiteSpaceOrNull(FirstChildValue(featureType, "Title")),
+            Description = FirstChildValue(featureType, "Abstract"),
+            LayerType = "feature-type",
+            Srid = GetWfsSrid(featureType) ?? extent?.Srid,
+            Extent = extent,
+            Fields = []
+        };
+    }
+
+    private static ExternalServiceExtent? MapWfsExtent(XElement featureType)
+    {
+        var wgs84BoundingBox = DescendantsByLocalName(featureType, "WGS84BoundingBox").FirstOrDefault();
+        if (wgs84BoundingBox is not null &&
+            TryParseCorner(FirstChildValue(wgs84BoundingBox, "LowerCorner"), out var lower) &&
+            TryParseCorner(FirstChildValue(wgs84BoundingBox, "UpperCorner"), out var upper))
+        {
+            return CreateExtent(lower, upper, 4326);
+        }
+
+        var latLongBoundingBox = DescendantsByLocalName(featureType, "LatLongBoundingBox").FirstOrDefault();
+        if (latLongBoundingBox is not null &&
+            TryGetDoubleAttribute(latLongBoundingBox, "minx", out var minX) &&
+            TryGetDoubleAttribute(latLongBoundingBox, "miny", out var minY) &&
+            TryGetDoubleAttribute(latLongBoundingBox, "maxx", out var maxX) &&
+            TryGetDoubleAttribute(latLongBoundingBox, "maxy", out var maxY))
+        {
+            return new ExternalServiceExtent
+            {
+                XMin = minX,
+                YMin = minY,
+                XMax = maxX,
+                YMax = maxY,
+                Srid = 4326
+            };
+        }
+
+        var boundingBox = DescendantsByLocalName(featureType, "BoundingBox").FirstOrDefault();
+        var bboxSrid = ParseOgcCrsSrid(
+            GetAttributeValue(boundingBox, "crs") ??
+            GetAttributeValue(boundingBox, "srsName") ??
+            GetAttributeValue(boundingBox, "SRS"));
+        if (boundingBox is not null &&
+            bboxSrid is not null &&
+            TryParseCorner(FirstChildValue(boundingBox, "LowerCorner"), out lower) &&
+            TryParseCorner(FirstChildValue(boundingBox, "UpperCorner"), out upper))
+        {
+            return CreateExtent(lower, upper, bboxSrid);
+        }
+
+        return null;
+    }
+
+    private static ExternalServiceExtent CreateExtent(double[] lower, double[] upper, int? srid)
+        => new()
+        {
+            XMin = Math.Min(lower[0], upper[0]),
+            YMin = Math.Min(lower[1], upper[1]),
+            XMax = Math.Max(lower[0], upper[0]),
+            YMax = Math.Max(lower[1], upper[1]),
+            Srid = srid
+        };
+
+    private static int? GetWfsSrid(XElement featureType)
+    {
+        foreach (var localName in new[] { "DefaultCRS", "DefaultSRS", "SRS", "OtherCRS", "OtherSRS" })
+        {
+            foreach (var value in ChildValues(featureType, localName))
+            {
+                if (ParseOgcCrsSrid(value) is { } srid)
+                {
+                    return srid;
+                }
+            }
+        }
+
+        return null;
+    }
+
     private async Task<OgcLandingDocument?> TryGetOgcLandingAsync(
         Uri serviceUri,
         int timeoutSeconds,
@@ -476,7 +694,7 @@ internal sealed partial class ExternalServiceDiscoveryService(
             return 4326;
         }
 
-        var lastSegment = crs.Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
+        var lastSegment = crs.Split(['/', ':'], StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
         return int.TryParse(lastSegment, NumberStyles.Integer, CultureInfo.InvariantCulture, out var srid) && srid > 0
             ? srid
             : null;
@@ -518,6 +736,16 @@ internal sealed partial class ExternalServiceDiscoveryService(
     private static Uri BuildLayerCountUri(Uri serviceUri, int layerId)
         => new($"{serviceUri}/{layerId}/query?where=1%3D1&returnCountOnly=true&f=json", UriKind.Absolute);
 
+    private static Uri BuildWfsGetCapabilitiesUri(Uri serviceUri)
+    {
+        var builder = new UriBuilder(serviceUri)
+        {
+            Query = "service=WFS&request=GetCapabilities"
+        };
+
+        return builder.Uri;
+    }
+
     private static Uri AppendPathSegment(Uri baseUri, string segment)
     {
         var builder = new UriBuilder(baseUri)
@@ -529,6 +757,44 @@ internal sealed partial class ExternalServiceDiscoveryService(
 
         return builder.Uri;
     }
+
+    private static bool IsWfsDiscoveryRequest(string sourceUrl, Uri serviceUri)
+    {
+        if (Uri.TryCreate(sourceUrl, UriKind.Absolute, out var originalUri) &&
+            QueryParameterEquals(originalUri, "service", "WFS"))
+        {
+            return true;
+        }
+
+        var segments = serviceUri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length > 0 && segments[^1].Equals("wfs", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool QueryParameterEquals(Uri uri, string parameterName, string expectedValue)
+    {
+        var query = uri.Query.TrimStart('?');
+        if (query.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (var pair in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var equalsIndex = pair.IndexOf('=');
+            var name = equalsIndex >= 0 ? pair[..equalsIndex] : pair;
+            var value = equalsIndex >= 0 ? pair[(equalsIndex + 1)..] : string.Empty;
+            if (DecodeQueryComponent(name).Equals(parameterName, StringComparison.OrdinalIgnoreCase) &&
+                DecodeQueryComponent(value).Equals(expectedValue, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string DecodeQueryComponent(string value)
+        => Uri.UnescapeDataString(value.Replace('+', ' '));
 
     private static bool IsOgcCollectionsUri(Uri uri)
     {
@@ -607,6 +873,118 @@ internal sealed partial class ExternalServiceDiscoveryService(
         }
 
         return Uri.UnescapeDataString(segments[^1]);
+    }
+
+    private static string ExtractWfsServiceName(Uri serviceUri)
+    {
+        var segments = serviceUri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0)
+        {
+            return serviceUri.Host;
+        }
+
+        return Uri.UnescapeDataString(segments[^1]);
+    }
+
+    private static string BuildWfsServiceType(XElement root)
+    {
+        var version = root.Attribute("version")?.Value;
+        return string.IsNullOrWhiteSpace(version) ? "WFS" : $"WFS {version}";
+    }
+
+    private static int? GetSharedSrid(ExternalServiceLayerCandidate[] candidates)
+    {
+        int? sharedSrid = null;
+        foreach (var candidate in candidates)
+        {
+            if (candidate.Srid is null)
+            {
+                continue;
+            }
+
+            if (sharedSrid is null)
+            {
+                sharedSrid = candidate.Srid;
+                continue;
+            }
+
+            if (sharedSrid != candidate.Srid)
+            {
+                return null;
+            }
+        }
+
+        return sharedSrid;
+    }
+
+    private static string? GetWfsServiceMetadataValue(XElement root, string localName)
+    {
+        var serviceMetadata = root.Elements()
+            .FirstOrDefault(static element =>
+                element.Name.LocalName.Equals("ServiceIdentification", StringComparison.OrdinalIgnoreCase) ||
+                element.Name.LocalName.Equals("Service", StringComparison.OrdinalIgnoreCase));
+
+        return serviceMetadata is null ? null : FirstChildValue(serviceMetadata, localName);
+    }
+
+    private static IEnumerable<XElement> DescendantsByLocalName(XContainer container, string localName)
+        => container.Descendants()
+            .Where(element => element.Name.LocalName.Equals(localName, StringComparison.OrdinalIgnoreCase));
+
+    private static IEnumerable<string> ChildValues(XElement element, string localName)
+        => element.Elements()
+            .Where(child => child.Name.LocalName.Equals(localName, StringComparison.OrdinalIgnoreCase))
+            .Select(child => child.Value)
+            .Where(static value => !string.IsNullOrWhiteSpace(value));
+
+    private static string? FirstChildValue(XElement element, params string[] localNames)
+    {
+        foreach (var localName in localNames)
+        {
+            var value = element.Elements()
+                .FirstOrDefault(child => child.Name.LocalName.Equals(localName, StringComparison.OrdinalIgnoreCase))
+                ?.Value;
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value.Trim();
+            }
+        }
+
+        return null;
+    }
+
+    private static string? GetAttributeValue(XElement? element, string localName)
+        => element?.Attributes()
+            .FirstOrDefault(attribute => attribute.Name.LocalName.Equals(localName, StringComparison.OrdinalIgnoreCase))
+            ?.Value;
+
+    private static bool TryGetDoubleAttribute(XElement element, string localName, out double value)
+        => double.TryParse(
+            GetAttributeValue(element, localName),
+            NumberStyles.Float,
+            CultureInfo.InvariantCulture,
+            out value);
+
+    private static bool TryParseCorner(string? value, out double[] coordinates)
+    {
+        coordinates = [];
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var parts = value.Split(
+            [' ', '\t', '\r', '\n', ','],
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length < 2 ||
+            !double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var x) ||
+            !double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var y))
+        {
+            return false;
+        }
+
+        coordinates = [x, y];
+        return true;
     }
 
     private static int? GetSrid(ArcGisSpatialReferenceDocument? spatialReference)

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/ExternalServiceDiscoveryEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/ExternalServiceDiscoveryEndpointsTests.cs
@@ -125,6 +125,36 @@ public sealed class ExternalServiceDiscoveryEndpointsTests : IAsyncLifetime, IDi
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/external-services/discover")]
+    public async Task DiscoverExternalService_WithWfsGetCapabilitiesFixture_ReturnsFeatureTypeCandidates()
+    {
+        using var response = await _client.PostAsync(
+            "/api/v1/admin/external-services/discover",
+            JsonContent("""
+            {
+              "url": "https://wfs.example.test/geoserver/wfs?SERVICE=WFS&REQUEST=GetCapabilities"
+            }
+            """));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        json.RootElement.GetProperty("sourceKind").GetString().Should().Be("wfs");
+        json.RootElement.GetProperty("serviceType").GetString().Should().Be("WFS 2.0.0");
+        json.RootElement.GetProperty("serviceName").GetString().Should().Be("Honolulu WFS");
+
+        var candidate = json.RootElement.GetProperty("candidates")[0];
+        candidate.GetProperty("externalId").GetString().Should().Be("honua:parcels");
+        candidate.GetProperty("name").GetString().Should().Be("honua:parcels");
+        candidate.GetProperty("title").GetString().Should().Be("Parcels");
+        candidate.GetProperty("layerType").GetString().Should().Be("feature-type");
+        candidate.GetProperty("srid").GetInt32().Should().Be(4326);
+        candidate.GetProperty("fields").GetArrayLength().Should().Be(0);
+        candidate.GetProperty("extent").GetProperty("xMin").GetDouble().Should().Be(-158.3);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/external-services/discover")]
     public async Task DiscoverExternalService_WithMissingUrl_ReturnsBadRequest()
     {
         using var response = await _client.PostAsync(

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/ExternalServiceDiscoveryServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/ExternalServiceDiscoveryServiceTests.cs
@@ -104,10 +104,59 @@ public sealed class ExternalServiceDiscoveryServiceTests
         ], options => options.WithStrictOrdering());
     }
 
+    [UnitTest]
+    public async Task DiscoverAsync_WithWfsGetCapabilitiesFixture_ReturnsFeatureTypeCandidates()
+    {
+        using var factory = new StubHttpClientFactory(WfsGetCapabilitiesResponses());
+        var service = new ExternalServiceDiscoveryService(
+            factory,
+            new AllowingNetworkGuard(),
+            NullLogger<ExternalServiceDiscoveryService>.Instance);
+
+        var response = await service.DiscoverAsync(new ExternalServiceDiscoveryRequest
+        {
+            Url = "https://wfs.example.test/geoserver/wfs?SERVICE=WFS&REQUEST=GetCapabilities",
+            TimeoutSeconds = 5
+        });
+
+        response.SourceKind.Should().Be("wfs");
+        response.ServiceType.Should().Be("WFS 2.0.0");
+        response.ServiceName.Should().Be("Honolulu WFS");
+        response.NormalizedUrl.Should().Be("https://wfs.example.test/geoserver/wfs?service=WFS&request=GetCapabilities");
+        response.Candidates.Should().ContainSingle();
+
+        var candidate = response.Candidates[0];
+        candidate.LayerId.Should().BeNull();
+        candidate.ExternalId.Should().Be("honua:parcels");
+        candidate.Name.Should().Be("honua:parcels");
+        candidate.Title.Should().Be("Parcels");
+        candidate.Description.Should().Be("Parcel polygons");
+        candidate.LayerType.Should().Be("feature-type");
+        candidate.Srid.Should().Be(4326);
+        candidate.Fields.Should().BeEmpty();
+        candidate.Extent.Should().BeEquivalentTo(new ExternalServiceExtent
+        {
+            XMin = -158.3,
+            YMin = 21.2,
+            XMax = -157.6,
+            YMax = 21.8,
+            Srid = 4326
+        });
+
+        factory.RequestedUrls.Should().BeEquivalentTo([
+            "https://wfs.example.test/geoserver/wfs?service=WFS&request=GetCapabilities"
+        ], options => options.WithStrictOrdering());
+    }
+
     internal static Dictionary<string, string> AllDiscoveryResponses()
     {
         var responses = ArcGisFeatureServerResponses();
         foreach (var (url, body) in OgcApiFeaturesResponses())
+        {
+            responses[url] = body;
+        }
+
+        foreach (var (url, body) in WfsGetCapabilitiesResponses())
         {
             responses[url] = body;
         }
@@ -204,6 +253,36 @@ public sealed class ExternalServiceDiscoveryServiceTests
                 }
               ]
             }
+            """
+        };
+
+    internal static Dictionary<string, string> WfsGetCapabilitiesResponses()
+        => new(StringComparer.Ordinal)
+        {
+            ["https://wfs.example.test/geoserver/wfs?service=WFS&request=GetCapabilities"] = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:WFS_Capabilities
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:ows="http://www.opengis.net/ows/1.1"
+                version="2.0.0">
+              <ows:ServiceIdentification>
+                <ows:Title>Honolulu WFS</ows:Title>
+                <ows:Abstract>WFS discovery fixture</ows:Abstract>
+              </ows:ServiceIdentification>
+              <wfs:FeatureTypeList>
+                <wfs:FeatureType>
+                  <wfs:Name>honua:parcels</wfs:Name>
+                  <wfs:Title>Parcels</wfs:Title>
+                  <wfs:Abstract>Parcel polygons</wfs:Abstract>
+                  <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::4326</wfs:DefaultCRS>
+                  <wfs:OtherCRS>urn:ogc:def:crs:EPSG::3857</wfs:OtherCRS>
+                  <ows:WGS84BoundingBox>
+                    <ows:LowerCorner>-158.3 21.2</ows:LowerCorner>
+                    <ows:UpperCorner>-157.6 21.8</ows:UpperCorner>
+                  </ows:WGS84BoundingBox>
+                </wfs:FeatureType>
+              </wfs:FeatureTypeList>
+            </wfs:WFS_Capabilities>
             """
         };
 


### PR DESCRIPTION
## Issue Link
Fixes #977

## Summary
Adds a focused WFS discovery path to the admin external-service discovery contract so operators can inspect WFS GetCapabilities documents and select advertised feature-type candidates.

## Changes Made
- Detect WFS discovery requests from `service=WFS` query parameters or `/wfs` service paths.
- Parse WFS GetCapabilities with secure XML reader settings and return feature type candidates with title, SRID, extent, and service metadata.
- Add focused service and endpoint coverage for WFS discovery fixtures.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Focused validation:
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~ExternalServiceDiscovery" --no-restore`
- `dotnet format Honua.sln`
- `git diff --check origin/trunk..HEAD`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

Adds the optional `title` field to external service layer candidates and expands admin discovery behavior for WFS services.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent focused local checks for this slice; full CI gate is running on the PR
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review