### PR TITLE
fix: guard GitOps watch commit processing (#992)

### DIFF
--- a/src/Honua.Core/Features/Metadata/Abstractions/IGitOpsWatchStore.cs
+++ b/src/Honua.Core/Features/Metadata/Abstractions/IGitOpsWatchStore.cs
@@ -31,6 +31,36 @@ public interface IGitOpsWatchStore
     Task<bool> UpdatePollStateAsync(Guid configId, string commitSha, DateTimeOffset polledAt, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Attempts to acquire the processing lease for a specific configuration commit.
+    /// </summary>
+    Task<bool> TryAcquireCommitProcessingLeaseAsync(
+        Guid configId,
+        string commitSha,
+        Guid leaseId,
+        DateTimeOffset acquiredAt,
+        DateTimeOffset leaseExpiresAt,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks a leased commit as observed and releases the processing lease atomically.
+    /// </summary>
+    Task<bool> CompleteCommitProcessingAsync(
+        Guid configId,
+        string commitSha,
+        Guid leaseId,
+        DateTimeOffset polledAt,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Releases the processing lease for a commit that should be retried later.
+    /// </summary>
+    Task<bool> ReleaseCommitProcessingLeaseAsync(
+        Guid configId,
+        string commitSha,
+        Guid leaseId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Records a detected change from the watched repository.
     /// </summary>
     Task<GitOpsChangeRecord> CreateChangeRecordAsync(GitOpsChangeRecord record, CancellationToken cancellationToken = default);

--- a/src/Honua.Postgres/Features/Metadata/PostgresGitOpsWatchStore.cs
+++ b/src/Honua.Postgres/Features/Metadata/PostgresGitOpsWatchStore.cs
@@ -49,7 +49,11 @@ internal sealed class PostgresGitOpsWatchStore : IGitOpsWatchStore
                 prune_enabled = EXCLUDED.prune_enabled,
                 enabled = EXCLUDED.enabled,
                 configured_by = EXCLUDED.configured_by,
-                updated_at = EXCLUDED.updated_at
+                updated_at = EXCLUDED.updated_at,
+                processing_commit_sha = NULL,
+                processing_lease_id = NULL,
+                processing_started_at = NULL,
+                processing_lease_expires_at = NULL
             RETURNING config_id
             """;
 
@@ -120,6 +124,100 @@ internal sealed class PostgresGitOpsWatchStore : IGitOpsWatchStore
         command.Parameters.AddWithValue("@configId", configId);
         command.Parameters.AddWithValue("@commitSha", commitSha);
         command.Parameters.AddWithValue("@polledAt", polledAt);
+
+        var affected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return affected > 0;
+    }
+
+    public async Task<bool> TryAcquireCommitProcessingLeaseAsync(
+        Guid configId,
+        string commitSha,
+        Guid leaseId,
+        DateTimeOffset acquiredAt,
+        DateTimeOffset leaseExpiresAt,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            UPDATE {_configTable}
+            SET processing_commit_sha = @commitSha,
+                processing_lease_id = @leaseId,
+                processing_started_at = @acquiredAt,
+                processing_lease_expires_at = @leaseExpiresAt
+            WHERE config_id = @configId
+              AND enabled = TRUE
+              AND last_known_commit_sha IS DISTINCT FROM @commitSha
+              AND (
+                  processing_commit_sha IS NULL
+                  OR processing_lease_expires_at IS NULL
+                  OR processing_lease_expires_at <= @acquiredAt
+              )
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@configId", configId);
+        command.Parameters.AddWithValue("@commitSha", commitSha);
+        command.Parameters.AddWithValue("@leaseId", leaseId);
+        command.Parameters.AddWithValue("@acquiredAt", acquiredAt);
+        command.Parameters.AddWithValue("@leaseExpiresAt", leaseExpiresAt);
+
+        var affected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return affected > 0;
+    }
+
+    public async Task<bool> CompleteCommitProcessingAsync(
+        Guid configId,
+        string commitSha,
+        Guid leaseId,
+        DateTimeOffset polledAt,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            UPDATE {_configTable}
+            SET last_known_commit_sha = @commitSha,
+                last_polled_at = @polledAt,
+                processing_commit_sha = NULL,
+                processing_lease_id = NULL,
+                processing_started_at = NULL,
+                processing_lease_expires_at = NULL
+            WHERE config_id = @configId
+              AND processing_commit_sha = @commitSha
+              AND processing_lease_id = @leaseId
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@configId", configId);
+        command.Parameters.AddWithValue("@commitSha", commitSha);
+        command.Parameters.AddWithValue("@leaseId", leaseId);
+        command.Parameters.AddWithValue("@polledAt", polledAt);
+
+        var affected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return affected > 0;
+    }
+
+    public async Task<bool> ReleaseCommitProcessingLeaseAsync(
+        Guid configId,
+        string commitSha,
+        Guid leaseId,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            UPDATE {_configTable}
+            SET processing_commit_sha = NULL,
+                processing_lease_id = NULL,
+                processing_started_at = NULL,
+                processing_lease_expires_at = NULL
+            WHERE config_id = @configId
+              AND processing_commit_sha = @commitSha
+              AND processing_lease_id = @leaseId
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@configId", configId);
+        command.Parameters.AddWithValue("@commitSha", commitSha);
+        command.Parameters.AddWithValue("@leaseId", leaseId);
 
         var affected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         return affected > 0;

--- a/src/Honua.Server/Features/Admin/GitOpsWatchService.cs
+++ b/src/Honua.Server/Features/Admin/GitOpsWatchService.cs
@@ -19,6 +19,9 @@ internal sealed partial class GitOpsWatchService : BackgroundService
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly GitOpsWatchOptions _options;
     private readonly ILogger<GitOpsWatchService> _logger;
+    private const string ManifestApplyFailedErrorMessage = "Manifest apply failed.";
+    private static readonly TimeSpan MinimumCommitProcessingLeaseDuration = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan MaximumCommitProcessingLeaseDuration = TimeSpan.FromMinutes(15);
 
     public GitOpsWatchService(
         IServiceScopeFactory scopeFactory,
@@ -94,64 +97,133 @@ internal sealed partial class GitOpsWatchService : BackgroundService
 
         LogPollNewCommit(_logger, config.RepositoryUrl, latestCommit.Sha);
 
-        if (!GitOpsWatchManifestPath.TryNormalize(config.ManifestPath, out var manifestPath, out var manifestPathError))
+        var leaseId = Guid.NewGuid();
+        var leaseAcquiredAt = DateTimeOffset.UtcNow;
+        var leaseExpiresAt = leaseAcquiredAt.Add(GetCommitProcessingLeaseDuration(pollInterval));
+        var leaseAcquired = await watchStore.TryAcquireCommitProcessingLeaseAsync(
+            config.ConfigId,
+            latestCommit.Sha,
+            leaseId,
+            leaseAcquiredAt,
+            leaseExpiresAt,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!leaseAcquired)
         {
-            var errorMessage = manifestPathError ?? GitOpsWatchManifestPath.RelativePathErrorMessage;
-            await RecordManifestPathFailureAsync(watchStore, config, latestCommit, errorMessage, cancellationToken)
-                .ConfigureAwait(false);
-            LogManifestPathRejected(_logger, config.RepositoryUrl, errorMessage);
+            LogCommitProcessingLeaseSkipped(_logger, latestCommit.Sha);
             return pollInterval;
         }
 
-        var fetchResult = await FetchManifestContentAsync(config, manifestPath, latestCommit.Sha, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (fetchResult == null)
+        var leaseCompleted = false;
+        try
         {
-            // Leave the commit unobserved so transient fetch, path, or parse failures retry on the next poll.
-            LogManifestFetchFailed(_logger, config.RepositoryUrl, manifestPath);
-            return pollInterval;
-        }
-
-        // Populate commit metadata from the fetched commit
-        latestCommit = new GitCommitInfo
-        {
-            Sha = latestCommit.Sha,
-            Author = fetchResult.CommitAuthor,
-            Message = fetchResult.CommitMessage,
-            Timestamp = fetchResult.CommitTimestamp
-        };
-
-        // Get previous manifest for diff
-        JsonElement? previousManifest = null;
-        if (!string.IsNullOrEmpty(config.LastKnownCommitSha))
-        {
-            var lastChanges = await watchStore.ListChangeRecordsAsync(1, 0, cancellationToken).ConfigureAwait(false);
-            if (lastChanges.Count > 0)
+            if (!GitOpsWatchManifestPath.TryNormalize(config.ManifestPath, out var manifestPath, out var manifestPathError))
             {
-                previousManifest = lastChanges[0].ManifestAfter;
+                var errorMessage = manifestPathError ?? GitOpsWatchManifestPath.RelativePathErrorMessage;
+                await RecordManifestPathFailureAsync(watchStore, config, latestCommit, errorMessage, cancellationToken)
+                    .ConfigureAwait(false);
+                LogManifestPathRejected(_logger, config.RepositoryUrl, errorMessage);
+                return pollInterval;
+            }
+
+            var fetchResult = await FetchManifestContentAsync(config, manifestPath, latestCommit.Sha, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (fetchResult == null)
+            {
+                // Leave the commit unobserved so transient fetch, path, or parse failures retry on the next poll.
+                LogManifestFetchFailed(_logger, config.RepositoryUrl, manifestPath);
+                return pollInterval;
+            }
+
+            // Populate commit metadata from the fetched commit
+            latestCommit = new GitCommitInfo
+            {
+                Sha = latestCommit.Sha,
+                Author = fetchResult.CommitAuthor,
+                Message = fetchResult.CommitMessage,
+                Timestamp = fetchResult.CommitTimestamp
+            };
+
+            // Get previous manifest for diff
+            JsonElement? previousManifest = null;
+            if (!string.IsNullOrEmpty(config.LastKnownCommitSha))
+            {
+                var lastChanges = await watchStore.ListChangeRecordsAsync(1, 0, cancellationToken).ConfigureAwait(false);
+                if (lastChanges.Count > 0)
+                {
+                    previousManifest = lastChanges[0].ManifestAfter;
+                }
+            }
+
+            var now = DateTimeOffset.UtcNow;
+
+            var manifest = fetchResult.ManifestContent;
+
+            var commitObserved = config.ApprovalRequired
+                ? await HandleApprovalRequiredAsync(scope, watchStore, config, latestCommit, manifest, previousManifest, now, cancellationToken)
+                    .ConfigureAwait(false)
+                : await HandleAutoApplyAsync(scope, watchStore, config, latestCommit, manifest, previousManifest, now, cancellationToken)
+                    .ConfigureAwait(false);
+
+            if (!commitObserved)
+            {
+                return pollInterval;
+            }
+
+            leaseCompleted = await watchStore.CompleteCommitProcessingAsync(
+                config.ConfigId,
+                latestCommit.Sha,
+                leaseId,
+                now,
+                cancellationToken).ConfigureAwait(false);
+            if (!leaseCompleted)
+            {
+                LogCommitProcessingLeaseLost(_logger, latestCommit.Sha);
+            }
+
+            return pollInterval;
+        }
+        finally
+        {
+            if (!leaseCompleted)
+            {
+                try
+                {
+                    await watchStore.ReleaseCommitProcessingLeaseAsync(
+                        config.ConfigId,
+                        latestCommit.Sha,
+                        leaseId,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // Cancellation can leave the lease for another node to reclaim after expiry.
+                }
+                catch (Exception ex)
+                {
+                    LogCommitProcessingLeaseReleaseFailed(_logger, latestCommit.Sha, ex);
+                }
             }
         }
+    }
 
-        var now = DateTimeOffset.UtcNow;
-
-        var manifest = fetchResult.ManifestContent;
-
-        var commitObserved = config.ApprovalRequired
-            ? await HandleApprovalRequiredAsync(scope, watchStore, config, latestCommit, manifest, previousManifest, now, cancellationToken)
-                .ConfigureAwait(false)
-            : await HandleAutoApplyAsync(scope, watchStore, config, latestCommit, manifest, previousManifest, now, cancellationToken)
-                .ConfigureAwait(false);
-
-        if (!commitObserved)
+    private static TimeSpan GetCommitProcessingLeaseDuration(TimeSpan pollInterval)
+    {
+        if (pollInterval <= TimeSpan.Zero)
         {
-            return pollInterval;
+            return MinimumCommitProcessingLeaseDuration;
         }
 
-        await watchStore.UpdatePollStateAsync(config.ConfigId, latestCommit.Sha, now, cancellationToken)
-            .ConfigureAwait(false);
+        var leaseDuration = pollInterval + pollInterval;
+        if (leaseDuration < MinimumCommitProcessingLeaseDuration)
+        {
+            return MinimumCommitProcessingLeaseDuration;
+        }
 
-        return pollInterval;
+        return leaseDuration > MaximumCommitProcessingLeaseDuration
+            ? MaximumCommitProcessingLeaseDuration
+            : leaseDuration;
     }
 
     private async Task<bool> HandleApprovalRequiredAsync(
@@ -334,7 +406,7 @@ internal sealed partial class GitOpsWatchService : BackgroundService
                 ManifestBefore = previousManifest,
                 ManifestAfter = manifestContent,
                 Status = GitOpsChangeStatus.Failed,
-                ErrorMessage = ex.Message,
+                ErrorMessage = ManifestApplyFailedErrorMessage,
                 DetectedAt = now
             };
             await watchStore.CreateChangeRecordAsync(failedRecord, cancellationToken).ConfigureAwait(false);
@@ -828,4 +900,13 @@ internal sealed partial class GitOpsWatchService : BackgroundService
 
     [LoggerMessage(EventId = 9411, Level = LogLevel.Error, Message = "GitOps auto-apply failed for commit {CommitSha}.")]
     private static partial void LogApplyFailed(ILogger logger, string commitSha, Exception exception);
+
+    [LoggerMessage(EventId = 9414, Level = LogLevel.Debug, Message = "GitOps commit processing lease was not acquired for commit {CommitSha}.")]
+    private static partial void LogCommitProcessingLeaseSkipped(ILogger logger, string commitSha);
+
+    [LoggerMessage(EventId = 9415, Level = LogLevel.Warning, Message = "GitOps commit processing lease was lost before commit {CommitSha} could be marked observed.")]
+    private static partial void LogCommitProcessingLeaseLost(ILogger logger, string commitSha);
+
+    [LoggerMessage(EventId = 9416, Level = LogLevel.Warning, Message = "GitOps commit processing lease release failed for commit {CommitSha}.")]
+    private static partial void LogCommitProcessingLeaseReleaseFailed(ILogger logger, string commitSha, Exception exception);
 }

--- a/src/Honua.Server/Migrations/027_AddGitOpsWatchProcessingGuard.sql
+++ b/src/Honua.Server/Migrations/027_AddGitOpsWatchProcessingGuard.sql
@@ -1,0 +1,25 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration: 027_AddGitOpsWatchProcessingGuard.sql
+-- Description: Adds a leased processing guard for GitOps watch commits.
+-- Dependencies: Requires 017_AddGitOpsWatch.sql.
+
+ALTER TABLE honua.gitops_watch_configs
+    ADD COLUMN IF NOT EXISTS processing_commit_sha TEXT,
+    ADD COLUMN IF NOT EXISTS processing_lease_id UUID,
+    ADD COLUMN IF NOT EXISTS processing_started_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS processing_lease_expires_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_gitops_watch_configs_processing_lease
+    ON honua.gitops_watch_configs(processing_lease_expires_at)
+    WHERE processing_commit_sha IS NOT NULL;
+
+COMMENT ON COLUMN honua.gitops_watch_configs.processing_commit_sha IS
+    'Commit SHA currently leased for GitOps watch processing.';
+COMMENT ON COLUMN honua.gitops_watch_configs.processing_lease_id IS
+    'Opaque lease token held by the node processing processing_commit_sha.';
+COMMENT ON COLUMN honua.gitops_watch_configs.processing_started_at IS
+    'Timestamp when the current GitOps watch processing lease was acquired.';
+COMMENT ON COLUMN honua.gitops_watch_configs.processing_lease_expires_at IS
+    'Timestamp after which another node may acquire GitOps watch processing for a commit.';

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/GitOpsWatchEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/GitOpsWatchEndpointsTests.cs
@@ -321,6 +321,121 @@ public sealed class GitOpsWatchEndpointsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.Metadata)]
+    [Endpoint("POST /api/v1/admin/gitops/watch")]
+    public async Task GitOpsWatchStore_CommitProcessingLease_AllowsOneActiveProcessor()
+    {
+        using var scope = _fixture.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IGitOpsWatchStore>();
+        var config = await store.UpsertConfigAsync(new GitOpsWatchConfig
+        {
+            ConfigId = Guid.NewGuid(),
+            RepositoryUrl = "https://github.com/example/lease-test.git",
+            Branch = "main",
+            ManifestPath = "manifests/",
+            PollIntervalSeconds = 60,
+            Enabled = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+
+        const string commitSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        var now = DateTimeOffset.UtcNow;
+        var firstLeaseId = Guid.NewGuid();
+        var secondLeaseId = Guid.NewGuid();
+
+        var firstAcquired = await store.TryAcquireCommitProcessingLeaseAsync(
+            config.ConfigId,
+            commitSha,
+            firstLeaseId,
+            now,
+            now.AddMinutes(5));
+        var secondAcquired = await store.TryAcquireCommitProcessingLeaseAsync(
+            config.ConfigId,
+            commitSha,
+            secondLeaseId,
+            now.AddSeconds(1),
+            now.AddMinutes(5));
+
+        firstAcquired.Should().BeTrue();
+        secondAcquired.Should().BeFalse();
+
+        var completed = await store.CompleteCommitProcessingAsync(
+            config.ConfigId,
+            commitSha,
+            firstLeaseId,
+            now.AddSeconds(2));
+
+        completed.Should().BeTrue();
+        var currentConfig = await store.GetConfigAsync();
+        currentConfig!.LastKnownCommitSha.Should().Be(commitSha);
+
+        var alreadyObservedAcquire = await store.TryAcquireCommitProcessingLeaseAsync(
+            config.ConfigId,
+            commitSha,
+            Guid.NewGuid(),
+            now.AddSeconds(3),
+            now.AddMinutes(6));
+
+        alreadyObservedAcquire.Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("POST /api/v1/admin/gitops/watch")]
+    public async Task GitOpsWatchStore_ExpiredCommitProcessingLease_CanBeReplacedByNewOwner()
+    {
+        using var scope = _fixture.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IGitOpsWatchStore>();
+        var config = await store.UpsertConfigAsync(new GitOpsWatchConfig
+        {
+            ConfigId = Guid.NewGuid(),
+            RepositoryUrl = "https://github.com/example/expired-lease-test.git",
+            Branch = "main",
+            ManifestPath = "manifests/",
+            PollIntervalSeconds = 60,
+            Enabled = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+
+        const string commitSha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        var now = DateTimeOffset.UtcNow;
+        var expiredLeaseId = Guid.NewGuid();
+        var replacementLeaseId = Guid.NewGuid();
+
+        var expiredAcquired = await store.TryAcquireCommitProcessingLeaseAsync(
+            config.ConfigId,
+            commitSha,
+            expiredLeaseId,
+            now.AddMinutes(-10),
+            now.AddMinutes(-5));
+        var replacementAcquired = await store.TryAcquireCommitProcessingLeaseAsync(
+            config.ConfigId,
+            commitSha,
+            replacementLeaseId,
+            now,
+            now.AddMinutes(5));
+
+        expiredAcquired.Should().BeTrue();
+        replacementAcquired.Should().BeTrue();
+
+        var expiredComplete = await store.CompleteCommitProcessingAsync(
+            config.ConfigId,
+            commitSha,
+            expiredLeaseId,
+            now.AddSeconds(1));
+        var replacementComplete = await store.CompleteCommitProcessingAsync(
+            config.ConfigId,
+            commitSha,
+            replacementLeaseId,
+            now.AddSeconds(2));
+
+        expiredComplete.Should().BeFalse();
+        replacementComplete.Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
     [Endpoint("GET /api/v1/admin/gitops/changes/{id}")]
     public async Task GetChange_ReturnsSingleChange()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/GitOpsWatchServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/GitOpsWatchServiceTests.cs
@@ -73,6 +73,40 @@ public sealed class GitOpsWatchServiceTests : IDisposable
     }
 
     [UnitTest]
+    public async Task PollOnceAsync_ConcurrentPolls_ProcessCommitOnce()
+    {
+        var repoDir = await CreateLocalRepositoryAsync(("manifests/group.json", ValidGroupManifest));
+        var latestCommit = await RunGitForOutputAsync(repoDir, "rev-parse", "HEAD");
+        var watchStore = new TestGitOpsWatchStore(CreateConfig(repoDir, manifestPath: "manifests/group.json"));
+        var pendingStore = new TestManifestPendingChangeStore
+        {
+            PauseOnCreate = true
+        };
+
+        using var services = CreateServices(watchStore, pendingStore);
+        var service = CreateService(services);
+
+        var firstPoll = service.PollOnceAsync(CancellationToken.None);
+        await pendingStore.WaitForCreateStartedAsync().ConfigureAwait(false);
+
+        var secondPoll = service.PollOnceAsync(CancellationToken.None);
+        await secondPoll.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+
+        pendingStore.AllowCreate();
+        await firstPoll.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+
+        watchStore.PollStateUpdateCount.Should().Be(1);
+        watchStore.CurrentConfig.LastKnownCommitSha.Should().Be(latestCommit);
+        watchStore.ChangeRecords.Should().ContainSingle();
+        pendingStore.Changes.Should().ContainSingle();
+        watchStore.LeaseAcquireAttemptCount.Should().Be(2);
+        watchStore.LeaseAcquireSuccessCount.Should().Be(1);
+        watchStore.LeaseCompleteCount.Should().Be(1);
+        watchStore.LeaseReleaseCount.Should().Be(0);
+        watchStore.HasActiveLease.Should().BeFalse();
+    }
+
+    [UnitTest]
     public async Task PollOnceAsync_DirectoryManifestPath_UsesHonuaManifest()
     {
         var repoDir = await CreateLocalRepositoryAsync(("manifests/honua-manifest.json", ValidGroupManifest));
@@ -201,6 +235,9 @@ public sealed class GitOpsWatchServiceTests : IDisposable
         watchStore.ChangeRecords[0].ErrorMessage.Should().StartWith("Manifest parse failed:");
         watchStore.ChangeRecords[0].ErrorMessage.Should().NotContain(repoDir);
         watchStore.ChangeRecords[0].ManifestAfter.GetProperty("resources").ValueKind.Should().Be(JsonValueKind.Object);
+        watchStore.LeaseAcquireSuccessCount.Should().Be(2);
+        watchStore.LeaseReleaseCount.Should().Be(2);
+        watchStore.HasActiveLease.Should().BeFalse();
     }
 
     public void Dispose()
@@ -365,18 +402,51 @@ public sealed class GitOpsWatchServiceTests : IDisposable
 
     private sealed class TestGitOpsWatchStore(GitOpsWatchConfig config) : IGitOpsWatchStore
     {
+        private readonly object _gate = new();
         private GitOpsWatchConfig? _config = config;
         private readonly List<GitOpsChangeRecord> _changeRecords = [];
+        private string? _processingCommitSha;
+        private Guid? _processingLeaseId;
+        private DateTimeOffset? _processingLeaseExpiresAt;
 
-        public GitOpsWatchConfig CurrentConfig => _config ?? throw new InvalidOperationException("No config is stored.");
+        public GitOpsWatchConfig CurrentConfig
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _config ?? throw new InvalidOperationException("No config is stored.");
+                }
+            }
+        }
+
         public List<GitOpsChangeRecord> ChangeRecords => _changeRecords;
         public int PollStateUpdateCount { get; private set; }
+        public int LeaseAcquireAttemptCount { get; private set; }
+        public int LeaseAcquireSuccessCount { get; private set; }
+        public int LeaseCompleteCount { get; private set; }
+        public int LeaseReleaseCount { get; private set; }
+        public bool HasActiveLease
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _processingCommitSha != null;
+                }
+            }
+        }
 
         public Task<GitOpsWatchConfig> UpsertConfigAsync(GitOpsWatchConfig config, CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();
 
-        public Task<GitOpsWatchConfig?> GetConfigAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult(_config);
+        public Task<GitOpsWatchConfig?> GetConfigAsync(CancellationToken cancellationToken = default)
+        {
+            lock (_gate)
+            {
+                return Task.FromResult(_config);
+            }
+        }
 
         public Task<bool> DeleteConfigAsync(Guid configId, CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();
@@ -387,21 +457,105 @@ public sealed class GitOpsWatchServiceTests : IDisposable
             DateTimeOffset polledAt,
             CancellationToken cancellationToken = default)
         {
-            if (_config?.ConfigId != configId)
+            lock (_gate)
             {
-                return Task.FromResult(false);
-            }
+                if (_config?.ConfigId != configId)
+                {
+                    return Task.FromResult(false);
+                }
 
-            PollStateUpdateCount++;
-            _config = CopyConfigWithPollState(_config, commitSha, polledAt);
-            return Task.FromResult(true);
+                PollStateUpdateCount++;
+                _config = CopyConfigWithPollState(_config, commitSha, polledAt);
+                return Task.FromResult(true);
+            }
+        }
+
+        public Task<bool> TryAcquireCommitProcessingLeaseAsync(
+            Guid configId,
+            string commitSha,
+            Guid leaseId,
+            DateTimeOffset acquiredAt,
+            DateTimeOffset leaseExpiresAt,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_gate)
+            {
+                LeaseAcquireAttemptCount++;
+                if (_config?.ConfigId != configId || !_config.Enabled ||
+                    string.Equals(_config.LastKnownCommitSha, commitSha, StringComparison.Ordinal))
+                {
+                    return Task.FromResult(false);
+                }
+
+                if (_processingCommitSha != null &&
+                    _processingLeaseExpiresAt.HasValue &&
+                    _processingLeaseExpiresAt.Value > acquiredAt)
+                {
+                    return Task.FromResult(false);
+                }
+
+                _processingCommitSha = commitSha;
+                _processingLeaseId = leaseId;
+                _processingLeaseExpiresAt = leaseExpiresAt;
+                LeaseAcquireSuccessCount++;
+                return Task.FromResult(true);
+            }
+        }
+
+        public Task<bool> CompleteCommitProcessingAsync(
+            Guid configId,
+            string commitSha,
+            Guid leaseId,
+            DateTimeOffset polledAt,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_gate)
+            {
+                if (_config?.ConfigId != configId ||
+                    !string.Equals(_processingCommitSha, commitSha, StringComparison.Ordinal) ||
+                    _processingLeaseId != leaseId)
+                {
+                    return Task.FromResult(false);
+                }
+
+                PollStateUpdateCount++;
+                LeaseCompleteCount++;
+                _config = CopyConfigWithPollState(_config, commitSha, polledAt);
+                ClearLease();
+                return Task.FromResult(true);
+            }
+        }
+
+        public Task<bool> ReleaseCommitProcessingLeaseAsync(
+            Guid configId,
+            string commitSha,
+            Guid leaseId,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_gate)
+            {
+                if (_config?.ConfigId != configId ||
+                    !string.Equals(_processingCommitSha, commitSha, StringComparison.Ordinal) ||
+                    _processingLeaseId != leaseId)
+                {
+                    return Task.FromResult(false);
+                }
+
+                LeaseReleaseCount++;
+                ClearLease();
+                return Task.FromResult(true);
+            }
         }
 
         public Task<GitOpsChangeRecord> CreateChangeRecordAsync(
             GitOpsChangeRecord record,
             CancellationToken cancellationToken = default)
         {
-            _changeRecords.Add(record);
+            lock (_gate)
+            {
+                _changeRecords.Add(record);
+            }
+
             return Task.FromResult(record);
         }
 
@@ -413,11 +567,15 @@ public sealed class GitOpsWatchServiceTests : IDisposable
             int offset = 0,
             CancellationToken cancellationToken = default)
         {
-            var records = _changeRecords
-                .OrderByDescending(record => record.DetectedAt)
-                .Skip(offset)
-                .Take(limit)
-                .ToArray();
+            GitOpsChangeRecord[] records;
+            lock (_gate)
+            {
+                records = _changeRecords
+                    .OrderByDescending(record => record.DetectedAt)
+                    .Skip(offset)
+                    .Take(limit)
+                    .ToArray();
+            }
 
             return Task.FromResult<IReadOnlyList<GitOpsChangeRecord>>(records);
         }
@@ -430,20 +588,39 @@ public sealed class GitOpsWatchServiceTests : IDisposable
             DateTimeOffset? appliedAt,
             CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();
+
+        private void ClearLease()
+        {
+            _processingCommitSha = null;
+            _processingLeaseId = null;
+            _processingLeaseExpiresAt = null;
+        }
     }
 
     private sealed class TestManifestPendingChangeStore : IManifestPendingChangeStore
     {
         private readonly List<ManifestPendingChange> _changes = [];
+        private readonly TaskCompletionSource<bool> _createStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _allowCreate = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public List<ManifestPendingChange> Changes => _changes;
+        public bool PauseOnCreate { get; init; }
 
-        public Task<ManifestPendingChange> CreateAsync(
+        public Task<bool> WaitForCreateStartedAsync() => _createStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        public void AllowCreate() => _allowCreate.TrySetResult(true);
+
+        public async Task<ManifestPendingChange> CreateAsync(
             ManifestPendingChange pendingChange,
             CancellationToken cancellationToken = default)
         {
+            if (PauseOnCreate)
+            {
+                _createStarted.TrySetResult(true);
+                await _allowCreate.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+
             _changes.Add(pendingChange);
-            return Task.FromResult(pendingChange);
+            return pendingChange;
         }
 
         public Task<ManifestPendingChange?> GetAsync(Guid pendingId, CancellationToken cancellationToken = default) =>

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -442,11 +442,16 @@ sql:
           enabled BOOLEAN NOT NULL DEFAULT TRUE,
           last_known_commit_sha TEXT,
           last_polled_at TIMESTAMPTZ,
+          processing_commit_sha TEXT,
+          processing_lease_id UUID,
+          processing_started_at TIMESTAMPTZ,
+          processing_lease_expires_at TIMESTAMPTZ,
           configured_by TEXT,
           created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
           updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
       );
   - "CREATE UNIQUE INDEX IF NOT EXISTS idx_gitops_watch_configs_singleton ON honua.gitops_watch_configs ((TRUE));"
+  - "CREATE INDEX IF NOT EXISTS idx_gitops_watch_configs_processing_lease ON honua.gitops_watch_configs(processing_lease_expires_at) WHERE processing_commit_sha IS NOT NULL;"
   - |
       CREATE TABLE IF NOT EXISTS honua.gitops_change_records (
           change_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## Issue Link
Related to #992

## Summary
Adds a distributed processing lease around GitOps Watch commit handling so concurrent nodes do not process the same commit more than once, while preserving retry behavior for fetch, parse, and apply failures.

## Changes Made
- Adds Postgres-backed commit processing lease acquisition, completion, release, and expiry handling for GitOps Watch configs.
- Updates GitOps Watch polling to complete observed commits only after successful queue/apply handling and to release leases on retryable failures.
- Adds migration coverage, seed config columns, and service/endpoint tests for duplicate-processing, lease expiry, retry release, and sanitized apply failures.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation run locally:
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter GitOpsWatch --no-restore` passed, 33 tests.
- `dotnet format Honua.sln` passed in the implementation worktree before publishing.
- `dotnet format Honua.sln --verify-no-changes --verbosity diagnostic` passed in the implementation worktree before publishing.
- `git diff --check HEAD~1..HEAD` passed.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [x] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [x] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent focused local checks: format, focused GitOps Watch integration tests, and diff whitespace validation all passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review
