### PR TITLE
feat: add layer field visibility persistence (#976)

### DIFF
--- a/docker/cite/shared/test-data/01-init-cite-test-data.sql
+++ b/docker/cite/shared/test-data/01-init-cite-test-data.sql
@@ -61,6 +61,8 @@ CREATE TABLE IF NOT EXISTS honua.layer_fields (
     nullable BOOLEAN NOT NULL DEFAULT TRUE,
     default_value TEXT,
     description TEXT,
+    domain JSONB,
+    hidden BOOLEAN NOT NULL DEFAULT FALSE,
     PRIMARY KEY (layer_id, field_name)
 );
 

--- a/docker/cite/wcs20/seed.sql
+++ b/docker/cite/wcs20/seed.sql
@@ -92,6 +92,8 @@ CREATE TABLE IF NOT EXISTS honua.layer_fields (
     nullable BOOLEAN NOT NULL DEFAULT TRUE,
     default_value TEXT,
     description TEXT,
+    domain JSONB,
+    hidden BOOLEAN NOT NULL DEFAULT FALSE,
     PRIMARY KEY (layer_id, field_name)
 );
 

--- a/src/Honua.Core/Features/Admin/Abstractions/ILayerFieldConfigurationStore.cs
+++ b/src/Honua.Core/Features/Admin/Abstractions/ILayerFieldConfigurationStore.cs
@@ -21,7 +21,7 @@ public interface ILayerFieldConfigurationStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Updates aliases and domains for the supplied fields and returns the full layer configuration.
+    /// Updates aliases, domains, and visibility for the supplied fields and returns the full layer configuration.
     /// </summary>
     /// <param name="layerId">Layer identifier.</param>
     /// <param name="updates">Field configuration updates to apply.</param>

--- a/src/Honua.Core/Features/Admin/Domain/LayerFieldConfigurationModels.cs
+++ b/src/Honua.Core/Features/Admin/Domain/LayerFieldConfigurationModels.cs
@@ -11,10 +11,12 @@ namespace Honua.Core.Features.Admin.Domain;
 /// <param name="Name">Field name.</param>
 /// <param name="Alias">Optional field alias displayed by protocol metadata surfaces.</param>
 /// <param name="Domain">Optional coded-value domain for the field.</param>
+/// <param name="Hidden">Whether public protocol output should omit the field.</param>
 public sealed record LayerFieldConfiguration(
     string Name,
     string? Alias,
-    FieldDomainDefinition? Domain);
+    FieldDomainDefinition? Domain,
+    bool Hidden);
 
 /// <summary>
 /// Operator-managed display metadata update for a layer field.
@@ -22,7 +24,9 @@ public sealed record LayerFieldConfiguration(
 /// <param name="Name">Field name.</param>
 /// <param name="Alias">Optional field alias displayed by protocol metadata surfaces.</param>
 /// <param name="Domain">Optional coded-value domain for the field.</param>
+/// <param name="Hidden">Optional hidden-field update. Null preserves the current value.</param>
 public sealed record LayerFieldConfigurationUpdate(
     string Name,
     string? Alias,
-    FieldDomainDefinition? Domain);
+    FieldDomainDefinition? Domain,
+    bool? Hidden);

--- a/src/Honua.Core/Features/Catalog/Domain/FieldDefinition.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/FieldDefinition.cs
@@ -13,6 +13,7 @@ namespace Honua.Core.Features.Catalog.Domain;
 /// <param name="DefaultValue">Default value for the field (optional)</param>
 /// <param name="Description">Human-readable description of the field (optional)</param>
 /// <param name="Domain">Optional schema-defined domain for the field.</param>
+/// <param name="IsHidden">Whether public protocol output should omit the field.</param>
 public record FieldDefinition(
     string Name,
     FieldType Type,
@@ -20,7 +21,8 @@ public record FieldDefinition(
     bool Nullable = true,
     object? DefaultValue = null,
     string? Description = null,
-    FieldDomainDefinition? Domain = null)
+    FieldDomainDefinition? Domain = null,
+    bool IsHidden = false)
 {
     /// <summary>
     /// Display name for the field (uses Name if not specified)
@@ -31,6 +33,11 @@ public record FieldDefinition(
     /// Whether this field is a geometry field
     /// </summary>
     public bool IsGeometry => Type == FieldType.Geometry;
+
+    /// <summary>
+    /// Whether this field is visible in public protocol metadata and feature output.
+    /// </summary>
+    public bool IsVisible => !IsHidden;
 
     /// <summary>
     /// Type name suitable for GeoServices REST API responses

--- a/src/Honua.Core/Features/Catalog/Domain/LayerDefinition.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/LayerDefinition.cs
@@ -46,6 +46,16 @@ public record LayerDefinition(
     public FieldDefinition? GeometryField => Fields.FirstOrDefault(f => f.IsGeometry);
 
     /// <summary>
+    /// Fields visible in public protocol metadata and feature output.
+    /// </summary>
+    public FieldDefinition[] VisibleFields => Fields.Where(f => f.IsVisible).ToArray();
+
+    /// <summary>
+    /// Visible non-geometry attribute fields.
+    /// </summary>
+    public FieldDefinition[] VisibleAttributeFields => Fields.Where(f => !f.IsGeometry && f.IsVisible).ToArray();
+
+    /// <summary>
     /// Non-geometry attribute fields
     /// </summary>
     public FieldDefinition[] AttributeFields => Fields.Where(f => !f.IsGeometry).ToArray();

--- a/src/Honua.Postgres/Features/Admin/PostgresLayerFieldConfigurationStore.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgresLayerFieldConfigurationStore.cs
@@ -47,12 +47,14 @@ internal sealed class PostgresLayerFieldConfigurationStore : ILayerFieldConfigur
         const string fieldNameParameter = "fieldName";
         const string aliasParameter = "alias";
         const string domainParameter = "domain";
+        const string hiddenParameter = "hidden";
 
         string sql = $"""
             UPDATE {_fieldsTable}
             SET
                 description = @{aliasParameter},
-                domain = @{domainParameter}
+                domain = @{domainParameter},
+                hidden = COALESCE(@{hiddenParameter}, hidden)
             WHERE layer_id = @layerId
               AND field_name = @{fieldNameParameter}
             """;
@@ -67,6 +69,8 @@ internal sealed class PostgresLayerFieldConfigurationStore : ILayerFieldConfigur
             domain.Value = update.Domain is null
                 ? DBNull.Value
                 : JsonSerializer.Serialize(update.Domain, CatalogJsonContext.Default.FieldDomainDefinition);
+            var hidden = command.Parameters.Add(hiddenParameter, NpgsqlDbType.Boolean);
+            hidden.Value = update.Hidden.HasValue ? update.Hidden.Value : DBNull.Value;
 
             await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -91,7 +95,7 @@ internal sealed class PostgresLayerFieldConfigurationStore : ILayerFieldConfigur
         CancellationToken cancellationToken)
     {
         string sql = $"""
-            SELECT field_name, description, domain
+            SELECT field_name, description, domain, hidden
             FROM {_fieldsTable}
             WHERE layer_id = @layerId
             ORDER BY field_order
@@ -114,8 +118,9 @@ internal sealed class PostgresLayerFieldConfigurationStore : ILayerFieldConfigur
                 : JsonSerializer.Deserialize(
                     reader.GetString(domainOrdinal),
                     CatalogJsonContext.Default.FieldDomainDefinition);
+            bool hidden = reader.GetBoolean(reader.GetOrdinal("hidden"));
 
-            fields.Add(new LayerFieldConfiguration(name, alias, domain));
+            fields.Add(new LayerFieldConfiguration(name, alias, domain, hidden));
         }
 
         return fields;

--- a/src/Honua.Postgres/Features/Catalog/PostgresLayerCatalog.cs
+++ b/src/Honua.Postgres/Features/Catalog/PostgresLayerCatalog.cs
@@ -334,7 +334,8 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
                 f.nullable,
                 f.default_value,
                 f.description,
-                f.domain
+                f.domain,
+                f.hidden
             FROM {_fieldsTable} f
             WHERE f.layer_id = @layerId
             ORDER BY f.field_order
@@ -369,7 +370,8 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
                 f.nullable,
                 f.default_value,
                 f.description,
-                f.domain
+                f.domain,
+                f.hidden
             FROM {_fieldsTable} f
             WHERE f.layer_id = ANY(@layerIds)
             ORDER BY f.layer_id, f.field_order
@@ -674,8 +676,9 @@ internal sealed class PostgresLayerCatalog : ILayerCatalog
             : JsonSerializer.Deserialize(
                 reader.GetString(domainOrdinal),
                 CatalogJsonContext.Default.FieldDomainDefinition);
+        bool hidden = reader.GetBoolean(reader.GetOrdinal("hidden"));
 
-        return new FieldDefinition(fieldName, fieldType, maxLength, nullable, defaultValue, description, domain);
+        return new FieldDefinition(fieldName, fieldType, maxLength, nullable, defaultValue, description, domain, hidden);
     }
 
     private static LayerDefinition PopulateLayerDetails(

--- a/src/Honua.Server/Features/Admin/AdminLayerFieldConfigurationEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AdminLayerFieldConfigurationEndpoints.cs
@@ -4,6 +4,7 @@
 using Honua.Core.Features.Admin.Abstractions;
 using Honua.Core.Features.Admin.Domain;
 using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Shared.Models;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Server.Features.Admin.Models;
 using Honua.Server.Features.Infrastructure.Authentication;
@@ -41,7 +42,7 @@ internal static class AdminLayerFieldConfigurationEndpoints
 
         _ = group.MapPut("/{layerId:int}/fields", HandleUpdateLayerFields)
             .WithName("UpdateAdminLayerFields")
-            .WithSummary("Update persisted layer field aliases and coded-value domains")
+            .WithSummary("Update persisted layer field aliases, coded-value domains, and visibility")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Put }));
     }
 
@@ -91,7 +92,8 @@ internal static class AdminLayerFieldConfigurationEndpoints
             .Select(field => new LayerFieldConfigurationUpdate(
                 field.Name.Trim(),
                 NormalizeAlias(field.Alias),
-                field.Domain))
+                field.Domain,
+                field.Hidden))
             .ToArray();
 
         var configurations = await fieldConfigurationStore.UpdateFieldConfigurationsAsync(
@@ -147,7 +149,7 @@ internal static class AdminLayerFieldConfigurationEndpoints
             }
 
             var fieldName = field.Name.Trim();
-            if (!knownFields.ContainsKey(fieldName))
+            if (!knownFields.TryGetValue(fieldName, out var layerField))
             {
                 return $"Field '{fieldName}' does not exist on layer {layer.Id}.";
             }
@@ -162,6 +164,11 @@ internal static class AdminLayerFieldConfigurationEndpoints
                 return $"Alias for field '{fieldName}' must be {MaxFieldAliasLength} characters or fewer.";
             }
 
+            if (field.Hidden == true && IsRequiredProtocolField(layer, layerField))
+            {
+                return $"Field '{fieldName}' cannot be hidden because it is required by public protocol contracts.";
+            }
+
             var domainError = ValidateDomain(fieldName, field.Domain);
             if (domainError != null)
             {
@@ -171,6 +178,11 @@ internal static class AdminLayerFieldConfigurationEndpoints
 
         return null;
     }
+
+    private static bool IsRequiredProtocolField(LayerDefinition layer, FieldDefinition field)
+        => field.IsGeometry
+           || field.Name.Equals(layer.ObjectIdFieldName, StringComparison.OrdinalIgnoreCase)
+           || field.Name.Equals(FieldNames.ObjectId, StringComparison.OrdinalIgnoreCase);
 
     private static string? ValidateDomain(string fieldName, FieldDomainDefinition? domain)
     {
@@ -235,7 +247,8 @@ internal static class AdminLayerFieldConfigurationEndpoints
                     Name = field.Name,
                     Type = field.Type.ToString(),
                     Alias = configuration is null ? field.Description : configuration.Alias,
-                    Domain = configuration is null ? field.Domain : configuration.Domain
+                    Domain = configuration is null ? field.Domain : configuration.Domain,
+                    Hidden = configuration is null ? field.IsHidden : configuration.Hidden
                 };
             })
             .ToArray();

--- a/src/Honua.Server/Features/Admin/Models/LayerFieldConfigurationModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/LayerFieldConfigurationModels.cs
@@ -35,6 +35,11 @@ public sealed class LayerFieldConfigurationUpdateItem
     /// Optional coded-value domain for the field. Null clears the domain.
     /// </summary>
     public FieldDomainDefinition? Domain { get; init; }
+
+    /// <summary>
+    /// Optional hidden-field flag. Null preserves the current value.
+    /// </summary>
+    public bool? Hidden { get; init; }
 }
 
 /// <summary>
@@ -77,4 +82,9 @@ public sealed class LayerFieldConfigurationItem
     /// Optional coded-value domain for the field.
     /// </summary>
     public FieldDomainDefinition? Domain { get; init; }
+
+    /// <summary>
+    /// Whether public protocol output should omit the field.
+    /// </summary>
+    public bool Hidden { get; init; }
 }

--- a/src/Honua.Server/Features/Infrastructure/GeoJson/GeoJsonFeatureBaseBuilder.cs
+++ b/src/Honua.Server/Features/Infrastructure/GeoJson/GeoJsonFeatureBaseBuilder.cs
@@ -67,8 +67,14 @@ internal static class GeoJsonFeatureBaseBuilder
         var projectedProperties = options.ProjectedProperties;
         var shouldProjectAll = projectedProperties is null;
         var shouldIncludeObjectId = options.IncludeObjectIdProperty;
+        var declaredAttributeFields = layer.AttributeFields
+            .Select(static field => field.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var visibleAttributeFields = layer.VisibleAttributeFields
+            .Select(static field => field.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var field in layer.AttributeFields)
+        foreach (var field in layer.VisibleAttributeFields)
         {
             var fieldName = field.Name;
             var isObjectIdField = fieldName.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase);
@@ -108,6 +114,11 @@ internal static class GeoJsonFeatureBaseBuilder
                 }
 
                 if (ContainsKeyIgnoreCase(properties, fieldName))
+                {
+                    continue;
+                }
+
+                if (declaredAttributeFields.Contains(fieldName) && !visibleAttributeFields.Contains(fieldName))
                 {
                     continue;
                 }

--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
@@ -475,8 +475,7 @@ internal static partial class FeatureServerEndpoints
         }
 
         var domains = FilterAccessibleLayers(context, service, selectedLayers)
-            .SelectMany(static layer => layer.Fields
-                .Where(static field => !field.IsGeometry)
+            .SelectMany(static layer => layer.VisibleAttributeFields
                 .Select(field => MapQueryDomainInfo(layer, field))
                 .Where(static domain => domain != null)!
                 .Cast<DomainInfo>())

--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/FeatureServerUtilities.cs
@@ -259,7 +259,7 @@ internal static partial class FeatureServerEndpoints
             MaxRecordCount = queryLimits.MaxRecordCount,
             SupportedQueryFormats = NormalizeSupportedQueryFormats(service.SupportedFormats, supportsGeobufOutput),
             Capabilities = BuildServiceCapabilities(service, supportsAttachmentUploads),
-            Fields = [.. service.AllFields.Select(MapFieldInfo)],
+            Fields = [.. service.Layers.SelectMany(static layer => layer.VisibleFields).Select(MapFieldInfo)],
             ObjectIdField = objectIdField,
             SupportsAdvancedQueries = supportsAdvancedQueries,
             SupportsStatistics = supportsStatistics,
@@ -274,14 +274,14 @@ internal static partial class FeatureServerEndpoints
     /// </summary>
     private static string ResolveDisplayFieldFromLayer(LayerDefinition layer, string objectIdField)
     {
-        var preferredNameField = layer.Fields.FirstOrDefault(
+        var preferredNameField = layer.VisibleAttributeFields.FirstOrDefault(
             field => field.Name.Equals("name", StringComparison.OrdinalIgnoreCase));
         if (preferredNameField != null)
         {
             return preferredNameField.Name;
         }
 
-        var firstStringField = layer.Fields.FirstOrDefault(
+        var firstStringField = layer.VisibleAttributeFields.FirstOrDefault(
             field => field.GeoServicesType.Equals("esriFieldTypeString", StringComparison.OrdinalIgnoreCase));
         return firstStringField?.Name ?? objectIdField;
     }
@@ -328,7 +328,7 @@ internal static partial class FeatureServerEndpoints
             Extent = layer.Extent.HasValue ? layer.Extent.Value.ToExtentInfo() : null,
             TimeInfo = timeInfo,
             ExtrusionInfo = extrusionInfo,
-            Fields = [.. layer.Fields.Select(MapFieldInfo)],
+            Fields = [.. layer.VisibleFields.Select(MapFieldInfo)],
             MaxRecordCount = queryLimits.MaxRecordCount,
             ObjectIdField = objectIdField,
             DisplayField = displayField,

--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Services/GeoParquetQueryFormatter.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Services/GeoParquetQueryFormatter.cs
@@ -140,7 +140,7 @@ internal sealed class GeoParquetQueryFormatter
             };
         }
 
-        var selectedFields = layer.Fields
+        var selectedFields = layer.VisibleFields
             .Where(field => !field.IsGeometry)
             .Where(field => includeAllFields || requestedFields!.Contains(field.Name))
             .ToList();

--- a/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Server/Features/Protocols/GeoServices/FeatureServer/Services/QueryFormatters.cs
@@ -173,11 +173,14 @@ internal sealed class QueryFormatter : IQueryFormatter
         string[]? outFields)
     {
         var objectIdFieldName = GeoServicesObjectIdFieldResolver.ResolveObjectIdFieldName(layer);
-        var declaredAttributeFields = layer.Fields
+        var allDeclaredAttributeFields = layer.Fields
             .Where(field => !field.IsGeometry)
             .Select(field => field.Name)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var runtimeFields = DetectRuntimeFields(result.Items, declaredAttributeFields, objectIdFieldName);
+        var visibleDeclaredAttributeFields = layer.VisibleAttributeFields
+            .Select(field => field.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var runtimeFields = DetectRuntimeFields(result.Items, allDeclaredAttributeFields, objectIdFieldName);
         var runtimeFieldNames = runtimeFields
             .Select(field => field.Name)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -187,7 +190,7 @@ internal sealed class QueryFormatter : IQueryFormatter
                 returnGeometry,
                 outputSrid,
                 outFields,
-                declaredAttributeFields,
+                visibleDeclaredAttributeFields,
                 runtimeFieldNames,
                 objectIdFieldName,
                 returnZ,
@@ -445,7 +448,7 @@ internal sealed class QueryFormatter : IQueryFormatter
             };
         }
 
-        var mappedFields = layer.Fields
+        var mappedFields = layer.VisibleFields
             .Where(field => !field.IsGeometry)
             .Where(field => includeAllFields || requestedFields!.Contains(field.Name))
             .Select(MapFieldInfo)
@@ -836,6 +839,13 @@ internal sealed class StreamingQueryFormatter
         var outFieldLookup = CreateFieldLookup(outFields);
         var srid = outputSrid ?? layer.SpatialReference.Wkid;
         var queryFields = QueryFormatter.BuildQueryFields(layer, outFields, objectIdFieldName);
+        var allDeclaredAttributeFields = layer.Fields
+            .Where(field => !field.IsGeometry)
+            .Select(field => field.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var visibleDeclaredAttributeFields = layer.VisibleAttributeFields
+            .Select(field => field.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
         var displayFieldName = QueryFormatter.ResolveDisplayFieldName(queryFields, objectIdFieldName);
 
         // Start object
@@ -881,6 +891,8 @@ internal sealed class StreamingQueryFormatter
                 returnGeometry,
                 outputSrid,
                 outFieldLookup,
+                allDeclaredAttributeFields,
+                visibleDeclaredAttributeFields,
                 objectIdFieldName,
                 returnZ,
                 returnM,
@@ -994,6 +1006,8 @@ internal sealed class StreamingQueryFormatter
         bool returnGeometry,
         int? outputSrid,
         HashSet<string>? outFieldLookup,
+        IReadOnlySet<string> allDeclaredAttributeFields,
+        IReadOnlySet<string> visibleDeclaredAttributeFields,
         string objectIdFieldName,
         bool returnZ,
         bool returnM,
@@ -1015,6 +1029,11 @@ internal sealed class StreamingQueryFormatter
 
                 // Skip fields not in outFields if specified
                 if (outFieldLookup != null && !outFieldLookup.Contains(fieldName))
+                {
+                    continue;
+                }
+
+                if (!ShouldWriteStreamingAttribute(fieldName, allDeclaredAttributeFields, visibleDeclaredAttributeFields))
                 {
                     continue;
                 }
@@ -1062,6 +1081,24 @@ internal sealed class StreamingQueryFormatter
         }
 
         writer.WriteEndObject(); // End feature
+    }
+
+    private static bool ShouldWriteStreamingAttribute(
+        string fieldName,
+        IReadOnlySet<string> allDeclaredAttributeFields,
+        IReadOnlySet<string> visibleDeclaredAttributeFields)
+    {
+        if (fieldName.StartsWith("__", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (visibleDeclaredAttributeFields.Contains(fieldName))
+        {
+            return true;
+        }
+
+        return !allDeclaredAttributeFields.Contains(fieldName);
     }
 
     /// <summary>

--- a/src/Honua.Server/Features/Protocols/Ogc/Api/Features/CollectionsEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Ogc/Api/Features/CollectionsEndpoints.cs
@@ -581,7 +581,7 @@ internal static class CollectionsEndpoints
         var requiredFields = new List<string>();
 
         // Add properties for all non-geometry fields
-        foreach (var field in layer.AttributeFields.Where(OgcFeaturesUtilities.IsSimpleQueryableField))
+        foreach (var field in layer.VisibleAttributeFields.Where(OgcFeaturesUtilities.IsSimpleQueryableField))
         {
             var jsonSchemaProperty = ConvertFieldToJsonSchemaProperty(field);
             properties[field.Name] = jsonSchemaProperty;

--- a/src/Honua.Server/Features/Protocols/Ogc/Api/Features/OgcFeaturesQueryHandler.cs
+++ b/src/Honua.Server/Features/Protocols/Ogc/Api/Features/OgcFeaturesQueryHandler.cs
@@ -784,7 +784,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
         LayerDefinition layer,
         ImmutableHashSet<string>? projectedProperties)
     {
-        IEnumerable<string> fieldNames = layer.AttributeFields.Select(field => field.Name);
+        IEnumerable<string> fieldNames = layer.VisibleAttributeFields.Select(field => field.Name);
         if (projectedProperties != null)
         {
             fieldNames = fieldNames.Where(projectedProperties.Contains);
@@ -913,7 +913,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
         ImmutableArray<Link> links,
         long? numberMatched)
     {
-        var propertyFields = layer.AttributeFields
+        var propertyFields = layer.VisibleAttributeFields
             .Where(field => !field.Name.Equals(layer.ObjectIdFieldName, StringComparison.OrdinalIgnoreCase))
             .Select(field => field.Name)
             .ToArray();
@@ -966,7 +966,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
         ImmutableArray<Link> links,
         long? numberMatched)
     {
-        var propertyFields = layer.AttributeFields
+        var propertyFields = layer.VisibleAttributeFields
             .Where(field => !field.Name.Equals(layer.ObjectIdFieldName, StringComparison.OrdinalIgnoreCase))
             .Select(field => field.Name)
             .ToArray();
@@ -1015,7 +1015,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
 
     private static string? ResolveRawPublicIdPropertyName(LayerDefinition layer)
     {
-        var configuredField = layer.AttributeFields.FirstOrDefault(
+        var configuredField = layer.VisibleAttributeFields.FirstOrDefault(
             field => field.Name.Equals(layer.ObjectIdFieldName, StringComparison.OrdinalIgnoreCase));
         if (configuredField?.Name is { Length: > 0 })
         {
@@ -1024,7 +1024,7 @@ internal sealed partial class OgcFeaturesQueryHandler(
 
         if (!layer.ObjectIdFieldName.Equals("id", StringComparison.OrdinalIgnoreCase))
         {
-            var idField = layer.AttributeFields.FirstOrDefault(
+            var idField = layer.VisibleAttributeFields.FirstOrDefault(
                 field => field.Name.Equals("id", StringComparison.OrdinalIgnoreCase));
             if (idField?.Name is { Length: > 0 })
             {

--- a/src/Honua.Server/Features/Protocols/Ogc/Api/Features/OgcFeaturesUtilities.cs
+++ b/src/Honua.Server/Features/Protocols/Ogc/Api/Features/OgcFeaturesUtilities.cs
@@ -210,7 +210,7 @@ internal static class OgcFeaturesUtilities
     {
         var allowed = new HashSet<string>(AllowedQueryParameters.Items, StringComparer.OrdinalIgnoreCase);
 
-        foreach (var field in layer.AttributeFields)
+        foreach (var field in layer.VisibleAttributeFields)
         {
             if (IsSimpleQueryableField(field))
             {

--- a/src/Honua.Server/Features/Protocols/Ogc/Api/Features/Services/OgcFeaturesQueryParameterAdapter.cs
+++ b/src/Honua.Server/Features/Protocols/Ogc/Api/Features/Services/OgcFeaturesQueryParameterAdapter.cs
@@ -209,7 +209,7 @@ internal sealed class OgcFeaturesQueryParameterAdapter(
             return false;
         }
 
-        var fieldsByName = layer.AttributeFields
+        var fieldsByName = layer.VisibleAttributeFields
             .ToDictionary(field => field.Name, StringComparer.OrdinalIgnoreCase);
         var selected = ImmutableArray.CreateBuilder<string>(tokens.Length);
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/Honua.Server/Features/Protocols/Ogc/Api/Features/Services/OgcFilterProcessor.cs
+++ b/src/Honua.Server/Features/Protocols/Ogc/Api/Features/Services/OgcFilterProcessor.cs
@@ -378,7 +378,7 @@ internal sealed partial class OgcFilterProcessor
                 continue;
             }
 
-            var field = layer.AttributeFields.FirstOrDefault(f => f.Name.Equals(key, StringComparison.OrdinalIgnoreCase));
+            var field = layer.VisibleAttributeFields.FirstOrDefault(f => f.Name.Equals(key, StringComparison.OrdinalIgnoreCase));
             if (field == null)
             {
                 return CombinedFilterResult.Failure($"Unknown query parameter: {key}");

--- a/src/Honua.Server/Features/Protocols/Ogc/Classic/Wfs20/Services/Wfs20Handler.Capabilities.cs
+++ b/src/Honua.Server/Features/Protocols/Ogc/Classic/Wfs20/Services/Wfs20Handler.Capabilities.cs
@@ -736,7 +736,7 @@ internal sealed partial class Wfs20Handler
                 schema.AppendLine($"""          <xsd:element name="{geometryFieldName}" type="{MapGeometryPropertyType(featureType.Layer.GeometryType)}" minOccurs="0" nillable="true"/>""");
             }
 
-            foreach (var field in featureType.Layer.AttributeFields)
+            foreach (var field in featureType.Layer.VisibleAttributeFields)
             {
                 var fieldName = XmlConvert.EncodeLocalName(field.Name);
                 var minOccurs = field.Nullable ? " minOccurs=\"0\"" : string.Empty;

--- a/src/Honua.Server/Features/Protocols/Ogc/Classic/Wfs20/Services/Wfs20Handler.Legacy.cs
+++ b/src/Honua.Server/Features/Protocols/Ogc/Classic/Wfs20/Services/Wfs20Handler.Legacy.cs
@@ -886,7 +886,7 @@ internal sealed partial class Wfs20Handler
                 schema.AppendLine($"""          <xsd:element name="{XmlConvert.EncodeLocalName(featureType.Layer.GeometryField.Name)}" type="gml:GeometryPropertyType" minOccurs="0" nillable="true"/>""");
             }
 
-            foreach (var field in featureType.Layer.AttributeFields)
+            foreach (var field in featureType.Layer.VisibleAttributeFields)
             {
                 var minOccurs = field.Nullable ? " minOccurs=\"0\"" : string.Empty;
                 var nillable = field.Nullable ? " nillable=\"true\"" : string.Empty;

--- a/src/Honua.Server/Features/Protocols/Ogc/Classic/Wfs20/Services/Wfs20Handler.cs
+++ b/src/Honua.Server/Features/Protocols/Ogc/Classic/Wfs20/Services/Wfs20Handler.cs
@@ -2174,7 +2174,7 @@ internal sealed partial class Wfs20Handler
     {
         if (query.OutFields is not { } outFields)
         {
-            return layer.AttributeFields;
+            return layer.VisibleAttributeFields;
         }
 
         if (outFields.IsDefaultOrEmpty)
@@ -2182,7 +2182,7 @@ internal sealed partial class Wfs20Handler
             return Array.Empty<FieldDefinition>();
         }
 
-        return layer.AttributeFields.Where(field =>
+        return layer.VisibleAttributeFields.Where(field =>
             outFields.Any(candidate => candidate.Equals(field.Name, StringComparison.OrdinalIgnoreCase)));
     }
 

--- a/src/Honua.Server/Migrations/001_CreateHonuaSchema.sql
+++ b/src/Honua.Server/Migrations/001_CreateHonuaSchema.sql
@@ -82,6 +82,7 @@ CREATE TABLE IF NOT EXISTS honua.layer_fields (
     default_value TEXT,
     description TEXT,
     domain JSONB,
+    hidden BOOLEAN NOT NULL DEFAULT FALSE,
     PRIMARY KEY (layer_id, field_name)
 );
 

--- a/src/Honua.Server/Migrations/028_AddLayerFieldVisibility.sql
+++ b/src/Honua.Server/Migrations/028_AddLayerFieldVisibility.sql
@@ -1,0 +1,9 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Persist operator-managed field visibility for public protocol output.
+
+ALTER TABLE honua.layer_fields
+    ADD COLUMN IF NOT EXISTS hidden BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN honua.layer_fields.hidden IS 'Operator-managed flag that omits the field from public protocol metadata and feature output';

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/LayerFieldConfigurationEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/LayerFieldConfigurationEndpointsTests.cs
@@ -32,10 +32,11 @@ public sealed class LayerFieldConfigurationEndpointsTests : IAsyncLifetime
     [Endpoint("GET /api/v1/admin/metadata/layers/{layerId}/fields")]
     [Endpoint("PUT /api/v1/admin/metadata/layers/{layerId}/fields")]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
-    public async Task UpdateLayerFields_WithAliasAndCodedValueDomain_PersistsAndHydratesCatalog()
+    public async Task UpdateLayerFields_WithAliasDomainAndHiddenField_PersistsAndHydratesCatalog()
     {
         var adminClient = _fixture.CreateAdminClient();
         var anonymousClient = _fixture.CreateClient();
+        var resetComplete = false;
         var request = new LayerFieldConfigurationUpdateRequest
         {
             Fields =
@@ -51,45 +52,15 @@ public sealed class LayerFieldConfigurationEndpointsTests : IAsyncLifetime
                             new DomainCodedValueDefinition("active", "Active"),
                             new DomainCodedValueDefinition("retired", "Retired")
                         ])
+                },
+                new LayerFieldConfigurationUpdateItem
+                {
+                    Name = "description",
+                    Alias = "Description",
+                    Hidden = true
                 }
             ]
         };
-
-        var updateResponse = await adminClient.PutAsync(
-            $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/fields",
-            JsonContent.Create(request, LayerFieldConfigurationJsonContext.Default.LayerFieldConfigurationUpdateRequest));
-
-        updateResponse.Be200Ok();
-        var update = await ReadFieldConfigurationResponseAsync(updateResponse);
-        var category = update.Data!.Fields.Single(field => field.Name == "category");
-        category.Alias.Should().Be("Lifecycle category");
-        category.Domain.Should().NotBeNull();
-        category.Domain!.Name.Should().Be("category-domain");
-        category.Domain.CodedValues.Should().HaveCount(2);
-
-        var getResponse = await adminClient.GetAsync(
-            $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/fields");
-
-        getResponse.Be200Ok();
-        var get = await ReadFieldConfigurationResponseAsync(getResponse);
-        get.Data!.Fields.Single(field => field.Name == "category").Alias.Should().Be("Lifecycle category");
-        get.Data!.Fields.Single(field => field.Name == "category").Domain!.CodedValues![0].Name.Should().Be("Active");
-
-        var featureLayerResponse = await anonymousClient.GetAsync(
-            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
-
-        featureLayerResponse.Be200Ok();
-        using var document = JsonDocument.Parse(await featureLayerResponse.Content.ReadAsStringAsync());
-        var fields = document.RootElement.GetProperty("fields").EnumerateArray();
-        var categoryField = fields.Single(field => field.GetProperty("name").GetString() == "category");
-        categoryField.GetProperty("alias").GetString().Should().Be("Lifecycle category");
-        var domain = categoryField.GetProperty("domain");
-        domain.GetProperty("name").GetString().Should().Be("category-domain");
-        domain.GetProperty("type").GetString().Should().Be("codedValue");
-        domain.GetProperty("codedValues").EnumerateArray()
-            .Select(value => value.GetProperty("name").GetString())
-            .Should()
-            .BeEquivalentTo("Active", "Retired");
 
         var clearRequest = new LayerFieldConfigurationUpdateRequest
         {
@@ -99,19 +70,89 @@ public sealed class LayerFieldConfigurationEndpointsTests : IAsyncLifetime
                 {
                     Name = "category",
                     Alias = " "
+                },
+                new LayerFieldConfigurationUpdateItem
+                {
+                    Name = "description",
+                    Alias = "Description",
+                    Hidden = false
                 }
             ]
         };
 
-        var clearResponse = await adminClient.PutAsync(
-            $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/fields",
-            JsonContent.Create(clearRequest, LayerFieldConfigurationJsonContext.Default.LayerFieldConfigurationUpdateRequest));
+        try
+        {
+            var updateResponse = await adminClient.PutAsync(
+                $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/fields",
+                JsonContent.Create(request, LayerFieldConfigurationJsonContext.Default.LayerFieldConfigurationUpdateRequest));
 
-        clearResponse.Be200Ok();
-        var clear = await ReadFieldConfigurationResponseAsync(clearResponse);
-        var clearedCategory = clear.Data!.Fields.Single(field => field.Name == "category");
-        clearedCategory.Alias.Should().BeNull();
-        clearedCategory.Domain.Should().BeNull();
+            updateResponse.Be200Ok();
+            var update = await ReadFieldConfigurationResponseAsync(updateResponse);
+            var category = update.Data!.Fields.Single(field => field.Name == "category");
+            category.Alias.Should().Be("Lifecycle category");
+            category.Domain.Should().NotBeNull();
+            category.Domain!.Name.Should().Be("category-domain");
+            category.Domain.CodedValues.Should().HaveCount(2);
+            update.Data!.Fields.Single(field => field.Name == "description").Hidden.Should().BeTrue();
+
+            var getResponse = await adminClient.GetAsync(
+                $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/fields");
+
+            getResponse.Be200Ok();
+            var get = await ReadFieldConfigurationResponseAsync(getResponse);
+            get.Data!.Fields.Single(field => field.Name == "category").Alias.Should().Be("Lifecycle category");
+            get.Data!.Fields.Single(field => field.Name == "category").Domain!.CodedValues![0].Name.Should().Be("Active");
+            get.Data!.Fields.Single(field => field.Name == "description").Hidden.Should().BeTrue();
+
+            var featureLayerResponse = await anonymousClient.GetAsync(
+                $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
+
+            featureLayerResponse.Be200Ok();
+            using var document = JsonDocument.Parse(await featureLayerResponse.Content.ReadAsStringAsync());
+            var fields = document.RootElement.GetProperty("fields").EnumerateArray().ToArray();
+            fields.Should().NotContain(field => field.GetProperty("name").GetString() == "description");
+            var categoryField = fields.Single(field => field.GetProperty("name").GetString() == "category");
+            categoryField.GetProperty("alias").GetString().Should().Be("Lifecycle category");
+            var domain = categoryField.GetProperty("domain");
+            domain.GetProperty("name").GetString().Should().Be("category-domain");
+            domain.GetProperty("type").GetString().Should().Be("codedValue");
+            domain.GetProperty("codedValues").EnumerateArray()
+                .Select(value => value.GetProperty("name").GetString())
+                .Should()
+                .BeEquivalentTo("Active", "Retired");
+
+            var queryResponse = await anonymousClient.GetAsync(
+                $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?where=1%3D1&outFields=*&returnGeometry=false&f=json");
+
+            queryResponse.Be200Ok();
+            using var queryDocument = JsonDocument.Parse(await queryResponse.Content.ReadAsStringAsync());
+            queryDocument.RootElement.GetProperty("fields").EnumerateArray()
+                .Should()
+                .NotContain(field => field.GetProperty("name").GetString() == "description");
+            var firstAttributes = queryDocument.RootElement.GetProperty("features")[0].GetProperty("attributes");
+            firstAttributes.TryGetProperty("description", out _).Should().BeFalse();
+
+            var clearResponse = await adminClient.PutAsync(
+                $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/fields",
+                JsonContent.Create(clearRequest, LayerFieldConfigurationJsonContext.Default.LayerFieldConfigurationUpdateRequest));
+
+            clearResponse.Be200Ok();
+            var clear = await ReadFieldConfigurationResponseAsync(clearResponse);
+            var clearedCategory = clear.Data!.Fields.Single(field => field.Name == "category");
+            clearedCategory.Alias.Should().BeNull();
+            clearedCategory.Domain.Should().BeNull();
+            clear.Data!.Fields.Single(field => field.Name == "description").Hidden.Should().BeFalse();
+            resetComplete = true;
+        }
+        finally
+        {
+            if (!resetComplete)
+            {
+                _ = await adminClient.PutAsync(
+                    $"/api/v1/admin/metadata/layers/{WebAppFixture.TestLayerId}/fields",
+                    JsonContent.Create(clearRequest, LayerFieldConfigurationJsonContext.Default.LayerFieldConfigurationUpdateRequest));
+            }
+        }
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/GeoServices/FeatureServer/Services/QueryFormatterTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/GeoServices/FeatureServer/Services/QueryFormatterTests.cs
@@ -169,6 +169,60 @@ public sealed class QueryFormatterTests
     }
 
     [Fact]
+    public async Task FormatQueryResultAsync_WithHiddenDeclaredField_ExcludesFromJsonAndGeoJson()
+    {
+        var limitsOptions = Options.Create(new LimitsOptions());
+        var formatter = new QueryFormatter(
+            limitsOptions,
+            new PbfQueryFormatter(limitsOptions),
+            NullLogger<QueryFormatter>.Instance);
+
+        var feature = Feature.Create(
+            42,
+            geometry: null,
+            new Dictionary<string, object?>
+            {
+                ["objectid"] = 42L,
+                ["name"] = "alpha",
+                ["secret"] = "hidden"
+            }.ToImmutableDictionary());
+        var layer = CreatePointLayerWithHiddenField();
+
+        var (jsonResponse, jsonContentType) = await formatter.FormatQueryResultAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            format: "json",
+            returnGeometry: false,
+            outputSrid: null,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        jsonContentType.Should().Be("application/json");
+        var queryResponse = jsonResponse.Should().BeOfType<QueryResponse>().Subject;
+        queryResponse.Fields.Should().NotContain(field => field.Name == "secret");
+        queryResponse.Features.Should().ContainSingle();
+        queryResponse.Features[0].Attributes.Should().NotContainKey("secret");
+
+        var (geoJsonResponse, geoJsonContentType) = await formatter.FormatQueryResultAsync(
+            QueryResult<Feature>.Create(1, [feature]),
+            layer,
+            format: "geojson",
+            returnGeometry: false,
+            outputSrid: null,
+            returnZ: false,
+            returnM: false,
+            geometryPrecision: null,
+            maxAllowableOffset: null);
+
+        geoJsonContentType.Should().Be("application/geo+json");
+        var geoJson = geoJsonResponse.Should().BeOfType<GeoJsonFeatureSet>().Subject;
+        geoJson.Features.Should().ContainSingle();
+        geoJson.Features[0].Properties.Should().NotContainKey("secret");
+    }
+
+    [Fact]
     public async Task FormatQueryResultAsync_WithGeoJsonAndMeasuredGeometry_DropsMOrdinate()
     {
         var limitsOptions = Options.Create(new LimitsOptions());
@@ -459,6 +513,19 @@ public sealed class QueryFormatterTests
             [
                 new FieldDefinition(FieldNames.ObjectId, FieldType.Integer, Nullable: false),
                 new FieldDefinition("name", FieldType.String, Length: 128)
+            ]);
+
+    private static LayerDefinition CreatePointLayerWithHiddenField()
+        => new(
+            10,
+            "hidden-field-test-layer",
+            null,
+            Honua.Core.Features.Catalog.Domain.GeometryType.Point,
+            SpatialReference.WGS84,
+            [
+                new FieldDefinition(FieldNames.ObjectId, FieldType.Integer, Nullable: false),
+                new FieldDefinition("name", FieldType.String, Length: 128),
+                new FieldDefinition("secret", FieldType.String, Length: 128, IsHidden: true)
             ]);
 
     private static LayerDefinition CreateIdBackedPointLayer()

--- a/tests/dotnet/Honua.Server.Tests/PostgresLayerCatalogTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/PostgresLayerCatalogTests.cs
@@ -72,6 +72,7 @@ public class PostgresLayerCatalogTests : IAsyncLifetime
                 default_value text,
                 description text,
                 domain jsonb,
+                hidden boolean NOT NULL DEFAULT false,
                 PRIMARY KEY (layer_id, field_name)
             );
 

--- a/tests/python/shared/postgis.py
+++ b/tests/python/shared/postgis.py
@@ -404,6 +404,7 @@ class PostGISFixture:
                         default_value TEXT,
                         description TEXT,
                         domain JSONB,
+                        hidden BOOLEAN NOT NULL DEFAULT FALSE,
                         PRIMARY KEY (layer_id, field_name)
                     );
                     """
@@ -411,6 +412,10 @@ class PostGISFixture:
                 conn.execute(
                     "ALTER TABLE IF EXISTS honua.layer_fields "
                     "ADD COLUMN IF NOT EXISTS domain JSONB;"
+                )
+                conn.execute(
+                    "ALTER TABLE IF EXISTS honua.layer_fields "
+                    "ADD COLUMN IF NOT EXISTS hidden BOOLEAN NOT NULL DEFAULT FALSE;"
                 )
 
                 conn.execute(

--- a/tests/seed/base-schema.sql
+++ b/tests/seed/base-schema.sql
@@ -124,6 +124,7 @@ CREATE TABLE IF NOT EXISTS honua.layer_fields (
     default_value TEXT,
     description TEXT,
     domain JSONB,
+    hidden BOOLEAN NOT NULL DEFAULT FALSE,
     PRIMARY KEY (layer_id, field_name)
 );
 

--- a/tests/seed/client-compat-v1.sql
+++ b/tests/seed/client-compat-v1.sql
@@ -112,6 +112,7 @@ CREATE TABLE IF NOT EXISTS honua.layer_fields (
     default_value TEXT,
     description TEXT,
     domain JSONB,
+    hidden BOOLEAN NOT NULL DEFAULT FALSE,
     PRIMARY KEY (layer_id, field_name)
 );
 

--- a/tests/seed/odata.yaml
+++ b/tests/seed/odata.yaml
@@ -70,8 +70,10 @@ sql:
           default_value TEXT,
           description TEXT,
           domain JSONB,
+          hidden BOOLEAN NOT NULL DEFAULT FALSE,
           PRIMARY KEY (layer_id, field_name)
       );
+  - "ALTER TABLE IF EXISTS honua.layer_fields ADD COLUMN IF NOT EXISTS hidden BOOLEAN NOT NULL DEFAULT FALSE;"
   - |
       CREATE TABLE IF NOT EXISTS honua.relationships (
           layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -71,8 +71,10 @@ sql:
           default_value TEXT,
           description TEXT,
           domain JSONB,
+          hidden BOOLEAN NOT NULL DEFAULT FALSE,
           PRIMARY KEY (layer_id, field_name)
       );
+  - "ALTER TABLE IF EXISTS honua.layer_fields ADD COLUMN IF NOT EXISTS hidden BOOLEAN NOT NULL DEFAULT FALSE;"
   - |
       CREATE TABLE IF NOT EXISTS honua.relationships (
           id SERIAL PRIMARY KEY,

--- a/tests/seed/spatial-reference.yaml
+++ b/tests/seed/spatial-reference.yaml
@@ -70,8 +70,10 @@ sql:
           default_value TEXT,
           description TEXT,
           domain JSONB,
+          hidden BOOLEAN NOT NULL DEFAULT FALSE,
           PRIMARY KEY (layer_id, field_name)
       );
+  - "ALTER TABLE IF EXISTS honua.layer_fields ADD COLUMN IF NOT EXISTS hidden BOOLEAN NOT NULL DEFAULT FALSE;"
   - |
       CREATE TABLE IF NOT EXISTS honua.relationships (
           layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,


### PR DESCRIPTION
## Issue Link
Related to #976

## Summary
Persists operator-managed field visibility alongside aliases and coded-value domains, then applies that hidden-field setting to public protocol metadata and feature output.

## Changes Made
- Adds a `hidden` column to layer field metadata, admin update/read contracts, Postgres persistence, and catalog hydration.
- Excludes hidden fields from GeoServices layer/query metadata, JSON/GeoJSON streaming output, GeoParquet selected fields, OGC API Features queryables/items/CSV/raw payloads, and WFS projected/schema output.
- Adds integration and formatter coverage for saving hidden fields, rejecting required protocol fields, hydrating catalog state, and omitting hidden attributes from public responses.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation run locally:
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~QueryFormatterTests|FullyQualifiedName~LayerFieldConfigurationEndpointsTests" --no-restore` passed, 61 tests.
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~OgcFeaturesEnhancementsTests|FullyQualifiedName~OgcFeaturesItemsTests|FullyQualifiedName~Wfs20EndpointsTests|FullyQualifiedName~WfsLegacyEndpointsTests" --no-restore` passed, 167 tests.
- `dotnet format Honua.sln` passed.
- `dotnet format Honua.sln --verify-no-changes --verbosity diagnostic` passed, formatted 0 files.
- `git diff --check HEAD~1..HEAD` passed.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [x] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent focused local checks: format, focused admin/formatter tests, OGC/WFS protocol tests, and diff whitespace validation all passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review
