### PR TITLE
ci: preserve real-client interop evidence

### DIFF
--- a/.github/workflows/client-interop-nightly.yml
+++ b/.github/workflows/client-interop-nightly.yml
@@ -144,12 +144,15 @@ jobs:
           if [[ "$build_exit" -ne 0 ]]; then
             exit_code="$build_exit"
           else
+            lane_log="docker/client-compat/output/${{ matrix.lane }}/lane.log"
             docker compose -f docker/client-compat/compose.yml \
               --profile ${{ matrix.lane }} \
-              up --no-build --abort-on-container-exit \
-              --exit-code-from ${{ matrix.lane }} \
-              ${{ matrix.lane }}
-            exit_code=$?
+              run --no-build --rm \
+              ${{ matrix.lane }} 2>&1 | tee "$lane_log"
+            exit_code=${PIPESTATUS[0]}
+            if [[ "$exit_code" -eq 0 ]]; then
+              rm -f "$lane_log"
+            fi
           fi
 
           if [[ "$exit_code" -ne 0 ]]; then

--- a/docker/client-compat/README.md
+++ b/docker/client-compat/README.md
@@ -63,10 +63,11 @@ cesium gdal`).
 
 The previous `--profile matrix up --abort-on-container-exit` shortcut is
 **not** safe for refresh use: `--abort-on-container-exit` terminates every
-container the moment any one of them exits, so the first lane to finish
-kills the rest before they can write evidence. Use a single
-`--profile <lane>` invocation per lane (with `--exit-code-from <lane>`)
-when you need to drive compose by hand.
+container the moment any one of them exits. In this stack, the one-shot
+`seed` dependency exits before `honua` and the client lane run, so `up` can
+tear the stack down before any `.cert.json` evidence is written. Use
+`docker compose --profile <lane> run --rm <lane>` when you need to drive
+compose by hand.
 
 ## Output layout
 
@@ -125,7 +126,7 @@ database.
 1. Add `docker/client-compat/<lane>/Dockerfile`.
 2. Add a service block to `compose.yml`:
    - `profiles: ["matrix", "<lane>"]` — the per-lane profile is what the
-     CI workflow targets via `docker compose --profile <lane> ... <lane>`,
+     CI workflow targets via `docker compose --profile <lane> run --rm <lane>`,
      and the `matrix` profile is what `--profile matrix up` selects to run
      the full set.
    - `depends_on: { honua: { condition: service_healthy } }`

--- a/docker/client-compat/compose.yml
+++ b/docker/client-compat/compose.yml
@@ -3,15 +3,13 @@
 # `honua` and `postgres` always start (depends_on healthy). Each client lane
 # is a separate service tagged with both a per-lane profile and the shared
 # `matrix` profile:
-#   - `docker compose --profile <lane> up --abort-on-container-exit
-#     --exit-code-from <lane> <lane>` runs one lane (the shape CI uses).
-#   - `docker compose run --rm <lane>` works locally for an ad-hoc single
-#     lane invocation.
+#   - `docker compose --profile <lane> run --rm <lane>` runs one lane (the
+#     shape CI uses).
 #   - The `matrix` profile is **not** suitable for parallel execution under
-#     `--abort-on-container-exit`: the first lane to exit terminates every
-#     other container before it can write evidence. Use
-#     scripts/client-compat/refresh-baselines.sh, which iterates the lanes
-#     sequentially, when you need every envelope captured.
+#     `--abort-on-container-exit`: the first container to exit, including the
+#     one-shot seed container, terminates the stack before every lane can write
+#     evidence. Use scripts/client-compat/refresh-baselines.sh, which iterates
+#     the lanes sequentially, when you need every envelope captured.
 #
 # Output `.cert.json` envelopes are written to ./output/<lane>/ on the host so
 # the baseline-diff step can compare them against tests/baselines/client-compat.

--- a/scripts/client-compat/refresh-baselines.sh
+++ b/scripts/client-compat/refresh-baselines.sh
@@ -46,21 +46,20 @@ echo "  Lanes: ${LANES[*]}"
 rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR"
 
-# Run lanes one at a time. The matrix-profile shortcut (--profile matrix
-# --abort-on-container-exit) brings every lane up in parallel, but
-# --abort-on-container-exit terminates *all* containers when any one of them
-# exits — so the first lane to finish kills the rest before they can write
-# their evidence. Mirroring the CI matrix shape (one --profile <lane>
-# --exit-code-from <lane> per loop iteration) is the only pattern that
-# reliably captures every lane's evidence even when one of them fails.
+# Run lanes one at a time. Avoid `up --abort-on-container-exit` here: the
+# one-shot seed dependency exits before honua and the lane start, and Compose
+# treats that as a reason to stop the stack. `run` starts dependencies without
+# using seed completion as an abort signal, so evidence written to /output is
+# preserved for every lane.
 for lane in "${LANES[@]}"; do
     echo
     echo "===> Refreshing lane: $lane"
+    docker compose -f "$COMPOSE_FILE" \
+        --profile "$lane" \
+        build seed honua "$lane"
     if docker compose -f "$COMPOSE_FILE" \
             --profile "$lane" \
-            up --build \
-            --abort-on-container-exit \
-            --exit-code-from "$lane" \
+            run --no-build --rm \
             "$lane"; then
         echo "lane $lane: ok"
     else


### PR DESCRIPTION
## Issue Link

Fixes #1014

## Summary

Fixes the real-client interop nightly lane runner so current-run `.cert.json` evidence is preserved for the baseline-diff job. The workflow previously used `docker compose up --abort-on-container-exit`, which can stop the stack when the one-shot `seed` container exits before the lane writes evidence.

## Changes Made

- Runs each client lane with `docker compose run --no-build --rm <lane>` instead of `up --abort-on-container-exit`.
- Captures per-lane logs only on failure so artifacts still include diagnostics without polluting passing evidence.
- Updates the baseline refresh script to mirror the fixed CI lane execution shape.
- Updates compose comments and README guidance to document the safe invocation.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:

- `bash -n scripts/client-compat/refresh-baselines.sh docker/client-compat/*/run.sh`
- `docker compose -f docker/client-compat/compose.yml --profile gdal config`
- `python3 scripts/client-compat/diff-baselines.py --baselines tests/baselines/client-compat --current tests/baselines/client-compat --gap-report /tmp/client-compat-gap-report.md --strict`
- `git diff --check`

`actionlint` and `shellcheck` were not installed locally.

## Gate Impact

- [ ] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None - no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes

None

---

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` or equivalent required PR CI, and all required checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
