### PR TITLE
feat: add migration performance cost evidence

### DIFF
--- a/src/Honua.Core/Features/Import/Domain/MigrationParityEvidenceArtifact.cs
+++ b/src/Honua.Core/Features/Import/Domain/MigrationParityEvidenceArtifact.cs
@@ -70,6 +70,11 @@ public sealed record MigrationParityEvidenceArtifact
     /// Cutover-readiness checklist and aggregate state.
     /// </summary>
     public required MigrationCutoverReadinessSummary CutoverReadiness { get; init; }
+
+    /// <summary>
+    /// Optional bounded performance and migration-cost evidence captured for this run.
+    /// </summary>
+    public MigrationPerformanceCostEvidence? PerformanceCost { get; init; }
 }
 
 /// <summary>
@@ -221,4 +226,152 @@ public sealed record MigrationReadinessAttestationItem
     /// Optional owner responsible for the item.
     /// </summary>
     public string? Owner { get; init; }
+}
+
+/// <summary>
+/// Bounded migration performance and cost evidence that can be attached to parity review artifacts.
+/// </summary>
+public sealed record MigrationPerformanceCostEvidence
+{
+    /// <summary>
+    /// Stable artifact kind identifier for embedded performance and cost evidence.
+    /// </summary>
+    public string ArtifactKind { get; init; } = "honua.migration.performance-cost-evidence";
+
+    /// <summary>
+    /// Artifact schema version.
+    /// </summary>
+    public string ArtifactVersion { get; init; } = "1.0";
+
+    /// <summary>
+    /// Evidence state: <c>pass</c>, <c>fail</c>, <c>unknown</c>, or <c>not-applicable</c>.
+    /// </summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// Short reviewer-facing summary of the collected measurements.
+    /// </summary>
+    public required string Summary { get; init; }
+
+    /// <summary>
+    /// Human-readable scope for the measurement, such as <c>fixture scan</c> or <c>pilot import dry run</c>.
+    /// </summary>
+    public required string MeasurementScope { get; init; }
+
+    /// <summary>
+    /// Aggregate duration, volume, retry, and review counters.
+    /// </summary>
+    public required MigrationPerformanceCostTotals Totals { get; init; }
+
+    /// <summary>
+    /// Operation-level measurements in deterministic order.
+    /// </summary>
+    public MigrationPerformanceCostOperation[] Operations { get; init; } = [];
+
+    /// <summary>
+    /// Secret-safe evidence artifact references. Query strings, fragments, and URL credentials are removed by the generator.
+    /// </summary>
+    public string[] EvidenceReferences { get; init; } = [];
+}
+
+/// <summary>
+/// Aggregate migration performance and cost counters for a measured run.
+/// </summary>
+public sealed record MigrationPerformanceCostTotals
+{
+    /// <summary>
+    /// Total measured duration in milliseconds.
+    /// </summary>
+    public long? DurationMilliseconds { get; init; }
+
+    /// <summary>
+    /// Total resources processed by the measured run.
+    /// </summary>
+    public long? ResourceCount { get; init; }
+
+    /// <summary>
+    /// Total features processed by the measured run.
+    /// </summary>
+    public long? FeatureCount { get; init; }
+
+    /// <summary>
+    /// Total bytes read from source systems or staged artifacts.
+    /// </summary>
+    public long? BytesRead { get; init; }
+
+    /// <summary>
+    /// Total bytes written to Honua-owned stores or output artifacts.
+    /// </summary>
+    public long? BytesWritten { get; init; }
+
+    /// <summary>
+    /// Total retry attempts observed across measured operations.
+    /// </summary>
+    public int? RetryCount { get; init; }
+
+    /// <summary>
+    /// Total items requiring manual review after the measured run.
+    /// </summary>
+    public int? ManualReviewCount { get; init; }
+}
+
+/// <summary>
+/// Operation-level performance and migration-cost measurement.
+/// </summary>
+public sealed record MigrationPerformanceCostOperation
+{
+    /// <summary>
+    /// Stable operation identifier.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Migration stage, such as <c>scan</c>, <c>manifest</c>, <c>import</c>, or <c>parity</c>.
+    /// </summary>
+    public required string Stage { get; init; }
+
+    /// <summary>
+    /// Evidence state for this measurement.
+    /// </summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// Measured duration in milliseconds for this operation.
+    /// </summary>
+    public long? DurationMilliseconds { get; init; }
+
+    /// <summary>
+    /// Number of resources processed by this operation.
+    /// </summary>
+    public long? ResourceCount { get; init; }
+
+    /// <summary>
+    /// Number of features processed by this operation.
+    /// </summary>
+    public long? FeatureCount { get; init; }
+
+    /// <summary>
+    /// Number of bytes read by this operation.
+    /// </summary>
+    public long? BytesRead { get; init; }
+
+    /// <summary>
+    /// Number of bytes written by this operation.
+    /// </summary>
+    public long? BytesWritten { get; init; }
+
+    /// <summary>
+    /// Retry attempts observed for this operation.
+    /// </summary>
+    public int? RetryCount { get; init; }
+
+    /// <summary>
+    /// Items from this operation that require manual review.
+    /// </summary>
+    public int? ManualReviewCount { get; init; }
+
+    /// <summary>
+    /// Secret-safe evidence artifact references. Query strings, fragments, and URL credentials are removed by the generator.
+    /// </summary>
+    public string[] EvidenceReferences { get; init; } = [];
 }

--- a/src/Honua.Core/Features/Import/Services/MigrationParityEvidenceGenerator.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationParityEvidenceGenerator.cs
@@ -27,11 +27,13 @@ public static class MigrationParityEvidenceGenerator
     /// <param name="inventory">Source inventory artifact.</param>
     /// <param name="manifest">Optional migration manifest artifact.</param>
     /// <param name="attestation">Optional operator-supplied readiness evidence.</param>
+    /// <param name="performanceCost">Optional performance and migration-cost measurements.</param>
     /// <returns>Deterministic parity evidence artifact.</returns>
     public static MigrationParityEvidenceArtifact Generate(
         MigrationSourceInventoryArtifact inventory,
         MigrationManifestArtifact? manifest = null,
-        MigrationReadinessAttestation? attestation = null)
+        MigrationReadinessAttestation? attestation = null,
+        MigrationPerformanceCostEvidence? performanceCost = null)
     {
         ArgumentNullException.ThrowIfNull(inventory);
 
@@ -52,7 +54,37 @@ public static class MigrationParityEvidenceGenerator
             Summary = BuildSummary(overallState, sections, readiness),
             ManifestAvailable = manifest != null,
             Sections = sections,
-            CutoverReadiness = readiness
+            CutoverReadiness = readiness,
+            PerformanceCost = NormalizePerformanceCost(performanceCost)
+        };
+    }
+
+    /// <summary>
+    /// Returns a deterministic, secret-safe performance/cost evidence block.
+    /// </summary>
+    /// <param name="performanceCost">Performance and cost evidence supplied by a scanner, importer, or test harness.</param>
+    /// <returns>Normalized evidence, or <c>null</c> when no evidence was supplied.</returns>
+    public static MigrationPerformanceCostEvidence? NormalizePerformanceCost(
+        MigrationPerformanceCostEvidence? performanceCost)
+    {
+        if (performanceCost == null)
+        {
+            return null;
+        }
+
+        return performanceCost with
+        {
+            State = NormalizeState(performanceCost.State),
+            EvidenceReferences = SanitizeEvidenceReferences(performanceCost.EvidenceReferences),
+            Operations = performanceCost.Operations
+                .OrderBy(static operation => operation.Id, StringComparer.Ordinal)
+                .ThenBy(static operation => operation.Stage, StringComparer.Ordinal)
+                .Select(static operation => operation with
+                {
+                    State = NormalizeState(operation.State),
+                    EvidenceReferences = SanitizeEvidenceReferences(operation.EvidenceReferences)
+                })
+                .ToArray()
         };
     }
 
@@ -378,6 +410,35 @@ public static class MigrationParityEvidenceGenerator
             .Distinct(StringComparer.Ordinal)
             .OrderBy(static value => value, StringComparer.Ordinal)
             .ToArray();
+
+    private static string[] SanitizeEvidenceReferences(IEnumerable<string> values)
+        => values
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => SanitizeEvidenceReference(value.Trim()))
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static value => value, StringComparer.Ordinal)
+            .ToArray();
+
+    private static string SanitizeEvidenceReference(string value)
+    {
+        var sensitiveTailIndex = value.IndexOfAny(['?', '#']);
+        var withoutQueryOrFragment = sensitiveTailIndex >= 0 ? value[..sensitiveTailIndex] : value;
+
+        if (!Uri.TryCreate(withoutQueryOrFragment, UriKind.Absolute, out var uri) ||
+            string.IsNullOrEmpty(uri.UserInfo))
+        {
+            return withoutQueryOrFragment;
+        }
+
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty
+        };
+
+        return builder.Uri.AbsoluteUri;
+    }
 
     private static bool IsPartial(string? level)
         => string.Equals(level, "partial", StringComparison.OrdinalIgnoreCase);

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationParityEvidenceGeneratorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationParityEvidenceGeneratorTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Import.Services;
 
@@ -8,6 +10,13 @@ namespace Honua.Core.Tests.Features.Import;
 
 public sealed class MigrationParityEvidenceGeneratorTests
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
     [Fact]
     public void Generate_WithoutReadinessAttestation_LeavesChecklistUnknown()
     {
@@ -117,6 +126,103 @@ public sealed class MigrationParityEvidenceGeneratorTests
             .Which.Should().Match<MigrationCutoverReadinessItem>(item =>
                 item.State == MigrationEvidenceStates.Unknown &&
                 item.Remediation.SequenceEqual(new[] { "Generate and review the migration manifest." }));
+    }
+
+    [Fact]
+    public void Generate_WithPerformanceCostEvidence_AttachesStableSecretSafeMetrics()
+    {
+        var inventory = CreateInventory(
+            resources:
+            [
+                CreateResource("workspace:roads", "Roads", "compatible", "Schema can be mapped.")
+            ]);
+        var manifest = MigrationManifestTranslator.Translate(inventory);
+        var performanceCost = new MigrationPerformanceCostEvidence
+        {
+            State = "collected",
+            Summary = "Fixture scan and manifest translation measurements captured.",
+            MeasurementScope = "fixture import dry run",
+            Totals = new MigrationPerformanceCostTotals
+            {
+                DurationMilliseconds = 1_250,
+                ResourceCount = 1,
+                FeatureCount = 42,
+                BytesRead = 4_096,
+                BytesWritten = 2_048,
+                RetryCount = 1,
+                ManualReviewCount = 0
+            },
+            EvidenceReferences =
+            [
+                " s3://migration-evidence/issue-1033/metrics.json?X-Amz-Signature=secret ",
+                "https://user:password@example.test/evidence/run.json?token=secret#fragment"
+            ],
+            Operations =
+            [
+                new MigrationPerformanceCostOperation
+                {
+                    Id = "manifest",
+                    Stage = "manifest",
+                    State = MigrationEvidenceStates.Pass,
+                    DurationMilliseconds = 50,
+                    ResourceCount = 1,
+                    EvidenceReferences =
+                    [
+                        "https://example.test/evidence/manifest.json?token=secret"
+                    ]
+                },
+                new MigrationPerformanceCostOperation
+                {
+                    Id = "scan",
+                    Stage = "scan",
+                    State = MigrationEvidenceStates.Pass,
+                    DurationMilliseconds = 1_200,
+                    ResourceCount = 1,
+                    FeatureCount = 42,
+                    BytesRead = 4_096,
+                    BytesWritten = 2_048,
+                    RetryCount = 1,
+                    ManualReviewCount = 0,
+                    EvidenceReferences =
+                    [
+                        "https://example.test/evidence/scan.json#secret-fragment"
+                    ]
+                }
+            ]
+        };
+
+        var evidence = MigrationParityEvidenceGenerator.Generate(
+            inventory,
+            manifest,
+            CreatePassingAttestation(),
+            performanceCost);
+
+        evidence.OverallState.Should().Be(MigrationEvidenceStates.Pass);
+        evidence.PerformanceCost.Should().NotBeNull();
+        evidence.PerformanceCost!.State.Should().Be(MigrationEvidenceStates.Unknown);
+        evidence.PerformanceCost.EvidenceReferences.Should().Equal(
+            "https://example.test/evidence/run.json",
+            "s3://migration-evidence/issue-1033/metrics.json");
+        evidence.PerformanceCost.Operations.Select(operation => operation.Id)
+            .Should().Equal("manifest", "scan");
+        evidence.PerformanceCost.Operations.SelectMany(operation => operation.EvidenceReferences)
+            .Should().OnlyContain(reference =>
+                !reference.Contains('?') &&
+                !reference.Contains('#') &&
+                !reference.Contains("secret", StringComparison.OrdinalIgnoreCase) &&
+                !reference.Contains("password", StringComparison.OrdinalIgnoreCase));
+
+        var json = JsonSerializer.Serialize(evidence, JsonOptions);
+
+        json.Should().Contain("\"performanceCost\"");
+        json.Should().Contain("\"durationMilliseconds\":1250");
+        json.Should().Contain("\"bytesRead\":4096");
+        json.Should().Contain("\"retryCount\":1");
+        json.Should().Contain("\"manualReviewCount\":0");
+        json.Should().NotContain("token");
+        json.Should().NotContain("password");
+        json.Should().NotContain("X-Amz-Signature");
+        json.Should().NotContain("#fragment");
     }
 
     private static MigrationReadinessAttestation CreatePassingAttestation()


### PR DESCRIPTION
## Issue Link

Related to #1033
Related to #1024

## Summary

Adds the first bounded artifact-model slice for migration cost/performance evidence. The parity evidence artifact can now carry secret-safe duration, volume, retry, byte, and manual-review metrics so later acceptance-suite work can publish measured migration cost evidence.

## Changes Made

- Added optional `performanceCost` evidence to migration parity evidence artifacts.
- Added totals and operation-level performance/cost metric records.
- Normalized metric evidence states and deterministic operation/reference ordering.
- Sanitized evidence references by stripping query strings, fragments, and URL credentials.
- Added serialization, redaction, metric field, and deterministic-ordering tests.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:

- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --filter FullyQualifiedName~MigrationParityEvidenceGeneratorTests --no-restore`
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --filter "FullyQualifiedName~MigrationParityEvidenceGeneratorTests|FullyQualifiedName~MigrationManifestTranslatorTests" --no-restore --no-build`
- `git diff --check`

## Gate Impact

- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None - no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes

None

---

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` or equivalent required PR CI, and all required checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
