### PR TITLE
feat: expose ogc geoprocessing result evidence (#1031)

### DIFF
--- a/src/Honua.Server/Features/Protocols/Ogc/Api/Processes/JobEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Ogc/Api/Processes/JobEndpoints.cs
@@ -3,12 +3,14 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Text.Json;
 using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
+using Honua.Server.Features.Geoprocessing;
 using Honua.Server.Features.Infrastructure.Authentication;
 using Honua.Server.Features.Infrastructure.ControlPlane;
 using Honua.Server.Features.Infrastructure.Helpers;
@@ -194,6 +196,7 @@ internal static class JobEndpoints
         string jobId,
         HttpContext context,
         ILogger<OgcProcessesEndpointsLog> logger,
+        [FromServices] IGeoprocessingJobService jobService,
         [FromServices] IExecutionJobStore? jobStore = null)
     {
         EnrichActivity("GetJobResults");
@@ -253,10 +256,8 @@ internal static class JobEndpoints
                 StatusCodes.Status404NotFound);
         }
 
-        // V1: document-mode, by-value results only.
-        // Result storage will be populated when the execution engine is available.
-        // For now return an empty results document for successful jobs,
-        // or an error for failed/dismissed jobs.
+        // V1 publishes document-mode results by adapting the canonical
+        // geoprocessing result package into OGC output members.
         if (job.Status == ExecutionJobStatus.Failed)
         {
             return Results.Json(
@@ -287,13 +288,16 @@ internal static class JobEndpoints
                 StatusCodes.Status410Gone);
         }
 
-        // OGC API Processes — Part 1 §7.11.1: a successful job must return a results
-        // document, not a 404. The canonical process declares no value-typed outputs in
-        // V1, so the spec-conformant body is an empty object. Clients walking the job
-        // lifecycle now see 200 OK + `{}` instead of "not available".
-        // When the artifact store is wired up the dictionary will be populated from the
-        // job's ArtifactRefs; until then the endpoint stays spec-legal.
-        return Results.Text("{}", MediaTypes.Json, statusCode: StatusCodes.Status200OK);
+        var resultPackage = await jobService
+            .GetJobResultsAsync(jobId, context.User, context.RequestAborted)
+            .ConfigureAwait(false);
+
+        var resultsDocument = ToOgcResultsDocument(resultPackage);
+        return Results.Json(
+            resultsDocument.Outputs ?? new Dictionary<string, JsonElement>(StringComparer.Ordinal),
+            OgcProcessesJsonContext.Default.DictionaryStringJsonElement,
+            MediaTypes.Json,
+            StatusCodes.Status200OK);
     }
 
     private static async Task<IResult> DismissJob(
@@ -736,6 +740,61 @@ internal static class JobEndpoints
 
     private static IResult JobNotFoundResult(string jobId) => OgcProcessesResults.NoSuchJob(jobId);
 
+    private static OgcResultsDocument ToOgcResultsDocument(AnalysisResultPackage resultPackage)
+    {
+        var outputs = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        foreach (var artifact in resultPackage.Artifacts)
+        {
+            var outputName = ResolveUniqueOutputName(ResolveOutputName(artifact, outputs.Count), outputs);
+            outputs[outputName] = JsonSerializer.SerializeToElement(
+                new OgcArtifactResult
+                {
+                    Id = artifact.ArtifactId,
+                    Kind = artifact.Kind.ToString(),
+                    Title = artifact.Label,
+                    Href = artifact.Uri,
+                    Type = artifact.ContentType
+                },
+                OgcProcessesJsonContext.Default.OgcArtifactResult);
+        }
+
+        return new OgcResultsDocument { Outputs = outputs };
+    }
+
+    private static string ResolveOutputName(ArtifactRef artifact, int index)
+    {
+        if (artifact.Metadata.TryGetValue(
+                GeoprocessingProtocolMetadataKeys.GeoServicesOutputParameterMetadataKey,
+                out var outputName) &&
+            !string.IsNullOrWhiteSpace(outputName))
+        {
+            return outputName;
+        }
+
+        return string.IsNullOrWhiteSpace(artifact.Label)
+            ? $"output{index + 1}"
+            : artifact.Label;
+    }
+
+    private static string ResolveUniqueOutputName(
+        string outputName,
+        Dictionary<string, JsonElement> existingOutputs)
+    {
+        if (!existingOutputs.ContainsKey(outputName))
+        {
+            return outputName;
+        }
+
+        for (var suffix = 2; ; suffix++)
+        {
+            var candidate = $"{outputName}_{suffix}";
+            if (!existingOutputs.ContainsKey(candidate))
+            {
+                return candidate;
+            }
+        }
+    }
+
     private static IResult BuildDismissOutcomeResult(
         string baseUrl,
         string jobId,
@@ -758,4 +817,17 @@ internal static class JobEndpoints
         activity.SetTag(HonuaTelemetry.Tags.Operation, operation);
     }
 
+}
+
+internal sealed record OgcArtifactResult
+{
+    public required string Id { get; init; }
+
+    public required string Kind { get; init; }
+
+    public string? Title { get; init; }
+
+    public string? Href { get; init; }
+
+    public string? Type { get; init; }
 }

--- a/src/Honua.Server/Features/Protocols/Ogc/Api/Processes/Models/OgcProcessesModels.cs
+++ b/src/Honua.Server/Features/Protocols/Ogc/Api/Processes/Models/OgcProcessesModels.cs
@@ -317,5 +317,5 @@ public sealed record OgcResultsDocument
     /// Output values keyed by stable output identifier.
     /// </summary>
     [JsonExtensionData]
-    public Dictionary<string, object?>? Outputs { get; init; }
+    public Dictionary<string, JsonElement>? Outputs { get; init; }
 }

--- a/src/Honua.Server/Features/Protocols/Ogc/Api/Processes/OgcProcessesJsonContext.cs
+++ b/src/Honua.Server/Features/Protocols/Ogc/Api/Processes/OgcProcessesJsonContext.cs
@@ -32,10 +32,12 @@ namespace Honua.Server.Features.Protocols.Ogc.Api.Processes;
 [JsonSerializable(typeof(OgcStatusInfo))]
 [JsonSerializable(typeof(OgcProcessError))]
 [JsonSerializable(typeof(OgcResultsDocument))]
+[JsonSerializable(typeof(OgcArtifactResult))]
 [JsonSerializable(typeof(OgcJobList))]
 [JsonSerializable(typeof(ImmutableArray<OgcStatusInfo>))]
 [JsonSerializable(typeof(OgcStatusInfo[]))]
 [JsonSerializable(typeof(Dictionary<string, object?>))]
+[JsonSerializable(typeof(Dictionary<string, JsonElement>))]
 [JsonSerializable(typeof(JsonElement))]
 [JsonSerializable(typeof(object))]
 internal sealed partial class OgcProcessesJsonContext : JsonSerializerContext

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Ogc/Api/Processes/OgcProcessesJobResultsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Ogc/Api/Processes/OgcProcessesJobResultsTests.cs
@@ -1,0 +1,198 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Server.Features.Geoprocessing;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.Server.Tests.Helpers;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes;
+
+/// <summary>
+/// Integration coverage for OGC API Processes result evidence.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.OgcApiProcesses)]
+public sealed class OgcProcessesJobResultsTests : IAsyncLifetime
+{
+    private const string JobId = "ogc-gp-result-job";
+
+    private readonly WebAppFixture _fixture;
+
+    public OgcProcessesJobResultsTests()
+    {
+        var jobStore = Substitute.For<IExecutionJobStore>().WithTrySet();
+        jobStore.GetAsync(JobId, Arg.Any<CancellationToken>()).Returns(CreateSucceededJob());
+
+        _fixture = new WebAppFixture()
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IExecutionJobStore>();
+                services.AddSingleton(jobStore);
+                services.RemoveAll<IGeoprocessingJobService>();
+                services.AddSingleton<IGeoprocessingJobService>(new ArtifactBackedJobService());
+            });
+    }
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.JobStatus)]
+    [Endpoint("GET /ogc/processes/jobs/{jobId}")]
+    public async Task JobStatus_SucceededArtifactBackedJob_ExposesResultsLink()
+    {
+        using var response = await _fixture.Client.GetAsync($"/ogc/processes/jobs/{JobId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var links = doc.RootElement.GetProperty("links").EnumerateArray();
+        links.Should().Contain(link =>
+            link.GetProperty("rel").GetString() == "http://www.opengis.net/def/rel/ogc/1.0/results" &&
+            link.GetProperty("href").GetString()!.EndsWith($"/ogc/processes/jobs/{JobId}/results", StringComparison.Ordinal));
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.JobResults)]
+    [Endpoint("GET /ogc/processes/jobs/{jobId}/results")]
+    public async Task JobResults_SucceededArtifactBackedJob_ReturnsNonEmptyResultEvidence()
+    {
+        using var response = await _fixture.Client.GetAsync($"/ogc/processes/jobs/{JobId}/results");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().NotBe("{}");
+
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.EnumerateObject().Should().NotBeEmpty();
+        var output = doc.RootElement.GetProperty("outputFeatureLayer");
+        output.GetProperty("kind").GetString().Should().Be("FeatureLayer");
+        output.GetProperty("href").GetString().Should().Be("https://example.test/ogc-buffer-output.geojson");
+        output.GetProperty("id").GetString().Should().Be("artifact-output-1");
+
+        var duplicateOutput = doc.RootElement.GetProperty("outputFeatureLayer_2");
+        duplicateOutput.GetProperty("kind").GetString().Should().Be("Report");
+        duplicateOutput.GetProperty("href").GetString().Should().Be("https://example.test/ogc-buffer-output-summary.json");
+        duplicateOutput.GetProperty("id").GetString().Should().Be("artifact-output-2");
+    }
+
+    private static ExecutionJobRecord CreateSucceededJob()
+        => new()
+        {
+            OperationId = JobId,
+            Status = ExecutionJobStatus.Succeeded,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            UpdatedAt = DateTimeOffset.UtcNow,
+            CompletedAt = DateTimeOffset.UtcNow,
+            ArtifactReferences = ["https://example.test/ogc-buffer-output.geojson"],
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geometry-buffer",
+                Parameters = new Dictionary<string, string>
+                {
+                    [ExecutionJobParameterKeys.GeoprocessingPlanId] = "geometry-buffer-plan",
+                    [ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = "geometry.buffer",
+                    [ExecutionJobParameterKeys.GeoprocessingOutputArtifactKinds] = "FeatureLayer",
+                    [$"{GeoprocessingProtocolMetadataKeys.GPServerOutputNamePrefix}0"] = "outputFeatureLayer"
+                }
+            }
+        };
+
+    private sealed class ArtifactBackedJobService : IGeoprocessingJobService
+    {
+        private static readonly AnalysisResultPackage Results = AnalysisResultPackage.CreateCompleted(
+            resultPackageId: "ogc-gp-result-job:v1",
+            summary: new ResultSummary
+            {
+                Title = "geometry.buffer results",
+                Description = "Produced 1 artifact."
+            },
+            artifacts:
+            [
+                new ArtifactRef
+                {
+                    ArtifactId = "artifact-output-1",
+                    Kind = ArtifactKind.FeatureLayer,
+                    Label = "outputFeatureLayer",
+                    Uri = "https://example.test/ogc-buffer-output.geojson",
+                    ContentType = "application/geo+json",
+                    Metadata = new Dictionary<string, string>
+                    {
+                        [GeoprocessingProtocolMetadataKeys.GeoServicesOutputParameterMetadataKey] = "outputFeatureLayer"
+                    }
+                },
+                new ArtifactRef
+                {
+                    ArtifactId = "artifact-output-2",
+                    Kind = ArtifactKind.Report,
+                    Label = "outputFeatureLayer",
+                    Uri = "https://example.test/ogc-buffer-output-summary.json",
+                    ContentType = "application/json",
+                    Metadata = new Dictionary<string, string>
+                    {
+                        [GeoprocessingProtocolMetadataKeys.GeoServicesOutputParameterMetadataKey] = "outputFeatureLayer"
+                    }
+                }
+            ],
+            workspaceRefs: [],
+            provenance: new ProvenanceRecord
+            {
+                Sources = [],
+                ProcessDefinitions = ["geometry.buffer"],
+                ExecutedAt = DateTimeOffset.UtcNow
+            });
+
+        public void EnsureCallerAuthorized(ClaimsPrincipal principal, OperatorResourceType resourceType, OperatorOperation operation)
+        {
+        }
+
+        public PlanValidationResult ValidatePlan(AnalysisPlan plan, ClaimsPrincipal principal)
+            => throw new NotSupportedException();
+
+        public DryRunResult DryRunPlan(AnalysisPlan plan, ClaimsPrincipal principal)
+            => throw new NotSupportedException();
+
+        public Task<ExecutionJobRecord> SubmitJobAsync(
+            AnalysisPlan plan,
+            string? idempotencyKey,
+            ClaimsPrincipal principal,
+            IReadOnlyDictionary<string, string>? protocolMetadata = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<ExecutionJobRecord> GetJobAsync(
+            string jobId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(CreateSucceededJob());
+
+        public Task<AnalysisResultPackage> GetJobResultsAsync(
+            string jobId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(Results);
+
+        public Task CancelJobAsync(
+            string jobId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1031

## Summary
This PR replaces the OGC API Processes successful-job placeholder result body with artifact-backed result evidence from the canonical geoprocessing job service.

It is the first split for #1031: result route evidence. It does not claim the full process portability story yet; per-process execution fixtures, heavyweight-process classification, and SDK runner evidence remain follow-up work under the issue.

## Changes Made
- Adapt `AnalysisResultPackage.Artifacts` into OGC API Processes results document output members.
- Use the shared geoprocessing output-parameter metadata key so migrated GP outputs surface under stable parameter names.
- Add source-generated JSON coverage for artifact result payloads.
- Add OGC API Processes integration coverage proving completed artifact-backed jobs expose a results link and return non-empty result evidence.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation run locally:
- `dotnet format Honua.sln`
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~OgcProcessesJobResultsTests|FullyQualifiedName~OgcProcessesEndpointsTests|FullyQualifiedName~OgcProcessesJobKindFilterTests|FullyQualifiedName~GPServerEndpointTests|FullyQualifiedName~GPServerClientCompatibilityTests" --no-restore`
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter FullyQualifiedName~OgcProcessesJobResultsTests --no-restore --no-build`
- `git diff --check origin/trunk...HEAD`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] `scripts/ci/pre-pr-check.sh` full end-to-end run not performed locally; targeted checks above passed and PR CI is running the full gate set.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review
