### PR TITLE
docs: add metadata v2 design docs (#1035)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -88,6 +88,11 @@
 - [Contributing](contributor/development/contributing.md)
 - [Architecture](contributor/ARCHITECTURE.md)
 - [ADRs](contributor/adr/README.md)
+- Metadata v2
+  - [Backlog Index](contributor/architecture/metadata-v2-backlog.md)
+  - [Roadmap](contributor/architecture/metadata-v2-roadmap.md)
+  - [Release Readiness](contributor/architecture/metadata-v2-release-readiness.md)
+  - [Admin UI Information Model](contributor/architecture/metadata-v2-admin-ui-information-model.md)
 - [TestKit](contributor/testkit.md)
 - [Public Interface Quality Model](contributor/public-interface-quality-model.md)
 - [Compatibility and Automated Migration Evidence](contributor/compatibility-and-migration-evidence.md)

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -17,6 +17,11 @@ This section is for people **building or extending** Honua (core contributors, a
 - [Architecture Review Criteria](architecture-criteria.md) — PR review quality gates
 - [Package and Module Governance](package-and-module-governance.md) — central package versions and optional module boundaries
 - [Honua Manifesto](HONUA_MANIFESTO.md) — core principles
+- Metadata v2 architecture artifacts:
+  - [Backlog Index](architecture/metadata-v2-backlog.md) — local issue index and sequencing guide for `#1035`
+  - [Roadmap](architecture/metadata-v2-roadmap.md) — milestone grouping derived from the GitHub issues
+  - [Release Readiness](architecture/metadata-v2-release-readiness.md) — non-authoritative release gates derived from the GitHub issues
+  - [Admin UI Information Model](architecture/metadata-v2-admin-ui-information-model.md) — Claude Design handoff for `#1046`
 
 ## Design Patterns
 
@@ -51,6 +56,7 @@ This section is for people **building or extending** Honua (core contributors, a
 
 - [GeoETL Roadmap](geoetl-roadmap.md) — pipeline architecture, child-ticket decomposition, and runtime boundary for `#361`
 - [GeoETL Strategy Spike](geoetl-spike.md) — competitor evaluation and positioning from `#682`
+- [Metadata v2 Roadmap](architecture/metadata-v2-roadmap.md) — milestone grouping for `#1035` and child issues
 
 ## Project Operations
 

--- a/docs/contributor/RELEASE_CHECKLIST.md
+++ b/docs/contributor/RELEASE_CHECKLIST.md
@@ -19,6 +19,9 @@ Use this checklist for every MVP release.
 
 ## Compatibility Contract Updates (Required)
 
+- [ ] If the release includes Metadata v2 scope, review the non-authoritative
+  [Metadata v2 Release Readiness](architecture/metadata-v2-release-readiness.md)
+  gates against the authoritative GitHub issues before sign-off.
 - [ ] Update [MVP Compatibility Contract](../gis/MVP_COMPATIBILITY_CONTRACT.md)
 - [ ] Validate [Public Interface Quality Model](public-interface-quality-model.md) and [public-interface-proof.json](../gis/data/public-interface-proof.json) against the shipped runtime surface
 - [ ] Refresh [GeoServices REST Parity](../gis/geoservices-rest-parity.md), the service drill-down matrices, and [data/geoservices-rest-parity.json](../gis/data/geoservices-rest-parity.json) when GeoServices routes, parameters, or response shapes changed in the release

--- a/docs/contributor/architecture/metadata-v2-admin-ui-information-model.md
+++ b/docs/contributor/architecture/metadata-v2-admin-ui-information-model.md
@@ -1,0 +1,283 @@
+# Metadata v2 Admin UI Information Model
+
+This is a Claude Design handoff derived from
+[honua-server#1046](https://github.com/honua-io/honua-server/issues/1046) and
+the Metadata v2 epic,
+[honua-server#1035](https://github.com/honua-io/honua-server/issues/1035).
+GitHub remains authoritative for scope and acceptance. This file translates the
+issue intent into a design brief for workflow, navigation, labels, and UI state.
+
+## Design Intent
+
+The admin UI should make Metadata v2 navigable through workflows, not through
+raw schema editing. Users should be able to connect to data, create or inspect a
+data resource, describe it once, publish it to services or catalogs, control
+access, and validate readiness across standards.
+
+The dominant mental model is:
+
+Catalog Workspace -> Connections -> Data Resources -> Source, Fields,
+Metadata, Publish, Access, Validation -> Services and Catalogs.
+
+Supporting schema objects can exist behind these workflows, but the main UI
+should keep users focused on what they are trying to manage.
+
+## UI Vocabulary
+
+Use these as primary interface terms:
+
+- Connections
+- Data Resources
+- Source
+- Fields
+- Metadata
+- Publish
+- Access
+- Validation
+- Readiness
+- Projection Preview
+- Advanced Overrides
+
+Forbidden as primary UI terms:
+
+- storageBinding
+- projectionProfile
+- ABAC
+- canonical graph
+- distribution object
+- policy condition
+- runtime snapshot
+
+These forbidden terms may appear only in advanced diagnostics, developer
+tooling, raw JSON inspection, or support documentation where the internal object
+name is necessary.
+
+## Top Navigation
+
+1. Dashboard
+2. Connections
+3. Data Resources
+4. Services
+5. Publishing
+6. Access
+7. Validation
+8. Settings
+
+Top navigation should favor operational scanning. Avoid marketing-style
+overview pages; the first screen should show actionable status, recent changes,
+validation blockers, and publishing readiness.
+
+## Data Resources List
+
+Recommended columns:
+
+| Column | Purpose |
+|---|---|
+| Name | Human display name and stable identity cue |
+| Type | Feature dataset, raster dataset, table, tile dataset, process, style, document, or external resource |
+| Source | Connection and source summary |
+| Metadata | Completeness state |
+| Published to | Service and catalog targets |
+| Access | Preset or custom access summary |
+| Validation | Ready, warning, blocked, or not applicable |
+| Modified | Last meaningful authoring change |
+
+Primary actions:
+
+- Create data resource
+- Filter by type, source, validation, access, and publish target
+- Open validation blockers
+- Open projection preview
+
+## Resource Detail Tabs
+
+1. Overview
+2. Source
+3. Fields
+4. Metadata
+5. Publish
+6. Access
+7. Validation
+8. Advanced
+
+### Overview
+
+Show identity, lifecycle state, source summary, metadata completeness, publish
+status, access summary, and validation state. The Overview tab should answer:
+"What is this resource, where does it come from, where is it published, and what
+blocks readiness?"
+
+### Source
+
+Show connection, selected table/file/API asset, detected capabilities, health,
+and source-specific warnings. Keep credential details behind secret references
+and do not expose resolved secrets.
+
+### Fields
+
+Recommended field columns:
+
+| Column | Purpose |
+|---|---|
+| Field name | Source field identifier |
+| Display name | User-facing label |
+| Type | Data type |
+| Role | Primary ID, geometry, display name, temporal field, owner, status, category, asset URL, license, quality flag |
+| Required | Whether this field is required for selected targets |
+| Query | Query exposure |
+| Edit | Edit exposure |
+| Sensitive | Visibility or masking state |
+| Standard bindings | Advanced mapping summary |
+
+The default field UI should expose simple roles first and advanced bindings
+second.
+
+### Metadata
+
+Sections:
+
+- Basic description
+- Themes and keywords
+- Publisher and contacts
+- License and rights
+- Dates
+- Spatial extent
+- Temporal extent
+- Quality and lineage
+- Links
+- Distributions
+
+Metadata editing should show completeness by selected readiness target instead
+of asking users to edit one standard-specific document at a time.
+
+### Publish
+
+Show publication targets and compatibility:
+
+| Target | Example Status | Common Blocker |
+|---|---|---|
+| OGC API Features collection | Ready | None |
+| WFS feature type | Blocked | Source is not queryable |
+| WMS layer | Ready | None |
+| WMTS layer | Warning | Tile settings incomplete |
+| GeoServices FeatureServer layer | Ready | None |
+| GeoServices MapServer layer | Ready | None |
+| GeoServices ImageServer raster | Warning | Raster source metadata incomplete |
+| OData entity set | Ready | None |
+| STAC collection | Warning | Missing license |
+| DCAT dataset/distribution | Warning | Missing publisher identifier |
+| OGC Records record | Ready | None |
+| Esri catalog/portal item | Warning | Missing thumbnail or owner details |
+
+### Access
+
+Access presets:
+
+- Public read
+- Organization read
+- Private
+- Publisher edit
+- Admin only
+- Custom
+
+Preset summaries should be human readable. Raw policy JSON is advanced-only.
+
+### Validation
+
+Show blockers and warnings grouped by workflow area, with a direct route to the
+tab that can fix each issue.
+
+### Advanced
+
+Advanced should contain raw object inspection, schema diagnostics, projection
+debugging, and override tools. It should not become the default path for normal
+resource authoring.
+
+## Create Resource Flow
+
+1. Choose source type.
+2. Select or create connection.
+3. Pick table, file, API asset, or external source.
+4. Inspect schema and capabilities.
+5. Confirm resource identity.
+6. Add required metadata.
+7. Choose access preset.
+8. Choose publishing targets.
+9. Review validation.
+10. Create as draft or publish.
+
+The flow should support draft creation before all publish targets are ready.
+Validation should distinguish blockers from warnings and from missing optional
+metadata.
+
+## Publish Resource Flow
+
+1. Choose target service or catalog.
+2. Review compatibility.
+3. Configure path, layer name, collection name, or item identity.
+4. Review field exposure.
+5. Review metadata projection.
+6. Validate.
+7. Publish.
+
+Publishing should show a projection preview before commit. The preview should be
+available as a drawer or side panel so users can compare canonical metadata with
+target output without leaving the workflow.
+
+## Validation Center
+
+Validation is both a global workspace view and a resource-level tab.
+
+Global Validation Center groups:
+
+- Source
+- Schema
+- Metadata
+- Publishing
+- Security
+- Standards
+- Cache/runtime
+
+Readiness targets:
+
+- OGC Records
+- DCAT
+- STAC
+- ISO 19115
+- Esri catalog/item
+- GeoServices REST
+- OGC API
+- OData
+
+Validation states:
+
+- Ready
+- Warning
+- Blocked
+- Not applicable
+
+Each validation row should identify the resource, target, issue, severity, and
+fix location. Rows should support filtering by severity, target, resource type,
+and publish target.
+
+## Claude Design Deliverables
+
+- Information architecture map
+- Dashboard layout
+- Connections list and detail page
+- Data Resources list
+- Data Resource detail page with tabs
+- Create Resource wizard
+- Publish Resource flow
+- Publishing matrix
+- Access preset and policy UI
+- Validation Center
+- Projection Preview drawer
+- Empty, loading, warning, blocked, and success states
+
+## Visual Direction
+
+This is an operational admin product. Use dense tables, tabs, side panels,
+segmented controls, status badges, inline validation, and projection preview
+drawers. Avoid decorative landing pages and avoid making raw schema editing the
+primary workflow.

--- a/docs/contributor/architecture/metadata-v2-backlog.md
+++ b/docs/contributor/architecture/metadata-v2-backlog.md
@@ -1,0 +1,84 @@
+# Metadata v2 Backlog Index
+
+This is a local navigation and sequencing guide for Metadata v2 planning. GitHub
+issues remain authoritative for scope, status, acceptance criteria, and closure:
+
+- Epic: [honua-server#1035](https://github.com/honua-io/honua-server/issues/1035)
+- Admin UI design handoff: [honua-server#1046](https://github.com/honua-io/honua-server/issues/1046)
+
+Use this file to decide which issue to read next, not to replace the issue body.
+When this file disagrees with GitHub, update this file or ignore it.
+
+## Reading Order
+
+1. Start with [#1035](https://github.com/honua-io/honua-server/issues/1035)
+   for the epic principle: resource first, service second.
+2. Read [ADR-0023](../adr/0023-metadata-architecture.md) for the existing
+   metadata resource-model direction.
+3. Use the [roadmap](metadata-v2-roadmap.md) for milestone grouping.
+4. Use the [release-readiness gates](metadata-v2-release-readiness.md) before
+   treating the Metadata v2 surface as shippable.
+5. Use the [admin UI information model](metadata-v2-admin-ui-information-model.md)
+   when handing workflow design to Claude Design or another UI agent.
+
+## Issue Map
+
+| Issue | Planning Role | Read When |
+|---|---|---|
+| [#1035](https://github.com/honua-io/honua-server/issues/1035) | Epic and source of truth | Any Metadata v2 scope, status, or gate question |
+| [#1036](https://github.com/honua-io/honua-server/issues/1036) | Canonical root schema and runtime snapshot contract | Starting schema work or cache-safe serialization |
+| [#1037](https://github.com/honua-io/honua-server/issues/1037) | Resource-first model | Mapping current layers, rasters, tables, processes, styles, or external assets |
+| [#1038](https://github.com/honua-io/honua-server/issues/1038) | Storage and capability model | Connecting relational, raster, object, tile, file, or external API sources |
+| [#1039](https://github.com/honua-io/honua-server/issues/1039) | Secret-reference model | Touching connections, credentials, health checks, snapshots, or admin responses |
+| [#1040](https://github.com/honua-io/honua-server/issues/1040) | Catalog metadata semantics | Projecting resource meaning to standards and catalog targets |
+| [#1041](https://github.com/honua-io/honua-server/issues/1041) | Field roles and bindings | Mapping fields into protocol, catalog, query, edit, or sensitivity behavior |
+| [#1042](https://github.com/honua-io/honua-server/issues/1042) | Publications | Linking one resource to many service or catalog targets |
+| [#1043](https://github.com/honua-io/honua-server/issues/1043) | Projection profiles | Building standards outputs, preview, health, or projection caches |
+| [#1044](https://github.com/honua-io/honua-server/issues/1044) | Policy-based access | Reworking RBAC, access presets, field restrictions, or readable policy summaries |
+| [#1045](https://github.com/honua-io/honua-server/issues/1045) | Redis snapshots and projections | Versioning normalized runtime snapshots and derived projection caches |
+| [#1046](https://github.com/honua-io/honua-server/issues/1046) | Admin UI information model | Designing admin workflows without exposing raw schema complexity |
+| [#1047](https://github.com/honua-io/honua-server/issues/1047) | v1-to-v2 migration | Converting current metadata and reporting diagnostics |
+
+## Suggested Sequence
+
+### Foundation
+
+Work starts with #1036 and #1037. These define the schema root and the
+resource-first model that every later slice depends on.
+
+### Source and Safety
+
+Then sequence #1038 and #1039 so source bindings, capabilities, connections,
+and secret references are settled before publication, validation, or cache work
+depends on them.
+
+### Meaning
+
+Sequence #1040 and #1041 after the resource and source model. These issues
+define the resource metadata and field semantics that projections and UI
+readiness need.
+
+### Publication and Projection
+
+Sequence #1042 and #1043 once resources, metadata, fields, and capabilities are
+stable enough to decide whether a target is ready, warning, blocked, or not
+applicable.
+
+### Access and Runtime
+
+Sequence #1044 and #1045 with publication/projection work. Access decisions and
+cache keys both need the canonical entity boundaries, but they should be
+validated before release readiness.
+
+### UI and Migration
+
+#1046 can begin from the issue body and this design handoff, but it should
+refresh after any naming or workflow change in the foundation issues. #1047 is
+the bridge from existing metadata into the v2 shape and should run against the
+same release gates as new v2 authoring.
+
+## Local Artifacts
+
+- [Metadata v2 roadmap](metadata-v2-roadmap.md)
+- [Metadata v2 release-readiness gates](metadata-v2-release-readiness.md)
+- [Metadata v2 admin UI information model](metadata-v2-admin-ui-information-model.md)

--- a/docs/contributor/architecture/metadata-v2-release-readiness.md
+++ b/docs/contributor/architecture/metadata-v2-release-readiness.md
@@ -1,0 +1,135 @@
+# Metadata v2 Release Readiness
+
+This checklist is derived from the Metadata v2 epic,
+[honua-server#1035](https://github.com/honua-io/honua-server/issues/1035), and
+its child issues. It is not authoritative. Use the GitHub issues for acceptance
+criteria, status, and closure decisions.
+
+Use this document as a release review aid after implementation work lands. It
+should help reviewers confirm that the issue-level gates have coherent evidence
+across schema, runtime, UI, migration, and standards projection.
+
+## Gate 1: Canonical Schema Exists
+
+Derived from:
+
+- [#1035](https://github.com/honua-io/honua-server/issues/1035)
+- [#1036](https://github.com/honua-io/honua-server/issues/1036)
+- [#1037](https://github.com/honua-io/honua-server/issues/1037)
+
+Release evidence:
+
+- There is one canonical Metadata v2 schema source in the repo.
+- Runtime snapshots validate against that schema without patching.
+- Root metadata includes schema version, revision, tenant, environment, and
+  generated time.
+- Data Resources are the canonical unit; service-specific identity lives on
+  publications or target-specific overrides.
+
+## Gate 2: Secret-Safe Metadata
+
+Derived from:
+
+- [#1038](https://github.com/honua-io/honua-server/issues/1038)
+- [#1039](https://github.com/honua-io/honua-server/issues/1039)
+- [#1045](https://github.com/honua-io/honua-server/issues/1045)
+
+Release evidence:
+
+- Connections use references for endpoints, credentials, or connection handles.
+- Production validation rejects dev-only inline credentials.
+- Admin APIs and Redis snapshots do not expose resolved connection strings or
+  secrets.
+- Health checks resolve secrets at runtime without mutating canonical metadata.
+
+## Gate 3: Resource Meaning Projects Without Duplication
+
+Derived from:
+
+- [#1040](https://github.com/honua-io/honua-server/issues/1040)
+- [#1041](https://github.com/honua-io/honua-server/issues/1041)
+- [#1042](https://github.com/honua-io/honua-server/issues/1042)
+- [#1043](https://github.com/honua-io/honua-server/issues/1043)
+
+Release evidence:
+
+- Canonical resource metadata can project to OGC Records, DCAT, STAC, ISO
+  19115, Esri catalog/items, GeoServices REST, OGC API, and OData.
+- Standards-specific data is sparse override data, not a competing source of
+  truth.
+- Field roles drive target mappings before advanced target-specific bindings.
+- One resource can have multiple publications with target readiness reporting.
+
+## Gate 4: Workflow-Based Admin UI
+
+Derived from:
+
+- [#1035](https://github.com/honua-io/honua-server/issues/1035)
+- [#1044](https://github.com/honua-io/honua-server/issues/1044)
+- [#1046](https://github.com/honua-io/honua-server/issues/1046)
+
+Release evidence:
+
+- The admin UI can navigate Metadata v2 through workflow screens without
+  requiring raw schema editing.
+- Primary screens use Connections, Data Resources, Source, Fields, Metadata,
+  Publish, Access, Validation, Readiness, Projection Preview, and Advanced
+  Overrides.
+- Access presets summarize policy behavior in human-readable language.
+- Validation Center groups source, schema, metadata, publishing, security,
+  standards, and cache/runtime findings.
+
+## Gate 5: Runtime Snapshot and Projection Cache Safety
+
+Derived from:
+
+- [#1043](https://github.com/honua-io/honua-server/issues/1043)
+- [#1045](https://github.com/honua-io/honua-server/issues/1045)
+
+Release evidence:
+
+- Cache keys include tenant, environment, catalog, schema version, revision,
+  projection target, and projection profile version where applicable.
+- Runtime snapshots exclude secrets and runtime-only handles.
+- Projection caches can be rebuilt independently from the canonical snapshot.
+- Schema migrations invalidate old cache keys deterministically.
+
+## Gate 6: v1 Migration Is Diagnosable
+
+Derived from:
+
+- [#1047](https://github.com/honua-io/honua-server/issues/1047)
+
+Release evidence:
+
+- Existing metadata snapshots can convert to Metadata v2.
+- Migration reports warnings, blockers, and inferred defaults.
+- Service-owned layers become resource publications.
+- Raw connection strings are flagged and converted to required secret
+  references.
+- Migration output validates against the Metadata v2 schema.
+
+## Gate 7: Release Notes and User Risk
+
+Derived from:
+
+- [#1035](https://github.com/honua-io/honua-server/issues/1035)
+- [Release checklist](../RELEASE_CHECKLIST.md)
+
+Release evidence:
+
+- Any user-visible behavior change is reflected in release notes or migration
+  guidance.
+- Known caveats and workarounds cover incomplete target projections,
+  validation warnings, migration blockers, or admin UI limitations.
+- Follow-up issues are linked for deferred Metadata v2 work.
+
+## Review Output
+
+For a Metadata v2 release candidate, capture:
+
+- GitHub issue list reviewed.
+- Schema and migration validation evidence.
+- Projection readiness evidence for each claimed target.
+- Admin UI workflow evidence or design sign-off.
+- Known caveats, waivers, and follow-up issues.

--- a/docs/contributor/architecture/metadata-v2-roadmap.md
+++ b/docs/contributor/architecture/metadata-v2-roadmap.md
@@ -1,0 +1,126 @@
+# Metadata v2 Roadmap
+
+This roadmap is derived from the Metadata v2 GitHub issues and is not
+authoritative. Use [honua-server#1035](https://github.com/honua-io/honua-server/issues/1035)
+and its child issues for current scope, status, and acceptance criteria.
+
+The roadmap groups issues into milestones so contributors can reason about
+dependencies and review shape. It does not create new requirements.
+
+## Milestone 0: Contract Orientation
+
+Goal: align contributors on the Metadata v2 model before implementation starts.
+
+Inputs:
+
+- [#1035](https://github.com/honua-io/honua-server/issues/1035) epic principle
+- [ADR-0023](../adr/0023-metadata-architecture.md) metadata resource model
+- [Backlog index](metadata-v2-backlog.md)
+
+Exit signals:
+
+- Contributors can explain "resource first, service second."
+- Planning docs point to GitHub as the source of truth.
+- UI handoff uses workflow vocabulary instead of internal schema terms.
+
+## Milestone 1: Canonical Model Foundation
+
+Issues:
+
+- [#1036](https://github.com/honua-io/honua-server/issues/1036) canonical root schema and runtime snapshot contract
+- [#1037](https://github.com/honua-io/honua-server/issues/1037) resource-first model
+
+Purpose:
+
+- Establish the root entities and metadata envelope.
+- Make Data Resource the canonical unit for datasets, rasters, tables, tile
+  sets, processes, styles, documents, and external resources.
+- Keep service-specific aliases, paths, indexes, and overrides outside the
+  canonical resource.
+
+## Milestone 2: Source, Capability, and Secret Safety
+
+Issues:
+
+- [#1038](https://github.com/honua-io/honua-server/issues/1038) storage and capability model
+- [#1039](https://github.com/honua-io/honua-server/issues/1039) secret references
+
+Purpose:
+
+- Normalize source attachments and computed capabilities.
+- Separate storage/source type from service or publication type.
+- Ensure cacheable metadata and admin responses never contain resolved secrets.
+
+## Milestone 3: Resource Meaning
+
+Issues:
+
+- [#1040](https://github.com/honua-io/honua-server/issues/1040) canonical catalog metadata semantics
+- [#1041](https://github.com/honua-io/honua-server/issues/1041) field semantic roles and standard bindings
+
+Purpose:
+
+- Store resource meaning once.
+- Use canonical metadata and field roles before target-specific overrides.
+- Make metadata and field completeness reviewable by standard target.
+
+## Milestone 4: Publication and Projection
+
+Issues:
+
+- [#1042](https://github.com/honua-io/honua-server/issues/1042) publications and distributions
+- [#1043](https://github.com/honua-io/honua-server/issues/1043) projection profiles
+
+Purpose:
+
+- Link one resource to many services and catalogs.
+- Make readiness visible per publication target.
+- Support projection health, projection preview, and target-specific output
+  caching.
+
+## Milestone 5: Access and Runtime Read Models
+
+Issues:
+
+- [#1044](https://github.com/honua-io/honua-server/issues/1044) policy-based access
+- [#1045](https://github.com/honua-io/honua-server/issues/1045) Redis snapshots and projections
+
+Purpose:
+
+- Replace ad hoc RBAC metadata with deterministic policy attachments and simple
+  UI presets.
+- Version runtime snapshots and derived projections with explicit cache-key
+  dimensions.
+- Ensure runtime read models exclude secrets and runtime-only handles.
+
+## Milestone 6: Admin UI Handoff
+
+Issue:
+
+- [#1046](https://github.com/honua-io/honua-server/issues/1046) Claude Design admin UI information model
+
+Purpose:
+
+- Design admin workflows around Connections, Data Resources, Source, Fields,
+  Metadata, Publish, Access, Validation, and Readiness.
+- Keep raw schema terminology in advanced diagnostics only.
+- Provide the screens and states listed in the
+  [admin UI information model](metadata-v2-admin-ui-information-model.md).
+
+## Milestone 7: Migration and Diagnostics
+
+Issue:
+
+- [#1047](https://github.com/honua-io/honua-server/issues/1047) v1-to-v2 migration adapter and diagnostics
+
+Purpose:
+
+- Convert existing metadata into the Metadata v2 shape.
+- Report warnings, blockers, and inferred defaults.
+- Validate migrated output against the v2 schema and release-readiness gates.
+
+## Review Rhythm
+
+During implementation, review this roadmap against the issue bodies during the
+weekly backlog cadence. If issue scope changes, GitHub wins and this document
+should be updated as a navigation aid.


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1035 and #1046

## Summary
Adds the Metadata v2 planning docs needed to review the design and feed the admin UI design lane.

## Changes Made
- Added a Metadata v2 backlog index that treats GitHub epic #1035 as authoritative.
- Added the admin UI information model with user-facing vocabulary rules.
- Added roadmap and release-readiness companion docs.
- Linked the new docs from contributor navigation and the release checklist.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation run locally:
- `git diff --check origin/trunk..HEAD`
- Fresh agent review of the docs lane completed before publishing.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] `scripts/ci/pre-pr-check.sh` full end-to-end run not performed locally; targeted checks above passed and PR CI is running the full gate set.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality or not applicable for docs-only changes
- [x] If protocol/auth behavior changed: updated compatibility contract or marked not applicable
- [x] If breaking admin/control-plane API changes: updated migration guide or marked not applicable
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review or marked not applicable
