### PR TITLE
feat: add metadata v2 core resource graph (#1036)

### DIFF
--- a/docs/contributor/architecture/metadata-v2-release-readiness.md
+++ b/docs/contributor/architecture/metadata-v2-release-readiness.md
@@ -21,7 +21,7 @@ Release evidence:
 
 - There is one canonical Metadata v2 schema source in the repo.
 - Runtime snapshots validate against that schema without patching.
-- Root metadata includes schema version, revision, tenant, environment, and
+- Root metadata includes schema version, revision, environment, and
   generated time.
 - Data Resources are the canonical unit; service-specific identity lives on
   publications or target-specific overrides.
@@ -88,7 +88,7 @@ Derived from:
 
 Release evidence:
 
-- Cache keys include tenant, environment, catalog, schema version, revision,
+- Cache keys include environment, catalog, schema version, revision,
   projection target, and projection profile version where applicable.
 - Runtime snapshots exclude secrets and runtime-only handles.
 - Projection caches can be rebuilt independently from the canonical snapshot.

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2Common.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2Common.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Constants for Metadata v2 model documents.
+/// </summary>
+public static class MetadataV2Constants
+{
+    /// <summary>
+    /// Initial Metadata v2 schema version.
+    /// </summary>
+    public const string SchemaVersion = "2.0.0-alpha.1";
+
+    /// <summary>
+    /// Initial Metadata v2 API version.
+    /// </summary>
+    public const string ApiVersion = "metadata.honua.io/v2alpha1";
+}
+
+/// <summary>
+/// Common metadata fields shared by Metadata v2 graph entities.
+/// </summary>
+public sealed record MetadataV2ObjectMetadata
+{
+    /// <summary>
+    /// Stable identifier within the graph.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Machine-friendly name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional namespace for grouping entities.
+    /// </summary>
+    [JsonPropertyName("namespace")]
+    public string? Namespace { get; init; }
+
+    /// <summary>
+    /// Human-readable display title.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Human-readable description.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Tags for discovery.
+    /// </summary>
+    [JsonPropertyName("tags")]
+    public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Labels for selection and grouping.
+    /// </summary>
+    [JsonPropertyName("labels")]
+    public IReadOnlyDictionary<string, string> Labels { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Tooling annotations.
+    /// </summary>
+    [JsonPropertyName("annotations")]
+    public IReadOnlyDictionary<string, string> Annotations { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Entity generation for optimistic concurrency.
+    /// </summary>
+    [JsonPropertyName("generation")]
+    public long? Generation { get; init; }
+
+    /// <summary>
+    /// Timestamp when the entity was created.
+    /// </summary>
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset? CreatedAt { get; init; }
+
+    /// <summary>
+    /// Timestamp when the entity was updated.
+    /// </summary>
+    [JsonPropertyName("updatedAt")]
+    public DateTimeOffset? UpdatedAt { get; init; }
+}
+
+/// <summary>
+/// Lifecycle and observed status shared by Metadata v2 graph entities.
+/// </summary>
+public sealed record MetadataV2Status
+{
+    /// <summary>
+    /// Desired or declared lifecycle state.
+    /// </summary>
+    [JsonPropertyName("lifecycle")]
+    public MetadataV2LifecycleStatus Lifecycle { get; init; } = MetadataV2LifecycleStatus.Draft;
+
+    /// <summary>
+    /// Observed operational state.
+    /// </summary>
+    [JsonPropertyName("state")]
+    public MetadataV2OperationalState State { get; init; } = MetadataV2OperationalState.Unknown;
+
+    /// <summary>
+    /// Reconciliation or validation conditions.
+    /// </summary>
+    [JsonPropertyName("conditions")]
+    public IReadOnlyList<MetadataV2Condition> Conditions { get; init; } = Array.Empty<MetadataV2Condition>();
+
+    /// <summary>
+    /// Last observed timestamp.
+    /// </summary>
+    [JsonPropertyName("observedAt")]
+    public DateTimeOffset? ObservedAt { get; init; }
+}
+
+/// <summary>
+/// A status condition attached to a Metadata v2 entity.
+/// </summary>
+public sealed record MetadataV2Condition
+{
+    /// <summary>
+    /// Condition type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Condition status.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Machine-readable reason.
+    /// </summary>
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+
+    /// <summary>
+    /// Human-readable message.
+    /// </summary>
+    [JsonPropertyName("message")]
+    public string? Message { get; init; }
+
+    /// <summary>
+    /// Last transition timestamp.
+    /// </summary>
+    [JsonPropertyName("lastTransitionAt")]
+    public DateTimeOffset? LastTransitionAt { get; init; }
+}
+
+/// <summary>
+/// Named extension point for Metadata v2 tools and plugins.
+/// </summary>
+public sealed record MetadataV2ExtensionPoint
+{
+    /// <summary>
+    /// Extension point identifier.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Graph entity kinds this extension point applies to.
+    /// </summary>
+    [JsonPropertyName("appliesTo")]
+    public IReadOnlyList<string> AppliesTo { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Optional description of the extension point.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Optional JSON schema fragment for extension values.
+    /// </summary>
+    [JsonPropertyName("schema")]
+    public JsonElement? Schema { get; init; }
+}
+
+/// <summary>
+/// Canonical field description owned by a Metadata v2 resource.
+/// </summary>
+public sealed record MetadataV2Field
+{
+    /// <summary>
+    /// Stable source field name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Canonical field type or provider-native type label.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable field title.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Human-readable field description.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// True when null values are valid for the field.
+    /// </summary>
+    [JsonPropertyName("nullable")]
+    public bool Nullable { get; init; }
+
+    /// <summary>
+    /// Semantic role identifiers used by catalog and service projections.
+    /// </summary>
+    [JsonPropertyName("semanticRoles")]
+    public IReadOnlyList<string> SemanticRoles { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Extension data for the field.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, JsonElement> Extensions { get; init; } = new Dictionary<string, JsonElement>();
+}

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2Enums.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2Enums.cs
@@ -1,0 +1,506 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Canonical resource categories in the Metadata v2 graph.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataV2ResourceType>))]
+public enum MetadataV2ResourceType
+{
+    /// <summary>
+    /// A vector feature dataset whose physical storage is described by one or more storage bindings.
+    /// </summary>
+    [JsonStringEnumMemberName("feature-dataset")]
+    FeatureDataset,
+
+    /// <summary>
+    /// A raster or gridded dataset.
+    /// </summary>
+    [JsonStringEnumMemberName("raster-dataset")]
+    RasterDataset,
+
+    /// <summary>
+    /// A tabular resource without required geometry.
+    /// </summary>
+    [JsonStringEnumMemberName("table")]
+    Table,
+
+    /// <summary>
+    /// A tile dataset.
+    /// </summary>
+    [JsonStringEnumMemberName("tile-dataset")]
+    TileDataset,
+
+    /// <summary>
+    /// A process resource.
+    /// </summary>
+    [JsonStringEnumMemberName("process")]
+    Process,
+
+    /// <summary>
+    /// A reusable style resource.
+    /// </summary>
+    [JsonStringEnumMemberName("style")]
+    Style,
+
+    /// <summary>
+    /// A document resource.
+    /// </summary>
+    [JsonStringEnumMemberName("document")]
+    Document,
+
+    /// <summary>
+    /// An external resource represented in the metadata graph.
+    /// </summary>
+    [JsonStringEnumMemberName("external-resource")]
+    ExternalResource
+}
+
+/// <summary>
+/// External or managed connection categories used by storage bindings.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataV2ConnectionType>))]
+public enum MetadataV2ConnectionType
+{
+    /// <summary>
+    /// A database connection.
+    /// </summary>
+    [JsonStringEnumMemberName("database")]
+    Database,
+
+    /// <summary>
+    /// Object storage such as S3, Azure Blob Storage, or Google Cloud Storage.
+    /// </summary>
+    [JsonStringEnumMemberName("object-storage")]
+    ObjectStorage,
+
+    /// <summary>
+    /// Local or network file storage.
+    /// </summary>
+    [JsonStringEnumMemberName("file-system")]
+    FileSystem,
+
+    /// <summary>
+    /// An external HTTP API.
+    /// </summary>
+    [JsonStringEnumMemberName("http-api")]
+    HttpApi,
+
+    /// <summary>
+    /// A STAC catalog or API.
+    /// </summary>
+    [JsonStringEnumMemberName("stac")]
+    Stac,
+
+    /// <summary>
+    /// A managed Honua platform connection.
+    /// </summary>
+    [JsonStringEnumMemberName("managed")]
+    Managed
+}
+
+/// <summary>
+/// Physical storage formats and access patterns for Metadata v2 storage bindings.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataV2StorageType>))]
+public enum MetadataV2StorageType
+{
+    /// <summary>
+    /// A relational database table.
+    /// </summary>
+    [JsonStringEnumMemberName("relational-table")]
+    RelationalTable,
+
+    /// <summary>
+    /// A SQL view.
+    /// </summary>
+    [JsonStringEnumMemberName("sql-view")]
+    SqlView,
+
+    /// <summary>
+    /// A SQL query.
+    /// </summary>
+    [JsonStringEnumMemberName("sql-query")]
+    SqlQuery,
+
+    /// <summary>
+    /// A GeoPackage table.
+    /// </summary>
+    [JsonStringEnumMemberName("geopackage-table")]
+    GeoPackageTable,
+
+    /// <summary>
+    /// A GeoJSON document or sequence.
+    /// </summary>
+    [JsonStringEnumMemberName("geojson")]
+    GeoJson,
+
+    /// <summary>
+    /// A GeoParquet dataset.
+    /// </summary>
+    [JsonStringEnumMemberName("geoparquet")]
+    GeoParquet,
+
+    /// <summary>
+    /// An Apache Arrow dataset.
+    /// </summary>
+    [JsonStringEnumMemberName("arrow")]
+    Arrow,
+
+    /// <summary>
+    /// A cloud optimized GeoTIFF.
+    /// </summary>
+    [JsonStringEnumMemberName("cloud-optimized-geotiff")]
+    CloudOptimizedGeoTiff,
+
+    /// <summary>
+    /// A Zarr dataset.
+    /// </summary>
+    [JsonStringEnumMemberName("zarr")]
+    Zarr,
+
+    /// <summary>
+    /// A NetCDF dataset.
+    /// </summary>
+    [JsonStringEnumMemberName("netcdf")]
+    NetCdf,
+
+    /// <summary>
+    /// An MBTiles archive.
+    /// </summary>
+    [JsonStringEnumMemberName("mbtiles")]
+    MbTiles,
+
+    /// <summary>
+    /// A PMTiles archive.
+    /// </summary>
+    [JsonStringEnumMemberName("pmtiles")]
+    PmTiles,
+
+    /// <summary>
+    /// A tile cache.
+    /// </summary>
+    [JsonStringEnumMemberName("tile-cache")]
+    TileCache,
+
+    /// <summary>
+    /// An object storage prefix.
+    /// </summary>
+    [JsonStringEnumMemberName("object-prefix")]
+    ObjectPrefix,
+
+    /// <summary>
+    /// An external API-backed storage source.
+    /// </summary>
+    [JsonStringEnumMemberName("external-api")]
+    ExternalApi,
+
+    /// <summary>
+    /// A STAC asset.
+    /// </summary>
+    [JsonStringEnumMemberName("stac-asset")]
+    StacAsset
+}
+
+/// <summary>
+/// Public service categories. These are intentionally separate from storage types.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataV2ServiceType>))]
+public enum MetadataV2ServiceType
+{
+    /// <summary>
+    /// An OGC API Features service.
+    /// </summary>
+    [JsonStringEnumMemberName("ogc-api-features")]
+    OgcApiFeatures,
+
+    /// <summary>
+    /// A WFS service.
+    /// </summary>
+    [JsonStringEnumMemberName("wfs")]
+    Wfs,
+
+    /// <summary>
+    /// A WMS service.
+    /// </summary>
+    [JsonStringEnumMemberName("wms")]
+    Wms,
+
+    /// <summary>
+    /// A WMTS service.
+    /// </summary>
+    [JsonStringEnumMemberName("wmts")]
+    Wmts,
+
+    /// <summary>
+    /// An Esri feature service.
+    /// </summary>
+    [JsonStringEnumMemberName("esri-feature-service")]
+    EsriFeatureService,
+
+    /// <summary>
+    /// An Esri map service.
+    /// </summary>
+    [JsonStringEnumMemberName("esri-map-service")]
+    EsriMapService,
+
+    /// <summary>
+    /// An Esri image service.
+    /// </summary>
+    [JsonStringEnumMemberName("esri-image-service")]
+    EsriImageService,
+
+    /// <summary>
+    /// A STAC API.
+    /// </summary>
+    [JsonStringEnumMemberName("stac-api")]
+    StacApi,
+
+    /// <summary>
+    /// A DCAT catalog.
+    /// </summary>
+    [JsonStringEnumMemberName("dcat-catalog")]
+    DcatCatalog,
+
+    /// <summary>
+    /// An OGC Records catalog service.
+    /// </summary>
+    [JsonStringEnumMemberName("ogc-records")]
+    OgcRecords,
+
+    /// <summary>
+    /// An OData service.
+    /// </summary>
+    [JsonStringEnumMemberName("odata")]
+    OData,
+
+    /// <summary>
+    /// A custom or extension-defined service.
+    /// </summary>
+    [JsonStringEnumMemberName("custom")]
+    Custom
+}
+
+/// <summary>
+/// Publication categories exposed by services. These are intentionally separate from storage types.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataV2PublicationType>))]
+public enum MetadataV2PublicationType
+{
+    /// <summary>
+    /// An OGC collection publication.
+    /// </summary>
+    [JsonStringEnumMemberName("ogc-collection")]
+    OgcCollection,
+
+    /// <summary>
+    /// A WFS feature type publication.
+    /// </summary>
+    [JsonStringEnumMemberName("wfs-feature-type")]
+    WfsFeatureType,
+
+    /// <summary>
+    /// A WMS layer publication.
+    /// </summary>
+    [JsonStringEnumMemberName("wms-layer")]
+    WmsLayer,
+
+    /// <summary>
+    /// A WMTS layer publication.
+    /// </summary>
+    [JsonStringEnumMemberName("wmts-layer")]
+    WmtsLayer,
+
+    /// <summary>
+    /// An Esri feature layer publication.
+    /// </summary>
+    [JsonStringEnumMemberName("esri-feature-layer")]
+    EsriFeatureLayer,
+
+    /// <summary>
+    /// An Esri map layer publication.
+    /// </summary>
+    [JsonStringEnumMemberName("esri-map-layer")]
+    EsriMapLayer,
+
+    /// <summary>
+    /// An Esri image layer publication.
+    /// </summary>
+    [JsonStringEnumMemberName("esri-image-layer")]
+    EsriImageLayer,
+
+    /// <summary>
+    /// A STAC collection publication.
+    /// </summary>
+    [JsonStringEnumMemberName("stac-collection")]
+    StacCollection,
+
+    /// <summary>
+    /// A DCAT distribution publication.
+    /// </summary>
+    [JsonStringEnumMemberName("dcat-distribution")]
+    DcatDistribution,
+
+    /// <summary>
+    /// An OGC record publication.
+    /// </summary>
+    [JsonStringEnumMemberName("ogc-record")]
+    OgcRecord,
+
+    /// <summary>
+    /// An OData entity set publication.
+    /// </summary>
+    [JsonStringEnumMemberName("odata-entity-set")]
+    ODataEntitySet,
+
+    /// <summary>
+    /// A custom or extension-defined publication.
+    /// </summary>
+    [JsonStringEnumMemberName("custom")]
+    Custom
+}
+
+/// <summary>
+/// Capabilities supported by a Metadata v2 storage binding.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataV2StorageBindingCapability>))]
+public enum MetadataV2StorageBindingCapability
+{
+    /// <summary>
+    /// The binding can execute read queries.
+    /// </summary>
+    [JsonStringEnumMemberName("query")]
+    Query,
+
+    /// <summary>
+    /// The binding can filter records or pixels server-side.
+    /// </summary>
+    [JsonStringEnumMemberName("filter")]
+    Filter,
+
+    /// <summary>
+    /// The binding can sort results server-side.
+    /// </summary>
+    [JsonStringEnumMemberName("sort")]
+    Sort,
+
+    /// <summary>
+    /// The binding can aggregate results server-side.
+    /// </summary>
+    [JsonStringEnumMemberName("aggregate")]
+    Aggregate,
+
+    /// <summary>
+    /// The binding supports edits.
+    /// </summary>
+    [JsonStringEnumMemberName("edit")]
+    Edit,
+
+    /// <summary>
+    /// The binding supports transactional edits.
+    /// </summary>
+    [JsonStringEnumMemberName("transactions")]
+    Transactions,
+
+    /// <summary>
+    /// The binding can render map or coverage outputs.
+    /// </summary>
+    [JsonStringEnumMemberName("render")]
+    Render,
+
+    /// <summary>
+    /// The binding can serve tiles.
+    /// </summary>
+    [JsonStringEnumMemberName("tile")]
+    Tile,
+
+    /// <summary>
+    /// The binding can provide downloadable artifacts.
+    /// </summary>
+    [JsonStringEnumMemberName("download")]
+    Download,
+
+    /// <summary>
+    /// The binding supports search.
+    /// </summary>
+    [JsonStringEnumMemberName("search")]
+    Search
+}
+
+/// <summary>
+/// Lifecycle values shared by Metadata v2 graph entities.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataV2LifecycleStatus>))]
+public enum MetadataV2LifecycleStatus
+{
+    /// <summary>
+    /// The entity is being drafted and should not be treated as active.
+    /// </summary>
+    [JsonStringEnumMemberName("draft")]
+    Draft,
+
+    /// <summary>
+    /// The entity is active.
+    /// </summary>
+    [JsonStringEnumMemberName("active")]
+    Active,
+
+    /// <summary>
+    /// The entity is deprecated but still available.
+    /// </summary>
+    [JsonStringEnumMemberName("deprecated")]
+    Deprecated,
+
+    /// <summary>
+    /// The entity is retired.
+    /// </summary>
+    [JsonStringEnumMemberName("retired")]
+    Retired,
+
+    /// <summary>
+    /// The entity is archived.
+    /// </summary>
+    [JsonStringEnumMemberName("archived")]
+    Archived
+}
+
+/// <summary>
+/// Observed operational state for Metadata v2 graph entities.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataV2OperationalState>))]
+public enum MetadataV2OperationalState
+{
+    /// <summary>
+    /// State has not been observed yet.
+    /// </summary>
+    [JsonStringEnumMemberName("unknown")]
+    Unknown,
+
+    /// <summary>
+    /// The entity is ready.
+    /// </summary>
+    [JsonStringEnumMemberName("ready")]
+    Ready,
+
+    /// <summary>
+    /// The entity is pending reconciliation.
+    /// </summary>
+    [JsonStringEnumMemberName("pending")]
+    Pending,
+
+    /// <summary>
+    /// The entity is degraded.
+    /// </summary>
+    [JsonStringEnumMemberName("degraded")]
+    Degraded,
+
+    /// <summary>
+    /// The entity failed reconciliation or health checks.
+    /// </summary>
+    [JsonStringEnumMemberName("failed")]
+    Failed
+}

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2Graph.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2Graph.cs
@@ -1,0 +1,685 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Canonical Metadata v2 root graph.
+/// </summary>
+public sealed record MetadataV2Graph
+{
+    /// <summary>
+    /// Canonical schema version for this graph document.
+    /// </summary>
+    [JsonPropertyName("schemaVersion")]
+    public string SchemaVersion { get; init; } = MetadataV2Constants.SchemaVersion;
+
+    /// <summary>
+    /// Metadata v2 API version for the graph document.
+    /// </summary>
+    [JsonPropertyName("apiVersion")]
+    public string ApiVersion { get; init; } = MetadataV2Constants.ApiVersion;
+
+    /// <summary>
+    /// Monotonic graph revision used by cache snapshots and migration diagnostics.
+    /// </summary>
+    [JsonPropertyName("revision")]
+    public long Revision { get; init; }
+
+    /// <summary>
+    /// Tenant identifier for multi-tenant metadata isolation.
+    /// </summary>
+    [JsonPropertyName("tenantId")]
+    public string TenantId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Environment identifier, such as dev, staging, or production.
+    /// </summary>
+    [JsonPropertyName("environment")]
+    public string Environment { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Timestamp when this graph snapshot was generated.
+    /// </summary>
+    [JsonPropertyName("generatedAt")]
+    public DateTimeOffset GeneratedAt { get; init; } = DateTimeOffset.UnixEpoch;
+
+    /// <summary>
+    /// Declared namespaces used by graph entity identifiers.
+    /// </summary>
+    [JsonPropertyName("namespaces")]
+    public IReadOnlyList<string> Namespaces { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Graph metadata.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public MetadataV2ObjectMetadata Metadata { get; init; } = new();
+
+    /// <summary>
+    /// Catalog definitions that can project canonical resources.
+    /// </summary>
+    [JsonPropertyName("catalogs")]
+    public IReadOnlyList<MetadataV2Catalog> Catalogs { get; init; } = Array.Empty<MetadataV2Catalog>();
+
+    /// <summary>
+    /// Canonical resources. Publications expose these resources through services.
+    /// </summary>
+    [JsonPropertyName("resources")]
+    public IReadOnlyList<MetadataV2Resource> Resources { get; init; } = Array.Empty<MetadataV2Resource>();
+
+    /// <summary>
+    /// Connections referenced by storage bindings.
+    /// </summary>
+    [JsonPropertyName("connections")]
+    public IReadOnlyList<MetadataV2Connection> Connections { get; init; } = Array.Empty<MetadataV2Connection>();
+
+    /// <summary>
+    /// Physical storage bindings for canonical resources.
+    /// </summary>
+    [JsonPropertyName("storageBindings")]
+    public IReadOnlyList<MetadataV2StorageBinding> StorageBindings { get; init; } = Array.Empty<MetadataV2StorageBinding>();
+
+    /// <summary>
+    /// Services that publish resources.
+    /// </summary>
+    [JsonPropertyName("services")]
+    public IReadOnlyList<MetadataV2Service> Services { get; init; } = Array.Empty<MetadataV2Service>();
+
+    /// <summary>
+    /// Resource-first publication links from resourceId to serviceId.
+    /// </summary>
+    [JsonPropertyName("publications")]
+    public IReadOnlyList<MetadataV2Publication> Publications { get; init; } = Array.Empty<MetadataV2Publication>();
+
+    /// <summary>
+    /// Projection profiles for service and catalog target formats.
+    /// </summary>
+    [JsonPropertyName("projectionProfiles")]
+    public IReadOnlyList<MetadataV2ProjectionProfile> ProjectionProfiles { get; init; } =
+        Array.Empty<MetadataV2ProjectionProfile>();
+
+    /// <summary>
+    /// Policy definitions referenced by resources, services, publications, and roles.
+    /// </summary>
+    [JsonPropertyName("policies")]
+    public IReadOnlyList<MetadataV2Policy> Policies { get; init; } = Array.Empty<MetadataV2Policy>();
+
+    /// <summary>
+    /// Role definitions used by metadata access control.
+    /// </summary>
+    [JsonPropertyName("roles")]
+    public IReadOnlyList<MetadataV2Role> Roles { get; init; } = Array.Empty<MetadataV2Role>();
+
+    /// <summary>
+    /// Runtime snapshot details for cache-safe graph materialization.
+    /// </summary>
+    [JsonPropertyName("runtime")]
+    public MetadataV2RuntimeSnapshot Runtime { get; init; } = new();
+
+    /// <summary>
+    /// Declared extension points for graph consumers.
+    /// </summary>
+    [JsonPropertyName("extensionPoints")]
+    public IReadOnlyList<MetadataV2ExtensionPoint> ExtensionPoints { get; init; } = Array.Empty<MetadataV2ExtensionPoint>();
+
+    /// <summary>
+    /// Extension data for the graph document.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, JsonElement> Extensions { get; init; } = new Dictionary<string, JsonElement>();
+}
+
+/// <summary>
+/// Canonical Metadata v2 resource.
+/// </summary>
+public sealed record MetadataV2Resource
+{
+    /// <summary>
+    /// Resource metadata and identity.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public MetadataV2ObjectMetadata Metadata { get; init; } = new();
+
+    /// <summary>
+    /// Logical resource type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public MetadataV2ResourceType Type { get; init; } = MetadataV2ResourceType.FeatureDataset;
+
+    /// <summary>
+    /// Storage bindings that can materialize this canonical resource.
+    /// </summary>
+    [JsonPropertyName("storageBindingIds")]
+    public IReadOnlyList<string> StorageBindingIds { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Optional primary storage binding identifier.
+    /// </summary>
+    [JsonPropertyName("primaryStorageBindingId")]
+    public string? PrimaryStorageBindingId { get; init; }
+
+    /// <summary>
+    /// Optional schema or field metadata for the resource.
+    /// </summary>
+    [JsonPropertyName("schema")]
+    public JsonElement? Schema { get; init; }
+
+    /// <summary>
+    /// Canonical schema fields and field-level semantic roles.
+    /// </summary>
+    [JsonPropertyName("schemaFields")]
+    public IReadOnlyList<MetadataV2Field> SchemaFields { get; init; } = Array.Empty<MetadataV2Field>();
+
+    /// <summary>
+    /// Style resources attached to this canonical resource.
+    /// </summary>
+    [JsonPropertyName("styleResourceIds")]
+    public IReadOnlyList<string> StyleResourceIds { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Policy identifiers attached to this resource.
+    /// </summary>
+    [JsonPropertyName("policyIds")]
+    public IReadOnlyList<string> PolicyIds { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Optional spatial extent, CRS, or geometry metadata.
+    /// </summary>
+    [JsonPropertyName("spatial")]
+    public JsonElement? Spatial { get; init; }
+
+    /// <summary>
+    /// Optional temporal extent metadata.
+    /// </summary>
+    [JsonPropertyName("temporal")]
+    public JsonElement? Temporal { get; init; }
+
+    /// <summary>
+    /// Lifecycle and observed status.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public MetadataV2Status Status { get; init; } = new();
+
+    /// <summary>
+    /// Extension data for the resource.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, JsonElement> Extensions { get; init; } = new Dictionary<string, JsonElement>();
+}
+
+/// <summary>
+/// Connection used by storage bindings.
+/// </summary>
+public sealed record MetadataV2Connection
+{
+    /// <summary>
+    /// Connection metadata and identity.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public MetadataV2ObjectMetadata Metadata { get; init; } = new();
+
+    /// <summary>
+    /// Connection type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public MetadataV2ConnectionType Type { get; init; } = MetadataV2ConnectionType.Managed;
+
+    /// <summary>
+    /// Provider name, such as postgres, s3, stac, or honua.
+    /// </summary>
+    [JsonPropertyName("provider")]
+    public string? Provider { get; init; }
+
+    /// <summary>
+    /// Endpoint or base URI, when safe to expose in metadata.
+    /// </summary>
+    [JsonPropertyName("endpoint")]
+    public Uri? Endpoint { get; init; }
+
+    /// <summary>
+    /// Reference to secret material outside the metadata graph.
+    /// </summary>
+    [JsonPropertyName("secretRef")]
+    public string? SecretRef { get; init; }
+
+    /// <summary>
+    /// Connection options.
+    /// </summary>
+    [JsonPropertyName("options")]
+    public IReadOnlyDictionary<string, JsonElement> Options { get; init; } = new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Lifecycle and observed status.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public MetadataV2Status Status { get; init; } = new();
+
+    /// <summary>
+    /// Extension data for the connection.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, JsonElement> Extensions { get; init; } = new Dictionary<string, JsonElement>();
+}
+
+/// <summary>
+/// Physical storage binding for a canonical resource.
+/// </summary>
+public sealed record MetadataV2StorageBinding
+{
+    /// <summary>
+    /// Storage binding metadata and identity.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public MetadataV2ObjectMetadata Metadata { get; init; } = new();
+
+    /// <summary>
+    /// Canonical resource identifier this storage binding materializes.
+    /// </summary>
+    [JsonPropertyName("resourceId")]
+    public string ResourceId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional connection identifier.
+    /// </summary>
+    [JsonPropertyName("connectionId")]
+    public string? ConnectionId { get; init; }
+
+    /// <summary>
+    /// Physical storage type. This is not a service or publication type.
+    /// </summary>
+    [JsonPropertyName("storageType")]
+    public MetadataV2StorageType StorageType { get; init; } = MetadataV2StorageType.RelationalTable;
+
+    /// <summary>
+    /// Storage locator, such as table name, object key, URI, or API route.
+    /// </summary>
+    [JsonPropertyName("locator")]
+    public string Locator { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Capabilities supported by this storage binding.
+    /// </summary>
+    [JsonPropertyName("capabilities")]
+    public IReadOnlyList<MetadataV2StorageBindingCapability> Capabilities { get; init; } =
+        Array.Empty<MetadataV2StorageBindingCapability>();
+
+    /// <summary>
+    /// Binding-specific options.
+    /// </summary>
+    [JsonPropertyName("options")]
+    public IReadOnlyDictionary<string, JsonElement> Options { get; init; } = new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Lifecycle and observed status.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public MetadataV2Status Status { get; init; } = new();
+
+    /// <summary>
+    /// Extension data for the storage binding.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, JsonElement> Extensions { get; init; } = new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Returns true when the storage binding declares the capability.
+    /// </summary>
+    /// <param name="capability">Capability to check.</param>
+    /// <returns>True when the capability is present.</returns>
+    public bool Supports(MetadataV2StorageBindingCapability capability)
+    {
+        return Capabilities.Contains(capability);
+    }
+}
+
+/// <summary>
+/// Service that can publish canonical resources.
+/// </summary>
+public sealed record MetadataV2Service
+{
+    /// <summary>
+    /// Service metadata and identity.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public MetadataV2ObjectMetadata Metadata { get; init; } = new();
+
+    /// <summary>
+    /// Public service type. This is not a storage type.
+    /// </summary>
+    [JsonPropertyName("serviceType")]
+    public MetadataV2ServiceType ServiceType { get; init; } = MetadataV2ServiceType.OgcApiFeatures;
+
+    /// <summary>
+    /// Service route or base path.
+    /// </summary>
+    [JsonPropertyName("route")]
+    public string? Route { get; init; }
+
+    /// <summary>
+    /// Optional publication identifiers exposed by this service.
+    /// </summary>
+    [JsonPropertyName("publicationIds")]
+    public IReadOnlyList<string> PublicationIds { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Service-specific options.
+    /// </summary>
+    [JsonPropertyName("options")]
+    public IReadOnlyDictionary<string, JsonElement> Options { get; init; } = new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Lifecycle and observed status.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public MetadataV2Status Status { get; init; } = new();
+
+    /// <summary>
+    /// Extension data for the service.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, JsonElement> Extensions { get; init; } = new Dictionary<string, JsonElement>();
+}
+
+/// <summary>
+/// Resource-first publication link from a canonical resource to a service.
+/// </summary>
+public sealed record MetadataV2Publication
+{
+    /// <summary>
+    /// Publication metadata and identity.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public MetadataV2ObjectMetadata Metadata { get; init; } = new();
+
+    /// <summary>
+    /// Canonical resource identifier being published.
+    /// </summary>
+    [JsonPropertyName("resourceId")]
+    public string ResourceId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Service identifier through which the resource is published.
+    /// </summary>
+    [JsonPropertyName("serviceId")]
+    public string ServiceId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional storage binding identifier used for this publication.
+    /// </summary>
+    [JsonPropertyName("storageBindingId")]
+    public string? StorageBindingId { get; init; }
+
+    /// <summary>
+    /// Publication type. This is not a storage type.
+    /// </summary>
+    [JsonPropertyName("publicationType")]
+    public MetadataV2PublicationType PublicationType { get; init; } = MetadataV2PublicationType.OgcCollection;
+
+    /// <summary>
+    /// Optional title override for this service or catalog publication.
+    /// </summary>
+    [JsonPropertyName("titleOverride")]
+    public string? TitleOverride { get; init; }
+
+    /// <summary>
+    /// Service path or catalog route override for this publication.
+    /// </summary>
+    [JsonPropertyName("path")]
+    public string? Path { get; init; }
+
+    /// <summary>
+    /// Service-local layer index when the target protocol requires one.
+    /// </summary>
+    [JsonPropertyName("layerIndex")]
+    public int? LayerIndex { get; init; }
+
+    /// <summary>
+    /// Format identifiers supported by this publication.
+    /// </summary>
+    [JsonPropertyName("supportedFormats")]
+    public IReadOnlyList<string> SupportedFormats { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Service-specific field aliases.
+    /// </summary>
+    [JsonPropertyName("fieldAliases")]
+    public IReadOnlyDictionary<string, string> FieldAliases { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Publication capabilities after service and storage validation.
+    /// </summary>
+    [JsonPropertyName("capabilities")]
+    public IReadOnlyList<string> Capabilities { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Route segment, layer id, collection id, or other service-local publication key.
+    /// </summary>
+    [JsonPropertyName("serviceLocalId")]
+    public string? ServiceLocalId { get; init; }
+
+    /// <summary>
+    /// Publication-specific options.
+    /// </summary>
+    [JsonPropertyName("options")]
+    public IReadOnlyDictionary<string, JsonElement> Options { get; init; } = new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Lifecycle and observed status.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public MetadataV2Status Status { get; init; } = new();
+
+    /// <summary>
+    /// Extension data for the publication.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, JsonElement> Extensions { get; init; } = new Dictionary<string, JsonElement>();
+}
+
+/// <summary>
+/// Catalog target that can expose canonical resources.
+/// </summary>
+public sealed record MetadataV2Catalog
+{
+    /// <summary>
+    /// Catalog metadata and identity.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public MetadataV2ObjectMetadata Metadata { get; init; } = new();
+
+    /// <summary>
+    /// Catalog target identifier, such as ogc-records, dcat, stac, or esri-portal.
+    /// </summary>
+    [JsonPropertyName("target")]
+    public string Target { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Catalog-specific options.
+    /// </summary>
+    [JsonPropertyName("options")]
+    public IReadOnlyDictionary<string, JsonElement> Options { get; init; } = new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Lifecycle and observed status.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public MetadataV2Status Status { get; init; } = new();
+
+    /// <summary>
+    /// Extension data for the catalog.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, JsonElement> Extensions { get; init; } = new Dictionary<string, JsonElement>();
+}
+
+/// <summary>
+/// Mapping profile for projecting canonical metadata into service or catalog formats.
+/// </summary>
+public sealed record MetadataV2ProjectionProfile
+{
+    /// <summary>
+    /// Projection profile metadata and identity.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public MetadataV2ObjectMetadata Metadata { get; init; } = new();
+
+    /// <summary>
+    /// Target format identifier.
+    /// </summary>
+    [JsonPropertyName("target")]
+    public string Target { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Required semantic keys for this profile.
+    /// </summary>
+    [JsonPropertyName("requiredSemantics")]
+    public IReadOnlyList<string> RequiredSemantics { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Profile-specific options.
+    /// </summary>
+    [JsonPropertyName("options")]
+    public IReadOnlyDictionary<string, JsonElement> Options { get; init; } = new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Lifecycle and observed status.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public MetadataV2Status Status { get; init; } = new();
+
+    /// <summary>
+    /// Extension data for the projection profile.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, JsonElement> Extensions { get; init; } = new Dictionary<string, JsonElement>();
+}
+
+/// <summary>
+/// Metadata policy definition.
+/// </summary>
+public sealed record MetadataV2Policy
+{
+    /// <summary>
+    /// Policy metadata and identity.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public MetadataV2ObjectMetadata Metadata { get; init; } = new();
+
+    /// <summary>
+    /// Policy engine or policy language identifier.
+    /// </summary>
+    [JsonPropertyName("engine")]
+    public string Engine { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Policy effect, such as allow, deny, mask, or audit.
+    /// </summary>
+    [JsonPropertyName("effect")]
+    public string Effect { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Policy-specific rules.
+    /// </summary>
+    [JsonPropertyName("rules")]
+    public IReadOnlyDictionary<string, JsonElement> Rules { get; init; } = new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Lifecycle and observed status.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public MetadataV2Status Status { get; init; } = new();
+
+    /// <summary>
+    /// Extension data for the policy.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, JsonElement> Extensions { get; init; } = new Dictionary<string, JsonElement>();
+}
+
+/// <summary>
+/// Metadata role definition.
+/// </summary>
+public sealed record MetadataV2Role
+{
+    /// <summary>
+    /// Role metadata and identity.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public MetadataV2ObjectMetadata Metadata { get; init; } = new();
+
+    /// <summary>
+    /// Permission identifiers granted by the role.
+    /// </summary>
+    [JsonPropertyName("permissions")]
+    public IReadOnlyList<string> Permissions { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Policy identifiers attached to the role.
+    /// </summary>
+    [JsonPropertyName("policyIds")]
+    public IReadOnlyList<string> PolicyIds { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Lifecycle and observed status.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public MetadataV2Status Status { get; init; } = new();
+
+    /// <summary>
+    /// Extension data for the role.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, JsonElement> Extensions { get; init; } = new Dictionary<string, JsonElement>();
+}
+
+/// <summary>
+/// Runtime metadata for cache-safe graph snapshots.
+/// </summary>
+public sealed record MetadataV2RuntimeSnapshot
+{
+    /// <summary>
+    /// Runtime metadata and identity.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public MetadataV2ObjectMetadata Metadata { get; init; } = new();
+
+    /// <summary>
+    /// Cache key for the materialized runtime snapshot.
+    /// </summary>
+    [JsonPropertyName("cacheKey")]
+    public string? CacheKey { get; init; }
+
+    /// <summary>
+    /// Source graph revision represented by this runtime snapshot.
+    /// </summary>
+    [JsonPropertyName("sourceRevision")]
+    public long? SourceRevision { get; init; }
+
+    /// <summary>
+    /// Optional cache entity tag for snapshot consumers.
+    /// </summary>
+    [JsonPropertyName("etag")]
+    public string? ETag { get; init; }
+
+    /// <summary>
+    /// Optional cache expiry for derived runtime snapshots.
+    /// </summary>
+    [JsonPropertyName("expiresAt")]
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>
+    /// Lifecycle and observed status.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public MetadataV2Status Status { get; init; } = new();
+
+    /// <summary>
+    /// Extension data for the runtime snapshot.
+    /// </summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, JsonElement> Extensions { get; init; } = new Dictionary<string, JsonElement>();
+}

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2Graph.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2Graph.cs
@@ -30,12 +30,6 @@ public sealed record MetadataV2Graph
     public long Revision { get; init; }
 
     /// <summary>
-    /// Tenant identifier for multi-tenant metadata isolation.
-    /// </summary>
-    [JsonPropertyName("tenantId")]
-    public string TenantId { get; init; } = string.Empty;
-
-    /// <summary>
     /// Environment identifier, such as dev, staging, or production.
     /// </summary>
     [JsonPropertyName("environment")]

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2JsonContext.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2JsonContext.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// JSON serialization context for Metadata v2 domain models.
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(MetadataV2Graph))]
+[JsonSerializable(typeof(MetadataV2Catalog))]
+[JsonSerializable(typeof(MetadataV2Resource))]
+[JsonSerializable(typeof(MetadataV2Connection))]
+[JsonSerializable(typeof(MetadataV2StorageBinding))]
+[JsonSerializable(typeof(MetadataV2Service))]
+[JsonSerializable(typeof(MetadataV2Publication))]
+[JsonSerializable(typeof(MetadataV2ProjectionProfile))]
+[JsonSerializable(typeof(MetadataV2Policy))]
+[JsonSerializable(typeof(MetadataV2Role))]
+[JsonSerializable(typeof(MetadataV2RuntimeSnapshot))]
+[JsonSerializable(typeof(MetadataV2ObjectMetadata))]
+[JsonSerializable(typeof(MetadataV2Status))]
+[JsonSerializable(typeof(MetadataV2Condition))]
+[JsonSerializable(typeof(MetadataV2ExtensionPoint))]
+[JsonSerializable(typeof(MetadataV2Field))]
+[JsonSerializable(typeof(IReadOnlyDictionary<string, string>), TypeInfoPropertyName = "ReadOnlyDictionaryStringString")]
+public sealed partial class MetadataV2JsonContext : JsonSerializerContext
+{
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
@@ -24,7 +24,6 @@ public sealed class MetadataV2ModelTests
         graph.SchemaVersion.Should().Be(MetadataV2Constants.SchemaVersion);
         graph.ApiVersion.Should().Be(MetadataV2Constants.ApiVersion);
         graph.Revision.Should().Be(0);
-        graph.TenantId.Should().BeEmpty();
         graph.Environment.Should().BeEmpty();
         graph.GeneratedAt.Should().Be(DateTimeOffset.UnixEpoch);
         graph.Namespaces.Should().BeEmpty();

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
@@ -157,6 +157,131 @@ public sealed class MetadataV2ModelTests
 
     [UnitTest]
     [Operation(Operations.Query)]
+    public void EsriServiceLayers_AreServiceLocalPublicationSlots()
+    {
+        var parcels = new MetadataV2Resource
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "resource.parcels",
+                Name = "Parcels"
+            },
+            SchemaFields =
+            [
+                new MetadataV2Field
+                {
+                    Name = "parcel_id",
+                    Type = "string",
+                    SemanticRoles =
+                    [
+                        "identifier.primary"
+                    ]
+                }
+            ]
+        };
+
+        var hydrants = new MetadataV2Resource
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "resource.hydrants",
+                Name = "Hydrants"
+            },
+            SchemaFields =
+            [
+                new MetadataV2Field
+                {
+                    Name = "hydrant_id",
+                    Type = "string",
+                    SemanticRoles =
+                    [
+                        "identifier.primary"
+                    ]
+                }
+            ]
+        };
+
+        var parcelsPublication = new MetadataV2Publication
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "publication.public-works.0",
+                Name = "Parcels"
+            },
+            ResourceId = parcels.Metadata.Id,
+            ServiceId = "service.public-works-feature-server",
+            PublicationType = MetadataV2PublicationType.EsriFeatureLayer,
+            LayerIndex = 0,
+            Path = "/PublicWorks/FeatureServer/0",
+            ServiceLocalId = "0"
+        };
+
+        var hydrantsPublication = new MetadataV2Publication
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "publication.public-works.1",
+                Name = "Hydrants"
+            },
+            ResourceId = hydrants.Metadata.Id,
+            ServiceId = "service.public-works-feature-server",
+            PublicationType = MetadataV2PublicationType.EsriFeatureLayer,
+            LayerIndex = 1,
+            Path = "/PublicWorks/FeatureServer/1",
+            ServiceLocalId = "1"
+        };
+
+        var service = new MetadataV2Service
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "service.public-works-feature-server",
+                Name = "Public Works FeatureServer"
+            },
+            ServiceType = MetadataV2ServiceType.EsriFeatureService,
+            Route = "/PublicWorks/FeatureServer",
+            PublicationIds =
+            [
+                parcelsPublication.Metadata.Id,
+                hydrantsPublication.Metadata.Id
+            ]
+        };
+
+        var graph = new MetadataV2Graph
+        {
+            Resources =
+            [
+                parcels,
+                hydrants
+            ],
+            Services = [service],
+            Publications =
+            [
+                parcelsPublication,
+                hydrantsPublication
+            ]
+        };
+
+        graph.Services.Single().PublicationIds.Should().BeEquivalentTo(
+            "publication.public-works.0",
+            "publication.public-works.1");
+        graph.Services.Single().ServiceType.Should().Be(MetadataV2ServiceType.EsriFeatureService);
+        graph.Publications.Should().OnlyContain(publication =>
+            publication.ServiceId == "service.public-works-feature-server" &&
+            publication.PublicationType == MetadataV2PublicationType.EsriFeatureLayer);
+        graph.Publications.Select(publication => publication.LayerIndex).Should().BeEquivalentTo(
+            new int?[] { 0, 1 });
+        graph.Publications.Select(publication => publication.ResourceId).Should().BeEquivalentTo(
+            "resource.parcels",
+            "resource.hydrants");
+        graph.Resources.Select(resource => resource.Metadata.Id).Should().BeEquivalentTo(
+            "resource.parcels",
+            "resource.hydrants");
+        graph.Resources.Should().OnlyContain(resource => resource.SchemaFields.Count == 1);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
     public void StorageBinding_Supports_ReturnsDeclaredCapabilityState()
     {
         var binding = new MetadataV2StorageBinding

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
@@ -1,0 +1,250 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Core.Tests.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Tests for the Metadata v2 core model scaffold.
+/// </summary>
+[Protocol(Protocols.TestQuality)]
+public sealed class MetadataV2ModelTests
+{
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Graph_Defaults_AreEmptyResourceFirstCollections()
+    {
+        var graph = new MetadataV2Graph();
+
+        graph.SchemaVersion.Should().Be(MetadataV2Constants.SchemaVersion);
+        graph.ApiVersion.Should().Be(MetadataV2Constants.ApiVersion);
+        graph.Revision.Should().Be(0);
+        graph.TenantId.Should().BeEmpty();
+        graph.Environment.Should().BeEmpty();
+        graph.GeneratedAt.Should().Be(DateTimeOffset.UnixEpoch);
+        graph.Namespaces.Should().BeEmpty();
+        graph.Catalogs.Should().BeEmpty();
+        graph.Resources.Should().BeEmpty();
+        graph.Connections.Should().BeEmpty();
+        graph.StorageBindings.Should().BeEmpty();
+        graph.Services.Should().BeEmpty();
+        graph.Publications.Should().BeEmpty();
+        graph.ProjectionProfiles.Should().BeEmpty();
+        graph.Policies.Should().BeEmpty();
+        graph.Roles.Should().BeEmpty();
+        graph.Runtime.Should().NotBeNull();
+        graph.ExtensionPoints.Should().BeEmpty();
+        graph.Extensions.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Records_WithExpression_PreservesOriginalValues()
+    {
+        var original = new MetadataV2Resource
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "parcels",
+                Name = "parcels",
+                Labels = new Dictionary<string, string>
+                {
+                    ["domain"] = "cadastre"
+                }
+            },
+            Type = MetadataV2ResourceType.FeatureDataset,
+            StorageBindingIds =
+            [
+                "storage.parcels.postgis",
+                "storage.parcels.parquet"
+            ],
+            SchemaFields =
+            [
+                new MetadataV2Field
+                {
+                    Name = "shape",
+                    Type = "geometry",
+                    SemanticRoles =
+                    [
+                        "geometry.primary"
+                    ]
+                }
+            ],
+            PolicyIds =
+            [
+                "policy.internal"
+            ]
+        };
+
+        var updated = original with
+        {
+            Metadata = original.Metadata with
+            {
+                Name = "parcels-v2"
+            }
+        };
+
+        original.Metadata.Name.Should().Be("parcels");
+        updated.Metadata.Name.Should().Be("parcels-v2");
+        updated.Metadata.Id.Should().Be("parcels");
+        updated.Metadata.Labels.Should().Contain("domain", "cadastre");
+        updated.StorageBindingIds.Should().HaveCount(2);
+        updated.SchemaFields.Single().SemanticRoles.Should().Contain("geometry.primary");
+        updated.PolicyIds.Should().Contain("policy.internal");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Publication_LinksCanonicalResourceToService()
+    {
+        var resource = new MetadataV2Resource
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "resource.parcels",
+                Name = "parcels"
+            }
+        };
+
+        var service = new MetadataV2Service
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "service.public"
+            },
+            ServiceType = MetadataV2ServiceType.OgcApiFeatures
+        };
+
+        var publication = new MetadataV2Publication
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "publication.parcels"
+            },
+            ResourceId = resource.Metadata.Id,
+            ServiceId = service.Metadata.Id,
+            StorageBindingId = "storage.parcels.postgis",
+            PublicationType = MetadataV2PublicationType.OgcCollection,
+            Path = "/collections/parcels",
+            LayerIndex = 0,
+            SupportedFormats =
+            [
+                "application/geo+json"
+            ],
+            FieldAliases = new Dictionary<string, string>
+            {
+                ["shape"] = "Geometry"
+            }
+        };
+
+        var graph = new MetadataV2Graph
+        {
+            Resources = [resource],
+            Services = [service],
+            Publications = [publication]
+        };
+
+        graph.Publications.Single().ResourceId.Should().Be("resource.parcels");
+        graph.Publications.Single().ServiceId.Should().Be("service.public");
+        graph.Publications.Single().PublicationType.Should().Be(MetadataV2PublicationType.OgcCollection);
+        graph.Publications.Single().Path.Should().Be("/collections/parcels");
+        graph.Publications.Single().FieldAliases.Should().Contain("shape", "Geometry");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void StorageBinding_Supports_ReturnsDeclaredCapabilityState()
+    {
+        var binding = new MetadataV2StorageBinding
+        {
+            ResourceId = "resource.parcels",
+            StorageType = MetadataV2StorageType.RelationalTable,
+            Capabilities =
+            [
+                MetadataV2StorageBindingCapability.Query,
+                MetadataV2StorageBindingCapability.Filter,
+                MetadataV2StorageBindingCapability.Sort,
+                MetadataV2StorageBindingCapability.Aggregate,
+                MetadataV2StorageBindingCapability.Search
+            ]
+        };
+
+        binding.Supports(MetadataV2StorageBindingCapability.Query).Should().BeTrue();
+        binding.Supports(MetadataV2StorageBindingCapability.Aggregate).Should().BeTrue();
+        binding.Supports(MetadataV2StorageBindingCapability.Edit).Should().BeFalse();
+        binding.Supports(MetadataV2StorageBindingCapability.Transactions).Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void StorageTypes_AreSeparateFromServiceAndPublicationTypes()
+    {
+        var storageNames = Enum.GetNames<MetadataV2StorageType>();
+        var serviceNames = Enum.GetNames<MetadataV2ServiceType>();
+        var publicationNames = Enum.GetNames<MetadataV2PublicationType>();
+
+        storageNames.Should().Contain(nameof(MetadataV2StorageType.GeoParquet));
+        storageNames.Should().Contain(nameof(MetadataV2StorageType.CloudOptimizedGeoTiff));
+        serviceNames.Intersect(storageNames).Should().BeEmpty();
+        publicationNames.Intersect(storageNames).Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void ResourceAndPublicationTypes_MatchCanonicalBacklogVocabulary()
+    {
+        Enum.GetNames<MetadataV2ResourceType>().Should().BeEquivalentTo(
+            nameof(MetadataV2ResourceType.FeatureDataset),
+            nameof(MetadataV2ResourceType.RasterDataset),
+            nameof(MetadataV2ResourceType.Table),
+            nameof(MetadataV2ResourceType.TileDataset),
+            nameof(MetadataV2ResourceType.Process),
+            nameof(MetadataV2ResourceType.Style),
+            nameof(MetadataV2ResourceType.Document),
+            nameof(MetadataV2ResourceType.ExternalResource));
+
+        Enum.GetNames<MetadataV2PublicationType>().Should().Contain(
+            [
+                nameof(MetadataV2PublicationType.OgcCollection),
+                nameof(MetadataV2PublicationType.WfsFeatureType),
+                nameof(MetadataV2PublicationType.WmsLayer),
+                nameof(MetadataV2PublicationType.WmtsLayer),
+                nameof(MetadataV2PublicationType.EsriFeatureLayer),
+                nameof(MetadataV2PublicationType.EsriMapLayer),
+                nameof(MetadataV2PublicationType.EsriImageLayer),
+                nameof(MetadataV2PublicationType.StacCollection),
+                nameof(MetadataV2PublicationType.DcatDistribution),
+                nameof(MetadataV2PublicationType.OgcRecord),
+                nameof(MetadataV2PublicationType.ODataEntitySet)
+            ]);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void JsonContext_SerializesHyphenatedStorageAndCapabilityNames()
+    {
+        var binding = new MetadataV2StorageBinding
+        {
+            ResourceId = "resource.elevation",
+            StorageType = MetadataV2StorageType.CloudOptimizedGeoTiff,
+            Capabilities =
+            [
+                MetadataV2StorageBindingCapability.Render,
+                MetadataV2StorageBindingCapability.Tile,
+                MetadataV2StorageBindingCapability.Download
+            ]
+        };
+
+        var json = JsonSerializer.Serialize(binding, MetadataV2JsonContext.Default.MetadataV2StorageBinding);
+
+        json.Should().Contain("\"storageType\":\"cloud-optimized-geotiff\"");
+        json.Should().Contain("\"render\"");
+        json.Should().Contain("\"tile\"");
+        json.Should().Contain("\"download\"");
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1036
Closes #1037
Closes #1038
Closes #1042

## Summary
Adds an additive Metadata v2 core model scaffold under `Honua.Core`.

## Changes Made
- Added a canonical root graph with schema version, revision, environment, generated time, namespaces, and required root collections.
- Added resource-first metadata models with storage binding references, schema fields, semantic roles, style references, and policy attachments.
- Split storage, service, and publication vocabularies so storage formats do not collapse into service/catalog outputs.
- Added publication models for service/catalog-specific paths, layer indexes, formats, aliases, capabilities, and overrides.
- Added semantic coverage for multi-layer Esri services as one service with service-local publication slots pointing to canonical Data Resources.
- Added source-generated JSON coverage and focused model tests.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation run locally:
- `git diff --check origin/trunk..HEAD`
- `dotnet build src/Honua.Core/Honua.Core.csproj --no-restore -m:1 /nr:false`
- `dotnet build tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --no-restore --no-dependencies -m:1 /nr:false`
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --no-restore --filter FullyQualifiedName~MetadataV2ModelTests -m:1 /p:BuildInParallel=false /nr:false /p:UseSharedCompilation=false --logger "console;verbosity=minimal"` (8 passed)

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] `scripts/ci/pre-pr-check.sh` full end-to-end run not performed locally; targeted checks above passed and PR CI is running the full gate set.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract or marked not applicable
- [x] If breaking admin/control-plane API changes: updated migration guide or marked not applicable
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review or marked not applicable