### PR TITLE
feat: add metadata v2 projection readiness (#1040)

### DIFF
--- a/src/Honua.Core/Features/Metadata/Projections/CatalogMetadataSemantics.cs
+++ b/src/Honua.Core/Features/Metadata/Projections/CatalogMetadataSemantics.cs
@@ -1,0 +1,235 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Projections;
+
+/// <summary>
+/// Minimal, projection-scoped catalog metadata semantics used to evaluate metadata v2 readiness.
+/// </summary>
+public sealed record CatalogMetadataSemantics
+{
+    public string? Title { get; init; }
+
+    public string? Summary { get; init; }
+
+    public string? Description { get; init; }
+
+    public IReadOnlyList<CatalogIdentifierSemantic> Identifiers { get; init; } = Array.Empty<CatalogIdentifierSemantic>();
+
+    public IReadOnlyList<CatalogContactSemantic> Contacts { get; init; } = Array.Empty<CatalogContactSemantic>();
+
+    public CatalogRightsSemantic? Rights { get; init; }
+
+    public IReadOnlyList<CatalogDateSemantic> Dates { get; init; } = Array.Empty<CatalogDateSemantic>();
+
+    public CatalogExtentSemantic? Extents { get; init; }
+
+    public CatalogLineageSemantic? Lineage { get; init; }
+
+    public IReadOnlyList<CatalogQualitySemantic> Quality { get; init; } = Array.Empty<CatalogQualitySemantic>();
+
+    public IReadOnlyList<CatalogLinkSemantic> Links { get; init; } = Array.Empty<CatalogLinkSemantic>();
+
+    public IReadOnlyList<CatalogDistributionSemantic> Distributions { get; init; } = Array.Empty<CatalogDistributionSemantic>();
+
+    public IReadOnlyList<FieldSemanticBinding> Fields { get; init; } = Array.Empty<FieldSemanticBinding>();
+}
+
+/// <summary>
+/// Identifier metadata for a catalog resource.
+/// </summary>
+public sealed record CatalogIdentifierSemantic(
+    string Value,
+    CatalogIdentifierKind Kind = CatalogIdentifierKind.Local,
+    string? Authority = null,
+    bool IsPrimary = false);
+
+/// <summary>
+/// Identifier authority or representation kind.
+/// </summary>
+public enum CatalogIdentifierKind
+{
+    Local,
+    Uri,
+    Uuid,
+    Doi,
+    Catalog,
+    External
+}
+
+/// <summary>
+/// Contact metadata for a catalog resource.
+/// </summary>
+public sealed record CatalogContactSemantic(
+    string Name,
+    CatalogContactRole Role = CatalogContactRole.PointOfContact,
+    string? Organization = null,
+    string? Email = null,
+    string? Url = null);
+
+/// <summary>
+/// Catalog contact responsibility role.
+/// </summary>
+public enum CatalogContactRole
+{
+    PointOfContact,
+    Originator,
+    Author,
+    Publisher,
+    Custodian,
+    Distributor,
+    Owner
+}
+
+/// <summary>
+/// Rights, license, and attribution metadata for a catalog resource.
+/// </summary>
+public sealed record CatalogRightsSemantic(
+    string? LicenseCode = null,
+    string? LicenseTitle = null,
+    Uri? LicenseUri = null,
+    string? RightsStatement = null,
+    string? Attribution = null);
+
+/// <summary>
+/// Date value with a catalog-specific semantic role.
+/// </summary>
+public sealed record CatalogDateSemantic(
+    DateTimeOffset Value,
+    CatalogDateRole Role);
+
+/// <summary>
+/// Semantic role for a catalog date value.
+/// </summary>
+public enum CatalogDateRole
+{
+    Created,
+    Modified,
+    Published,
+    Issued,
+    ValidFrom,
+    ValidTo,
+    TemporalInstant,
+    TemporalStart,
+    TemporalEnd
+}
+
+/// <summary>
+/// Spatial and temporal extent metadata for a catalog resource.
+/// </summary>
+public sealed record CatalogExtentSemantic
+{
+    public CatalogSpatialExtentSemantic? Spatial { get; init; }
+
+    public CatalogTemporalExtentSemantic? Temporal { get; init; }
+}
+
+/// <summary>
+/// Bounding-box extent metadata for catalog projections.
+/// </summary>
+public sealed record CatalogSpatialExtentSemantic(
+    double West,
+    double South,
+    double East,
+    double North,
+    string Crs = "EPSG:4326");
+
+/// <summary>
+/// Temporal extent metadata for catalog projections.
+/// </summary>
+public sealed record CatalogTemporalExtentSemantic(
+    DateTimeOffset? Start = null,
+    DateTimeOffset? End = null,
+    DateTimeOffset? Instant = null);
+
+/// <summary>
+/// Lineage metadata describing source and processing history.
+/// </summary>
+public sealed record CatalogLineageSemantic(
+    string Statement,
+    CatalogLineageScope Scope = CatalogLineageScope.Dataset,
+    IReadOnlyList<string>? Sources = null,
+    IReadOnlyList<string>? ProcessSteps = null);
+
+/// <summary>
+/// Scope for a lineage statement.
+/// </summary>
+public enum CatalogLineageScope
+{
+    Dataset,
+    Collection,
+    Item,
+    Field,
+    Service
+}
+
+/// <summary>
+/// Quality metadata used by catalog projection readiness checks.
+/// </summary>
+public sealed record CatalogQualitySemantic(
+    string Name,
+    CatalogQualityKind Kind = CatalogQualityKind.Statement,
+    string? Value = null,
+    bool? Flag = null);
+
+/// <summary>
+/// Quality metadata category.
+/// </summary>
+public enum CatalogQualityKind
+{
+    Statement,
+    Completeness,
+    LogicalConsistency,
+    PositionalAccuracy,
+    TemporalAccuracy,
+    ThematicAccuracy,
+    Flag
+}
+
+/// <summary>
+/// Hypermedia link metadata for catalog resources.
+/// </summary>
+public sealed record CatalogLinkSemantic(
+    Uri Href,
+    CatalogLinkRelation Relation = CatalogLinkRelation.Related,
+    string? MediaType = null,
+    string? Title = null);
+
+/// <summary>
+/// Catalog link relation vocabulary.
+/// </summary>
+public enum CatalogLinkRelation
+{
+    Self,
+    Alternate,
+    Canonical,
+    DescribedBy,
+    License,
+    Preview,
+    Related,
+    Service,
+    Data
+}
+
+/// <summary>
+/// Distribution endpoint or artifact metadata for catalog resources.
+/// </summary>
+public sealed record CatalogDistributionSemantic(
+    Uri Href,
+    CatalogDistributionKind Kind = CatalogDistributionKind.Download,
+    string? MediaType = null,
+    string? Title = null,
+    string? Format = null);
+
+/// <summary>
+/// Distribution access kind.
+/// </summary>
+public enum CatalogDistributionKind
+{
+    Download,
+    Api,
+    Tile,
+    Asset,
+    Service,
+    Documentation
+}

--- a/src/Honua.Core/Features/Metadata/Projections/FieldSemanticRoles.cs
+++ b/src/Honua.Core/Features/Metadata/Projections/FieldSemanticRoles.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Projections;
+
+/// <summary>
+/// Stable semantic role identifier for a source field.
+/// </summary>
+public readonly record struct FieldSemanticRole
+{
+    public FieldSemanticRole(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Field semantic role cannot be blank.", nameof(value));
+        }
+
+        Value = value.Trim();
+    }
+
+    public string Value { get; }
+
+    public bool IsKnown => FieldSemanticRoleVocabulary.IsKnown(Value);
+
+    public override string ToString() => Value;
+
+    public static FieldSemanticRole Parse(string value)
+    {
+        if (!TryParse(value, out var role))
+        {
+            throw new ArgumentException("Field semantic role cannot be blank.", nameof(value));
+        }
+
+        return role;
+    }
+
+    public static bool TryParse(string? value, out FieldSemanticRole role)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            role = default;
+            return false;
+        }
+
+        role = new FieldSemanticRole(value);
+        return true;
+    }
+
+    public static implicit operator FieldSemanticRole(string value) => Parse(value);
+}
+
+/// <summary>
+/// Well-known metadata v2 field semantic roles.
+/// </summary>
+public static class FieldSemanticRoleVocabulary
+{
+    public const string IdentifierPrimary = "identifier.primary";
+    public const string DisplayTitle = "display.title";
+    public const string GeometryPrimary = "geometry.primary";
+    public const string TemporalInstant = "temporal.instant";
+    public const string TemporalStart = "temporal.start";
+    public const string TemporalEnd = "temporal.end";
+    public const string MetadataCreated = "metadata.created";
+    public const string MetadataModified = "metadata.modified";
+    public const string AssetHref = "asset.href";
+    public const string LicenseCode = "license.code";
+    public const string QualityFlag = "quality.flag";
+    public const string StatusLifecycle = "status.lifecycle";
+
+    private static readonly HashSet<string> KnownRoles = new(StringComparer.Ordinal)
+    {
+        IdentifierPrimary,
+        DisplayTitle,
+        GeometryPrimary,
+        TemporalInstant,
+        TemporalStart,
+        TemporalEnd,
+        MetadataCreated,
+        MetadataModified,
+        AssetHref,
+        LicenseCode,
+        QualityFlag,
+        StatusLifecycle
+    };
+
+    public static IReadOnlyCollection<string> All => KnownRoles;
+
+    public static bool IsKnown(string? value) => value is not null && KnownRoles.Contains(value);
+}
+
+/// <summary>
+/// Semantic role assignment for a source field.
+/// </summary>
+public sealed record FieldSemanticBinding(
+    string FieldName,
+    FieldSemanticRole Role,
+    FieldStandardBinding? StandardBinding = null);
+
+/// <summary>
+/// Optional mapping from a field semantic role to an external metadata standard term.
+/// </summary>
+public sealed record FieldStandardBinding(
+    string Standard,
+    string? Version = null,
+    Uri? Uri = null,
+    string? Term = null);

--- a/src/Honua.Core/Features/Metadata/Projections/ProjectionReadinessEvaluator.cs
+++ b/src/Honua.Core/Features/Metadata/Projections/ProjectionReadinessEvaluator.cs
@@ -64,8 +64,7 @@ public static class ProjectionReadinessEvaluator
                 || HasRole(metadata, FieldSemanticRoleVocabulary.MetadataCreated),
             ProjectionMetadataSemantic.ModifiedDate => HasDate(metadata, CatalogDateRole.Modified)
                 || HasRole(metadata, FieldSemanticRoleVocabulary.MetadataModified),
-            ProjectionMetadataSemantic.SpatialExtent => metadata.Extents?.Spatial is not null
-                || HasRole(metadata, FieldSemanticRoleVocabulary.GeometryPrimary),
+            ProjectionMetadataSemantic.SpatialExtent => metadata.Extents?.Spatial is not null,
             ProjectionMetadataSemantic.TemporalExtent => HasTemporalExtent(metadata),
             ProjectionMetadataSemantic.Lineage => HasText(metadata.Lineage?.Statement),
             ProjectionMetadataSemantic.Quality => metadata.Quality.Any()
@@ -101,12 +100,7 @@ public static class ProjectionReadinessEvaluator
             && (temporal.Instant.HasValue || temporal.Start.HasValue || temporal.End.HasValue)
         || HasDate(metadata, CatalogDateRole.TemporalInstant)
         || HasDate(metadata, CatalogDateRole.TemporalStart)
-        || HasDate(metadata, CatalogDateRole.TemporalEnd)
-        || HasAnyRole(
-            metadata,
-            FieldSemanticRoleVocabulary.TemporalInstant,
-            FieldSemanticRoleVocabulary.TemporalStart,
-            FieldSemanticRoleVocabulary.TemporalEnd);
+        || HasDate(metadata, CatalogDateRole.TemporalEnd);
 
     private static bool HasDate(CatalogMetadataSemantics metadata, CatalogDateRole role) =>
         metadata.Dates.Any(date => date.Role == role);

--- a/src/Honua.Core/Features/Metadata/Projections/ProjectionReadinessEvaluator.cs
+++ b/src/Honua.Core/Features/Metadata/Projections/ProjectionReadinessEvaluator.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Projections;
+
+/// <summary>
+/// Evaluates catalog metadata against projection target requirements.
+/// </summary>
+public static class ProjectionReadinessEvaluator
+{
+    public static ProjectionReadinessResult Evaluate(CatalogMetadataSemantics metadata, MetadataProjectionTarget target)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        var definition = MetadataProjectionTargets.Get(target);
+        var satisfied = new List<ProjectionRequirement>();
+        var missingRequired = new List<ProjectionRequirement>();
+        var missingRecommended = new List<ProjectionRequirement>();
+
+        foreach (var requirement in definition.Requirements)
+        {
+            if (IsAvailable(metadata, requirement.Semantic))
+            {
+                satisfied.Add(requirement);
+                continue;
+            }
+
+            if (requirement.Importance == ProjectionRequirementImportance.Required)
+            {
+                missingRequired.Add(requirement);
+            }
+            else
+            {
+                missingRecommended.Add(requirement);
+            }
+        }
+
+        return new ProjectionReadinessResult(
+            definition.Target,
+            definition.Label,
+            definition.Slug,
+            missingRequired.Count == 0,
+            satisfied,
+            missingRequired,
+            missingRecommended);
+    }
+
+    public static IReadOnlyList<ProjectionReadinessResult> EvaluateAll(CatalogMetadataSemantics metadata) =>
+        MetadataProjectionTargets.All
+            .Select(definition => Evaluate(metadata, definition.Target))
+            .ToArray();
+
+    private static bool IsAvailable(CatalogMetadataSemantics metadata, ProjectionMetadataSemantic semantic) =>
+        semantic switch
+        {
+            ProjectionMetadataSemantic.PrimaryIdentifier => HasPrimaryIdentifier(metadata),
+            ProjectionMetadataSemantic.Title => HasText(metadata.Title) || HasRole(metadata, FieldSemanticRoleVocabulary.DisplayTitle),
+            ProjectionMetadataSemantic.Summary => HasText(metadata.Summary),
+            ProjectionMetadataSemantic.Description => HasText(metadata.Description),
+            ProjectionMetadataSemantic.Contact => metadata.Contacts.Any(contact => HasText(contact.Name)),
+            ProjectionMetadataSemantic.License => HasLicense(metadata),
+            ProjectionMetadataSemantic.Rights => HasText(metadata.Rights?.RightsStatement) || HasText(metadata.Rights?.Attribution),
+            ProjectionMetadataSemantic.CreatedDate => HasDate(metadata, CatalogDateRole.Created)
+                || HasRole(metadata, FieldSemanticRoleVocabulary.MetadataCreated),
+            ProjectionMetadataSemantic.ModifiedDate => HasDate(metadata, CatalogDateRole.Modified)
+                || HasRole(metadata, FieldSemanticRoleVocabulary.MetadataModified),
+            ProjectionMetadataSemantic.SpatialExtent => metadata.Extents?.Spatial is not null
+                || HasRole(metadata, FieldSemanticRoleVocabulary.GeometryPrimary),
+            ProjectionMetadataSemantic.TemporalExtent => HasTemporalExtent(metadata),
+            ProjectionMetadataSemantic.Lineage => HasText(metadata.Lineage?.Statement),
+            ProjectionMetadataSemantic.Quality => metadata.Quality.Any()
+                || HasRole(metadata, FieldSemanticRoleVocabulary.QualityFlag),
+            ProjectionMetadataSemantic.Link => metadata.Links.Any(link => link.Href.IsAbsoluteUri),
+            ProjectionMetadataSemantic.Distribution => metadata.Distributions.Any(distribution => distribution.Href.IsAbsoluteUri),
+            ProjectionMetadataSemantic.PrimaryGeometryField => HasRole(metadata, FieldSemanticRoleVocabulary.GeometryPrimary),
+            ProjectionMetadataSemantic.TemporalField => HasAnyRole(
+                metadata,
+                FieldSemanticRoleVocabulary.TemporalInstant,
+                FieldSemanticRoleVocabulary.TemporalStart,
+                FieldSemanticRoleVocabulary.TemporalEnd),
+            ProjectionMetadataSemantic.AssetHrefField => HasRole(metadata, FieldSemanticRoleVocabulary.AssetHref)
+                || metadata.Distributions.Any(distribution => distribution.Href.IsAbsoluteUri),
+            ProjectionMetadataSemantic.LicenseCodeField => HasRole(metadata, FieldSemanticRoleVocabulary.LicenseCode),
+            ProjectionMetadataSemantic.QualityFlagField => HasRole(metadata, FieldSemanticRoleVocabulary.QualityFlag),
+            ProjectionMetadataSemantic.LifecycleStatusField => HasRole(metadata, FieldSemanticRoleVocabulary.StatusLifecycle),
+            _ => false
+        };
+
+    private static bool HasPrimaryIdentifier(CatalogMetadataSemantics metadata) =>
+        metadata.Identifiers.Any(identifier => identifier.IsPrimary && HasText(identifier.Value))
+        || HasRole(metadata, FieldSemanticRoleVocabulary.IdentifierPrimary);
+
+    private static bool HasLicense(CatalogMetadataSemantics metadata) =>
+        HasText(metadata.Rights?.LicenseCode)
+        || HasText(metadata.Rights?.LicenseTitle)
+        || metadata.Rights?.LicenseUri is not null
+        || HasRole(metadata, FieldSemanticRoleVocabulary.LicenseCode);
+
+    private static bool HasTemporalExtent(CatalogMetadataSemantics metadata) =>
+        metadata.Extents?.Temporal is { } temporal
+            && (temporal.Instant.HasValue || temporal.Start.HasValue || temporal.End.HasValue)
+        || HasDate(metadata, CatalogDateRole.TemporalInstant)
+        || HasDate(metadata, CatalogDateRole.TemporalStart)
+        || HasDate(metadata, CatalogDateRole.TemporalEnd)
+        || HasAnyRole(
+            metadata,
+            FieldSemanticRoleVocabulary.TemporalInstant,
+            FieldSemanticRoleVocabulary.TemporalStart,
+            FieldSemanticRoleVocabulary.TemporalEnd);
+
+    private static bool HasDate(CatalogMetadataSemantics metadata, CatalogDateRole role) =>
+        metadata.Dates.Any(date => date.Role == role);
+
+    private static bool HasRole(CatalogMetadataSemantics metadata, string role) =>
+        metadata.Fields.Any(field => string.Equals(field.Role.Value, role, StringComparison.Ordinal));
+
+    private static bool HasAnyRole(CatalogMetadataSemantics metadata, params string[] roles) =>
+        metadata.Fields.Any(field => roles.Contains(field.Role.Value, StringComparer.Ordinal));
+
+    private static bool HasText(string? value) => !string.IsNullOrWhiteSpace(value);
+}
+
+/// <summary>
+/// Readiness result for one metadata projection target.
+/// </summary>
+public sealed record ProjectionReadinessResult(
+    MetadataProjectionTarget Target,
+    string TargetLabel,
+    string TargetSlug,
+    bool IsReady,
+    IReadOnlyList<ProjectionRequirement> Satisfied,
+    IReadOnlyList<ProjectionRequirement> MissingRequired,
+    IReadOnlyList<ProjectionRequirement> MissingRecommended);

--- a/src/Honua.Core/Features/Metadata/Projections/ProjectionTargets.cs
+++ b/src/Honua.Core/Features/Metadata/Projections/ProjectionTargets.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Projections;
+
+/// <summary>
+/// Supported catalog or protocol metadata projection target.
+/// </summary>
+public enum MetadataProjectionTarget
+{
+    OgcRecords,
+    Dcat3,
+    StacCollection,
+    StacItem,
+    Iso19115,
+    EsriPortalItem,
+    GeoServicesRest,
+    OgcApiFeaturesCollection,
+    ODataEdm
+}
+
+/// <summary>
+/// Importance of a metadata projection requirement.
+/// </summary>
+public enum ProjectionRequirementImportance
+{
+    Required,
+    Recommended
+}
+
+/// <summary>
+/// Metadata semantic that may be required by a projection target.
+/// </summary>
+public enum ProjectionMetadataSemantic
+{
+    PrimaryIdentifier,
+    Title,
+    Summary,
+    Description,
+    Contact,
+    License,
+    Rights,
+    CreatedDate,
+    ModifiedDate,
+    SpatialExtent,
+    TemporalExtent,
+    Lineage,
+    Quality,
+    Link,
+    Distribution,
+    PrimaryGeometryField,
+    TemporalField,
+    AssetHrefField,
+    LicenseCodeField,
+    QualityFlagField,
+    LifecycleStatusField
+}
+
+/// <summary>
+/// One semantic requirement for a projection target.
+/// </summary>
+public sealed record ProjectionRequirement(
+    ProjectionMetadataSemantic Semantic,
+    string Label,
+    ProjectionRequirementImportance Importance);
+
+/// <summary>
+/// Definition of a metadata projection target and its readiness requirements.
+/// </summary>
+public sealed record MetadataProjectionTargetDefinition(
+    MetadataProjectionTarget Target,
+    string Label,
+    string Slug,
+    IReadOnlyList<ProjectionRequirement> Requirements);
+
+/// <summary>
+/// Registry of built-in metadata projection target definitions.
+/// </summary>
+public static class MetadataProjectionTargets
+{
+    private static readonly MetadataProjectionTargetDefinition[] Definitions =
+    [
+        Define(
+            MetadataProjectionTarget.OgcRecords,
+            "OGC Records",
+            "ogc-records",
+            Required(ProjectionMetadataSemantic.PrimaryIdentifier, "primary identifier"),
+            Required(ProjectionMetadataSemantic.Title, "title"),
+            Recommended(ProjectionMetadataSemantic.Description, "description"),
+            Recommended(ProjectionMetadataSemantic.SpatialExtent, "spatial extent"),
+            Recommended(ProjectionMetadataSemantic.TemporalExtent, "temporal extent"),
+            Recommended(ProjectionMetadataSemantic.Contact, "contact"),
+            Recommended(ProjectionMetadataSemantic.License, "license"),
+            Recommended(ProjectionMetadataSemantic.Link, "link")),
+        Define(
+            MetadataProjectionTarget.Dcat3,
+            "DCAT 3",
+            "dcat-3",
+            Required(ProjectionMetadataSemantic.PrimaryIdentifier, "primary identifier"),
+            Required(ProjectionMetadataSemantic.Title, "title"),
+            Recommended(ProjectionMetadataSemantic.Description, "description"),
+            Recommended(ProjectionMetadataSemantic.Contact, "contact"),
+            Recommended(ProjectionMetadataSemantic.License, "license"),
+            Recommended(ProjectionMetadataSemantic.Rights, "rights statement"),
+            Recommended(ProjectionMetadataSemantic.SpatialExtent, "spatial extent"),
+            Recommended(ProjectionMetadataSemantic.TemporalExtent, "temporal extent"),
+            Recommended(ProjectionMetadataSemantic.Distribution, "distribution"),
+            Recommended(ProjectionMetadataSemantic.ModifiedDate, "modified date")),
+        Define(
+            MetadataProjectionTarget.StacCollection,
+            "STAC Collection",
+            "stac-collection",
+            Required(ProjectionMetadataSemantic.PrimaryIdentifier, "collection id"),
+            Required(ProjectionMetadataSemantic.Title, "title"),
+            Required(ProjectionMetadataSemantic.Description, "description"),
+            Required(ProjectionMetadataSemantic.SpatialExtent, "spatial extent"),
+            Required(ProjectionMetadataSemantic.TemporalExtent, "temporal extent"),
+            Recommended(ProjectionMetadataSemantic.License, "license"),
+            Recommended(ProjectionMetadataSemantic.Link, "link"),
+            Recommended(ProjectionMetadataSemantic.Quality, "quality statement")),
+        Define(
+            MetadataProjectionTarget.StacItem,
+            "STAC Item",
+            "stac-item",
+            Required(ProjectionMetadataSemantic.PrimaryIdentifier, "item id"),
+            Required(ProjectionMetadataSemantic.SpatialExtent, "spatial extent"),
+            Required(ProjectionMetadataSemantic.TemporalExtent, "temporal extent"),
+            Required(ProjectionMetadataSemantic.AssetHrefField, "asset href field or distribution"),
+            Recommended(ProjectionMetadataSemantic.Title, "title"),
+            Recommended(ProjectionMetadataSemantic.Description, "description"),
+            Recommended(ProjectionMetadataSemantic.License, "license")),
+        Define(
+            MetadataProjectionTarget.Iso19115,
+            "ISO 19115/19139",
+            "iso-19115-19139",
+            Required(ProjectionMetadataSemantic.PrimaryIdentifier, "file identifier"),
+            Required(ProjectionMetadataSemantic.Title, "citation title"),
+            Required(ProjectionMetadataSemantic.Contact, "responsible party"),
+            Recommended(ProjectionMetadataSemantic.Description, "abstract"),
+            Recommended(ProjectionMetadataSemantic.CreatedDate, "created date"),
+            Recommended(ProjectionMetadataSemantic.ModifiedDate, "modified date"),
+            Recommended(ProjectionMetadataSemantic.SpatialExtent, "spatial extent"),
+            Recommended(ProjectionMetadataSemantic.TemporalExtent, "temporal extent"),
+            Recommended(ProjectionMetadataSemantic.Lineage, "lineage statement"),
+            Recommended(ProjectionMetadataSemantic.Quality, "quality statement")),
+        Define(
+            MetadataProjectionTarget.EsriPortalItem,
+            "Esri portal item/catalog item",
+            "esri-portal-item",
+            Required(ProjectionMetadataSemantic.Title, "title"),
+            Required(ProjectionMetadataSemantic.Description, "description"),
+            Recommended(ProjectionMetadataSemantic.PrimaryIdentifier, "item id"),
+            Recommended(ProjectionMetadataSemantic.Summary, "summary"),
+            Recommended(ProjectionMetadataSemantic.License, "license"),
+            Recommended(ProjectionMetadataSemantic.Rights, "access and use constraints"),
+            Recommended(ProjectionMetadataSemantic.Link, "item link"),
+            Recommended(ProjectionMetadataSemantic.Distribution, "distribution")),
+        Define(
+            MetadataProjectionTarget.GeoServicesRest,
+            "GeoServices REST service/layer metadata",
+            "geoservices-rest",
+            Required(ProjectionMetadataSemantic.Title, "name or title"),
+            Required(ProjectionMetadataSemantic.PrimaryGeometryField, "primary geometry field"),
+            Recommended(ProjectionMetadataSemantic.PrimaryIdentifier, "layer id"),
+            Recommended(ProjectionMetadataSemantic.Description, "description"),
+            Recommended(ProjectionMetadataSemantic.SpatialExtent, "extent"),
+            Recommended(ProjectionMetadataSemantic.TemporalField, "time field"),
+            Recommended(ProjectionMetadataSemantic.Rights, "copyright or rights")),
+        Define(
+            MetadataProjectionTarget.OgcApiFeaturesCollection,
+            "OGC API Features collection metadata",
+            "ogc-api-features-collection",
+            Required(ProjectionMetadataSemantic.PrimaryIdentifier, "collection id"),
+            Required(ProjectionMetadataSemantic.Title, "title"),
+            Recommended(ProjectionMetadataSemantic.Description, "description"),
+            Recommended(ProjectionMetadataSemantic.SpatialExtent, "spatial extent"),
+            Recommended(ProjectionMetadataSemantic.TemporalExtent, "temporal extent"),
+            Recommended(ProjectionMetadataSemantic.Link, "links")),
+        Define(
+            MetadataProjectionTarget.ODataEdm,
+            "OData EDM metadata",
+            "odata-edm",
+            Required(ProjectionMetadataSemantic.PrimaryIdentifier, "entity key"),
+            Recommended(ProjectionMetadataSemantic.Title, "entity set title"),
+            Recommended(ProjectionMetadataSemantic.PrimaryGeometryField, "spatial property"),
+            Recommended(ProjectionMetadataSemantic.TemporalField, "temporal property"),
+            Recommended(ProjectionMetadataSemantic.CreatedDate, "created timestamp"),
+            Recommended(ProjectionMetadataSemantic.ModifiedDate, "modified timestamp"),
+            Recommended(ProjectionMetadataSemantic.LifecycleStatusField, "lifecycle status field"))
+    ];
+
+    public static IReadOnlyList<MetadataProjectionTargetDefinition> All => Definitions;
+
+    public static MetadataProjectionTargetDefinition Get(MetadataProjectionTarget target) =>
+        Definitions.First(definition => definition.Target == target);
+
+    public static string GetLabel(MetadataProjectionTarget target) => Get(target).Label;
+
+    private static MetadataProjectionTargetDefinition Define(
+        MetadataProjectionTarget target,
+        string label,
+        string slug,
+        params ProjectionRequirement[] requirements) =>
+        new(target, label, slug, requirements);
+
+    private static ProjectionRequirement Required(ProjectionMetadataSemantic semantic, string label) =>
+        new(semantic, label, ProjectionRequirementImportance.Required);
+
+    private static ProjectionRequirement Recommended(ProjectionMetadataSemantic semantic, string label) =>
+        new(semantic, label, ProjectionRequirementImportance.Recommended);
+}

--- a/src/Honua.Core/Features/Metadata/Projections/ProjectionTargets.cs
+++ b/src/Honua.Core/Features/Metadata/Projections/ProjectionTargets.cs
@@ -78,7 +78,7 @@ public sealed record MetadataProjectionTargetDefinition(
 /// </summary>
 public static class MetadataProjectionTargets
 {
-    private static readonly MetadataProjectionTargetDefinition[] Definitions =
+    private static readonly IReadOnlyList<MetadataProjectionTargetDefinition> Definitions = Array.AsReadOnly(
     [
         Define(
             MetadataProjectionTarget.OgcRecords,
@@ -187,7 +187,7 @@ public static class MetadataProjectionTargets
             Recommended(ProjectionMetadataSemantic.CreatedDate, "created timestamp"),
             Recommended(ProjectionMetadataSemantic.ModifiedDate, "modified timestamp"),
             Recommended(ProjectionMetadataSemantic.LifecycleStatusField, "lifecycle status field"))
-    ];
+    ]);
 
     public static IReadOnlyList<MetadataProjectionTargetDefinition> All => Definitions;
 
@@ -201,7 +201,7 @@ public static class MetadataProjectionTargets
         string label,
         string slug,
         params ProjectionRequirement[] requirements) =>
-        new(target, label, slug, requirements);
+        new(target, label, slug, Array.AsReadOnly(requirements.ToArray()));
 
     private static ProjectionRequirement Required(ProjectionMetadataSemantic semantic, string label) =>
         new(semantic, label, ProjectionRequirementImportance.Required);

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/MetadataProjectionReadinessTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/MetadataProjectionReadinessTests.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Projections;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Core.Tests.Features.Metadata;
+
+[Protocol(Protocols.TestQuality)]
+public sealed class MetadataProjectionReadinessTests
+{
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void TargetDefinitions_ExposeExpectedLabels()
+    {
+        MetadataProjectionTargets.GetLabel(MetadataProjectionTarget.OgcRecords).Should().Be("OGC Records");
+        MetadataProjectionTargets.GetLabel(MetadataProjectionTarget.Dcat3).Should().Be("DCAT 3");
+        MetadataProjectionTargets.GetLabel(MetadataProjectionTarget.StacCollection).Should().Be("STAC Collection");
+        MetadataProjectionTargets.GetLabel(MetadataProjectionTarget.StacItem).Should().Be("STAC Item");
+        MetadataProjectionTargets.GetLabel(MetadataProjectionTarget.Iso19115).Should().Be("ISO 19115/19139");
+        MetadataProjectionTargets.GetLabel(MetadataProjectionTarget.EsriPortalItem)
+            .Should().Be("Esri portal item/catalog item");
+        MetadataProjectionTargets.GetLabel(MetadataProjectionTarget.GeoServicesRest)
+            .Should().Be("GeoServices REST service/layer metadata");
+        MetadataProjectionTargets.GetLabel(MetadataProjectionTarget.OgcApiFeaturesCollection)
+            .Should().Be("OGC API Features collection metadata");
+        MetadataProjectionTargets.GetLabel(MetadataProjectionTarget.ODataEdm).Should().Be("OData EDM metadata");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void FieldSemanticRole_Parse_PreservesKnownRoleAndRejectsBlank()
+    {
+        var role = FieldSemanticRole.Parse("geometry.primary");
+
+        role.Value.Should().Be(FieldSemanticRoleVocabulary.GeometryPrimary);
+        role.IsKnown.Should().BeTrue();
+        FieldSemanticRoleVocabulary.All.Should().Contain(
+            [
+                FieldSemanticRoleVocabulary.IdentifierPrimary,
+                FieldSemanticRoleVocabulary.DisplayTitle,
+                FieldSemanticRoleVocabulary.GeometryPrimary,
+                FieldSemanticRoleVocabulary.TemporalInstant,
+                FieldSemanticRoleVocabulary.TemporalStart,
+                FieldSemanticRoleVocabulary.TemporalEnd,
+                FieldSemanticRoleVocabulary.MetadataCreated,
+                FieldSemanticRoleVocabulary.MetadataModified,
+                FieldSemanticRoleVocabulary.AssetHref,
+                FieldSemanticRoleVocabulary.LicenseCode,
+                FieldSemanticRoleVocabulary.QualityFlag,
+                FieldSemanticRoleVocabulary.StatusLifecycle
+            ]);
+
+        FieldSemanticRole.TryParse(" ", out _).Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Evaluate_StacCollection_WithRequiredSemantics_IsReady()
+    {
+        var metadata = CreateBaselineMetadata();
+
+        var result = ProjectionReadinessEvaluator.Evaluate(metadata, MetadataProjectionTarget.StacCollection);
+
+        result.IsReady.Should().BeTrue();
+        result.MissingRequired.Should().BeEmpty();
+        result.MissingRecommended.Select(requirement => requirement.Semantic)
+            .Should().NotContain(ProjectionMetadataSemantic.License);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Evaluate_StacItem_CanUseDistributionAsAssetHref()
+    {
+        var metadata = CreateBaselineMetadata() with
+        {
+            Distributions =
+            [
+                new CatalogDistributionSemantic(
+                    new Uri("https://example.test/data/buildings.parquet"),
+                    CatalogDistributionKind.Asset)
+            ]
+        };
+
+        var result = ProjectionReadinessEvaluator.Evaluate(metadata, MetadataProjectionTarget.StacItem);
+
+        result.IsReady.Should().BeTrue();
+        result.MissingRequired.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Evaluate_OgcRecords_ReportsMissingRequiredBeforeRecommended()
+    {
+        var metadata = new CatalogMetadataSemantics
+        {
+            Description = "Parks and open space."
+        };
+
+        var result = ProjectionReadinessEvaluator.Evaluate(metadata, MetadataProjectionTarget.OgcRecords);
+
+        result.IsReady.Should().BeFalse();
+        result.MissingRequired.Select(requirement => requirement.Semantic)
+            .Should().Equal(ProjectionMetadataSemantic.PrimaryIdentifier, ProjectionMetadataSemantic.Title);
+        result.MissingRecommended.Select(requirement => requirement.Semantic)
+            .Should().Contain(ProjectionMetadataSemantic.SpatialExtent);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Evaluate_GeoServicesRest_UsesFieldRoles()
+    {
+        var metadata = new CatalogMetadataSemantics
+        {
+            Title = "Buildings",
+            Fields =
+            [
+                new FieldSemanticBinding("shape", FieldSemanticRole.Parse(FieldSemanticRoleVocabulary.GeometryPrimary)),
+                new FieldSemanticBinding("observed_at", FieldSemanticRole.Parse(FieldSemanticRoleVocabulary.TemporalInstant))
+            ]
+        };
+
+        var result = ProjectionReadinessEvaluator.Evaluate(metadata, MetadataProjectionTarget.GeoServicesRest);
+
+        result.IsReady.Should().BeTrue();
+        result.MissingRequired.Should().BeEmpty();
+        result.MissingRecommended.Select(requirement => requirement.Semantic)
+            .Should().NotContain(ProjectionMetadataSemantic.TemporalField);
+    }
+
+    private static CatalogMetadataSemantics CreateBaselineMetadata() => new()
+    {
+        Title = "Building footprints",
+        Summary = "Current building footprint catalog.",
+        Description = "Building footprint polygons maintained for catalog projection tests.",
+        Identifiers =
+        [
+            new CatalogIdentifierSemantic("buildings", CatalogIdentifierKind.Local, IsPrimary: true)
+        ],
+        Contacts =
+        [
+            new CatalogContactSemantic("Catalog Steward", CatalogContactRole.PointOfContact, "Honua")
+        ],
+        Rights = new CatalogRightsSemantic(LicenseCode: "CC-BY-4.0"),
+        Extents = new CatalogExtentSemantic
+        {
+            Spatial = new CatalogSpatialExtentSemantic(-158.3, 21.2, -157.6, 21.8),
+            Temporal = new CatalogTemporalExtentSemantic(Start: new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero))
+        },
+        Links =
+        [
+            new CatalogLinkSemantic(new Uri("https://example.test/catalog/buildings"), CatalogLinkRelation.Canonical)
+        ]
+    };
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/MetadataProjectionReadinessTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/MetadataProjectionReadinessTests.cs
@@ -31,6 +31,15 @@ public sealed class MetadataProjectionReadinessTests
 
     [UnitTest]
     [Operation(Operations.Query)]
+    public void TargetDefinitions_ReturnReadOnlyCollections()
+    {
+        MetadataProjectionTargets.All.GetType().IsArray.Should().BeFalse();
+        MetadataProjectionTargets.Get(MetadataProjectionTarget.StacCollection)
+            .Requirements.GetType().IsArray.Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
     public void FieldSemanticRole_Parse_PreservesKnownRoleAndRejectsBlank()
     {
         var role = FieldSemanticRole.Parse("geometry.primary");
@@ -88,6 +97,39 @@ public sealed class MetadataProjectionReadinessTests
 
         result.IsReady.Should().BeTrue();
         result.MissingRequired.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Evaluate_StacCollection_RequiresExplicitSpatialAndTemporalExtents()
+    {
+        var metadata = new CatalogMetadataSemantics
+        {
+            Title = "Buildings",
+            Description = "Building footprints.",
+            Identifiers =
+            [
+                new CatalogIdentifierSemantic("buildings", CatalogIdentifierKind.Local, IsPrimary: true)
+            ],
+            Fields =
+            [
+                new FieldSemanticBinding("shape", FieldSemanticRole.Parse(FieldSemanticRoleVocabulary.GeometryPrimary)),
+                new FieldSemanticBinding("observed_at", FieldSemanticRole.Parse(FieldSemanticRoleVocabulary.TemporalInstant))
+            ]
+        };
+
+        var result = ProjectionReadinessEvaluator.Evaluate(metadata, MetadataProjectionTarget.StacCollection);
+
+        result.IsReady.Should().BeFalse();
+        result.MissingRequired.Select(requirement => requirement.Semantic).Should().Contain(
+            [
+                ProjectionMetadataSemantic.SpatialExtent,
+                ProjectionMetadataSemantic.TemporalExtent
+            ]);
+        result.Satisfied.Select(requirement => requirement.Semantic)
+            .Should().NotContain(ProjectionMetadataSemantic.SpatialExtent);
+        result.Satisfied.Select(requirement => requirement.Semantic)
+            .Should().NotContain(ProjectionMetadataSemantic.TemporalExtent);
     }
 
     [UnitTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1040
Closes #1041
Closes #1043

## Summary
Adds an additive projection/readiness scaffold for translating one canonical metadata model into multiple catalog and service metadata targets.

## Changes Made
- Added canonical catalog metadata semantics for identifiers, contacts, rights, dates, extents, lineage, quality, links, distributions, and fields.
- Added field semantic role vocabulary for geometry, temporal fields, identifiers, display titles, asset hrefs, license codes, quality flags, lifecycle status, and audit dates.
- Added projection target definitions for OGC Records, DCAT 3, STAC, ISO 19115/19139, Esri catalog/GeoServices, OGC API Features, and OData EDM.
- Added readiness evaluator tests for required vs recommended semantic coverage.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation run locally:
- `git diff --check origin/trunk..HEAD`
- `dotnet build src/Honua.Core/Honua.Core.csproj --no-restore -m:1 /nr:false`
- `dotnet build tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --no-restore --no-dependencies -m:1 /nr:false`
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --no-build --filter FullyQualifiedName~MetadataProjectionReadinessTests`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] `scripts/ci/pre-pr-check.sh` full end-to-end run not performed locally; targeted checks above passed and PR CI is running the full gate set.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract or marked not applicable
- [x] If breaking admin/control-plane API changes: updated migration guide or marked not applicable
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review or marked not applicable