### PR TITLE
feat: add metadata v2 security cache scaffolds (#1039)

### DIFF
--- a/src/Honua.Core/Features/Metadata/Domain/MetadataV2CacheKeys.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/MetadataV2CacheKeys.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Security.Cryptography;
 using System.Text;
 
 namespace Honua.Core.Features.Metadata.Domain;
@@ -87,6 +88,7 @@ public static class MetadataV2CacheKeyBuilder
     public const string DefaultKeyPrefix = "honua:metadata:v2";
 
     private const int MaxComponentLength = 96;
+    private const int ComponentFingerprintLength = 16;
 
     /// <summary>
     /// Builds a metadata v2 snapshot cache key.
@@ -192,7 +194,22 @@ public static class MetadataV2CacheKeyBuilder
             return fallback;
         }
 
-        return component.Length <= MaxComponentLength ? component : component[..MaxComponentLength].TrimEnd('-');
+        if (component.Length <= MaxComponentLength)
+        {
+            return component;
+        }
+
+        var prefixLength = MaxComponentLength - ComponentFingerprintLength - 1;
+        return string.Concat(
+            component.AsSpan(0, prefixLength).TrimEnd('-'),
+            "-",
+            Fingerprint(component).AsSpan(0, ComponentFingerprintLength));
+    }
+
+    private static string Fingerprint(string value)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
     }
 
     private static string CollapseSeparators(string value, char separator)

--- a/src/Honua.Core/Features/Metadata/Domain/MetadataV2CacheKeys.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/MetadataV2CacheKeys.cs
@@ -33,11 +33,6 @@ public sealed record MetadataV2CacheKeyRequest
     public string KeyPrefix { get; init; } = MetadataV2CacheKeyBuilder.DefaultKeyPrefix;
 
     /// <summary>
-    /// Tenant dimension.
-    /// </summary>
-    public string? TenantId { get; init; }
-
-    /// <summary>
     /// Environment dimension, for example <c>dev</c>, <c>staging</c>, or <c>prod</c>.
     /// </summary>
     public string? Environment { get; init; }
@@ -110,8 +105,6 @@ public static class MetadataV2CacheKeyBuilder
         {
             NormalizePrefix(request.KeyPrefix),
             NormalizeComponent(kind.ToString(), "unknown"),
-            "tenant",
-            NormalizeScopedComponent(request.TenantId),
             "environment",
             NormalizeScopedComponent(request.Environment),
             "catalog",

--- a/src/Honua.Core/Features/Metadata/Domain/MetadataV2CacheKeys.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/MetadataV2CacheKeys.cs
@@ -1,0 +1,229 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+
+namespace Honua.Core.Features.Metadata.Domain;
+
+/// <summary>
+/// Metadata v2 cache entry family.
+/// </summary>
+public enum MetadataV2CacheEntryKind
+{
+    /// <summary>
+    /// Versioned metadata snapshot.
+    /// </summary>
+    Snapshot,
+
+    /// <summary>
+    /// Derived metadata projection.
+    /// </summary>
+    Projection
+}
+
+/// <summary>
+/// Request used to build metadata v2 snapshot and projection cache keys.
+/// </summary>
+public sealed record MetadataV2CacheKeyRequest
+{
+    /// <summary>
+    /// Cache key namespace prefix.
+    /// </summary>
+    public string KeyPrefix { get; init; } = MetadataV2CacheKeyBuilder.DefaultKeyPrefix;
+
+    /// <summary>
+    /// Tenant dimension.
+    /// </summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>
+    /// Environment dimension, for example <c>dev</c>, <c>staging</c>, or <c>prod</c>.
+    /// </summary>
+    public string? Environment { get; init; }
+
+    /// <summary>
+    /// Catalog dimension.
+    /// </summary>
+    public string? CatalogId { get; init; }
+
+    /// <summary>
+    /// Metadata schema version dimension.
+    /// </summary>
+    public string? SchemaVersion { get; init; }
+
+    /// <summary>
+    /// Metadata revision dimension.
+    /// </summary>
+    public string? Revision { get; init; }
+
+    /// <summary>
+    /// Projection target dimension.
+    /// </summary>
+    public string? ProjectionTarget { get; init; }
+
+    /// <summary>
+    /// Projection profile version dimension.
+    /// </summary>
+    public string? ProjectionProfileVersion { get; init; }
+}
+
+/// <summary>
+/// Built metadata v2 cache key.
+/// </summary>
+public sealed record MetadataV2CacheKey(MetadataV2CacheEntryKind Kind, string Value)
+{
+    /// <inheritdoc />
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Builds deterministic metadata v2 cache keys for snapshots and projections.
+/// </summary>
+public static class MetadataV2CacheKeyBuilder
+{
+    /// <summary>
+    /// Default namespace for metadata v2 cache entries.
+    /// </summary>
+    public const string DefaultKeyPrefix = "honua:metadata:v2";
+
+    private const int MaxComponentLength = 96;
+
+    /// <summary>
+    /// Builds a metadata v2 snapshot cache key.
+    /// </summary>
+    public static MetadataV2CacheKey BuildSnapshot(MetadataV2CacheKeyRequest request)
+        => Build(MetadataV2CacheEntryKind.Snapshot, request);
+
+    /// <summary>
+    /// Builds a metadata v2 projection cache key.
+    /// </summary>
+    public static MetadataV2CacheKey BuildProjection(MetadataV2CacheKeyRequest request)
+        => Build(MetadataV2CacheEntryKind.Projection, request);
+
+    private static MetadataV2CacheKey Build(MetadataV2CacheEntryKind kind, MetadataV2CacheKeyRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var parts = new List<string>
+        {
+            NormalizePrefix(request.KeyPrefix),
+            NormalizeComponent(kind.ToString(), "unknown"),
+            "tenant",
+            NormalizeScopedComponent(request.TenantId),
+            "environment",
+            NormalizeScopedComponent(request.Environment),
+            "catalog",
+            NormalizeScopedComponent(request.CatalogId),
+            "schema",
+            NormalizeScopedComponent(request.SchemaVersion),
+            "revision",
+            NormalizeScopedComponent(request.Revision)
+        };
+
+        if (kind == MetadataV2CacheEntryKind.Projection)
+        {
+            parts.Add("target");
+            parts.Add(NormalizeScopedComponent(request.ProjectionTarget));
+            parts.Add("profile");
+            parts.Add(NormalizeScopedComponent(request.ProjectionProfileVersion));
+        }
+
+        return new MetadataV2CacheKey(kind, string.Join(':', parts));
+    }
+
+    private static string NormalizePrefix(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return DefaultKeyPrefix;
+        }
+
+        var builder = new StringBuilder(value.Length);
+        foreach (var c in value.Trim())
+        {
+            if (IsSafeKeyCharacter(c) || c == ':')
+            {
+                builder.Append(char.ToLowerInvariant(c));
+            }
+            else if (char.IsWhiteSpace(c) || c == '/')
+            {
+                builder.Append(':');
+            }
+            else
+            {
+                builder.Append('-');
+            }
+        }
+
+        var normalized = CollapseSeparators(builder.ToString(), ':').Trim(':');
+        return string.IsNullOrEmpty(normalized) ? DefaultKeyPrefix : normalized;
+    }
+
+    private static string NormalizeScopedComponent(string? value)
+        => string.IsNullOrWhiteSpace(value) ? "none" : $"id-{NormalizeComponent(value, "none")}";
+
+    private static string NormalizeComponent(string? value, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+        var builder = new StringBuilder(normalized.Length);
+        var previousWasDash = false;
+        foreach (var c in normalized)
+        {
+            if (IsSafeKeyCharacter(c))
+            {
+                builder.Append(c);
+                previousWasDash = false;
+            }
+            else if (!previousWasDash)
+            {
+                builder.Append('-');
+                previousWasDash = true;
+            }
+        }
+
+        var component = builder.ToString().Trim('-');
+        if (string.IsNullOrEmpty(component))
+        {
+            return fallback;
+        }
+
+        return component.Length <= MaxComponentLength ? component : component[..MaxComponentLength].TrimEnd('-');
+    }
+
+    private static string CollapseSeparators(string value, char separator)
+    {
+        var builder = new StringBuilder(value.Length);
+        var previousWasSeparator = false;
+        foreach (var c in value)
+        {
+            if (c == separator)
+            {
+                if (!previousWasSeparator)
+                {
+                    builder.Append(c);
+                }
+
+                previousWasSeparator = true;
+                continue;
+            }
+
+            builder.Append(c);
+            previousWasSeparator = false;
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool IsSafeKeyCharacter(char c)
+        => (c >= 'a' && c <= 'z') ||
+            (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') ||
+            c == '.' ||
+            c == '_' ||
+            c == '-';
+}

--- a/src/Honua.Core/Features/Metadata/Domain/MetadataV2ConnectionSecrets.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/MetadataV2ConnectionSecrets.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Metadata.Domain;
+
+/// <summary>
+/// Connection secret references used by metadata v2 connection resources.
+/// </summary>
+public sealed record MetadataV2ConnectionSecrets
+{
+    /// <summary>
+    /// Reference to endpoint material such as host, port, and database name.
+    /// </summary>
+    [JsonPropertyName("endpointRef")]
+    public MetadataV2SecretReference? EndpointRef { get; init; }
+
+    /// <summary>
+    /// Reference to credential material such as username and password.
+    /// </summary>
+    [JsonPropertyName("credentialRef")]
+    public MetadataV2SecretReference? CredentialRef { get; init; }
+
+    /// <summary>
+    /// Reference to a complete connection secret.
+    /// </summary>
+    [JsonPropertyName("connectionRef")]
+    public MetadataV2SecretReference? ConnectionRef { get; init; }
+
+    /// <summary>
+    /// Explicit marker for inline development-only connection material.
+    /// </summary>
+    [JsonPropertyName("inlineDevOnly")]
+    public MetadataV2InlineDevelopmentSecretMarker? InlineDevOnly { get; init; }
+
+    /// <summary>
+    /// Indicates whether any external reference is present.
+    /// </summary>
+    [JsonIgnore]
+    public bool HasExternalReferences => EndpointRef is not null || CredentialRef is not null || ConnectionRef is not null;
+
+    /// <summary>
+    /// Returns a copy that is safe to expose in diagnostics and logs.
+    /// </summary>
+    public MetadataV2ConnectionSecrets Redacted()
+        => this with
+        {
+            EndpointRef = EndpointRef?.Redacted(),
+            CredentialRef = CredentialRef?.Redacted(),
+            ConnectionRef = ConnectionRef?.Redacted()
+        };
+
+    /// <summary>
+    /// Validates the shape of the reference set without resolving secrets.
+    /// </summary>
+    public IReadOnlyList<MetadataV2SecretReferenceValidationIssue> Validate()
+    {
+        var issues = new List<MetadataV2SecretReferenceValidationIssue>();
+
+        ValidateReference(issues, "endpointRef", EndpointRef);
+        ValidateReference(issues, "credentialRef", CredentialRef);
+        ValidateReference(issues, "connectionRef", ConnectionRef);
+
+        if (ConnectionRef is not null && (EndpointRef is not null || CredentialRef is not null))
+        {
+            issues.Add(new MetadataV2SecretReferenceValidationIssue(
+                "connectionRef",
+                "connectionRef is mutually exclusive with endpointRef and credentialRef."));
+        }
+
+        if (InlineDevOnly?.Enabled == true && HasExternalReferences)
+        {
+            issues.Add(new MetadataV2SecretReferenceValidationIssue(
+                "inlineDevOnly",
+                "inlineDevOnly cannot be combined with external secret references."));
+        }
+
+        if (InlineDevOnly?.Enabled == true && string.IsNullOrWhiteSpace(InlineDevOnly.Reason))
+        {
+            issues.Add(new MetadataV2SecretReferenceValidationIssue(
+                "inlineDevOnly.reason",
+                "inlineDevOnly requires a reason."));
+        }
+
+        return issues;
+    }
+
+    private static void ValidateReference(
+        List<MetadataV2SecretReferenceValidationIssue> issues,
+        string path,
+        MetadataV2SecretReference? reference)
+    {
+        if (reference is null)
+        {
+            return;
+        }
+
+        foreach (var issue in reference.Validate(path))
+        {
+            issues.Add(issue);
+        }
+    }
+}
+
+/// <summary>
+/// Reference to secret material managed outside the metadata document.
+/// </summary>
+public sealed record MetadataV2SecretReference
+{
+    /// <summary>
+    /// Secret provider or registry name, for example <c>env</c>, <c>azure-key-vault</c>, or <c>connection-registry</c>.
+    /// </summary>
+    [JsonPropertyName("provider")]
+    public string Provider { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Provider-local reference name or path.
+    /// </summary>
+    [JsonPropertyName("ref")]
+    public string Reference { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional provider-local version, stage, or label.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// Creates a secret reference value.
+    /// </summary>
+    public static MetadataV2SecretReference Create(string provider, string reference, string? version = null)
+        => new()
+        {
+            Provider = provider,
+            Reference = reference,
+            Version = version
+        };
+
+    /// <summary>
+    /// Returns a copy that preserves provider shape while hiding provider-local identifiers.
+    /// </summary>
+    public MetadataV2SecretReference Redacted()
+        => this with
+        {
+            Reference = Redact(Reference),
+            Version = Version is null ? null : "***"
+        };
+
+    /// <summary>
+    /// Validates the reference shape without resolving it.
+    /// </summary>
+    public IReadOnlyList<MetadataV2SecretReferenceValidationIssue> Validate(string path)
+    {
+        var issues = new List<MetadataV2SecretReferenceValidationIssue>();
+
+        if (string.IsNullOrWhiteSpace(Provider))
+        {
+            issues.Add(new MetadataV2SecretReferenceValidationIssue($"{path}.provider", "provider is required."));
+        }
+
+        if (string.IsNullOrWhiteSpace(Reference))
+        {
+            issues.Add(new MetadataV2SecretReferenceValidationIssue($"{path}.ref", "ref is required."));
+        }
+
+        if (Provider.Contains(':', StringComparison.Ordinal) || Provider.Contains('/', StringComparison.Ordinal))
+        {
+            issues.Add(new MetadataV2SecretReferenceValidationIssue(
+                $"{path}.provider",
+                "provider must be a provider name, not a full secret URI."));
+        }
+
+        return issues;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => $"{Provider}:{Redact(Reference)}";
+
+    private static string Redact(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "***";
+        }
+
+        var trimmed = value.Trim();
+        var lastSeparator = trimmed.LastIndexOfAny(['/', ':']);
+        var leaf = lastSeparator >= 0 ? trimmed[(lastSeparator + 1)..] : trimmed;
+        if (leaf.Length <= 4)
+        {
+            return "***";
+        }
+
+        return string.Concat(leaf.AsSpan(0, 2), "***", leaf.AsSpan(leaf.Length - 2, 2));
+    }
+}
+
+/// <summary>
+/// Explicit marker for inline connection material that must remain development-only.
+/// </summary>
+public sealed record MetadataV2InlineDevelopmentSecretMarker
+{
+    /// <summary>
+    /// Indicates whether inline development-only material is present.
+    /// </summary>
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Human-readable explanation for allowing inline material in a development fixture.
+    /// </summary>
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+
+    /// <summary>
+    /// Optional owner responsible for removing or externalizing the inline material.
+    /// </summary>
+    [JsonPropertyName("owner")]
+    public string? Owner { get; init; }
+}
+
+/// <summary>
+/// Shape validation issue for metadata v2 secret references.
+/// </summary>
+public sealed record MetadataV2SecretReferenceValidationIssue(string Path, string Message);

--- a/src/Honua.Core/Features/Metadata/Domain/MetadataV2MigrationDiagnostics.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/MetadataV2MigrationDiagnostics.cs
@@ -1,0 +1,221 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Domain;
+
+/// <summary>
+/// Severity for metadata v1 to v2 migration diagnostics.
+/// </summary>
+public enum MetadataV2MigrationDiagnosticSeverity
+{
+    /// <summary>
+    /// Informational diagnostic.
+    /// </summary>
+    Info,
+
+    /// <summary>
+    /// Non-blocking warning.
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// Blocking diagnostic that prevents automated migration.
+    /// </summary>
+    Blocker
+}
+
+/// <summary>
+/// Category for metadata v1 to v2 migration diagnostics.
+/// </summary>
+public enum MetadataV2MigrationDiagnosticKind
+{
+    /// <summary>
+    /// Default value inferred during migration planning.
+    /// </summary>
+    InferredDefault,
+
+    /// <summary>
+    /// Warning that should be reviewed before migration.
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// Blocker that must be resolved before migration.
+    /// </summary>
+    Blocker,
+
+    /// <summary>
+    /// Manual follow-up needed after or before migration.
+    /// </summary>
+    ManualFollowUp
+}
+
+/// <summary>
+/// Diagnostic emitted by metadata v1 to v2 migration planning.
+/// </summary>
+public sealed record MetadataV2MigrationDiagnostic
+{
+    /// <summary>
+    /// Stable diagnostic code.
+    /// </summary>
+    public required string Code { get; init; }
+
+    /// <summary>
+    /// Human-readable diagnostic message.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// Diagnostic kind.
+    /// </summary>
+    public required MetadataV2MigrationDiagnosticKind Kind { get; init; }
+
+    /// <summary>
+    /// Diagnostic severity.
+    /// </summary>
+    public required MetadataV2MigrationDiagnosticSeverity Severity { get; init; }
+
+    /// <summary>
+    /// Optional v1 resource identifier or path.
+    /// </summary>
+    public string? ResourceRef { get; init; }
+
+    /// <summary>
+    /// Optional v2 field path affected by the diagnostic.
+    /// </summary>
+    public string? TargetPath { get; init; }
+
+    /// <summary>
+    /// Creates an inferred-default diagnostic.
+    /// </summary>
+    public static MetadataV2MigrationDiagnostic InferredDefault(
+        string code,
+        string message,
+        string? resourceRef = null,
+        string? targetPath = null)
+        => new()
+        {
+            Code = code,
+            Message = message,
+            Kind = MetadataV2MigrationDiagnosticKind.InferredDefault,
+            Severity = MetadataV2MigrationDiagnosticSeverity.Info,
+            ResourceRef = resourceRef,
+            TargetPath = targetPath
+        };
+
+    /// <summary>
+    /// Creates a warning diagnostic.
+    /// </summary>
+    public static MetadataV2MigrationDiagnostic Warning(
+        string code,
+        string message,
+        string? resourceRef = null,
+        string? targetPath = null)
+        => new()
+        {
+            Code = code,
+            Message = message,
+            Kind = MetadataV2MigrationDiagnosticKind.Warning,
+            Severity = MetadataV2MigrationDiagnosticSeverity.Warning,
+            ResourceRef = resourceRef,
+            TargetPath = targetPath
+        };
+
+    /// <summary>
+    /// Creates a blocker diagnostic.
+    /// </summary>
+    public static MetadataV2MigrationDiagnostic Blocker(
+        string code,
+        string message,
+        string? resourceRef = null,
+        string? targetPath = null)
+        => new()
+        {
+            Code = code,
+            Message = message,
+            Kind = MetadataV2MigrationDiagnosticKind.Blocker,
+            Severity = MetadataV2MigrationDiagnosticSeverity.Blocker,
+            ResourceRef = resourceRef,
+            TargetPath = targetPath
+        };
+
+    /// <summary>
+    /// Creates a manual follow-up diagnostic.
+    /// </summary>
+    public static MetadataV2MigrationDiagnostic ManualFollowUp(
+        string code,
+        string message,
+        MetadataV2MigrationDiagnosticSeverity severity = MetadataV2MigrationDiagnosticSeverity.Warning,
+        string? resourceRef = null,
+        string? targetPath = null)
+        => new()
+        {
+            Code = code,
+            Message = message,
+            Kind = MetadataV2MigrationDiagnosticKind.ManualFollowUp,
+            Severity = severity,
+            ResourceRef = resourceRef,
+            TargetPath = targetPath
+        };
+}
+
+/// <summary>
+/// Aggregated metadata v1 to v2 migration diagnostics.
+/// </summary>
+public sealed record MetadataV2MigrationDiagnosticReport
+{
+    /// <summary>
+    /// Diagnostics in deterministic insertion order.
+    /// </summary>
+    public IReadOnlyList<MetadataV2MigrationDiagnostic> Diagnostics { get; init; } = [];
+
+    /// <summary>
+    /// Highest severity present in the report.
+    /// </summary>
+    public MetadataV2MigrationDiagnosticSeverity MaxSeverity
+        => Diagnostics.Count == 0
+            ? MetadataV2MigrationDiagnosticSeverity.Info
+            : Diagnostics.Max(diagnostic => diagnostic.Severity);
+
+    /// <summary>
+    /// Indicates whether any blockers are present.
+    /// </summary>
+    public bool HasBlockers => Diagnostics.Any(diagnostic => diagnostic.Severity == MetadataV2MigrationDiagnosticSeverity.Blocker);
+
+    /// <summary>
+    /// Inferred-default diagnostics.
+    /// </summary>
+    public IReadOnlyList<MetadataV2MigrationDiagnostic> InferredDefaults
+        => Diagnostics.Where(diagnostic => diagnostic.Kind == MetadataV2MigrationDiagnosticKind.InferredDefault).ToArray();
+
+    /// <summary>
+    /// Warning diagnostics.
+    /// </summary>
+    public IReadOnlyList<MetadataV2MigrationDiagnostic> Warnings
+        => Diagnostics.Where(diagnostic => diagnostic.Severity == MetadataV2MigrationDiagnosticSeverity.Warning).ToArray();
+
+    /// <summary>
+    /// Blocking diagnostics.
+    /// </summary>
+    public IReadOnlyList<MetadataV2MigrationDiagnostic> Blockers
+        => Diagnostics.Where(diagnostic => diagnostic.Severity == MetadataV2MigrationDiagnosticSeverity.Blocker).ToArray();
+
+    /// <summary>
+    /// Manual follow-up diagnostics.
+    /// </summary>
+    public IReadOnlyList<MetadataV2MigrationDiagnostic> ManualFollowUps
+        => Diagnostics.Where(diagnostic => diagnostic.Kind == MetadataV2MigrationDiagnosticKind.ManualFollowUp).ToArray();
+
+    /// <summary>
+    /// Creates a migration diagnostic report.
+    /// </summary>
+    public static MetadataV2MigrationDiagnosticReport Create(IEnumerable<MetadataV2MigrationDiagnostic> diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(diagnostics);
+
+        return new MetadataV2MigrationDiagnosticReport
+        {
+            Diagnostics = diagnostics.ToArray()
+        };
+    }
+}

--- a/src/Honua.Core/Features/Metadata/Domain/MetadataV2Policies.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/MetadataV2Policies.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Domain;
+
+/// <summary>
+/// Metadata v2 authorization action identifier.
+/// </summary>
+public readonly record struct MetadataV2PolicyAction(string Value)
+{
+    /// <inheritdoc />
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Known metadata v2 authorization actions.
+/// </summary>
+public static class MetadataV2PolicyActions
+{
+    /// <summary>
+    /// Read metadata resources and resolved projections.
+    /// </summary>
+    public static readonly MetadataV2PolicyAction MetadataRead = new("metadata.read");
+
+    /// <summary>
+    /// Create or update metadata resources.
+    /// </summary>
+    public static readonly MetadataV2PolicyAction MetadataWrite = new("metadata.write");
+
+    /// <summary>
+    /// Query feature payloads through metadata-backed services.
+    /// </summary>
+    public static readonly MetadataV2PolicyAction FeaturesQuery = new("features.query");
+
+    /// <summary>
+    /// Edit feature payloads through metadata-backed services.
+    /// </summary>
+    public static readonly MetadataV2PolicyAction FeaturesEdit = new("features.edit");
+
+    /// <summary>
+    /// Read vector tile payloads.
+    /// </summary>
+    public static readonly MetadataV2PolicyAction TilesRead = new("tiles.read");
+
+    /// <summary>
+    /// Render raster payloads.
+    /// </summary>
+    public static readonly MetadataV2PolicyAction RasterRender = new("raster.render");
+
+    /// <summary>
+    /// Publish catalog entries from approved metadata.
+    /// </summary>
+    public static readonly MetadataV2PolicyAction CatalogPublish = new("catalog.publish");
+
+    /// <summary>
+    /// Manage metadata connection definitions and references.
+    /// </summary>
+    public static readonly MetadataV2PolicyAction ConnectionsManage = new("connections.manage");
+
+    /// <summary>
+    /// Write RBAC policy configuration.
+    /// </summary>
+    public static readonly MetadataV2PolicyAction AdminRbacWrite = new("admin.rbac.write");
+
+    /// <summary>
+    /// All known metadata v2 authorization actions.
+    /// </summary>
+    public static IReadOnlyList<MetadataV2PolicyAction> All { get; } =
+    [
+        MetadataRead,
+        MetadataWrite,
+        FeaturesQuery,
+        FeaturesEdit,
+        TilesRead,
+        RasterRender,
+        CatalogPublish,
+        ConnectionsManage,
+        AdminRbacWrite
+    ];
+}
+
+/// <summary>
+/// Named metadata v2 policy preset.
+/// </summary>
+public sealed record MetadataV2PolicyPreset(string Name, IReadOnlyList<MetadataV2PolicyAction> Actions)
+{
+    /// <summary>
+    /// Indicates whether the preset includes the supplied action.
+    /// </summary>
+    public bool Allows(MetadataV2PolicyAction action) => Actions.Contains(action);
+}
+
+/// <summary>
+/// Built-in metadata v2 policy presets.
+/// </summary>
+public static class MetadataV2PolicyPresets
+{
+    /// <summary>
+    /// Read-only catalog and data access.
+    /// </summary>
+    public static MetadataV2PolicyPreset Reader { get; } = new(
+        "metadata.reader",
+        [
+            MetadataV2PolicyActions.MetadataRead,
+            MetadataV2PolicyActions.FeaturesQuery,
+            MetadataV2PolicyActions.TilesRead,
+            MetadataV2PolicyActions.RasterRender
+        ]);
+
+    /// <summary>
+    /// Metadata and feature editing access.
+    /// </summary>
+    public static MetadataV2PolicyPreset Editor { get; } = new(
+        "metadata.editor",
+        [
+            MetadataV2PolicyActions.MetadataRead,
+            MetadataV2PolicyActions.MetadataWrite,
+            MetadataV2PolicyActions.FeaturesQuery,
+            MetadataV2PolicyActions.FeaturesEdit,
+            MetadataV2PolicyActions.TilesRead,
+            MetadataV2PolicyActions.RasterRender
+        ]);
+
+    /// <summary>
+    /// Catalog publishing access.
+    /// </summary>
+    public static MetadataV2PolicyPreset Publisher { get; } = new(
+        "metadata.publisher",
+        [
+            MetadataV2PolicyActions.MetadataRead,
+            MetadataV2PolicyActions.MetadataWrite,
+            MetadataV2PolicyActions.FeaturesQuery,
+            MetadataV2PolicyActions.FeaturesEdit,
+            MetadataV2PolicyActions.TilesRead,
+            MetadataV2PolicyActions.RasterRender,
+            MetadataV2PolicyActions.CatalogPublish
+        ]);
+
+    /// <summary>
+    /// Connection reference administration access.
+    /// </summary>
+    public static MetadataV2PolicyPreset ConnectionManager { get; } = new(
+        "metadata.connection-manager",
+        [
+            MetadataV2PolicyActions.MetadataRead,
+            MetadataV2PolicyActions.ConnectionsManage
+        ]);
+
+    /// <summary>
+    /// RBAC administration access for metadata policies.
+    /// </summary>
+    public static MetadataV2PolicyPreset RbacAdministrator { get; } = new(
+        "metadata.rbac-administrator",
+        [
+            MetadataV2PolicyActions.MetadataRead,
+            MetadataV2PolicyActions.AdminRbacWrite
+        ]);
+
+    /// <summary>
+    /// All built-in metadata v2 policy presets.
+    /// </summary>
+    public static IReadOnlyList<MetadataV2PolicyPreset> All { get; } =
+    [
+        Reader,
+        Editor,
+        Publisher,
+        ConnectionManager,
+        RbacAdministrator
+    ];
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/MetadataV2SecurityCacheMigrationScaffoldTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/MetadataV2SecurityCacheMigrationScaffoldTests.cs
@@ -120,6 +120,33 @@ public sealed class MetadataV2SecurityCacheMigrationScaffoldTests
 
     [UnitTest]
     [Operation(Operations.Query)]
+    public void CacheKeyBuilder_PreservesUniquenessWhenComponentsAreTruncated()
+    {
+        var sharedPrefix = new string('a', 96);
+        var first = new MetadataV2CacheKeyRequest
+        {
+            TenantId = sharedPrefix + "-first",
+            Environment = "prod",
+            CatalogId = "main",
+            SchemaVersion = "v2",
+            Revision = "current"
+        };
+
+        var second = first with
+        {
+            TenantId = sharedPrefix + "-second"
+        };
+
+        var firstKey = MetadataV2CacheKeyBuilder.BuildSnapshot(first).Value;
+        var secondKey = MetadataV2CacheKeyBuilder.BuildSnapshot(second).Value;
+
+        firstKey.Should().NotBe(secondKey);
+        firstKey.Should().MatchRegex("tenant:id-a{79}-[0-9a-f]{16}:environment");
+        secondKey.Should().MatchRegex("tenant:id-a{79}-[0-9a-f]{16}:environment");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
     public void MigrationDiagnosticReport_AggregatesSeverityAndDiagnosticGroups()
     {
         var report = MetadataV2MigrationDiagnosticReport.Create(

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/MetadataV2SecurityCacheMigrationScaffoldTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/MetadataV2SecurityCacheMigrationScaffoldTests.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Domain;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Core.Tests.Features.Metadata;
+
+[Protocol(Protocols.TestQuality)]
+public sealed class MetadataV2SecurityCacheMigrationScaffoldTests
+{
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void ConnectionSecrets_RedactsReferences_AndValidatesShape()
+    {
+        var secrets = new MetadataV2ConnectionSecrets
+        {
+            EndpointRef = MetadataV2SecretReference.Create("azure-key-vault", "kv/prod/honua-endpoint", "7"),
+            CredentialRef = MetadataV2SecretReference.Create("env", "HONUA_PROD_PASSWORD")
+        };
+
+        var redacted = secrets.Redacted();
+
+        secrets.Validate().Should().BeEmpty();
+        redacted.EndpointRef.Should().NotBeNull();
+        redacted.EndpointRef!.Provider.Should().Be("azure-key-vault");
+        redacted.EndpointRef.Reference.Should().Be("ho***nt");
+        redacted.EndpointRef.Version.Should().Be("***");
+        redacted.EndpointRef.ToString().Should().NotContain("honua-endpoint");
+
+        var invalid = new MetadataV2ConnectionSecrets
+        {
+            ConnectionRef = MetadataV2SecretReference.Create("env:bad", "HONUA_CONNECTION"),
+            CredentialRef = MetadataV2SecretReference.Create("env", "HONUA_PASSWORD"),
+            InlineDevOnly = new MetadataV2InlineDevelopmentSecretMarker { Enabled = true }
+        };
+
+        invalid.Validate().Should().BeEquivalentTo(
+        [
+            new MetadataV2SecretReferenceValidationIssue(
+                "connectionRef.provider",
+                "provider must be a provider name, not a full secret URI."),
+            new MetadataV2SecretReferenceValidationIssue(
+                "connectionRef",
+                "connectionRef is mutually exclusive with endpointRef and credentialRef."),
+            new MetadataV2SecretReferenceValidationIssue(
+                "inlineDevOnly",
+                "inlineDevOnly cannot be combined with external secret references."),
+            new MetadataV2SecretReferenceValidationIssue(
+                "inlineDevOnly.reason",
+                "inlineDevOnly requires a reason.")
+        ], options => options.WithStrictOrdering());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void PolicyPresets_ExposeExpectedActions()
+    {
+        MetadataV2PolicyActions.All.Select(action => action.Value).Should().BeEquivalentTo(
+        [
+            "metadata.read",
+            "metadata.write",
+            "features.query",
+            "features.edit",
+            "tiles.read",
+            "raster.render",
+            "catalog.publish",
+            "connections.manage",
+            "admin.rbac.write"
+        ], options => options.WithStrictOrdering());
+
+        MetadataV2PolicyPresets.Reader.Actions.Should().Equal(
+            MetadataV2PolicyActions.MetadataRead,
+            MetadataV2PolicyActions.FeaturesQuery,
+            MetadataV2PolicyActions.TilesRead,
+            MetadataV2PolicyActions.RasterRender);
+
+        MetadataV2PolicyPresets.Publisher.Allows(MetadataV2PolicyActions.CatalogPublish).Should().BeTrue();
+        MetadataV2PolicyPresets.Publisher.Allows(MetadataV2PolicyActions.ConnectionsManage).Should().BeFalse();
+        MetadataV2PolicyPresets.ConnectionManager.Actions.Should().Contain(MetadataV2PolicyActions.ConnectionsManage);
+        MetadataV2PolicyPresets.RbacAdministrator.Actions.Should().Contain(MetadataV2PolicyActions.AdminRbacWrite);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void CacheKeyBuilder_BuildsDeterministicSnapshotAndProjectionKeys()
+    {
+        var first = new MetadataV2CacheKeyRequest
+        {
+            TenantId = " Tenant A ",
+            Environment = "Prod",
+            CatalogId = "Main/Catalog",
+            SchemaVersion = "honua.io/v2",
+            Revision = " Rev 42 ",
+            ProjectionTarget = "OGC API Features",
+            ProjectionProfileVersion = "Profile 1"
+        };
+
+        var second = first with
+        {
+            TenantId = "tenant-a",
+            Environment = "prod",
+            CatalogId = "main catalog",
+            Revision = "rev-42",
+            ProjectionTarget = "ogc-api-features",
+            ProjectionProfileVersion = "profile-1"
+        };
+
+        var snapshot = MetadataV2CacheKeyBuilder.BuildSnapshot(first);
+        var projection = MetadataV2CacheKeyBuilder.BuildProjection(first);
+
+        MetadataV2CacheKeyBuilder.BuildSnapshot(second).Value.Should().Be(snapshot.Value);
+        MetadataV2CacheKeyBuilder.BuildProjection(second).Value.Should().Be(projection.Value);
+        snapshot.Value.Should().Be(
+            "honua:metadata:v2:snapshot:tenant:id-tenant-a:environment:id-prod:catalog:id-main-catalog:schema:id-honua.io-v2:revision:id-rev-42");
+        projection.Value.Should().Be(
+            "honua:metadata:v2:projection:tenant:id-tenant-a:environment:id-prod:catalog:id-main-catalog:schema:id-honua.io-v2:revision:id-rev-42:target:id-ogc-api-features:profile:id-profile-1");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void MigrationDiagnosticReport_AggregatesSeverityAndDiagnosticGroups()
+    {
+        var report = MetadataV2MigrationDiagnosticReport.Create(
+        [
+            MetadataV2MigrationDiagnostic.InferredDefault(
+                "metadata.v2.default.environment",
+                "Environment defaulted to prod.",
+                "service:roads",
+                "metadata.environment"),
+            MetadataV2MigrationDiagnostic.Warning(
+                "metadata.v2.legacy.style",
+                "Legacy style requires review.",
+                "layer:roads",
+                "spec.style"),
+            MetadataV2MigrationDiagnostic.ManualFollowUp(
+                "metadata.v2.connection.owner",
+                "Assign an owner to the migrated connection.",
+                resourceRef: "connection:roads-db"),
+            MetadataV2MigrationDiagnostic.Blocker(
+                "metadata.v2.inline.secret",
+                "Inline production secret cannot be migrated automatically.",
+                "connection:roads-db",
+                "spec.connection")
+        ]);
+
+        report.MaxSeverity.Should().Be(MetadataV2MigrationDiagnosticSeverity.Blocker);
+        report.HasBlockers.Should().BeTrue();
+        report.InferredDefaults.Should().ContainSingle().Which.Code.Should().Be("metadata.v2.default.environment");
+        report.Warnings.Should().HaveCount(2);
+        report.Blockers.Should().ContainSingle().Which.Code.Should().Be("metadata.v2.inline.secret");
+        report.ManualFollowUps.Should().ContainSingle().Which.ResourceRef.Should().Be("connection:roads-db");
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/MetadataV2SecurityCacheMigrationScaffoldTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/MetadataV2SecurityCacheMigrationScaffoldTests.cs
@@ -88,7 +88,6 @@ public sealed class MetadataV2SecurityCacheMigrationScaffoldTests
     {
         var first = new MetadataV2CacheKeyRequest
         {
-            TenantId = " Tenant A ",
             Environment = "Prod",
             CatalogId = "Main/Catalog",
             SchemaVersion = "honua.io/v2",
@@ -99,7 +98,6 @@ public sealed class MetadataV2SecurityCacheMigrationScaffoldTests
 
         var second = first with
         {
-            TenantId = "tenant-a",
             Environment = "prod",
             CatalogId = "main catalog",
             Revision = "rev-42",
@@ -113,9 +111,9 @@ public sealed class MetadataV2SecurityCacheMigrationScaffoldTests
         MetadataV2CacheKeyBuilder.BuildSnapshot(second).Value.Should().Be(snapshot.Value);
         MetadataV2CacheKeyBuilder.BuildProjection(second).Value.Should().Be(projection.Value);
         snapshot.Value.Should().Be(
-            "honua:metadata:v2:snapshot:tenant:id-tenant-a:environment:id-prod:catalog:id-main-catalog:schema:id-honua.io-v2:revision:id-rev-42");
+            "honua:metadata:v2:snapshot:environment:id-prod:catalog:id-main-catalog:schema:id-honua.io-v2:revision:id-rev-42");
         projection.Value.Should().Be(
-            "honua:metadata:v2:projection:tenant:id-tenant-a:environment:id-prod:catalog:id-main-catalog:schema:id-honua.io-v2:revision:id-rev-42:target:id-ogc-api-features:profile:id-profile-1");
+            "honua:metadata:v2:projection:environment:id-prod:catalog:id-main-catalog:schema:id-honua.io-v2:revision:id-rev-42:target:id-ogc-api-features:profile:id-profile-1");
     }
 
     [UnitTest]
@@ -125,24 +123,23 @@ public sealed class MetadataV2SecurityCacheMigrationScaffoldTests
         var sharedPrefix = new string('a', 96);
         var first = new MetadataV2CacheKeyRequest
         {
-            TenantId = sharedPrefix + "-first",
             Environment = "prod",
-            CatalogId = "main",
+            CatalogId = sharedPrefix + "-first",
             SchemaVersion = "v2",
             Revision = "current"
         };
 
         var second = first with
         {
-            TenantId = sharedPrefix + "-second"
+            CatalogId = sharedPrefix + "-second"
         };
 
         var firstKey = MetadataV2CacheKeyBuilder.BuildSnapshot(first).Value;
         var secondKey = MetadataV2CacheKeyBuilder.BuildSnapshot(second).Value;
 
         firstKey.Should().NotBe(secondKey);
-        firstKey.Should().MatchRegex("tenant:id-a{79}-[0-9a-f]{16}:environment");
-        secondKey.Should().MatchRegex("tenant:id-a{79}-[0-9a-f]{16}:environment");
+        firstKey.Should().MatchRegex("catalog:id-a{79}-[0-9a-f]{16}:schema");
+        secondKey.Should().MatchRegex("catalog:id-a{79}-[0-9a-f]{16}:schema");
     }
 
     [UnitTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1039
Closes #1044
Closes #1045
Closes #1047

## Summary
Adds additive Metadata v2 internals for security, cache keys, connection secret references, and migration diagnostics.

## Changes Made
- Added a secret reference model for connection credentials without embedding secret material in metadata.
- Added policy and role attachment scaffolds for metadata RBAC/policy semantics.
- Added Redis/cache key helpers for environment/revision-aware Metadata v2 graph snapshots and projections.
- Added migration diagnostic models for v1-to-v2 adapter readiness and release gates.
- Added focused scaffold tests.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation run locally:
- `git diff --check origin/trunk..HEAD`
- `dotnet build src/Honua.Core/Honua.Core.csproj --no-restore -m:1 /nr:false`
- `dotnet build tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --no-restore --no-dependencies -m:1 /nr:false`
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --no-restore --no-build --filter FullyQualifiedName~Features.Metadata`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] `scripts/ci/pre-pr-check.sh` full end-to-end run not performed locally; targeted checks above passed and PR CI is running the full gate set.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract or marked not applicable
- [x] If breaking admin/control-plane API changes: updated migration guide or marked not applicable
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review or marked not applicable