### PR TITLE
feat: add OGC migration service plans (#1016)

### DIFF
--- a/docs/operator/migration-toolkit.md
+++ b/docs/operator/migration-toolkit.md
@@ -54,6 +54,11 @@ The manifest does not claim that unsupported source items are migrated:
 incompatible resources are excluded from `targetResources` and emitted under
 `unsupportedItems`; partially compatible resources are emitted with the
 `manual-review` action and a matching `manualReviewItems` entry.
+Protocol-specific planning metadata is carried alongside those target
+resources. WFS feature targets identify `migrationMode: feature-import` and
+the WFS source protocol, while WMS/WMTS render-only inventories emit
+`servicePlans` for manual review of service metadata, styles, tile matrices,
+and captured endpoints without claiming a data-copy target.
 
 Generate parity evidence after the manifest has been produced. A missing
 manifest leaves data parity `unknown`; it is never treated as a pass.
@@ -75,6 +80,9 @@ styles, tile matrix sets, and service endpoints where advertised, but render
 and tile services are marked manual-review or unsupported for automated data
 copy unless paired with a WFS, coverage, database, or file source. This keeps
 render compatibility distinct from applied migration.
+The generated manifest preserves those render-only services as
+`servicePlans`, so operators can review equivalent Honua map/tile publication
+work without confusing it with automated feature import.
 
 ## State Values
 
@@ -97,6 +105,8 @@ recorded explicitly.
 Use the manifest as the technical planning contract before pilot migration:
 
 - Review `targetResources` for target service and resource names.
+- Review `servicePlans` for WMS/WMTS metadata, style, tile matrix, and endpoint
+  work that must be completed manually.
 - Review `styleActions` before importing or recreating styles.
 - Resolve every `manualReviewItems` entry or record a waiver.
 - Remove or route around every `unsupportedItems` entry before cutover.

--- a/src/Honua.Core/Features/Import/Domain/MigrationManifestArtifact.cs
+++ b/src/Honua.Core/Features/Import/Domain/MigrationManifestArtifact.cs
@@ -56,6 +56,12 @@ public sealed record MigrationManifestArtifact
     public MigrationManifestStyleAction[] StyleActions { get; init; } = [];
 
     /// <summary>
+    /// Service-level migration plans for protocol surfaces that require operator
+    /// review before Honua can publish an equivalent service.
+    /// </summary>
+    public MigrationManifestServicePlan[] ServicePlans { get; init; } = [];
+
+    /// <summary>
     /// Items that require operator review before migration can proceed.
     /// </summary>
     public MigrationManifestReviewItem[] ManualReviewItems { get; init; } = [];
@@ -85,6 +91,11 @@ public sealed record MigrationManifestSummary
     /// Number of style actions emitted into the manifest.
     /// </summary>
     public int StyleActionCount { get; init; }
+
+    /// <summary>
+    /// Number of service-level migration plans emitted into the manifest.
+    /// </summary>
+    public int ServicePlanCount { get; init; }
 
     /// <summary>
     /// Number of source items requiring manual review.
@@ -133,6 +144,17 @@ public sealed record MigrationManifestTargetResource
     public string? GeometryType { get; init; }
 
     /// <summary>
+    /// Migration mode selected for the resource, such as <c>feature-import</c>
+    /// for WFS feature sources.
+    /// </summary>
+    public string? MigrationMode { get; init; }
+
+    /// <summary>
+    /// Source protocol used to stage the resource when it is protocol-specific.
+    /// </summary>
+    public string? SourceProtocol { get; init; }
+
+    /// <summary>
     /// Field schema copied from the source inventory.
     /// </summary>
     public MigrationInventoryField[] Fields { get; init; } = [];
@@ -159,6 +181,57 @@ public sealed record MigrationManifestTargetResource
 
     /// <summary>
     /// Compatibility assessment that justified the target action.
+    /// </summary>
+    public required MigrationCompatibilityAssessment Compatibility { get; init; }
+}
+
+/// <summary>
+/// Service-level migration planning item translated from a source container.
+/// </summary>
+public sealed record MigrationManifestServicePlan
+{
+    /// <summary>
+    /// Source inventory container identifier.
+    /// </summary>
+    public required string SourceContainerId { get; init; }
+
+    /// <summary>
+    /// Source inventory container kind.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Target migration action such as <c>manual-review</c>.
+    /// </summary>
+    public required string Action { get; init; }
+
+    /// <summary>
+    /// Target service name suggested for this plan.
+    /// </summary>
+    public required string TargetServiceName { get; init; }
+
+    /// <summary>
+    /// Source service type or protocol, such as <c>WMS</c> or <c>WMTS</c>.
+    /// </summary>
+    public string? ServiceType { get; init; }
+
+    /// <summary>
+    /// Source resources covered by the plan.
+    /// </summary>
+    public string[] ResourceIds { get; init; } = [];
+
+    /// <summary>
+    /// Source styles covered by the plan.
+    /// </summary>
+    public string[] StyleIds { get; init; } = [];
+
+    /// <summary>
+    /// External dependencies covered by the plan.
+    /// </summary>
+    public string[] ExternalDependencyIds { get; init; } = [];
+
+    /// <summary>
+    /// Compatibility assessment that justified the service plan action.
     /// </summary>
     public required MigrationCompatibilityAssessment Compatibility { get; init; }
 }

--- a/src/Honua.Core/Features/Import/Services/MigrationManifestTranslator.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationManifestTranslator.cs
@@ -28,8 +28,10 @@ public static partial class MigrationManifestTranslator
             fallback: "migration-service");
         var targetResources = new List<MigrationManifestTargetResource>();
         var styleActions = new List<MigrationManifestStyleAction>();
+        var servicePlans = new List<MigrationManifestServicePlan>();
         var manualReviewItems = new List<MigrationManifestReviewItem>();
         var unsupportedItems = new List<MigrationManifestReviewItem>();
+        var sourceProtocol = GetSourceProtocol(inventory);
 
         foreach (var resource in inventory.Resources.OrderBy(static item => item.Id, StringComparer.Ordinal))
         {
@@ -54,6 +56,8 @@ public static partial class MigrationManifestTranslator
                 TargetServiceName = targetServiceName,
                 TargetResourceName = NormalizeName(resource.Name, fallback: resource.Id),
                 GeometryType = resource.GeometryType,
+                MigrationMode = GetResourceMigrationMode(inventory.SourceKind, resource),
+                SourceProtocol = sourceProtocol,
                 Fields = resource.Fields.OrderBy(static item => item.Name, StringComparer.Ordinal).ToArray(),
                 Capabilities = Order(resource.Capabilities),
                 SpatialReferences = resource.SpatialReferences
@@ -61,7 +65,7 @@ public static partial class MigrationManifestTranslator
                     .ThenBy(static item => item.SourceValue, StringComparer.Ordinal)
                     .ToArray(),
                 StyleIds = Order(resource.StyleIds),
-                ExternalDependencyIds = Order(resource.ExternalDependencyIds),
+                ExternalDependencyIds = BuildResourceExternalDependencyIds(inventory, resource),
                 Compatibility = resource.Compatibility
             });
         }
@@ -98,6 +102,8 @@ public static partial class MigrationManifestTranslator
                 unsupportedItems);
         }
 
+        servicePlans.AddRange(BuildServicePlans(inventory, targetServiceName));
+
         return new MigrationManifestArtifact
         {
             SourceArtifactKind = inventory.ArtifactKind,
@@ -109,11 +115,15 @@ public static partial class MigrationManifestTranslator
                 SourceResourceCount = inventory.Resources.Length,
                 TargetResourceCount = targetResources.Count,
                 StyleActionCount = styleActions.Count,
+                ServicePlanCount = servicePlans.Count,
                 ManualReviewCount = manualReviewItems.Count,
                 UnsupportedCount = unsupportedItems.Count
             },
             TargetResources = targetResources.ToArray(),
             StyleActions = styleActions.ToArray(),
+            ServicePlans = servicePlans
+                .OrderBy(static item => item.SourceContainerId, StringComparer.Ordinal)
+                .ToArray(),
             ManualReviewItems = manualReviewItems
                 .OrderBy(static item => item.SourceId, StringComparer.Ordinal)
                 .ThenBy(static item => item.Code, StringComparer.Ordinal)
@@ -158,6 +168,89 @@ public static partial class MigrationManifestTranslator
             manualReviewItems.Add(reviewItem);
         }
     }
+
+    private static MigrationManifestServicePlan[] BuildServicePlans(
+        MigrationSourceInventoryArtifact inventory,
+        string targetServiceName)
+    {
+        if (!IsOgcRenderOnlySource(inventory.SourceKind))
+        {
+            return [];
+        }
+
+        var serviceType = GetSourceProtocol(inventory);
+        return inventory.Containers
+            .OrderBy(static container => container.Id, StringComparer.Ordinal)
+            .Select(container =>
+            {
+                var resources = inventory.Resources
+                    .Where(resource => string.Equals(resource.ContainerId, container.Id, StringComparison.Ordinal));
+                var styles = inventory.Styles
+                    .Where(style => string.Equals(style.ContainerId, container.Id, StringComparison.Ordinal));
+                var dependencies = inventory.ExternalDependencies
+                    .Where(dependency => string.Equals(dependency.ContainerId, container.Id, StringComparison.Ordinal));
+
+                return new MigrationManifestServicePlan
+                {
+                    SourceContainerId = container.Id,
+                    SourceKind = container.Kind,
+                    Action = "manual-review",
+                    TargetServiceName = targetServiceName,
+                    ServiceType = serviceType,
+                    ResourceIds = Order(resources.Select(static resource => resource.Id)),
+                    StyleIds = Order(styles.Select(static style => style.Id)),
+                    ExternalDependencyIds = Order(dependencies.Select(static dependency => dependency.Id)),
+                    Compatibility = container.Compatibility
+                };
+            })
+            .ToArray();
+    }
+
+    private static string[] BuildResourceExternalDependencyIds(
+        MigrationSourceInventoryArtifact inventory,
+        MigrationInventoryResource resource)
+    {
+        var dependencyIds = resource.ExternalDependencyIds.AsEnumerable();
+        if (string.Equals(inventory.SourceKind, "ogc-wfs", StringComparison.OrdinalIgnoreCase))
+        {
+            dependencyIds = dependencyIds.Concat(inventory.ExternalDependencies
+                .Where(static dependency => IsOgcWfsEndpointDependency(dependency))
+                .Select(static dependency => dependency.Id));
+        }
+
+        return Order(dependencyIds);
+    }
+
+    private static bool IsOgcWfsEndpointDependency(MigrationExternalDependency dependency)
+        => string.Equals(dependency.Kind, "ogc-endpoint", StringComparison.OrdinalIgnoreCase) &&
+           dependency.Metadata.TryGetValue("service", out var service) &&
+           string.Equals(service, "WFS", StringComparison.OrdinalIgnoreCase);
+
+    private static string? GetResourceMigrationMode(string sourceKind, MigrationInventoryResource resource)
+        => string.Equals(sourceKind, "ogc-wfs", StringComparison.OrdinalIgnoreCase) &&
+           string.Equals(resource.Kind, "feature-type", StringComparison.OrdinalIgnoreCase)
+            ? "feature-import"
+            : null;
+
+    private static string? GetSourceProtocol(MigrationSourceInventoryArtifact inventory)
+    {
+        if (!string.IsNullOrWhiteSpace(inventory.Source.ServiceType))
+        {
+            return inventory.Source.ServiceType.Trim();
+        }
+
+        return inventory.SourceKind.ToLowerInvariant() switch
+        {
+            "ogc-wfs" => "WFS",
+            "ogc-wms" => "WMS",
+            "ogc-wmts" => "WMTS",
+            _ => null
+        };
+    }
+
+    private static bool IsOgcRenderOnlySource(string sourceKind)
+        => sourceKind.Equals("ogc-wms", StringComparison.OrdinalIgnoreCase) ||
+           sourceKind.Equals("ogc-wmts", StringComparison.OrdinalIgnoreCase);
 
     private static string BuildFallbackCode(string sourceKind, string kind, string level)
         => $"{ToCodePart(sourceKind)}_{ToCodePart(kind)}_{ToCodePart(level)}";

--- a/src/Honua.Core/Features/Import/Services/OgcServiceMigrationScanner.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcServiceMigrationScanner.cs
@@ -109,8 +109,8 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
         catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or System.Xml.XmlException ||
                                    ex is TaskCanceledException && !cancellationToken.IsCancellationRequested)
         {
-            Log.ScanFailed(_logger, sourceKind, request.ServiceUrl, ex);
-            return CreateFailedArtifact(sourceKind, request.ServiceUrl, normalizedServiceType, ToSafeScanFailureReason(ex));
+            Log.ScanFailed(_logger, sourceKind, ToSafeSourceUrl(serviceUri), ex);
+            return CreateFailedArtifact(sourceKind, serviceUri, normalizedServiceType, ToSafeScanFailureReason(ex));
         }
     }
 
@@ -197,7 +197,7 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
                 Kind = "ogc-endpoint",
                 Name = "WFS GetCapabilities",
                 DependencyType = "capabilities",
-                Address = capabilitiesUrl.ToString(),
+                Address = ToSafeCapabilitiesUrl(capabilitiesUrl),
                 Metadata = new Dictionary<string, string>
                 {
                     ["service"] = "WFS",
@@ -380,7 +380,7 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
                 Kind = "ogc-endpoint",
                 Name = $"{serviceType} GetCapabilities",
                 DependencyType = "capabilities",
-                Address = capabilitiesUrl.ToString(),
+                Address = ToSafeCapabilitiesUrl(capabilitiesUrl),
                 Metadata = new Dictionary<string, string>
                 {
                     ["service"] = serviceType,
@@ -459,7 +459,7 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
             Source = new MigrationSourceIdentity
             {
                 DisplayName = displayName,
-                BaseUrl = serviceUri.ToString(),
+                BaseUrl = ToSafeSourceUrl(serviceUri),
                 Product = product,
                 Version = version,
                 ServiceType = serviceType
@@ -485,7 +485,7 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
 
     private static MigrationSourceInventoryArtifact CreateFailedArtifact(
         string sourceKind,
-        string serviceUrl,
+        Uri serviceUri,
         string serviceType,
         string reason)
         => new()
@@ -494,7 +494,7 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
             Source = new MigrationSourceIdentity
             {
                 DisplayName = $"OGC {serviceType}",
-                BaseUrl = serviceUrl,
+                BaseUrl = ToSafeSourceUrl(serviceUri),
                 Product = $"OGC {serviceType}",
                 ServiceType = serviceType
             },
@@ -946,6 +946,64 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
 
         return false;
     }
+
+    private static string ToSafeSourceUrl(Uri uri)
+    {
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+
+        return builder.Uri.AbsoluteUri;
+    }
+
+    private static string ToSafeCapabilitiesUrl(Uri uri)
+    {
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Fragment = string.Empty,
+            Query = BuildSafeCapabilitiesQuery(uri.Query)
+        };
+
+        return builder.Uri.AbsoluteUri;
+    }
+
+    private static string BuildSafeCapabilitiesQuery(string query)
+    {
+        var pairs = new List<KeyValuePair<string, string>>();
+        var trimmed = query.TrimStart('?');
+        if (trimmed.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        foreach (var part in trimmed.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var separator = part.IndexOf('=', StringComparison.Ordinal);
+            var key = separator < 0 ? Uri.UnescapeDataString(part) : Uri.UnescapeDataString(part[..separator]);
+            if (!IsSafeCapabilitiesQueryParameter(key))
+            {
+                continue;
+            }
+
+            var value = separator < 0 ? string.Empty : Uri.UnescapeDataString(part[(separator + 1)..]);
+            pairs.Add(new KeyValuePair<string, string>(key, value));
+        }
+
+        return string.Join("&", pairs
+            .OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(static pair => $"{Uri.EscapeDataString(pair.Key)}={Uri.EscapeDataString(pair.Value)}"));
+    }
+
+    private static bool IsSafeCapabilitiesQueryParameter(string key)
+        => key.Equals("service", StringComparison.OrdinalIgnoreCase) ||
+           key.Equals("request", StringComparison.OrdinalIgnoreCase) ||
+           key.Equals("version", StringComparison.OrdinalIgnoreCase);
 
     private static string? GetRootVersion(XDocument document)
         => document.Root?.Attribute("version")?.Value;

--- a/src/Honua.Server/Features/Import/ImportJsonContext.cs
+++ b/src/Honua.Server/Features/Import/ImportJsonContext.cs
@@ -21,6 +21,8 @@ namespace Honua.Server.Features.Import;
 [JsonSerializable(typeof(MigrationManifestTargetResource[]))]
 [JsonSerializable(typeof(MigrationManifestStyleAction))]
 [JsonSerializable(typeof(MigrationManifestStyleAction[]))]
+[JsonSerializable(typeof(MigrationManifestServicePlan))]
+[JsonSerializable(typeof(MigrationManifestServicePlan[]))]
 [JsonSerializable(typeof(MigrationManifestReviewItem))]
 [JsonSerializable(typeof(MigrationManifestReviewItem[]))]
 [JsonSerializable(typeof(MigrationParityEvidenceArtifact))]

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationManifestTranslatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationManifestTranslatorTests.cs
@@ -92,8 +92,176 @@ public sealed class MigrationManifestTranslatorTests
         manifest.UnsupportedItems.Should().BeEmpty();
     }
 
+    [Fact]
+    public void Translate_WithOgcWfsFeatureType_EmitsFeatureImportPlan()
+    {
+        var inventory = CreateInventory(
+            sourceKind: "ogc-wfs",
+            serviceType: "WFS",
+            containerKind: "ogc-service",
+            resources:
+            [
+                CreateResource(
+                    "feature-type:roads",
+                    "topp:roads",
+                    "compatible",
+                    "WFS feature type metadata can be represented.",
+                    code: ImportCompatibilityCodes.OgcWfsFeatureSource,
+                    kind: "feature-type",
+                    capabilities: ["wfs:GetCapabilities", "wfs:DescribeFeatureType", "wfs:GetFeature"])
+            ],
+            dependencies:
+            [
+                CreateDependency(
+                    "endpoint:wfs:get-capabilities",
+                    "ogc-endpoint",
+                    "WFS GetCapabilities",
+                    "compatible",
+                    "Capabilities endpoint captured.",
+                    ImportCompatibilityCodes.OgcWfsFeatureSource,
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["service"] = "WFS"
+                    })
+            ]);
+
+        var manifest = MigrationManifestTranslator.Translate(inventory, new MigrationManifestTranslationOptions
+        {
+            TargetServiceName = "Reference WFS"
+        });
+
+        manifest.TargetResources.Should().ContainSingle()
+            .Which.Should().Match<MigrationManifestTargetResource>(resource =>
+                resource.SourceResourceId == "feature-type:roads" &&
+                resource.Action == "publish" &&
+                resource.MigrationMode == "feature-import" &&
+                resource.SourceProtocol == "WFS" &&
+                resource.TargetServiceName == "reference-wfs" &&
+                resource.TargetResourceName == "topp-roads" &&
+                resource.ExternalDependencyIds.SequenceEqual(new[] { "endpoint:wfs:get-capabilities" }));
+        manifest.ServicePlans.Should().BeEmpty();
+        manifest.Summary.ServicePlanCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Translate_WithOgcWmsRenderOnlyInventory_EmitsManualReviewServicePlan()
+    {
+        var inventory = CreateInventory(
+            sourceKind: "ogc-wms",
+            serviceType: "WMS",
+            containerKind: "ogc-service",
+            resources:
+            [
+                CreateResource(
+                    "wms-layer:roads",
+                    "roads",
+                    "incompatible",
+                    "WMS exposes rendered map images and cannot supply automated feature data-copy by itself.",
+                    code: ImportCompatibilityCodes.OgcWmsRenderOnlySource,
+                    kind: "render-layer",
+                    capabilities: ["wms:GetCapabilities", "wms:GetMap", "wms:GetFeatureInfo"],
+                    manualSteps: ["Pair this WMS layer with a WFS, coverage, database, or file source before planning data import."])
+            ],
+            styles:
+            [
+                CreateStyle(
+                    "style:roads:default",
+                    "partial",
+                    "WMS style metadata was captured for manual render-service migration planning.",
+                    code: ImportCompatibilityCodes.OgcWmsRenderOnlySource,
+                    manualSteps: ["Review WMS style semantics and recreate equivalent Honua styles where required."])
+            ],
+            dependencies:
+            [
+                CreateDependency(
+                    "endpoint:wms:get-capabilities",
+                    "ogc-endpoint",
+                    "WMS GetCapabilities",
+                    "partial",
+                    "WMS capabilities endpoint was captured for manual service migration planning.",
+                    ImportCompatibilityCodes.OgcWmsRenderOnlySource)
+            ]);
+
+        var manifest = MigrationManifestTranslator.Translate(inventory);
+
+        manifest.TargetResources.Should().BeEmpty();
+        manifest.ServicePlans.Should().ContainSingle()
+            .Which.Should().Match<MigrationManifestServicePlan>(plan =>
+                plan.SourceContainerId == "workspace" &&
+                plan.SourceKind == "ogc-service" &&
+                plan.Action == "manual-review" &&
+                plan.ServiceType == "WMS" &&
+                plan.ResourceIds.SequenceEqual(new[] { "wms-layer:roads" }) &&
+                plan.StyleIds.SequenceEqual(new[] { "style:roads:default" }) &&
+                plan.ExternalDependencyIds.SequenceEqual(new[] { "endpoint:wms:get-capabilities" }));
+        manifest.UnsupportedItems.Should().ContainSingle(item => item.SourceId == "wms-layer:roads")
+            .Which.Severity.Should().Be("unsupported");
+        manifest.ManualReviewItems.Should().Contain(item => item.SourceId == "style:roads:default");
+        manifest.ManualReviewItems.Should().Contain(item => item.SourceId == "endpoint:wms:get-capabilities");
+        manifest.Summary.Should().BeEquivalentTo(new MigrationManifestSummary
+        {
+            SourceResourceCount = 1,
+            TargetResourceCount = 0,
+            StyleActionCount = 1,
+            ServicePlanCount = 1,
+            ManualReviewCount = 2,
+            UnsupportedCount = 1
+        });
+    }
+
+    [Fact]
+    public void Translate_WithOgcWmtsInventory_IncludesTileMatrixDependenciesInServicePlan()
+    {
+        var inventory = CreateInventory(
+            sourceKind: "ogc-wmts",
+            serviceType: "WMTS",
+            containerKind: "ogc-service",
+            resources:
+            [
+                CreateResource(
+                    "wmts-layer:roads",
+                    "roads",
+                    "incompatible",
+                    "WMTS exposes pre-rendered tiles and cannot supply automated feature data-copy by itself.",
+                    code: ImportCompatibilityCodes.OgcWmtsTileOnlySource,
+                    kind: "tile-layer",
+                    capabilities: ["wmts:GetCapabilities", "wmts:GetTile"],
+                    manualSteps: ["Pair this WMTS layer with a WFS, coverage, database, or file source before planning data import."])
+            ],
+            dependencies:
+            [
+                CreateDependency(
+                    "endpoint:wmts:get-capabilities",
+                    "ogc-endpoint",
+                    "WMTS GetCapabilities",
+                    "partial",
+                    "WMTS capabilities endpoint was captured for manual service migration planning.",
+                    ImportCompatibilityCodes.OgcWmtsTileOnlySource),
+                CreateDependency(
+                    "tile-matrix-set:webmercator",
+                    "tile-matrix-set",
+                    "WebMercatorQuad",
+                    "partial",
+                    "WMTS tile matrix set metadata was captured for manual service migration planning.",
+                    ImportCompatibilityCodes.OgcWmtsTileOnlySource)
+            ]);
+
+        var manifest = MigrationManifestTranslator.Translate(inventory);
+
+        manifest.ServicePlans.Should().ContainSingle()
+            .Which.ExternalDependencyIds.Should().Equal(
+                "endpoint:wmts:get-capabilities",
+                "tile-matrix-set:webmercator");
+        manifest.TargetResources.Should().BeEmpty();
+        manifest.UnsupportedItems.Should().ContainSingle(item => item.SourceId == "wmts-layer:roads");
+        manifest.Summary.ServicePlanCount.Should().Be(1);
+    }
+
     private static MigrationSourceInventoryArtifact CreateInventory(
         MigrationInventoryResource[] resources,
+        string sourceKind = "geoserver-rest",
+        string? serviceType = null,
+        string containerKind = "workspace",
         MigrationInventoryStyle[]? styles = null,
         MigrationExternalDependency[]? dependencies = null)
     {
@@ -102,7 +270,7 @@ public sealed class MigrationManifestTranslatorTests
             new MigrationInventoryContainer
             {
                 Id = "workspace",
-                Kind = "workspace",
+                Kind = containerKind,
                 Name = "workspace",
                 Compatibility = Compatible("Workspace can be represented.")
             }
@@ -113,13 +281,14 @@ public sealed class MigrationManifestTranslatorTests
 
         return new MigrationSourceInventoryArtifact
         {
-            SourceKind = "geoserver-rest",
+            SourceKind = sourceKind,
             Source = new MigrationSourceIdentity
             {
                 DisplayName = "Migration Source",
                 BaseUrl = "https://geoserver.example.test/geoserver",
                 Product = "GeoServer",
-                Version = "2.26.0"
+                Version = "2.26.0",
+                ServiceType = serviceType
             },
             AuthPosture = new MigrationInventoryAuthPosture
             {
@@ -162,16 +331,19 @@ public sealed class MigrationManifestTranslatorTests
         string level,
         string reason,
         string? code = null,
+        string kind = "layer",
         string[]? capabilities = null,
-        string[]? manualSteps = null)
+        string[]? manualSteps = null,
+        string[]? externalDependencyIds = null)
         => new()
         {
             Id = id,
             ContainerId = "workspace",
-            Kind = "layer",
+            Kind = kind,
             Name = name,
             GeometryType = "Point",
             Capabilities = capabilities ?? ["Query"],
+            ExternalDependencyIds = externalDependencyIds ?? [],
             Fields =
             [
                 new MigrationInventoryField
@@ -181,6 +353,25 @@ public sealed class MigrationManifestTranslatorTests
                     Nullable = true
                 }
             ],
+            Compatibility = Assessment(level, reason, code, manualSteps)
+        };
+
+    private static MigrationExternalDependency CreateDependency(
+        string id,
+        string kind,
+        string name,
+        string level,
+        string reason,
+        string? code = null,
+        string[]? manualSteps = null,
+        Dictionary<string, string>? metadata = null)
+        => new()
+        {
+            Id = id,
+            ContainerId = "workspace",
+            Kind = kind,
+            Name = name,
+            Metadata = metadata ?? [],
             Compatibility = Assessment(level, reason, code, manualSteps)
         };
 

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcServiceMigrationScannerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcServiceMigrationScannerTests.cs
@@ -68,6 +68,28 @@ public sealed class OgcServiceMigrationScannerTests
     }
 
     [Fact]
+    public async Task ScanSourceAsync_ServiceUrlWithSecretQuery_RedactsArtifactUrls()
+    {
+        using var httpClient = new HttpClient(new OgcFixtureHandler());
+        var scanner = CreateScanner(httpClient, CreateCrsRegistry());
+
+        var artifact = await scanner.ScanSourceAsync(new OgcServiceScanRequest
+        {
+            ServiceType = "WFS",
+            ServiceUrl = "https://example.com/geoserver/wfs?token=super-secret&request=GetCapabilities&service=WFS&version=2.0.0",
+            Version = "2.0.0",
+            TimeoutSeconds = 10
+        });
+
+        artifact.Source.BaseUrl.Should().Be("https://example.com/geoserver/wfs");
+        artifact.ExternalDependencies.Should().ContainSingle(dependency => dependency.Kind == "ogc-endpoint")
+            .Which.Address.Should().Be("https://example.com/geoserver/wfs?request=GetCapabilities&service=WFS&version=2.0.0");
+        artifact.Source.BaseUrl.Should().NotContain("super-secret");
+        artifact.ExternalDependencies.Select(dependency => dependency.Address)
+            .Should().OnlyContain(address => address == null || !address.Contains("super-secret", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task ScanSourceAsync_DescribeFeatureTypeFailure_UsesSanitizedManualReviewWarning()
     {
         using var httpClient = new HttpClient(new DescribeFeatureTypeFailureHandler());


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1016

## Summary
Adds the follow-up OGC migration planning slice on top of the merged inventory scanner. WFS sources now carry feature-import planning metadata, while WMS/WMTS render-only sources emit service-level manual-review plans instead of being treated as automated data-copy migrations.

## Changes Made
- Add manifest `servicePlans` and summary counts for service-level OGC migration planning.
- Add WFS target resource metadata for `migrationMode`, source protocol, and WFS endpoint dependency linkage.
- Add WMS/WMTS manual-review service plans covering render/tile resources, styles, and tile matrix or endpoint dependencies.
- Harden OGC scanner artifact URLs so credentials and secret query parameters are not persisted in inventory artifacts.
- Update JSON source generation context, migration toolkit docs, and focused scanner/manifest tests.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] `scripts/ci/pre-pr-check.sh` coverage is satisfied by focused local gates plus required CI; full script was not run end-to-end locally
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Validation run locally:
- `git diff --check HEAD~1..HEAD`
- `dotnet build src/Honua.Core/Honua.Core.csproj --no-restore -m:1 /p:BuildInParallel=false /nr:false /p:UseSharedCompilation=false`
- `dotnet build src/Honua.Server/Honua.Server.csproj --no-restore -m:1 /nr:false /p:BuildInParallel=false`
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --no-restore --filter "FullyQualifiedName~OgcServiceMigrationScannerTests|FullyQualifiedName~MigrationManifestTranslatorTests" -m:1 /p:BuildInParallel=false /nr:false /p:UseSharedCompilation=false`
- `dotnet format Honua.sln --include <touched files> --no-restore --verbosity minimal`

Scope note: WMS/WMTS render and tile sources remain planning/manual-review paths unless paired with a data source such as WFS, coverage, database, or file input.