### PR TITLE
docs: clarify Esri service layer publication semantics

### DIFF
--- a/docs/contributor/architecture/admin-operator-workflows.md
+++ b/docs/contributor/architecture/admin-operator-workflows.md
@@ -94,15 +94,20 @@ landing page.
 | Field | A source attribute with display, query, edit, sensitivity, and semantic role controls | Field name/type, alias, role, domain, exposure, target-specific bindings in advanced view |
 | Metadata | Human and standards meaning for the resource | Description, contacts, rights, license, dates, extents, quality, lineage, links, distributions |
 | Service or Catalog | Runtime endpoint or catalog surface that can expose one or more resources | GeoServices, OGC API, WMS, WMTS, WFS, OData, STAC, DCAT, OGC Records, Esri catalog |
-| Publication | A resource exposed to a target endpoint or catalog item | Target, path or item identity, field exposure, metadata projection, readiness state |
+| Service Layer Slot | A service-local publication position for one resource, especially useful for Esri MapServer/FeatureServer ergonomics | Service id, layer index or route, display name, linked data resource, readiness state |
+| Publication | A resource exposed to a target endpoint, service layer slot, or catalog item | Target, path or item identity, field exposure, metadata projection, readiness state |
 | Projection Preview | Read-only preview of target output before publish | Derived standard output for OGC, DCAT, STAC, ISO, GeoServices, OData, or Esri catalog |
 | Access Preset | Human-readable security choice | Roles, grants, anonymous access, service/resource/field restrictions, advanced policy diagnostics |
 | Job | Long-running import, publish, tile, validation, or migration operation | Job type, status, progress, logs, result links, retry/cancel support |
 | Validation Result | Readiness issue tied to a fix location | Severity, target, resource, workflow area, blocker or warning, deep link |
 
-The semantic center is the Data Resource, not the service. A resource can publish
-to many service and catalog formats. A service or catalog is a target surface,
-not the owner of the resource meaning.
+The semantic center is the Data Resource, not the service. Canonical source
+binding, field roles, descriptive metadata, lineage, rights, and access policy
+remain owned by the Data Resource. A resource can publish to many service and
+catalog formats. A service or catalog is a target surface, not the owner of the
+resource meaning. For multi-layer Esri services, the service can have many
+layer slots or publication entries under it; each slot is a publication
+representation linked back to one Data Resource.
 
 ## Storage, Service, And Catalog Mapping Rules
 
@@ -111,9 +116,12 @@ The admin UI should reinforce these rules:
 - Connection explains how Honua reaches storage or an external API.
 - Source explains which concrete table, file, raster, tile set, remote layer, or
   API asset the resource comes from.
-- Data Resource explains what the thing means.
+- Data Resource explains what the thing means and owns the canonical source,
+  fields, metadata, lineage, rights, and access controls.
 - Field roles explain field semantics once.
-- Publication explains where the resource is exposed.
+- Publication explains where the resource is exposed. In an Esri service this
+  may be a service layer slot with a service-local layer id, route, display
+  name, renderer, popup, or field exposure override.
 - Projection Preview explains how that one resource will look in a specific
   service, catalog, or standard output.
 - Runtime snapshots and Redis caches are derived outputs. They should never be
@@ -129,6 +137,12 @@ Target-specific differences belong in the publication or projection preview,
 not in duplicated resource metadata. A target may need a collection id, item id,
 layer index, route, output format, thumbnail, or field exposure override, but
 those choices should not fork the canonical resource meaning.
+
+Service detail pages should still show layers underneath a service for Esri
+admin ergonomics. This is a navigation and publication-management view, not a
+change in ownership: service layers are slots/publication entries, and edits to
+source, fields, metadata, lineage, rights, or canonical access deep-link back to
+the linked Data Resource.
 
 ## Workflow Matrix
 
@@ -355,6 +369,55 @@ Outputs:
 - Publication record.
 - Target-specific projection output.
 - Runtime cache/projection invalidation job when needed.
+
+### Service Detail Layer Slots
+
+Service and catalog detail pages should include a concise table of the
+publication entries under that service. For Esri MapServer and FeatureServer
+targets, label these entries as layers so administrators can scan the service in
+the same shape as ArcGIS REST.
+
+Recommended columns:
+
+| Column | Purpose |
+|---|---|
+| Layer | Service-local layer index, route, or display name |
+| Data Resource | Linked canonical resource; opens the resource detail |
+| Kind | Feature, table, raster, tile, catalog item, or other target-specific type |
+| Source | Read-only connection/source summary from the resource |
+| Fields | Readiness or exposure summary, with edit link to Resource -> Fields |
+| Metadata | Projection readiness, with edit link to Resource -> Metadata |
+| Access | Effective access summary, with canonical edit link to Resource -> Access |
+| Status | Draft, warning, blocked, published, stale, or failed |
+| Actions | Preview, reorder where supported, validate, unpublish, or open resource |
+
+Do not make the service layer table the canonical authoring surface for the
+resource. It can manage service-local choices such as layer order, layer route,
+published display name, renderer override, popup override, target field
+exposure, cache settings, and unpublish/reorder actions. It should deep-link to
+the Data Resource for source, field role, metadata, rights, lineage, and access
+ownership.
+
+### Data Resource Publish View
+
+The Data Resource Publish tab should provide the inverse view: all places where
+one canonical resource is published or drafted for publication.
+
+Recommended columns:
+
+| Column | Purpose |
+|---|---|
+| Target | Service, catalog, or standard output name |
+| Entry | Layer index, collection id, route, entity set, record id, or portal item |
+| Type | GeoServices, OGC API, WMS, WFS, OData, STAC, DCAT, OGC Records, or Esri catalog |
+| Projection | Ready, warning, blocked, or stale projection state |
+| Access | Effective access compared with the resource policy |
+| Last publish | Timestamp, author, and job link |
+| Actions | Preview, validate, publish, republish, unpublish, or open service |
+
+This inverse view makes it clear that the resource owns meaning once, while
+each row is a publication representation of that resource in a specific service
+or catalog target.
 
 ## Resource Authoring Flows
 

--- a/docs/contributor/architecture/metadata-v2-admin-ui-information-model.md
+++ b/docs/contributor/architecture/metadata-v2-admin-ui-information-model.md
@@ -25,6 +25,13 @@ Metadata, Publish, Access, Validation -> Services and Catalogs.
 Supporting schema objects can exist behind these workflows, but the main UI
 should keep users focused on what they are trying to manage.
 
+The ownership rule is explicit: Data Resources own canonical source binding,
+fields, metadata, lineage, rights, and access. Services and catalogs own
+publication shape. A service can have many layer slots or publication entries,
+and each slot is a service-local representation linked to a Data Resource. This
+lets Esri administrators see layers under a MapServer or FeatureServer without
+turning the service into the owner of source, field, metadata, or access truth.
+
 ## UI Vocabulary
 
 Use these as primary interface terms:
@@ -91,6 +98,27 @@ Primary actions:
 - Filter by type, source, validation, access, and publish target
 - Open validation blockers
 - Open projection preview
+
+## Services List
+
+Recommended columns:
+
+| Column | Purpose |
+|---|---|
+| Name | Service or catalog display name and stable route |
+| Type | GeoServices, OGC API, WMS, WMTS, WFS, OData, STAC, DCAT, OGC Records, or Esri catalog |
+| Entries | Count of layer slots, collections, entity sets, records, or items |
+| Status | Draft, running, degraded, stopped, warning, or blocked |
+| Access | Service-level access and anonymous availability summary |
+| Validation | Highest severity across publication entries |
+| Modified | Last publish or runtime configuration change |
+
+Primary actions:
+
+- Create service or catalog
+- Filter by type, status, access, and validation
+- Open validation blockers
+- Add or import publication entries
 
 ## Resource Detail Tabs
 
@@ -171,6 +199,54 @@ Show publication targets and compatibility:
 | DCAT dataset/distribution | Warning | Missing publisher identifier |
 | OGC Records record | Ready | None |
 | Esri catalog/portal item | Warning | Missing thumbnail or owner details |
+
+The Publish tab is the inverse of service detail: it shows every publication
+entry for this one Data Resource across services and catalogs.
+
+Recommended publication columns:
+
+| Column | Purpose |
+|---|---|
+| Target | Service or catalog name |
+| Entry | Layer index, route, collection id, entity set, record id, or portal item |
+| Type | Target protocol or catalog type |
+| Projection | Ready, warning, blocked, or stale |
+| Access | Effective access compared with canonical resource access |
+| Last publish | Timestamp and job link |
+| Actions | Preview, validate, publish, republish, unpublish, or open target |
+
+The table should make it clear that source, fields, metadata, lineage, rights,
+and canonical access are edited on the Data Resource, while each row stores only
+target-specific publication representation such as layer id, route, display
+name, renderer or popup override, field exposure override, cache settings, and
+readiness state.
+
+## Service Detail
+
+Service detail pages should show entries underneath the service. For Esri
+MapServer and FeatureServer targets, label these entries as layers and preserve
+service-local layer ordering/indexes for admin ergonomics. For non-Esri targets,
+the same pattern can be labeled as collections, entity sets, records, items, or
+layers according to the target.
+
+Recommended entry columns:
+
+| Column | Purpose |
+|---|---|
+| Entry | Layer index, route, collection id, entity set, record id, or item name |
+| Data Resource | Linked canonical resource |
+| Kind | Feature, table, raster, tile, catalog item, or other supported kind |
+| Source | Read-only source summary from the Data Resource |
+| Fields | Exposure/readiness summary with edit link to Resource -> Fields |
+| Metadata | Projection readiness with edit link to Resource -> Metadata |
+| Access | Effective access with edit link to Resource -> Access |
+| Status | Draft, warning, blocked, published, stale, or failed |
+| Actions | Preview, validate, reorder where supported, unpublish, or open resource |
+
+Service-local controls can edit publication concerns such as order, route,
+published display name, service capability toggles, cache settings, renderer
+override, popup override, and unpublish actions. They should not duplicate
+canonical source, fields, metadata, lineage, rights, or access authoring.
 
 ### Access
 


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1035
Related to #1042
Related to #1046
Related to #1057

## Summary
Clarifies the Metadata v2 admin and workflow handoff semantics for multi-layer Esri services. Services remain publication containers; each Esri service layer is represented by a service-local publication slot that points back to a canonical Data Resource.

## Changes Made
- Clarified that Data Resources own canonical source, fields, metadata, lineage, rights, and access.
- Documented service layer slots/publication entries for multi-layer Esri service ergonomics.
- Added service-detail layer table guidance and inverse Data Resource publish view guidance.
- Kept internal Metadata v2 vocabulary out of the primary admin UI language while preserving mapping precision for design.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- `git diff --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] `scripts/ci/pre-pr-check.sh` full end-to-end run not performed locally; docs-only targeted check above passed and PR CI is running the relevant gate set.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract or marked not applicable
- [x] If breaking admin/control-plane API changes: updated migration guide or marked not applicable
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review or marked not applicable