### PR TITLE
feat: add OGC coverage migration scanner scaffold (#1030)

### DIFF
--- a/docs/operator/migration-toolkit.md
+++ b/docs/operator/migration-toolkit.md
@@ -95,6 +95,12 @@ required source kinds, per-source automation classification, stage state, and
 blocking gaps. Use required source kinds for website or release claims so the
 suite fails when ArcGIS, GeoServer, or OGC evidence is absent.
 
+WCS and OGC API Coverages migration planning is tracked separately from WFS,
+WMS, and WMTS. The first coverage slice is documented in
+[OGC Coverage Migration](ogc-coverage-migration.md); it captures coverage
+metadata, output formats, CRS/subset metadata, bands/ranges, and temporal
+dimensions without claiming end-to-end coverage import or parity.
+
 ## State Values
 
 Every parity and readiness item uses one of these state values:

--- a/docs/operator/ogc-coverage-migration.md
+++ b/docs/operator/ogc-coverage-migration.md
@@ -1,0 +1,65 @@
+# OGC Coverage Migration
+
+This page describes the first Honua migration planning slice for OGC coverage
+services tracked by honua-server#1030. It covers WCS and OGC API Coverages
+source inventory. It does not claim full coverage import, target publication,
+or cutover parity.
+
+## First Slice Scope
+
+The first slice introduces `OgcCoverageMigrationInventoryScanner`, which builds
+a `MigrationSourceInventoryArtifact` from structured coverage service metadata.
+The scanner is intentionally contract-first: it captures what a source advertises
+so the migration toolkit can classify automated, manual-review, and unsupported
+coverage paths before any data is copied.
+
+The scanner records:
+
+- service type, version, title, provider, fees, and access constraints
+- coverage identifiers, titles, descriptions, native formats, and coverage type
+- CRS declarations, axis order, subset axes, axis bounds, resolution, and
+  discrete allowed values
+- range and band metadata, including data type, units, no-data values, and
+  interpretations
+- advertised output formats, with GeoTIFF and COG separated from NetCDF, HDF,
+  Zarr, and unknown formats
+- temporal dimensions that require explicit parity review before cutover
+
+## Compatibility Semantics
+
+The first automated coverage data path is GeoTIFF or Cloud Optimized GeoTIFF.
+If a coverage advertises GeoTIFF or COG, the inventory marks the resource as a
+candidate for automated raster migration planning.
+
+Scientific or multidimensional outputs are classified separately:
+
+| Source output | First-slice classification |
+|---|---|
+| GeoTIFF | Candidate automated path |
+| Cloud Optimized GeoTIFF | Candidate automated path |
+| NetCDF | Unsupported until format support lands |
+| HDF/HDF5 | Unsupported until format support lands |
+| Zarr | Unsupported until format support lands |
+| Unknown output format | Unsupported/manual review |
+
+Temporal dimensions, access constraints, axis-order behavior, and uncommon
+subset semantics keep a resource in manual review even when a GeoTIFF or COG
+path exists. This prevents rendered WMS output or partial metadata discovery
+from being treated as coverage-data migration proof.
+
+## Operator Review
+
+Before using coverage migration language beyond inventory planning, operators
+need evidence for:
+
+- source metadata inventory reviewed with the source owner
+- GeoTIFF/COG export or retrieval path validated for each automated candidate
+- sample pixel/window parity across source and Honua target
+- CRS, axis order, subset, no-data, band/range, and temporal metadata parity
+- explicit unsupported/manual-review records for multidimensional or scientific
+  formats
+- cutover readiness linked from the standard migration evidence pack
+
+Until those evidence items exist, WCS and OGC API Coverages support should be
+described as inventory and migration planning, not automated end-to-end
+migration.

--- a/src/Honua.Core/Features/Import/Domain/OgcCoverageMigrationCompatibilityCodes.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcCoverageMigrationCompatibilityCodes.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Stable compatibility codes emitted by the OGC coverage migration inventory scanner.
+/// </summary>
+public static class OgcCoverageMigrationCompatibilityCodes
+{
+    /// <summary>Coverage can be migrated through a GeoTIFF output path.</summary>
+    public const string GeoTiffSupported = "OGC_COVERAGE_GEOTIFF_SUPPORTED";
+
+    /// <summary>Coverage can be migrated through a Cloud Optimized GeoTIFF output path.</summary>
+    public const string CogSupported = "OGC_COVERAGE_COG_SUPPORTED";
+
+    /// <summary>Coverage is discoverable, but needs manual migration review.</summary>
+    public const string ManualReview = "OGC_COVERAGE_MANUAL_REVIEW";
+
+    /// <summary>Coverage did not advertise an output format that can be planned deterministically.</summary>
+    public const string OutputFormatMissing = "OGC_COVERAGE_OUTPUT_FORMAT_MISSING";
+
+    /// <summary>Coverage advertises NetCDF output, which is not yet supported by the automated path.</summary>
+    public const string NetCdfUnsupported = "OGC_COVERAGE_NETCDF_UNSUPPORTED";
+
+    /// <summary>Coverage advertises HDF output, which is not yet supported by the automated path.</summary>
+    public const string HdfUnsupported = "OGC_COVERAGE_HDF_UNSUPPORTED";
+
+    /// <summary>Coverage advertises Zarr output, which is not yet supported by the automated path.</summary>
+    public const string ZarrUnsupported = "OGC_COVERAGE_ZARR_UNSUPPORTED";
+
+    /// <summary>Coverage advertises one or more scientific formats without an automated import path.</summary>
+    public const string ScientificFormatUnsupported = "OGC_COVERAGE_SCIENTIFIC_FORMAT_UNSUPPORTED";
+
+    /// <summary>Coverage advertises only output formats that are not recognized by this scanner.</summary>
+    public const string UnsupportedFormat = "OGC_COVERAGE_UNSUPPORTED_FORMAT";
+}

--- a/src/Honua.Core/Features/Import/Domain/OgcCoverageServiceScanRequest.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcCoverageServiceScanRequest.cs
@@ -1,0 +1,327 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Structured request used to build an OGC coverage service migration inventory.
+/// </summary>
+public sealed record OgcCoverageServiceScanRequest
+{
+    /// <summary>
+    /// Coverage protocol surface to scan. Supported values are <c>WCS</c> and <c>OGC API Coverages</c>.
+    /// </summary>
+    public required string ServiceType { get; init; }
+
+    /// <summary>
+    /// Source service URL used for migration planning.
+    /// </summary>
+    public required string ServiceUrl { get; init; }
+
+    /// <summary>
+    /// Optional service version advertised by the source.
+    /// </summary>
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// Service-level metadata captured from capabilities or landing-page documents.
+    /// </summary>
+    public OgcCoverageServiceMetadata ServiceMetadata { get; init; } = new();
+
+    /// <summary>
+    /// Coverage resources advertised by the source service.
+    /// </summary>
+    public OgcCoverageDescription[] Coverages { get; init; } = [];
+}
+
+/// <summary>
+/// Service-level metadata for an OGC coverage source.
+/// </summary>
+public sealed record OgcCoverageServiceMetadata
+{
+    /// <summary>
+    /// Human-readable service title.
+    /// </summary>
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Service abstract or description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Source product or implementation name.
+    /// </summary>
+    public string? Product { get; init; }
+
+    /// <summary>
+    /// Provider or organization name advertised by the source.
+    /// </summary>
+    public string? ProviderName { get; init; }
+
+    /// <summary>
+    /// Service fees or licensing statements.
+    /// </summary>
+    public string[] Fees { get; init; } = [];
+
+    /// <summary>
+    /// Access constraints advertised by the source.
+    /// </summary>
+    public string[] AccessConstraints { get; init; } = [];
+}
+
+/// <summary>
+/// Coverage metadata captured for migration planning.
+/// </summary>
+public sealed record OgcCoverageDescription
+{
+    /// <summary>
+    /// Stable source coverage identifier.
+    /// </summary>
+    public required string CoverageId { get; init; }
+
+    /// <summary>
+    /// Optional human-readable coverage title.
+    /// </summary>
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Optional coverage abstract or description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Coverage type advertised by the source, such as <c>RectifiedGridCoverage</c>.
+    /// </summary>
+    public string? CoverageType { get; init; }
+
+    /// <summary>
+    /// Native source storage format when advertised.
+    /// </summary>
+    public string? NativeFormat { get; init; }
+
+    /// <summary>
+    /// Access constraints specific to this coverage.
+    /// </summary>
+    public string[] AccessConstraints { get; init; } = [];
+
+    /// <summary>
+    /// CRS values associated with the coverage.
+    /// </summary>
+    public OgcCoverageCrsMetadata[] Crs { get; init; } = [];
+
+    /// <summary>
+    /// Axis and subset metadata associated with the coverage domain.
+    /// </summary>
+    public OgcCoverageAxisMetadata[] Axes { get; init; } = [];
+
+    /// <summary>
+    /// Range, band, or field metadata associated with the coverage values.
+    /// </summary>
+    public OgcCoverageRangeMetadata[] Ranges { get; init; } = [];
+
+    /// <summary>
+    /// Output formats advertised for the coverage.
+    /// </summary>
+    public OgcCoverageFormatMetadata[] OutputFormats { get; init; } = [];
+
+    /// <summary>
+    /// Temporal dimensions advertised for the coverage.
+    /// </summary>
+    public OgcCoverageTemporalDimensionMetadata[] TemporalDimensions { get; init; } = [];
+}
+
+/// <summary>
+/// CRS metadata for a coverage domain or output path.
+/// </summary>
+public sealed record OgcCoverageCrsMetadata
+{
+    /// <summary>
+    /// Role of the CRS entry, such as <c>native</c>, <c>supported</c>, or <c>output</c>.
+    /// </summary>
+    public required string Role { get; init; }
+
+    /// <summary>
+    /// Source-provided CRS identifier or definition.
+    /// </summary>
+    public required string Crs { get; init; }
+
+    /// <summary>
+    /// Axis order advertised by the source for this CRS.
+    /// </summary>
+    public string? AxisOrder { get; init; }
+
+    /// <summary>
+    /// Axis labels associated with this CRS entry.
+    /// </summary>
+    public string[] AxisLabels { get; init; } = [];
+}
+
+/// <summary>
+/// Axis and subset metadata for an OGC coverage domain.
+/// </summary>
+public sealed record OgcCoverageAxisMetadata
+{
+    /// <summary>
+    /// Axis name or subset identifier.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Axis type such as <c>x</c>, <c>y</c>, <c>time</c>, <c>elevation</c>, or <c>band</c>.
+    /// </summary>
+    public string? AxisType { get; init; }
+
+    /// <summary>
+    /// Source CRS axis label when distinct from the subset name.
+    /// </summary>
+    public string? CrsAxisLabel { get; init; }
+
+    /// <summary>
+    /// Axis unit of measure.
+    /// </summary>
+    public string? Unit { get; init; }
+
+    /// <summary>
+    /// Lower domain bound advertised for the axis.
+    /// </summary>
+    public string? LowerBound { get; init; }
+
+    /// <summary>
+    /// Upper domain bound advertised for the axis.
+    /// </summary>
+    public string? UpperBound { get; init; }
+
+    /// <summary>
+    /// Axis resolution when available.
+    /// </summary>
+    public string? Resolution { get; init; }
+
+    /// <summary>
+    /// Whether the source explicitly allows subsetting by this axis.
+    /// </summary>
+    public bool? Subsettable { get; init; }
+
+    /// <summary>
+    /// Discrete values advertised for the axis.
+    /// </summary>
+    public string[] AllowedValues { get; init; } = [];
+
+    /// <summary>
+    /// Default axis value used by the source.
+    /// </summary>
+    public string? DefaultValue { get; init; }
+}
+
+/// <summary>
+/// Range, band, or field metadata for an OGC coverage.
+/// </summary>
+public sealed record OgcCoverageRangeMetadata
+{
+    /// <summary>
+    /// Range or band name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Display label for the range or band.
+    /// </summary>
+    public string? Label { get; init; }
+
+    /// <summary>
+    /// Source data type, such as <c>UInt16</c> or <c>Float32</c>.
+    /// </summary>
+    public string? DataType { get; init; }
+
+    /// <summary>
+    /// Unit of measure for range values.
+    /// </summary>
+    public string? Unit { get; init; }
+
+    /// <summary>
+    /// No-data value advertised for the range.
+    /// </summary>
+    public string? NoDataValue { get; init; }
+
+    /// <summary>
+    /// Range interpretation, such as <c>red</c>, <c>green</c>, <c>blue</c>, or <c>temperature</c>.
+    /// </summary>
+    public string? Interpretation { get; init; }
+
+    /// <summary>
+    /// Lower valid sample value when advertised.
+    /// </summary>
+    public string? MinimumValue { get; init; }
+
+    /// <summary>
+    /// Upper valid sample value when advertised.
+    /// </summary>
+    public string? MaximumValue { get; init; }
+}
+
+/// <summary>
+/// Output format metadata advertised for an OGC coverage.
+/// </summary>
+public sealed record OgcCoverageFormatMetadata
+{
+    /// <summary>
+    /// Source format token.
+    /// </summary>
+    public required string Format { get; init; }
+
+    /// <summary>
+    /// Optional media type for the format.
+    /// </summary>
+    public string? MediaType { get; init; }
+
+    /// <summary>
+    /// Optional format profile, such as a Cloud Optimized GeoTIFF profile URI.
+    /// </summary>
+    public string? Profile { get; init; }
+
+    /// <summary>
+    /// Whether this format is the native source encoding.
+    /// </summary>
+    public bool? IsNative { get; init; }
+}
+
+/// <summary>
+/// Temporal dimension metadata advertised for an OGC coverage.
+/// </summary>
+public sealed record OgcCoverageTemporalDimensionMetadata
+{
+    /// <summary>
+    /// Temporal dimension name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Start instant or date for the dimension extent.
+    /// </summary>
+    public string? Start { get; init; }
+
+    /// <summary>
+    /// End instant or date for the dimension extent.
+    /// </summary>
+    public string? End { get; init; }
+
+    /// <summary>
+    /// Default temporal value selected by the source.
+    /// </summary>
+    public string? DefaultValue { get; init; }
+
+    /// <summary>
+    /// Temporal resolution or interval when advertised.
+    /// </summary>
+    public string? Interval { get; init; }
+
+    /// <summary>
+    /// Discrete temporal values when advertised.
+    /// </summary>
+    public string[] Values { get; init; } = [];
+
+    /// <summary>
+    /// Whether the source explicitly allows subsetting by this temporal dimension.
+    /// </summary>
+    public bool? Subsettable { get; init; }
+}

--- a/src/Honua.Core/Features/Import/Services/OgcCoverageMigrationInventoryScanner.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcCoverageMigrationInventoryScanner.cs
@@ -1,0 +1,704 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Builds deterministic migration inventory artifacts for OGC coverage service sources.
+/// </summary>
+public sealed partial class OgcCoverageMigrationInventoryScanner
+{
+    private readonly ICrsRegistry _crsRegistry;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OgcCoverageMigrationInventoryScanner"/> class.
+    /// </summary>
+    /// <param name="crsRegistry">CRS registry used to normalize advertised coverage references.</param>
+    public OgcCoverageMigrationInventoryScanner(ICrsRegistry crsRegistry)
+    {
+        _crsRegistry = crsRegistry ?? throw new ArgumentNullException(nameof(crsRegistry));
+    }
+
+    /// <summary>
+    /// Builds a migration source inventory artifact from structured coverage service metadata.
+    /// </summary>
+    /// <param name="request">Coverage service scan request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A deterministic source inventory artifact.</returns>
+    public async Task<MigrationSourceInventoryArtifact> ScanAsync(
+        OgcCoverageServiceScanRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var serviceKind = NormalizeServiceType(request.ServiceType);
+        var sourceKind = serviceKind == "WCS" ? "ogc-wcs" : "ogc-api-coverages";
+        var product = serviceKind == "WCS" ? "OGC Web Coverage Service" : "OGC API Coverages";
+        var serviceUri = ValidateServiceUri(request.ServiceUrl);
+        var version = FirstNonBlank(request.Version) ?? "unknown";
+        var displayName = FirstNonBlank(request.ServiceMetadata.Title, serviceUri.Host) ?? product;
+        var containerId = $"service:{sourceKind}";
+        var capabilities = BuildCoverageCapabilities(serviceKind);
+        var warnings = new List<string>();
+        var missingArtifacts = new List<string>();
+        var dependencies = new List<MigrationExternalDependency>
+        {
+            BuildServiceEndpointDependency(containerId, serviceKind, serviceUri, version),
+            BuildServiceMetadataDependency(containerId, request, sourceKind, product, version)
+        };
+
+        var resources = new List<MigrationInventoryResource>(request.Coverages.Length);
+        foreach (var coverage in request.Coverages.OrderBy(static item => item.CoverageId, StringComparer.Ordinal))
+        {
+            var resource = await BuildCoverageResourceAsync(
+                    containerId,
+                    coverage,
+                    serviceKind,
+                    capabilities,
+                    dependencies,
+                    warnings,
+                    missingArtifacts,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            resources.Add(resource);
+        }
+
+        if (resources.Count == 0)
+        {
+            warnings.Add("No coverage resources were advertised by the source service.");
+        }
+
+        var containers = new[]
+        {
+            new MigrationInventoryContainer
+            {
+                Id = containerId,
+                Kind = "ogc-coverage-service",
+                Name = serviceKind,
+                Title = displayName,
+                Description = request.ServiceMetadata.Description,
+                IsDefault = true,
+                Compatibility = MigrationInventoryHelpers.Aggregate(
+                    resources.Select(static resource => resource.Compatibility)
+                        .Concat(dependencies.Select(static dependency => dependency.Compatibility)),
+                    "No OGC coverage inventory items were discovered.")
+            }
+        };
+
+        var orderedDependencies = dependencies
+            .OrderBy(static dependency => dependency.Id, StringComparer.Ordinal)
+            .ToArray();
+        var orderedResources = resources
+            .OrderBy(static resource => resource.Id, StringComparer.Ordinal)
+            .ToArray();
+        var summary = MigrationInventoryHelpers.BuildSummary(containers, orderedResources, [], orderedDependencies);
+        var overallCompatibility = MigrationInventoryHelpers.Aggregate(
+            containers.Select(static container => container.Compatibility)
+                .Concat(orderedResources.Select(static resource => resource.Compatibility))
+                .Concat(orderedDependencies.Select(static dependency => dependency.Compatibility)),
+            "No OGC coverage inventory items were discovered.");
+
+        return new MigrationSourceInventoryArtifact
+        {
+            SourceKind = sourceKind,
+            Source = new MigrationSourceIdentity
+            {
+                DisplayName = displayName,
+                BaseUrl = serviceUri.ToString(),
+                Product = product,
+                Version = version,
+                ServiceType = serviceKind
+            },
+            AuthPosture = BuildAuthPosture(request.ServiceMetadata, request.Coverages),
+            ScanCompleteness = MigrationInventoryHelpers.BuildCompleteness(
+                warnings.Count == 0 ? "complete" : "partial",
+                warnings,
+                missingArtifacts),
+            Summary = summary,
+            OverallCompatibility = overallCompatibility,
+            Containers = containers,
+            Resources = orderedResources,
+            ExternalDependencies = orderedDependencies
+        };
+    }
+
+    private async Task<MigrationInventoryResource> BuildCoverageResourceAsync(
+        string containerId,
+        OgcCoverageDescription coverage,
+        string serviceKind,
+        string[] capabilities,
+        List<MigrationExternalDependency> dependencies,
+        List<string> warnings,
+        List<string> missingArtifacts,
+        CancellationToken cancellationToken)
+    {
+        var resourceId = $"coverage:{ToStableId(coverage.CoverageId)}";
+        var spatialReferences = await BuildSpatialReferencesAsync(coverage.Crs, cancellationToken).ConfigureAwait(false);
+        var formatDependencies = BuildFormatDependencies(containerId, resourceId, coverage).ToArray();
+        var axisDependencies = BuildAxisDependencies(containerId, resourceId, coverage).ToArray();
+        var rangeDependencies = BuildRangeDependencies(containerId, resourceId, coverage).ToArray();
+        var temporalDependencies = BuildTemporalDependencies(containerId, resourceId, coverage).ToArray();
+        var compatibility = BuildCoverageCompatibility(coverage, formatDependencies, temporalDependencies);
+
+        dependencies.AddRange(formatDependencies);
+        dependencies.AddRange(axisDependencies);
+        dependencies.AddRange(rangeDependencies);
+        dependencies.AddRange(temporalDependencies);
+
+        if (coverage.OutputFormats.Length == 0)
+        {
+            missingArtifacts.Add($"output-format:{coverage.CoverageId}");
+            warnings.Add($"Coverage {coverage.CoverageId} did not advertise output formats.");
+        }
+
+        return new MigrationInventoryResource
+        {
+            Id = resourceId,
+            ContainerId = containerId,
+            Kind = "coverage",
+            Name = coverage.CoverageId,
+            Title = coverage.Title,
+            Description = coverage.Description,
+            Capabilities = capabilities,
+            SpatialReferences = spatialReferences,
+            Fields = coverage.Ranges
+                .Where(static range => !string.IsNullOrWhiteSpace(range.Name))
+                .OrderBy(static range => range.Name, StringComparer.Ordinal)
+                .Select(static range => new MigrationInventoryField
+                {
+                    Name = range.Name,
+                    Alias = range.Label,
+                    FieldType = FirstNonBlank(range.DataType, "coverage-range")!,
+                    Nullable = true,
+                    DomainType = range.Interpretation,
+                    DomainName = range.Unit
+                })
+                .ToArray(),
+            ExternalDependencyIds = formatDependencies
+                .Concat(axisDependencies)
+                .Concat(rangeDependencies)
+                .Concat(temporalDependencies)
+                .Select(static dependency => dependency.Id)
+                .OrderBy(static value => value, StringComparer.Ordinal)
+                .ToArray(),
+            Compatibility = compatibility
+        };
+    }
+
+    private static MigrationExternalDependency BuildServiceEndpointDependency(
+        string containerId,
+        string serviceKind,
+        Uri serviceUri,
+        string version)
+    {
+        var operation = serviceKind == "WCS" ? "GetCapabilities" : "Landing Page";
+        return new MigrationExternalDependency
+        {
+            Id = $"endpoint:{serviceKind.ToLowerInvariant().Replace(' ', '-')}",
+            ContainerId = containerId,
+            Kind = "ogc-coverage-endpoint",
+            Name = $"{serviceKind} {operation}",
+            DependencyType = "capabilities",
+            Address = MigrationInventoryHelpers.NormalizeExternalAddress(serviceUri.ToString()),
+            Metadata = new Dictionary<string, string>
+            {
+                ["service"] = serviceKind,
+                ["version"] = version
+            },
+            Compatibility = MigrationInventoryHelpers.Compatible(
+                $"{serviceKind} service endpoint was captured for coverage migration planning.",
+                code: OgcCoverageMigrationCompatibilityCodes.ManualReview)
+        };
+    }
+
+    private static MigrationExternalDependency BuildServiceMetadataDependency(
+        string containerId,
+        OgcCoverageServiceScanRequest request,
+        string sourceKind,
+        string product,
+        string version)
+    {
+        var metadata = new SortedDictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["coverageCount"] = request.Coverages.Length.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ["product"] = product,
+            ["serviceType"] = NormalizeServiceType(request.ServiceType),
+            ["sourceKind"] = sourceKind,
+            ["version"] = version
+        };
+        AddMetadata(metadata, "title", request.ServiceMetadata.Title);
+        AddMetadata(metadata, "description", request.ServiceMetadata.Description);
+        AddMetadata(metadata, "providerName", request.ServiceMetadata.ProviderName);
+        AddMetadata(metadata, "fees", string.Join("; ", NormalizeStrings(request.ServiceMetadata.Fees)));
+        AddMetadata(metadata, "accessConstraints", string.Join("; ", NormalizeAccessConstraints(request.ServiceMetadata.AccessConstraints)));
+
+        var hasAccessConstraints = NormalizeAccessConstraints(request.ServiceMetadata.AccessConstraints).Length > 0;
+        return new MigrationExternalDependency
+        {
+            Id = "metadata:coverage-service",
+            ContainerId = containerId,
+            Kind = "coverage-service-metadata",
+            Name = "Coverage service metadata",
+            DependencyType = "service-metadata",
+            Metadata = metadata.ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value, StringComparer.Ordinal),
+            Compatibility = hasAccessConstraints
+                ? MigrationInventoryHelpers.Partial(
+                    "Coverage service metadata advertises access constraints that must be reviewed before cutover.",
+                    request.ServiceMetadata.AccessConstraints,
+                    ["Confirm licensing, authentication, and redistribution constraints before automating coverage migration."],
+                    OgcCoverageMigrationCompatibilityCodes.ManualReview)
+                : MigrationInventoryHelpers.Compatible(
+                    "Coverage service metadata was captured for migration planning.",
+                    code: OgcCoverageMigrationCompatibilityCodes.ManualReview)
+        };
+    }
+
+    private static IEnumerable<MigrationExternalDependency> BuildFormatDependencies(
+        string containerId,
+        string resourceId,
+        OgcCoverageDescription coverage)
+    {
+        foreach (var format in coverage.OutputFormats
+                     .Where(static item => !string.IsNullOrWhiteSpace(item.Format))
+                     .OrderBy(static item => item.Format, StringComparer.Ordinal)
+                     .ThenBy(static item => item.MediaType, StringComparer.Ordinal)
+                     .ThenBy(static item => item.Profile, StringComparer.Ordinal))
+        {
+            var classification = ClassifyFormat(format);
+            var metadata = new SortedDictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["classification"] = classification.Label,
+                ["format"] = format.Format
+            };
+            AddMetadata(metadata, "mediaType", format.MediaType);
+            AddMetadata(metadata, "profile", format.Profile);
+            if (format.IsNative.HasValue)
+            {
+                metadata["isNative"] = format.IsNative.Value ? "true" : "false";
+            }
+
+            yield return new MigrationExternalDependency
+            {
+                Id = $"format:{ToStableId(coverage.CoverageId)}:{ToStableId(format.Format)}:{ShortHash(format.MediaType, format.Profile)}",
+                ContainerId = containerId,
+                ResourceId = resourceId,
+                Kind = "coverage-output-format",
+                Name = format.Format,
+                DependencyType = classification.Label,
+                Metadata = metadata.ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value, StringComparer.Ordinal),
+                Compatibility = classification.Compatibility
+            };
+        }
+    }
+
+    private static IEnumerable<MigrationExternalDependency> BuildAxisDependencies(
+        string containerId,
+        string resourceId,
+        OgcCoverageDescription coverage)
+    {
+        foreach (var axis in coverage.Axes
+                     .Where(static item => !string.IsNullOrWhiteSpace(item.Name))
+                     .OrderBy(static item => item.Name, StringComparer.Ordinal))
+        {
+            var metadata = new SortedDictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["axisName"] = axis.Name
+            };
+            AddMetadata(metadata, "axisType", axis.AxisType);
+            AddMetadata(metadata, "crsAxisLabel", axis.CrsAxisLabel);
+            AddMetadata(metadata, "unit", axis.Unit);
+            AddMetadata(metadata, "lowerBound", axis.LowerBound);
+            AddMetadata(metadata, "upperBound", axis.UpperBound);
+            AddMetadata(metadata, "resolution", axis.Resolution);
+            AddMetadata(metadata, "defaultValue", axis.DefaultValue);
+            AddMetadata(metadata, "allowedValues", string.Join(",", NormalizeStrings(axis.AllowedValues)));
+            if (axis.Subsettable.HasValue)
+            {
+                metadata["subsettable"] = axis.Subsettable.Value ? "true" : "false";
+            }
+
+            yield return new MigrationExternalDependency
+            {
+                Id = $"axis:{ToStableId(coverage.CoverageId)}:{ToStableId(axis.Name)}",
+                ContainerId = containerId,
+                ResourceId = resourceId,
+                Kind = "coverage-axis",
+                Name = axis.Name,
+                DependencyType = axis.AxisType,
+                Metadata = metadata.ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value, StringComparer.Ordinal),
+                Compatibility = MigrationInventoryHelpers.Compatible(
+                    "Coverage axis and subset metadata was captured for migration planning.",
+                    code: OgcCoverageMigrationCompatibilityCodes.ManualReview)
+            };
+        }
+    }
+
+    private static IEnumerable<MigrationExternalDependency> BuildRangeDependencies(
+        string containerId,
+        string resourceId,
+        OgcCoverageDescription coverage)
+    {
+        foreach (var range in coverage.Ranges
+                     .Where(static item => !string.IsNullOrWhiteSpace(item.Name))
+                     .OrderBy(static item => item.Name, StringComparer.Ordinal))
+        {
+            var metadata = new SortedDictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["rangeName"] = range.Name
+            };
+            AddMetadata(metadata, "label", range.Label);
+            AddMetadata(metadata, "dataType", range.DataType);
+            AddMetadata(metadata, "unit", range.Unit);
+            AddMetadata(metadata, "noDataValue", range.NoDataValue);
+            AddMetadata(metadata, "interpretation", range.Interpretation);
+            AddMetadata(metadata, "minimumValue", range.MinimumValue);
+            AddMetadata(metadata, "maximumValue", range.MaximumValue);
+
+            yield return new MigrationExternalDependency
+            {
+                Id = $"range:{ToStableId(coverage.CoverageId)}:{ToStableId(range.Name)}",
+                ContainerId = containerId,
+                ResourceId = resourceId,
+                Kind = "coverage-range",
+                Name = range.Name,
+                DependencyType = range.Interpretation,
+                Metadata = metadata.ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value, StringComparer.Ordinal),
+                Compatibility = MigrationInventoryHelpers.Compatible(
+                    "Coverage range or band metadata was captured for migration planning.",
+                    code: OgcCoverageMigrationCompatibilityCodes.ManualReview)
+            };
+        }
+    }
+
+    private static IEnumerable<MigrationExternalDependency> BuildTemporalDependencies(
+        string containerId,
+        string resourceId,
+        OgcCoverageDescription coverage)
+    {
+        foreach (var temporal in coverage.TemporalDimensions
+                     .Where(static item => !string.IsNullOrWhiteSpace(item.Name))
+                     .OrderBy(static item => item.Name, StringComparer.Ordinal))
+        {
+            var metadata = new SortedDictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["dimensionName"] = temporal.Name
+            };
+            AddMetadata(metadata, "start", temporal.Start);
+            AddMetadata(metadata, "end", temporal.End);
+            AddMetadata(metadata, "defaultValue", temporal.DefaultValue);
+            AddMetadata(metadata, "interval", temporal.Interval);
+            AddMetadata(metadata, "values", string.Join(",", NormalizeStrings(temporal.Values)));
+            if (temporal.Subsettable.HasValue)
+            {
+                metadata["subsettable"] = temporal.Subsettable.Value ? "true" : "false";
+            }
+
+            yield return new MigrationExternalDependency
+            {
+                Id = $"temporal:{ToStableId(coverage.CoverageId)}:{ToStableId(temporal.Name)}",
+                ContainerId = containerId,
+                ResourceId = resourceId,
+                Kind = "coverage-temporal-dimension",
+                Name = temporal.Name,
+                DependencyType = "time",
+                Metadata = metadata.ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value, StringComparer.Ordinal),
+                Compatibility = MigrationInventoryHelpers.Partial(
+                    "Temporal coverage dimension metadata was captured and needs parity review before cutover.",
+                    [],
+                    ["Add temporal subset and sample-window parity probes before promoting this coverage migration."],
+                    OgcCoverageMigrationCompatibilityCodes.ManualReview)
+            };
+        }
+    }
+
+    private static MigrationCompatibilityAssessment BuildCoverageCompatibility(
+        OgcCoverageDescription coverage,
+        MigrationExternalDependency[] formatDependencies,
+        MigrationExternalDependency[] temporalDependencies)
+    {
+        if (formatDependencies.Length == 0)
+        {
+            return MigrationInventoryHelpers.Partial(
+                "Coverage output formats were not advertised.",
+                ["No output formats were available in the coverage metadata."],
+                ["Run DescribeCoverage or the OGC API Coverages coverage metadata request and verify available output encodings."],
+                OgcCoverageMigrationCompatibilityCodes.OutputFormatMissing);
+        }
+
+        var formatAssessments = formatDependencies.Select(static dependency => dependency.Compatibility).ToArray();
+        var hasCog = formatAssessments.Any(static item => item.Code == OgcCoverageMigrationCompatibilityCodes.CogSupported);
+        var hasGeoTiff = formatAssessments.Any(static item => item.Code == OgcCoverageMigrationCompatibilityCodes.GeoTiffSupported);
+        var hasUnsupported = formatAssessments.Any(static item => string.Equals(item.Level, "incompatible", StringComparison.Ordinal));
+        var hasTemporalReview = temporalDependencies.Length > 0;
+
+        if ((hasCog || hasGeoTiff) && (hasUnsupported || hasTemporalReview))
+        {
+            return MigrationInventoryHelpers.Partial(
+                "Coverage advertises a GeoTIFF/COG migration path, but some dimensions or alternate formats need manual review.",
+                formatAssessments.SelectMany(static item => item.Warnings),
+                ["Use GeoTIFF or COG as the first automated import path and review unsupported scientific formats separately."],
+                hasCog ? OgcCoverageMigrationCompatibilityCodes.CogSupported : OgcCoverageMigrationCompatibilityCodes.GeoTiffSupported);
+        }
+
+        if (hasCog)
+        {
+            return MigrationInventoryHelpers.Compatible(
+                "Coverage advertises Cloud Optimized GeoTIFF output that can seed the automated raster migration path.",
+                code: OgcCoverageMigrationCompatibilityCodes.CogSupported);
+        }
+
+        if (hasGeoTiff)
+        {
+            return MigrationInventoryHelpers.Compatible(
+                "Coverage advertises GeoTIFF output that can seed the automated raster migration path.",
+                code: OgcCoverageMigrationCompatibilityCodes.GeoTiffSupported);
+        }
+
+        if (formatAssessments.Any(static item =>
+                item.Code is OgcCoverageMigrationCompatibilityCodes.NetCdfUnsupported or
+                    OgcCoverageMigrationCompatibilityCodes.HdfUnsupported or
+                    OgcCoverageMigrationCompatibilityCodes.ZarrUnsupported))
+        {
+            return MigrationInventoryHelpers.Incompatible(
+                "Coverage advertises scientific multidimensional formats without a current automated import path.",
+                formatAssessments.SelectMany(static item => item.Warnings),
+                ["Track NetCDF, HDF, or Zarr format support before claiming automated migration for this coverage."],
+                OgcCoverageMigrationCompatibilityCodes.ScientificFormatUnsupported);
+        }
+
+        return MigrationInventoryHelpers.Incompatible(
+            "Coverage does not advertise a recognized automated output format.",
+            formatAssessments.SelectMany(static item => item.Warnings),
+            ["Add a source-specific importer or identify a GeoTIFF/COG output option before migration."],
+            OgcCoverageMigrationCompatibilityCodes.UnsupportedFormat);
+    }
+
+    private static (string Label, MigrationCompatibilityAssessment Compatibility) ClassifyFormat(
+        OgcCoverageFormatMetadata format)
+    {
+        var haystack = string.Join(
+            " ",
+            format.Format,
+            format.MediaType,
+            format.Profile).ToUpperInvariant();
+
+        if (haystack.Contains("COG", StringComparison.Ordinal) ||
+            haystack.Contains("CLOUD OPTIMIZED GEOTIFF", StringComparison.Ordinal) ||
+            haystack.Contains("CLOUD-OPTIMIZED-GEOTIFF", StringComparison.Ordinal))
+        {
+            return ("cog", MigrationInventoryHelpers.Compatible(
+                "Cloud Optimized GeoTIFF output is supported by the first coverage migration path.",
+                code: OgcCoverageMigrationCompatibilityCodes.CogSupported));
+        }
+
+        if (haystack.Contains("GEOTIFF", StringComparison.Ordinal) ||
+            haystack.Contains("GEO TIFF", StringComparison.Ordinal) ||
+            haystack.Contains("IMAGE/TIFF", StringComparison.Ordinal) ||
+            haystack.Contains("TIFF", StringComparison.Ordinal))
+        {
+            return ("geotiff", MigrationInventoryHelpers.Compatible(
+                "GeoTIFF output is supported by the first coverage migration path.",
+                code: OgcCoverageMigrationCompatibilityCodes.GeoTiffSupported));
+        }
+
+        if (haystack.Contains("NETCDF", StringComparison.Ordinal) ||
+            haystack.Contains("X-NETCDF", StringComparison.Ordinal))
+        {
+            return ("netcdf", MigrationInventoryHelpers.Incompatible(
+                "NetCDF coverage output needs a dedicated format importer before automated migration.",
+                ["NetCDF is classified separately from GeoTIFF/COG coverage outputs."],
+                ["Track NetCDF format support before automating this coverage migration."],
+                OgcCoverageMigrationCompatibilityCodes.NetCdfUnsupported));
+        }
+
+        if (haystack.Contains("HDF", StringComparison.Ordinal) ||
+            haystack.Contains("HDF5", StringComparison.Ordinal))
+        {
+            return ("hdf", MigrationInventoryHelpers.Incompatible(
+                "HDF coverage output needs a dedicated format importer before automated migration.",
+                ["HDF is classified separately from GeoTIFF/COG coverage outputs."],
+                ["Track HDF format support before automating this coverage migration."],
+                OgcCoverageMigrationCompatibilityCodes.HdfUnsupported));
+        }
+
+        if (haystack.Contains("ZARR", StringComparison.Ordinal))
+        {
+            return ("zarr", MigrationInventoryHelpers.Incompatible(
+                "Zarr coverage output needs a dedicated format importer before automated migration.",
+                ["Zarr is classified separately from GeoTIFF/COG coverage outputs."],
+                ["Track Zarr format support before automating this coverage migration."],
+                OgcCoverageMigrationCompatibilityCodes.ZarrUnsupported));
+        }
+
+        return ("unsupported", MigrationInventoryHelpers.Incompatible(
+            "Coverage output format is not recognized by the first automated coverage migration path.",
+            [$"Unsupported coverage output format: {format.Format}"],
+            ["Review the source coverage output list and decide whether a format importer or manual export is required."],
+            OgcCoverageMigrationCompatibilityCodes.UnsupportedFormat));
+    }
+
+    private async Task<MigrationSpatialReferenceInfo[]> BuildSpatialReferencesAsync(
+        IEnumerable<OgcCoverageCrsMetadata> crsValues,
+        CancellationToken cancellationToken)
+    {
+        var references = new List<MigrationSpatialReferenceInfo>();
+        foreach (var crs in crsValues
+                     .Where(static value => !string.IsNullOrWhiteSpace(value.Role) && !string.IsNullOrWhiteSpace(value.Crs))
+                     .OrderBy(static value => value.Role, StringComparer.Ordinal)
+                     .ThenBy(static value => value.Crs, StringComparer.Ordinal))
+        {
+            var reference = await MigrationInventoryHelpers.BuildSpatialReferenceAsync(
+                    _crsRegistry,
+                    crs.Role,
+                    crs.Crs,
+                    cancellationToken,
+                    explicitSrid: TryParseCoverageSrid(crs.Crs))
+                .ConfigureAwait(false);
+            if (reference == null)
+            {
+                continue;
+            }
+
+            reference = reference with
+            {
+                AxisOrder = FirstNonBlank(crs.AxisOrder, reference.AxisOrder)
+            };
+
+            if (!references.Any(existing =>
+                    string.Equals(existing.Role, reference.Role, StringComparison.Ordinal) &&
+                    string.Equals(existing.SourceValue, reference.SourceValue, StringComparison.Ordinal)))
+            {
+                references.Add(reference);
+            }
+        }
+
+        return references.ToArray();
+    }
+
+    private static MigrationInventoryAuthPosture BuildAuthPosture(
+        OgcCoverageServiceMetadata serviceMetadata,
+        IEnumerable<OgcCoverageDescription> coverages)
+    {
+        var constraints = NormalizeAccessConstraints(serviceMetadata.AccessConstraints
+            .Concat(coverages.SelectMany(static coverage => coverage.AccessConstraints)));
+        return new MigrationInventoryAuthPosture
+        {
+            Mode = constraints.Length == 0 ? "anonymous" : "access-constrained",
+            CredentialsSupplied = false,
+            AccessConfirmed = true,
+            Notes = constraints.Length == 0 ? [] : constraints
+        };
+    }
+
+    private static string[] BuildCoverageCapabilities(string serviceKind)
+        => serviceKind == "WCS"
+            ? ["wcs:GetCapabilities", "wcs:DescribeCoverage", "wcs:GetCoverage"]
+            : ["ogcapi-coverages:LandingPage", "ogcapi-coverages:Collection", "ogcapi-coverages:Coverage"];
+
+    private static string NormalizeServiceType(string serviceType)
+    {
+        var normalized = serviceType.Trim().ToUpperInvariant().Replace("_", " ", StringComparison.Ordinal);
+        normalized = SpaceRegex().Replace(normalized, " ");
+        return normalized switch
+        {
+            "WCS" or "WEB COVERAGE SERVICE" => "WCS",
+            "OGC API COVERAGES" or "OGC API - COVERAGES" or "OGCAPI COVERAGES" or "COVERAGES" => "OGC API Coverages",
+            _ => throw new InvalidOperationException("Unsupported OGC coverage service type.")
+        };
+    }
+
+    private static Uri ValidateServiceUri(string serviceUrl)
+    {
+        if (!Uri.TryCreate(serviceUrl, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new ArgumentException("OGC coverage service URL must be a valid HTTP or HTTPS URL.", nameof(serviceUrl));
+        }
+
+        if (!string.IsNullOrWhiteSpace(uri.UserInfo))
+        {
+            throw new ArgumentException("OGC coverage service URL must not include embedded credentials.", nameof(serviceUrl));
+        }
+
+        return uri;
+    }
+
+    private static string ToStableId(string value)
+    {
+        var normalized = StableIdRegex().Replace(value.Trim().ToLowerInvariant(), "-").Trim('-');
+        return string.IsNullOrWhiteSpace(normalized) ? "unnamed" : normalized;
+    }
+
+    private static string ShortHash(params string?[] values)
+    {
+        var payload = string.Join("|", values.Where(static value => !string.IsNullOrWhiteSpace(value)));
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            return "default";
+        }
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
+        return Convert.ToHexString(hash.AsSpan(0, 4)).ToLowerInvariant();
+    }
+
+    private static string[] NormalizeAccessConstraints(IEnumerable<string> values)
+        => NormalizeStrings(values)
+            .Where(static value => !IsUnconstrainedAccessValue(value))
+            .ToArray();
+
+    private static string[] NormalizeStrings(IEnumerable<string>? values)
+        => values?
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static value => value, StringComparer.Ordinal)
+            .ToArray() ?? [];
+
+    private static bool IsUnconstrainedAccessValue(string value)
+        => string.Equals(value, "none", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(value, "no constraints", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(value, "unrestricted", StringComparison.OrdinalIgnoreCase);
+
+    private static int? TryParseCoverageSrid(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var epsgMatch = EpsgSridRegex().Match(value);
+        if (epsgMatch.Success &&
+            int.TryParse(epsgMatch.Groups["srid"].Value, out var epsgSrid))
+        {
+            return epsgSrid;
+        }
+
+        return int.TryParse(value, out var srid) ? srid : null;
+    }
+
+    private static string? FirstNonBlank(params string?[] values)
+        => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value))?.Trim();
+
+    private static void AddMetadata(SortedDictionary<string, string> metadata, string key, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            metadata[key] = value.Trim();
+        }
+    }
+
+    [GeneratedRegex("[^a-z0-9]+", RegexOptions.CultureInvariant)]
+    private static partial Regex StableIdRegex();
+
+    [GeneratedRegex("\\s+", RegexOptions.CultureInvariant)]
+    private static partial Regex SpaceRegex();
+
+    [GeneratedRegex("EPSG(?::|/)(?::|0/)?(?<srid>\\d+)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex EpsgSridRegex();
+}

--- a/src/Honua.Core/Features/Import/Services/OgcCoverageMigrationInventoryScanner.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcCoverageMigrationInventoryScanner.cs
@@ -39,7 +39,9 @@ public sealed partial class OgcCoverageMigrationInventoryScanner
 
         var serviceKind = NormalizeServiceType(request.ServiceType);
         var sourceKind = serviceKind == "WCS" ? "ogc-wcs" : "ogc-api-coverages";
-        var product = serviceKind == "WCS" ? "OGC Web Coverage Service" : "OGC API Coverages";
+        var product = FirstNonBlank(
+            request.ServiceMetadata.Product,
+            serviceKind == "WCS" ? "OGC Web Coverage Service" : "OGC API Coverages")!;
         var serviceUri = ValidateServiceUri(request.ServiceUrl);
         var version = FirstNonBlank(request.Version) ?? "unknown";
         var displayName = FirstNonBlank(request.ServiceMetadata.Title, serviceUri.Host) ?? product;
@@ -236,9 +238,11 @@ public sealed partial class OgcCoverageMigrationInventoryScanner
         AddMetadata(metadata, "description", request.ServiceMetadata.Description);
         AddMetadata(metadata, "providerName", request.ServiceMetadata.ProviderName);
         AddMetadata(metadata, "fees", string.Join("; ", NormalizeStrings(request.ServiceMetadata.Fees)));
-        AddMetadata(metadata, "accessConstraints", string.Join("; ", NormalizeAccessConstraints(request.ServiceMetadata.AccessConstraints)));
+        var accessConstraints = NormalizeAccessConstraints(request.ServiceMetadata.AccessConstraints
+            .Concat(request.Coverages.SelectMany(static coverage => coverage.AccessConstraints)));
+        AddMetadata(metadata, "accessConstraints", string.Join("; ", accessConstraints));
 
-        var hasAccessConstraints = NormalizeAccessConstraints(request.ServiceMetadata.AccessConstraints).Length > 0;
+        var hasAccessConstraints = accessConstraints.Length > 0;
         return new MigrationExternalDependency
         {
             Id = "metadata:coverage-service",
@@ -250,7 +254,7 @@ public sealed partial class OgcCoverageMigrationInventoryScanner
             Compatibility = hasAccessConstraints
                 ? MigrationInventoryHelpers.Partial(
                     "Coverage service metadata advertises access constraints that must be reviewed before cutover.",
-                    request.ServiceMetadata.AccessConstraints,
+                    accessConstraints,
                     ["Confirm licensing, authentication, and redistribution constraints before automating coverage migration."],
                     OgcCoverageMigrationCompatibilityCodes.ManualReview)
                 : MigrationInventoryHelpers.Compatible(

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcCoverageMigrationInventoryScannerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcCoverageMigrationInventoryScannerTests.cs
@@ -1,0 +1,300 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Shared.Models;
+using Moq;
+
+namespace Honua.Core.Tests.Features.Import;
+
+public sealed class OgcCoverageMigrationInventoryScannerTests
+{
+    [Fact]
+    public async Task ScanAsync_WcsCoverageWithCogAndTemporalMetadata_ProducesCoverageInventory()
+    {
+        var scanner = CreateScanner();
+
+        var artifact = await scanner.ScanAsync(new OgcCoverageServiceScanRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = "https://example.com/geoserver/wcs",
+            Version = "2.0.1",
+            ServiceMetadata = new OgcCoverageServiceMetadata
+            {
+                Title = "Reference WCS",
+                Product = "GeoServer",
+                ProviderName = "Example GIS",
+                Fees = ["none"],
+                AccessConstraints = ["none"]
+            },
+            Coverages =
+            [
+                new OgcCoverageDescription
+                {
+                    CoverageId = "nurc:temperature",
+                    Title = "Temperature",
+                    CoverageType = "RectifiedGridCoverage",
+                    NativeFormat = "image/tiff",
+                    Crs =
+                    [
+                        new OgcCoverageCrsMetadata
+                        {
+                            Role = "native",
+                            Crs = "http://www.opengis.net/def/crs/EPSG/0/4326",
+                            AxisOrder = "lat,lon",
+                            AxisLabels = ["Lat", "Long"]
+                        }
+                    ],
+                    Axes =
+                    [
+                        new OgcCoverageAxisMetadata
+                        {
+                            Name = "Long",
+                            AxisType = "x",
+                            Unit = "deg",
+                            LowerBound = "-180",
+                            UpperBound = "180",
+                            Resolution = "0.1",
+                            Subsettable = true
+                        },
+                        new OgcCoverageAxisMetadata
+                        {
+                            Name = "Lat",
+                            AxisType = "y",
+                            Unit = "deg",
+                            LowerBound = "-90",
+                            UpperBound = "90",
+                            Resolution = "0.1",
+                            Subsettable = true
+                        }
+                    ],
+                    Ranges =
+                    [
+                        new OgcCoverageRangeMetadata
+                        {
+                            Name = "temperature",
+                            Label = "Air temperature",
+                            DataType = "Float32",
+                            Unit = "K",
+                            NoDataValue = "-9999",
+                            Interpretation = "temperature",
+                            MinimumValue = "200",
+                            MaximumValue = "330"
+                        }
+                    ],
+                    OutputFormats =
+                    [
+                        new OgcCoverageFormatMetadata
+                        {
+                            Format = "image/tiff",
+                            MediaType = "image/tiff; application=geotiff",
+                            Profile = "cloud-optimized-geotiff",
+                            IsNative = true
+                        }
+                    ],
+                    TemporalDimensions =
+                    [
+                        new OgcCoverageTemporalDimensionMetadata
+                        {
+                            Name = "time",
+                            Start = "2020-01-01T00:00:00Z",
+                            End = "2020-01-03T00:00:00Z",
+                            DefaultValue = "2020-01-01T00:00:00Z",
+                            Interval = "P1D",
+                            Subsettable = true
+                        }
+                    ]
+                }
+            ]
+        });
+
+        artifact.SourceKind.Should().Be("ogc-wcs");
+        artifact.Source.ServiceType.Should().Be("WCS");
+        artifact.Source.Version.Should().Be("2.0.1");
+        artifact.AuthPosture.Mode.Should().Be("anonymous");
+        artifact.ScanCompleteness.Status.Should().Be("complete");
+        artifact.Resources.Should().ContainSingle();
+        var resource = artifact.Resources.Single();
+        resource.Kind.Should().Be("coverage");
+        resource.Capabilities.Should().Contain(["wcs:DescribeCoverage", "wcs:GetCoverage"]);
+        resource.SpatialReferences.Should().ContainSingle().Which.Should().Match<MigrationSpatialReferenceInfo>(reference =>
+            reference.Role == "native" &&
+            reference.Srid == 4326 &&
+            reference.AxisOrder == "lat,lon");
+        resource.Fields.Should().ContainSingle(field =>
+            field.Name == "temperature" &&
+            field.FieldType == "Float32" &&
+            field.DomainName == "K");
+        resource.Compatibility.Level.Should().Be("partial");
+        resource.Compatibility.Code.Should().Be(OgcCoverageMigrationCompatibilityCodes.CogSupported);
+        artifact.ExternalDependencies.Should().Contain(dependency =>
+            dependency.Kind == "coverage-output-format" &&
+            dependency.DependencyType == "cog" &&
+            dependency.Compatibility.Code == OgcCoverageMigrationCompatibilityCodes.CogSupported);
+        artifact.ExternalDependencies.Should().Contain(dependency =>
+            dependency.Kind == "coverage-axis" &&
+            dependency.Name == "Lat" &&
+            dependency.Metadata["subsettable"] == "true");
+        artifact.ExternalDependencies.Should().Contain(dependency =>
+            dependency.Kind == "coverage-range" &&
+            dependency.Name == "temperature" &&
+            dependency.Metadata["noDataValue"] == "-9999");
+        artifact.ExternalDependencies.Should().Contain(dependency =>
+            dependency.Kind == "coverage-temporal-dimension" &&
+            dependency.Name == "time" &&
+            dependency.Metadata["interval"] == "P1D");
+    }
+
+    [Fact]
+    public async Task ScanAsync_OgcApiCoveragesScientificFormats_ClassifiesUnsupportedFormatsSeparately()
+    {
+        var scanner = CreateScanner();
+
+        var artifact = await scanner.ScanAsync(new OgcCoverageServiceScanRequest
+        {
+            ServiceType = "OGC API Coverages",
+            ServiceUrl = "https://coverages.example.com/collections",
+            ServiceMetadata = new OgcCoverageServiceMetadata
+            {
+                Title = "Scientific coverages",
+                AccessConstraints = ["license review required"]
+            },
+            Coverages =
+            [
+                new OgcCoverageDescription
+                {
+                    CoverageId = "ocean-forecast",
+                    CoverageType = "Coverage",
+                    Crs =
+                    [
+                        new OgcCoverageCrsMetadata
+                        {
+                            Role = "native",
+                            Crs = "EPSG:4326"
+                        }
+                    ],
+                    Axes =
+                    [
+                        new OgcCoverageAxisMetadata
+                        {
+                            Name = "time",
+                            AxisType = "time",
+                            LowerBound = "2026-01-01T00:00:00Z",
+                            UpperBound = "2026-01-02T00:00:00Z",
+                            Subsettable = true
+                        }
+                    ],
+                    Ranges =
+                    [
+                        new OgcCoverageRangeMetadata
+                        {
+                            Name = "salinity",
+                            DataType = "Float32",
+                            Unit = "PSU"
+                        }
+                    ],
+                    OutputFormats =
+                    [
+                        new OgcCoverageFormatMetadata
+                        {
+                            Format = "application/x-netcdf"
+                        },
+                        new OgcCoverageFormatMetadata
+                        {
+                            Format = "application/x-hdf5"
+                        },
+                        new OgcCoverageFormatMetadata
+                        {
+                            Format = "application/vnd+zarr"
+                        }
+                    ]
+                }
+            ]
+        });
+
+        artifact.SourceKind.Should().Be("ogc-api-coverages");
+        artifact.AuthPosture.Mode.Should().Be("access-constrained");
+        artifact.AuthPosture.Notes.Should().ContainSingle().Which.Should().Be("license review required");
+        var resource = artifact.Resources.Should().ContainSingle().Subject;
+        resource.Compatibility.Level.Should().Be("incompatible");
+        resource.Compatibility.Code.Should().Be(OgcCoverageMigrationCompatibilityCodes.ScientificFormatUnsupported);
+        artifact.ExternalDependencies.Where(static dependency => dependency.Kind == "coverage-output-format")
+            .Select(static dependency => dependency.Compatibility.Code)
+            .Should()
+            .BeEquivalentTo(
+                [
+                    OgcCoverageMigrationCompatibilityCodes.NetCdfUnsupported,
+                    OgcCoverageMigrationCompatibilityCodes.HdfUnsupported,
+                    OgcCoverageMigrationCompatibilityCodes.ZarrUnsupported
+                ]);
+    }
+
+    [Fact]
+    public async Task ScanAsync_MissingOutputFormats_EmitsManualReviewCompletenessSignal()
+    {
+        var scanner = CreateScanner();
+
+        var artifact = await scanner.ScanAsync(new OgcCoverageServiceScanRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = "https://example.com/wcs",
+            Coverages =
+            [
+                new OgcCoverageDescription
+                {
+                    CoverageId = "dem"
+                }
+            ]
+        });
+
+        artifact.ScanCompleteness.Status.Should().Be("partial");
+        artifact.ScanCompleteness.MissingArtifacts.Should().ContainSingle().Which.Should().Be("output-format:dem");
+        artifact.Resources.Should().ContainSingle().Which.Compatibility.Should().Match<MigrationCompatibilityAssessment>(compatibility =>
+            compatibility.Level == "partial" &&
+            compatibility.Code == OgcCoverageMigrationCompatibilityCodes.OutputFormatMissing);
+    }
+
+    [Fact]
+    public async Task ScanAsync_ReordersCoverageInventoryDeterministically()
+    {
+        var scanner = CreateScanner();
+
+        var artifact = await scanner.ScanAsync(new OgcCoverageServiceScanRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = "https://example.com/wcs",
+            Coverages =
+            [
+                BuildGeoTiffCoverage("z-last"),
+                BuildGeoTiffCoverage("a-first")
+            ]
+        });
+
+        artifact.Resources.Select(static resource => resource.Name).Should().Equal("a-first", "z-last");
+        artifact.ExternalDependencies.Select(static dependency => dependency.Id).Should().BeInAscendingOrder(StringComparer.Ordinal);
+    }
+
+    private static OgcCoverageDescription BuildGeoTiffCoverage(string coverageId)
+        => new()
+        {
+            CoverageId = coverageId,
+            OutputFormats =
+            [
+                new OgcCoverageFormatMetadata
+                {
+                    Format = "GeoTIFF"
+                }
+            ]
+        };
+
+    private static OgcCoverageMigrationInventoryScanner CreateScanner()
+    {
+        var registry = new Mock<ICrsRegistry>(MockBehavior.Strict);
+        registry.Setup(item => item.ResolveBySridAsync(4326, It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<CrsDefinition?>((CrsDefinition?)null));
+        return new OgcCoverageMigrationInventoryScanner(registry.Object);
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcCoverageMigrationInventoryScannerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcCoverageMigrationInventoryScannerTests.cs
@@ -113,6 +113,7 @@ public sealed class OgcCoverageMigrationInventoryScannerTests
 
         artifact.SourceKind.Should().Be("ogc-wcs");
         artifact.Source.ServiceType.Should().Be("WCS");
+        artifact.Source.Product.Should().Be("GeoServer");
         artifact.Source.Version.Should().Be("2.0.1");
         artifact.AuthPosture.Mode.Should().Be("anonymous");
         artifact.ScanCompleteness.Status.Should().Be("complete");
@@ -230,6 +231,42 @@ public sealed class OgcCoverageMigrationInventoryScannerTests
                     OgcCoverageMigrationCompatibilityCodes.HdfUnsupported,
                     OgcCoverageMigrationCompatibilityCodes.ZarrUnsupported
                 ]);
+    }
+
+    [Fact]
+    public async Task ScanAsync_CoverageLevelAccessConstraints_MarkServiceMetadataForManualReview()
+    {
+        var scanner = CreateScanner();
+
+        var artifact = await scanner.ScanAsync(new OgcCoverageServiceScanRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = "https://example.com/wcs",
+            ServiceMetadata = new OgcCoverageServiceMetadata
+            {
+                Title = "Reference WCS",
+                AccessConstraints = ["none"]
+            },
+            Coverages =
+            [
+                BuildGeoTiffCoverage("restricted") with
+                {
+                    AccessConstraints = ["internal use only"]
+                }
+            ]
+        });
+
+        artifact.AuthPosture.Mode.Should().Be("access-constrained");
+        artifact.AuthPosture.Notes.Should().ContainSingle().Which.Should().Be("internal use only");
+
+        var serviceMetadata = artifact.ExternalDependencies.Should()
+            .ContainSingle(dependency => dependency.Id == "metadata:coverage-service")
+            .Subject;
+        serviceMetadata.Metadata["accessConstraints"].Should().Be("internal use only");
+        serviceMetadata.Compatibility.Should().Match<MigrationCompatibilityAssessment>(compatibility =>
+            compatibility.Level == "partial" &&
+            compatibility.Code == OgcCoverageMigrationCompatibilityCodes.ManualReview &&
+            compatibility.Warnings.Contains("internal use only"));
     }
 
     [Fact]


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1030

## Summary
Adds a Core-only first slice for OGC coverage service migration planning. The scanner turns structured WCS and OGC API Coverages metadata into the shared `MigrationSourceInventoryArtifact` shape, with explicit classification for GeoTIFF/COG candidates, scientific formats, CRS/subset metadata, bands/ranges, and temporal review.

## Changes Made
- Added OGC coverage service scan request/domain models and stable compatibility codes.
- Added a deterministic coverage inventory scanner for WCS and OGC API Coverages sources.
- Classified GeoTIFF and COG as first-slice automated candidates while keeping NetCDF, HDF, Zarr, temporal dimensions, unknown formats, and access constraints explicit for review.
- Added focused Core unit tests for COG metadata, scientific-format classification, missing output formats, and deterministic ordering.
- Added operator documentation for the coverage planning scope and linked it from the migration toolkit.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation run locally:
- `dotnet format Honua.sln --include src/Honua.Core/Features/Import/Domain/OgcCoverageMigrationCompatibilityCodes.cs src/Honua.Core/Features/Import/Domain/OgcCoverageServiceScanRequest.cs src/Honua.Core/Features/Import/Services/OgcCoverageMigrationInventoryScanner.cs tests/dotnet/Honua.Core.Tests/Features/Import/OgcCoverageMigrationInventoryScannerTests.cs --no-restore --verbosity minimal`
- `dotnet build src/Honua.Core/Honua.Core.csproj --no-restore -m:1 /p:BuildInParallel=false /p:UseSharedCompilation=false /nr:false`
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --no-restore --filter FullyQualifiedName~OgcCoverageMigrationInventoryScannerTests -m:1 /p:BuildInParallel=false /p:UseSharedCompilation=false /nr:false --logger "console;verbosity=minimal"`
- `git diff --check origin/trunk...HEAD`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] `scripts/ci/pre-pr-check.sh` full end-to-end run not performed locally; focused local gates above passed and PR CI is running the relevant gate set.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: marked not applicable
- [x] If breaking admin/control-plane API changes: marked not applicable
- [x] If breaking gRPC/proto wire changes: marked not applicable

Scope note: this is inventory/planning only. It does not complete issue #1030 because full import execution, fixture integration, target publication, and parity evidence remain follow-up work.
