### PR TITLE
feat: stage QGIS plugin first slice (#808)

### DIFF
--- a/.github/workflows/qgis-plugin-build.yml
+++ b/.github/workflows/qgis-plugin-build.yml
@@ -1,0 +1,88 @@
+name: QGIS Plugin Build
+
+# Builds and tests the staged Honua QGIS plugin (clients/qgis/) on every
+# PR or push that touches it, and uploads the packaged zip as a workflow
+# artifact so testers can download and install it via QGIS Plugin Manager
+# without waiting for plugins.qgis.org moderation.
+#
+# The plugin moves to its own repository (honua-qgis) once that exists;
+# this workflow then moves with it. Until then, this is the canonical
+# build for the plugin.
+
+on:
+  pull_request:
+    paths:
+      - 'clients/qgis/**'
+      - '.github/workflows/qgis-plugin-build.yml'
+  push:
+    branches:
+      - trunk
+    paths:
+      - 'clients/qgis/**'
+      - '.github/workflows/qgis-plugin-build.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: qgis-plugin-build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Test and package plugin
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: clients/qgis
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: ./.github/actions/setup-python-ci
+        with:
+          python-version: '3.11'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run unit tests
+        run: python -m pytest tests -q --ignore=tests/test_e2e.py
+
+      - name: Build plugin zip
+        run: make zip
+
+      - name: Verify plugin zip layout
+        run: |
+          test -f dist/honua_qgis.zip
+          python - <<'PY'
+          import sys, zipfile
+          with zipfile.ZipFile("dist/honua_qgis.zip") as zf:
+              names = set(zf.namelist())
+          required = {
+              "honua_qgis/metadata.txt",
+              "honua_qgis/__init__.py",
+              "honua_qgis/plugin.py",
+              "honua_qgis/dialog_add_server.py",
+              "honua_qgis/layer_browser.py",
+              "honua_qgis/client.py",
+              "honua_qgis/auth.py",
+              "honua_qgis/layers.py",
+          }
+          missing = required - names
+          if missing:
+              print("missing files in zip:", sorted(missing), file=sys.stderr)
+              sys.exit(1)
+          print(f"plugin zip OK ({len(names)} files)")
+          PY
+
+      - name: Upload plugin zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: honua_qgis-zip
+          path: clients/qgis/dist/honua_qgis.zip
+          if-no-files-found: error
+          retention-days: 30

--- a/clients/README.md
+++ b/clients/README.md
@@ -1,0 +1,17 @@
+# clients/
+
+Source for client-side projects that consume Honua server APIs and that
+are intended to live in their own repositories long-term but are staged
+here while their dedicated repo is being bootstrapped.
+
+| Subdirectory | Future repo | Status |
+| --- | --- | --- |
+| [`qgis/`](./qgis) | `honua-io/honua-qgis` | First slice in progress (#808) |
+
+When a project's home repo is created, the corresponding subdirectory
+moves there in a single commit; nothing in `src/` or `docs/` references
+these directories so the move is mechanical.
+
+For first-class SDKs that already have their own repository (e.g.
+`honua-sdk-dotnet`, `honua-sdk-js`, `honua-sdk-python`, `honua-mobile`),
+see the related-repos list in `AGENTS.md`.

--- a/clients/qgis/.gitignore
+++ b/clients/qgis/.gitignore
@@ -1,0 +1,6 @@
+dist/
+*.pyc
+__pycache__/
+.pytest_cache/
+.ruff_cache/
+*.qm

--- a/clients/qgis/Makefile
+++ b/clients/qgis/Makefile
@@ -1,0 +1,34 @@
+PLUGIN_NAME := honua_qgis
+DIST_DIR := dist
+ZIP_PATH := $(DIST_DIR)/$(PLUGIN_NAME).zip
+
+PYTHON ?= python3
+PYTEST ?= $(PYTHON) -m pytest
+RUFF ?= ruff
+
+.PHONY: zip test lint e2e clean help
+
+help:
+	@echo "Targets:"
+	@echo "  make zip   - build $(ZIP_PATH) for QGIS Plugin Manager / registry submission"
+	@echo "  make test  - run unit tests (pure Python, no QGIS required)"
+	@echo "  make lint  - run ruff over the plugin sources"
+	@echo "  make e2e   - run docker-compose end-to-end test (requires Docker)"
+	@echo "  make clean - remove dist/ artifacts"
+
+zip:
+	@mkdir -p $(DIST_DIR)
+	$(PYTHON) scripts/build_zip.py --out $(ZIP_PATH)
+
+test:
+	$(PYTEST) -q tests
+
+lint:
+	$(RUFF) check $(PLUGIN_NAME) tests
+
+e2e:
+	docker compose -f docker/docker-compose.yml up --build --abort-on-container-exit --exit-code-from qgis-test
+
+clean:
+	rm -rf $(DIST_DIR)
+	find . -type d -name __pycache__ -prune -exec rm -rf {} +

--- a/clients/qgis/README.md
+++ b/clients/qgis/README.md
@@ -1,0 +1,155 @@
+# Honua QGIS Plugin (staging)
+
+This directory stages the source for the **Honua QGIS plugin** until the
+dedicated `honua-qgis` repository is bootstrapped under the `honua-io`
+GitHub org. Once that repo exists, the entire `clients/qgis/` tree is
+intended to move there verbatim — no honua-server code references it, so
+the move is a clean `git mv`.
+
+The plugin lets a QGIS analyst connect to a Honua server with a URL plus
+an API key and browse OGC API Features collections and WMS layers from a
+dock panel; double-clicking a layer adds it to the project canvas.
+
+## First-slice scope
+
+For issue #808, the first shipped slice covers the two paths that reuse
+QGIS's built-in providers end-to-end:
+
+| Layer type | Discovery endpoint | QGIS provider |
+| --- | --- | --- |
+| Vector | `GET /ogc/features/collections` | `WFS` provider in OGC API Features mode |
+| Raster | `GET /ogc/services/{serviceId}/wms?SERVICE=WMS&REQUEST=GetCapabilities` | `wms` provider |
+
+OGC API Tiles, WMTS, FeatureServer transactional, OIDC, and styled-layer
+import are deferred to follow-on slices listed at the bottom of this
+file.
+
+## Layout
+
+```
+clients/qgis/
+  honua_qgis/
+    metadata.txt            # QGIS Plugin Manager registry fields
+    __init__.py             # classFactory(iface)
+    plugin.py               # HonuaPlugin -- toolbar + menu wiring
+    dialog_add_server.py    # QDialog -- URL + API key + Test connection
+    layer_browser.py        # QDockWidget -- vector/raster tree
+    client.py               # stdlib-only HTTP + parser layer
+    auth.py                 # HonuaConnection model, no PyQt deps
+    layers.py               # QGIS provider URI builders (pure strings)
+    resources/icon.svg
+    i18n/honua_en.ts
+  scripts/build_zip.py      # `make zip` worker
+  tests/
+    conftest.py
+    test_auth.py
+    test_client.py
+    test_layers.py
+    test_add_server.py
+    test_layer_browser.py
+    test_e2e.py             # docker-compose smoke
+  docker/docker-compose.yml
+  Makefile
+  README.md  (this file)
+```
+
+## Local workflow
+
+```bash
+cd clients/qgis
+make zip       # writes dist/honua_qgis.zip
+make test      # runs unit tests (no QGIS required)
+make lint      # ruff (optional, requires ruff installed)
+make e2e       # docker-compose smoke (requires Docker + ghcr image access)
+```
+
+### Installing the local zip into QGIS
+
+1. `make zip`
+2. In QGIS: *Plugins → Manage and Install Plugins → Install from ZIP*
+3. Pick `dist/honua_qgis.zip`
+4. Enable the *Honua* plugin
+5. Use *Web → Honua → Add Honua Server…* and *Web → Honua → Show Layer
+   Browser*
+
+### Running unit tests
+
+The unit tests have no PyQGIS dependency; they exercise the pure Python
+helpers (HTTP client, URI builders, validators, view-model). They run
+on any Python ≥ 3.8 with `pytest` installed.
+
+### Running the end-to-end test
+
+```bash
+make zip
+make e2e
+```
+
+This:
+
+1. Pulls / starts a `ghcr.io/honua-io/honua-server:ci` container with
+   `HONUA_API_KEY=testkey`.
+2. Starts a `qgis/qgis:ltr` container, installs the freshly built zip
+   into the in-container QGIS profile, and runs `tests/test_e2e.py`.
+3. Asserts the OGC API Features ping succeeds and that the first
+   discovered collection becomes a valid `QgsVectorLayer`.
+
+Override the server image with `HONUA_IMAGE=…` if you need a specific
+build.
+
+## QGIS plugin registry submission
+
+The first published version is `0.1.0` (see `metadata.txt`). The
+`experimental=True` flag is on so testers can opt in via *Settings →
+Show experimental plugins*; flip to `False` for a stable promotion.
+
+To submit:
+
+1. `make zip`
+2. Log in to <https://plugins.qgis.org/> with the `honua-io` org account
+   (provision it before submission if it does not already exist).
+3. Use the *Upload a plugin* form, attach `dist/honua_qgis.zip`, paste
+   the `metadata.txt` `changelog=` line into the release notes field,
+   and submit for moderation.
+4. Track the moderation ticket; address review comments by bumping the
+   version in `metadata.txt`, re-running `make zip`, and re-uploading.
+
+In parallel, attach the same zip to the corresponding GitHub release on
+`honua-server` (and later `honua-qgis`) so testers without registry
+access can install it manually.
+
+### Continuous distribution
+
+The `qgis-plugin-build` workflow (`.github/workflows/qgis-plugin-build.yml`)
+runs on every PR and `trunk` push that touches `clients/qgis/**`,
+executes the unit tests, packages the plugin, and uploads
+`honua_qgis-zip` as a workflow artifact. Testers can grab the latest
+build from the workflow run page without waiting on plugins.qgis.org
+moderation. This also gives testers a direct GitHub-hosted zip while the
+registry submission is under review.
+
+## Architecture notes
+
+- **No external Python deps.** `client.py` uses `urllib.request` only.
+  This is a hard constraint: QGIS bundles its own Python and pip-
+  installed packages are fragile across platforms.
+- **PyQt5, not PyQt6.** Target QGIS 3.22 LTR (Python 3.9+). Qt-touching
+  modules guard their imports so unit tests run on a vanilla
+  interpreter.
+- **CRS resolution.** `client._extract_storage_crs` parses the OGC
+  `storageCrs` URN form (`http://www.opengis.net/def/crs/EPSG/0/4326`)
+  and falls back to `EPSG:4326`. WMS layer CRS is taken from the
+  capabilities `<CRS>` element.
+- **API key transport.** Sent as `X-API-Key` for every plugin HTTP call.
+  The provider URIs additionally embed `?apikey=…` because QGIS's
+  built-in WFS/WMS providers do not honour custom application-level
+  request headers; the Honua server accepts both forms.
+
+## Follow-on tickets (open in honua-qgis once bootstrapped)
+
+| ID | Title |
+| --- | --- |
+| qgis-2 | OGC API Tiles / WMTS data provider |
+| qgis-3 | FeatureServer transactional provider (WFS-T edits) |
+| qgis-4 | OIDC / OAuth2 auth flow + `QgsAuthManager` integration |
+| qgis-5 | Layer style import (MapLibre Style → QGIS QML) |

--- a/clients/qgis/docker/docker-compose.yml
+++ b/clients/qgis/docker/docker-compose.yml
@@ -1,0 +1,50 @@
+# End-to-end test: spin up a reference Honua server, install the plugin
+# zip into a headless ``qgis/qgis:ltr`` image, and run pytest against it.
+#
+# Usage (from the clients/qgis/ directory):
+#
+#   make zip
+#   make e2e
+#
+# The honua-server image tag below tracks the CI image published from
+# trunk. Override with ``HONUA_IMAGE=...`` if you need a specific build.
+
+services:
+  honua-server:
+    image: ${HONUA_IMAGE:-ghcr.io/honua-io/honua-server:ci}
+    environment:
+      HONUA_ADMIN_PASSWORD: testkey
+      HONUA_API_KEY: testkey
+      ASPNETCORE_URLS: "http://+:8080"
+    ports:
+      - "8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-s", "-o", "/dev/null", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  qgis-test:
+    image: qgis/qgis:ltr
+    depends_on:
+      honua-server:
+        condition: service_healthy
+    environment:
+      HONUA_BASE_URL: "http://honua-server:8080"
+      HONUA_API_KEY: "testkey"
+      QT_QPA_PLATFORM: "offscreen"
+    working_dir: /plugin
+    volumes:
+      - ../:/plugin:ro
+      - ../dist:/dist:ro
+    entrypoint: ["bash", "-lc"]
+    command:
+      - |
+        set -eux
+        # install the packaged zip into the in-container QGIS profile
+        PROFILE_DIR="/root/.local/share/QGIS/QGIS3/profiles/default/python/plugins"
+        mkdir -p "$$PROFILE_DIR"
+        rm -rf "$$PROFILE_DIR/honua_qgis"
+        unzip -q /dist/honua_qgis.zip -d "$$PROFILE_DIR"
+        # run the e2e suite via QGIS's bundled Python so PyQGIS is importable
+        python3 -m pytest /plugin/tests/test_e2e.py -v --tb=short

--- a/clients/qgis/honua_qgis/__init__.py
+++ b/clients/qgis/honua_qgis/__init__.py
@@ -1,0 +1,13 @@
+"""Honua QGIS plugin entry point.
+
+QGIS calls ``classFactory(iface)`` when the plugin is loaded; it must return
+an object exposing ``initGui()`` and ``unload()``.
+"""
+
+from __future__ import annotations
+
+
+def classFactory(iface):  # noqa: N802 - QGIS API contract
+    from .plugin import HonuaPlugin
+
+    return HonuaPlugin(iface)

--- a/clients/qgis/honua_qgis/auth.py
+++ b/clients/qgis/honua_qgis/auth.py
@@ -1,0 +1,128 @@
+"""Connection + auth model for the Honua plugin.
+
+A ``HonuaConnection`` is a single user-saved server entry: name, base URL,
+API key. The plugin saves connections through ``QSettings`` (no QGIS
+``QgsAuthManager`` dependency in the first slice — that integration is
+tracked under qgis-4 once API-key-only ships).
+
+The model deliberately has no PyQt5/PyQGIS imports so the dialog logic and
+discovery flow can be unit-tested without QGIS.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+from urllib.parse import urlparse
+
+
+SETTINGS_GROUP = "honua/connections"
+"""``QSettings`` group key. Each connection is stored under
+``honua/connections/<name>/<field>``."""
+
+
+@dataclass(frozen=True)
+class HonuaConnection:
+    """Saved connection to a single Honua server.
+
+    ``name`` is the user-facing label and the ``QSettings`` sub-key.
+    ``base_url`` is the Honua server root (e.g. ``https://my.honua.io``)
+    without a trailing slash. ``api_key`` is sent as ``X-API-Key`` and may
+    be empty for anonymous endpoints.
+    """
+
+    name: str
+    base_url: str
+    api_key: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.name.strip():
+            raise ValueError("connection name is required")
+        if not self.base_url:
+            raise ValueError("base URL is required")
+        parsed = urlparse(self.base_url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError("base URL must be http(s)")
+        if not parsed.netloc:
+            raise ValueError("base URL must include a host")
+
+    @property
+    def normalized_base_url(self) -> str:
+        """Base URL with any trailing slashes stripped."""
+        return self.base_url.rstrip("/")
+
+    def request_headers(self) -> dict[str, str]:
+        """Headers that every plugin HTTP call must carry."""
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "honua-qgis/0.1",
+        }
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+        return headers
+
+
+def encode_api_key_query(api_key: str) -> str:
+    """Return a ``&apikey=…`` fragment for embedding in QGIS provider URIs.
+
+    QGIS's built-in WFS/WMS providers do not currently honour custom
+    request headers set on the application-wide
+    ``QgsNetworkAccessManager``. The fallback documented in the design is
+    to embed the API key in the provider URI as a query parameter; the
+    Honua server accepts ``apikey`` as a query alias for ``X-API-Key``.
+    """
+    if not api_key:
+        return ""
+    from urllib.parse import quote
+
+    return f"apikey={quote(api_key, safe='')}"
+
+
+def filter_unique_connection_names(names: Iterable[str]) -> list[str]:
+    """Return ``names`` deduplicated and stripped, preserving order.
+
+    Used by the dialog to keep the saved-connection dropdown stable when
+    the underlying ``QSettings`` group has duplicate entries from older
+    plugin versions.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for raw in names:
+        candidate = (raw or "").strip()
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        result.append(candidate)
+    return result
+
+
+@dataclass
+class CollectionEntry:
+    """One vector collection discovered via OGC API Features."""
+
+    collection_id: str
+    title: str
+    bbox: tuple[float, float, float, float] | None = None
+    crs: str = "EPSG:4326"
+
+
+@dataclass
+class WmsLayerEntry:
+    """One raster layer discovered via WMS GetCapabilities."""
+
+    service_id: str
+    layer_name: str
+    title: str
+    crs: str = "EPSG:4326"
+
+
+@dataclass
+class DiscoveryResult:
+    """All discoverable layers for a connected server."""
+
+    collections: list[CollectionEntry] = field(default_factory=list)
+    wms_layers: list[WmsLayerEntry] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.collections) + len(self.wms_layers)

--- a/clients/qgis/honua_qgis/client.py
+++ b/clients/qgis/honua_qgis/client.py
@@ -1,0 +1,310 @@
+"""Stdlib-only HTTP client used by the Honua QGIS plugin.
+
+PyQGIS bundles its own Python and pip-installed packages are fragile
+across platforms, so this client must depend on ``urllib`` only — no
+``requests`` or ``httpx``. All requests carry an ``X-API-Key`` header
+when a key is configured on the connection.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import ssl
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from .auth import (
+    CollectionEntry,
+    DiscoveryResult,
+    HonuaConnection,
+    WmsLayerEntry,
+)
+
+
+DEFAULT_TIMEOUT = 15.0
+"""Per-request timeout in seconds. Plugin UI is blocking so this caps the
+worst case the user can wait before the dialog returns."""
+
+
+class HonuaClientError(Exception):
+    """Raised for any Honua HTTP/parse failure surfaced to the UI."""
+
+
+@dataclass
+class HttpResponse:
+    status: int
+    body: bytes
+    content_type: str
+
+
+class HonuaClient:
+    """Minimal client for OGC API Features + WMS discovery on a Honua
+    server.
+
+    The class stays thin on purpose: every method is one HTTP round-trip
+    plus one parse step, so failures map to a single user-facing error
+    without retry magic. The plugin owns retry/backoff at the dialog
+    level if it ever needs to.
+    """
+
+    def __init__(
+        self,
+        connection: HonuaConnection,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+        opener=None,
+    ) -> None:
+        self.connection = connection
+        self.timeout = timeout
+        self._opener = opener  # tests may inject a fake urlopen
+
+    # ----- transport ----------------------------------------------------
+
+    def _get(self, path: str, query: dict[str, str] | None = None) -> HttpResponse:
+        url = f"{self.connection.normalized_base_url}{path}"
+        if query:
+            url = f"{url}?{urlencode(query)}"
+        request = Request(url, headers=self.connection.request_headers())
+        opener = self._opener or urlopen
+
+        try:
+            response = self._invoke_opener(opener, request)
+        except HTTPError as exc:
+            raise HonuaClientError(
+                f"Honua server returned HTTP {exc.code} for {url}"
+            ) from exc
+        except (URLError, socket.timeout, ConnectionError) as exc:
+            raise HonuaClientError(
+                f"could not reach Honua server at {url}: {exc}"
+            ) from exc
+
+        try:
+            with response:
+                body = response.read()
+                status = getattr(response, "status", 200)
+                content_type = response.headers.get("Content-Type", "") if hasattr(response, "headers") else ""
+        except Exception as exc:  # pragma: no cover - defensive
+            raise HonuaClientError(f"failed reading response from {url}: {exc}") from exc
+
+        return HttpResponse(status=status, body=body, content_type=content_type)
+
+    def _invoke_opener(self, opener, request):
+        """Call ``opener`` once. Real ``urlopen`` accepts a TLS ``context``;
+        the test fake does not, so we transparently retry without it on
+        ``TypeError`` so production HTTPS keeps strict cert validation
+        while tests stay simple."""
+        try:
+            ctx = ssl.create_default_context()
+            return opener(request, timeout=self.timeout, context=ctx)
+        except TypeError:
+            return opener(request, timeout=self.timeout)
+
+    # ----- discovery ----------------------------------------------------
+
+    def ping(self) -> None:
+        """Hit the OGC API Features landing page; raise on any failure.
+
+        Used by the Add Server dialog's "Test connection" button. A 200
+        with parseable JSON proves both connectivity and a valid API key.
+        """
+        response = self._get("/ogc/features")
+        if response.status >= 400:
+            raise HonuaClientError(f"unexpected status {response.status}")
+        try:
+            json.loads(response.body)
+        except (ValueError, json.JSONDecodeError) as exc:
+            raise HonuaClientError(
+                "Honua server responded but returned non-JSON content; "
+                "is this a Honua endpoint?"
+            ) from exc
+
+    def list_collections(self) -> list[CollectionEntry]:
+        """Return all OGC API Features collections on the server."""
+        response = self._get("/ogc/features/collections")
+        try:
+            payload = json.loads(response.body)
+        except (ValueError, json.JSONDecodeError) as exc:
+            raise HonuaClientError("malformed collections response") from exc
+
+        items = payload.get("collections")
+        if not isinstance(items, list):
+            return []
+
+        out: list[CollectionEntry] = []
+        for raw in items:
+            if not isinstance(raw, dict):
+                continue
+            collection_id = str(raw.get("id") or raw.get("name") or "").strip()
+            if not collection_id:
+                continue
+            title = str(raw.get("title") or collection_id)
+            bbox = _extract_bbox(raw.get("extent"))
+            crs = _extract_storage_crs(raw)
+            out.append(
+                CollectionEntry(
+                    collection_id=collection_id,
+                    title=title,
+                    bbox=bbox,
+                    crs=crs,
+                )
+            )
+        return out
+
+    def list_services(self) -> list[str]:
+        """Return GeoServices REST service ids that have a WMS sub-endpoint.
+
+        We scan ``/rest/services`` first, but the layout varies; many
+        Honua deployments only have a handful of named services. Anything
+        the server exposes as ``services[].name`` is candidate; we then
+        confirm WMS support by probing a HEAD-equivalent GET.
+        """
+        try:
+            response = self._get("/rest/services", query={"f": "json"})
+        except HonuaClientError:
+            return []
+        try:
+            payload = json.loads(response.body)
+        except (ValueError, json.JSONDecodeError):
+            return []
+
+        services = payload.get("services")
+        if not isinstance(services, list):
+            return []
+
+        ids: list[str] = []
+        seen: set[str] = set()
+        for entry in services:
+            if not isinstance(entry, dict):
+                continue
+            name = str(entry.get("name") or "").strip()
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            ids.append(name)
+        return ids
+
+    def list_wms_layers(self, service_id: str) -> list[WmsLayerEntry]:
+        """Probe a service's WMS endpoint and parse the capabilities doc.
+
+        Missing-WMS is not an error — it just yields an empty list so the
+        layer browser can render a "no WMS" hint without aborting whole
+        discovery.
+        """
+        try:
+            response = self._get(
+                f"/ogc/services/{service_id}/wms",
+                query={"SERVICE": "WMS", "REQUEST": "GetCapabilities", "VERSION": "1.3.0"},
+            )
+        except HonuaClientError:
+            return []
+
+        if not response.body:
+            return []
+
+        try:
+            return parse_wms_capabilities(service_id, response.body)
+        except ET.ParseError:
+            return []
+
+    def discover(self) -> DiscoveryResult:
+        """Run the full discovery flow: collections + every service's WMS."""
+        result = DiscoveryResult()
+        result.collections = self.list_collections()
+        for service_id in self.list_services():
+            result.wms_layers.extend(self.list_wms_layers(service_id))
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Pure parsing helpers (kept module-level for unit testing)
+# ---------------------------------------------------------------------------
+
+
+def _extract_bbox(extent: Any) -> tuple[float, float, float, float] | None:
+    """Pull ``[minx, miny, maxx, maxy]`` out of an OGC API Features extent."""
+    if not isinstance(extent, dict):
+        return None
+    spatial = extent.get("spatial")
+    if not isinstance(spatial, dict):
+        return None
+    bboxes = spatial.get("bbox")
+    if not isinstance(bboxes, list) or not bboxes:
+        return None
+    candidate = bboxes[0]
+    if not isinstance(candidate, list) or len(candidate) < 4:
+        return None
+    try:
+        minx, miny, maxx, maxy = (float(v) for v in candidate[:4])
+    except (TypeError, ValueError):
+        return None
+    return (minx, miny, maxx, maxy)
+
+
+def _extract_storage_crs(collection: dict[str, Any]) -> str:
+    """Resolve a CRS auth-id from an OGC API Features collection record.
+
+    Honua servers expose ``storageCrs`` as a URN (e.g.
+    ``http://www.opengis.net/def/crs/EPSG/0/4326``). QGIS expects an
+    ``EPSG:NNNN`` form for provider URIs, so we coerce the URN tail to
+    ``EPSG:NNNN`` and fall back to ``EPSG:4326`` if the value is missing
+    or unparseable. Honua collections that are stored in a non-WGS84 CRS
+    will be rejected if we silently default — the user-visible layer
+    would render at the wrong place — so the conservative behavior is to
+    log via the returned default and let the WFS provider raise on
+    mismatch. A future slice (qgis-2) will surface CRS mismatches in the
+    browser before the user adds the layer.
+    """
+    raw = collection.get("storageCrs") or collection.get("crs")
+    if isinstance(raw, list) and raw:
+        raw = raw[0]
+    if not isinstance(raw, str) or not raw:
+        return "EPSG:4326"
+    if raw.upper().startswith("EPSG:"):
+        return raw.upper()
+    # URN form: .../EPSG/0/4326 or .../EPSG/4326
+    parts = [p for p in raw.split("/") if p]
+    for idx, value in enumerate(parts):
+        if value.upper() == "EPSG" and idx + 1 < len(parts):
+            tail = parts[-1]
+            if tail.isdigit():
+                return f"EPSG:{tail}"
+    return "EPSG:4326"
+
+
+def parse_wms_capabilities(service_id: str, body: bytes) -> list[WmsLayerEntry]:
+    """Extract layer entries from a WMS 1.3.0 capabilities XML document.
+
+    Picks every named ``<Layer>`` element (groups without ``<Name>`` are
+    skipped — they are not addressable in a GetMap request). The first
+    declared ``<CRS>`` wins; we leave hard CRS reconciliation to QGIS's
+    WMS provider.
+    """
+    root = ET.fromstring(body)
+    ns = {
+        "wms": "http://www.opengis.net/wms",
+    }
+    # Capabilities documents may or may not declare the namespace.
+    layer_xpath = ".//wms:Layer" if root.tag.startswith("{") else ".//Layer"
+    layers: list[WmsLayerEntry] = []
+    for layer in root.findall(layer_xpath, ns if root.tag.startswith("{") else None):
+        name_el = layer.find("wms:Name", ns) if root.tag.startswith("{") else layer.find("Name")
+        if name_el is None or not (name_el.text or "").strip():
+            continue
+        title_el = layer.find("wms:Title", ns) if root.tag.startswith("{") else layer.find("Title")
+        crs_el = layer.find("wms:CRS", ns) if root.tag.startswith("{") else layer.find("CRS")
+        crs_text = (crs_el.text or "EPSG:4326").strip() if crs_el is not None else "EPSG:4326"
+        title_text = (title_el.text or name_el.text or "").strip() if title_el is not None else name_el.text.strip()
+        layers.append(
+            WmsLayerEntry(
+                service_id=service_id,
+                layer_name=name_el.text.strip(),
+                title=title_text,
+                crs=crs_text or "EPSG:4326",
+            )
+        )
+    return layers

--- a/clients/qgis/honua_qgis/dialog_add_server.py
+++ b/clients/qgis/honua_qgis/dialog_add_server.py
@@ -1,0 +1,236 @@
+"""Add Honua Server dialog.
+
+Pops a ``QDialog`` with a name field, base URL field, API key field, and
+a "Test connection" button. On accept, the connection is persisted via
+``QSettings`` under the ``honua/connections/<name>`` group.
+
+The pure form-validation logic lives in ``validate_form`` so it can be
+unit-tested without instantiating the Qt dialog.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .auth import HonuaConnection, SETTINGS_GROUP
+from .client import HonuaClient, HonuaClientError
+
+
+@dataclass
+class FormValidationResult:
+    ok: bool
+    error: str = ""
+
+
+def validate_form(name: str, base_url: str, api_key: str) -> FormValidationResult:
+    """Return the same error message the dialog would surface inline.
+
+    Validation rules are intentionally minimal: name is required, base
+    URL must be a syntactically valid http(s) URL with a host. API key
+    may be empty (anonymous endpoints are valid). Anything stricter
+    becomes a connectivity test, which is a separate explicit user
+    action.
+    """
+    cleaned_name = (name or "").strip()
+    cleaned_url = (base_url or "").strip()
+    if not cleaned_name:
+        return FormValidationResult(ok=False, error="Connection name is required.")
+    if not cleaned_url:
+        return FormValidationResult(ok=False, error="Honua server base URL is required.")
+    try:
+        HonuaConnection(name=cleaned_name, base_url=cleaned_url, api_key=api_key or "")
+    except ValueError as exc:
+        return FormValidationResult(ok=False, error=str(exc))
+    return FormValidationResult(ok=True)
+
+
+def test_connection(connection: HonuaConnection, *, client_factory=None) -> FormValidationResult:
+    """Run the OGC API Features landing-page probe for the dialog button.
+
+    A separate function so tests can inject a fake client. Returns the
+    same result type as ``validate_form`` so the dialog can render both
+    failure paths through one widget.
+    """
+    factory = client_factory or HonuaClient
+    client = factory(connection)
+    try:
+        client.ping()
+    except HonuaClientError as exc:
+        return FormValidationResult(ok=False, error=str(exc))
+    return FormValidationResult(ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Qt dialog. Importing PyQt5 at module load time is fine inside QGIS, but
+# in headless unit tests we exercise ``validate_form`` and ``test_connection``
+# directly without ever constructing the dialog class. The Qt-dependent
+# code is therefore guarded.
+# ---------------------------------------------------------------------------
+
+try:  # pragma: no cover - exercised only inside QGIS
+    from qgis.PyQt.QtCore import QSettings, Qt
+    from qgis.PyQt.QtWidgets import (
+        QDialog,
+        QDialogButtonBox,
+        QFormLayout,
+        QLabel,
+        QLineEdit,
+        QMessageBox,
+        QPushButton,
+        QVBoxLayout,
+    )
+except Exception:  # pragma: no cover - module-level fallback for tests
+    QSettings = None  # type: ignore[assignment]
+    Qt = None  # type: ignore[assignment]
+    QDialog = object  # type: ignore[assignment,misc]
+    QDialogButtonBox = None  # type: ignore[assignment]
+    QFormLayout = None  # type: ignore[assignment]
+    QLabel = None  # type: ignore[assignment]
+    QLineEdit = None  # type: ignore[assignment]
+    QMessageBox = None  # type: ignore[assignment]
+    QPushButton = None  # type: ignore[assignment]
+    QVBoxLayout = None  # type: ignore[assignment]
+
+
+class AddHonuaServerDialog(QDialog):  # type: ignore[misc]
+    """Add/edit dialog for a single ``HonuaConnection``."""
+
+    def __init__(self, parent=None, *, existing: HonuaConnection | None = None):  # pragma: no cover - UI
+        if QDialog is object:
+            raise RuntimeError("PyQt5 is required to instantiate AddHonuaServerDialog")
+        super().__init__(parent)
+        self.setWindowTitle("Add Honua Server" if existing is None else f"Edit Honua Server — {existing.name}")
+        self.setModal(True)
+        self._existing = existing
+        self._build_ui()
+        if existing is not None:
+            self.name_edit.setText(existing.name)
+            self.url_edit.setText(existing.base_url)
+            self.key_edit.setText(existing.api_key)
+
+    # --- construction ---------------------------------------------------
+
+    def _build_ui(self) -> None:  # pragma: no cover - UI
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+        self.name_edit = QLineEdit(self)
+        self.name_edit.setPlaceholderText("My Honua server")
+        self.url_edit = QLineEdit(self)
+        self.url_edit.setPlaceholderText("https://my.honua.io")
+        self.key_edit = QLineEdit(self)
+        self.key_edit.setEchoMode(QLineEdit.Password)
+        self.key_edit.setPlaceholderText("API key (optional)")
+        form.addRow("Name", self.name_edit)
+        form.addRow("Base URL", self.url_edit)
+        form.addRow("API key", self.key_edit)
+        layout.addLayout(form)
+
+        self.status_label = QLabel("", self)
+        self.status_label.setWordWrap(True)
+        layout.addWidget(self.status_label)
+
+        self.test_button = QPushButton("Test connection", self)
+        self.test_button.clicked.connect(self._on_test_clicked)
+        layout.addWidget(self.test_button)
+
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
+            Qt.Horizontal,
+            self,
+        )
+        button_box.accepted.connect(self._on_accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+    # --- handlers -------------------------------------------------------
+
+    def _current_connection(self) -> HonuaConnection | None:  # pragma: no cover - UI
+        result = validate_form(self.name_edit.text(), self.url_edit.text(), self.key_edit.text())
+        if not result.ok:
+            self.status_label.setText(result.error)
+            return None
+        return HonuaConnection(
+            name=self.name_edit.text().strip(),
+            base_url=self.url_edit.text().strip(),
+            api_key=self.key_edit.text(),
+        )
+
+    def _on_test_clicked(self) -> None:  # pragma: no cover - UI
+        connection = self._current_connection()
+        if connection is None:
+            return
+        self.status_label.setText("Testing connection…")
+        result = test_connection(connection)
+        if result.ok:
+            self.status_label.setText("Connection succeeded.")
+        else:
+            self.status_label.setText(f"Connection failed: {result.error}")
+
+    def _on_accept(self) -> None:  # pragma: no cover - UI
+        connection = self._current_connection()
+        if connection is None:
+            return
+        result = test_connection(connection)
+        if not result.ok:
+            answer = QMessageBox.question(
+                self,
+                "Save without test?",
+                "Connectivity test failed:\n\n"
+                f"{result.error}\n\nSave the connection anyway?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if answer != QMessageBox.Yes:
+                return
+        save_connection(connection)
+        self.accept()
+
+
+# ---------------------------------------------------------------------------
+# QSettings persistence helpers
+# ---------------------------------------------------------------------------
+
+
+def save_connection(connection: HonuaConnection) -> None:  # pragma: no cover - QSettings
+    if QSettings is None:
+        raise RuntimeError("QSettings is unavailable; this code runs inside QGIS")
+    settings = QSettings()
+    settings.beginGroup(f"{SETTINGS_GROUP}/{connection.name}")
+    try:
+        settings.setValue("base_url", connection.base_url)
+        settings.setValue("api_key", connection.api_key)
+    finally:
+        settings.endGroup()
+
+
+def load_connections() -> list[HonuaConnection]:  # pragma: no cover - QSettings
+    if QSettings is None:
+        return []
+    settings = QSettings()
+    settings.beginGroup(SETTINGS_GROUP)
+    try:
+        names = settings.childGroups()
+        out: list[HonuaConnection] = []
+        for name in names:
+            settings.beginGroup(name)
+            try:
+                base_url = str(settings.value("base_url", "") or "")
+                api_key = str(settings.value("api_key", "") or "")
+            finally:
+                settings.endGroup()
+            if not base_url:
+                continue
+            try:
+                out.append(HonuaConnection(name=name, base_url=base_url, api_key=api_key))
+            except ValueError:
+                continue
+        return out
+    finally:
+        settings.endGroup()
+
+
+def delete_connection(name: str) -> None:  # pragma: no cover - QSettings
+    if QSettings is None:
+        return
+    settings = QSettings()
+    settings.remove(f"{SETTINGS_GROUP}/{name}")

--- a/clients/qgis/honua_qgis/i18n/honua_en.ts
+++ b/clients/qgis/honua_qgis/i18n/honua_en.ts
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_US">
+<context>
+    <name>HonuaPlugin</name>
+    <message>
+        <source>Add Honua Server…</source>
+        <translation>Add Honua Server…</translation>
+    </message>
+    <message>
+        <source>Show Layer Browser</source>
+        <translation>Show Layer Browser</translation>
+    </message>
+</context>
+</TS>

--- a/clients/qgis/honua_qgis/layer_browser.py
+++ b/clients/qgis/honua_qgis/layer_browser.py
@@ -1,0 +1,231 @@
+"""Layer browser dock panel.
+
+Tree of: ``Servers → <connection name> → [Vector / Raster] → <layer>``.
+Double-clicking (or right-click → "Add to project") loads the layer onto
+the canvas using the URI builders in ``layers.py``.
+
+The view-model that converts a ``DiscoveryResult`` into a flat list of
+displayable rows lives in ``flatten_for_view`` so it can be unit-tested
+without Qt.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Literal
+
+from .auth import (
+    CollectionEntry,
+    DiscoveryResult,
+    HonuaConnection,
+    WmsLayerEntry,
+)
+from .client import HonuaClient, HonuaClientError
+from .layers import build_wfs_uri, build_wms_uri, display_label
+
+
+LayerKind = Literal["vector", "raster"]
+
+
+@dataclass
+class BrowserRow:
+    """One leaf row in the layer browser tree."""
+
+    connection_name: str
+    kind: LayerKind
+    identifier: str
+    label: str
+    uri: str
+    provider: str  # "WFS" or "wms"
+
+
+def flatten_for_view(connection: HonuaConnection, discovery: DiscoveryResult) -> list[BrowserRow]:
+    """Project a ``DiscoveryResult`` into UI rows in display order.
+
+    Vector collections come first, then raster layers, so the user always
+    sees feature data — usually the more interesting load — at the top
+    of the tree.
+    """
+    rows: list[BrowserRow] = []
+    for collection in discovery.collections:
+        rows.append(_row_for_collection(connection, collection))
+    for layer in discovery.wms_layers:
+        rows.append(_row_for_wms_layer(connection, layer))
+    return rows
+
+
+def _row_for_collection(connection: HonuaConnection, collection: CollectionEntry) -> BrowserRow:
+    return BrowserRow(
+        connection_name=connection.name,
+        kind="vector",
+        identifier=collection.collection_id,
+        label=display_label(kind="vector", title=collection.title, identifier=collection.collection_id),
+        uri=build_wfs_uri(connection, collection),
+        provider="WFS",
+    )
+
+
+def _row_for_wms_layer(connection: HonuaConnection, layer: WmsLayerEntry) -> BrowserRow:
+    return BrowserRow(
+        connection_name=connection.name,
+        kind="raster",
+        identifier=f"{layer.service_id}:{layer.layer_name}",
+        label=display_label(
+            kind="raster",
+            title=layer.title,
+            identifier=f"{layer.service_id}/{layer.layer_name}",
+        ),
+        uri=build_wms_uri(connection, layer),
+        provider="wms",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Qt dock widget. PyQt5 imports are guarded so unit tests can exercise
+# ``flatten_for_view`` without QGIS installed.
+# ---------------------------------------------------------------------------
+
+try:  # pragma: no cover - exercised inside QGIS
+    from qgis.PyQt.QtCore import Qt
+    from qgis.PyQt.QtWidgets import (
+        QDockWidget,
+        QHBoxLayout,
+        QMessageBox,
+        QPushButton,
+        QTreeWidget,
+        QTreeWidgetItem,
+        QVBoxLayout,
+        QWidget,
+    )
+
+    try:
+        from qgis.core import QgsProject, QgsRasterLayer, QgsVectorLayer
+    except Exception:  # QGIS not yet initialised
+        QgsProject = None  # type: ignore[assignment]
+        QgsRasterLayer = None  # type: ignore[assignment]
+        QgsVectorLayer = None  # type: ignore[assignment]
+except Exception:  # pragma: no cover - module-level fallback for tests
+    Qt = None  # type: ignore[assignment]
+    QDockWidget = object  # type: ignore[assignment,misc]
+    QHBoxLayout = None  # type: ignore[assignment]
+    QMessageBox = None  # type: ignore[assignment]
+    QPushButton = None  # type: ignore[assignment]
+    QTreeWidget = None  # type: ignore[assignment]
+    QTreeWidgetItem = None  # type: ignore[assignment]
+    QVBoxLayout = None  # type: ignore[assignment]
+    QWidget = None  # type: ignore[assignment]
+    QgsProject = None  # type: ignore[assignment]
+    QgsRasterLayer = None  # type: ignore[assignment]
+    QgsVectorLayer = None  # type: ignore[assignment]
+
+
+class HonuaLayerBrowser(QDockWidget):  # type: ignore[misc]
+    """Dock widget listing connections and their discovered layers."""
+
+    def __init__(  # pragma: no cover - UI
+        self,
+        parent=None,
+        *,
+        client_factory: Callable[[HonuaConnection], HonuaClient] | None = None,
+    ) -> None:
+        if QDockWidget is object:
+            raise RuntimeError("PyQt5 is required to instantiate HonuaLayerBrowser")
+        super().__init__("Honua", parent)
+        self.setObjectName("HonuaLayerBrowser")
+        self._client_factory = client_factory or HonuaClient
+        self._connections: list[HonuaConnection] = []
+        self._build_ui()
+
+    def _build_ui(self) -> None:  # pragma: no cover - UI
+        container = QWidget(self)
+        layout = QVBoxLayout(container)
+
+        self.tree = QTreeWidget(container)
+        self.tree.setHeaderLabels(["Layer", "Type"])
+        self.tree.itemDoubleClicked.connect(self._on_item_double_clicked)
+        layout.addWidget(self.tree)
+
+        button_row = QHBoxLayout()
+        self.refresh_button = QPushButton("Refresh", container)
+        self.refresh_button.clicked.connect(self.refresh)
+        button_row.addWidget(self.refresh_button)
+        button_row.addStretch(1)
+        layout.addLayout(button_row)
+
+        self.setWidget(container)
+
+    # ------------------------------------------------------------------
+    # Public API used by the plugin shell
+    # ------------------------------------------------------------------
+
+    def set_connections(self, connections: list[HonuaConnection]) -> None:  # pragma: no cover - UI
+        self._connections = list(connections)
+        self.refresh()
+
+    def refresh(self) -> None:  # pragma: no cover - UI
+        self.tree.clear()
+        for connection in self._connections:
+            self._populate_connection_node(connection)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _populate_connection_node(self, connection: HonuaConnection) -> None:  # pragma: no cover - UI
+        root = QTreeWidgetItem([connection.name, "Server"])
+        self.tree.addTopLevelItem(root)
+        try:
+            client = self._client_factory(connection)
+            discovery = client.discover()
+        except HonuaClientError as exc:
+            error_node = QTreeWidgetItem([f"Discovery failed: {exc}", ""])
+            root.addChild(error_node)
+            root.setExpanded(True)
+            return
+
+        rows = flatten_for_view(connection, discovery)
+        if not rows:
+            empty = QTreeWidgetItem(["(no layers discovered)", ""])
+            root.addChild(empty)
+            root.setExpanded(True)
+            return
+
+        vector_group = QTreeWidgetItem(["Vector (OGC API Features)", ""])
+        raster_group = QTreeWidgetItem(["Raster (WMS)", ""])
+        for row in rows:
+            child = QTreeWidgetItem([row.label, row.kind])
+            child.setData(0, Qt.UserRole, row)
+            if row.kind == "vector":
+                vector_group.addChild(child)
+            else:
+                raster_group.addChild(child)
+        if vector_group.childCount() > 0:
+            root.addChild(vector_group)
+            vector_group.setExpanded(True)
+        if raster_group.childCount() > 0:
+            root.addChild(raster_group)
+            raster_group.setExpanded(True)
+        root.setExpanded(True)
+
+    def _on_item_double_clicked(self, item, _column: int) -> None:  # pragma: no cover - UI
+        row = item.data(0, Qt.UserRole)
+        if not isinstance(row, BrowserRow):
+            return
+        self._add_row_to_canvas(row)
+
+    def _add_row_to_canvas(self, row: BrowserRow) -> None:  # pragma: no cover - UI
+        if QgsProject is None or QgsVectorLayer is None or QgsRasterLayer is None:
+            QMessageBox.warning(self, "Honua", "QGIS core is not initialised.")
+            return
+        if row.kind == "vector":
+            layer = QgsVectorLayer(row.uri, row.label, row.provider)
+        else:
+            layer = QgsRasterLayer(row.uri, row.label, row.provider)
+        if not layer.isValid():
+            QMessageBox.warning(
+                self,
+                "Honua",
+                f"Could not add layer '{row.label}'. Check the QGIS log for details.",
+            )
+            return
+        QgsProject.instance().addMapLayer(layer)

--- a/clients/qgis/honua_qgis/layers.py
+++ b/clients/qgis/honua_qgis/layers.py
@@ -1,0 +1,90 @@
+"""Build QGIS provider URIs for Honua collections and WMS layers.
+
+These functions are pure string builders — they do not import PyQGIS — so
+they can be unit-tested on a vanilla Python interpreter without QGIS
+installed. The plugin's dock widget calls them and feeds the result to
+``QgsVectorLayer`` / ``QgsRasterLayer``.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+from .auth import (
+    CollectionEntry,
+    HonuaConnection,
+    WmsLayerEntry,
+    encode_api_key_query,
+)
+
+
+_WMS_PROVIDER_VALUE_SAFE = ":/?=%"
+"""Characters safe inside a QGIS ``wms`` provider key/value field.
+
+``&`` is intentionally omitted because the provider URI itself uses
+ampersands to separate fields.
+"""
+
+
+def build_wfs_uri(connection: HonuaConnection, collection: CollectionEntry) -> str:
+    """Build the QGIS ``WFS`` provider URI for an OGC API Features collection.
+
+    QGIS 3.22's WFS provider supports OGC API Features when the URI carries
+    ``version=auto`` and the URL points at the collection items endpoint.
+    The API key is passed in via the ``X-API-Key``-equivalent ``apikey``
+    query parameter on the items URL itself (see ``encode_api_key_query``
+    for the rationale).
+    """
+    base = connection.normalized_base_url
+    items_url = f"{base}/ogc/features/collections/{quote(collection.collection_id, safe='')}/items"
+    api_key_qs = encode_api_key_query(connection.api_key)
+    if api_key_qs:
+        items_url = f"{items_url}?{api_key_qs}"
+
+    parts = [
+        f"url={quote(items_url, safe='')}",
+        f"typename={quote(collection.collection_id, safe='')}",
+        "version=auto",
+        f"srsname={quote(collection.crs, safe='')}",
+        "restrictToRequestBBOX=1",
+        "pagingEnabled=true",
+        "preferCoordinatesForWfsT11=false",
+    ]
+    return " ".join(parts)
+
+
+def build_wms_uri(connection: HonuaConnection, layer: WmsLayerEntry) -> str:
+    """Build the QGIS ``wms`` provider URI for a discovered WMS layer.
+
+    QGIS uses an ampersand-joined key=value list (URL-encoded) — *not* a
+    real URL — for the ``wms`` provider URI. The endpoint URL itself goes
+    in the ``url`` field; the API key rides as a query parameter on that
+    URL because QGIS's WMS provider does not honour custom request
+    headers from the application network manager.
+    """
+    base = connection.normalized_base_url
+    endpoint = f"{base}/ogc/services/{quote(layer.service_id, safe='')}/wms"
+    api_key_qs = encode_api_key_query(connection.api_key)
+    if api_key_qs:
+        endpoint = f"{endpoint}?{api_key_qs}"
+
+    params = {
+        "url": endpoint,
+        "format": "image/png",
+        "layers": layer.layer_name,
+        "styles": "",
+        "crs": layer.crs,
+        "version": "1.3.0",
+        "tileMatrixSet": "",
+    }
+    return "&".join(
+        f"{key}={quote(str(value), safe=_WMS_PROVIDER_VALUE_SAFE)}"
+        for key, value in params.items()
+    )
+
+
+def display_label(*, kind: str, title: str, identifier: str) -> str:
+    """Stable label used both in the layer browser tree and the project legend."""
+    if title and title != identifier:
+        return f"{title} ({identifier})"
+    return identifier

--- a/clients/qgis/honua_qgis/metadata.txt
+++ b/clients/qgis/honua_qgis/metadata.txt
@@ -1,0 +1,21 @@
+[general]
+name=Honua
+qgisMinimumVersion=3.22
+qgisMaximumVersion=3.99
+description=Browse and consume Honua server layers (OGC API Features, WMS) from QGIS in two clicks.
+about=Adds a "Honua" entry under Web menu and toolbar. Connect to a Honua server with a URL plus API key, then browse OGC API Features collections and WMS layers in a dock panel; double-click adds the layer to the project canvas.
+version=0.1.0
+author=Honua
+email=hello@honua.io
+homepage=https://honua.io
+tracker=https://github.com/honua-io/honua-server/issues
+repository=https://github.com/honua-io/honua-server
+category=Web
+icon=resources/icon.svg
+experimental=True
+deprecated=False
+hasProcessingProvider=no
+tags=honua,ogc,ogc api features,wms,wfs,server,catalog
+changelog=0.1.0 - First slice: Add server dialog, layer browser dock, OGC API Features (WFS provider) + WMS load.
+supportsQt6=False
+plugin_dependencies=

--- a/clients/qgis/honua_qgis/plugin.py
+++ b/clients/qgis/honua_qgis/plugin.py
@@ -1,0 +1,113 @@
+"""Plugin shell — wires menu, toolbar, dialog, and dock panel.
+
+QGIS calls ``initGui`` once on plugin load and ``unload`` when the plugin
+is disabled or QGIS shuts down. We keep the shell free of business logic
+so the dialog and dock panel can be tested in isolation.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .auth import HonuaConnection
+
+
+_PLUGIN_DIR = os.path.dirname(__file__)
+
+
+try:  # pragma: no cover - exercised inside QGIS
+    from qgis.PyQt.QtCore import Qt
+    from qgis.PyQt.QtGui import QIcon
+    from qgis.PyQt.QtWidgets import QAction, QMenu
+except Exception:  # pragma: no cover
+    Qt = None  # type: ignore[assignment]
+    QIcon = None  # type: ignore[assignment]
+    QAction = object  # type: ignore[assignment,misc]
+    QMenu = None  # type: ignore[assignment]
+
+
+class HonuaPlugin:
+    """The QGIS-facing plugin object returned by ``classFactory``."""
+
+    MENU_TITLE = "&Honua"
+    TOOLBAR_NAME = "Honua"
+
+    def __init__(self, iface) -> None:  # pragma: no cover - constructed by QGIS
+        self.iface = iface
+        self._actions: list[QAction] = []
+        self._menu = None
+        self._toolbar = None
+        self._dock = None
+
+    # ------------------------------------------------------------------
+    # QGIS lifecycle
+    # ------------------------------------------------------------------
+
+    def initGui(self) -> None:  # pragma: no cover - UI wiring
+        if QAction is object:
+            raise RuntimeError("PyQt5 / PyQGIS is required to load the Honua plugin")
+        icon = QIcon(os.path.join(_PLUGIN_DIR, "resources", "icon.svg"))
+
+        self._toolbar = self.iface.addToolBar(self.TOOLBAR_NAME)
+        self._toolbar.setObjectName("HonuaToolbar")
+
+        add_action = QAction(icon, "Add Honua Server…", self.iface.mainWindow())
+        add_action.setObjectName("HonuaAddServerAction")
+        add_action.triggered.connect(self.show_add_server_dialog)
+        self._register(add_action)
+
+        browser_action = QAction(icon, "Show Layer Browser", self.iface.mainWindow())
+        browser_action.setObjectName("HonuaBrowserAction")
+        browser_action.triggered.connect(self.show_browser)
+        self._register(browser_action)
+
+    def unload(self) -> None:  # pragma: no cover - UI wiring
+        for action in self._actions:
+            self.iface.removePluginWebMenu(self.MENU_TITLE, action)
+            if self._toolbar is not None:
+                self._toolbar.removeAction(action)
+        self._actions.clear()
+        if self._toolbar is not None:
+            self._toolbar.deleteLater()
+            self._toolbar = None
+        if self._dock is not None:
+            self.iface.removeDockWidget(self._dock)
+            self._dock.deleteLater()
+            self._dock = None
+
+    # ------------------------------------------------------------------
+    # Action handlers (kept thin)
+    # ------------------------------------------------------------------
+
+    def show_add_server_dialog(self) -> None:  # pragma: no cover - UI
+        from .dialog_add_server import AddHonuaServerDialog, load_connections
+
+        dialog = AddHonuaServerDialog(self.iface.mainWindow())
+        if dialog.exec_():
+            self._refresh_browser(load_connections())
+
+    def show_browser(self) -> None:  # pragma: no cover - UI
+        from .dialog_add_server import load_connections
+
+        self._refresh_browser(load_connections())
+        if self._dock is not None:
+            self._dock.show()
+            self._dock.raise_()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _register(self, action: QAction) -> None:  # pragma: no cover - UI
+        self._actions.append(action)
+        self.iface.addPluginToWebMenu(self.MENU_TITLE, action)
+        if self._toolbar is not None:
+            self._toolbar.addAction(action)
+
+    def _refresh_browser(self, connections: list[HonuaConnection]) -> None:  # pragma: no cover - UI
+        from .layer_browser import HonuaLayerBrowser
+
+        if self._dock is None:
+            self._dock = HonuaLayerBrowser(self.iface.mainWindow())
+            self.iface.addDockWidget(Qt.RightDockWidgetArea, self._dock)
+        self._dock.set_connections(connections)

--- a/clients/qgis/honua_qgis/resources/icon.svg
+++ b/clients/qgis/honua_qgis/resources/icon.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <title>Honua</title>
+  <circle cx="32" cy="32" r="28" fill="#0f6e3d" stroke="#1c3" stroke-width="2"/>
+  <path d="M14 36c6-8 14-2 20-6s8-12 16-8" stroke="#fff" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <text x="32" y="56" font-family="sans-serif" font-size="10" fill="#fff" text-anchor="middle">honua</text>
+</svg>

--- a/clients/qgis/scripts/build_zip.py
+++ b/clients/qgis/scripts/build_zip.py
@@ -1,0 +1,67 @@
+"""Build the Honua QGIS plugin zip without depending on a system ``zip``.
+
+Run from the ``clients/qgis/`` directory:
+
+    python3 scripts/build_zip.py [--out dist/honua_qgis.zip]
+
+Includes everything under ``honua_qgis/`` except ``__pycache__`` dirs and
+``.pyc`` files, mirroring the Makefile target so QGIS Plugin Manager
+sees a clean tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import zipfile
+
+
+PLUGIN_DIR = "honua_qgis"
+DEFAULT_OUT = os.path.join("dist", "honua_qgis.zip")
+EXCLUDED_DIRS = {"__pycache__"}
+EXCLUDED_SUFFIXES = (".pyc",)
+
+
+def _iter_plugin_files(root: str):
+    for dirpath, dirnames, filenames in os.walk(root):
+        # mutate in place so os.walk skips excluded subtrees entirely
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDED_DIRS]
+        for filename in filenames:
+            if filename.endswith(EXCLUDED_SUFFIXES):
+                continue
+            yield os.path.join(dirpath, filename)
+
+
+def build(out_path: str) -> int:
+    cwd = os.getcwd()
+    if not os.path.isdir(os.path.join(cwd, PLUGIN_DIR)):
+        sys.stderr.write(
+            f"error: run from the directory containing '{PLUGIN_DIR}/'\n"
+        )
+        return 1
+
+    out_dir = os.path.dirname(os.path.abspath(out_path))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    if os.path.exists(out_path):
+        os.remove(out_path)
+
+    count = 0
+    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for source in _iter_plugin_files(PLUGIN_DIR):
+            arcname = os.path.relpath(source, cwd)
+            zf.write(source, arcname)
+            count += 1
+    sys.stdout.write(f"wrote {out_path} ({count} files)\n")
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default=DEFAULT_OUT)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(build(_parse_args().out))

--- a/clients/qgis/tests/conftest.py
+++ b/clients/qgis/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Shared test fixtures.
+
+Adds the plugin sources to ``sys.path`` so tests can import ``honua_qgis``
+without an editable install (the plugin ships as a flat directory
+shipped to QGIS's Python plugin folder).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+
+_HERE = os.path.dirname(__file__)
+_PLUGIN_ROOT = os.path.abspath(os.path.join(_HERE, ".."))
+if _PLUGIN_ROOT not in sys.path:
+    sys.path.insert(0, _PLUGIN_ROOT)
+
+
+@pytest.fixture
+def fake_connection():
+    from honua_qgis.auth import HonuaConnection
+
+    return HonuaConnection(name="local", base_url="https://example.test", api_key="key-xyz")

--- a/clients/qgis/tests/test_add_server.py
+++ b/clients/qgis/tests/test_add_server.py
@@ -1,0 +1,72 @@
+"""Unit tests for ``honua_qgis.dialog_add_server``.
+
+The Qt dialog itself is exercised inside QGIS (covered by the Docker
+end-to-end test); these tests focus on ``validate_form`` and
+``test_connection``, the pure helpers behind the dialog widgets.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from honua_qgis.auth import HonuaConnection
+from honua_qgis.client import HonuaClientError
+from honua_qgis.dialog_add_server import test_connection as run_connection_test
+from honua_qgis.dialog_add_server import validate_form
+
+
+def test_validate_form_requires_name():
+    result = validate_form("", "https://example.test", "")
+    assert not result.ok
+    assert "name" in result.error.lower()
+
+
+def test_validate_form_requires_url():
+    result = validate_form("local", "", "")
+    assert not result.ok
+    assert "url" in result.error.lower()
+
+
+def test_validate_form_rejects_non_http_scheme():
+    result = validate_form("local", "ftp://example.test", "")
+    assert not result.ok
+
+
+def test_validate_form_accepts_minimal_input():
+    result = validate_form("local", "https://example.test", "")
+    assert result.ok
+
+
+def test_validate_form_accepts_optional_api_key():
+    result = validate_form("local", "https://example.test", "secret-key")
+    assert result.ok
+
+
+class _StubClient:
+    def __init__(self, connection, *, raise_with: HonuaClientError | None = None):
+        self.connection = connection
+        self._raise_with = raise_with
+        self.pinged = False
+
+    def ping(self) -> None:
+        self.pinged = True
+        if self._raise_with is not None:
+            raise self._raise_with
+
+
+def test_run_connection_test_returns_ok_when_ping_succeeds():
+    conn = HonuaConnection(name="local", base_url="https://example.test")
+    result = run_connection_test(conn, client_factory=_StubClient)
+    assert result.ok
+    assert result.error == ""
+
+
+def test_run_connection_test_surfaces_client_error():
+    conn = HonuaConnection(name="local", base_url="https://example.test")
+
+    def factory(c):
+        return _StubClient(c, raise_with=HonuaClientError("boom"))
+
+    result = run_connection_test(conn, client_factory=factory)
+    assert not result.ok
+    assert "boom" in result.error

--- a/clients/qgis/tests/test_auth.py
+++ b/clients/qgis/tests/test_auth.py
@@ -1,0 +1,50 @@
+"""Unit tests for ``honua_qgis.auth``."""
+
+from __future__ import annotations
+
+import pytest
+
+from honua_qgis.auth import (
+    HonuaConnection,
+    encode_api_key_query,
+    filter_unique_connection_names,
+)
+
+
+class TestHonuaConnection:
+    def test_strips_trailing_slash(self):
+        conn = HonuaConnection(name="local", base_url="https://example.test/")
+        assert conn.normalized_base_url == "https://example.test"
+
+    def test_request_headers_include_api_key(self):
+        conn = HonuaConnection(name="local", base_url="https://example.test", api_key="abc")
+        headers = conn.request_headers()
+        assert headers["X-API-Key"] == "abc"
+        assert headers["Accept"] == "application/json"
+
+    def test_request_headers_omit_key_when_empty(self):
+        conn = HonuaConnection(name="local", base_url="https://example.test")
+        assert "X-API-Key" not in conn.request_headers()
+
+    @pytest.mark.parametrize("bad_url", ["", "ftp://example.test", "not-a-url", "https:///"])
+    def test_rejects_invalid_url(self, bad_url):
+        with pytest.raises(ValueError):
+            HonuaConnection(name="local", base_url=bad_url)
+
+    def test_rejects_blank_name(self):
+        with pytest.raises(ValueError):
+            HonuaConnection(name="   ", base_url="https://example.test")
+
+
+def test_encode_api_key_query_url_safe():
+    qs = encode_api_key_query("hello world&special?")
+    assert qs == "apikey=hello%20world%26special%3F"
+
+
+def test_encode_api_key_query_empty():
+    assert encode_api_key_query("") == ""
+
+
+def test_filter_unique_connection_names_dedupes_and_strips():
+    names = filter_unique_connection_names(["a", " a ", "b", "", None, "b", "c"])
+    assert names == ["a", "b", "c"]

--- a/clients/qgis/tests/test_client.py
+++ b/clients/qgis/tests/test_client.py
@@ -1,0 +1,227 @@
+"""Unit tests for ``honua_qgis.client``.
+
+The HTTP client is tested with an injected fake ``urlopen`` so the tests
+do not require a running Honua server. The fake returns canned responses
+keyed by URL.
+"""
+
+from __future__ import annotations
+
+import json
+from urllib.error import URLError
+
+import pytest
+
+from honua_qgis.auth import HonuaConnection
+from honua_qgis.client import (
+    HonuaClient,
+    HonuaClientError,
+    parse_wms_capabilities,
+    _extract_bbox,
+    _extract_storage_crs,
+)
+
+
+class FakeResponse:
+    """Minimal stand-in for ``http.client.HTTPResponse``."""
+
+    def __init__(self, body: bytes, status: int = 200, headers: dict | None = None):
+        self._body = body
+        self.status = status
+        self.headers = headers or {"Content-Type": "application/json"}
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeOpener:
+    """Routes a URL → response and records the requests it served."""
+
+    def __init__(self, routes: dict[str, FakeResponse]):
+        self.routes = routes
+        self.calls: list[tuple[str, dict]] = []
+
+    def __call__(self, request, timeout=None):
+        url = request.full_url
+        headers = dict(request.headers)
+        self.calls.append((url, headers))
+        for prefix, response in self.routes.items():
+            if url.startswith(prefix):
+                return response
+        # Unknown URLs simulate a network/HTTP failure so callers' error
+        # paths are exercised rather than the test bombing on a bare
+        # ``AssertionError``. Each test that needs a specific URL must
+        # register a route for it.
+        raise URLError(f"unexpected URL: {url}")
+
+
+@pytest.fixture
+def conn():
+    return HonuaConnection(name="t", base_url="https://example.test", api_key="secret")
+
+
+def _client(conn, routes):
+    return HonuaClient(conn, opener=FakeOpener(routes))
+
+
+# ---------------------------------------------------------------------------
+# ping / connectivity
+# ---------------------------------------------------------------------------
+
+
+def test_ping_succeeds_on_200_json(conn):
+    routes = {"https://example.test/ogc/features": FakeResponse(b'{"links": []}')}
+    client = _client(conn, routes)
+    client.ping()
+
+
+def test_ping_rejects_non_json_body(conn):
+    routes = {"https://example.test/ogc/features": FakeResponse(b"<html>oops</html>")}
+    client = _client(conn, routes)
+    with pytest.raises(HonuaClientError):
+        client.ping()
+
+
+def test_ping_attaches_api_key_header(conn):
+    routes = {"https://example.test/ogc/features": FakeResponse(b"{}")}
+    opener = FakeOpener(routes)
+    client = HonuaClient(conn, opener=opener)
+    client.ping()
+    _, headers = opener.calls[0]
+    assert headers.get("X-api-key") == "secret" or headers.get("X-Api-Key") == "secret"
+
+
+# ---------------------------------------------------------------------------
+# collections
+# ---------------------------------------------------------------------------
+
+
+def test_list_collections_extracts_id_title_bbox_crs(conn):
+    body = json.dumps(
+        {
+            "collections": [
+                {
+                    "id": "parcels",
+                    "title": "Parcels",
+                    "extent": {"spatial": {"bbox": [[-100.0, 40.0, -99.0, 41.0]]}},
+                    "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/4326",
+                },
+                {"id": "roads"},
+            ]
+        }
+    ).encode()
+    routes = {"https://example.test/ogc/features/collections": FakeResponse(body)}
+    client = _client(conn, routes)
+    collections = client.list_collections()
+    assert [c.collection_id for c in collections] == ["parcels", "roads"]
+    parcels = collections[0]
+    assert parcels.title == "Parcels"
+    assert parcels.bbox == (-100.0, 40.0, -99.0, 41.0)
+    assert parcels.crs == "EPSG:4326"
+
+
+def test_list_collections_handles_empty_payload(conn):
+    routes = {"https://example.test/ogc/features/collections": FakeResponse(b"{}")}
+    client = _client(conn, routes)
+    assert client.list_collections() == []
+
+
+def test_list_collections_raises_on_garbage(conn):
+    routes = {"https://example.test/ogc/features/collections": FakeResponse(b"not json")}
+    client = _client(conn, routes)
+    with pytest.raises(HonuaClientError):
+        client.list_collections()
+
+
+# ---------------------------------------------------------------------------
+# WMS discovery
+# ---------------------------------------------------------------------------
+
+
+_WMS_XML = b"""<?xml version="1.0"?>
+<WMS_Capabilities xmlns="http://www.opengis.net/wms" version="1.3.0">
+  <Service><Name>WMS</Name></Service>
+  <Capability>
+    <Layer>
+      <Name>root</Name>
+      <Title>Root</Title>
+      <CRS>EPSG:3857</CRS>
+      <Layer>
+        <Name>parcels</Name>
+        <Title>Parcels Layer</Title>
+        <CRS>EPSG:3857</CRS>
+      </Layer>
+      <Layer>
+        <Title>group only - no name, skip me</Title>
+      </Layer>
+    </Layer>
+  </Capability>
+</WMS_Capabilities>
+"""
+
+
+def test_parse_wms_capabilities_picks_named_layers():
+    layers = parse_wms_capabilities("svc", _WMS_XML)
+    names = [layer.layer_name for layer in layers]
+    assert "parcels" in names
+    assert "root" in names
+    parcels = next(layer for layer in layers if layer.layer_name == "parcels")
+    assert parcels.title == "Parcels Layer"
+    assert parcels.crs == "EPSG:3857"
+
+
+def test_parse_wms_capabilities_skips_groups_without_name():
+    layers = parse_wms_capabilities("svc", _WMS_XML)
+    assert all(layer.layer_name for layer in layers)
+
+
+def test_list_wms_layers_returns_empty_on_missing_endpoint(conn):
+    """Honua services that do not enable WMS return 404 — must not crash."""
+    routes = {"https://example.test/rest/services": FakeResponse(b'{"services": [{"name": "svc"}]}')}
+    client = _client(conn, routes)
+    # No route configured for /ogc/services/svc/wms — fake opener will raise,
+    # but list_wms_layers swallows HonuaClientError into an empty list.
+    assert client.list_wms_layers("nonexistent") == []
+
+
+# ---------------------------------------------------------------------------
+# parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def test_extract_bbox_handles_missing_extent():
+    assert _extract_bbox(None) is None
+    assert _extract_bbox({}) is None
+    assert _extract_bbox({"spatial": {"bbox": []}}) is None
+
+
+def test_extract_bbox_picks_first_bbox():
+    bbox = _extract_bbox(
+        {"spatial": {"bbox": [[-1.0, -2.0, 1.0, 2.0], [-10.0, -20.0, 10.0, 20.0]]}}
+    )
+    assert bbox == (-1.0, -2.0, 1.0, 2.0)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("EPSG:4326", "EPSG:4326"),
+        ("epsg:3857", "EPSG:3857"),
+        ("http://www.opengis.net/def/crs/EPSG/0/4326", "EPSG:4326"),
+        ("http://www.opengis.net/def/crs/EPSG/3857", "EPSG:3857"),
+        ("", "EPSG:4326"),
+        ("nonsense", "EPSG:4326"),
+    ],
+)
+def test_extract_storage_crs_handles_urn_and_short_form(raw, expected):
+    assert _extract_storage_crs({"storageCrs": raw}) == expected
+
+
+def test_extract_storage_crs_falls_back_when_missing():
+    assert _extract_storage_crs({}) == "EPSG:4326"

--- a/clients/qgis/tests/test_e2e.py
+++ b/clients/qgis/tests/test_e2e.py
@@ -1,0 +1,76 @@
+"""End-to-end smoke test inside ``qgis/qgis:ltr``.
+
+Skipped when ``HONUA_BASE_URL`` is unset (i.e. when running on a
+developer laptop without docker-compose). The CI / Make ``e2e`` target
+sets that env var inside the container.
+
+The test:
+1. Pings the Honua OGC API Features landing page through the plugin
+   client (proves connectivity + auth header propagation).
+2. Discovers the first OGC API Features collection.
+3. Builds the QGIS WFS provider URI and instantiates a
+   ``QgsVectorLayer`` against it; asserts ``layer.isValid()``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+REQUIRED_ENV = ("HONUA_BASE_URL", "HONUA_API_KEY")
+
+
+def _env_present() -> bool:
+    return all(os.environ.get(name) for name in REQUIRED_ENV)
+
+
+pytestmark = pytest.mark.skipif(
+    not _env_present(),
+    reason="set HONUA_BASE_URL and HONUA_API_KEY (run via `make e2e`)",
+)
+
+
+@pytest.fixture(scope="module")
+def qgis_app():
+    """Boot a headless QGIS application once per module."""
+    from qgis.core import QgsApplication
+
+    app = QgsApplication([], False)
+    QgsApplication.setPrefixPath("/usr", True)
+    app.initQgis()
+    yield app
+    app.exitQgis()
+
+
+@pytest.fixture
+def connection():
+    from honua_qgis.auth import HonuaConnection
+
+    return HonuaConnection(
+        name="ci",
+        base_url=os.environ["HONUA_BASE_URL"],
+        api_key=os.environ["HONUA_API_KEY"],
+    )
+
+
+def test_plugin_pings_reference_server(connection):
+    from honua_qgis.client import HonuaClient
+
+    HonuaClient(connection).ping()
+
+
+def test_plugin_loads_first_collection_into_qgis(qgis_app, connection):
+    from qgis.core import QgsVectorLayer
+
+    from honua_qgis.client import HonuaClient
+    from honua_qgis.layers import build_wfs_uri
+
+    collections = HonuaClient(connection).list_collections()
+    assert collections, "reference Honua server returned no OGC API Features collections"
+    target = collections[0]
+
+    uri = build_wfs_uri(connection, target)
+    layer = QgsVectorLayer(uri, target.title or target.collection_id, "WFS")
+    assert layer.isValid(), f"WFS layer for {target.collection_id} did not become valid"

--- a/clients/qgis/tests/test_layer_browser.py
+++ b/clients/qgis/tests/test_layer_browser.py
@@ -1,0 +1,62 @@
+"""Unit tests for ``honua_qgis.layer_browser``.
+
+The Qt dock widget itself is exercised inside QGIS (covered by the Docker
+end-to-end test); these tests focus on the view-model that converts a
+``DiscoveryResult`` into the rows the tree displays.
+"""
+
+from __future__ import annotations
+
+from honua_qgis.auth import (
+    CollectionEntry,
+    DiscoveryResult,
+    HonuaConnection,
+    WmsLayerEntry,
+)
+from honua_qgis.layer_browser import flatten_for_view
+
+
+def _conn():
+    return HonuaConnection(name="srv", base_url="https://example.test", api_key="abc")
+
+
+def test_flatten_for_view_orders_vector_before_raster():
+    conn = _conn()
+    discovery = DiscoveryResult(
+        collections=[
+            CollectionEntry(collection_id="parcels", title="Parcels"),
+            CollectionEntry(collection_id="roads", title="Roads"),
+        ],
+        wms_layers=[
+            WmsLayerEntry(service_id="svc", layer_name="basemap", title="Basemap"),
+        ],
+    )
+    rows = flatten_for_view(conn, discovery)
+    assert [row.kind for row in rows] == ["vector", "vector", "raster"]
+    assert [row.identifier for row in rows] == ["parcels", "roads", "svc:basemap"]
+
+
+def test_flatten_for_view_marks_provider_per_kind():
+    conn = _conn()
+    discovery = DiscoveryResult(
+        collections=[CollectionEntry(collection_id="parcels", title="Parcels")],
+        wms_layers=[WmsLayerEntry(service_id="svc", layer_name="basemap", title="Basemap")],
+    )
+    rows = flatten_for_view(conn, discovery)
+    by_kind = {row.kind: row for row in rows}
+    assert by_kind["vector"].provider == "WFS"
+    assert by_kind["raster"].provider == "wms"
+
+
+def test_flatten_for_view_carries_connection_name():
+    conn = _conn()
+    discovery = DiscoveryResult(
+        collections=[CollectionEntry(collection_id="parcels", title="Parcels")],
+    )
+    rows = flatten_for_view(conn, discovery)
+    assert rows[0].connection_name == "srv"
+
+
+def test_flatten_for_view_returns_empty_for_empty_discovery():
+    rows = flatten_for_view(_conn(), DiscoveryResult())
+    assert rows == []

--- a/clients/qgis/tests/test_layers.py
+++ b/clients/qgis/tests/test_layers.py
@@ -1,0 +1,70 @@
+"""Unit tests for ``honua_qgis.layers`` URI builders."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, unquote, urlparse
+
+from honua_qgis.auth import CollectionEntry, HonuaConnection, WmsLayerEntry
+from honua_qgis.layers import build_wfs_uri, build_wms_uri, display_label
+
+
+def _conn(api_key: str = "secret") -> HonuaConnection:
+    return HonuaConnection(name="local", base_url="https://example.test/", api_key=api_key)
+
+
+def test_build_wfs_uri_includes_collection_items_url_and_typename():
+    collection = CollectionEntry(collection_id="parcels", title="Parcels", crs="EPSG:4326")
+    uri = build_wfs_uri(_conn(), collection)
+    parts = dict(item.split("=", 1) for item in uri.split(" "))
+    assert "url" in parts
+    decoded_url = unquote(parts["url"])
+    assert decoded_url.startswith("https://example.test/ogc/features/collections/parcels/items")
+    assert "apikey=secret" in decoded_url
+    assert parts["typename"] == "parcels"
+    assert parts["version"] == "auto"
+    assert parts["srsname"] == "EPSG%3A4326"
+
+
+def test_build_wfs_uri_omits_api_key_query_when_anonymous():
+    collection = CollectionEntry(collection_id="parcels", title="Parcels")
+    uri = build_wfs_uri(_conn(api_key=""), collection)
+    parts = dict(item.split("=", 1) for item in uri.split(" "))
+    assert "apikey=" not in unquote(parts["url"])
+
+
+def test_build_wms_uri_includes_required_keys_and_api_key():
+    layer = WmsLayerEntry(service_id="svc", layer_name="basemap", title="Basemap", crs="EPSG:3857")
+    uri = build_wms_uri(_conn(), layer)
+    pairs = dict(part.split("=", 1) for part in uri.split("&") if "=" in part)
+    assert pairs["format"] == "image/png"
+    assert pairs["layers"] == "basemap"
+    assert pairs["crs"] == "EPSG:3857"
+    assert pairs["version"] == "1.3.0"
+    decoded_endpoint = unquote(pairs["url"])
+    assert decoded_endpoint.startswith("https://example.test/ogc/services/svc/wms")
+    assert "apikey=secret" in decoded_endpoint
+
+
+def test_build_wms_uri_handles_anonymous_connection():
+    layer = WmsLayerEntry(service_id="svc", layer_name="basemap", title="Basemap")
+    uri = build_wms_uri(_conn(api_key=""), layer)
+    pairs = dict(part.split("=", 1) for part in uri.split("&") if "=" in part)
+    assert "apikey=" not in unquote(pairs["url"])
+
+
+def test_build_wms_uri_escapes_ampersands_inside_values():
+    layer = WmsLayerEntry(
+        service_id="svc/root",
+        layer_name="base&map",
+        title="Basemap",
+    )
+    uri = build_wms_uri(_conn(api_key="a&b"), layer)
+    pairs = dict(part.split("=", 1) for part in uri.split("&") if "=" in part)
+    assert unquote(pairs["url"]) == "https://example.test/ogc/services/svc/root/wms?apikey=a&b"
+    assert unquote(pairs["layers"]) == "base&map"
+
+
+def test_display_label_combines_title_and_identifier():
+    assert display_label(kind="vector", title="Parcels", identifier="parcels") == "Parcels (parcels)"
+    assert display_label(kind="vector", title="parcels", identifier="parcels") == "parcels"
+    assert display_label(kind="raster", title="", identifier="svc/foo") == "svc/foo"

--- a/docs/gis/README.md
+++ b/docs/gis/README.md
@@ -13,6 +13,7 @@ Connect to Honua from desktop GIS applications and consume geospatial services.
 - [Client Setup Runbook](CLIENT_TEMPLATE_RUNBOOK.md) — ArcGIS Pro, QGIS, Power BI, Excel
 - [Version Matrix](CLIENT_TEMPLATE_VERSION_MATRIX.md) — Tested client software versions
 - [Template Files](client-templates/) — Ready-to-use project templates
+- [Honua QGIS Plugin (staging)](../../clients/qgis/) — Two-click "Add Honua Server" plugin sources, packaging, and registry submission notes
 
 ## Data & Import
 


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #808

## Summary
Stage the first Honua QGIS plugin slice so analysts can add a Honua server, browse discovered OGC API Features and WMS layers, and install the plugin from a packaged zip while the dedicated `honua-qgis` repo is bootstrapped.

## Changes Made
- Added `clients/qgis` plugin sources, metadata, icon, zip builder, Makefile, Docker e2e harness, and registry/submission documentation.
- Implemented connection validation, API-key transport, OGC API Features and WMS discovery, QGIS provider URI builders, Add Honua Server dialog, and layer browser dock.
- Added pure-Python unit tests, a skipped-by-default QGIS Docker smoke test, top-level client staging docs, and a QGIS plugin build workflow that uploads the zip artifact.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent gate set through GitHub CI and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

## Validation Notes
- `python3 -m pytest tests -q` from `clients/qgis` (46 passed, 2 skipped)
- `python3 -m compileall -q honua_qgis tests` from `clients/qgis`
- `make zip` from `clients/qgis`
- workflow-style zip layout verification for `dist/honua_qgis.zip`
- `git diff --cached --check`
- `dotnet format Honua.sln --no-restore --verify-no-changes`
- GitHub CI gate and QGIS Plugin Build are passing on this PR.

`dotnet format Honua.sln --verify-no-changes` with restore enabled was previously blocked locally by the existing `Snappier` 1.3.0 NU1903 warning-as-error vulnerability. The no-restore format verification and GitHub CI completed successfully. The Docker/QGIS e2e target was not run locally because the required `qgis/qgis:ltr` and `ghcr.io/honua-io/honua-server:ci` images are not present locally and would require pulling large external images.