### PR TITLE
test: cover authenticated GeoServices import

### DIFF
--- a/docs/contributor/import-capability-evidence.md
+++ b/docs/contributor/import-capability-evidence.md
@@ -13,8 +13,8 @@ For the website-level compatibility and automated migration claims, start with
 
 Use this wording for public material:
 
-> Honua imports common GIS file formats and public, queryable ArcGIS GeoServices
-> REST feature/map-service layers into PostGIS. It also inventories ArcGIS
+> Honua imports common GIS file formats and public or credentialed queryable
+> ArcGIS GeoServices REST feature/map-service layers into PostGIS. It also inventories ArcGIS
 > GeoServices REST and GeoServer REST sources for migration planning, supports
 > GeoServer dry-run validation, and runs cross-server WMS/WFS/WMTS consume tests
 > against reference GeoServer and MapServer services.
@@ -61,6 +61,7 @@ is passing and linked from the compatibility evidence page.
   and `tests/dotnet/Honua.Postgres.Tests/Features/Import/Baselines/ArcGis/`
 - Integration coverage:
   `tests/dotnet/Honua.Server.Tests/Import/GeoservicesImportEndpointTests.cs`,
+  `tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportServiceAuthenticatedImportTests.cs`,
   `GeoservicesParityIntegrationTests.cs`, and
   `GeoservicesGeoportalImportIntegrationTests.cs`
 
@@ -70,6 +71,13 @@ metadata, queues a distributed import job, pages source features with
 converts Esri JSON geometries to GeoJSON/PostGIS geometry, creates a spatial
 index, analyzes the table, and optionally publishes the imported table as a
 Honua layer.
+
+Credentialed import uses the GeoServices `credentials` descriptor. Discovery
+and scan requests may use inline token/password values for immediate use, but
+queued import jobs require secret references; the worker resolves the secret
+inside job execution before calling ArcGIS. Local integration coverage includes
+a token-protected ArcGIS-compatible fixture that pages a private layer into
+PostGIS and verifies request/job artifacts do not persist token material.
 
 ### GeoServer REST
 
@@ -131,6 +139,13 @@ The focused baseline checks were refreshed on 2026-05-17:
 | Server endpoints and migration scanner slice | 47 passed, 0 failed, 0 skipped |
 | Postgres service inventory and baseline slice | 23 passed, 0 failed, 0 skipped |
 
+Additional authenticated GeoServices checks were refreshed on 2026-05-18:
+
+| Check | Result |
+|---|---:|
+| ArcGIS REST client auth and secret-redaction slice | 10 passed, 0 failed, 0 skipped |
+| Token-protected private GeoServices import fixture | 1 passed, 0 failed, 0 skipped |
+
 ## Suggested Verification Commands
 
 Run these focused checks when refreshing this evidence:
@@ -141,6 +156,12 @@ dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj \
 
 dotnet test tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj \
   --filter "FullyQualifiedName~GeoservicesImportServiceScanTests|FullyQualifiedName~GeoServerImportServiceScanTests|FullyQualifiedName~GeoservicesArcGisInventoryBaselineTests|FullyQualifiedName~GeoServerInventoryBaselineTests"
+
+dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj \
+  --filter "FullyQualifiedName~ArcGisRestClientSecurityTests"
+
+dotnet test tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj \
+  --filter "FullyQualifiedName~GeoservicesImportServiceAuthenticatedImportTests"
 ```
 
 External/live tests such as `GeoservicesGeoportalImportIntegrationTests` and

--- a/docs/operator/CONTROL_PLANE_API.md
+++ b/docs/operator/CONTROL_PLANE_API.md
@@ -261,6 +261,7 @@ Request body:
 | `sourceUrl` | Yes | Canonical source URL to scan. GeoServices requires an HTTPS ArcGIS service root ending in `FeatureServer` or `MapServer`; layer or table URLs are rejected. GeoServer and GeoServices reject embedded credentials. GeoServices also rejects private, loopback, or unresolvable addresses. GeoServer follows the same HTTPS and address-safety rules in normal environments; test-only unsafe local URLs can be enabled separately. |
 | `username` | No | GeoServer basic-auth username. Both `username` and `password` are required before the scan sends Basic auth; if only one is supplied the scan proceeds anonymously and records a note. Ignored for GeoServices scans. |
 | `password` | No | GeoServer basic-auth password. Both `username` and `password` are required before the scan sends Basic auth; if only one is supplied the scan proceeds anonymously and records a note. Ignored for GeoServices scans. |
+| `credentials` | No | GeoServices-only credential descriptor. Supported modes are `token`, `oauth`, and `basic`. Discovery and scan requests may use inline `accessToken`/`password` values or secret references; queued imports must use `accessTokenSecretReference` or `passwordSecretReference`. Secret values and references are not echoed into inventory artifacts. |
 | `timeoutSeconds` | No | Defaults to `120` for GeoServer scans and `30` for GeoServices scans. |
 | `includeStyleContent` | No | GeoServer-only. Fetches SLD documents for deeper classification and external graphic detection. Raw style documents are not returned in the artifact. |
 
@@ -286,6 +287,19 @@ GeoServices example:
 }
 ```
 
+Credentialed GeoServices scan example:
+
+```json
+{
+  "sourceKind": "geoservices",
+  "sourceUrl": "https://example.com/arcgis/rest/services/Private/FeatureServer",
+  "credentials": {
+    "mode": "token",
+    "accessTokenSecretReference": "env:ARCGIS_PRIVATE_TOKEN"
+  }
+}
+```
+
 Successful response contract:
 
 | Field | Notes |
@@ -294,7 +308,7 @@ Successful response contract:
 | `artifactVersion` | Current schema version: `1.0`. |
 | `sourceKind` | Canonical source kind: `geoserver-rest` or `arcgis-geoservices-rest`. |
 | `source` | Source identity, product, version, build, and service type metadata. |
-| `authPosture` | Observed authentication mode (`anonymous`, `basic`, `auth-required`, `anonymous-or-auth-required`, or `unknown`), whether usable credentials were supplied, whether access was confirmed, and any auth notes. |
+| `authPosture` | Observed authentication mode (`anonymous`, `token`, `basic`, `oauth`, `auth-required`, `denied`, `expired-token`, `anonymous-or-auth-required`, or `unknown`), whether usable credentials were supplied, whether access was confirmed, and any auth notes. |
 | `scanCompleteness` | Scan status (`complete`, `partial`, or `failed`) plus warnings and missing artifact categories. |
 | `summary` | Aggregate counts for containers, resources, styles, dependencies, and compatibility tallies. |
 | `overallCompatibility` | Roll-up compatibility level (`compatible`, `partial`, `incompatible`) with warnings and manual follow-up steps. |
@@ -326,7 +340,7 @@ Behavior notes:
 - Sensitive connection metadata is redacted before serialization. Password-, token-, API-key-, and secret-like values are returned as `[redacted]`.
 - External URL dependencies strip embedded credentials, query strings, and fragments before serialization, and the corresponding dependency IDs use stable hashed fingerprints instead of raw URLs.
 - GeoServer `includeStyleContent=true` deepens classification and dependency discovery only. The artifact still returns metadata, compatibility, and external dependency references rather than raw SLD payloads.
-- GeoServices scans run anonymously: `username` and `password` are accepted by the request model for contract stability but are not used by the GeoServices scanner. Successful GeoServices artifacts therefore report `authPosture.mode = "anonymous"`, while failed artifacts can report `auth-required` or `unknown`. The ArcGIS scanner classifies supported, partial, unsupported, and manual-review cases using the codes documented in [ArcGIS Inventory Discovery](arcgis-inventory-discovery.md).
+- GeoServices scans ignore the top-level GeoServer `username`/`password` fields and use the GeoServices `credentials` descriptor instead. Successful credentialed scans report `authPosture.mode` as `token`, `basic`, or `oauth`; anonymous scans report `anonymous`. ArcGIS auth failures are deterministic: missing credentials report `auth-required`, invalid or expired ArcGIS tokens report `expired-token`, and forbidden identities report `denied`. The scanner does not refresh tokens; rotate the referenced secret and rerun the scan or queued import.
 - The `?export=json` query parameter on the scan endpoint returns the artifact as an indented JSON attachment with `Content-Disposition: attachment; filename="<service-slug>-inventory.json"` and `X-Content-Type-Options: nosniff`. The slug is derived from the source `displayName`, sanitized to alphanumeric, dash, and underscore characters, and capped at 64 characters; credentials supplied in the request body are never echoed into the artifact.
 - GeoServer can emit a synthetic `workspace:global` container when global styles or layer groups are discovered.
 - Stable artifact IDs are keyed from canonical source names rather than display text, so changing a source description does not churn container, resource, style, or dependency identifiers. Arrays and compatibility note collections are normalized for repeatable output so unchanged sources produce materially stable planning artifacts. Nullable scalar properties are omitted when the scanner has no value to emit.

--- a/docs/operator/arcgis-inventory-discovery.md
+++ b/docs/operator/arcgis-inventory-discovery.md
@@ -97,6 +97,34 @@ with HTTP 200 but flagged:
 Operators should add credentials and rerun. The discovery slice does **not**
 attempt token acquisition itself.
 
+### Credentialed scans
+
+Credentialed scans use the `credentials` object on the scan or GeoServices
+discovery request. Supported modes are `token`, `basic`, and `oauth`; OAuth is
+treated as an operator-supplied access token rather than a server-side token
+mint flow. Tokens are sent to ArcGIS REST as request token parameters, while
+Basic credentials are sent with an `Authorization: Basic` header. Queued import
+jobs must use secret references so plaintext token and password values are not
+persisted in job state.
+
+`authPosture.mode` is deterministic:
+
+| Mode | Meaning |
+|---|---|
+| `anonymous` | No credential descriptor was supplied and access was confirmed. |
+| `token` | A token credential was supplied and access was confirmed. |
+| `basic` | Basic credentials were supplied and access was confirmed. |
+| `oauth` | An OAuth access-token credential was supplied and access was confirmed. |
+| `auth-required` | ArcGIS returned 401/499 before access could be confirmed. |
+| `denied` | ArcGIS returned 403 or rejected a supplied identity. |
+| `expired-token` | ArcGIS returned 498 for an invalid or expired token. |
+| `unknown` | The scanner could not classify the source response. |
+
+Honua does not refresh ArcGIS tokens. Expired token handling is deterministic:
+the artifact uses `authPosture.mode = "expired-token"` with
+`overallCompatibility.code = "ARCGIS_TOKEN_EXPIRED"`. Operators should rotate
+the referenced secret or provide a fresh token, then rerun discovery or import.
+
 ## Artifact shape
 
 The artifact is a `MigrationSourceInventoryArtifact`. The top-level fields

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/ArcGisRestClientSecurityTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/ArcGisRestClientSecurityTests.cs
@@ -4,7 +4,9 @@
 using System.Net;
 using System.Reflection;
 using System.Text;
+using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Import.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Honua.Core.Tests.Features.Import;
@@ -79,6 +81,58 @@ public sealed class ArcGisRestClientSecurityTests
 
         result.ServiceName.Should().Be("Test Service");
         handler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetJsonDocumentAsync_WithBasicCredentials_SendsAuthorizationHeaderWithoutQuerySecret()
+    {
+        var handler = new RecordingHandler("{}");
+        var client = CreateClient(handler, (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+
+        using var document = await client.GetJsonDocumentAsync(
+            "https://example.com/arcgis/rest/services/Test/FeatureServer?f=json",
+            maxRetries: 0,
+            timeoutSeconds: 5,
+            new GeoservicesCredentialDescriptor
+            {
+                Mode = GeoservicesAuthenticationModes.Basic,
+                Username = "scanner",
+                Password = "private-password"
+            },
+            CancellationToken.None);
+
+        handler.RequestCount.Should().Be(1);
+        handler.LastRequestUri.Should().NotBeNull();
+        handler.LastRequestUri!.Query.Should().NotContain("private-password");
+        handler.LastAuthorizationHeader.Should().Be("Basic c2Nhbm5lcjpwcml2YXRlLXBhc3N3b3Jk");
+    }
+
+    [Fact]
+    public async Task DiscoverServiceAsync_WhenRetryLogsTokenRequest_RedactsTokenValue()
+    {
+        const string accessToken = "retry-secret-token";
+        var logger = new RecordingLogger<ArcGisRestClient>();
+        var handler = new TransientFailureHandler();
+        var client = CreateClient(
+            handler,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }),
+            logger);
+
+        var result = await client.DiscoverServiceAsync(
+            "https://example.com/arcgis/rest/services/Test/FeatureServer",
+            timeoutSeconds: 5,
+            maxRetries: 1,
+            CancellationToken.None,
+            new GeoservicesCredentialDescriptor
+            {
+                Mode = GeoservicesAuthenticationModes.Token,
+                AccessToken = accessToken
+            });
+
+        result.ServiceName.Should().Be("Retry Test");
+        handler.RequestCount.Should().Be(2);
+        logger.Messages.Should().Contain(message => message.Contains("token=<redacted>", StringComparison.Ordinal));
+        logger.Messages.Should().NotContain(message => message.Contains(accessToken, StringComparison.Ordinal));
     }
 
     [Fact]
@@ -158,10 +212,11 @@ public sealed class ArcGisRestClientSecurityTests
 
     private static ArcGisRestClient CreateClient(
         HttpMessageHandler handler,
-        Func<string, CancellationToken, Task<IPAddress[]>> resolver)
+        Func<string, CancellationToken, Task<IPAddress[]>> resolver,
+        ILogger<ArcGisRestClient>? logger = null)
     {
         var httpClient = new HttpClient(handler);
-        return new ArcGisRestClient(httpClient, NullLogger<ArcGisRestClient>.Instance, resolver);
+        return new ArcGisRestClient(httpClient, logger ?? NullLogger<ArcGisRestClient>.Instance, resolver);
     }
 
     private static SocketsHttpConnectionContext CreateConnectionContext(DnsEndPoint dnsEndPoint, HttpRequestMessage request)
@@ -221,6 +276,96 @@ public sealed class ArcGisRestClientSecurityTests
             {
                 Content = new StringContent(_jsonResponse, Encoding.UTF8, "application/json")
             });
+        }
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly string _jsonResponse;
+        private int _requestCount;
+
+        public RecordingHandler(string jsonResponse)
+        {
+            _jsonResponse = jsonResponse;
+        }
+
+        public int RequestCount => _requestCount;
+
+        public Uri? LastRequestUri { get; private set; }
+
+        public string? LastAuthorizationHeader { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _requestCount);
+            LastRequestUri = request.RequestUri;
+            LastAuthorizationHeader = request.Headers.Authorization?.ToString();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_jsonResponse, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class TransientFailureHandler : HttpMessageHandler
+    {
+        private int _requestCount;
+
+        public int RequestCount => _requestCount;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref _requestCount) == 1)
+            {
+                throw new HttpRequestException($"Transient ArcGIS failure for {request.RequestUri}");
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                      "serviceDescription": "Retry Test",
+                      "layers": []
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json")
+            });
+        }
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+            if (exception != null)
+            {
+                Messages.Add(exception.ToString());
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportServiceAuthenticatedImportTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportServiceAuthenticatedImportTests.cs
@@ -1,0 +1,233 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Shared.Models;
+using Honua.Postgres.Features.Import;
+using Honua.TestKit;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+[Collection("Database")]
+public sealed class GeoservicesImportServiceAuthenticatedImportTests(PostgresFixture fixture)
+{
+    [Fact]
+    public async Task ImportLayerAsync_WithTokenCredential_PagesPrivateLayerIntoPostgisWithoutPersistingSecrets()
+    {
+        const string accessToken = "private-import-token";
+        const string secretReference = "env:HONUA_PRIVATE_ARCGIS_TOKEN";
+        const string tableName = "private_geoservices_import";
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(GeoservicesImportServiceAuthenticatedImportTests));
+        var handler = new PrivateFeatureServerHandler(accessToken);
+        var service = CreateService(handler);
+
+        try
+        {
+            var result = await service.ImportLayerAsync(new GeoservicesImportRequest
+            {
+                ServiceUrl = "https://example.com/arcgis/rest/services/Private/FeatureServer",
+                LayerId = 0,
+                TableName = tableName,
+                TargetSchema = schemaName,
+                TargetSrid = 4326,
+                BatchSize = 1,
+                RequestTimeoutSeconds = 5,
+                MaxRetries = 0,
+                AutoPublish = false,
+                Credentials = new GeoservicesCredentialDescriptor
+                {
+                    Mode = GeoservicesAuthenticationModes.Token,
+                    AccessToken = accessToken,
+                    AccessTokenSecretReference = secretReference
+                }
+            });
+
+            result.Success.Should().BeTrue();
+            result.FeatureCount.Should().Be(2);
+            result.SourceServiceUrl.Should().NotContain(accessToken);
+            result.SourceServiceUrl.Should().NotContain(secretReference);
+            handler.SanitizedPaths.Should().Equal(
+                "/arcgis/rest/services/Private/FeatureServer/0?f=json",
+                "/arcgis/rest/services/Private/FeatureServer/0/query?where=1=1&returnCountOnly=true&f=json",
+                "/arcgis/rest/services/Private/FeatureServer/0/query?f=json&where=1%3D1&outFields=%2A&returnGeometry=true&resultOffset=0&resultRecordCount=1&outSR=4326",
+                "/arcgis/rest/services/Private/FeatureServer/0/query?f=json&where=1%3D1&outFields=%2A&returnGeometry=true&resultOffset=1&resultRecordCount=1&outSR=4326",
+                "/arcgis/rest/services/Private/FeatureServer/0/query?f=json&where=1%3D1&outFields=%2A&returnGeometry=true&resultOffset=2&resultRecordCount=1&outSR=4326");
+            handler.SanitizedPaths.Should().NotContain(path => path.Contains(accessToken, StringComparison.Ordinal));
+
+            var rows = await ReadImportedRowsAsync(schemaName, tableName);
+            rows.Should().Equal(
+                new ImportedRow("Alpha", 7, -157.1, 21.3),
+                new ImportedRow("Beta", 11, -157.2, 21.4));
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    private GeoservicesImportService CreateService(HttpMessageHandler handler)
+    {
+        var restClient = new ArcGisRestClient(
+            new HttpClient(handler),
+            NullLogger<ArcGisRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+
+        var crsRegistry = new Mock<ICrsRegistry>(MockBehavior.Strict);
+        crsRegistry.Setup(registry => registry.ResolveBySridAsync(4326, It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<CrsDefinition?>(new CrsDefinition(
+                "http://www.opengis.net/def/crs/EPSG/0/4326",
+                4326,
+                AxisOrder.EastNorth,
+                true)));
+
+        return new GeoservicesImportService(
+            restClient,
+            new FixtureConnectionProvider(fixture),
+            crsRegistry.Object,
+            NullLogger<GeoservicesImportService>.Instance);
+    }
+
+    private async Task<ImportedRow[]> ReadImportedRowsAsync(string schemaName, string tableName)
+    {
+        var rows = new List<ImportedRow>();
+        await using var connection = await fixture.GetConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            SELECT name, value, ST_X(geom), ST_Y(geom)
+            FROM {QuoteIdentifier(schemaName)}.{QuoteIdentifier(tableName)}
+            ORDER BY value;
+            """;
+
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            rows.Add(new ImportedRow(
+                reader.GetString(0),
+                reader.GetInt32(1),
+                reader.GetDouble(2),
+                reader.GetDouble(3)));
+        }
+
+        return rows.ToArray();
+    }
+
+    private static string QuoteIdentifier(string identifier) => $"\"{identifier.Replace("\"", "\"\"")}\"";
+
+    private sealed record ImportedRow(string Name, int Value, double X, double Y);
+
+    private sealed class PrivateFeatureServerHandler(string expectedToken) : HttpMessageHandler
+    {
+        private readonly string _escapedToken = Uri.EscapeDataString(expectedToken);
+
+        public List<string> SanitizedPaths { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var pathAndQuery = request.RequestUri?.PathAndQuery ?? string.Empty;
+            pathAndQuery.Should().Contain($"token={_escapedToken}");
+            request.Headers.Authorization.Should().BeNull();
+
+            var sanitizedPath = pathAndQuery.Replace($"&token={_escapedToken}", string.Empty, StringComparison.Ordinal);
+            SanitizedPaths.Add(sanitizedPath);
+
+            var payload = sanitizedPath switch
+            {
+                "/arcgis/rest/services/Private/FeatureServer/0?f=json" => """
+                    {
+                      "id": 0,
+                      "name": "Private Parcels",
+                      "geometryType": "esriGeometryPoint",
+                      "maxRecordCount": 1,
+                      "fields": [
+                        { "name": "OBJECTID", "type": "esriFieldTypeOID", "nullable": false },
+                        { "name": "Name", "type": "esriFieldTypeString", "nullable": true },
+                        { "name": "Value", "type": "esriFieldTypeInteger", "nullable": true }
+                      ]
+                    }
+                    """,
+                "/arcgis/rest/services/Private/FeatureServer/0/query?where=1=1&returnCountOnly=true&f=json" => """{"count":2}""",
+                "/arcgis/rest/services/Private/FeatureServer/0/query?f=json&where=1%3D1&outFields=%2A&returnGeometry=true&resultOffset=0&resultRecordCount=1&outSR=4326" => """
+                    {
+                      "features": [
+                        {
+                          "attributes": { "OBJECTID": 1, "Name": "Alpha", "Value": 7 },
+                          "geometry": { "x": -157.1, "y": 21.3 }
+                        }
+                      ],
+                      "exceededTransferLimit": true,
+                      "spatialReference": { "wkid": 4326 }
+                    }
+                    """,
+                "/arcgis/rest/services/Private/FeatureServer/0/query?f=json&where=1%3D1&outFields=%2A&returnGeometry=true&resultOffset=1&resultRecordCount=1&outSR=4326" => """
+                    {
+                      "features": [
+                        {
+                          "attributes": { "OBJECTID": 2, "Name": "Beta", "Value": 11 },
+                          "geometry": { "x": -157.2, "y": 21.4 }
+                        }
+                      ],
+                      "exceededTransferLimit": false,
+                      "spatialReference": { "wkid": 4326 }
+                    }
+                    """,
+                "/arcgis/rest/services/Private/FeatureServer/0/query?f=json&where=1%3D1&outFields=%2A&returnGeometry=true&resultOffset=2&resultRecordCount=1&outSR=4326" => """
+                    {
+                      "features": [],
+                      "exceededTransferLimit": false,
+                      "spatialReference": { "wkid": 4326 }
+                    }
+                    """,
+                _ => throw new InvalidOperationException($"Unexpected ArcGIS request path: {sanitizedPath}")
+            };
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class FixtureConnectionProvider(PostgresFixture postgresFixture) : IDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => postgresFixture.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+            => await postgresFixture.DataSource.OpenConnectionAsync(cancellationToken);
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var connection = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var transaction = await connection.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (connection, transaction);
+            }
+            catch
+            {
+                await connection.DisposeAsync();
+                throw;
+            }
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(
+            Func<Task<T>> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(
+            Func<Task> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1017

## Summary
Adds deterministic credentialed GeoServices import coverage and updates operator evidence docs so authenticated/private ArcGIS source handling is covered without leaking secrets into artifacts or logs.

## Changes Made
- Expanded ArcGIS REST client security tests for credential handling and redaction behavior.
- Added a Postgres authenticated GeoServices import fixture covering private-layer import behavior.
- Updated import capability, control-plane, and ArcGIS discovery docs to distinguish authenticated import evidence from public import evidence.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- Core ArcGIS REST client security slice passed, 10 tests.
- Postgres authenticated GeoServices import fixture passed, 1 test.
- `dotnet format Honua.sln --no-restore --verbosity minimal`
- `git diff --check`
- `git diff --cached --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [x] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

## Notes
No live external private ArcGIS smoke test was run locally. The PR uses deterministic ArcGIS-compatible fixtures for credentialed import coverage; optional external/private-source evidence can still refresh separately when credentials are available.

---

## Pre-PR Checklist
- [x] Focused draft-PR checks completed; full `scripts/ci/pre-pr-check.sh` remains delegated to CI for this draft PR
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
