### PR TITLE
feat: add classic OGC migration planning artifacts

### DIFF
--- a/docs/contributor/compatibility-and-migration-evidence.md
+++ b/docs/contributor/compatibility-and-migration-evidence.md
@@ -23,12 +23,14 @@ Use this wording until the open backlog items below are complete:
 > Its automated migration tooling imports public, queryable ArcGIS GeoServices
 > REST layers into PostGIS, generates deterministic ArcGIS and GeoServer
 > migration inventories, validates GeoServer dry-run plans, emits deterministic
-> GeoServer apply-plan evidence, and produces migration evidence artifacts for
-> review before cutover.
+> GeoServer apply-plan evidence, emits classic OGC WFS/WMS/WMTS migration
+> planning artifacts, and produces migration evidence artifacts for review
+> before cutover.
 
 Do not yet claim full automated production migration from all GeoServer catalog
-items, arbitrary OGC services, private ArcGIS services, process workloads, or
-licensed ArcGIS Pro desktop workflows. Do not claim full ArcGIS Server
+items, applied WMS/WMTS render-service migration, private ArcGIS services,
+process workloads, or licensed ArcGIS Pro desktop workflows. Do not claim full
+ArcGIS Server
 service-fidelity migration until service topology, layer identity, domains,
 relationships, attachments, renderers/styles, time metadata, and app-facing
 parity are covered by
@@ -58,7 +60,7 @@ passing and linked from this page. Those gaps are tracked below.
 | ArcGIS Server service-fidelity migration | Partial; current strongest proof is data/layer import, not full service behavior portability | [Import and Migration Capability Evidence](import-capability-evidence.md); [GeoServices REST Parity](../gis/geoservices-rest-parity.md) | Expand migration fidelity for stable layer identity, domains/subtypes, relationships, attachments, renderers/styles, time metadata, service metadata, route parity, and post-migration parity evidence: [honua-server#1025](https://github.com/honua-io/honua-server/issues/1025). |
 | ArcGIS GeoServices REST, private/authenticated services | Focused token/OAuth/Basic credential plumbing is implemented for discovery, inventory, and queued layer import; broader private-service parity remains issue-scoped | [Import and Migration Capability Evidence](import-capability-evidence.md); [ArcGIS Migration Inventory Discovery](../operator/arcgis-inventory-discovery.md) documents auth posture artifacts | Complete full private-service parity and external evidence under [honua-server#1017](https://github.com/honua-io/honua-server/issues/1017). |
 | GeoServer REST | Automated inventory, dry-run validation, and non-dry-run apply-plan generation only | [Import and Migration Capability Evidence](import-capability-evidence.md); [GeoServer to Honua Migration Guide](../gis/tutorials/geoserver-migration-guide.md); `POST /api/v1/admin/import/geoserver/start` can emit a `honua.migration.apply-plan` artifact | Apply-plan jobs do not yet mutate catalog/data/style state. Add applied GeoServer migration: [honua-server#1015](https://github.com/honua-io/honua-server/issues/1015). |
-| Classic OGC WFS/WMS/WMTS services | Compatibility and consume evidence exist; production service import is not implemented | [Cross-Server Consume Gap Report](../compatibility/cross-server-consume-gap-report.md); OGC CITE evidence above | Add classic OGC service migration importers: [honua-server#1016](https://github.com/honua-io/honua-server/issues/1016). |
+| Classic OGC WFS/WMS/WMTS services | First operator-facing scanner and planning artifact slice | `POST /api/v1/admin/import/scan` accepts `sourceKind=ogc-wfs`, `ogc-wms`, and `ogc-wmts`; [Import and Migration Capability Evidence](import-capability-evidence.md); OGC CITE and cross-server consume evidence above remain compatibility proof, not import proof | WFS emits feature-import manifest targets after GetCapabilities/DescribeFeatureType discovery. WMS/WMTS emit service plans, style/tile metadata, and unsupported/manual-review classifications for render/tile-only sources. Applied data/catalog migration remains tracked by [honua-server#1016](https://github.com/honua-io/honua-server/issues/1016). |
 | OGC API Features services | Honua can serve OGC API Features, but external OGC API Features source migration is not yet implemented | OGC API Features CITE evidence above proves serving compatibility, not source migration | Add OGC API Features source migration importer and parity evidence: [honua-server#1029](https://github.com/honua-io/honua-server/issues/1029). |
 | OGC coverage services | Honua has raster import and WCS/OGC API Coverages serving surfaces, but external WCS/OGC API Coverages service migration is not yet implemented | [Import and Migration Capability Evidence](import-capability-evidence.md) documents raster file import, not coverage-service migration | Add WCS/OGC API Coverages source migration importers and parity evidence: [honua-server#1030](https://github.com/honua-io/honua-server/issues/1030). |
 | Migration artifact chain and review workflow | Core artifact contracts exist for inventory, manifest, parity evidence, and cutover readiness; operator review/cutover workbench is not yet complete | [Migration Toolkit](../operator/migration-toolkit.md); Core tests cover manifest translation and parity evidence generation | Managed admin persistence/orchestration and broader UI/SDK workflows remain downstream work; SDK evidence gap is tracked by [honua-server#1018](https://github.com/honua-io/honua-server/issues/1018), and low-risk operator review/cutover UI is tracked by [honua-server-admin#94](https://github.com/honua-io/honua-server-admin/issues/94). |

--- a/docs/contributor/import-capability-evidence.md
+++ b/docs/contributor/import-capability-evidence.md
@@ -16,15 +16,20 @@ Use this wording for public material:
 > Honua imports common GIS file formats and public, queryable ArcGIS GeoServices
 > REST feature/map-service layers into PostGIS. It also inventories ArcGIS
 > GeoServices REST and GeoServer REST sources for migration planning, supports
-> GeoServer dry-run validation, and runs cross-server WMS/WFS/WMTS consume tests
-> against reference GeoServer and MapServer services.
+> GeoServer dry-run validation, emits classic OGC WFS/WMS/WMTS scan, manifest,
+> parity, and fidelity-classification artifacts for operator review, and runs
+> cross-server WMS/WFS/WMTS consume tests against reference GeoServer and
+> MapServer services.
 
-Do not currently claim general production import from OGC WFS/WMS/WMTS services
-or non-dry-run GeoServer catalog migration. Those are not implemented as
-operator-facing import paths in `honua-server`. Do not use broad low-risk/cost
-automated migration language until the release-gated acceptance evidence suite
-in [honua-server#1024](https://github.com/honua-io/honua-server/issues/1024)
-is passing and linked from the compatibility evidence page.
+Do not currently claim applied catalog/data migration from WMS/WMTS render
+services or non-dry-run GeoServer catalog migration. The classic OGC path is an
+operator-facing planning path: WFS feature types can produce feature-import
+manifest targets, while WMS/WMTS produce explicit service plans, unsupported
+data-copy items, and manual-review classifications. Do not use broad
+low-risk/cost automated migration language until the release-gated acceptance
+evidence suite in
+[honua-server#1024](https://github.com/honua-io/honua-server/issues/1024) is
+passing and linked from the compatibility evidence page.
 
 ## Current Capability Matrix
 
@@ -39,7 +44,7 @@ is passing and linked from the compatibility evidence page.
 | GeoServer REST discovery | Production path | `POST /api/v1/admin/import/geoserver/discover` and scanner support | HTTPS public URL required outside test mode. Basic auth is supported when both username and password are supplied. |
 | GeoServer REST import job | Dry-run validation plus apply-plan generation | `POST /api/v1/admin/import/geoserver/start` supports `dryRun=true` validation and `dryRun=false` deterministic apply-plan jobs | Non-dry-run jobs emit replayable intent only. They do not yet mutate the Honua catalog, copy data, or persist migrated styles. |
 | GeoServer SLD migration | Partial supporting path | Admin SLD import/export endpoints and `ISldStyleConverter` integration | Bulk GeoServer import validates/converts SLD content for diagnostics, but per-layer style persistence is handled by the admin SLD endpoint. |
-| Classic OGC WFS/WMS/WMTS service import | Not implemented | No production import endpoint exists for arbitrary classic OGC services | Current evidence is consume/read interoperability, not import. Track WFS/WMS/WMTS migration in [honua-server#1016](https://github.com/honua-io/honua-server/issues/1016). |
+| Classic OGC WFS/WMS/WMTS service migration planning | First operator-facing scanner slice | `POST /api/v1/admin/import/scan` with `sourceKind=ogc-wfs`, `ogc-wms`, or `ogc-wmts`; `artifactSet=all` returns inventory, manifest, and parity evidence; Core scanner tests cover WFS feature types plus WMS/WMTS render/tile manual-review classifications | WFS is a feature-import planning path only. WMS/WMTS are metadata/style/tile/service-plan paths and are marked unsupported for automated data copy unless paired with WFS, coverage, database, or file sources. Track further applied migration work in [honua-server#1016](https://github.com/honua-io/honua-server/issues/1016). |
 | OGC API Features service import | Not implemented | Honua serves OGC API Features but does not yet import external OGC API Features sources | Track source scan/import/parity evidence in [honua-server#1029](https://github.com/honua-io/honua-server/issues/1029). |
 | OGC coverage service import | Not implemented | Raster file import exists, but WCS/OGC API Coverages source migration is not an operator path | Track WCS/OGC API Coverages migration in [honua-server#1030](https://github.com/honua-io/honua-server/issues/1030). |
 | Cross-server OGC consume | Test/nightly evidence | Test-only `/__test/cross-server-consume/proxy`; nightly `cross-server-consume-nightly.yml`; gap report at `docs/compatibility/cross-server-consume-gap-report.md` | The probe exists only in the Test environment and should not be presented as an operator API. |
@@ -106,6 +111,25 @@ WFS 2.0, and WMTS 1.0 from reference GeoServer and MapServer containers. This
 is interoperability evidence for consuming OGC services. It is not a production
 import feature.
 
+### Classic OGC WFS/WMS/WMTS Migration Planning
+
+- Operator endpoint: `src/Honua.Server/Features/Import/MigrationScannerEndpoints.cs`
+- Scanner implementation: `src/Honua.Core/Features/Import/Services/OgcServiceMigrationScanner.cs`
+- URL validation: `src/Honua.Server/Features/Import/OgcServiceUrlValidation.cs`
+- Focused coverage:
+  `tests/dotnet/Honua.Core.Tests/Features/Import/OgcServiceMigrationScannerTests.cs`
+  and `tests/dotnet/Honua.Server.Tests/Import/MigrationScannerEndpointTests.cs`
+
+The classic OGC scanner validates a secret-safe HTTPS source URL, reads
+GetCapabilities, and emits the shared migration artifact chain. WFS scans
+enumerate feature types, attempt DescribeFeatureType, capture CRS/schema
+metadata, and generate feature-import manifest targets. WMS scans capture
+render layers, styles, GetMap/GetFeatureInfo operation metadata, and explicit
+unsupported data-copy classifications. WMTS scans capture tile layers, styles,
+GetTile operation metadata, ResourceURL templates, tile matrix sets, and
+manual-review tile-service classifications. The path does not apply catalog
+changes or copy rendered WMS/WMTS data by itself.
+
 ## Review Checklist
 
 Before using import language in marketing, sales, or website copy:
@@ -114,10 +138,12 @@ Before using import language in marketing, sales, or website copy:
   import path.
 - Use "GeoServer REST migration inventory, dry-run validation, and apply-plan
   generation" for GeoServer.
+- Use "classic OGC WFS/WMS/WMTS migration planning artifacts" for the
+  `POST /api/v1/admin/import/scan` path.
 - Use "cross-server WMS/WFS/WMTS consume testing" for OGC reference-service
   evidence.
-- Do not say "OGC service import" unless a production WFS/WMS/WMTS import path
-  has been implemented and tested.
+- Do not say "applied OGC service migration" unless a production WFS/WMS/WMTS
+  apply path has been implemented and tested.
 - Do not say "GeoServer catalog import applies changes" until non-dry-run jobs
   write real catalog, data, and style state rather than emitting apply-plan
   evidence only.
@@ -138,6 +164,9 @@ Run these focused checks when refreshing this evidence:
 ```bash
 dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj \
   --filter "FullyQualifiedName~GeoservicesImportEndpointTests|FullyQualifiedName~GeoServerImportEndpointTests|FullyQualifiedName~MigrationScannerEndpointTests"
+
+dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj \
+  --filter "FullyQualifiedName~OgcServiceMigrationScannerTests|FullyQualifiedName~MigrationManifestTranslatorTests|FullyQualifiedName~MigrationParityEvidenceGeneratorTests"
 
 dotnet test tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj \
   --filter "FullyQualifiedName~GeoservicesImportServiceScanTests|FullyQualifiedName~GeoServerImportServiceScanTests|FullyQualifiedName~GeoservicesArcGisInventoryBaselineTests|FullyQualifiedName~GeoServerInventoryBaselineTests"

--- a/docs/operator/migration-toolkit.md
+++ b/docs/operator/migration-toolkit.md
@@ -80,13 +80,18 @@ DescribeFeatureType so the inventory can emit fields, geometry type, CRS
 metadata, capabilities, manifest targets, and parity evidence.
 
 WMS and WMTS scans are metadata and planning paths only. They capture layers,
-styles, tile matrix sets, and service endpoints where advertised, but render
-and tile services are marked manual-review or unsupported for automated data
-copy unless paired with a WFS, coverage, database, or file source. This keeps
-render compatibility distinct from applied migration.
+styles, WMS GetMap/GetFeatureInfo operation metadata, WMTS GetTile and
+ResourceURL metadata, tile matrix sets, and service endpoints where advertised.
+Render and tile services are marked manual-review or unsupported for automated
+data copy unless paired with a WFS, coverage, database, or file source. This
+keeps render compatibility distinct from applied migration.
 The generated manifest preserves those render-only services as
 `servicePlans`, so operators can review equivalent Honua map/tile publication
 work without confusing it with automated feature import.
+The inventory also emits `fidelityClassifications` so parity evidence can show
+which WFS schema items are automated candidates and which WMS/WMTS render,
+style, endpoint, or tile-matrix constructs require manual review or are
+unsupported for data copy.
 
 Build an acceptance evidence suite only after each representative source has
 inventory, manifest, and parity evidence. The suite is an index and gate, not a

--- a/src/Honua.Core/Features/Import/Services/OgcServiceMigrationScanner.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcServiceMigrationScanner.cs
@@ -261,6 +261,11 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
             .SelectMany(layer => BuildWmsStyles(containerId, layer))
             .OrderBy(static style => style.Id, StringComparer.Ordinal)
             .ToArray();
+        var dependencies = BuildWmsOperationDependencies(
+            containerId,
+            capabilities,
+            version,
+            ImportCompatibilityCodes.OgcWmsRenderOnlySource);
 
         return CreateRenderOnlyArtifact(
             "ogc-wms",
@@ -273,7 +278,8 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
             capabilitiesUrl,
             resources,
             styles,
-            ImportCompatibilityCodes.OgcWmsRenderOnlySource);
+            ImportCompatibilityCodes.OgcWmsRenderOnlySource,
+            dependencies);
     }
 
     private static MigrationSourceInventoryArtifact BuildWmtsInventory(
@@ -339,6 +345,15 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
                         ImportCompatibilityCodes.OgcWmtsTileOnlySource)
                 };
             })
+            .Concat(BuildWmtsOperationDependencies(
+                containerId,
+                capabilities,
+                version,
+                ImportCompatibilityCodes.OgcWmtsTileOnlySource))
+            .Concat(BuildWmtsResourceUrlDependencies(
+                containerId,
+                layers,
+                ImportCompatibilityCodes.OgcWmtsTileOnlySource))
             .OrderBy(static dependency => dependency.Id, StringComparer.Ordinal)
             .ToArray();
 
@@ -479,7 +494,13 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
             Containers = containers,
             Resources = resources.OrderBy(static resource => resource.Id, StringComparer.Ordinal).ToArray(),
             Styles = styles.OrderBy(static style => style.Id, StringComparer.Ordinal).ToArray(),
-            ExternalDependencies = dependencies.OrderBy(static dependency => dependency.Id, StringComparer.Ordinal).ToArray()
+            ExternalDependencies = dependencies.OrderBy(static dependency => dependency.Id, StringComparer.Ordinal).ToArray(),
+            FidelityClassifications = BuildFidelityClassifications(
+                sourceKind,
+                serviceType,
+                resources,
+                styles,
+                dependencies)
         };
     }
 
@@ -602,6 +623,7 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
                     Name = styleName,
                     Format = "WMS",
                     ResourceIds = [resourceId],
+                    Metadata = BuildOptionalMetadata(("title", ChildValue(style, "Title"))),
                     Compatibility = MigrationInventoryHelpers.Partial(
                         "WMS style metadata was captured for manual render-service migration planning.",
                         [],
@@ -633,6 +655,7 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
                     Name = styleName,
                     Format = "WMTS",
                     ResourceIds = [resourceId],
+                    Metadata = BuildOptionalMetadata(("title", ChildValue(style, "Title"))),
                     Compatibility = MigrationInventoryHelpers.Partial(
                         "WMTS style metadata was captured for manual tile-service migration planning.",
                         [],
@@ -642,6 +665,431 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
             })
             .ToArray();
     }
+
+    private static MigrationExternalDependency[] BuildWmsOperationDependencies(
+        string containerId,
+        XDocument capabilities,
+        string version,
+        string compatibilityCode)
+    {
+        var dependencies = new List<MigrationExternalDependency>();
+        AddWmsOperationDependency(
+            dependencies,
+            containerId,
+            capabilities,
+            version,
+            operationName: "GetMap",
+            dependencyType: "render",
+            compatibilityCode);
+        AddWmsOperationDependency(
+            dependencies,
+            containerId,
+            capabilities,
+            version,
+            operationName: "GetFeatureInfo",
+            dependencyType: "feature-info",
+            compatibilityCode);
+
+        return dependencies.ToArray();
+    }
+
+    private static void AddWmsOperationDependency(
+        List<MigrationExternalDependency> dependencies,
+        string containerId,
+        XDocument capabilities,
+        string version,
+        string operationName,
+        string dependencyType,
+        string compatibilityCode)
+    {
+        var operation = Descendants(capabilities, operationName)
+            .FirstOrDefault(static element => element.Parent?.Name.LocalName == "Request");
+        if (operation == null)
+        {
+            return;
+        }
+
+        var formats = Elements(operation, "Format")
+            .Select(static element => element.Value.Trim())
+            .Where(static value => value.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static value => value, StringComparer.Ordinal)
+            .ToArray();
+
+        dependencies.Add(new MigrationExternalDependency
+        {
+            Id = $"endpoint:wms:{ToOperationId(operationName)}",
+            ContainerId = containerId,
+            Kind = "ogc-endpoint",
+            Name = $"WMS {operationName}",
+            DependencyType = dependencyType,
+            Address = ToSafeExternalAddress(ReadOnlineResourceHref(operation)),
+            Metadata = BuildOperationMetadata("WMS", version, operationName, formats),
+            Compatibility = MigrationInventoryHelpers.Partial(
+                $"WMS {operationName} endpoint metadata was captured for manual render-service migration planning.",
+                [],
+                ["Review equivalent Honua map-service routing, supported formats, and client cutover URLs."],
+                compatibilityCode)
+        });
+    }
+
+    private static MigrationExternalDependency[] BuildWmtsOperationDependencies(
+        string containerId,
+        XDocument capabilities,
+        string version,
+        string compatibilityCode)
+    {
+        var dependencies = new List<MigrationExternalDependency>();
+        AddWmtsOperationDependency(
+            dependencies,
+            containerId,
+            capabilities,
+            version,
+            operationName: "GetTile",
+            dependencyType: "tile",
+            compatibilityCode);
+        AddWmtsOperationDependency(
+            dependencies,
+            containerId,
+            capabilities,
+            version,
+            operationName: "GetFeatureInfo",
+            dependencyType: "feature-info",
+            compatibilityCode);
+
+        return dependencies.ToArray();
+    }
+
+    private static void AddWmtsOperationDependency(
+        List<MigrationExternalDependency> dependencies,
+        string containerId,
+        XDocument capabilities,
+        string version,
+        string operationName,
+        string dependencyType,
+        string compatibilityCode)
+    {
+        var operation = Descendants(capabilities, "Operation")
+            .FirstOrDefault(element => string.Equals(
+                element.Attribute("name")?.Value,
+                operationName,
+                StringComparison.OrdinalIgnoreCase));
+        if (operation == null)
+        {
+            return;
+        }
+
+        dependencies.Add(new MigrationExternalDependency
+        {
+            Id = $"endpoint:wmts:{ToOperationId(operationName)}",
+            ContainerId = containerId,
+            Kind = "ogc-endpoint",
+            Name = $"WMTS {operationName}",
+            DependencyType = dependencyType,
+            Address = ToSafeExternalAddress(ReadOnlineResourceHref(operation)),
+            Metadata = BuildOperationMetadata("WMTS", version, operationName, []),
+            Compatibility = MigrationInventoryHelpers.Partial(
+                $"WMTS {operationName} endpoint metadata was captured for manual tile-service migration planning.",
+                [],
+                ["Review equivalent Honua tile-service routing, cache grid configuration, and client cutover URLs."],
+                compatibilityCode)
+        });
+    }
+
+    private static MigrationExternalDependency[] BuildWmtsResourceUrlDependencies(
+        string containerId,
+        IReadOnlyList<XElement> layers,
+        string compatibilityCode)
+    {
+        return layers
+            .SelectMany(layer =>
+            {
+                var layerId = ChildValue(layer, "Identifier");
+                if (string.IsNullOrWhiteSpace(layerId))
+                {
+                    return [];
+                }
+
+                var resourceId = $"wmts-layer:{ToStableId(layerId)}";
+                return Elements(layer, "ResourceURL")
+                    .Select(resourceUrl =>
+                    {
+                        var resourceType = AttributeValue(resourceUrl, "resourceType") ?? "resource";
+                        var format = AttributeValue(resourceUrl, "format");
+                        var template = AttributeValue(resourceUrl, "template");
+                        return new MigrationExternalDependency
+                        {
+                            Id = $"endpoint:wmts:{ToStableId(resourceType)}:{ToStableId(layerId)}:{ToStableId(format ?? "default")}",
+                            ContainerId = containerId,
+                            ResourceId = resourceId,
+                            Kind = "ogc-endpoint",
+                            Name = $"WMTS {resourceType} template {layerId}",
+                            DependencyType = $"resource-url:{resourceType}",
+                            Address = ToSafeExternalAddress(template),
+                            Metadata = BuildOptionalMetadata(
+                                ("service", "WMTS"),
+                                ("operation", "ResourceURL"),
+                                ("resourceType", resourceType),
+                                ("format", format)),
+                            Compatibility = MigrationInventoryHelpers.Partial(
+                                "WMTS ResourceURL template was captured for manual tile-service migration planning.",
+                                [],
+                                ["Review tile template compatibility with Honua cache and tile matrix configuration."],
+                                compatibilityCode)
+                        };
+                    });
+            })
+            .OrderBy(static dependency => dependency.Id, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static MigrationFidelityClassificationRecord[] BuildFidelityClassifications(
+        string sourceKind,
+        string serviceType,
+        MigrationInventoryResource[] resources,
+        MigrationInventoryStyle[] styles,
+        MigrationExternalDependency[] dependencies)
+    {
+        var records = new List<MigrationFidelityClassificationRecord>();
+
+        foreach (var resource in resources.OrderBy(static item => item.Id, StringComparer.Ordinal))
+        {
+            records.Add(CreateFidelityRecord(
+                sourceKind,
+                serviceType,
+                resource.Id,
+                resource.Kind,
+                GetResourceFidelityCategory(sourceKind, resource),
+                resource.Name,
+                GetAutomationStatus(resource.Compatibility),
+                resource.Compatibility,
+                GetResourceTargetKind(sourceKind, resource),
+                resource.StyleIds.Concat(resource.ExternalDependencyIds)));
+        }
+
+        foreach (var style in styles.OrderBy(static item => item.Id, StringComparer.Ordinal))
+        {
+            records.Add(CreateFidelityRecord(
+                sourceKind,
+                serviceType,
+                style.Id,
+                style.Kind,
+                "style",
+                style.Name,
+                GetAutomationStatus(style.Compatibility),
+                style.Compatibility,
+                "style",
+                style.ResourceIds.Concat(style.ExternalDependencyIds)));
+        }
+
+        foreach (var dependency in dependencies.OrderBy(static item => item.Id, StringComparer.Ordinal))
+        {
+            records.Add(CreateFidelityRecord(
+                sourceKind,
+                serviceType,
+                dependency.Id,
+                dependency.Kind,
+                GetDependencyFidelityCategory(dependency),
+                dependency.Name,
+                GetAutomationStatus(dependency.Compatibility),
+                dependency.Compatibility,
+                dependency.Kind,
+                string.IsNullOrWhiteSpace(dependency.ResourceId) ? [] : [dependency.ResourceId]));
+        }
+
+        return records
+            .OrderBy(static record => record.Id, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static MigrationFidelityClassificationRecord CreateFidelityRecord(
+        string sourceKind,
+        string serviceType,
+        string sourceId,
+        string kind,
+        string category,
+        string? name,
+        string automationStatus,
+        MigrationCompatibilityAssessment compatibility,
+        string? targetKind,
+        IEnumerable<string> relatedIds)
+        => new()
+        {
+            Id = $"classification:{sourceId}:{category}",
+            SourceId = sourceId,
+            Kind = kind,
+            Category = category,
+            Name = name,
+            AutomationStatus = automationStatus,
+            Code = compatibility.Code ?? BuildFallbackFidelityCode(sourceKind, kind, category),
+            Reason = compatibility.Reason,
+            TargetKind = targetKind,
+            ManualSteps = automationStatus == MigrationFidelityAutomationStatuses.Automated
+                ? []
+                : MigrationInventoryHelpers.NormalizeStrings(compatibility.ManualSteps),
+            RelatedIds = MigrationInventoryHelpers.NormalizeStrings(relatedIds),
+            Metadata = BuildOptionalMetadata(
+                ("sourceKind", sourceKind),
+                ("serviceType", serviceType),
+                ("compatibilityLevel", compatibility.Level))
+        };
+
+    private static string GetResourceFidelityCategory(string sourceKind, MigrationInventoryResource resource)
+    {
+        if (sourceKind.Equals("ogc-wfs", StringComparison.OrdinalIgnoreCase))
+        {
+            return "feature-schema";
+        }
+
+        return sourceKind.Equals("ogc-wmts", StringComparison.OrdinalIgnoreCase)
+            ? "tile-data-copy"
+            : "render-data-copy";
+    }
+
+    private static string? GetResourceTargetKind(string sourceKind, MigrationInventoryResource resource)
+    {
+        if (sourceKind.Equals("ogc-wfs", StringComparison.OrdinalIgnoreCase) &&
+            resource.Kind.Equals("feature-type", StringComparison.OrdinalIgnoreCase))
+        {
+            return "feature-layer";
+        }
+
+        if (sourceKind.Equals("ogc-wmts", StringComparison.OrdinalIgnoreCase))
+        {
+            return "tile-service-layer";
+        }
+
+        if (sourceKind.Equals("ogc-wms", StringComparison.OrdinalIgnoreCase))
+        {
+            return "map-service-layer";
+        }
+
+        return null;
+    }
+
+    private static string GetDependencyFidelityCategory(MigrationExternalDependency dependency)
+        => dependency.Kind.Equals("tile-matrix-set", StringComparison.OrdinalIgnoreCase)
+            ? "tile-matrix-set"
+            : "service-endpoint";
+
+    private static string GetAutomationStatus(MigrationCompatibilityAssessment compatibility)
+    {
+        if (IsCompatible(compatibility.Level))
+        {
+            return MigrationFidelityAutomationStatuses.Automated;
+        }
+
+        return IsIncompatible(compatibility.Level)
+            ? MigrationFidelityAutomationStatuses.Unsupported
+            : MigrationFidelityAutomationStatuses.ManualReview;
+    }
+
+    private static bool IsCompatible(string? level)
+        => string.Equals(level, "compatible", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsIncompatible(string? level)
+        => string.Equals(level, "incompatible", StringComparison.OrdinalIgnoreCase);
+
+    private static Dictionary<string, string> BuildOperationMetadata(
+        string serviceType,
+        string version,
+        string operationName,
+        string[] formats)
+    {
+        var metadata = BuildOptionalMetadata(
+            ("service", serviceType),
+            ("version", version),
+            ("operation", operationName));
+        if (formats.Length > 0)
+        {
+            metadata["formats"] = string.Join(",", formats);
+        }
+
+        return metadata;
+    }
+
+    private static Dictionary<string, string> BuildOptionalMetadata(params (string Key, string? Value)[] pairs)
+    {
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (key, value) in pairs)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                metadata[key] = value.Trim();
+            }
+        }
+
+        return metadata;
+    }
+
+    private static string? ReadOnlineResourceHref(XElement element)
+        => Descendants(element, "OnlineResource")
+            .Concat(Descendants(element, "Get"))
+            .Select(static candidate => AttributeValue(candidate, "href"))
+            .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+
+    private static string? ToSafeExternalAddress(string? address)
+    {
+        if (string.IsNullOrWhiteSpace(address))
+        {
+            return null;
+        }
+
+        var trimmed = address.Trim();
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+        {
+            var fragmentIndex = trimmed.IndexOf('#', StringComparison.Ordinal);
+            if (fragmentIndex >= 0)
+            {
+                trimmed = trimmed[..fragmentIndex];
+            }
+
+            var queryIndex = trimmed.IndexOf('?', StringComparison.Ordinal);
+            if (queryIndex < 0)
+            {
+                return trimmed;
+            }
+
+            var safeQuery = BuildSafeCapabilitiesQuery(trimmed[queryIndex..]);
+            return safeQuery.Length == 0
+                ? trimmed[..queryIndex]
+                : $"{trimmed[..queryIndex]}?{safeQuery}";
+        }
+
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Fragment = string.Empty,
+            Query = BuildSafeCapabilitiesQuery(uri.Query)
+        };
+
+        return builder.Uri.AbsoluteUri;
+    }
+
+    private static string? AttributeValue(XElement element, string localName)
+        => element.Attributes()
+            .FirstOrDefault(attribute => string.Equals(attribute.Name.LocalName, localName, StringComparison.Ordinal))?
+            .Value
+            .Trim();
+
+    private static string ToOperationId(string operationName)
+        => operationName switch
+        {
+            "GetCapabilities" => "get-capabilities",
+            "GetFeatureInfo" => "get-feature-info",
+            "GetMap" => "get-map",
+            "GetTile" => "get-tile",
+            _ => ToStableId(operationName)
+        };
+
+    private static string BuildFallbackFidelityCode(string sourceKind, string kind, string category)
+        => $"{ToCodePart(sourceKind)}_{ToCodePart(kind)}_{ToCodePart(category)}";
+
+    private static string ToCodePart(string value)
+        => ToStableId(value)
+            .Replace('-', '_')
+            .ToUpperInvariant();
 
     private async Task<MigrationSpatialReferenceInfo[]> BuildSpatialReferencesAsync(
         IReadOnlyList<(string Role, string? Value)> crsValues,

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcServiceMigrationScannerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcServiceMigrationScannerTests.cs
@@ -40,6 +40,12 @@ public sealed class OgcServiceMigrationScannerTests
         resource.Fields.Should().Contain(field => field.Name == "STATE_NAME" && field.FieldType == "xsd:string");
         resource.SpatialReferences.Should().ContainSingle(reference => reference.Srid == 4326);
         resource.Compatibility.Code.Should().Be(ImportCompatibilityCodes.OgcWfsFeatureSource);
+        artifact.FidelityClassifications.Should().ContainSingle(record =>
+                record.Id == "classification:feature-type:topp-states:feature-schema")
+            .Which.Should().Match<MigrationFidelityClassificationRecord>(record =>
+                record.AutomationStatus == MigrationFidelityAutomationStatuses.Automated &&
+                record.Code == ImportCompatibilityCodes.OgcWfsFeatureSource &&
+                record.TargetKind == "feature-layer");
     }
 
     [Fact]
@@ -129,6 +135,10 @@ public sealed class OgcServiceMigrationScannerTests
             .Which.Should().Be("DescribeFeatureType metadata was unavailable for topp:states: DescribeFeatureType metadata could not be retrieved.");
         artifact.Resources.Should().ContainSingle().Which.Compatibility.Warnings
             .Should().ContainSingle().Which.Should().Be("DescribeFeatureType metadata could not be retrieved.");
+        artifact.FidelityClassifications.Should().Contain(record =>
+            record.SourceId == "feature-type:topp-states" &&
+            record.AutomationStatus == MigrationFidelityAutomationStatuses.ManualReview &&
+            record.Code == ImportCompatibilityCodes.OgcFeatureSchemaManualReview);
         artifact.ScanCompleteness.Warnings
             .Concat(artifact.Resources.SelectMany(resource => resource.Compatibility.Warnings))
             .Should().NotContain(value => value.Contains("secret", StringComparison.OrdinalIgnoreCase));
@@ -154,6 +164,21 @@ public sealed class OgcServiceMigrationScannerTests
                 compatibility.Level == "incompatible" &&
                 compatibility.Code == ImportCompatibilityCodes.OgcWmsRenderOnlySource);
         artifact.Styles.Should().ContainSingle(style => style.Kind == "wms-style");
+        artifact.ExternalDependencies.Should().Contain(dependency =>
+            dependency.Id == "endpoint:wms:get-map" &&
+            dependency.DependencyType == "render" &&
+            dependency.Metadata["formats"] == "image/jpeg,image/png" &&
+            dependency.Address == "https://example.com/geoserver/wms");
+        artifact.ExternalDependencies.Select(dependency => dependency.Address)
+            .Should().OnlyContain(address => address == null || !address.Contains("secret", StringComparison.OrdinalIgnoreCase));
+        artifact.FidelityClassifications.Should().Contain(record =>
+            record.SourceId == "wms-layer:topp-states" &&
+            record.Category == "render-data-copy" &&
+            record.AutomationStatus == MigrationFidelityAutomationStatuses.Unsupported);
+        artifact.FidelityClassifications.Should().Contain(record =>
+            record.SourceId == "style:topp-states:polygon" &&
+            record.Category == "style" &&
+            record.AutomationStatus == MigrationFidelityAutomationStatuses.ManualReview);
     }
 
     [Fact]
@@ -174,6 +199,26 @@ public sealed class OgcServiceMigrationScannerTests
         artifact.Resources.Should().ContainSingle(resource => resource.Name == "topp:states")
             .Which.Compatibility.Code.Should().Be(ImportCompatibilityCodes.OgcWmtsTileOnlySource);
         artifact.ExternalDependencies.Should().Contain(dependency => dependency.Kind == "tile-matrix-set" && dependency.Name == "EPSG:3857");
+        artifact.ExternalDependencies.Should().Contain(dependency =>
+            dependency.Id == "endpoint:wmts:get-tile" &&
+            dependency.DependencyType == "tile" &&
+            dependency.Address == "https://example.com/geoserver/gwc/service/wmts");
+        artifact.ExternalDependencies.Should().Contain(dependency =>
+            dependency.Id == "endpoint:wmts:tile:topp-states:image-png" &&
+            dependency.ResourceId == "wmts-layer:topp-states" &&
+            dependency.DependencyType == "resource-url:tile" &&
+            dependency.Address != null &&
+            dependency.Address.Contains("format=image%2Fpng", StringComparison.Ordinal));
+        artifact.ExternalDependencies.Select(dependency => dependency.Address)
+            .Should().OnlyContain(address => address == null || !address.Contains("secret", StringComparison.OrdinalIgnoreCase));
+        artifact.FidelityClassifications.Should().Contain(record =>
+            record.SourceId == "wmts-layer:topp-states" &&
+            record.Category == "tile-data-copy" &&
+            record.AutomationStatus == MigrationFidelityAutomationStatuses.Unsupported);
+        artifact.FidelityClassifications.Should().Contain(record =>
+            record.SourceId == "tile-matrix-set:epsg-3857" &&
+            record.Category == "tile-matrix-set" &&
+            record.AutomationStatus == MigrationFidelityAutomationStatuses.ManualReview);
     }
 
     private static OgcServiceMigrationScanner CreateScanner(HttpClient httpClient, Mock<ICrsRegistry> crsRegistry)
@@ -275,9 +320,20 @@ public sealed class OgcServiceMigrationScannerTests
         """;
 
     private const string WmsCapabilities = """
-        <WMS_Capabilities version="1.3.0">
+        <WMS_Capabilities xmlns:xlink="http://www.w3.org/1999/xlink" version="1.3.0">
           <Service><Title>Reference WMS</Title></Service>
           <Capability>
+            <Request>
+              <GetMap>
+                <Format>image/png</Format>
+                <Format>image/jpeg</Format>
+                <DCPType><HTTP><Get><OnlineResource xlink:href="https://example.com/geoserver/wms?token=secret" /></Get></HTTP></DCPType>
+              </GetMap>
+              <GetFeatureInfo>
+                <Format>text/plain</Format>
+                <DCPType><HTTP><Get><OnlineResource xlink:href="https://example.com/geoserver/wms?token=secret" /></Get></HTTP></DCPType>
+              </GetFeatureInfo>
+            </Request>
             <Layer>
               <Title>Root</Title>
               <Layer>
@@ -291,13 +347,19 @@ public sealed class OgcServiceMigrationScannerTests
         """;
 
     private const string WmtsCapabilities = """
-        <Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" version="1.0.0">
+        <Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.0.0">
           <ows:ServiceIdentification><ows:Title>Reference WMTS</ows:Title></ows:ServiceIdentification>
+          <ows:OperationsMetadata>
+            <ows:Operation name="GetTile">
+              <ows:DCP><ows:HTTP><ows:Get xlink:href="https://example.com/geoserver/gwc/service/wmts?token=secret" /></ows:HTTP></ows:DCP>
+            </ows:Operation>
+          </ows:OperationsMetadata>
           <Contents>
             <Layer>
               <ows:Title>States</ows:Title>
               <ows:Identifier>topp:states</ows:Identifier>
               <Style><ows:Identifier>default</ows:Identifier></Style>
+              <ResourceURL format="image/png" resourceType="tile" template="https://example.com/geoserver/gwc/service/wmts/rest/topp:states/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png?token=secret&amp;format=image/png" />
               <TileMatrixSetLink><TileMatrixSet>EPSG:3857</TileMatrixSet></TileMatrixSetLink>
             </Layer>
             <TileMatrixSet><ows:Identifier>EPSG:3857</ows:Identifier></TileMatrixSet>

--- a/tests/dotnet/Honua.Server.Tests/Import/MigrationScannerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/MigrationScannerEndpointTests.cs
@@ -135,6 +135,9 @@ public sealed class MigrationScannerEndpointTests : IAsyncLifetime
         root.GetProperty("manifest").GetProperty("targetResources").GetArrayLength().Should().Be(1);
         root.GetProperty("parityEvidence").GetProperty("artifactKind").GetString().Should().Be("honua.migration.parity-evidence-pack");
         root.GetProperty("parityEvidence").GetProperty("manifestAvailable").GetBoolean().Should().BeTrue();
+        root.GetProperty("inventory").GetProperty("fidelityClassifications").GetArrayLength().Should().BeGreaterThan(0);
+        root.GetProperty("parityEvidence").GetProperty("sections").EnumerateArray()
+            .Should().Contain(section => section.GetProperty("id").GetString() == "fidelity");
     }
 
     [IntegrationTest]
@@ -662,6 +665,22 @@ public sealed class MigrationScannerEndpointTests : IAsyncLifetime
                                 Reason = "WMS exposes rendered map images and cannot supply automated feature data-copy by itself."
                             }
                         }
+                    ],
+                    FidelityClassifications =
+                    [
+                        new MigrationFidelityClassificationRecord
+                        {
+                            Id = "classification:wms-layer:topp-states:render-data-copy",
+                            SourceId = "wms-layer:topp-states",
+                            Kind = "render-layer",
+                            Category = "render-data-copy",
+                            Name = "topp:states",
+                            AutomationStatus = MigrationFidelityAutomationStatuses.Unsupported,
+                            Code = ImportCompatibilityCodes.OgcWmsRenderOnlySource,
+                            Reason = "WMS exposes rendered map images and cannot supply automated feature data-copy by itself.",
+                            TargetKind = "map-service-layer",
+                            ManualSteps = ["Pair this WMS layer with a WFS, coverage, database, or file source before planning data import."]
+                        }
                     ]
                 });
             }
@@ -728,6 +747,21 @@ public sealed class MigrationScannerEndpointTests : IAsyncLifetime
                             Code = ImportCompatibilityCodes.OgcWfsFeatureSource,
                             Reason = "WFS feature type metadata can be represented in the migration inventory."
                         }
+                    }
+                ],
+                FidelityClassifications =
+                [
+                    new MigrationFidelityClassificationRecord
+                    {
+                        Id = "classification:feature-type:topp-states:feature-schema",
+                        SourceId = "feature-type:topp-states",
+                        Kind = "feature-type",
+                        Category = "feature-schema",
+                        Name = "topp:states",
+                        AutomationStatus = MigrationFidelityAutomationStatuses.Automated,
+                        Code = ImportCompatibilityCodes.OgcWfsFeatureSource,
+                        Reason = "WFS feature type metadata can be represented in the migration inventory.",
+                        TargetKind = "feature-layer"
                     }
                 ]
             });


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1016

## Summary
Adds the classic OGC migration planning slice for WFS/WMS/WMTS sources, keeping consume compatibility distinct from migratable source evidence.

## Changes Made
- Extended the OGC service migration scanner to classify classic service sources and planning artifacts.
- Added focused core scanner and server endpoint tests for WFS/WMS/WMTS migration planning behavior.
- Updated migration evidence and operator docs to distinguish OGC migration/import from read-only compatibility.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- `dotnet build src/Honua.Core/Honua.Core.csproj -m:1 /nr:false /p:BuildInParallel=false /p:UseSharedCompilation=false`
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --filter FullyQualifiedName~OgcServiceMigrationScannerTests` passed, 7 tests.
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter FullyQualifiedName~MigrationScannerEndpointTests` passed, 17 tests.
- `dotnet format Honua.sln`
- Targeted `dotnet format Honua.sln --include <changed files>`
- `git diff --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

## Remaining Scope
This is the scanner/planning artifact slice. WFS data import, WMS/WMTS metadata/style/tile migration, reference-container integration evidence, and passing evidence links remain before #1016 should close.

---

## Pre-PR Checklist
- [x] Focused draft-PR checks completed; full `scripts/ci/pre-pr-check.sh` remains delegated to CI for this draft PR
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
