### PR TITLE
feat: add migration acceptance evidence suite

### DIFF
--- a/docs/operator/migration-toolkit.md
+++ b/docs/operator/migration-toolkit.md
@@ -101,6 +101,13 @@ WMS, and WMTS. The first coverage slice is documented in
 metadata, output formats, CRS/subset metadata, bands/ranges, and temporal
 dimensions without claiming end-to-end coverage import or parity.
 
+Build an acceptance evidence suite only after each representative source has
+inventory, manifest, and parity evidence. The suite is an index and gate, not a
+replacement for the source-specific artifacts. It records covered source kinds,
+required source kinds, per-source automation classification, stage state, and
+blocking gaps. Use required source kinds for website or release claims so the
+suite fails when ArcGIS, GeoServer, or OGC evidence is absent.
+
 ## State Values
 
 Every parity and readiness item uses one of these state values:

--- a/src/Honua.Core/Features/Import/Domain/MigrationAcceptanceEvidenceArtifact.cs
+++ b/src/Honua.Core/Features/Import/Domain/MigrationAcceptanceEvidenceArtifact.cs
@@ -29,6 +29,11 @@ public sealed record MigrationAcceptanceEvidenceArtifact
     public required MigrationAcceptanceEvidenceSummary Summary { get; init; }
 
     /// <summary>
+    /// Aggregate cost and performance evidence across measured source entries.
+    /// </summary>
+    public required MigrationAcceptanceCostEvidenceSummary CostEvidence { get; init; }
+
+    /// <summary>
     /// Per-source evidence entries in deterministic order.
     /// </summary>
     public MigrationAcceptanceEvidenceEntry[] Entries { get; init; } = [];
@@ -93,6 +98,82 @@ public sealed record MigrationAcceptanceEvidenceSummary
     /// Source kinds covered by this evidence suite.
     /// </summary>
     public string[] CoveredSourceKinds { get; init; } = [];
+}
+
+/// <summary>
+/// Aggregate cost and performance evidence for a migration acceptance suite.
+/// </summary>
+public sealed record MigrationAcceptanceCostEvidenceSummary
+{
+    /// <summary>
+    /// Cost evidence classification: <c>pass</c>, <c>warn</c>, <c>fail</c>, or <c>unknown</c>.
+    /// </summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// Number of source entries with cost evidence attached.
+    /// </summary>
+    public int MeasuredSourceCount { get; init; }
+
+    /// <summary>
+    /// Number of source entries missing cost evidence.
+    /// </summary>
+    public int MissingSourceCount { get; init; }
+
+    /// <summary>
+    /// Total measured duration across entries in milliseconds.
+    /// </summary>
+    public long? DurationMilliseconds { get; init; }
+
+    /// <summary>
+    /// Total scan duration across entries in milliseconds.
+    /// </summary>
+    public long? ScanDurationMilliseconds { get; init; }
+
+    /// <summary>
+    /// Total apply, import, or dry-run duration across entries in milliseconds.
+    /// </summary>
+    public long? ApplyDurationMilliseconds { get; init; }
+
+    /// <summary>
+    /// Aggregate feature throughput across entries in features per second.
+    /// </summary>
+    public double? FeatureThroughputPerSecond { get; init; }
+
+    /// <summary>
+    /// Total source-system requests observed across entries.
+    /// </summary>
+    public int? SourceRequestCount { get; init; }
+
+    /// <summary>
+    /// Total retry attempts observed across entries.
+    /// </summary>
+    public int? RetryCount { get; init; }
+
+    /// <summary>
+    /// Total bytes read from source systems or staged inputs.
+    /// </summary>
+    public long? BytesRead { get; init; }
+
+    /// <summary>
+    /// Total bytes written to Honua-owned stores or output artifacts.
+    /// </summary>
+    public long? BytesWritten { get; init; }
+
+    /// <summary>
+    /// Total emitted evidence artifact size in bytes.
+    /// </summary>
+    public long? ArtifactSizeBytes { get; init; }
+
+    /// <summary>
+    /// Aggregate manual-review ratio across measured entries.
+    /// </summary>
+    public double? ManualReviewRatio { get; init; }
+
+    /// <summary>
+    /// Findings that explain warning, failure, or unknown classifications.
+    /// </summary>
+    public MigrationAcceptanceCostEvidenceFinding[] Findings { get; init; } = [];
 }
 
 /// <summary>
@@ -166,9 +247,192 @@ public sealed record MigrationAcceptanceEvidenceEntry
     public string[] EvidenceReferences { get; init; } = [];
 
     /// <summary>
+    /// Optional cost and performance evidence derived from the parity evidence pack.
+    /// </summary>
+    public MigrationAcceptanceCostEvidenceEntry? CostEvidence { get; init; }
+
+    /// <summary>
     /// Deterministic notes explaining important evidence gaps.
     /// </summary>
     public string[] Notes { get; init; } = [];
+}
+
+/// <summary>
+/// Per-source cost and performance evidence summary.
+/// </summary>
+public sealed record MigrationAcceptanceCostEvidenceEntry
+{
+    /// <summary>
+    /// Cost evidence classification: <c>pass</c>, <c>warn</c>, <c>fail</c>, or <c>unknown</c>.
+    /// </summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// Short reviewer-facing summary of the measured cost evidence.
+    /// </summary>
+    public required string Summary { get; init; }
+
+    /// <summary>
+    /// Measurement scope supplied by the source collector or test harness.
+    /// </summary>
+    public required string MeasurementScope { get; init; }
+
+    /// <summary>
+    /// Total measured duration in milliseconds.
+    /// </summary>
+    public long? DurationMilliseconds { get; init; }
+
+    /// <summary>
+    /// Measured scan duration in milliseconds.
+    /// </summary>
+    public long? ScanDurationMilliseconds { get; init; }
+
+    /// <summary>
+    /// Measured apply, import, or dry-run duration in milliseconds.
+    /// </summary>
+    public long? ApplyDurationMilliseconds { get; init; }
+
+    /// <summary>
+    /// Feature throughput in features per second.
+    /// </summary>
+    public double? FeatureThroughputPerSecond { get; init; }
+
+    /// <summary>
+    /// Resource throughput in resources per second.
+    /// </summary>
+    public double? ResourceThroughputPerSecond { get; init; }
+
+    /// <summary>
+    /// Total source-system requests issued by the run.
+    /// </summary>
+    public int? SourceRequestCount { get; init; }
+
+    /// <summary>
+    /// Total retry attempts observed by the run.
+    /// </summary>
+    public int? RetryCount { get; init; }
+
+    /// <summary>
+    /// Total bytes read from sources or staged inputs.
+    /// </summary>
+    public long? BytesRead { get; init; }
+
+    /// <summary>
+    /// Total bytes written to Honua-owned stores or artifacts.
+    /// </summary>
+    public long? BytesWritten { get; init; }
+
+    /// <summary>
+    /// Size in bytes of the emitted cost evidence artifact.
+    /// </summary>
+    public long? ArtifactSizeBytes { get; init; }
+
+    /// <summary>
+    /// Ratio of manual-review items to measured resources.
+    /// </summary>
+    public double? ManualReviewRatio { get; init; }
+
+    /// <summary>
+    /// Normalized operation-level cost measurements.
+    /// </summary>
+    public MigrationAcceptanceCostOperationEvidence[] Operations { get; init; } = [];
+
+    /// <summary>
+    /// Secret-safe cost evidence artifact references.
+    /// </summary>
+    public string[] EvidenceReferences { get; init; } = [];
+
+    /// <summary>
+    /// Findings that explain warning, failure, or unknown classifications.
+    /// </summary>
+    public MigrationAcceptanceCostEvidenceFinding[] Findings { get; init; } = [];
+}
+
+/// <summary>
+/// Operation-level cost and performance evidence normalized for the acceptance suite.
+/// </summary>
+public sealed record MigrationAcceptanceCostOperationEvidence
+{
+    /// <summary>
+    /// Stable operation identifier.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Migration stage measured by this operation.
+    /// </summary>
+    public required string Stage { get; init; }
+
+    /// <summary>
+    /// Operation evidence state.
+    /// </summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// Measured operation duration in milliseconds.
+    /// </summary>
+    public long? DurationMilliseconds { get; init; }
+
+    /// <summary>
+    /// Operation feature throughput in features per second.
+    /// </summary>
+    public double? FeatureThroughputPerSecond { get; init; }
+
+    /// <summary>
+    /// Source-system requests issued by this operation.
+    /// </summary>
+    public int? SourceRequestCount { get; init; }
+
+    /// <summary>
+    /// Retry attempts observed for this operation.
+    /// </summary>
+    public int? RetryCount { get; init; }
+
+    /// <summary>
+    /// Bytes read by this operation.
+    /// </summary>
+    public long? BytesRead { get; init; }
+
+    /// <summary>
+    /// Bytes written by this operation.
+    /// </summary>
+    public long? BytesWritten { get; init; }
+
+    /// <summary>
+    /// Operation evidence artifact size in bytes.
+    /// </summary>
+    public long? ArtifactSizeBytes { get; init; }
+
+    /// <summary>
+    /// Secret-safe operation evidence references.
+    /// </summary>
+    public string[] EvidenceReferences { get; init; } = [];
+}
+
+/// <summary>
+/// Finding that explains a cost evidence classification.
+/// </summary>
+public sealed record MigrationAcceptanceCostEvidenceFinding
+{
+    /// <summary>
+    /// Stable finding identifier.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Finding state: <c>warn</c>, <c>fail</c>, or <c>unknown</c>.
+    /// </summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// Human-readable finding summary.
+    /// </summary>
+    public required string Summary { get; init; }
+
+    /// <summary>
+    /// Remediation guidance for reviewers or follow-up work.
+    /// </summary>
+    public string[] Remediation { get; init; } = [];
 }
 
 /// <summary>
@@ -278,4 +542,22 @@ public static class MigrationAcceptanceStageIds
 
     /// <summary>Cutover readiness stage.</summary>
     public const string Readiness = "readiness";
+}
+
+/// <summary>
+/// Stable cost evidence classifications.
+/// </summary>
+public static class MigrationCostEvidenceStates
+{
+    /// <summary>Cost evidence satisfies configured thresholds.</summary>
+    public const string Pass = "pass";
+
+    /// <summary>Cost evidence is present but exceeds warning thresholds.</summary>
+    public const string Warn = "warn";
+
+    /// <summary>Cost evidence is missing required measurements or exceeds failure thresholds.</summary>
+    public const string Fail = "fail";
+
+    /// <summary>Cost evidence is not available or not yet reviewed.</summary>
+    public const string Unknown = "unknown";
 }

--- a/src/Honua.Core/Features/Import/Domain/MigrationParityEvidenceArtifact.cs
+++ b/src/Honua.Core/Features/Import/Domain/MigrationParityEvidenceArtifact.cs
@@ -310,9 +310,19 @@ public sealed record MigrationPerformanceCostTotals
     public int? RetryCount { get; init; }
 
     /// <summary>
+    /// Total source-system requests issued by the measured run.
+    /// </summary>
+    public int? SourceRequestCount { get; init; }
+
+    /// <summary>
     /// Total items requiring manual review after the measured run.
     /// </summary>
     public int? ManualReviewCount { get; init; }
+
+    /// <summary>
+    /// Size in bytes of the emitted cost or performance evidence artifact.
+    /// </summary>
+    public long? ArtifactSizeBytes { get; init; }
 }
 
 /// <summary>
@@ -366,9 +376,19 @@ public sealed record MigrationPerformanceCostOperation
     public int? RetryCount { get; init; }
 
     /// <summary>
+    /// Source-system requests issued by this operation.
+    /// </summary>
+    public int? SourceRequestCount { get; init; }
+
+    /// <summary>
     /// Items from this operation that require manual review.
     /// </summary>
     public int? ManualReviewCount { get; init; }
+
+    /// <summary>
+    /// Size in bytes of the operation-specific evidence artifact.
+    /// </summary>
+    public long? ArtifactSizeBytes { get; init; }
 
     /// <summary>
     /// Secret-safe evidence artifact references. Query strings, fragments, and URL credentials are removed by the generator.

--- a/src/Honua.Core/Features/Import/Services/MigrationAcceptanceEvidenceBuilder.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationAcceptanceEvidenceBuilder.cs
@@ -57,6 +57,8 @@ public static class MigrationAcceptanceEvidenceBuilder
             manifest,
             input.ReadinessAttestation,
             input.PerformanceCost);
+        ValidateEvidenceIdentity(input.Inventory, manifest, parityEvidence);
+
         var stages = BuildStages(
             input,
             manifest,
@@ -77,7 +79,7 @@ public static class MigrationAcceptanceEvidenceBuilder
             Stages = stages,
             ManualReviewCount = manualReviewCount,
             UnsupportedCount = unsupportedCount,
-            ManifestAvailable = parityEvidence.ManifestAvailable,
+            ManifestAvailable = true,
             InventoryArtifactKind = input.Inventory.ArtifactKind,
             ManifestArtifactKind = manifest.ArtifactKind,
             ParityEvidenceArtifactKind = parityEvidence.ArtifactKind,
@@ -85,6 +87,39 @@ public static class MigrationAcceptanceEvidenceBuilder
             Notes = BuildEntryNotes(manifest, parityEvidence, options)
         };
     }
+
+    private static void ValidateEvidenceIdentity(
+        MigrationSourceInventoryArtifact inventory,
+        MigrationManifestArtifact manifest,
+        MigrationParityEvidenceArtifact parityEvidence)
+    {
+        if (!StringEquals(inventory.SourceKind, manifest.SourceKind))
+        {
+            throw new ArgumentException("Migration manifest source kind must match inventory source kind.");
+        }
+
+        if (!SourceIdentityMatches(inventory.Source, manifest.Source))
+        {
+            throw new ArgumentException("Migration manifest source identity must match inventory source identity.");
+        }
+
+        if (!StringEquals(inventory.SourceKind, parityEvidence.SourceKind))
+        {
+            throw new ArgumentException("Migration parity evidence source kind must match inventory source kind.");
+        }
+
+        if (!SourceIdentityMatches(inventory.Source, parityEvidence.Source))
+        {
+            throw new ArgumentException("Migration parity evidence source identity must match inventory source identity.");
+        }
+    }
+
+    private static bool SourceIdentityMatches(MigrationSourceIdentity left, MigrationSourceIdentity right)
+        => StringEquals(left.DisplayName, right.DisplayName) &&
+           StringEquals(left.BaseUrl, right.BaseUrl);
+
+    private static bool StringEquals(string? left, string? right)
+        => string.Equals(left?.Trim(), right?.Trim(), StringComparison.Ordinal);
 
     private static IEnumerable<MigrationAcceptanceEvidenceGap> BuildBlockingGaps(
         IReadOnlyCollection<MigrationAcceptanceEvidenceEntry> entries,

--- a/src/Honua.Core/Features/Import/Services/MigrationAcceptanceEvidenceBuilder.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationAcceptanceEvidenceBuilder.cs
@@ -34,11 +34,13 @@ public static class MigrationAcceptanceEvidenceBuilder
             .ToArray();
         var gaps = BuildBlockingGaps(entries, options).ToArray();
         var summary = BuildSummary(entries, gaps, options);
+        var costEvidence = BuildCostEvidenceSummary(entries, options);
 
         return new MigrationAcceptanceEvidenceArtifact
         {
             RunId = runId.Trim(),
             Summary = summary,
+            CostEvidence = costEvidence,
             Entries = entries,
             BlockingGaps = gaps
         };
@@ -68,6 +70,11 @@ public static class MigrationAcceptanceEvidenceBuilder
         var manualReviewCount = manifest.ManualReviewItems.Length + manifest.StyleActions.Count(static action =>
             string.Equals(action.Action, "manual-review", StringComparison.OrdinalIgnoreCase));
         var unsupportedCount = manifest.UnsupportedItems.Length;
+        var costEvidence = BuildCostEvidenceEntry(
+            parityEvidence.PerformanceCost,
+            manifest,
+            manualReviewCount,
+            options);
 
         return new MigrationAcceptanceEvidenceEntry
         {
@@ -84,6 +91,7 @@ public static class MigrationAcceptanceEvidenceBuilder
             ManifestArtifactKind = manifest.ArtifactKind,
             ParityEvidenceArtifactKind = parityEvidence.ArtifactKind,
             EvidenceReferences = SanitizeEvidenceReferences(input.EvidenceReferences),
+            CostEvidence = costEvidence,
             Notes = BuildEntryNotes(manifest, parityEvidence, options)
         };
     }
@@ -164,6 +172,30 @@ public static class MigrationAcceptanceEvidenceBuilder
 
         foreach (var entry in entries)
         {
+            if (options.RequireCostEvidence)
+            {
+                var costState = entry.CostEvidence?.State ?? MigrationCostEvidenceStates.Fail;
+                if (costState != MigrationCostEvidenceStates.Pass)
+                {
+                    yield return new MigrationAcceptanceEvidenceGap
+                    {
+                        Id = $"cost-evidence:{entry.Id}",
+                        SourceKind = entry.SourceKind,
+                        State = costState == MigrationCostEvidenceStates.Fail
+                            ? MigrationEvidenceStates.Fail
+                            : MigrationEvidenceStates.Unknown,
+                        Summary = costState == MigrationCostEvidenceStates.Fail
+                            ? $"{entry.Id} cost evidence failed the configured release contract."
+                            : $"{entry.Id} cost evidence is {costState}.",
+                        Remediation = entry.CostEvidence?.Findings
+                            .SelectMany(static finding => finding.Remediation)
+                            .DefaultIfEmpty("Attach passing performance and cost evidence before using migration cost claims.")
+                            .ToArray() ??
+                            ["Attach passing performance and cost evidence before using migration cost claims."]
+                    };
+                }
+            }
+
             foreach (var stage in entry.Stages.Where(static stage =>
                          stage.State is MigrationEvidenceStates.Fail or MigrationEvidenceStates.Unknown))
             {
@@ -214,6 +246,485 @@ public static class MigrationAcceptanceEvidenceBuilder
                 .OrderBy(static sourceKind => sourceKind, StringComparer.Ordinal)
                 .ToArray()
         };
+    }
+
+    private static MigrationAcceptanceCostEvidenceSummary BuildCostEvidenceSummary(
+        MigrationAcceptanceEvidenceEntry[] entries,
+        MigrationAcceptanceEvidenceOptions options)
+    {
+        var measured = entries
+            .Select(static entry => entry.CostEvidence)
+            .OfType<MigrationAcceptanceCostEvidenceEntry>()
+            .ToArray();
+        var missingSourceCount = entries.Length - measured.Length;
+        var states = measured.Select(static entry => entry.State);
+        if (missingSourceCount > 0)
+        {
+            states = states.Append(options.RequireCostEvidence
+                ? MigrationCostEvidenceStates.Fail
+                : MigrationCostEvidenceStates.Unknown);
+        }
+
+        return new MigrationAcceptanceCostEvidenceSummary
+        {
+            State = AggregateCostState(states),
+            MeasuredSourceCount = measured.Length,
+            MissingSourceCount = missingSourceCount,
+            DurationMilliseconds = SumNullable(measured.Select(static entry => entry.DurationMilliseconds)),
+            ScanDurationMilliseconds = SumNullable(measured.Select(static entry => entry.ScanDurationMilliseconds)),
+            ApplyDurationMilliseconds = SumNullable(measured.Select(static entry => entry.ApplyDurationMilliseconds)),
+            FeatureThroughputPerSecond = AverageNullable(measured.Select(static entry => entry.FeatureThroughputPerSecond)),
+            SourceRequestCount = SumNullable(measured.Select(static entry => entry.SourceRequestCount)),
+            RetryCount = SumNullable(measured.Select(static entry => entry.RetryCount)),
+            BytesRead = SumNullable(measured.Select(static entry => entry.BytesRead)),
+            BytesWritten = SumNullable(measured.Select(static entry => entry.BytesWritten)),
+            ArtifactSizeBytes = SumNullable(measured.Select(static entry => entry.ArtifactSizeBytes)),
+            ManualReviewRatio = AverageNullable(measured.Select(static entry => entry.ManualReviewRatio)),
+            Findings = measured
+                .SelectMany(static entry => entry.Findings)
+                .OrderBy(static finding => finding.Id, StringComparer.Ordinal)
+                .ToArray()
+        };
+    }
+
+    private static MigrationAcceptanceCostEvidenceEntry? BuildCostEvidenceEntry(
+        MigrationPerformanceCostEvidence? performanceCost,
+        MigrationManifestArtifact manifest,
+        int manifestManualReviewCount,
+        MigrationAcceptanceEvidenceOptions options)
+    {
+        var normalized = MigrationParityEvidenceGenerator.NormalizePerformanceCost(performanceCost);
+        if (normalized == null)
+        {
+            return null;
+        }
+
+        var operations = normalized.Operations
+            .Select(static operation => new MigrationAcceptanceCostOperationEvidence
+            {
+                Id = operation.Id,
+                Stage = operation.Stage,
+                State = operation.State,
+                DurationMilliseconds = operation.DurationMilliseconds,
+                FeatureThroughputPerSecond = CalculateThroughput(
+                    operation.FeatureCount,
+                    operation.DurationMilliseconds),
+                SourceRequestCount = operation.SourceRequestCount,
+                RetryCount = operation.RetryCount,
+                BytesRead = operation.BytesRead,
+                BytesWritten = operation.BytesWritten,
+                ArtifactSizeBytes = operation.ArtifactSizeBytes,
+                EvidenceReferences = SanitizeEvidenceReferences(operation.EvidenceReferences)
+            })
+            .OrderBy(static operation => operation.Id, StringComparer.Ordinal)
+            .ThenBy(static operation => operation.Stage, StringComparer.Ordinal)
+            .ToArray();
+        var totals = normalized.Totals;
+        var durationMilliseconds = totals.DurationMilliseconds ??
+            SumNullable(operations.Select(static operation => operation.DurationMilliseconds));
+        var scanDurationMilliseconds = SumNullable(operations
+            .Where(static operation => IsScanStage(operation.Stage))
+            .Select(static operation => operation.DurationMilliseconds));
+        var applyDurationMilliseconds = SumNullable(operations
+            .Where(static operation => IsApplyStage(operation.Stage))
+            .Select(static operation => operation.DurationMilliseconds));
+        var sourceRequestCount = totals.SourceRequestCount ??
+            SumNullable(operations.Select(static operation => operation.SourceRequestCount));
+        var retryCount = totals.RetryCount ??
+            SumNullable(operations.Select(static operation => operation.RetryCount));
+        var bytesRead = totals.BytesRead ??
+            SumNullable(operations.Select(static operation => operation.BytesRead));
+        var bytesWritten = totals.BytesWritten ??
+            SumNullable(operations.Select(static operation => operation.BytesWritten));
+        var artifactSizeBytes = totals.ArtifactSizeBytes ??
+            SumNullable(operations.Select(static operation => operation.ArtifactSizeBytes));
+        var manualReviewCount = totals.ManualReviewCount ?? manifestManualReviewCount;
+        var resourceCount = totals.ResourceCount ??
+            manifest.TargetResources.Length + manifest.ManualReviewItems.Length + manifest.UnsupportedItems.Length;
+        var manualReviewRatio = CalculateRatio(manualReviewCount, resourceCount);
+        var featureThroughput = CalculateThroughput(totals.FeatureCount, durationMilliseconds) ??
+            AverageNullable(operations.Select(static operation => operation.FeatureThroughputPerSecond));
+        var resourceThroughput = CalculateThroughput(resourceCount, durationMilliseconds);
+
+        var findings = BuildCostEvidenceFindings(
+                normalized,
+                options.CostEvidenceThresholds,
+                durationMilliseconds,
+                scanDurationMilliseconds,
+                applyDurationMilliseconds,
+                featureThroughput,
+                sourceRequestCount,
+                retryCount,
+                bytesRead,
+                bytesWritten,
+                artifactSizeBytes,
+                manualReviewRatio,
+                operations)
+            .OrderBy(static finding => finding.Id, StringComparer.Ordinal)
+            .ToArray();
+        var state = AggregateCostState(
+            [NormalizeCostState(normalized.State), .. findings.Select(static finding => finding.State)]);
+
+        return new MigrationAcceptanceCostEvidenceEntry
+        {
+            State = state,
+            Summary = normalized.Summary,
+            MeasurementScope = normalized.MeasurementScope,
+            DurationMilliseconds = durationMilliseconds,
+            ScanDurationMilliseconds = scanDurationMilliseconds,
+            ApplyDurationMilliseconds = applyDurationMilliseconds,
+            FeatureThroughputPerSecond = featureThroughput,
+            ResourceThroughputPerSecond = resourceThroughput,
+            SourceRequestCount = sourceRequestCount,
+            RetryCount = retryCount,
+            BytesRead = bytesRead,
+            BytesWritten = bytesWritten,
+            ArtifactSizeBytes = artifactSizeBytes,
+            ManualReviewRatio = manualReviewRatio,
+            Operations = operations,
+            EvidenceReferences = SanitizeEvidenceReferences(normalized.EvidenceReferences),
+            Findings = findings
+        };
+    }
+
+    private static IEnumerable<MigrationAcceptanceCostEvidenceFinding> BuildCostEvidenceFindings(
+        MigrationPerformanceCostEvidence performanceCost,
+        MigrationAcceptanceCostEvidenceThresholds thresholds,
+        long? durationMilliseconds,
+        long? scanDurationMilliseconds,
+        long? applyDurationMilliseconds,
+        double? featureThroughput,
+        int? sourceRequestCount,
+        int? retryCount,
+        long? bytesRead,
+        long? bytesWritten,
+        long? artifactSizeBytes,
+        double? manualReviewRatio,
+        IReadOnlyCollection<MigrationAcceptanceCostOperationEvidence> operations)
+    {
+        foreach (var operation in performanceCost.Operations.Where(static operation =>
+                     NormalizeCostState(operation.State) == MigrationCostEvidenceStates.Fail))
+        {
+            yield return new MigrationAcceptanceCostEvidenceFinding
+            {
+                Id = $"operation-failed:{operation.Id}",
+                State = MigrationCostEvidenceStates.Fail,
+                Summary = $"{operation.Id} cost operation reported failed evidence.",
+                Remediation = ["Inspect the source operation evidence and rerun the measured migration lane."]
+            };
+        }
+
+        if (thresholds.RequireMetricContract)
+        {
+            if (durationMilliseconds == null)
+            {
+                yield return MissingMetric("duration-milliseconds", "Total measured duration is required.");
+            }
+
+            if (scanDurationMilliseconds == null)
+            {
+                yield return MissingMetric("scan-duration-milliseconds", "Measured scan duration is required.");
+            }
+
+            if (applyDurationMilliseconds == null)
+            {
+                yield return MissingMetric("apply-duration-milliseconds", "Measured apply or dry-run duration is required.");
+            }
+
+            if (featureThroughput == null)
+            {
+                yield return MissingMetric("feature-throughput-per-second", "Feature throughput is required.");
+            }
+
+            if (sourceRequestCount == null)
+            {
+                yield return MissingMetric("source-request-count", "Source request count is required.");
+            }
+
+            if (retryCount == null)
+            {
+                yield return MissingMetric("retry-count", "Retry count is required.");
+            }
+
+            if (bytesRead == null || bytesWritten == null)
+            {
+                yield return MissingMetric("bytes", "Bytes read and written are required.");
+            }
+
+            if (artifactSizeBytes == null)
+            {
+                yield return MissingMetric("artifact-size-bytes", "Cost evidence artifact size is required.");
+            }
+
+            if (manualReviewRatio == null)
+            {
+                yield return MissingMetric("manual-review-ratio", "Manual-review ratio is required.");
+            }
+        }
+
+        foreach (var requiredStage in Order(thresholds.RequiredDurationStages))
+        {
+            if (!operations.Any(operation =>
+                    StageMatches(operation.Stage, requiredStage) &&
+                    operation.DurationMilliseconds is > 0))
+            {
+                yield return MissingMetric(
+                    $"stage-duration:{requiredStage}",
+                    $"Measured {requiredStage} duration is required.");
+            }
+        }
+
+        foreach (var finding in EvaluateUpperLimit(
+                     "duration-milliseconds",
+                     durationMilliseconds,
+                     thresholds.MaxDurationMillisecondsWarn,
+                     thresholds.MaxDurationMillisecondsFail,
+                     "Total measured duration exceeded the configured threshold."))
+        {
+            yield return finding;
+        }
+
+        foreach (var finding in EvaluateLowerLimit(
+                     "feature-throughput-per-second",
+                     featureThroughput,
+                     thresholds.MinFeatureThroughputPerSecondWarn,
+                     thresholds.MinFeatureThroughputPerSecondFail,
+                     "Feature throughput fell below the configured threshold."))
+        {
+            yield return finding;
+        }
+
+        foreach (var finding in EvaluateUpperLimit(
+                     "source-request-count",
+                     sourceRequestCount,
+                     thresholds.MaxSourceRequestCountWarn,
+                     thresholds.MaxSourceRequestCountFail,
+                     "Source request count exceeded the configured threshold."))
+        {
+            yield return finding;
+        }
+
+        foreach (var finding in EvaluateUpperLimit(
+                     "retry-count",
+                     retryCount,
+                     thresholds.MaxRetryCountWarn,
+                     thresholds.MaxRetryCountFail,
+                     "Retry count exceeded the configured threshold."))
+        {
+            yield return finding;
+        }
+
+        foreach (var finding in EvaluateUpperLimit(
+                     "artifact-size-bytes",
+                     artifactSizeBytes,
+                     thresholds.MaxArtifactSizeBytesWarn,
+                     thresholds.MaxArtifactSizeBytesFail,
+                     "Evidence artifact size exceeded the configured threshold."))
+        {
+            yield return finding;
+        }
+
+        foreach (var finding in EvaluateUpperLimit(
+                     "manual-review-ratio",
+                     manualReviewRatio,
+                     thresholds.MaxManualReviewRatioWarn,
+                     thresholds.MaxManualReviewRatioFail,
+                     "Manual-review ratio exceeded the configured threshold."))
+        {
+            yield return finding;
+        }
+    }
+
+    private static MigrationAcceptanceCostEvidenceFinding MissingMetric(string id, string summary)
+        => new()
+        {
+            Id = $"missing-metric:{id}",
+            State = MigrationCostEvidenceStates.Fail,
+            Summary = summary,
+            Remediation = ["Update the migration evidence collector to emit this metric before accepting cost claims."]
+        };
+
+    private static IEnumerable<MigrationAcceptanceCostEvidenceFinding> EvaluateUpperLimit(
+        string id,
+        long? value,
+        long? warnThreshold,
+        long? failThreshold,
+        string summary)
+    {
+        if (value == null)
+        {
+            yield break;
+        }
+
+        foreach (var finding in EvaluateUpperLimit(id, (double)value.Value, warnThreshold, failThreshold, summary))
+        {
+            yield return finding;
+        }
+    }
+
+    private static IEnumerable<MigrationAcceptanceCostEvidenceFinding> EvaluateUpperLimit(
+        string id,
+        int? value,
+        int? warnThreshold,
+        int? failThreshold,
+        string summary)
+    {
+        if (value == null)
+        {
+            yield break;
+        }
+
+        foreach (var finding in EvaluateUpperLimit(id, (double)value.Value, warnThreshold, failThreshold, summary))
+        {
+            yield return finding;
+        }
+    }
+
+    private static IEnumerable<MigrationAcceptanceCostEvidenceFinding> EvaluateUpperLimit(
+        string id,
+        double? value,
+        double? warnThreshold,
+        double? failThreshold,
+        string summary)
+    {
+        if (value == null)
+        {
+            yield break;
+        }
+
+        if (failThreshold != null && value.Value > failThreshold.Value)
+        {
+            yield return ThresholdFinding(id, MigrationCostEvidenceStates.Fail, summary, value.Value, failThreshold.Value);
+            yield break;
+        }
+
+        if (warnThreshold != null && value.Value > warnThreshold.Value)
+        {
+            yield return ThresholdFinding(id, MigrationCostEvidenceStates.Warn, summary, value.Value, warnThreshold.Value);
+        }
+    }
+
+    private static IEnumerable<MigrationAcceptanceCostEvidenceFinding> EvaluateLowerLimit(
+        string id,
+        double? value,
+        double? warnThreshold,
+        double? failThreshold,
+        string summary)
+    {
+        if (value == null)
+        {
+            yield break;
+        }
+
+        if (failThreshold != null && value.Value < failThreshold.Value)
+        {
+            yield return ThresholdFinding(id, MigrationCostEvidenceStates.Fail, summary, value.Value, failThreshold.Value);
+            yield break;
+        }
+
+        if (warnThreshold != null && value.Value < warnThreshold.Value)
+        {
+            yield return ThresholdFinding(id, MigrationCostEvidenceStates.Warn, summary, value.Value, warnThreshold.Value);
+        }
+    }
+
+    private static MigrationAcceptanceCostEvidenceFinding ThresholdFinding(
+        string id,
+        string state,
+        string summary,
+        double value,
+        double threshold)
+        => new()
+        {
+            Id = $"threshold:{id}",
+            State = state,
+            Summary = $"{summary} value={value:0.###}, threshold={threshold:0.###}.",
+            Remediation = ["Review the fixture, collector, and threshold before publishing migration cost evidence."]
+        };
+
+    private static string AggregateCostState(IEnumerable<string> states)
+    {
+        var materialized = states.Select(NormalizeCostState).ToArray();
+        if (materialized.Any(static state => state == MigrationCostEvidenceStates.Fail))
+        {
+            return MigrationCostEvidenceStates.Fail;
+        }
+
+        if (materialized.Any(static state => state == MigrationCostEvidenceStates.Warn))
+        {
+            return MigrationCostEvidenceStates.Warn;
+        }
+
+        if (materialized.Length == 0 || materialized.Any(static state => state == MigrationCostEvidenceStates.Unknown))
+        {
+            return MigrationCostEvidenceStates.Unknown;
+        }
+
+        return MigrationCostEvidenceStates.Pass;
+    }
+
+    private static string NormalizeCostState(string state)
+        => state switch
+        {
+            MigrationCostEvidenceStates.Pass => MigrationCostEvidenceStates.Pass,
+            MigrationCostEvidenceStates.Warn => MigrationCostEvidenceStates.Warn,
+            MigrationCostEvidenceStates.Fail => MigrationCostEvidenceStates.Fail,
+            MigrationCostEvidenceStates.Unknown => MigrationCostEvidenceStates.Unknown,
+            _ => MigrationCostEvidenceStates.Unknown
+        };
+
+    private static double? CalculateThroughput(long? count, long? durationMilliseconds)
+    {
+        if (count is null || durationMilliseconds is null or <= 0)
+        {
+            return null;
+        }
+
+        return count.Value / (durationMilliseconds.Value / 1000d);
+    }
+
+    private static double? CalculateRatio(long? numerator, long? denominator)
+    {
+        if (numerator is null || denominator is null or <= 0)
+        {
+            return null;
+        }
+
+        return numerator.Value / (double)denominator.Value;
+    }
+
+    private static bool StageMatches(string actualStage, string requiredStage)
+        => string.Equals(actualStage, requiredStage, StringComparison.Ordinal) ||
+            (string.Equals(requiredStage, MigrationAcceptanceStageIds.ApplyOrDryRun, StringComparison.Ordinal) &&
+                IsApplyStage(actualStage)) ||
+            (string.Equals(requiredStage, MigrationAcceptanceStageIds.Scan, StringComparison.Ordinal) &&
+                IsScanStage(actualStage));
+
+    private static bool IsScanStage(string stage)
+        => string.Equals(stage, MigrationAcceptanceStageIds.Scan, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsApplyStage(string stage)
+        => string.Equals(stage, MigrationAcceptanceStageIds.ApplyOrDryRun, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(stage, "apply", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(stage, "import", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(stage, "dry-run", StringComparison.OrdinalIgnoreCase);
+
+    private static long? SumNullable(IEnumerable<long?> values)
+    {
+        var materialized = values.Where(static value => value.HasValue).Select(static value => value!.Value).ToArray();
+        return materialized.Length == 0 ? null : materialized.Sum();
+    }
+
+    private static int? SumNullable(IEnumerable<int?> values)
+    {
+        var materialized = values.Where(static value => value.HasValue).Select(static value => value!.Value).ToArray();
+        return materialized.Length == 0 ? null : materialized.Sum();
+    }
+
+    private static double? AverageNullable(IEnumerable<double?> values)
+    {
+        var materialized = values.Where(static value => value.HasValue).Select(static value => value!.Value).ToArray();
+        return materialized.Length == 0 ? null : materialized.Average();
     }
 
     private static string ClassifyAutomation(
@@ -525,4 +1036,90 @@ public sealed record MigrationAcceptanceEvidenceOptions
     /// Whether non-passing readiness should be surfaced in entry notes.
     /// </summary>
     public bool RequireReadinessPass { get; init; } = true;
+
+    /// <summary>
+    /// Whether each entry must include passing cost evidence for the suite to pass.
+    /// </summary>
+    public bool RequireCostEvidence { get; init; }
+
+    /// <summary>
+    /// Cost evidence metric coverage and warning/failure thresholds.
+    /// </summary>
+    public MigrationAcceptanceCostEvidenceThresholds CostEvidenceThresholds { get; init; } = new();
+}
+
+/// <summary>
+/// Thresholds and required metric coverage for migration cost evidence.
+/// </summary>
+public sealed record MigrationAcceptanceCostEvidenceThresholds
+{
+    /// <summary>
+    /// Whether core cost metrics must be present: duration, scan/apply durations, throughput, source requests, retries, bytes, artifact size, and manual-review ratio.
+    /// </summary>
+    public bool RequireMetricContract { get; init; }
+
+    /// <summary>
+    /// Operation stages that must include measured durations.
+    /// </summary>
+    public string[] RequiredDurationStages { get; init; } = [];
+
+    /// <summary>
+    /// Total duration warning threshold in milliseconds.
+    /// </summary>
+    public long? MaxDurationMillisecondsWarn { get; init; }
+
+    /// <summary>
+    /// Total duration failure threshold in milliseconds.
+    /// </summary>
+    public long? MaxDurationMillisecondsFail { get; init; }
+
+    /// <summary>
+    /// Feature throughput warning threshold in features per second.
+    /// </summary>
+    public double? MinFeatureThroughputPerSecondWarn { get; init; }
+
+    /// <summary>
+    /// Feature throughput failure threshold in features per second.
+    /// </summary>
+    public double? MinFeatureThroughputPerSecondFail { get; init; }
+
+    /// <summary>
+    /// Source request warning threshold.
+    /// </summary>
+    public int? MaxSourceRequestCountWarn { get; init; }
+
+    /// <summary>
+    /// Source request failure threshold.
+    /// </summary>
+    public int? MaxSourceRequestCountFail { get; init; }
+
+    /// <summary>
+    /// Retry warning threshold.
+    /// </summary>
+    public int? MaxRetryCountWarn { get; init; }
+
+    /// <summary>
+    /// Retry failure threshold.
+    /// </summary>
+    public int? MaxRetryCountFail { get; init; }
+
+    /// <summary>
+    /// Cost evidence artifact-size warning threshold in bytes.
+    /// </summary>
+    public long? MaxArtifactSizeBytesWarn { get; init; }
+
+    /// <summary>
+    /// Cost evidence artifact-size failure threshold in bytes.
+    /// </summary>
+    public long? MaxArtifactSizeBytesFail { get; init; }
+
+    /// <summary>
+    /// Manual-review ratio warning threshold.
+    /// </summary>
+    public double? MaxManualReviewRatioWarn { get; init; }
+
+    /// <summary>
+    /// Manual-review ratio failure threshold.
+    /// </summary>
+    public double? MaxManualReviewRatioFail { get; init; }
 }

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationAcceptanceEvidenceBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationAcceptanceEvidenceBuilderTests.cs
@@ -156,6 +156,61 @@ public sealed class MigrationAcceptanceEvidenceBuilderTests
         json.Should().NotContain("#fragment");
     }
 
+    [Fact]
+    public void Build_WithMismatchedManifestSourceKind_Throws()
+    {
+        var input = AutomatedInput("arcgis", "arcgis-geoservices-rest");
+        var otherManifest = MigrationManifestTranslator.Translate(CreateInventory(
+            "geoserver-rest",
+            [CreateResource("workspace:roads", "Roads", "compatible", "Schema can be mapped.")]));
+
+        Action act = () => MigrationAcceptanceEvidenceBuilder.Build(
+            "nightly-20260518",
+            [input with { Manifest = otherManifest }]);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Migration manifest source kind must match inventory source kind.");
+    }
+
+    [Fact]
+    public void Build_WithMismatchedParitySourceIdentity_Throws()
+    {
+        var input = AutomatedInput("arcgis", "arcgis-geoservices-rest");
+        var parity = MigrationParityEvidenceGenerator.Generate(
+            input.Inventory,
+            MigrationManifestTranslator.Translate(input.Inventory),
+            CreatePassingAttestation()) with
+        {
+            Source = input.Inventory.Source with { BaseUrl = "https://example.test/other-source" }
+        };
+
+        Action act = () => MigrationAcceptanceEvidenceBuilder.Build(
+            "nightly-20260518",
+            [input with { ParityEvidence = parity }]);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Migration parity evidence source identity must match inventory source identity.");
+    }
+
+    [Fact]
+    public void Build_WithSuppliedManifestAndStaleParityManifestFlag_ReportsManifestAvailable()
+    {
+        var input = AutomatedInput("arcgis", "arcgis-geoservices-rest");
+        var manifest = MigrationManifestTranslator.Translate(input.Inventory);
+        var parity = MigrationParityEvidenceGenerator.Generate(
+            input.Inventory,
+            attestation: CreatePassingAttestation());
+
+        parity.ManifestAvailable.Should().BeFalse();
+
+        var suite = MigrationAcceptanceEvidenceBuilder.Build(
+            "nightly-20260518",
+            [input with { Manifest = manifest, ParityEvidence = parity }]);
+
+        suite.Entries.Should().ContainSingle()
+            .Which.ManifestAvailable.Should().BeTrue();
+    }
+
     private static MigrationAcceptanceEvidenceInput AutomatedInput(
         string id,
         string sourceKind,

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationAcceptanceEvidenceBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationAcceptanceEvidenceBuilderTests.cs
@@ -211,11 +211,151 @@ public sealed class MigrationAcceptanceEvidenceBuilderTests
             .Which.ManifestAvailable.Should().BeTrue();
     }
 
+    [Fact]
+    public void Build_WithPassingCostEvidence_AttachesSuiteMetricsAndRedactsReferences()
+    {
+        var suite = MigrationAcceptanceEvidenceBuilder.Build(
+            "nightly-20260518",
+            [
+                AutomatedInput(
+                    "arcgis",
+                    "arcgis-geoservices-rest",
+                    performanceCost: CompletePerformanceCostEvidence())
+            ],
+            new MigrationAcceptanceEvidenceOptions
+            {
+                RequireCostEvidence = true,
+                CostEvidenceThresholds = StrictCostContract()
+            });
+
+        suite.Summary.OverallState.Should().Be(MigrationEvidenceStates.Pass);
+        suite.CostEvidence.Should().Match<MigrationAcceptanceCostEvidenceSummary>(cost =>
+            cost.State == MigrationCostEvidenceStates.Pass &&
+            cost.MeasuredSourceCount == 1 &&
+            cost.MissingSourceCount == 0 &&
+            cost.DurationMilliseconds == 2_000 &&
+            cost.ScanDurationMilliseconds == 500 &&
+            cost.ApplyDurationMilliseconds == 1_500 &&
+            cost.FeatureThroughputPerSecond == 50 &&
+            cost.SourceRequestCount == 3 &&
+            cost.RetryCount == 1 &&
+            cost.BytesRead == 10_240 &&
+            cost.BytesWritten == 20_480 &&
+            cost.ArtifactSizeBytes == 4_096 &&
+            cost.ManualReviewRatio == 0);
+        suite.BlockingGaps.Should().BeEmpty();
+
+        var entryCost = suite.Entries.Should().ContainSingle().Which.CostEvidence;
+        entryCost.Should().NotBeNull();
+
+        entryCost!.Operations.Select(operation => (operation.Stage, operation.DurationMilliseconds)).Should().Equal(
+            ("apply-dry-run", 1_500L),
+            ("scan", 500L));
+        entryCost.EvidenceReferences.Should().Equal(
+            "https://example.test/evidence/cost.json",
+            "s3://migration-evidence/issue-1033/cost.json");
+
+        var json = JsonSerializer.Serialize(suite, JsonOptions);
+
+        json.Should().Contain("\"costEvidence\"");
+        json.Should().Contain("\"featureThroughputPerSecond\":50");
+        json.Should().Contain("\"sourceRequestCount\":3");
+        json.Should().Contain("\"artifactSizeBytes\":4096");
+        json.Should().NotContain("password");
+        json.Should().NotContain("token");
+        json.Should().NotContain("X-Amz-Signature");
+        json.Should().NotContain("#fragment");
+    }
+
+    [Fact]
+    public void Build_WithRequiredCostEvidenceMissing_FailsCostEvidenceContract()
+    {
+        var suite = MigrationAcceptanceEvidenceBuilder.Build(
+            "nightly-20260518",
+            [AutomatedInput("arcgis", "arcgis-geoservices-rest")],
+            new MigrationAcceptanceEvidenceOptions
+            {
+                RequireCostEvidence = true,
+                CostEvidenceThresholds = StrictCostContract()
+            });
+
+        suite.Summary.OverallState.Should().Be(MigrationEvidenceStates.Fail);
+        suite.CostEvidence.Should().Match<MigrationAcceptanceCostEvidenceSummary>(cost =>
+            cost.State == MigrationCostEvidenceStates.Fail &&
+            cost.MeasuredSourceCount == 0 &&
+            cost.MissingSourceCount == 1);
+        suite.BlockingGaps.Should().ContainSingle(gap => gap.Id == "cost-evidence:arcgis")
+            .Which.State.Should().Be(MigrationEvidenceStates.Fail);
+    }
+
+    [Fact]
+    public void Build_WithCostEvidenceWarning_BlocksReleaseCostClaimWithoutFailingFunctionalEvidence()
+    {
+        var suite = MigrationAcceptanceEvidenceBuilder.Build(
+            "nightly-20260518",
+            [
+                AutomatedInput(
+                    "arcgis",
+                    "arcgis-geoservices-rest",
+                    performanceCost: CompletePerformanceCostEvidence(manualReviewCount: 1, resourceCount: 4))
+            ],
+            new MigrationAcceptanceEvidenceOptions
+            {
+                RequireCostEvidence = true,
+                CostEvidenceThresholds = StrictCostContract() with
+                {
+                    MaxManualReviewRatioWarn = 0.20,
+                    MaxManualReviewRatioFail = 0.50
+                }
+            });
+
+        suite.Summary.OverallState.Should().Be(MigrationEvidenceStates.Unknown);
+        suite.CostEvidence.State.Should().Be(MigrationCostEvidenceStates.Warn);
+        var entryCost = suite.Entries.Should().ContainSingle().Which.CostEvidence;
+        entryCost.Should().NotBeNull();
+        entryCost!.Findings.Should().ContainSingle(finding =>
+            finding.Id == "threshold:manual-review-ratio" &&
+            finding.State == MigrationCostEvidenceStates.Warn);
+        suite.BlockingGaps.Should().ContainSingle(gap => gap.Id == "cost-evidence:arcgis")
+            .Which.State.Should().Be(MigrationEvidenceStates.Unknown);
+    }
+
+    [Fact]
+    public void Build_WithMissingRequiredCostMetrics_FailsCostEvidenceContract()
+    {
+        var suite = MigrationAcceptanceEvidenceBuilder.Build(
+            "nightly-20260518",
+            [
+                AutomatedInput(
+                    "arcgis",
+                    "arcgis-geoservices-rest",
+                    performanceCost: IncompletePerformanceCostEvidence())
+            ],
+            new MigrationAcceptanceEvidenceOptions
+            {
+                RequireCostEvidence = true,
+                CostEvidenceThresholds = StrictCostContract()
+            });
+
+        suite.Summary.OverallState.Should().Be(MigrationEvidenceStates.Fail);
+        suite.CostEvidence.State.Should().Be(MigrationCostEvidenceStates.Fail);
+        var entryCost = suite.Entries.Should().ContainSingle().Which.CostEvidence;
+        entryCost.Should().NotBeNull();
+        entryCost!.Findings.Select(finding => finding.Id).Should().Contain(
+            "missing-metric:apply-duration-milliseconds",
+            "missing-metric:bytes",
+            "missing-metric:artifact-size-bytes",
+            "missing-metric:stage-duration:apply-dry-run");
+        suite.BlockingGaps.Should().ContainSingle(gap => gap.Id == "cost-evidence:arcgis")
+            .Which.State.Should().Be(MigrationEvidenceStates.Fail);
+    }
+
     private static MigrationAcceptanceEvidenceInput AutomatedInput(
         string id,
         string sourceKind,
         string[]? evidenceReferences = null,
-        bool includeApplyAndPublishEvidence = true)
+        bool includeApplyAndPublishEvidence = true,
+        MigrationPerformanceCostEvidence? performanceCost = null)
         => new()
         {
             Id = id,
@@ -227,7 +367,112 @@ public sealed class MigrationAcceptanceEvidenceBuilderTests
                 ]),
             ReadinessAttestation = CreatePassingAttestation(),
             StageEvidence = includeApplyAndPublishEvidence ? PassingApplyAndPublishEvidence(id) : [],
-            EvidenceReferences = evidenceReferences ?? []
+            EvidenceReferences = evidenceReferences ?? [],
+            PerformanceCost = performanceCost
+        };
+
+    private static MigrationAcceptanceCostEvidenceThresholds StrictCostContract()
+        => new()
+        {
+            RequireMetricContract = true,
+            RequiredDurationStages = [MigrationAcceptanceStageIds.Scan, MigrationAcceptanceStageIds.ApplyOrDryRun],
+            MinFeatureThroughputPerSecondWarn = 20,
+            MinFeatureThroughputPerSecondFail = 10,
+            MaxSourceRequestCountWarn = 10,
+            MaxSourceRequestCountFail = 20,
+            MaxRetryCountWarn = 2,
+            MaxRetryCountFail = 5,
+            MaxArtifactSizeBytesWarn = 16_384,
+            MaxArtifactSizeBytesFail = 65_536,
+            MaxManualReviewRatioWarn = 0.10,
+            MaxManualReviewRatioFail = 0.25
+        };
+
+    private static MigrationPerformanceCostEvidence CompletePerformanceCostEvidence(
+        int manualReviewCount = 0,
+        long resourceCount = 1)
+        => new()
+        {
+            State = MigrationEvidenceStates.Pass,
+            Summary = "Fixture scan and apply measurements passed configured thresholds.",
+            MeasurementScope = "small deterministic fixture",
+            Totals = new MigrationPerformanceCostTotals
+            {
+                DurationMilliseconds = 2_000,
+                ResourceCount = resourceCount,
+                FeatureCount = 100,
+                BytesRead = 10_240,
+                BytesWritten = 20_480,
+                RetryCount = 1,
+                SourceRequestCount = 3,
+                ManualReviewCount = manualReviewCount,
+                ArtifactSizeBytes = 4_096
+            },
+            EvidenceReferences =
+            [
+                "https://user:password@example.test/evidence/cost.json?token=secret#fragment",
+                "s3://migration-evidence/issue-1033/cost.json?X-Amz-Signature=secret"
+            ],
+            Operations =
+            [
+                new MigrationPerformanceCostOperation
+                {
+                    Id = "scan",
+                    Stage = MigrationAcceptanceStageIds.Scan,
+                    State = MigrationEvidenceStates.Pass,
+                    DurationMilliseconds = 500,
+                    ResourceCount = resourceCount,
+                    FeatureCount = 100,
+                    BytesRead = 10_240,
+                    RetryCount = 1,
+                    SourceRequestCount = 2,
+                    ArtifactSizeBytes = 2_048,
+                    EvidenceReferences = ["https://example.test/evidence/scan.json?token=secret"]
+                },
+                new MigrationPerformanceCostOperation
+                {
+                    Id = "apply",
+                    Stage = MigrationAcceptanceStageIds.ApplyOrDryRun,
+                    State = MigrationEvidenceStates.Pass,
+                    DurationMilliseconds = 1_500,
+                    ResourceCount = resourceCount,
+                    FeatureCount = 100,
+                    BytesWritten = 20_480,
+                    SourceRequestCount = 1,
+                    ArtifactSizeBytes = 2_048,
+                    EvidenceReferences = ["https://example.test/evidence/apply.json#fragment"]
+                }
+            ]
+        };
+
+    private static MigrationPerformanceCostEvidence IncompletePerformanceCostEvidence()
+        => new()
+        {
+            State = MigrationEvidenceStates.Pass,
+            Summary = "Fixture scan measurements are incomplete.",
+            MeasurementScope = "small deterministic fixture",
+            Totals = new MigrationPerformanceCostTotals
+            {
+                DurationMilliseconds = 500,
+                ResourceCount = 1,
+                FeatureCount = 100,
+                RetryCount = 0,
+                SourceRequestCount = 1,
+                ManualReviewCount = 0
+            },
+            Operations =
+            [
+                new MigrationPerformanceCostOperation
+                {
+                    Id = "scan",
+                    Stage = MigrationAcceptanceStageIds.Scan,
+                    State = MigrationEvidenceStates.Pass,
+                    DurationMilliseconds = 500,
+                    ResourceCount = 1,
+                    FeatureCount = 100,
+                    SourceRequestCount = 1
+                }
+            ]
         };
 
     private static Honua.Core.Features.Import.Services.MigrationAcceptanceStageEvidenceInput[] PassingApplyAndPublishEvidence(string id)


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1024

## Summary
Adds migration acceptance evidence artifact fields and builder logic for cost/readiness gates, providing a server-side foundation for the release-gated migration acceptance suite.

## Changes Made
- Extended migration acceptance and parity evidence artifacts with cost/performance gate data.
- Updated `MigrationAcceptanceEvidenceBuilder` to include the new acceptance evidence signals.
- Added focused tests and operator documentation for the acceptance evidence contract.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --filter FullyQualifiedName~MigrationAcceptanceEvidenceBuilderTests` passed, 12 tests.
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj` passed, 1560 tests.
- `dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj --filter FullyQualifiedName~DocumentationCoverageTests` passed, 4 tests.
- `dotnet format Honua.sln --include <changed files>`
- `git diff --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

## Remaining Scope
This is a contract/evidence-builder slice. Deterministic ArcGIS, GeoServer, OGC, SDK, and release-gated end-to-end workflow lanes remain before #1024 should close.

---

## Pre-PR Checklist
- [x] Focused draft-PR checks completed; full `scripts/ci/pre-pr-check.sh` remains delegated to CI for this draft PR
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
