### PR TITLE
feat: add OGC API Features migration scanner

### DIFF
--- a/src/Honua.Core/Features/Import/Abstractions/IOgcApiFeaturesMigrationScanner.cs
+++ b/src/Honua.Core/Features/Import/Abstractions/IOgcApiFeaturesMigrationScanner.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Abstractions;
+
+/// <summary>
+/// Scans OGC API Features endpoints and produces deterministic migration planning artifacts.
+/// </summary>
+public interface IOgcApiFeaturesMigrationScanner
+{
+    /// <summary>
+    /// Scan an OGC API Features landing page into the shared source inventory contract.
+    /// </summary>
+    /// <param name="request">OGC API Features scan request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Normalized source inventory artifact.</returns>
+    Task<MigrationSourceInventoryArtifact> ScanSourceAsync(
+        OgcApiFeaturesScanRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Import/Domain/OgcApiFeaturesMigrationInventoryModels.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcApiFeaturesMigrationInventoryModels.cs
@@ -105,6 +105,11 @@ public sealed record OgcApiFeaturesCollectionSnapshot
     public string[] ItemEncodings { get; init; } = [];
 
     /// <summary>
+    /// Field metadata captured from collection schema or queryables documents.
+    /// </summary>
+    public MigrationInventoryField[] Fields { get; init; } = [];
+
+    /// <summary>
     /// Collection-level vendor extensions or non-standard capability names observed during the scan.
     /// </summary>
     public string[] VendorExtensions { get; init; } = [];
@@ -151,4 +156,3 @@ public sealed record OgcApiFeaturesCrsDeclaration
     /// </summary>
     public required string Value { get; init; }
 }
-

--- a/src/Honua.Core/Features/Import/Domain/OgcApiFeaturesScanRequest.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcApiFeaturesScanRequest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Request to scan an OGC API Features landing page for migration planning.
+/// </summary>
+public sealed record OgcApiFeaturesScanRequest
+{
+    /// <summary>
+    /// Source OGC API Features landing page URL.
+    /// </summary>
+    public required string ServiceUrl { get; init; }
+
+    /// <summary>
+    /// Optional scan timeout in seconds.
+    /// </summary>
+    public int TimeoutSeconds { get; init; } = 60;
+
+    /// <summary>
+    /// Maximum number of collections to inspect during the bounded scan.
+    /// </summary>
+    public int MaxCollections { get; init; } = 100;
+
+    /// <summary>
+    /// Number of features requested from each items endpoint probe.
+    /// </summary>
+    public int ItemsProbeLimit { get; init; } = 1;
+
+    /// <summary>
+    /// Whether HTTP and local URLs are allowed for test or controlled operator environments.
+    /// </summary>
+    public bool AllowUnsafeLocalUrls { get; init; }
+}

--- a/src/Honua.Core/Features/Import/ServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Import/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Services;
+using Honua.Core.Features.Infrastructure.Resilience;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -22,6 +23,18 @@ public static class ServiceCollectionExtensions
     {
         services.TryAddScoped<IFileFormatDetectionService, FileFormatDetectionService>();
         services.TryAddSingleton<IImportSchemaSuggestionService, ImportSchemaSuggestionService>();
+        services.AddResilientHttpClient<OgcApiFeaturesMigrationScanner>(
+            "ogc-api-features-migration",
+            HttpResiliencePolicies.SlowServiceDefaults,
+            configureClient: client =>
+            {
+                client.DefaultRequestHeaders.Add("User-Agent", "HonuaServer/1.0");
+                client.Timeout = TimeSpan.FromMinutes(2);
+            },
+            configureHandler: static () => OgcApiFeaturesMigrationScanner.CreatePinnedDnsHttpMessageHandler());
+        services.TryAddScoped<IOgcApiFeaturesMigrationScanner>(serviceProvider =>
+            serviceProvider.GetRequiredService<OgcApiFeaturesMigrationScanner>());
+
         return services;
     }
 }

--- a/src/Honua.Core/Features/Import/Services/MigrationManifestTranslator.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationManifestTranslator.cs
@@ -266,10 +266,21 @@ public static partial class MigrationManifestTranslator
            string.Equals(service, "WFS", StringComparison.OrdinalIgnoreCase);
 
     private static string? GetResourceMigrationMode(string sourceKind, MigrationInventoryResource resource)
-        => string.Equals(sourceKind, "ogc-wfs", StringComparison.OrdinalIgnoreCase) &&
-           string.Equals(resource.Kind, "feature-type", StringComparison.OrdinalIgnoreCase)
-            ? "feature-import"
-            : null;
+    {
+        if (string.Equals(sourceKind, "ogc-wfs", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(resource.Kind, "feature-type", StringComparison.OrdinalIgnoreCase))
+        {
+            return "feature-import";
+        }
+
+        if (string.Equals(sourceKind, "ogc-api-features", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(resource.Kind, "ogc-api-features-collection", StringComparison.OrdinalIgnoreCase))
+        {
+            return "feature-import";
+        }
+
+        return null;
+    }
 
     private static string? GetSourceProtocol(MigrationSourceInventoryArtifact inventory)
     {
@@ -281,6 +292,7 @@ public static partial class MigrationManifestTranslator
         return inventory.SourceKind.ToLowerInvariant() switch
         {
             "ogc-wfs" => "WFS",
+            "ogc-api-features" => "OGC API Features",
             "ogc-wms" => "WMS",
             "ogc-wmts" => "WMTS",
             _ => null

--- a/src/Honua.Core/Features/Import/Services/OgcApiFeaturesMigrationInventoryScanner.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcApiFeaturesMigrationInventoryScanner.cs
@@ -120,7 +120,8 @@ public static class OgcApiFeaturesMigrationInventoryScanner
             OverallCompatibility = overallCompatibility,
             Containers = containers,
             Resources = orderedResources,
-            ExternalDependencies = orderedDependencies
+            ExternalDependencies = orderedDependencies,
+            FidelityClassifications = BuildFidelityClassifications(orderedResources, orderedDependencies)
         };
     }
 
@@ -158,6 +159,10 @@ public static class OgcApiFeaturesMigrationInventoryScanner
                 hasTransactionalConformance,
                 collection.VendorExtensions),
             SpatialReferences = spatialReferences,
+            Fields = collection.Fields
+                .Where(static field => !string.IsNullOrWhiteSpace(field.Name))
+                .OrderBy(static field => field.Name, StringComparer.Ordinal)
+                .ToArray(),
             ExternalDependencyIds = BuildRelatedDependencyIds(collection, resourceId, baseUri),
             Compatibility = AssessCollectionCompatibility(
                 collection,
@@ -543,6 +548,188 @@ public static class OgcApiFeaturesMigrationInventoryScanner
 
         return MigrationInventoryHelpers.NormalizeStrings(capabilities);
     }
+
+    private static MigrationFidelityClassificationRecord[] BuildFidelityClassifications(
+        MigrationInventoryResource[] resources,
+        MigrationExternalDependency[] dependencies)
+    {
+        var records = new List<MigrationFidelityClassificationRecord>();
+
+        foreach (var resource in resources.OrderBy(static resource => resource.Id, StringComparer.Ordinal))
+        {
+            records.Add(BuildResourceFidelityRecord(resource));
+            records.Add(BuildSchemaFidelityRecord(resource));
+            records.Add(BuildCrsFidelityRecord(resource));
+            records.Add(BuildPaginationFidelityRecord(resource));
+            records.Add(BuildTargetExposureFidelityRecord(resource));
+        }
+
+        foreach (var dependency in dependencies
+                     .Where(static dependency => dependency.Compatibility.Level != "compatible")
+                     .OrderBy(static dependency => dependency.Id, StringComparer.Ordinal))
+        {
+            records.Add(new MigrationFidelityClassificationRecord
+            {
+                Id = $"fidelity:{dependency.Id}:dependency",
+                SourceId = dependency.Id,
+                Kind = dependency.Kind,
+                Category = dependency.DependencyType ?? "dependency",
+                Name = dependency.Name,
+                AutomationStatus = dependency.Compatibility.Level == "incompatible"
+                    ? MigrationFidelityAutomationStatuses.Unsupported
+                    : MigrationFidelityAutomationStatuses.ManualReview,
+                Code = dependency.Compatibility.Code ?? OgcApiFeaturesImportCompatibilityCodes.ManualReview,
+                Reason = dependency.Compatibility.Reason,
+                ManualSteps = dependency.Compatibility.ManualSteps,
+                RelatedIds = string.IsNullOrWhiteSpace(dependency.ResourceId) ? [] : [dependency.ResourceId],
+                Metadata = dependency.Metadata
+            });
+        }
+
+        return records
+            .OrderBy(static record => record.Id, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static MigrationFidelityClassificationRecord BuildResourceFidelityRecord(MigrationInventoryResource resource)
+    {
+        var status = resource.Compatibility.Level switch
+        {
+            "compatible" => MigrationFidelityAutomationStatuses.Automated,
+            "partial" => MigrationFidelityAutomationStatuses.ManualReview,
+            "incompatible" => MigrationFidelityAutomationStatuses.Unsupported,
+            _ => MigrationFidelityAutomationStatuses.ManualReview
+        };
+
+        return new MigrationFidelityClassificationRecord
+        {
+            Id = $"fidelity:{resource.Id}:feature-data",
+            SourceId = resource.Id,
+            Kind = resource.Kind,
+            Category = "feature-data",
+            Name = resource.Name,
+            AutomationStatus = status,
+            Code = resource.Compatibility.Code ?? OgcApiFeaturesImportCompatibilityCodes.ManualReview,
+            Reason = resource.Compatibility.Reason,
+            TargetKind = status == MigrationFidelityAutomationStatuses.Unsupported ? null : "layer",
+            ManualSteps = status == MigrationFidelityAutomationStatuses.Automated ? [] : resource.Compatibility.ManualSteps,
+            RelatedIds = resource.ExternalDependencyIds,
+            Metadata = new Dictionary<string, string>
+            {
+                ["capabilities"] = string.Join(",", resource.Capabilities)
+            }
+        };
+    }
+
+    private static MigrationFidelityClassificationRecord BuildSchemaFidelityRecord(MigrationInventoryResource resource)
+    {
+        var hasSchema = resource.Capabilities.Contains("ogcapi-features:schema", StringComparer.Ordinal) ||
+                        resource.Capabilities.Contains("ogcapi-features:queryables", StringComparer.Ordinal) ||
+                        resource.Fields.Length > 0;
+
+        return new MigrationFidelityClassificationRecord
+        {
+            Id = $"fidelity:{resource.Id}:schema-queryables",
+            SourceId = resource.Id,
+            Kind = resource.Kind,
+            Category = "schema-queryables",
+            Name = resource.Name,
+            AutomationStatus = hasSchema
+                ? MigrationFidelityAutomationStatuses.Automated
+                : MigrationFidelityAutomationStatuses.Assisted,
+            Code = hasSchema
+                ? OgcApiFeaturesImportCompatibilityCodes.CollectionSource
+                : OgcApiFeaturesImportCompatibilityCodes.ManualReview,
+            Reason = hasSchema
+                ? "Collection schema/queryables metadata was captured for target field planning."
+                : "Collection schema/queryables metadata was not advertised and needs assisted field review.",
+            ManualSteps = hasSchema ? [] : ["Confirm field names, types, nullability, and geometry mapping before import."],
+            RelatedIds = resource.ExternalDependencyIds,
+            Metadata = new Dictionary<string, string>
+            {
+                ["fieldCount"] = resource.Fields.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            }
+        };
+    }
+
+    private static MigrationFidelityClassificationRecord BuildCrsFidelityRecord(MigrationInventoryResource resource)
+    {
+        var unusualCrs = resource.SpatialReferences
+            .Any(static reference => !IsPortableDefaultCrs(reference));
+
+        return new MigrationFidelityClassificationRecord
+        {
+            Id = $"fidelity:{resource.Id}:crs",
+            SourceId = resource.Id,
+            Kind = resource.Kind,
+            Category = "crs",
+            Name = resource.Name,
+            AutomationStatus = unusualCrs
+                ? MigrationFidelityAutomationStatuses.ManualReview
+                : MigrationFidelityAutomationStatuses.Automated,
+            Code = unusualCrs
+                ? OgcApiFeaturesImportCompatibilityCodes.ManualReview
+                : OgcApiFeaturesImportCompatibilityCodes.CollectionSource,
+            Reason = unusualCrs
+                ? "Collection advertises CRS declarations that need axis-order and transformation review."
+                : "Collection CRS declarations are compatible with the automated import baseline.",
+            ManualSteps = unusualCrs ? ["Confirm source CRS axis order and target CRS transformation behavior before cutover."] : [],
+            Metadata = new Dictionary<string, string>
+            {
+                ["spatialReferenceCount"] = resource.SpatialReferences.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            }
+        };
+    }
+
+    private static MigrationFidelityClassificationRecord BuildPaginationFidelityRecord(MigrationInventoryResource resource)
+    {
+        var hasPagination = resource.Capabilities.Contains("ogcapi-features:pagination", StringComparer.Ordinal);
+
+        return new MigrationFidelityClassificationRecord
+        {
+            Id = $"fidelity:{resource.Id}:pagination",
+            SourceId = resource.Id,
+            Kind = resource.Kind,
+            Category = "pagination",
+            Name = resource.Name,
+            AutomationStatus = hasPagination
+                ? MigrationFidelityAutomationStatuses.Automated
+                : MigrationFidelityAutomationStatuses.Assisted,
+            Code = hasPagination
+                ? OgcApiFeaturesImportCompatibilityCodes.CollectionSource
+                : OgcApiFeaturesImportCompatibilityCodes.ManualReview,
+            Reason = hasPagination
+                ? "Items pagination links were captured for deterministic page traversal."
+                : "Items pagination links were not captured and paging behavior needs assisted review.",
+            ManualSteps = hasPagination ? [] : ["Confirm source paging parameters and deterministic traversal before bulk import."],
+            RelatedIds = resource.ExternalDependencyIds
+        };
+    }
+
+    private static MigrationFidelityClassificationRecord BuildTargetExposureFidelityRecord(MigrationInventoryResource resource)
+        => new()
+        {
+            Id = $"fidelity:{resource.Id}:target-exposure",
+            SourceId = resource.Id,
+            Kind = resource.Kind,
+            Category = "target-exposure",
+            Name = resource.Name,
+            AutomationStatus = resource.Compatibility.Level == "incompatible"
+                ? MigrationFidelityAutomationStatuses.Unsupported
+                : MigrationFidelityAutomationStatuses.Automated,
+            Code = resource.Compatibility.Level == "incompatible"
+                ? resource.Compatibility.Code ?? OgcApiFeaturesImportCompatibilityCodes.MissingItemsEndpoint
+                : OgcApiFeaturesImportCompatibilityCodes.CollectionSource,
+            Reason = resource.Compatibility.Level == "incompatible"
+                ? "Unsupported source collection cannot be published as target OGC API Features or FeatureServer layers by this slice."
+                : "Imported collections are planned for target OGC API Features and FeatureServer exposure through shared feature pipelines.",
+            TargetKind = resource.Compatibility.Level == "incompatible" ? null : "feature-layer",
+            ManualSteps = resource.Compatibility.Level == "incompatible" ? resource.Compatibility.ManualSteps : [],
+            Metadata = new Dictionary<string, string>
+            {
+                ["targetProtocols"] = "OGC API Features,FeatureServer"
+            }
+        };
 
     private static string[] BuildRelatedDependencyIds(OgcApiFeaturesCollectionSnapshot collection, string resourceId, Uri baseUri)
     {

--- a/src/Honua.Core/Features/Import/Services/OgcApiFeaturesMigrationScanner.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcApiFeaturesMigrationScanner.cs
@@ -1,0 +1,904 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Import.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// HTTP-backed scanner for OGC API Features migration inventories.
+/// </summary>
+public sealed partial class OgcApiFeaturesMigrationScanner : IOgcApiFeaturesMigrationScanner
+{
+    private const string SourceKind = "ogc-api-features";
+    private const string DisallowedNetworkAddressMessage = "OGC API Features URL resolves to a disallowed network address.";
+
+    private static readonly AsyncLocal<bool> UnsafeLocalUrlsAllowed = new();
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<OgcApiFeaturesMigrationScanner> _logger;
+    private readonly Func<string, CancellationToken, Task<IPAddress[]>> _hostAddressResolver;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OgcApiFeaturesMigrationScanner"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client used for OGC API Features discovery.</param>
+    /// <param name="logger">Logger instance.</param>
+    /// <param name="hostAddressResolver">Optional host resolver used by tests.</param>
+    public OgcApiFeaturesMigrationScanner(
+        HttpClient httpClient,
+        ILogger<OgcApiFeaturesMigrationScanner> logger,
+        Func<string, CancellationToken, Task<IPAddress[]>>? hostAddressResolver = null)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _hostAddressResolver = hostAddressResolver ?? ((host, ct) => Dns.GetHostAddressesAsync(host, ct));
+    }
+
+    /// <summary>
+    /// Creates an HTTP handler that pins DNS resolution before connecting to an OGC API Features source host.
+    /// </summary>
+    /// <param name="hostAddressResolver">Optional host resolver used by tests.</param>
+    /// <returns>HTTP message handler with bounded connections and pinned DNS validation.</returns>
+    public static HttpMessageHandler CreatePinnedDnsHttpMessageHandler(
+        Func<string, CancellationToken, Task<IPAddress[]>>? hostAddressResolver = null)
+    {
+        var resolver = hostAddressResolver ?? ((host, ct) => Dns.GetHostAddressesAsync(host, ct));
+
+        return new SocketsHttpHandler
+        {
+            AllowAutoRedirect = false,
+            MaxConnectionsPerServer = 16,
+            ConnectCallback = (context, cancellationToken) =>
+                ConnectWithPinnedDnsAsync(context, resolver, UnsafeLocalUrlsAllowed.Value, cancellationToken)
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<MigrationSourceInventoryArtifact> ScanSourceAsync(
+        OgcApiFeaturesScanRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var serviceUri = ValidateServiceUri(request.ServiceUrl, request.AllowUnsafeLocalUrls);
+
+        try
+        {
+            _ = await ResolveAllowedAddressesAsync(
+                    serviceUri.DnsSafeHost,
+                    _hostAddressResolver,
+                    request.AllowUnsafeLocalUrls,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            var previousUnsafeLocalUrlsAllowed = UnsafeLocalUrlsAllowed.Value;
+            UnsafeLocalUrlsAllowed.Value = request.AllowUnsafeLocalUrls;
+
+            try
+            {
+                using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeout.CancelAfter(TimeSpan.FromSeconds(request.TimeoutSeconds <= 0 ? 60 : request.TimeoutSeconds));
+
+                var snapshot = await BuildSnapshotAsync(serviceUri, request, timeout.Token).ConfigureAwait(false);
+                var artifact = OgcApiFeaturesMigrationInventoryScanner.BuildInventory(snapshot);
+                return artifact with
+                {
+                    AuthPosture = new MigrationInventoryAuthPosture
+                    {
+                        Mode = "anonymous",
+                        CredentialsSupplied = false,
+                        AccessConfirmed = true
+                    }
+                };
+            }
+            finally
+            {
+                UnsafeLocalUrlsAllowed.Value = previousUnsafeLocalUrlsAllowed;
+            }
+        }
+        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or JsonException ||
+                                   ex is TaskCanceledException && !cancellationToken.IsCancellationRequested)
+        {
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                Log.ScanFailed(_logger, ToSafeSourceUrl(serviceUri), ex);
+            }
+
+            return CreateFailedArtifact(serviceUri, ToSafeScanFailureReason(ex));
+        }
+    }
+
+    private async Task<OgcApiFeaturesMigrationSourceSnapshot> BuildSnapshotAsync(
+        Uri serviceUri,
+        OgcApiFeaturesScanRequest request,
+        CancellationToken cancellationToken)
+    {
+        using var landingDocument = await GetJsonDocumentAsync(serviceUri, cancellationToken).ConfigureAwait(false);
+        var landing = landingDocument.RootElement;
+        var landingLinks = ReadLinks(landing).ToArray();
+        var baseUrl = ToSafeSourceUrl(serviceUri);
+        var collectionsUri = FindLinkUri(landingLinks, serviceUri, static link => IsRel(link, "data") || LinkLooksLikeCollections(link))
+            ?? AppendPath(serviceUri, "collections");
+        var conformanceUri = FindLinkUri(landingLinks, serviceUri, static link => IsRel(link, "conformance"))
+            ?? AppendPath(serviceUri, "conformance");
+        var sourceCrs = ReadCrsDeclarations(landing, "source").ToArray();
+
+        var conformanceClasses = await TryReadConformanceClassesAsync(conformanceUri, cancellationToken).ConfigureAwait(false);
+        var collections = await ReadCollectionsAsync(
+                collectionsUri,
+                serviceUri,
+                request,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return new OgcApiFeaturesMigrationSourceSnapshot
+        {
+            BaseUrl = baseUrl,
+            Title = ReadString(landing, "title"),
+            Description = ReadString(landing, "description"),
+            Version = ReadString(landing, "version") ?? ReadString(landing, "apiVersion"),
+            LandingPageLinks = landingLinks,
+            ConformanceClasses = conformanceClasses,
+            Collections = collections,
+            CrsDeclarations = sourceCrs,
+            VendorExtensions = ReadVendorExtensions(landing)
+        };
+    }
+
+    private async Task<string[]> TryReadConformanceClassesAsync(Uri conformanceUri, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var document = await GetJsonDocumentAsync(conformanceUri, cancellationToken).ConfigureAwait(false);
+            if (!document.RootElement.TryGetProperty("conformsTo", out var conformsTo) ||
+                conformsTo.ValueKind != JsonValueKind.Array)
+            {
+                return [];
+            }
+
+            return conformsTo.EnumerateArray()
+                .Select(static item => item.ValueKind == JsonValueKind.String ? item.GetString() : null)
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Select(static value => value!)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(static value => value, StringComparer.Ordinal)
+                .ToArray();
+        }
+        catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException)
+        {
+            var conformanceUrl = ToSafeSourceUrl(conformanceUri);
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                Log.OptionalDocumentUnavailable(_logger, "conformance", conformanceUrl, ex);
+            }
+
+            return [];
+        }
+    }
+
+    private async Task<OgcApiFeaturesCollectionSnapshot[]> ReadCollectionsAsync(
+        Uri collectionsUri,
+        Uri serviceUri,
+        OgcApiFeaturesScanRequest request,
+        CancellationToken cancellationToken)
+    {
+        using var document = await GetJsonDocumentAsync(collectionsUri, cancellationToken).ConfigureAwait(false);
+        if (!document.RootElement.TryGetProperty("collections", out var collectionsElement) ||
+            collectionsElement.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var maxCollections = request.MaxCollections <= 0 ? 100 : request.MaxCollections;
+        var collections = new List<OgcApiFeaturesCollectionSnapshot>();
+
+        foreach (var collectionElement in collectionsElement.EnumerateArray().Take(maxCollections))
+        {
+            var id = ReadString(collectionElement, "id");
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                continue;
+            }
+
+            collections.Add(await ReadCollectionAsync(
+                    collectionElement,
+                    id,
+                    serviceUri,
+                    request,
+                    cancellationToken)
+                .ConfigureAwait(false));
+        }
+
+        return collections
+            .OrderBy(static collection => collection.Id, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private async Task<OgcApiFeaturesCollectionSnapshot> ReadCollectionAsync(
+        JsonElement collectionElement,
+        string id,
+        Uri serviceUri,
+        OgcApiFeaturesScanRequest request,
+        CancellationToken cancellationToken)
+    {
+        var links = ReadLinks(collectionElement).ToArray();
+        var itemEncodings = links
+            .Where(static link => IsRel(link, "items") || LinkLooksLikeItems(link))
+            .Select(static link => link.Type)
+            .Where(static type => !string.IsNullOrWhiteSpace(type))
+            .Select(static type => type!)
+            .ToArray();
+        var fields = await ReadCollectionFieldsAsync(links, serviceUri, cancellationToken).ConfigureAwait(false);
+        var itemsProbe = await ProbeItemsAsync(id, links, serviceUri, request, cancellationToken).ConfigureAwait(false);
+
+        return new OgcApiFeaturesCollectionSnapshot
+        {
+            Id = id,
+            Title = ReadString(collectionElement, "title"),
+            Description = ReadString(collectionElement, "description"),
+            GeometryType = itemsProbe.GeometryType,
+            FeatureCount = itemsProbe.FeatureCount ?? ReadNullableInt32(collectionElement, "itemCount"),
+            Links = links,
+            PaginationLinks = itemsProbe.PaginationLinks,
+            CrsDeclarations = ReadCrsDeclarations(collectionElement, "collection").ToArray(),
+            ItemEncodings = itemEncodings.Concat(itemsProbe.ItemEncodings).ToArray(),
+            Fields = fields,
+            VendorExtensions = ReadVendorExtensions(collectionElement)
+        };
+    }
+
+    private async Task<MigrationInventoryField[]> ReadCollectionFieldsAsync(
+        OgcApiFeaturesLink[] links,
+        Uri baseUri,
+        CancellationToken cancellationToken)
+    {
+        var fieldDocuments = links
+            .Where(static link => IsRel(link, "queryables") ||
+                                  IsRel(link, "http://www.opengis.net/def/rel/ogc/1.0/queryables") ||
+                                  IsRel(link, "describedby") ||
+                                  IsRel(link, "schema") ||
+                                  IsRel(link, "http://www.opengis.net/def/rel/ogc/1.0/schema"))
+            .Select(link => ResolveUri(link.Href, baseUri))
+            .Where(static uri => uri != null)
+            .Select(static uri => uri!)
+            .DistinctBy(static uri => uri.ToString(), StringComparer.Ordinal)
+            .ToArray();
+
+        var fields = new List<MigrationInventoryField>();
+        foreach (var uri in fieldDocuments)
+        {
+            try
+            {
+                using var document = await GetJsonDocumentAsync(uri, cancellationToken).ConfigureAwait(false);
+                fields.AddRange(ReadFields(document.RootElement));
+            }
+            catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException)
+            {
+                var documentUrl = ToSafeSourceUrl(uri);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    Log.OptionalDocumentUnavailable(_logger, "schema-queryables", documentUrl, ex);
+                }
+            }
+        }
+
+        return fields
+            .GroupBy(static field => field.Name, StringComparer.Ordinal)
+            .Select(static group => group.OrderByDescending(static field => field.Alias != null).First())
+            .OrderBy(static field => field.Name, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private async Task<ItemsProbeResult> ProbeItemsAsync(
+        string collectionId,
+        OgcApiFeaturesLink[] links,
+        Uri baseUri,
+        OgcApiFeaturesScanRequest request,
+        CancellationToken cancellationToken)
+    {
+        var itemsUri = FindLinkUri(links, baseUri, static link => IsRel(link, "items") || LinkLooksLikeItems(link))
+            ?? AppendPath(baseUri, $"collections/{Uri.EscapeDataString(collectionId)}/items");
+        itemsUri = AddMissingQueryParameter(itemsUri, "limit", Math.Max(request.ItemsProbeLimit, 1).ToString(CultureInfo.InvariantCulture));
+
+        try
+        {
+            using var document = await GetJsonDocumentAsync(itemsUri, cancellationToken).ConfigureAwait(false);
+            var root = document.RootElement;
+            var paginationLinks = ReadLinks(root)
+                .Where(static link => IsRel(link, "next") || IsRel(link, "prev") || IsRel(link, "previous"))
+                .ToArray();
+            var geometryType = ReadFirstFeatureGeometryType(root);
+            var featureCount = ReadNullableInt32(root, "numberMatched");
+            var encodings = new[] { "application/geo+json" };
+
+            return new ItemsProbeResult(featureCount, geometryType, paginationLinks, encodings);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException)
+        {
+            var itemsUrl = ToSafeSourceUrl(itemsUri);
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                Log.OptionalDocumentUnavailable(_logger, "items", itemsUrl, ex);
+            }
+
+            return new ItemsProbeResult(null, null, [], []);
+        }
+    }
+
+    private async Task<JsonDocument> GetJsonDocumentAsync(Uri uri, CancellationToken cancellationToken)
+    {
+        using var message = new HttpRequestMessage(HttpMethod.Get, uri);
+        message.Headers.Accept.ParseAdd("application/json");
+        message.Headers.Accept.ParseAdd("application/geo+json");
+
+        using var response = await _httpClient
+            .SendAsync(message, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+
+        if ((int)response.StatusCode is >= 300 and < 400)
+        {
+            throw new HttpRequestException("OGC API Features endpoint returned a redirect.");
+        }
+
+        response.EnsureSuccessStatusCode();
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        return await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private static IEnumerable<MigrationInventoryField> ReadFields(JsonElement root)
+    {
+        var properties = FindPropertiesObject(root);
+        if (properties == null)
+        {
+            yield break;
+        }
+
+        foreach (var property in properties.Value.EnumerateObject()
+                     .OrderBy(static property => property.Name, StringComparer.Ordinal))
+        {
+            if (string.Equals(property.Name, "geometry", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            yield return new MigrationInventoryField
+            {
+                Name = property.Name,
+                Alias = ReadString(property.Value, "title"),
+                FieldType = ReadJsonSchemaType(property.Value),
+                Nullable = ReadNullable(property.Value)
+            };
+        }
+    }
+
+    private static JsonElement? FindPropertiesObject(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (root.TryGetProperty("properties", out var properties) &&
+            properties.ValueKind == JsonValueKind.Object)
+        {
+            return properties;
+        }
+
+        if (root.TryGetProperty("schema", out var schema) &&
+            schema.ValueKind == JsonValueKind.Object &&
+            schema.TryGetProperty("properties", out var schemaProperties) &&
+            schemaProperties.ValueKind == JsonValueKind.Object)
+        {
+            return schemaProperties;
+        }
+
+        return null;
+    }
+
+    private static string ReadJsonSchemaType(JsonElement property)
+    {
+        if (!property.TryGetProperty("type", out var type))
+        {
+            return "unknown";
+        }
+
+        if (type.ValueKind == JsonValueKind.String)
+        {
+            return type.GetString() ?? "unknown";
+        }
+
+        if (type.ValueKind == JsonValueKind.Array)
+        {
+            var types = type.EnumerateArray()
+                .Select(static item => item.ValueKind == JsonValueKind.String ? item.GetString() : null)
+                .Where(static value => !string.IsNullOrWhiteSpace(value) && value != "null")
+                .Select(static value => value!)
+                .ToArray();
+            return types.Length == 0 ? "unknown" : string.Join("|", types);
+        }
+
+        return "unknown";
+    }
+
+    private static bool? ReadNullable(JsonElement property)
+    {
+        if (property.TryGetProperty("nullable", out var nullable) &&
+            nullable.ValueKind is JsonValueKind.True or JsonValueKind.False)
+        {
+            return nullable.GetBoolean();
+        }
+
+        if (!property.TryGetProperty("type", out var type) ||
+            type.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        return type.EnumerateArray()
+            .Any(static item => item.ValueKind == JsonValueKind.String &&
+                                string.Equals(item.GetString(), "null", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static IEnumerable<OgcApiFeaturesCrsDeclaration> ReadCrsDeclarations(JsonElement element, string defaultRole)
+    {
+        if (element.TryGetProperty("storageCrs", out var storageCrs) &&
+            storageCrs.ValueKind == JsonValueKind.String &&
+            !string.IsNullOrWhiteSpace(storageCrs.GetString()))
+        {
+            yield return new OgcApiFeaturesCrsDeclaration
+            {
+                Role = "storage",
+                Value = storageCrs.GetString()!
+            };
+        }
+
+        if (element.TryGetProperty("crs", out var crs) &&
+            crs.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in crs.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.String &&
+                    !string.IsNullOrWhiteSpace(item.GetString()))
+                {
+                    yield return new OgcApiFeaturesCrsDeclaration
+                    {
+                        Role = "supported",
+                        Value = item.GetString()!
+                    };
+                }
+            }
+        }
+
+        if (element.TryGetProperty("extent", out var extent) &&
+            extent.ValueKind == JsonValueKind.Object &&
+            extent.TryGetProperty("spatial", out var spatial) &&
+            spatial.ValueKind == JsonValueKind.Object &&
+            spatial.TryGetProperty("crs", out var spatialCrs) &&
+            spatialCrs.ValueKind == JsonValueKind.String &&
+            !string.IsNullOrWhiteSpace(spatialCrs.GetString()))
+        {
+            yield return new OgcApiFeaturesCrsDeclaration
+            {
+                Role = "extent",
+                Value = spatialCrs.GetString()!
+            };
+        }
+
+        if (!element.TryGetProperty("crs", out _) &&
+            !element.TryGetProperty("storageCrs", out _) &&
+            !element.TryGetProperty("extent", out _) &&
+            string.Equals(defaultRole, "source", StringComparison.Ordinal))
+        {
+            yield break;
+        }
+    }
+
+    private static OgcApiFeaturesLink[] ReadLinks(JsonElement element)
+    {
+        if (!element.TryGetProperty("links", out var links) ||
+            links.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return links.EnumerateArray()
+            .Where(static link => link.ValueKind == JsonValueKind.Object)
+            .Select(static link => new OgcApiFeaturesLink
+            {
+                Rel = ReadString(link, "rel") ?? "related",
+                Href = ReadString(link, "href") ?? string.Empty,
+                Type = ReadString(link, "type"),
+                Title = ReadString(link, "title")
+            })
+            .Where(static link => !string.IsNullOrWhiteSpace(link.Href))
+            .OrderBy(static link => link.Rel, StringComparer.Ordinal)
+            .ThenBy(static link => link.Href, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string[] ReadVendorExtensions(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return [];
+        }
+
+        return element.EnumerateObject()
+            .Select(static property => property.Name)
+            .Where(static name => name.StartsWith("x-", StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string? ReadFirstFeatureGeometryType(JsonElement root)
+    {
+        if (!root.TryGetProperty("features", out var features) ||
+            features.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        foreach (var feature in features.EnumerateArray())
+        {
+            if (feature.ValueKind == JsonValueKind.Object &&
+                feature.TryGetProperty("geometry", out var geometry) &&
+                geometry.ValueKind == JsonValueKind.Object &&
+                geometry.TryGetProperty("type", out var type) &&
+                type.ValueKind == JsonValueKind.String)
+            {
+                return type.GetString();
+            }
+        }
+
+        return null;
+    }
+
+    private static Uri? FindLinkUri(
+        IEnumerable<OgcApiFeaturesLink> links,
+        Uri baseUri,
+        Func<OgcApiFeaturesLink, bool> predicate)
+        => links.Where(predicate)
+            .Select(link => ResolveUri(link.Href, baseUri))
+            .FirstOrDefault(static uri => uri != null);
+
+    private static bool IsRel(OgcApiFeaturesLink link, string rel)
+        => string.Equals(link.Rel, rel, StringComparison.OrdinalIgnoreCase);
+
+    private static bool LinkLooksLikeCollections(OgcApiFeaturesLink link)
+        => link.Href.Contains("/collections", StringComparison.OrdinalIgnoreCase);
+
+    private static bool LinkLooksLikeItems(OgcApiFeaturesLink link)
+        => link.Href.Contains("/items", StringComparison.OrdinalIgnoreCase);
+
+    private static Uri? ResolveUri(string href, Uri baseUri)
+    {
+        if (string.IsNullOrWhiteSpace(href))
+        {
+            return null;
+        }
+
+        return Uri.TryCreate(href, UriKind.Absolute, out var absolute)
+            ? absolute
+            : Uri.TryCreate(EnsureDirectoryBase(baseUri), href, out var relative)
+                ? relative
+                : null;
+    }
+
+    private static Uri AppendPath(Uri baseUri, string relativePath)
+    {
+        var root = EnsureDirectoryBase(baseUri);
+        return new Uri(root, relativePath.TrimStart('/'));
+    }
+
+    private static Uri EnsureDirectoryBase(Uri uri)
+    {
+        var builder = new UriBuilder(uri)
+        {
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+
+        if (builder.Path.Length == 0 || builder.Path[^1] != '/')
+        {
+            builder.Path += "/";
+        }
+
+        return builder.Uri;
+    }
+
+    private static Uri AddMissingQueryParameter(Uri uri, string name, string value)
+    {
+        var parameters = uri.Query.TrimStart('?')
+            .Split('&', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToList();
+
+        if (parameters.Any(parameter =>
+                parameter.Split('=', 2)[0].Equals(name, StringComparison.OrdinalIgnoreCase)))
+        {
+            return uri;
+        }
+
+        parameters.Add($"{Uri.EscapeDataString(name)}={Uri.EscapeDataString(value)}");
+        var builder = new UriBuilder(uri)
+        {
+            Query = string.Join("&", parameters)
+        };
+        return builder.Uri;
+    }
+
+    private static string? ReadString(JsonElement element, string name)
+        => element.ValueKind == JsonValueKind.Object &&
+           element.TryGetProperty(name, out var value) &&
+           value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static int? ReadNullableInt32(JsonElement element, string name)
+    {
+        if (element.ValueKind != JsonValueKind.Object ||
+            !element.TryGetProperty(name, out var value))
+        {
+            return null;
+        }
+
+        if (value.ValueKind == JsonValueKind.Number &&
+            value.TryGetInt32(out var number))
+        {
+            return number;
+        }
+
+        return value.ValueKind == JsonValueKind.String &&
+               int.TryParse(value.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out number)
+            ? number
+            : null;
+    }
+
+    private static MigrationSourceInventoryArtifact CreateFailedArtifact(Uri serviceUri, string reason)
+        => new()
+        {
+            SourceKind = SourceKind,
+            Source = new MigrationSourceIdentity
+            {
+                DisplayName = "OGC API Features",
+                BaseUrl = ToSafeSourceUrl(serviceUri),
+                Product = "OGC API Features",
+                ServiceType = "OGC API Features"
+            },
+            AuthPosture = new MigrationInventoryAuthPosture
+            {
+                Mode = "anonymous-or-auth-required",
+                CredentialsSupplied = false,
+                AccessConfirmed = false,
+                Notes = [reason]
+            },
+            ScanCompleteness = MigrationInventoryHelpers.BuildCompleteness("failed", [reason], ["source-inventory"]),
+            Summary = new MigrationInventorySummary(),
+            OverallCompatibility = MigrationInventoryHelpers.Partial(
+                "The OGC API Features scan did not complete successfully.",
+                [reason],
+                ["Verify OGC API Features landing page reachability, JSON support, and access requirements, then rerun the scan."],
+                OgcApiFeaturesImportCompatibilityCodes.ManualReview)
+        };
+
+    private static string ToSafeScanFailureReason(Exception exception)
+        => exception switch
+        {
+            TaskCanceledException => "OGC API Features scan timed out.",
+            HttpRequestException => "OGC API Features endpoint could not be reached or returned an unsupported response.",
+            JsonException => "OGC API Features metadata could not be parsed as JSON.",
+            _ => "OGC API Features metadata could not be scanned."
+        };
+
+    private static Uri ValidateServiceUri(string serviceUrl, bool allowUnsafeLocalUrls)
+    {
+        if (!Uri.TryCreate(serviceUrl, UriKind.Absolute, out var uri) ||
+            (allowUnsafeLocalUrls
+                ? uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps
+                : uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new HttpRequestException(allowUnsafeLocalUrls
+                ? "OGC API Features URL must be a valid HTTP or HTTPS URL."
+                : "OGC API Features URL must be a valid HTTPS URL.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(uri.UserInfo))
+        {
+            throw new HttpRequestException("OGC API Features URL must not include embedded credentials.");
+        }
+
+        if (!allowUnsafeLocalUrls &&
+            (uri.IsLoopback || string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase) ||
+             uri.Host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new HttpRequestException(DisallowedNetworkAddressMessage);
+        }
+
+        return uri;
+    }
+
+    private static async Task<IPAddress[]> ResolveAllowedAddressesAsync(
+        string host,
+        Func<string, CancellationToken, Task<IPAddress[]>> hostAddressResolver,
+        bool allowUnsafeLocalUrls,
+        CancellationToken cancellationToken)
+    {
+        if (IPAddress.TryParse(host, out var literalAddress))
+        {
+            if (!allowUnsafeLocalUrls && IsPrivateOrReservedAddress(literalAddress))
+            {
+                throw new HttpRequestException(DisallowedNetworkAddressMessage);
+            }
+
+            return [literalAddress];
+        }
+
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await hostAddressResolver(host, cancellationToken).ConfigureAwait(false);
+        }
+        catch (SocketException)
+        {
+            throw new HttpRequestException(DisallowedNetworkAddressMessage);
+        }
+        catch (ArgumentException)
+        {
+            throw new HttpRequestException(DisallowedNetworkAddressMessage);
+        }
+
+        if (addresses.Length == 0)
+        {
+            throw new HttpRequestException(DisallowedNetworkAddressMessage);
+        }
+
+        if (!allowUnsafeLocalUrls)
+        {
+            foreach (var address in addresses)
+            {
+                if (IsPrivateOrReservedAddress(address))
+                {
+                    throw new HttpRequestException(DisallowedNetworkAddressMessage);
+                }
+            }
+        }
+
+        return addresses;
+    }
+
+    private static async ValueTask<Stream> ConnectWithPinnedDnsAsync(
+        SocketsHttpConnectionContext context,
+        Func<string, CancellationToken, Task<IPAddress[]>> hostAddressResolver,
+        bool allowUnsafeLocalUrls,
+        CancellationToken cancellationToken)
+    {
+        var addresses = await ResolveAllowedAddressesAsync(
+                context.DnsEndPoint.Host,
+                hostAddressResolver,
+                allowUnsafeLocalUrls,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        Exception? lastException = null;
+        foreach (var address in addresses)
+        {
+            var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            var connected = false;
+
+            try
+            {
+                await socket.ConnectAsync(address, context.DnsEndPoint.Port, cancellationToken).ConfigureAwait(false);
+                connected = true;
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex) when (ex is SocketException or ObjectDisposedException)
+            {
+                lastException = ex;
+            }
+            finally
+            {
+                if (!connected)
+                {
+                    socket.Dispose();
+                }
+            }
+        }
+
+        throw new HttpRequestException("Unable to establish a connection to the OGC API Features host.", lastException);
+    }
+
+    private static bool IsPrivateOrReservedAddress(IPAddress address)
+    {
+        if (IPAddress.IsLoopback(address))
+        {
+            return true;
+        }
+
+        if (address.IsIPv4MappedToIPv6)
+        {
+            address = address.MapToIPv4();
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var bytes = address.GetAddressBytes();
+            return bytes[0] == 0 ||
+                   bytes[0] == 10 ||
+                   (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) ||
+                   bytes[0] == 127 ||
+                   (bytes[0] == 169 && bytes[1] == 254) ||
+                   (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) ||
+                   (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 0) ||
+                   (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 2) ||
+                   (bytes[0] == 192 && bytes[1] == 168) ||
+                   (bytes[0] == 198 && (bytes[1] == 18 || bytes[1] == 19)) ||
+                   (bytes[0] == 198 && bytes[1] == 51 && bytes[2] == 100) ||
+                   bytes[0] >= 224;
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            var bytes = address.GetAddressBytes();
+            return address.IsIPv6LinkLocal ||
+                   address.IsIPv6Multicast ||
+                   address.IsIPv6SiteLocal ||
+                   bytes.All(static value => value == 0) ||
+                   bytes[0] == 0xfc ||
+                   bytes[0] == 0xfd ||
+                   bytes[0] == 0xfe;
+        }
+
+        return true;
+    }
+
+    private static string ToSafeSourceUrl(Uri uri)
+    {
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+
+        return builder.Uri.AbsoluteUri;
+    }
+
+    private sealed record ItemsProbeResult(
+        int? FeatureCount,
+        string? GeometryType,
+        OgcApiFeaturesLink[] PaginationLinks,
+        string[] ItemEncodings);
+
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 21001,
+            Level = LogLevel.Warning,
+            Message = "OGC API Features migration scan failed for {SourceUrl}.",
+            SkipEnabledCheck = true)]
+        public static partial void ScanFailed(ILogger logger, string sourceUrl, Exception exception);
+
+        [LoggerMessage(
+            EventId = 21002,
+            Level = LogLevel.Debug,
+            Message = "Optional OGC API Features {DocumentKind} document was unavailable at {DocumentUrl}.",
+            SkipEnabledCheck = true)]
+        public static partial void OptionalDocumentUnavailable(
+            ILogger logger,
+            string documentKind,
+            string documentUrl,
+            Exception exception);
+    }
+}

--- a/src/Honua.Core/Features/Import/Services/OgcApiFeaturesMigrationScanner.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcApiFeaturesMigrationScanner.cs
@@ -18,6 +18,7 @@ public sealed partial class OgcApiFeaturesMigrationScanner : IOgcApiFeaturesMigr
 {
     private const string SourceKind = "ogc-api-features";
     private const string DisallowedNetworkAddressMessage = "OGC API Features URL resolves to a disallowed network address.";
+    private const int MaxJsonDocumentRedirects = 5;
 
     private static readonly AsyncLocal<bool> UnsafeLocalUrlsAllowed = new();
 
@@ -334,22 +335,93 @@ public sealed partial class OgcApiFeaturesMigrationScanner : IOgcApiFeaturesMigr
 
     private async Task<JsonDocument> GetJsonDocumentAsync(Uri uri, CancellationToken cancellationToken)
     {
-        using var message = new HttpRequestMessage(HttpMethod.Get, uri);
-        message.Headers.Accept.ParseAdd("application/json");
-        message.Headers.Accept.ParseAdd("application/geo+json");
+        var requestUri = uri;
 
-        using var response = await _httpClient
-            .SendAsync(message, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
-
-        if ((int)response.StatusCode is >= 300 and < 400)
+        for (var redirectCount = 0;; redirectCount++)
         {
-            throw new HttpRequestException("OGC API Features endpoint returned a redirect.");
+            using var message = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            message.Headers.Accept.ParseAdd("application/json");
+            message.Headers.Accept.ParseAdd("application/geo+json");
+
+            using var response = await _httpClient
+                .SendAsync(message, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
+
+            if ((int)response.StatusCode is >= 300 and < 400)
+            {
+                if (redirectCount >= MaxJsonDocumentRedirects)
+                {
+                    throw new HttpRequestException("OGC API Features endpoint returned too many redirects.");
+                }
+
+                var redirectUri = ResolveRedirectUri(requestUri, response.Headers.Location);
+                if (redirectUri == null || !IsSafeRedirectUri(requestUri, redirectUri))
+                {
+                    throw new HttpRequestException("OGC API Features endpoint returned an unsafe redirect.");
+                }
+
+                requestUri = redirectUri;
+                continue;
+            }
+
+            response.EnsureSuccessStatusCode();
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            return await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static Uri? ResolveRedirectUri(Uri requestUri, Uri? location)
+    {
+        if (location == null)
+        {
+            return null;
         }
 
-        response.EnsureSuccessStatusCode();
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-        return await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return location.IsAbsoluteUri
+            ? location
+            : Uri.TryCreate(requestUri, location, out var redirectUri)
+                ? redirectUri
+                : null;
+    }
+
+    private static bool IsSafeRedirectUri(Uri requestUri, Uri redirectUri)
+    {
+        if (redirectUri.Scheme != Uri.UriSchemeHttp &&
+            redirectUri.Scheme != Uri.UriSchemeHttps)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(redirectUri.UserInfo) ||
+            !string.Equals(requestUri.DnsSafeHost, redirectUri.DnsSafeHost, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (requestUri.Scheme == Uri.UriSchemeHttps && redirectUri.Scheme != Uri.UriSchemeHttps)
+        {
+            return false;
+        }
+
+        if (requestUri.Scheme == redirectUri.Scheme)
+        {
+            return requestUri.Port == redirectUri.Port;
+        }
+
+        return requestUri.Scheme == Uri.UriSchemeHttp &&
+               redirectUri.Scheme == Uri.UriSchemeHttps &&
+               IsDefaultPort(requestUri) &&
+               IsDefaultPort(redirectUri);
+    }
+
+    private static bool IsDefaultPort(Uri uri)
+    {
+        if (uri.Scheme == Uri.UriSchemeHttp)
+        {
+            return uri.Port == 80;
+        }
+
+        return uri.Scheme == Uri.UriSchemeHttps && uri.Port == 443;
     }
 
     private static IEnumerable<MigrationInventoryField> ReadFields(JsonElement root)

--- a/src/Honua.Core/Features/Import/Services/OgcApiFeaturesMigrationScanner.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcApiFeaturesMigrationScanner.cs
@@ -337,7 +337,7 @@ public sealed partial class OgcApiFeaturesMigrationScanner : IOgcApiFeaturesMigr
     {
         var requestUri = uri;
 
-        for (var redirectCount = 0;; redirectCount++)
+        for (var redirectCount = 0; ; redirectCount++)
         {
             using var message = new HttpRequestMessage(HttpMethod.Get, requestUri);
             message.Headers.Accept.ParseAdd("application/json");

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -363,6 +363,19 @@ internal static class ServiceCollectionExtensions
         services.AddScoped<IOgcServiceMigrationScanner>(serviceProvider =>
             serviceProvider.GetRequiredService<OgcServiceMigrationScanner>());
 
+        // Register OGC API Features migration scanner for landing/conformance/collections/items inventory planning.
+        services.AddResilientHttpClient<OgcApiFeaturesMigrationScanner>(
+            "ogc-api-features-migration",
+            HttpResiliencePolicies.SlowServiceDefaults,
+            configureClient: client =>
+            {
+                client.DefaultRequestHeaders.Add("User-Agent", "HonuaServer/1.0");
+                client.Timeout = TimeSpan.FromMinutes(2);
+            },
+            configureHandler: static () => OgcApiFeaturesMigrationScanner.CreatePinnedDnsHttpMessageHandler());
+        services.AddScoped<IOgcApiFeaturesMigrationScanner>(serviceProvider =>
+            serviceProvider.GetRequiredService<OgcApiFeaturesMigrationScanner>());
+
         // Register secure connection management services
         services.AddSecureConnectionServices(configuration);
         services.UseSecureConnectionProvider(configuration);

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -363,19 +363,6 @@ internal static class ServiceCollectionExtensions
         services.AddScoped<IOgcServiceMigrationScanner>(serviceProvider =>
             serviceProvider.GetRequiredService<OgcServiceMigrationScanner>());
 
-        // Register OGC API Features migration scanner for landing/conformance/collections/items inventory planning.
-        services.AddResilientHttpClient<OgcApiFeaturesMigrationScanner>(
-            "ogc-api-features-migration",
-            HttpResiliencePolicies.SlowServiceDefaults,
-            configureClient: client =>
-            {
-                client.DefaultRequestHeaders.Add("User-Agent", "HonuaServer/1.0");
-                client.Timeout = TimeSpan.FromMinutes(2);
-            },
-            configureHandler: static () => OgcApiFeaturesMigrationScanner.CreatePinnedDnsHttpMessageHandler());
-        services.AddScoped<IOgcApiFeaturesMigrationScanner>(serviceProvider =>
-            serviceProvider.GetRequiredService<OgcApiFeaturesMigrationScanner>());
-
         // Register secure connection management services
         services.AddSecureConnectionServices(configuration);
         services.UseSecureConnectionProvider(configuration);

--- a/src/Honua.Server/Features/Import/MigrationScannerEndpoints.cs
+++ b/src/Honua.Server/Features/Import/MigrationScannerEndpoints.cs
@@ -61,7 +61,7 @@ internal static class MigrationScannerEndpoints
         {
             await AdminResponseWriter.WriteErrorAsync(
                 context,
-                "SourceKind must be one of: geoserver, geoserver-rest, geoservices, arcgis-geoservices-rest, ogc-wfs, ogc-wms, ogc-wmts.",
+                "SourceKind must be one of: geoserver, geoserver-rest, geoservices, arcgis-geoservices-rest, ogc-api-features, ogc-wfs, ogc-wms, ogc-wmts.",
                 StatusCodes.Status400BadRequest);
             return;
         }
@@ -140,6 +140,33 @@ internal static class MigrationScannerEndpoints
                                 ServiceType = sourceKind["ogc-".Length..],
                                 ServiceUrl = request.SourceUrl,
                                 Version = request.ServiceVersion,
+                                TimeoutSeconds = request.TimeoutSeconds ?? 60,
+                                AllowUnsafeLocalUrls = allowUnsafeLocalUrls
+                            },
+                            cancellationToken).ConfigureAwait(false);
+                        break;
+                    }
+                case "ogc-api-features":
+                    {
+                        var allowUnsafeLocalUrls = GeoServerImportExecutionSettings.ShouldAllowUnsafeLocalUrls(context.RequestServices);
+                        var validation = await OgcServiceUrlValidation.ValidateAsync(
+                            request.SourceUrl,
+                            allowUnsafeLocalUrls,
+                            cancellationToken).ConfigureAwait(false);
+                        if (!validation.IsValid)
+                        {
+                            await AdminResponseWriter.WriteErrorAsync(
+                                context,
+                                validation.ErrorMessage!,
+                                StatusCodes.Status400BadRequest);
+                            return;
+                        }
+
+                        var scanner = context.RequestServices.GetRequiredService<IOgcApiFeaturesMigrationScanner>();
+                        artifact = await scanner.ScanSourceAsync(
+                            new OgcApiFeaturesScanRequest
+                            {
+                                ServiceUrl = request.SourceUrl,
                                 TimeoutSeconds = request.TimeoutSeconds ?? 60,
                                 AllowUnsafeLocalUrls = allowUnsafeLocalUrls
                             },
@@ -257,6 +284,7 @@ internal static class MigrationScannerEndpoints
         {
             "geoserver" or "geoserver-rest" => "geoserver-rest",
             "geoservices" or "arcgis-geoservices-rest" => "arcgis-geoservices-rest",
+            "ogc-api" or "ogc-api-features" or "oapif" => "ogc-api-features",
             "wfs" or "ogc-wfs" => "ogc-wfs",
             "wms" or "ogc-wms" => "ogc-wms",
             "wmts" or "ogc-wmts" => "ogc-wmts",

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcApiFeaturesMigrationInventoryScannerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcApiFeaturesMigrationInventoryScannerTests.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using FluentAssertions;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Import.Services;
@@ -321,6 +322,53 @@ public sealed class OgcApiFeaturesMigrationInventoryScannerTests
     }
 
     [Fact]
+    public async Task ScanSourceAsync_WithSameHostRedirect_FollowsRedirectAndScans()
+    {
+        using var httpClient = new HttpClient(new FixtureOgcApiFeaturesHandler())
+        {
+            BaseAddress = new Uri("https://demo.example")
+        };
+        var scanner = new OgcApiFeaturesMigrationScanner(
+            httpClient,
+            NullLogger<OgcApiFeaturesMigrationScanner>.Instance,
+            static (_, _) => Task.FromResult<IPAddress[]>([IPAddress.Parse("8.8.8.8")]));
+
+        var artifact = await scanner.ScanSourceAsync(new OgcApiFeaturesScanRequest
+        {
+            ServiceUrl = "https://demo.example/redirect",
+            TimeoutSeconds = 5
+        });
+
+        artifact.ScanCompleteness.Status.Should().Be("complete");
+        artifact.Resources.Should().ContainSingle(resource => resource.Name == "roads");
+    }
+
+    [Fact]
+    public async Task ScanSourceAsync_WithCrossHostRedirect_BlocksRedirectWithoutForwardingAuthorization()
+    {
+        var handler = new FixtureOgcApiFeaturesHandler();
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://demo.example")
+        };
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "secret");
+        var scanner = new OgcApiFeaturesMigrationScanner(
+            httpClient,
+            NullLogger<OgcApiFeaturesMigrationScanner>.Instance,
+            static (_, _) => Task.FromResult<IPAddress[]>([IPAddress.Parse("8.8.8.8")]));
+
+        var artifact = await scanner.ScanSourceAsync(new OgcApiFeaturesScanRequest
+        {
+            ServiceUrl = "https://demo.example/external-redirect",
+            TimeoutSeconds = 5
+        });
+
+        artifact.ScanCompleteness.Status.Should().Be("failed");
+        handler.RequestUris.Should().ContainSingle(uri => uri.Host == "demo.example");
+        handler.RequestUris.Should().NotContain(uri => uri.Host == "other.example");
+    }
+
+    [Fact]
     public void Translate_WithOgcApiFeaturesInventory_EmitsFeatureImportTarget()
     {
         var inventory = OgcApiFeaturesMigrationInventoryScanner.BuildInventory(new OgcApiFeaturesMigrationSourceSnapshot
@@ -380,9 +428,12 @@ public sealed class OgcApiFeaturesMigrationInventoryScannerTests
 
     private sealed class FixtureOgcApiFeaturesHandler : HttpMessageHandler
     {
+        public List<Uri> RequestUris { get; } = [];
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             request.RequestUri.Should().NotBeNull();
+            RequestUris.Add(request.RequestUri!);
             var pathAndQuery = request.RequestUri!.PathAndQuery;
             var json = pathAndQuery switch
             {
@@ -463,6 +514,22 @@ public sealed class OgcApiFeaturesMigrationInventoryScannerTests
                     """,
                 _ => null
             };
+
+            if (pathAndQuery == "/redirect")
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Found)
+                {
+                    Headers = { Location = new Uri("/ogcapi/", UriKind.Relative) }
+                });
+            }
+
+            if (pathAndQuery == "/external-redirect")
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Found)
+                {
+                    Headers = { Location = new Uri("https://other.example/ogcapi/") }
+                });
+            }
 
             return Task.FromResult(json == null
                 ? new HttpResponseMessage(HttpStatusCode.NotFound)

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcApiFeaturesMigrationInventoryScannerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcApiFeaturesMigrationInventoryScannerTests.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Net;
+using System.Net.Http;
 using FluentAssertions;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Import.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Honua.Core.Tests.Features.Import;
 
@@ -52,7 +55,17 @@ public sealed class OgcApiFeaturesMigrationInventoryScannerTests
                         Crs("storage", "http://www.opengis.net/def/crs/OGC/1.3/CRS84"),
                         Crs("supported", "http://www.opengis.net/def/crs/EPSG/0/4326")
                     ],
-                    ItemEncodings = ["application/geo+json"]
+                    ItemEncodings = ["application/geo+json"],
+                    Fields =
+                    [
+                        new MigrationInventoryField
+                        {
+                            Name = "name",
+                            Alias = "Road name",
+                            FieldType = "string",
+                            Nullable = false
+                        }
+                    ]
                 }
             ]
         });
@@ -75,7 +88,13 @@ public sealed class OgcApiFeaturesMigrationInventoryScannerTests
             "ogcapi-features:crs");
         resource.SpatialReferences.Should().Contain(reference => reference.Role == "supported" && reference.Srid == 4326);
         resource.SpatialReferences.Should().Contain(reference => reference.Role == "storage" && reference.CrsUri == "http://www.opengis.net/def/crs/OGC/1.3/CRS84");
+        resource.Fields.Should().ContainSingle(field => field.Name == "name" && field.Alias == "Road name");
         resource.Compatibility.Code.Should().Be(OgcApiFeaturesImportCompatibilityCodes.CollectionSource);
+        artifact.FidelityClassifications.Should().Contain(record =>
+            record.SourceId == resource.Id &&
+            record.Category == "target-exposure" &&
+            record.AutomationStatus == MigrationFidelityAutomationStatuses.Automated &&
+            record.Metadata["targetProtocols"] == "OGC API Features,FeatureServer");
 
         var pagination = artifact.ExternalDependencies.Should()
             .ContainSingle(dependency => dependency.ResourceId == resource.Id && dependency.DependencyType == "pagination")
@@ -251,6 +270,97 @@ public sealed class OgcApiFeaturesMigrationInventoryScannerTests
         artifact.ExternalDependencies.Should().Contain(dependency =>
             dependency.DependencyType == "manual-review-link" &&
             dependency.Compatibility.Code == OgcApiFeaturesImportCompatibilityCodes.ManualReview);
+        artifact.FidelityClassifications.Should().Contain(record =>
+            record.Category == "vendor-extension" &&
+            record.AutomationStatus == MigrationFidelityAutomationStatuses.ManualReview);
+    }
+
+    [Fact]
+    public async Task ScanSourceAsync_WithFixtureSource_CapturesCollectionsSchemaPagingAndItems()
+    {
+        using var httpClient = new HttpClient(new FixtureOgcApiFeaturesHandler())
+        {
+            BaseAddress = new Uri("https://demo.example")
+        };
+        var scanner = new OgcApiFeaturesMigrationScanner(
+            httpClient,
+            NullLogger<OgcApiFeaturesMigrationScanner>.Instance,
+            static (_, _) => Task.FromResult<IPAddress[]>([IPAddress.Parse("8.8.8.8")]));
+
+        var artifact = await scanner.ScanSourceAsync(new OgcApiFeaturesScanRequest
+        {
+            ServiceUrl = "https://demo.example/ogcapi/",
+            TimeoutSeconds = 5
+        });
+
+        artifact.SourceKind.Should().Be("ogc-api-features");
+        artifact.AuthPosture.Mode.Should().Be("anonymous");
+        artifact.ScanCompleteness.Status.Should().Be("complete");
+        artifact.OverallCompatibility.Level.Should().Be("compatible");
+
+        var resource = artifact.Resources.Should().ContainSingle().Subject;
+        resource.Name.Should().Be("roads");
+        resource.GeometryType.Should().Be("Point");
+        resource.FeatureCount.Should().Be(2);
+        resource.Fields.Should().Contain(field => field.Name == "name" && field.Alias == "Road name");
+        resource.Fields.Should().Contain(field => field.Name == "speed" && field.FieldType == "integer");
+        resource.Capabilities.Should().Contain(
+            "ogcapi-features:items",
+            "ogcapi-features:queryables",
+            "ogcapi-features:schema",
+            "ogcapi-features:pagination");
+        resource.ExternalDependencyIds.Should().Contain(id => id.Contains("pagination", StringComparison.Ordinal));
+
+        artifact.ExternalDependencies.Should().Contain(dependency =>
+            dependency.DependencyType == "pagination" &&
+            dependency.Metadata["queryParameters"] == "limit,offset");
+        artifact.FidelityClassifications.Should().Contain(record =>
+            record.SourceId == resource.Id &&
+            record.Category == "feature-data" &&
+            record.AutomationStatus == MigrationFidelityAutomationStatuses.Automated);
+    }
+
+    [Fact]
+    public void Translate_WithOgcApiFeaturesInventory_EmitsFeatureImportTarget()
+    {
+        var inventory = OgcApiFeaturesMigrationInventoryScanner.BuildInventory(new OgcApiFeaturesMigrationSourceSnapshot
+        {
+            BaseUrl = "https://demo.example/ogcapi/",
+            Title = "Demo OGC API Features",
+            Collections =
+            [
+                new OgcApiFeaturesCollectionSnapshot
+                {
+                    Id = "roads",
+                    Links =
+                    [
+                        Link("items", "https://demo.example/ogcapi/collections/roads/items", "application/geo+json"),
+                        Link("queryables", "https://demo.example/ogcapi/collections/roads/queryables", "application/schema+json"),
+                        Link("describedby", "https://demo.example/ogcapi/collections/roads/schema", "application/schema+json")
+                    ],
+                    PaginationLinks =
+                    [
+                        Link("next", "https://demo.example/ogcapi/collections/roads/items?offset=100&limit=100", "application/geo+json")
+                    ],
+                    CrsDeclarations = [Crs("storage", "http://www.opengis.net/def/crs/EPSG/0/4326")],
+                    ItemEncodings = ["application/geo+json"]
+                }
+            ]
+        });
+
+        var manifest = MigrationManifestTranslator.Translate(inventory, new MigrationManifestTranslationOptions
+        {
+            TargetServiceName = "Migrated OAPIF"
+        });
+        var evidence = MigrationParityEvidenceGenerator.Generate(inventory, manifest);
+
+        var target = manifest.TargetResources.Should().ContainSingle().Subject;
+        target.MigrationMode.Should().Be("feature-import");
+        target.SourceProtocol.Should().Be("OGC API Features");
+        target.Capabilities.Should().Contain("ogcapi-features:geojson-items");
+        evidence.ManifestAvailable.Should().BeTrue();
+        evidence.Sections.Should().Contain(section => section.Id == "fidelity")
+            .Which.Items.Should().Contain(item => item.Id.Contains("target-exposure", StringComparison.Ordinal));
     }
 
     private static OgcApiFeaturesLink Link(string rel, string href, string? type = null)
@@ -267,4 +377,99 @@ public sealed class OgcApiFeaturesMigrationInventoryScannerTests
             Role = role,
             Value = value
         };
+
+    private sealed class FixtureOgcApiFeaturesHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.RequestUri.Should().NotBeNull();
+            var pathAndQuery = request.RequestUri!.PathAndQuery;
+            var json = pathAndQuery switch
+            {
+                "/ogcapi/" => """
+                    {
+                      "title": "Fixture OGC API Features",
+                      "version": "1.0.0",
+                      "links": [
+                        { "rel": "self", "href": "https://demo.example/ogcapi/", "type": "application/json" },
+                        { "rel": "conformance", "href": "https://demo.example/ogcapi/conformance", "type": "application/json" },
+                        { "rel": "data", "href": "https://demo.example/ogcapi/collections", "type": "application/json" }
+                      ]
+                    }
+                    """,
+                "/ogcapi/conformance" => """
+                    {
+                      "conformsTo": [
+                        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+                        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+                        "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables"
+                      ]
+                    }
+                    """,
+                "/ogcapi/collections" => """
+                    {
+                      "collections": [
+                        {
+                          "id": "roads",
+                          "title": "Roads",
+                          "description": "Reference road centerlines",
+                          "storageCrs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                          "crs": ["http://www.opengis.net/def/crs/EPSG/0/4326"],
+                          "links": [
+                            { "rel": "items", "href": "https://demo.example/ogcapi/collections/roads/items", "type": "application/geo+json" },
+                            { "rel": "queryables", "href": "https://demo.example/ogcapi/collections/roads/queryables", "type": "application/schema+json" },
+                            { "rel": "describedby", "href": "https://demo.example/ogcapi/collections/roads/schema", "type": "application/schema+json" }
+                          ]
+                        }
+                      ]
+                    }
+                    """,
+                "/ogcapi/collections/roads/queryables" => """
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": { "type": "string", "title": "Road name", "nullable": false },
+                        "speed": { "type": "integer" }
+                      }
+                    }
+                    """,
+                "/ogcapi/collections/roads/schema" => """
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": { "type": "string", "title": "Road name" },
+                        "speed": { "type": "integer" }
+                      }
+                    }
+                    """,
+                "/ogcapi/collections/roads/items?limit=1" => """
+                    {
+                      "type": "FeatureCollection",
+                      "numberMatched": 2,
+                      "numberReturned": 1,
+                      "links": [
+                        { "rel": "self", "href": "https://demo.example/ogcapi/collections/roads/items?limit=1", "type": "application/geo+json" },
+                        { "rel": "next", "href": "https://demo.example/ogcapi/collections/roads/items?offset=1&limit=1", "type": "application/geo+json" }
+                      ],
+                      "features": [
+                        {
+                          "type": "Feature",
+                          "id": "road.1",
+                          "geometry": { "type": "Point", "coordinates": [-157.8583, 21.3069] },
+                          "properties": { "name": "King", "speed": 25 }
+                        }
+                      ]
+                    }
+                    """,
+                _ => null
+            };
+
+            return Task.FromResult(json == null
+                ? new HttpResponseMessage(HttpStatusCode.NotFound)
+                : new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+                });
+        }
+    }
 }

--- a/tests/dotnet/Honua.Server.Tests/Import/MigrationScannerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/MigrationScannerEndpointTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using FluentAssertions;
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
 using Honua.Server.Features.Import;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
@@ -26,6 +27,7 @@ public sealed class MigrationScannerEndpointTests : IAsyncLifetime
     private readonly FakeGeoServerScanService _geoServerService = new();
     private readonly FakeGeoservicesScanService _geoservicesService = new();
     private readonly FakeOgcScanService _ogcService = new();
+    private readonly FakeOgcApiFeaturesScanService _ogcApiFeaturesService = new();
     private HttpClient _client = null!;
 
     public MigrationScannerEndpointTests()
@@ -33,7 +35,8 @@ public sealed class MigrationScannerEndpointTests : IAsyncLifetime
         _fixture = new WebAppFixture()
             .ReplaceService<IGeoServerImportService>(_geoServerService)
             .ReplaceService<IGeoservicesImportService>(_geoservicesService)
-            .ReplaceService<IOgcServiceMigrationScanner>(_ogcService);
+            .ReplaceService<IOgcServiceMigrationScanner>(_ogcService)
+            .ReplaceService<IOgcApiFeaturesMigrationScanner>(_ogcApiFeaturesService);
     }
 
     public async Task InitializeAsync()
@@ -160,6 +163,38 @@ public sealed class MigrationScannerEndpointTests : IAsyncLifetime
         resource.GetProperty("kind").GetString().Should().Be("render-layer");
         resource.GetProperty("compatibility").GetProperty("level").GetString().Should().Be("incompatible");
         resource.GetProperty("compatibility").GetProperty("code").GetString().Should().Be(ImportCompatibilityCodes.OgcWmsRenderOnlySource);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/scan")]
+    public async Task Scan_OgcApiFeaturesSourceWithAllArtifacts_ReturnsInventoryManifestAndEvidence()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/import/scan", new
+        {
+            SourceKind = "ogc-api-features",
+            SourceUrl = "https://example.com/ogcapi/",
+            ArtifactSet = "all",
+            TargetServiceName = "Migrated OAPIF"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var payload = await response.Content.ReadFromJsonAsync<JsonDocument>();
+        payload.Should().NotBeNull();
+
+        var root = payload!.RootElement;
+        root.GetProperty("inventory").GetProperty("sourceKind").GetString().Should().Be("ogc-api-features");
+        root.GetProperty("inventory").GetProperty("resources")[0].GetProperty("kind").GetString()
+            .Should().Be("ogc-api-features-collection");
+        root.GetProperty("manifest").GetProperty("targetResources")[0].GetProperty("migrationMode").GetString()
+            .Should().Be("feature-import");
+        root.GetProperty("manifest").GetProperty("targetResources")[0].GetProperty("sourceProtocol").GetString()
+            .Should().Be("OGC API Features");
+        root.GetProperty("parityEvidence").GetProperty("sections").EnumerateArray()
+            .Should().Contain(section => section.GetProperty("id").GetString() == "fidelity");
+
+        _ogcApiFeaturesService.Requests.Should().ContainSingle()
+            .Which.ServiceUrl.Should().Be("https://example.com/ogcapi/");
     }
 
     [IntegrationTest]
@@ -765,6 +800,85 @@ public sealed class MigrationScannerEndpointTests : IAsyncLifetime
                     }
                 ]
             });
+        }
+    }
+
+    private sealed class FakeOgcApiFeaturesScanService : IOgcApiFeaturesMigrationScanner
+    {
+        public List<OgcApiFeaturesScanRequest> Requests { get; } = [];
+
+        public Task<MigrationSourceInventoryArtifact> ScanSourceAsync(
+            OgcApiFeaturesScanRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            return Task.FromResult(OgcApiFeaturesMigrationInventoryScanner.BuildInventory(new OgcApiFeaturesMigrationSourceSnapshot
+            {
+                BaseUrl = request.ServiceUrl,
+                Title = "Reference OGC API Features",
+                ConformanceClasses =
+                [
+                    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+                    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"
+                ],
+                Collections =
+                [
+                    new OgcApiFeaturesCollectionSnapshot
+                    {
+                        Id = "roads",
+                        Title = "Roads",
+                        GeometryType = "Point",
+                        FeatureCount = 2,
+                        Links =
+                        [
+                            new OgcApiFeaturesLink
+                            {
+                                Rel = "items",
+                                Href = "https://example.com/ogcapi/collections/roads/items",
+                                Type = "application/geo+json"
+                            },
+                            new OgcApiFeaturesLink
+                            {
+                                Rel = "queryables",
+                                Href = "https://example.com/ogcapi/collections/roads/queryables",
+                                Type = "application/schema+json"
+                            },
+                            new OgcApiFeaturesLink
+                            {
+                                Rel = "describedby",
+                                Href = "https://example.com/ogcapi/collections/roads/schema",
+                                Type = "application/schema+json"
+                            }
+                        ],
+                        PaginationLinks =
+                        [
+                            new OgcApiFeaturesLink
+                            {
+                                Rel = "next",
+                                Href = "https://example.com/ogcapi/collections/roads/items?offset=1&limit=1",
+                                Type = "application/geo+json"
+                            }
+                        ],
+                        CrsDeclarations =
+                        [
+                            new OgcApiFeaturesCrsDeclaration
+                            {
+                                Role = "storage",
+                                Value = "http://www.opengis.net/def/crs/EPSG/0/4326"
+                            }
+                        ],
+                        ItemEncodings = ["application/geo+json"],
+                        Fields =
+                        [
+                            new MigrationInventoryField
+                            {
+                                Name = "name",
+                                FieldType = "string"
+                            }
+                        ]
+                    }
+                ]
+            }));
         }
     }
 }


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1029

## Summary
Adds the operator-facing OGC API Features source scanner and wires it through the migration scan endpoint so modern OGC feature sources can produce inventory and manifest evidence.

## Changes Made
- Added HTTP-backed OGC API Features scanning for landing pages, conformance, collections, queryables/schema, CRS, pagination, and items probes.
- Extended inventory artifacts with schema fields, fidelity classifications, and target exposure evidence.
- Registered the scanner in DI and exposed `sourceKind: ogc-api-features` through the admin migration scan endpoint.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --filter "FullyQualifiedName~OgcApiFeaturesMigrationInventoryScannerTests"`
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~MigrationScannerEndpointTests"`
- `dotnet format Honua.sln --verbosity diagnostic`
- `git diff --cached --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

## Remaining Scope
This is the source scanner/inventory slice. Feature collection import, publication, CRS/queryables parity, reference fixture evidence, and SDK/admin orchestration remain before #1029 should close.

---

## Pre-PR Checklist
- [x] Focused draft-PR checks completed; full `scripts/ci/pre-pr-check.sh` remains delegated to CI for this draft PR
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
