### PR TITLE
feat: add OGC coverage migration scan path

### DIFF
--- a/src/Honua.Core/Features/Import/Abstractions/IOgcServiceMigrationScanner.cs
+++ b/src/Honua.Core/Features/Import/Abstractions/IOgcServiceMigrationScanner.cs
@@ -11,7 +11,7 @@ namespace Honua.Core.Features.Import.Abstractions;
 public interface IOgcServiceMigrationScanner
 {
     /// <summary>
-    /// Scan an OGC WFS, WMS, or WMTS endpoint into the shared source inventory contract.
+    /// Scan an OGC WFS, WMS, WMTS, WCS, or OGC API Coverages endpoint into the shared source inventory contract.
     /// </summary>
     /// <param name="request">OGC service scan request.</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/src/Honua.Core/Features/Import/Services/MigrationManifestTranslator.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationManifestTranslator.cs
@@ -279,6 +279,13 @@ public static partial class MigrationManifestTranslator
             return "feature-import";
         }
 
+        if ((string.Equals(sourceKind, "ogc-wcs", StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(sourceKind, "ogc-api-coverages", StringComparison.OrdinalIgnoreCase)) &&
+            string.Equals(resource.Kind, "coverage", StringComparison.OrdinalIgnoreCase))
+        {
+            return "raster-coverage-import";
+        }
+
         return null;
     }
 
@@ -295,6 +302,8 @@ public static partial class MigrationManifestTranslator
             "ogc-api-features" => "OGC API Features",
             "ogc-wms" => "WMS",
             "ogc-wmts" => "WMTS",
+            "ogc-wcs" => "WCS",
+            "ogc-api-coverages" => "OGC API Coverages",
             _ => null
         };
     }

--- a/src/Honua.Core/Features/Import/Services/OgcCoverageMigrationInventoryScanner.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcCoverageMigrationInventoryScanner.cs
@@ -105,6 +105,7 @@ public sealed partial class OgcCoverageMigrationInventoryScanner
                 .Concat(orderedResources.Select(static resource => resource.Compatibility))
                 .Concat(orderedDependencies.Select(static dependency => dependency.Compatibility)),
             "No OGC coverage inventory items were discovered.");
+        var fidelityClassifications = BuildFidelityClassifications(orderedResources, orderedDependencies);
 
         return new MigrationSourceInventoryArtifact
         {
@@ -126,9 +127,79 @@ public sealed partial class OgcCoverageMigrationInventoryScanner
             OverallCompatibility = overallCompatibility,
             Containers = containers,
             Resources = orderedResources,
-            ExternalDependencies = orderedDependencies
+            ExternalDependencies = orderedDependencies,
+            FidelityClassifications = fidelityClassifications
         };
     }
+
+    private static MigrationFidelityClassificationRecord[] BuildFidelityClassifications(
+        MigrationInventoryResource[] resources,
+        MigrationExternalDependency[] dependencies)
+    {
+        var records = new List<MigrationFidelityClassificationRecord>();
+        foreach (var resource in resources)
+        {
+            var relatedDependencies = dependencies
+                .Where(dependency => string.Equals(dependency.ResourceId, resource.Id, StringComparison.Ordinal))
+                .Select(static dependency => dependency.Id)
+                .OrderBy(static id => id, StringComparer.Ordinal)
+                .ToArray();
+            records.Add(new MigrationFidelityClassificationRecord
+            {
+                Id = $"fidelity:{resource.Id}:metadata",
+                SourceId = resource.Id,
+                Kind = resource.Kind,
+                Category = "coverage-metadata",
+                Name = resource.Name,
+                AutomationStatus = IsCoverageAutomated(resource.Compatibility)
+                    ? MigrationFidelityAutomationStatuses.Assisted
+                    : ToFidelityStatus(resource.Compatibility),
+                Code = resource.Compatibility.Code ?? OgcCoverageMigrationCompatibilityCodes.ManualReview,
+                Reason = "Coverage service metadata, CRS, output format, subset axis, range, band, no-data, and temporal facts were captured for parity review.",
+                TargetKind = "raster-coverage",
+                ManualSteps = IsCoverageAutomated(resource.Compatibility)
+                    ? ["Run pilot coverage import and compare metadata, bbox/subsets, CRS axis order, sample window pixels, no-data values, band/range metadata, output format, and target WCS/OGC API Coverages/ImageServer exposure."]
+                    : resource.Compatibility.ManualSteps,
+                RelatedIds = relatedDependencies
+            });
+        }
+
+        foreach (var dependency in dependencies.Where(static item => item.Kind == "coverage-output-format"))
+        {
+            records.Add(new MigrationFidelityClassificationRecord
+            {
+                Id = $"fidelity:{dependency.Id}:format",
+                SourceId = dependency.Id,
+                Kind = dependency.Kind,
+                Category = "coverage-output-format",
+                Name = dependency.Name,
+                AutomationStatus = IsCoverageAutomated(dependency.Compatibility)
+                    ? MigrationFidelityAutomationStatuses.Assisted
+                    : ToFidelityStatus(dependency.Compatibility),
+                Code = dependency.Compatibility.Code ?? OgcCoverageMigrationCompatibilityCodes.ManualReview,
+                Reason = dependency.Compatibility.Reason,
+                ManualSteps = dependency.Compatibility.ManualSteps,
+                RelatedIds = dependency.ResourceId == null ? [] : [dependency.ResourceId],
+                Metadata = new Dictionary<string, string>(dependency.Metadata, StringComparer.Ordinal)
+            });
+        }
+
+        return records
+            .OrderBy(static record => record.Id, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static bool IsCoverageAutomated(MigrationCompatibilityAssessment compatibility)
+        => compatibility.Code is OgcCoverageMigrationCompatibilityCodes.GeoTiffSupported or OgcCoverageMigrationCompatibilityCodes.CogSupported;
+
+    private static string ToFidelityStatus(MigrationCompatibilityAssessment compatibility)
+        => compatibility.Level switch
+        {
+            "compatible" => MigrationFidelityAutomationStatuses.Automated,
+            "partial" => MigrationFidelityAutomationStatuses.ManualReview,
+            "incompatible" => MigrationFidelityAutomationStatuses.Unsupported,
+            _ => MigrationFidelityAutomationStatuses.ManualReview
+        };
 
     private async Task<MigrationInventoryResource> BuildCoverageResourceAsync(
         string containerId,

--- a/src/Honua.Core/Features/Import/Services/OgcServiceMigrationScanner.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcServiceMigrationScanner.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Net.Sockets;
+using System.Text.Json;
 using System.Xml.Linq;
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Domain;
@@ -70,7 +71,7 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
         ArgumentNullException.ThrowIfNull(request);
 
         var normalizedServiceType = NormalizeServiceType(request.ServiceType);
-        var sourceKind = $"ogc-{normalizedServiceType.ToLowerInvariant()}";
+        var sourceKind = GetSourceKind(normalizedServiceType);
         var serviceUri = ValidateServiceUri(request.ServiceUrl, request.AllowUnsafeLocalUrls);
 
         try
@@ -91,14 +92,20 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
                 using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 timeout.CancelAfter(TimeSpan.FromSeconds(request.TimeoutSeconds <= 0 ? 60 : request.TimeoutSeconds));
 
-                var capabilitiesXml = await _httpClient.GetStringAsync(capabilitiesUrl, timeout.Token).ConfigureAwait(false);
-                var capabilities = XDocument.Parse(capabilitiesXml, LoadOptions.None);
                 return normalizedServiceType switch
                 {
-                    "WFS" => await BuildWfsInventoryAsync(request, serviceUri, capabilitiesUrl, capabilities, timeout.Token).ConfigureAwait(false),
-                    "WMS" => BuildWmsInventory(request, serviceUri, capabilitiesUrl, capabilities),
-                    "WMTS" => BuildWmtsInventory(request, serviceUri, capabilitiesUrl, capabilities),
-                    _ => throw new InvalidOperationException("Unsupported OGC service type.")
+                    "OGC API Coverages" => await BuildOgcApiCoveragesInventoryAsync(
+                            request,
+                            serviceUri,
+                            timeout.Token)
+                        .ConfigureAwait(false),
+                    _ => await BuildXmlBackedInventoryAsync(
+                            request,
+                            normalizedServiceType,
+                            serviceUri,
+                            capabilitiesUrl,
+                            timeout.Token)
+                        .ConfigureAwait(false)
                 };
             }
             finally
@@ -107,11 +114,137 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
             }
         }
         catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or System.Xml.XmlException ||
+                                   ex is JsonException ||
                                    ex is TaskCanceledException && !cancellationToken.IsCancellationRequested)
         {
             Log.ScanFailed(_logger, sourceKind, ToSafeSourceUrl(serviceUri), ex);
             return CreateFailedArtifact(sourceKind, serviceUri, normalizedServiceType, ToSafeScanFailureReason(ex));
         }
+    }
+
+    private async Task<MigrationSourceInventoryArtifact> BuildXmlBackedInventoryAsync(
+        OgcServiceScanRequest request,
+        string normalizedServiceType,
+        Uri serviceUri,
+        Uri capabilitiesUrl,
+        CancellationToken cancellationToken)
+    {
+        var capabilitiesXml = await _httpClient.GetStringAsync(capabilitiesUrl, cancellationToken).ConfigureAwait(false);
+        var capabilities = XDocument.Parse(capabilitiesXml, LoadOptions.None);
+        return normalizedServiceType switch
+        {
+            "WFS" => await BuildWfsInventoryAsync(request, serviceUri, capabilitiesUrl, capabilities, cancellationToken).ConfigureAwait(false),
+            "WMS" => BuildWmsInventory(request, serviceUri, capabilitiesUrl, capabilities),
+            "WMTS" => BuildWmtsInventory(request, serviceUri, capabilitiesUrl, capabilities),
+            "WCS" => await BuildWcsInventoryAsync(request, serviceUri, capabilities, cancellationToken).ConfigureAwait(false),
+            _ => throw new InvalidOperationException("Unsupported OGC service type.")
+        };
+    }
+
+    private async Task<MigrationSourceInventoryArtifact> BuildWcsInventoryAsync(
+        OgcServiceScanRequest request,
+        Uri serviceUri,
+        XDocument capabilities,
+        CancellationToken cancellationToken)
+    {
+        var version = GetRootVersion(capabilities) ?? request.Version ?? "unknown";
+        var serviceMetadata = new OgcCoverageServiceMetadata
+        {
+            Title = GetServiceTitle(capabilities),
+            Description = Descendants(capabilities, "ServiceIdentification")
+                .Select(static element => ChildValue(element, "Abstract"))
+                .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value)),
+            Product = "OGC Web Coverage Service",
+            ProviderName = Descendants(capabilities, "ProviderName")
+                .Select(static element => element.Value.Trim())
+                .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value)),
+            Fees = ReadServiceConstraintValues(capabilities, "Fees"),
+            AccessConstraints = ReadServiceConstraintValues(capabilities, "AccessConstraints")
+        };
+        var serviceFormats = ReadWcsServiceFormats(capabilities);
+        var coverageIds = ReadWcsCoverageIds(capabilities);
+        var coverages = new List<OgcCoverageDescription>(coverageIds.Length);
+
+        foreach (var coverageId in coverageIds)
+        {
+            var description = await TryDescribeCoverageAsync(
+                    serviceUri,
+                    version,
+                    coverageId,
+                    serviceFormats,
+                    request.TimeoutSeconds,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            coverages.Add(description);
+        }
+
+        var scanner = new OgcCoverageMigrationInventoryScanner(_crsRegistry);
+        return await scanner.ScanAsync(
+                new OgcCoverageServiceScanRequest
+                {
+                    ServiceType = "WCS",
+                    ServiceUrl = serviceUri.ToString(),
+                    Version = version,
+                    ServiceMetadata = serviceMetadata,
+                    Coverages = coverages.ToArray()
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<MigrationSourceInventoryArtifact> BuildOgcApiCoveragesInventoryAsync(
+        OgcServiceScanRequest request,
+        Uri serviceUri,
+        CancellationToken cancellationToken)
+    {
+        var collectionsUri = BuildOgcApiCoveragesCollectionsUrl(serviceUri);
+        var payload = await _httpClient.GetStringAsync(collectionsUri, cancellationToken).ConfigureAwait(false);
+        using var document = JsonDocument.Parse(payload);
+        var root = document.RootElement;
+        var serviceMetadata = new OgcCoverageServiceMetadata
+        {
+            Title = ReadJsonString(root, "title") ?? serviceUri.Host,
+            Description = ReadJsonString(root, "description"),
+            Product = "OGC API Coverages"
+        };
+
+        var coverages = new List<OgcCoverageDescription>();
+        if (root.TryGetProperty("collections", out var collections) &&
+            collections.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var collection in collections.EnumerateArray())
+            {
+                var id = ReadJsonString(collection, "id");
+                if (string.IsNullOrWhiteSpace(id))
+                {
+                    continue;
+                }
+
+                coverages.Add(new OgcCoverageDescription
+                {
+                    CoverageId = id,
+                    Title = ReadJsonString(collection, "title"),
+                    Description = ReadJsonString(collection, "description"),
+                    CoverageType = ReadJsonString(collection, "itemType") ?? "Coverage",
+                    Crs = ReadOgcApiCoverageCrs(collection),
+                    Axes = ReadOgcApiCoverageAxes(collection),
+                    OutputFormats = ReadOgcApiCoverageFormats(collection)
+                });
+            }
+        }
+
+        var scanner = new OgcCoverageMigrationInventoryScanner(_crsRegistry);
+        return await scanner.ScanAsync(
+                new OgcCoverageServiceScanRequest
+                {
+                    ServiceType = "OGC API Coverages",
+                    ServiceUrl = serviceUri.ToString(),
+                    Version = request.Version,
+                    ServiceMetadata = serviceMetadata,
+                    Coverages = coverages.ToArray()
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private async Task<MigrationSourceInventoryArtifact> BuildWfsInventoryAsync(
@@ -558,12 +691,181 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
         }
     }
 
+    private async Task<OgcCoverageDescription> TryDescribeCoverageAsync(
+        Uri serviceUri,
+        string version,
+        string coverageId,
+        OgcCoverageFormatMetadata[] serviceFormats,
+        int timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var url = BuildDescribeCoverageUrl(serviceUri, version, coverageId);
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds <= 0 ? 60 : timeoutSeconds));
+            var coverageXml = await _httpClient.GetStringAsync(url, timeout.Token).ConfigureAwait(false);
+            var document = XDocument.Parse(coverageXml, LoadOptions.None);
+            return BuildCoverageDescription(coverageId, document, serviceFormats);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or System.Xml.XmlException)
+        {
+            return new OgcCoverageDescription
+            {
+                CoverageId = coverageId,
+                OutputFormats = serviceFormats,
+                AccessConstraints = [ToSafeDescribeCoverageFailureReason(ex)]
+            };
+        }
+    }
+
+    private static OgcCoverageDescription BuildCoverageDescription(
+        string fallbackCoverageId,
+        XDocument document,
+        OgcCoverageFormatMetadata[] serviceFormats)
+    {
+        var coverageElement = Descendants(document, "CoverageDescription").FirstOrDefault() ??
+                              Descendants(document, "CoverageOffering").FirstOrDefault() ??
+                              document.Root;
+        var coverageId = coverageElement == null
+            ? fallbackCoverageId
+            : FirstNonBlank(
+                ChildValue(coverageElement, "CoverageId"),
+                ChildValue(coverageElement, "Identifier"),
+                ChildValue(coverageElement, "name"),
+                fallbackCoverageId)!;
+        var axes = coverageElement == null ? Array.Empty<OgcCoverageAxisMetadata>() : ReadWcsAxes(coverageElement);
+        var ranges = coverageElement == null ? Array.Empty<OgcCoverageRangeMetadata>() : ReadWcsRanges(coverageElement);
+        var formats = coverageElement == null ? serviceFormats : ReadWcsCoverageFormats(coverageElement, serviceFormats);
+        var crs = coverageElement == null ? Array.Empty<OgcCoverageCrsMetadata>() : ReadWcsCoverageCrs(coverageElement);
+
+        return new OgcCoverageDescription
+        {
+            CoverageId = coverageId,
+            Title = coverageElement == null ? null : ChildValue(coverageElement, "Title"),
+            Description = coverageElement == null ? null : ChildValue(coverageElement, "Abstract") ?? ChildValue(coverageElement, "description"),
+            CoverageType = coverageElement?.Name.LocalName,
+            NativeFormat = formats.FirstOrDefault(static format => format.IsNative == true)?.Format,
+            Crs = crs,
+            Axes = axes,
+            Ranges = ranges,
+            OutputFormats = formats
+        };
+    }
+
+    private static OgcCoverageCrsMetadata[] ReadWcsCoverageCrs(XElement coverageElement)
+    {
+        var values = new List<OgcCoverageCrsMetadata>();
+        var envelope = Descendants(coverageElement, "Envelope").FirstOrDefault();
+        var envelopeCrs = envelope?.Attribute("srsName")?.Value;
+        if (!string.IsNullOrWhiteSpace(envelopeCrs))
+        {
+            values.Add(new OgcCoverageCrsMetadata
+            {
+                Role = "native",
+                Crs = envelopeCrs.Trim(),
+                AxisLabels = SplitTokens(envelope?.Attribute("axisLabels")?.Value)
+            });
+        }
+
+        foreach (var crsElement in Descendants(coverageElement, "SupportedCRS")
+                     .Concat(Descendants(coverageElement, "supportedCRS"))
+                     .Concat(Descendants(coverageElement, "nativeCRS")))
+        {
+            var value = crsElement.Value.Trim();
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                values.Add(new OgcCoverageCrsMetadata
+                {
+                    Role = crsElement.Name.LocalName.Contains("native", StringComparison.OrdinalIgnoreCase) ? "native" : "supported",
+                    Crs = value
+                });
+            }
+        }
+
+        return values
+            .GroupBy(static item => $"{item.Role}\u001f{item.Crs}", StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .OrderBy(static item => item.Role, StringComparer.Ordinal)
+            .ThenBy(static item => item.Crs, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static OgcCoverageAxisMetadata[] ReadWcsAxes(XElement coverageElement)
+    {
+        var axisLabels = Descendants(coverageElement, "axisLabels")
+            .SelectMany(static element => SplitTokens(element.Value))
+            .Concat(Descendants(coverageElement, "Envelope")
+                .SelectMany(static element => SplitTokens(element.Attribute("axisLabels")?.Value)))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        var lower = Descendants(coverageElement, "lowerCorner")
+            .SelectMany(static element => SplitTokens(element.Value))
+            .ToArray();
+        var upper = Descendants(coverageElement, "upperCorner")
+            .SelectMany(static element => SplitTokens(element.Value))
+            .ToArray();
+
+        return axisLabels
+            .Select((axis, index) => new OgcCoverageAxisMetadata
+            {
+                Name = axis,
+                AxisType = NormalizeAxisType(axis),
+                LowerBound = index < lower.Length ? lower[index] : null,
+                UpperBound = index < upper.Length ? upper[index] : null,
+                Subsettable = true
+            })
+            .OrderBy(static axis => axis.Name, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static OgcCoverageRangeMetadata[] ReadWcsRanges(XElement coverageElement)
+        => Descendants(coverageElement, "field")
+            .Select(field => new OgcCoverageRangeMetadata
+            {
+                Name = field.Attribute("name")?.Value ?? ChildValue(field, "name") ?? "range",
+                Label = ChildValue(field, "label"),
+                DataType = Descendants(field, "DataType").Select(static item => item.Value.Trim()).FirstOrDefault(static value => value.Length > 0) ??
+                           Descendants(field, "dataType").Select(static item => item.Value.Trim()).FirstOrDefault(static value => value.Length > 0),
+                Unit = Descendants(field, "uom").Select(static item => item.Attribute("code")?.Value ?? item.Value.Trim()).FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value)),
+                NoDataValue = Descendants(field, "nilValue").Select(static item => item.Value.Trim()).FirstOrDefault(static value => value.Length > 0),
+                Interpretation = ChildValue(field, "definition")
+            })
+            .OrderBy(static range => range.Name, StringComparer.Ordinal)
+            .ToArray();
+
+    private static OgcCoverageFormatMetadata[] ReadWcsCoverageFormats(
+        XElement coverageElement,
+        OgcCoverageFormatMetadata[] serviceFormats)
+    {
+        var formats = Descendants(coverageElement, "format")
+            .Concat(Descendants(coverageElement, "SupportedFormat"))
+            .Select(element => BuildCoverageFormat(element.Value, isNative: null))
+            .Concat(serviceFormats)
+            .Where(static format => !string.IsNullOrWhiteSpace(format.Format))
+            .GroupBy(static format => NormalizeFormatKey(format.Format), StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .OrderBy(static format => format.Format, StringComparer.Ordinal)
+            .ToArray();
+        return formats.Length == 0 ? serviceFormats : formats;
+    }
+
+    private static string ToSafeDescribeCoverageFailureReason(Exception exception)
+        => exception switch
+        {
+            TaskCanceledException => "DescribeCoverage request timed out.",
+            HttpRequestException => "DescribeCoverage metadata could not be retrieved.",
+            System.Xml.XmlException => "DescribeCoverage metadata could not be parsed.",
+            _ => "DescribeCoverage metadata was unavailable."
+        };
+
     private static string ToSafeScanFailureReason(Exception exception)
         => exception switch
         {
             TaskCanceledException => "OGC service scan timed out.",
             HttpRequestException => "OGC service endpoint could not be reached or returned an unsupported response.",
             System.Xml.XmlException => "OGC service capabilities metadata could not be parsed.",
+            JsonException => "OGC API Coverages metadata could not be parsed.",
             _ => "OGC service metadata could not be scanned."
         };
 
@@ -1131,13 +1433,234 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
         return values;
     }
 
+    private static string[] ReadWcsCoverageIds(XDocument capabilities)
+        => Descendants(capabilities, "CoverageSummary")
+            .Select(static element => ChildValue(element, "CoverageId") ?? ChildValue(element, "Identifier") ?? ChildValue(element, "Name"))
+            .Concat(Descendants(capabilities, "CoverageOfferingBrief").Select(static element => ChildValue(element, "name")))
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value!.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static value => value, StringComparer.Ordinal)
+            .ToArray();
+
+    private static OgcCoverageFormatMetadata[] ReadWcsServiceFormats(XDocument capabilities)
+        => Descendants(capabilities, "formatSupported")
+            .Concat(Descendants(capabilities, "FormatSupported"))
+            .Concat(Descendants(capabilities, "formats"))
+            .Select(static element => BuildCoverageFormat(element.Value, isNative: null))
+            .Where(static format => !string.IsNullOrWhiteSpace(format.Format))
+            .GroupBy(static format => NormalizeFormatKey(format.Format), StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .OrderBy(static format => format.Format, StringComparer.Ordinal)
+            .ToArray();
+
+    private static string[] ReadServiceConstraintValues(XDocument document, string name)
+        => Descendants(document, name)
+            .Select(static element => element.Value.Trim())
+            .Concat(Descendants(document, "Fees").Where(_ => string.Equals(name, "Fees", StringComparison.Ordinal)).Select(static element => element.Value.Trim()))
+            .Where(static value => !string.IsNullOrWhiteSpace(value) &&
+                                   !string.Equals(value, "none", StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static value => value, StringComparer.Ordinal)
+            .ToArray();
+
+    private static Uri BuildDescribeCoverageUrl(Uri serviceUri, string version, string coverageId)
+    {
+        var isWcs2 = version.StartsWith("2.", StringComparison.Ordinal);
+        var builder = new UriBuilder(serviceUri)
+        {
+            Query = BuildQuery(
+                serviceUri.Query,
+                new Dictionary<string, string?>
+                {
+                    ["service"] = "WCS",
+                    ["version"] = version.Equals("unknown", StringComparison.OrdinalIgnoreCase) ? null : version,
+                    ["request"] = "DescribeCoverage",
+                    [isWcs2 ? "coverageId" : "coverage"] = coverageId
+                })
+        };
+        return builder.Uri;
+    }
+
+    private static Uri BuildOgcApiCoveragesCollectionsUrl(Uri serviceUri)
+    {
+        if (serviceUri.AbsolutePath.EndsWith("/collections", StringComparison.OrdinalIgnoreCase))
+        {
+            return serviceUri;
+        }
+
+        var builder = new UriBuilder(serviceUri);
+        builder.Path = $"{builder.Path.TrimEnd('/')}/collections";
+        return builder.Uri;
+    }
+
+    private static string? ReadJsonString(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property))
+        {
+            return null;
+        }
+
+        return property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+    }
+
+    private static OgcCoverageCrsMetadata[] ReadOgcApiCoverageCrs(JsonElement collection)
+    {
+        var values = new List<OgcCoverageCrsMetadata>();
+        if (collection.TryGetProperty("crs", out var crs) && crs.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in crs.EnumerateArray())
+            {
+                var value = item.ValueKind == JsonValueKind.String ? item.GetString() : null;
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    values.Add(new OgcCoverageCrsMetadata { Role = "supported", Crs = value });
+                }
+            }
+        }
+
+        var extentCrs = TryReadNestedString(collection, "extent", "spatial", "crs");
+        if (!string.IsNullOrWhiteSpace(extentCrs))
+        {
+            values.Add(new OgcCoverageCrsMetadata { Role = "native", Crs = extentCrs });
+        }
+
+        return values
+            .GroupBy(static value => $"{value.Role}\u001f{value.Crs}", StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .OrderBy(static value => value.Role, StringComparer.Ordinal)
+            .ThenBy(static value => value.Crs, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static OgcCoverageAxisMetadata[] ReadOgcApiCoverageAxes(JsonElement collection)
+    {
+        if (!collection.TryGetProperty("extent", out var extent) ||
+            !extent.TryGetProperty("spatial", out var spatial) ||
+            !spatial.TryGetProperty("bbox", out var bbox) ||
+            bbox.ValueKind != JsonValueKind.Array ||
+            bbox.GetArrayLength() == 0)
+        {
+            return [];
+        }
+
+        var firstBbox = bbox[0];
+        if (firstBbox.ValueKind != JsonValueKind.Array || firstBbox.GetArrayLength() < 4)
+        {
+            return [];
+        }
+
+        return
+        [
+            new OgcCoverageAxisMetadata
+            {
+                Name = "x",
+                AxisType = "x",
+                LowerBound = firstBbox[0].ToString(),
+                UpperBound = firstBbox[2].ToString(),
+                Subsettable = true
+            },
+            new OgcCoverageAxisMetadata
+            {
+                Name = "y",
+                AxisType = "y",
+                LowerBound = firstBbox[1].ToString(),
+                UpperBound = firstBbox[3].ToString(),
+                Subsettable = true
+            }
+        ];
+    }
+
+    private static OgcCoverageFormatMetadata[] ReadOgcApiCoverageFormats(JsonElement collection)
+    {
+        if (!collection.TryGetProperty("links", out var links) || links.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return links.EnumerateArray()
+            .Select(link => ReadJsonString(link, "type"))
+            .Where(static type => !string.IsNullOrWhiteSpace(type))
+            .Select(static type => BuildCoverageFormat(type!, isNative: null))
+            .GroupBy(static format => NormalizeFormatKey(format.Format), StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .OrderBy(static format => format.Format, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string? TryReadNestedString(JsonElement element, params string[] path)
+    {
+        var current = element;
+        foreach (var segment in path)
+        {
+            if (!current.TryGetProperty(segment, out current))
+            {
+                return null;
+            }
+        }
+
+        return current.ValueKind == JsonValueKind.String ? current.GetString() : null;
+    }
+
+    private static OgcCoverageFormatMetadata BuildCoverageFormat(string format, bool? isNative)
+        => new()
+        {
+            Format = format.Trim(),
+            MediaType = LooksLikeMediaType(format) ? format.Trim() : null,
+            Profile = IsCogFormat(format) ? "cloud-optimized-geotiff" : null,
+            IsNative = isNative
+        };
+
+    private static string NormalizeFormatKey(string value)
+        => value.Trim().ToUpperInvariant();
+
+    private static bool LooksLikeMediaType(string value)
+        => value.Contains('/', StringComparison.Ordinal);
+
+    private static bool IsCogFormat(string value)
+        => value.Contains("cog", StringComparison.OrdinalIgnoreCase) ||
+           value.Contains("cloud-optimized", StringComparison.OrdinalIgnoreCase);
+
+    private static string[] SplitTokens(string? value)
+        => string.IsNullOrWhiteSpace(value)
+            ? []
+            : value.Split([' ', ',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static string? FirstNonBlank(params string?[] values)
+        => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value))?.Trim();
+
+    private static string NormalizeAxisType(string axis)
+    {
+        var normalized = axis.Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            "long" or "lon" or "longitude" or "x" => "x",
+            "lat" or "latitude" or "y" => "y",
+            "time" or "ansi" => "time",
+            "elev" or "elevation" or "height" => "elevation",
+            _ => normalized
+        };
+    }
+
     private static string NormalizeServiceType(string serviceType)
     {
         var normalized = serviceType.Trim().ToUpperInvariant();
-        return normalized is "WFS" or "WMS" or "WMTS"
-            ? normalized
-            : throw new InvalidOperationException("Unsupported OGC service type.");
+        return normalized switch
+        {
+            "WFS" or "WMS" or "WMTS" or "WCS" => normalized,
+            "OGC API COVERAGES" or "OGC-API-COVERAGES" or "OGC_API_COVERAGES" or "COVERAGES" => "OGC API Coverages",
+            _ => throw new InvalidOperationException("Unsupported OGC service type.")
+        };
     }
+
+    private static string GetSourceKind(string normalizedServiceType)
+        => normalizedServiceType switch
+        {
+            "OGC API Coverages" => "ogc-api-coverages",
+            _ => $"ogc-{normalizedServiceType.ToLowerInvariant()}"
+        };
 
     private static Uri ValidateServiceUri(string serviceUrl, bool allowUnsafeLocalUrls)
     {
@@ -1307,6 +1830,11 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
 
     private static Uri BuildCapabilitiesUrl(Uri serviceUri, string serviceType, string? version)
     {
+        if (string.Equals(serviceType, "OGC API Coverages", StringComparison.Ordinal))
+        {
+            return serviceUri;
+        }
+
         if (HasQueryParameter(serviceUri, "request", "GetCapabilities"))
         {
             return serviceUri;

--- a/src/Honua.Core/Features/Import/Services/OgcServiceMigrationScanner.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcServiceMigrationScanner.cs
@@ -708,13 +708,12 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
             var document = XDocument.Parse(coverageXml, LoadOptions.None);
             return BuildCoverageDescription(coverageId, document, serviceFormats);
         }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or System.Xml.XmlException)
+        catch (Exception ex) when (IsRecoverableDescribeCoverageException(ex))
         {
             return new OgcCoverageDescription
             {
                 CoverageId = coverageId,
-                OutputFormats = serviceFormats,
-                AccessConstraints = [ToSafeDescribeCoverageFailureReason(ex)]
+                OutputFormats = []
             };
         }
     }
@@ -850,14 +849,8 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
         return formats.Length == 0 ? serviceFormats : formats;
     }
 
-    private static string ToSafeDescribeCoverageFailureReason(Exception exception)
-        => exception switch
-        {
-            TaskCanceledException => "DescribeCoverage request timed out.",
-            HttpRequestException => "DescribeCoverage metadata could not be retrieved.",
-            System.Xml.XmlException => "DescribeCoverage metadata could not be parsed.",
-            _ => "DescribeCoverage metadata was unavailable."
-        };
+    private static bool IsRecoverableDescribeCoverageException(Exception exception)
+        => exception is HttpRequestException or TaskCanceledException or System.Xml.XmlException;
 
     private static string ToSafeScanFailureReason(Exception exception)
         => exception switch
@@ -1581,6 +1574,7 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
         }
 
         return links.EnumerateArray()
+            .Where(static link => IsOgcApiCoverageOutputLink(link))
             .Select(link => ReadJsonString(link, "type"))
             .Where(static type => !string.IsNullOrWhiteSpace(type))
             .Select(static type => BuildCoverageFormat(type!, isNative: null))
@@ -1588,6 +1582,18 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
             .Select(static group => group.First())
             .OrderBy(static format => format.Format, StringComparer.Ordinal)
             .ToArray();
+    }
+
+    private static bool IsOgcApiCoverageOutputLink(JsonElement link)
+    {
+        var rel = ReadJsonString(link, "rel");
+        if (string.IsNullOrWhiteSpace(rel))
+        {
+            return false;
+        }
+
+        return rel.Equals("coverage", StringComparison.OrdinalIgnoreCase) ||
+               rel.EndsWith("/coverage", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? TryReadNestedString(JsonElement element, params string[] path)

--- a/src/Honua.Server/Features/Import/MigrationScannerEndpoints.cs
+++ b/src/Honua.Server/Features/Import/MigrationScannerEndpoints.cs
@@ -61,7 +61,7 @@ internal static class MigrationScannerEndpoints
         {
             await AdminResponseWriter.WriteErrorAsync(
                 context,
-                "SourceKind must be one of: geoserver, geoserver-rest, geoservices, arcgis-geoservices-rest, ogc-api-features, ogc-wfs, ogc-wms, ogc-wmts.",
+                "SourceKind must be one of: geoserver, geoserver-rest, geoservices, arcgis-geoservices-rest, ogc-api-features, ogc-wfs, ogc-wms, ogc-wmts, ogc-wcs, ogc-api-coverages.",
                 StatusCodes.Status400BadRequest);
             return;
         }
@@ -118,6 +118,8 @@ internal static class MigrationScannerEndpoints
                 case "ogc-wfs":
                 case "ogc-wms":
                 case "ogc-wmts":
+                case "ogc-wcs":
+                case "ogc-api-coverages":
                     {
                         var allowUnsafeLocalUrls = GeoServerImportExecutionSettings.ShouldAllowUnsafeLocalUrls(context.RequestServices);
                         var validation = await OgcServiceUrlValidation.ValidateAsync(
@@ -137,7 +139,7 @@ internal static class MigrationScannerEndpoints
                         artifact = await scanner.ScanSourceAsync(
                             new OgcServiceScanRequest
                             {
-                                ServiceType = sourceKind["ogc-".Length..],
+                                ServiceType = ToOgcServiceType(sourceKind),
                                 ServiceUrl = request.SourceUrl,
                                 Version = request.ServiceVersion,
                                 TimeoutSeconds = request.TimeoutSeconds ?? 60,
@@ -288,11 +290,20 @@ internal static class MigrationScannerEndpoints
             "wfs" or "ogc-wfs" => "ogc-wfs",
             "wms" or "ogc-wms" => "ogc-wms",
             "wmts" or "ogc-wmts" => "ogc-wmts",
+            "wcs" or "ogc-wcs" => "ogc-wcs",
+            "coverages" or "ogc-coverages" or "ogc-api-coverages" => "ogc-api-coverages",
             _ => string.Empty
         };
 
         return normalized.Length > 0;
     }
+
+    private static string ToOgcServiceType(string sourceKind)
+        => sourceKind switch
+        {
+            "ogc-api-coverages" => "OGC API Coverages",
+            _ => sourceKind["ogc-".Length..]
+        };
 
     private static object CreateScanResponse(
         MigrationSourceInventoryArtifact artifact,

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcServiceMigrationScannerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcServiceMigrationScannerTests.cs
@@ -221,6 +221,58 @@ public sealed class OgcServiceMigrationScannerTests
             record.AutomationStatus == MigrationFidelityAutomationStatuses.ManualReview);
     }
 
+    [Fact]
+    public async Task ScanSourceAsync_WcsCapabilitiesAndDescribeCoverage_ProducesCoverageInventory()
+    {
+        using var httpClient = new HttpClient(new OgcFixtureHandler());
+        var scanner = CreateScanner(httpClient, CreateCrsRegistry());
+
+        var artifact = await scanner.ScanSourceAsync(new OgcServiceScanRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = "https://example.com/geoserver/wcs",
+            Version = "2.0.1",
+            TimeoutSeconds = 10
+        });
+
+        artifact.SourceKind.Should().Be("ogc-wcs");
+        artifact.Resources.Should().ContainSingle(resource => resource.Kind == "coverage" && resource.Name == "nurc:temperature");
+        var resource = artifact.Resources.Single();
+        resource.Fields.Should().ContainSingle(field => field.Name == "temperature" && field.FieldType == "Float32");
+        resource.SpatialReferences.Should().ContainSingle(reference => reference.Srid == 4326);
+        resource.Compatibility.Code.Should().Be(OgcCoverageMigrationCompatibilityCodes.CogSupported);
+        artifact.ExternalDependencies.Should().Contain(dependency =>
+            dependency.Kind == "coverage-output-format" &&
+            dependency.DependencyType == "cog");
+        artifact.ExternalDependencies.Should().Contain(dependency =>
+            dependency.Kind == "coverage-axis" &&
+            dependency.Name == "Lat");
+        artifact.FidelityClassifications.Should().Contain(record =>
+            record.Category == "coverage-metadata" &&
+            record.AutomationStatus == MigrationFidelityAutomationStatuses.Assisted);
+    }
+
+    [Fact]
+    public async Task ScanSourceAsync_OgcApiCoveragesCollections_ProducesCoverageInventory()
+    {
+        using var httpClient = new HttpClient(new OgcFixtureHandler());
+        var scanner = CreateScanner(httpClient, CreateCrsRegistry());
+
+        var artifact = await scanner.ScanSourceAsync(new OgcServiceScanRequest
+        {
+            ServiceType = "OGC API Coverages",
+            ServiceUrl = "https://coverages.example.com",
+            TimeoutSeconds = 10
+        });
+
+        artifact.SourceKind.Should().Be("ogc-api-coverages");
+        artifact.Resources.Should().ContainSingle(resource => resource.Kind == "coverage" && resource.Name == "ocean-forecast");
+        artifact.Resources.Single().Compatibility.Code.Should().Be(OgcCoverageMigrationCompatibilityCodes.ScientificFormatUnsupported);
+        artifact.ExternalDependencies.Should().Contain(dependency =>
+            dependency.Kind == "coverage-output-format" &&
+            dependency.Compatibility.Code == OgcCoverageMigrationCompatibilityCodes.NetCdfUnsupported);
+    }
+
     private static OgcServiceMigrationScanner CreateScanner(HttpClient httpClient, Mock<ICrsRegistry> crsRegistry)
         => new(
             httpClient,
@@ -248,6 +300,9 @@ public sealed class OgcServiceMigrationScannerTests
                 ("/geoserver/wfs", _) => WfsCapabilities,
                 ("/geoserver/wms", _) => WmsCapabilities,
                 ("/geoserver/gwc/service/wmts", _) => WmtsCapabilities,
+                ("/geoserver/wcs", var q) when q.Contains("DescribeCoverage", StringComparison.OrdinalIgnoreCase) => WcsDescribeCoverage,
+                ("/geoserver/wcs", _) => WcsCapabilities,
+                ("/collections", _) => OgcApiCoveragesCollections,
                 _ => throw new HttpRequestException("Unexpected test URL.")
             };
 
@@ -365,5 +420,76 @@ public sealed class OgcServiceMigrationScannerTests
             <TileMatrixSet><ows:Identifier>EPSG:3857</ows:Identifier></TileMatrixSet>
           </Contents>
         </Capabilities>
+        """;
+
+    private const string WcsCapabilities = """
+        <wcs:Capabilities xmlns:wcs="http://www.opengis.net/wcs/2.0" xmlns:ows="http://www.opengis.net/ows/2.0" version="2.0.1">
+          <ows:ServiceIdentification>
+            <ows:Title>Reference WCS</ows:Title>
+            <ows:Abstract>Coverage migration fixture</ows:Abstract>
+          </ows:ServiceIdentification>
+          <wcs:ServiceMetadata>
+            <wcs:formatSupported>image/tiff; application=geotiff; profile=cloud-optimized-geotiff</wcs:formatSupported>
+          </wcs:ServiceMetadata>
+          <wcs:Contents>
+            <wcs:CoverageSummary>
+              <wcs:CoverageId>nurc:temperature</wcs:CoverageId>
+            </wcs:CoverageSummary>
+          </wcs:Contents>
+        </wcs:Capabilities>
+        """;
+
+    private const string WcsDescribeCoverage = """
+        <wcs:CoverageDescriptions xmlns:wcs="http://www.opengis.net/wcs/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:swe="http://www.opengis.net/swe/2.0">
+          <wcs:CoverageDescription gml:id="nurc_temperature">
+            <wcs:CoverageId>nurc:temperature</wcs:CoverageId>
+            <gml:boundedBy>
+              <gml:Envelope srsName="EPSG:4326" axisLabels="Lat Long">
+                <gml:lowerCorner>-90 -180</gml:lowerCorner>
+                <gml:upperCorner>90 180</gml:upperCorner>
+              </gml:Envelope>
+            </gml:boundedBy>
+            <gml:domainSet>
+              <gml:RectifiedGrid dimension="2">
+                <gml:axisLabels>Lat Long</gml:axisLabels>
+              </gml:RectifiedGrid>
+            </gml:domainSet>
+            <gml:rangeType>
+              <swe:DataRecord>
+                <swe:field name="temperature">
+                  <swe:Quantity definition="temperature">
+                    <swe:dataType>Float32</swe:dataType>
+                    <swe:uom code="K" />
+                    <swe:nilValues><swe:nilValue>-9999</swe:nilValue></swe:nilValues>
+                    <swe:constraint><swe:AllowedValues><swe:interval>200 330</swe:interval></swe:AllowedValues></swe:constraint>
+                  </swe:Quantity>
+                </swe:field>
+              </swe:DataRecord>
+            </gml:rangeType>
+            <wcs:format>image/tiff; application=geotiff; profile=cloud-optimized-geotiff</wcs:format>
+          </wcs:CoverageDescription>
+        </wcs:CoverageDescriptions>
+        """;
+
+    private const string OgcApiCoveragesCollections = """
+        {
+          "title": "Reference Coverages",
+          "collections": [
+            {
+              "id": "ocean-forecast",
+              "title": "Ocean forecast",
+              "itemType": "coverage",
+              "extent": {
+                "spatial": {
+                  "bbox": [[-180, -90, 180, 90]],
+                  "crs": "EPSG:4326"
+                }
+              },
+              "links": [
+                { "rel": "coverage", "href": "https://coverages.example.com/collections/ocean-forecast/coverage", "type": "application/x-netcdf" }
+              ]
+            }
+          ]
+        }
         """;
 }

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcServiceMigrationScannerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcServiceMigrationScannerTests.cs
@@ -253,7 +253,35 @@ public sealed class OgcServiceMigrationScannerTests
     }
 
     [Fact]
-    public async Task ScanSourceAsync_OgcApiCoveragesCollections_ProducesCoverageInventory()
+    public async Task ScanSourceAsync_WcsDescribeCoverageFailure_LeavesAccessConstraintsEmptyAndFlagsManualReview()
+    {
+        using var httpClient = new HttpClient(new DescribeCoverageFailureHandler());
+        var scanner = CreateScanner(httpClient, CreateCrsRegistry());
+
+        var artifact = await scanner.ScanSourceAsync(new OgcServiceScanRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = "https://example.com/geoserver/wcs",
+            Version = "2.0.1",
+            TimeoutSeconds = 10
+        });
+
+        artifact.ScanCompleteness.Status.Should().Be("partial");
+        artifact.ScanCompleteness.Warnings.Should().ContainSingle()
+            .Which.Should().Be("Coverage nurc:temperature did not advertise output formats.");
+        artifact.ExternalDependencies.Should().Contain(dependency =>
+            dependency.Kind == "coverage-service-metadata" &&
+            !dependency.Metadata.ContainsKey("accessConstraints"));
+        artifact.ExternalDependencies.Should().NotContain(dependency =>
+            dependency.Kind == "coverage-service-metadata" &&
+            dependency.Compatibility.Warnings.Any(warning =>
+                warning.Contains("DescribeCoverage", StringComparison.OrdinalIgnoreCase)));
+        artifact.Resources.Should().ContainSingle().Which.Compatibility.Code
+            .Should().Be(OgcCoverageMigrationCompatibilityCodes.OutputFormatMissing);
+    }
+
+    [Fact]
+    public async Task ScanSourceAsync_OgcApiCoveragesCollections_UsesOnlyCoverageOutputLinksForFormats()
     {
         using var httpClient = new HttpClient(new OgcFixtureHandler());
         var scanner = CreateScanner(httpClient, CreateCrsRegistry());
@@ -271,6 +299,10 @@ public sealed class OgcServiceMigrationScannerTests
         artifact.ExternalDependencies.Should().Contain(dependency =>
             dependency.Kind == "coverage-output-format" &&
             dependency.Compatibility.Code == OgcCoverageMigrationCompatibilityCodes.NetCdfUnsupported);
+        artifact.ExternalDependencies
+            .Where(static dependency => dependency.Kind == "coverage-output-format")
+            .Should().ContainSingle()
+            .Which.Name.Should().Be("application/x-netcdf");
     }
 
     private static OgcServiceMigrationScanner CreateScanner(HttpClient httpClient, Mock<ICrsRegistry> crsRegistry)
@@ -339,6 +371,23 @@ public sealed class OgcServiceMigrationScannerTests
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(WfsCapabilities)
+            });
+        }
+    }
+
+    private sealed class DescribeCoverageFailureHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var query = request.RequestUri?.Query ?? string.Empty;
+            if (query.Contains("DescribeCoverage", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromException<HttpResponseMessage>(new HttpRequestException("secret=/var/private/provider-token"));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(WcsCapabilities)
             });
         }
     }
@@ -486,6 +535,9 @@ public sealed class OgcServiceMigrationScannerTests
                 }
               },
               "links": [
+                { "rel": "self", "href": "https://coverages.example.com/collections/ocean-forecast", "type": "application/json" },
+                { "rel": "alternate", "href": "https://coverages.example.com/collections/ocean-forecast?f=html", "type": "text/html" },
+                { "rel": "items", "href": "https://coverages.example.com/collections/ocean-forecast/items", "type": "application/geo+json" },
                 { "rel": "coverage", "href": "https://coverages.example.com/collections/ocean-forecast/coverage", "type": "application/x-netcdf" }
               ]
             }

--- a/tests/dotnet/Honua.Server.Tests/Import/MigrationScannerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/MigrationScannerEndpointTests.cs
@@ -145,6 +145,54 @@ public sealed class MigrationScannerEndpointTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/import/scan")]
+    public async Task Scan_OgcWcsSourceWithAllArtifacts_ReturnsCoverageInventoryManifestAndEvidence()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/import/scan", new
+        {
+            SourceKind = "ogc-wcs",
+            SourceUrl = "https://example.com/geoserver/wcs",
+            ServiceVersion = "2.0.1",
+            ArtifactSet = "all",
+            TargetServiceName = "Migrated Coverages"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var payload = await response.Content.ReadFromJsonAsync<JsonDocument>();
+        payload.Should().NotBeNull();
+
+        var root = payload!.RootElement;
+        root.GetProperty("inventory").GetProperty("sourceKind").GetString().Should().Be("ogc-wcs");
+        root.GetProperty("inventory").GetProperty("resources")[0].GetProperty("kind").GetString().Should().Be("coverage");
+        root.GetProperty("manifest").GetProperty("targetResources")[0].GetProperty("migrationMode").GetString()
+            .Should().Be("raster-coverage-import");
+        root.GetProperty("parityEvidence").GetProperty("sections").EnumerateArray()
+            .Should().Contain(section => section.GetProperty("id").GetString() == "fidelity");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/scan")]
+    public async Task Scan_OgcApiCoveragesSource_ReturnsCoverageInventory()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/import/scan", new
+        {
+            SourceKind = "ogc-api-coverages",
+            SourceUrl = "https://example.com/coverages",
+            ArtifactSet = "all"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var payload = await response.Content.ReadFromJsonAsync<JsonDocument>();
+        payload.Should().NotBeNull();
+
+        var inventory = payload!.RootElement.GetProperty("inventory");
+        inventory.GetProperty("sourceKind").GetString().Should().Be("ogc-api-coverages");
+        inventory.GetProperty("resources")[0].GetProperty("name").GetString().Should().Be("ocean-forecast");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/scan")]
     public async Task Scan_OgcWmsSource_ReturnsUnsupportedRenderOnlyInventory()
     {
         var response = await _client.PostAsJsonAsync("/api/v1/admin/import/scan", new
@@ -715,6 +763,99 @@ public sealed class MigrationScannerEndpointTests : IAsyncLifetime
                             Reason = "WMS exposes rendered map images and cannot supply automated feature data-copy by itself.",
                             TargetKind = "map-service-layer",
                             ManualSteps = ["Pair this WMS layer with a WFS, coverage, database, or file source before planning data import."]
+                        }
+                    ]
+                });
+            }
+
+            if (request.ServiceType.Equals("WCS", StringComparison.OrdinalIgnoreCase) ||
+                request.ServiceType.Equals("OGC API Coverages", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new MigrationSourceInventoryArtifact
+                {
+                    SourceKind = request.ServiceType.Equals("WCS", StringComparison.OrdinalIgnoreCase)
+                        ? "ogc-wcs"
+                        : "ogc-api-coverages",
+                    Source = new MigrationSourceIdentity
+                    {
+                        DisplayName = request.ServiceType.Equals("WCS", StringComparison.OrdinalIgnoreCase)
+                            ? "Reference WCS"
+                            : "Reference Coverages",
+                        BaseUrl = request.ServiceUrl,
+                        Product = request.ServiceType.Equals("WCS", StringComparison.OrdinalIgnoreCase)
+                            ? "OGC Web Coverage Service"
+                            : "OGC API Coverages",
+                        Version = request.Version,
+                        ServiceType = request.ServiceType
+                    },
+                    AuthPosture = new MigrationInventoryAuthPosture
+                    {
+                        Mode = "anonymous",
+                        AccessConfirmed = true
+                    },
+                    ScanCompleteness = new MigrationInventoryCompleteness
+                    {
+                        Status = "complete"
+                    },
+                    Summary = new MigrationInventorySummary
+                    {
+                        ContainerCount = 1,
+                        ResourceCount = 1,
+                        PartiallyCompatibleCount = 1
+                    },
+                    OverallCompatibility = new MigrationCompatibilityAssessment
+                    {
+                        Level = "partial",
+                        Code = OgcCoverageMigrationCompatibilityCodes.CogSupported,
+                        Reason = "Coverage advertises Cloud Optimized GeoTIFF output that can seed the automated raster migration path."
+                    },
+                    Containers =
+                    [
+                        new MigrationInventoryContainer
+                        {
+                            Id = "service:coverage",
+                            Kind = "ogc-coverage-service",
+                            Name = request.ServiceType,
+                            Compatibility = new MigrationCompatibilityAssessment
+                            {
+                                Level = "partial",
+                                Reason = "Coverage service contains migration-review items."
+                            }
+                        }
+                    ],
+                    Resources =
+                    [
+                        new MigrationInventoryResource
+                        {
+                            Id = request.ServiceType.Equals("WCS", StringComparison.OrdinalIgnoreCase)
+                                ? "coverage:nurc-temperature"
+                                : "coverage:ocean-forecast",
+                            ContainerId = "service:coverage",
+                            Kind = "coverage",
+                            Name = request.ServiceType.Equals("WCS", StringComparison.OrdinalIgnoreCase)
+                                ? "nurc:temperature"
+                                : "ocean-forecast",
+                            Capabilities = ["wcs:DescribeCoverage", "wcs:GetCoverage"],
+                            Compatibility = new MigrationCompatibilityAssessment
+                            {
+                                Level = "partial",
+                                Code = OgcCoverageMigrationCompatibilityCodes.CogSupported,
+                                Reason = "Coverage advertises Cloud Optimized GeoTIFF output that can seed the automated raster migration path.",
+                                ManualSteps = ["Run pilot coverage import and verify parity."]
+                            }
+                        }
+                    ],
+                    FidelityClassifications =
+                    [
+                        new MigrationFidelityClassificationRecord
+                        {
+                            Id = "fidelity:coverage:nurc-temperature:metadata",
+                            SourceId = "coverage:nurc-temperature",
+                            Kind = "coverage",
+                            Category = "coverage-metadata",
+                            AutomationStatus = MigrationFidelityAutomationStatuses.Assisted,
+                            Code = OgcCoverageMigrationCompatibilityCodes.CogSupported,
+                            Reason = "Coverage parity probes were scheduled for metadata, subset, CRS, format, no-data, and band review."
                         }
                     ]
                 });


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1030

## Summary
Adds OGC coverage-service scan support for WCS and OGC API Coverages sources, producing migration planning and evidence artifacts for raster/coverage estates.

## Changes Made
- Added WCS and OGC API Coverages source kinds to the admin migration scan endpoint.
- Extended coverage inventory scanning from capabilities, `DescribeCoverage`, and collections metadata.
- Emitted coverage manifest modes and fidelity/parity review records for supported GeoTIFF/COG outputs and unsupported scientific formats.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- Core focused tests passed, 25/25.
- New server endpoint tests passed, 2/2.
- Full `MigrationScannerEndpointTests` passed, 19/19.
- `git diff --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

## Remaining Scope
This is the coverage scanner/planning slice. GeoTIFF/COG import, CRS/subset/band metadata mapping, parity probes, fixture evidence, and SDK/admin orchestration remain before #1030 should close.

## Notes
Full `dotnet format Honua.sln` was attempted but repeatedly hung while competing background format/test processes were running in the worktree. `git diff --check` and focused tests passed.

---

## Pre-PR Checklist
- [x] Focused draft-PR checks completed; full `scripts/ci/pre-pr-check.sh` remains delegated to CI for this draft PR
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
