### PR TITLE
feat: validate metadata v2 graph references

### DIFF
--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2GraphValidation.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2GraphValidation.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Validates canonical Metadata v2 graph identity and reference integrity.
+/// </summary>
+public static class MetadataV2GraphValidator
+{
+    /// <summary>
+    /// Validates graph entity identifiers and resource-first references.
+    /// </summary>
+    /// <param name="graph">Graph to validate.</param>
+    /// <returns>Validation result with stable error messages.</returns>
+    public static MetadataV2GraphValidationResult Validate(MetadataV2Graph graph)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+
+        var errors = new List<string>();
+        var entityIds = new HashSet<string>(StringComparer.Ordinal);
+
+        AddEntityIds(errors, entityIds, "catalog", graph.Catalogs.Select(catalog => catalog.Metadata.Id));
+        AddEntityIds(errors, entityIds, "resource", graph.Resources.Select(resource => resource.Metadata.Id));
+        AddEntityIds(errors, entityIds, "connection", graph.Connections.Select(connection => connection.Metadata.Id));
+        AddEntityIds(
+            errors,
+            entityIds,
+            "storage binding",
+            graph.StorageBindings.Select(storageBinding => storageBinding.Metadata.Id));
+        AddEntityIds(errors, entityIds, "service", graph.Services.Select(service => service.Metadata.Id));
+        AddEntityIds(errors, entityIds, "publication", graph.Publications.Select(publication => publication.Metadata.Id));
+        AddEntityIds(
+            errors,
+            entityIds,
+            "projection profile",
+            graph.ProjectionProfiles.Select(profile => profile.Metadata.Id));
+        AddEntityIds(errors, entityIds, "policy", graph.Policies.Select(policy => policy.Metadata.Id));
+        AddEntityIds(errors, entityIds, "role", graph.Roles.Select(role => role.Metadata.Id));
+
+        var resourceIds = graph.Resources.Select(resource => resource.Metadata.Id).ToHashSet(StringComparer.Ordinal);
+        var connectionIds = graph.Connections.Select(connection => connection.Metadata.Id).ToHashSet(StringComparer.Ordinal);
+        var storageBindingsById = ToUniqueDictionary(
+            graph.StorageBindings,
+            storageBinding => storageBinding.Metadata.Id);
+        var serviceIds = graph.Services.Select(service => service.Metadata.Id).ToHashSet(StringComparer.Ordinal);
+        var publicationsById = ToUniqueDictionary(
+            graph.Publications,
+            publication => publication.Metadata.Id);
+
+        ValidateStorageBindings(errors, graph.StorageBindings, resourceIds, connectionIds);
+        ValidateResources(errors, graph.Resources, storageBindingsById);
+        ValidatePublications(errors, graph.Publications, resourceIds, storageBindingsById, serviceIds);
+        ValidateServices(errors, graph.Services, publicationsById);
+
+        return new MetadataV2GraphValidationResult(errors.Count == 0, errors);
+    }
+
+    private static Dictionary<string, TEntity> ToUniqueDictionary<TEntity>(
+        IEnumerable<TEntity> entities,
+        Func<TEntity, string> getId)
+    {
+        var dictionary = new Dictionary<string, TEntity>(StringComparer.Ordinal);
+
+        foreach (var entity in entities)
+        {
+            var id = getId(entity);
+            if (string.IsNullOrWhiteSpace(id) || dictionary.ContainsKey(id))
+            {
+                continue;
+            }
+
+            dictionary.Add(id, entity);
+        }
+
+        return dictionary;
+    }
+
+    private static void AddEntityIds(
+        List<string> errors,
+        HashSet<string> entityIds,
+        string entityKind,
+        IEnumerable<string> ids)
+    {
+        foreach (var id in ids)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                errors.Add($"{entityKind} metadata id is required.");
+                continue;
+            }
+
+            if (!entityIds.Add(id))
+            {
+                errors.Add($"metadata id '{id}' is duplicated.");
+            }
+        }
+    }
+
+    private static void ValidateStorageBindings(
+        List<string> errors,
+        IEnumerable<MetadataV2StorageBinding> storageBindings,
+        HashSet<string> resourceIds,
+        HashSet<string> connectionIds)
+    {
+        foreach (var storageBinding in storageBindings)
+        {
+            if (!resourceIds.Contains(storageBinding.ResourceId))
+            {
+                errors.Add(
+                    $"storage binding '{storageBinding.Metadata.Id}' references missing resource '{storageBinding.ResourceId}'.");
+            }
+
+            if (storageBinding.ConnectionId is not null && !connectionIds.Contains(storageBinding.ConnectionId))
+            {
+                errors.Add(
+                    $"storage binding '{storageBinding.Metadata.Id}' references missing connection '{storageBinding.ConnectionId}'.");
+            }
+        }
+    }
+
+    private static void ValidateResources(
+        List<string> errors,
+        IEnumerable<MetadataV2Resource> resources,
+        Dictionary<string, MetadataV2StorageBinding> storageBindingsById)
+    {
+        foreach (var resource in resources)
+        {
+            foreach (var storageBindingId in resource.StorageBindingIds)
+            {
+                if (!storageBindingsById.TryGetValue(storageBindingId, out var storageBinding))
+                {
+                    errors.Add(
+                        $"resource '{resource.Metadata.Id}' references missing storage binding '{storageBindingId}'.");
+                    continue;
+                }
+
+                if (!string.Equals(storageBinding.ResourceId, resource.Metadata.Id, StringComparison.Ordinal))
+                {
+                    errors.Add(
+                        $"resource '{resource.Metadata.Id}' references storage binding '{storageBindingId}' owned by resource '{storageBinding.ResourceId}'.");
+                }
+            }
+
+            if (resource.PrimaryStorageBindingId is not null && !resource.StorageBindingIds.Contains(
+                    resource.PrimaryStorageBindingId,
+                    StringComparer.Ordinal))
+            {
+                errors.Add(
+                    $"resource '{resource.Metadata.Id}' primary storage binding '{resource.PrimaryStorageBindingId}' must be listed in storageBindingIds.");
+            }
+        }
+    }
+
+    private static void ValidatePublications(
+        List<string> errors,
+        IEnumerable<MetadataV2Publication> publications,
+        HashSet<string> resourceIds,
+        Dictionary<string, MetadataV2StorageBinding> storageBindingsById,
+        HashSet<string> serviceIds)
+    {
+        foreach (var publication in publications)
+        {
+            if (!resourceIds.Contains(publication.ResourceId))
+            {
+                errors.Add(
+                    $"publication '{publication.Metadata.Id}' references missing resource '{publication.ResourceId}'.");
+            }
+
+            if (!serviceIds.Contains(publication.ServiceId))
+            {
+                errors.Add(
+                    $"publication '{publication.Metadata.Id}' references missing service '{publication.ServiceId}'.");
+            }
+
+            if (publication.StorageBindingId is null)
+            {
+                continue;
+            }
+
+            if (!storageBindingsById.TryGetValue(publication.StorageBindingId, out var storageBinding))
+            {
+                errors.Add(
+                    $"publication '{publication.Metadata.Id}' references missing storage binding '{publication.StorageBindingId}'.");
+                continue;
+            }
+
+            if (!string.Equals(storageBinding.ResourceId, publication.ResourceId, StringComparison.Ordinal))
+            {
+                errors.Add(
+                    $"publication '{publication.Metadata.Id}' uses storage binding '{publication.StorageBindingId}' owned by resource '{storageBinding.ResourceId}'.");
+            }
+        }
+    }
+
+    private static void ValidateServices(
+        List<string> errors,
+        IEnumerable<MetadataV2Service> services,
+        Dictionary<string, MetadataV2Publication> publicationsById)
+    {
+        foreach (var service in services)
+        {
+            foreach (var publicationId in service.PublicationIds)
+            {
+                if (!publicationsById.TryGetValue(publicationId, out var publication))
+                {
+                    errors.Add($"service '{service.Metadata.Id}' references missing publication '{publicationId}'.");
+                    continue;
+                }
+
+                if (!string.Equals(publication.ServiceId, service.Metadata.Id, StringComparison.Ordinal))
+                {
+                    errors.Add(
+                        $"service '{service.Metadata.Id}' references publication '{publicationId}' owned by service '{publication.ServiceId}'.");
+                }
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Result of validating a canonical Metadata v2 graph.
+/// </summary>
+/// <param name="IsValid">True when graph identity and references are valid.</param>
+/// <param name="Errors">Stable validation errors in discovery order.</param>
+public sealed record MetadataV2GraphValidationResult(bool IsValid, IReadOnlyList<string> Errors);

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2GraphValidation.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2GraphValidation.cs
@@ -126,7 +126,9 @@ public static class MetadataV2GraphValidator
     {
         foreach (var resource in resources)
         {
-            foreach (var storageBindingId in resource.StorageBindingIds)
+            var storageBindingIds = resource.StorageBindingIds ?? Array.Empty<string>();
+
+            foreach (var storageBindingId in storageBindingIds)
             {
                 if (!storageBindingsById.TryGetValue(storageBindingId, out var storageBinding))
                 {
@@ -142,7 +144,7 @@ public static class MetadataV2GraphValidator
                 }
             }
 
-            if (resource.PrimaryStorageBindingId is not null && !resource.StorageBindingIds.Contains(
+            if (resource.PrimaryStorageBindingId is not null && !storageBindingIds.Contains(
                     resource.PrimaryStorageBindingId,
                     StringComparer.Ordinal))
             {

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
@@ -371,4 +371,231 @@ public sealed class MetadataV2ModelTests
         json.Should().Contain("\"tile\"");
         json.Should().Contain("\"download\"");
     }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Validate_WithConsistentResourceFirstReferences_ReturnsValid()
+    {
+        var graph = CreateValidGraph();
+
+        var result = MetadataV2GraphValidator.Validate(graph);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Validate_WithDuplicateGraphEntityId_ReturnsError()
+    {
+        var graph = CreateValidGraph() with
+        {
+            Services =
+            [
+                new MetadataV2Service
+                {
+                    Metadata = new MetadataV2ObjectMetadata
+                    {
+                        Id = "resource.parcels"
+                    }
+                }
+            ]
+        };
+
+        var result = MetadataV2GraphValidator.Validate(graph);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain("metadata id 'resource.parcels' is duplicated.");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Validate_WithDanglingPublicationReferences_ReturnsResourceAndServiceErrors()
+    {
+        var graph = CreateValidGraph() with
+        {
+            Publications =
+            [
+                new MetadataV2Publication
+                {
+                    Metadata = new MetadataV2ObjectMetadata
+                    {
+                        Id = "publication.dangling"
+                    },
+                    ResourceId = "resource.missing",
+                    ServiceId = "service.missing",
+                    StorageBindingId = "storage.missing"
+                }
+            ]
+        };
+
+        var result = MetadataV2GraphValidator.Validate(graph);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(
+            "publication 'publication.dangling' references missing resource 'resource.missing'.");
+        result.Errors.Should().Contain(
+            "publication 'publication.dangling' references missing service 'service.missing'.");
+        result.Errors.Should().Contain(
+            "publication 'publication.dangling' references missing storage binding 'storage.missing'.");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Validate_WithStorageBindingOwnedByDifferentResource_ReturnsResourceFirstError()
+    {
+        var graph = CreateValidGraph() with
+        {
+            Resources =
+            [
+                new MetadataV2Resource
+                {
+                    Metadata = new MetadataV2ObjectMetadata
+                    {
+                        Id = "resource.parcels"
+                    },
+                    StorageBindingIds =
+                    [
+                        "storage.hydrants.postgis"
+                    ],
+                    PrimaryStorageBindingId = "storage.parcels.postgis"
+                }
+            ],
+            StorageBindings =
+            [
+                new MetadataV2StorageBinding
+                {
+                    Metadata = new MetadataV2ObjectMetadata
+                    {
+                        Id = "storage.hydrants.postgis"
+                    },
+                    ResourceId = "resource.hydrants"
+                }
+            ]
+        };
+
+        var result = MetadataV2GraphValidator.Validate(graph);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(
+            "storage binding 'storage.hydrants.postgis' references missing resource 'resource.hydrants'.");
+        result.Errors.Should().Contain(
+            "resource 'resource.parcels' references storage binding 'storage.hydrants.postgis' owned by resource 'resource.hydrants'.");
+        result.Errors.Should().Contain(
+            "resource 'resource.parcels' primary storage binding 'storage.parcels.postgis' must be listed in storageBindingIds.");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public void Validate_WithServiceReferencingForeignPublication_ReturnsError()
+    {
+        var graph = CreateValidGraph() with
+        {
+            Services =
+            [
+                new MetadataV2Service
+                {
+                    Metadata = new MetadataV2ObjectMetadata
+                    {
+                        Id = "service.parcels"
+                    },
+                    PublicationIds =
+                    [
+                        "publication.parcels"
+                    ]
+                }
+            ],
+            Publications =
+            [
+                new MetadataV2Publication
+                {
+                    Metadata = new MetadataV2ObjectMetadata
+                    {
+                        Id = "publication.parcels"
+                    },
+                    ResourceId = "resource.parcels",
+                    ServiceId = "service.other",
+                    StorageBindingId = "storage.parcels.postgis"
+                }
+            ]
+        };
+
+        var result = MetadataV2GraphValidator.Validate(graph);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain("publication 'publication.parcels' references missing service 'service.other'.");
+        result.Errors.Should().Contain(
+            "service 'service.parcels' references publication 'publication.parcels' owned by service 'service.other'.");
+    }
+
+    private static MetadataV2Graph CreateValidGraph()
+    {
+        return new MetadataV2Graph
+        {
+            Resources =
+            [
+                new MetadataV2Resource
+                {
+                    Metadata = new MetadataV2ObjectMetadata
+                    {
+                        Id = "resource.parcels"
+                    },
+                    StorageBindingIds =
+                    [
+                        "storage.parcels.postgis"
+                    ],
+                    PrimaryStorageBindingId = "storage.parcels.postgis"
+                }
+            ],
+            Connections =
+            [
+                new MetadataV2Connection
+                {
+                    Metadata = new MetadataV2ObjectMetadata
+                    {
+                        Id = "connection.postgis"
+                    }
+                }
+            ],
+            StorageBindings =
+            [
+                new MetadataV2StorageBinding
+                {
+                    Metadata = new MetadataV2ObjectMetadata
+                    {
+                        Id = "storage.parcels.postgis"
+                    },
+                    ResourceId = "resource.parcels",
+                    ConnectionId = "connection.postgis"
+                }
+            ],
+            Services =
+            [
+                new MetadataV2Service
+                {
+                    Metadata = new MetadataV2ObjectMetadata
+                    {
+                        Id = "service.parcels"
+                    },
+                    PublicationIds =
+                    [
+                        "publication.parcels"
+                    ]
+                }
+            ],
+            Publications =
+            [
+                new MetadataV2Publication
+                {
+                    Metadata = new MetadataV2ObjectMetadata
+                    {
+                        Id = "publication.parcels"
+                    },
+                    ResourceId = "resource.parcels",
+                    ServiceId = "service.parcels",
+                    StorageBindingId = "storage.parcels.postgis"
+                }
+            ]
+        };
+    }
 }

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
@@ -386,6 +386,25 @@ public sealed class MetadataV2ModelTests
 
     [UnitTest]
     [Operation(Operations.Query)]
+    public void Validate_WithNullDeserializedResourceStorageBindingIds_ReturnsValidationError()
+    {
+        var json = JsonSerializer.Serialize(CreateValidGraph(), MetadataV2JsonContext.Default.MetadataV2Graph)
+            .Replace(
+                "\"storageBindingIds\":[\"storage.parcels.postgis\"]",
+                "\"storageBindingIds\":null",
+                StringComparison.Ordinal);
+        json.Should().Contain("\"storageBindingIds\":null");
+        var graph = JsonSerializer.Deserialize(json, MetadataV2JsonContext.Default.MetadataV2Graph);
+
+        var result = MetadataV2GraphValidator.Validate(graph!);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(
+            "resource 'resource.parcels' primary storage binding 'storage.parcels.postgis' must be listed in storageBindingIds.");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
     public void Validate_WithDuplicateGraphEntityId_ReturnsError()
     {
         var graph = CreateValidGraph() with


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1035

## Summary
Adds a narrow Core-only Metadata v2 graph validation slice for canonical identity and resource-first reference integrity.

## Changes Made
- Added `MetadataV2GraphValidator` for duplicate entity IDs and dangling resource/service/storage/connection references.
- Validated resource-owned storage binding consistency, primary storage binding membership, and service/publication ownership.
- Added unit coverage for valid graphs and invalid resource-first reference cases.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- `dotnet build src/Honua.Core/Honua.Core.csproj --no-restore -m:1 --disable-build-servers` passed, 0 warnings/errors.
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --filter FullyQualifiedName~Metadata` exited 0 after build, but local runner emitted no summary.
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --filter FullyQualifiedName~MetadataV2ModelTests -m:1 --logger "console;verbosity=minimal"` timed out after 180s after build with no test-host output.
- `dotnet format whitespace Honua.sln --verbosity minimal`
- `git diff --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

## Remaining Epic Scope
This is only a graph-integrity slice. Persistence, migration, projection generation, secret handling, cache snapshots, admin UI workflows, protocol adapters, and the child issues under #1035 remain open.

---

## Pre-PR Checklist
- [x] Focused draft-PR checks completed; full `scripts/ci/pre-pr-check.sh` remains delegated to CI for this draft PR
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
