### PR TITLE
feat: add Zarr coverage format support (#1009)

### DIFF
--- a/docs/gis/raster-overview.md
+++ b/docs/gis/raster-overview.md
@@ -15,6 +15,7 @@ by issue `#381`.
 | Multi-raster mosaic and raster catalog completion | Remaining (`#522`) | MVP layer-level raster selection and simple PostGIS mosaic rendering exist, but full mosaic dataset/raster catalog behavior remains the remaining implementation child. |
 | WCS protocol adapter | Shipped (`#377`) | WCS adapts to the shared raster backend for primary-raster `GetCapabilities`, `DescribeCoverage`, and `GetCoverage`. |
 | OGC API Coverages protocol adapter | Shipped (`#521`) | OGC API Coverages adapts to the shared raster backend for REST/JSON coverage discovery, schema metadata, and GeoTIFF/PNG coverage retrieval. |
+| Zarr coverage support | MVP (`#1009`) | Read-only Zarr v2 registration via the admin catalog. Pure-managed metadata reader and bounded chunk-aligned subset reader. Wider protocol-adapter exposure (STAC, OGC API Coverages/Maps/Tiles, ImageServer) is a deferred follow-on. |
 
 ## Raster upload and import
 
@@ -90,6 +91,51 @@ COG driver is available it can emit `COG`; otherwise it falls back to `GTiff`
 with COG-compatible options such as internal tiling and `DEFLATE` compression.
 The public ArcGIS ImageServer `exportImage` format parameter remains limited to
 the documented ImageServer formats and does not expose `format=cog`.
+
+## Zarr coverage support
+
+Honua exposes read-only Zarr coverage support through the shared raster/coverage
+pipeline. Zarr stores are registered alongside COGs and surfaced through the
+canonical admin catalog rather than a protocol-local reader.
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/v1/admin/zarr-stores` | Register a Zarr store for a layer. |
+| `GET /api/v1/admin/zarr-stores?layerId={layerId}` | List Zarr registrations for a layer. |
+| `GET /api/v1/admin/zarr-stores/{id}` | Read one Zarr registration including discovered variables. |
+| `DELETE /api/v1/admin/zarr-stores/{id}` | Unregister a Zarr store. |
+| `POST /api/v1/admin/zarr-stores/{id}/refresh` | Re-scan store metadata via the shared range reader. |
+
+### MVP support matrix
+
+| Capability | Status |
+| --- | --- |
+| Zarr format version | v2 only. v3 stores are detected and rejected with a clear error. |
+| Layout | C order chunks named `0.0`, `0.1`, ... using the default `.` separator. Fortran order is rejected. |
+| Compressors | Uncompressed and `zlib`. `blosc`, `gzip`, `lz4`, `zstd`, and filter pipelines are deferred. |
+| dtypes | Little-endian numpy dtypes: `<f4`, `<f8`, `<i1`..`<i8`, `<u1`..`<u8`, and `|u1`/`|i1`. Big-endian and structured dtypes are rejected. |
+| Sources | `AwsS3` and `AzureBlob` via `ICloudRangeReader`. `Local` is permitted for registration so single-host deployments can serve filesystem stores. |
+| Variables | Single-array stores or grouped stores that list variable names in `.zattrs.variables` (max 64 variables). |
+| Georeferencing | `crs_wkid` or `crs` (`EPSG:NNNN`) and `extent` (`[xmin,ymin,xmax,ymax]`) in the root `.zattrs`. Dimension hints (`x_dimension`, `y_dimension`, `t_dimension`) are read when present. CF-style `_ARRAY_DIMENSIONS` per array is honored. |
+| Subset reads | Per-variable, per-dimension bounded `[start,stop)` reads. Capped at 4096 chunks and 256 MiB per request. |
+| Write/rechunk | Out of scope. Stores are read-only. |
+| STAC, OGC API Coverages/Maps/Tiles, ImageServer exposure | Deferred follow-on; the admin catalog records the registration so a later PR can plug Zarr variables into the shared `IRasterStore` surface. |
+
+### Object-storage layout requirements
+
+A registered root path must resolve to either a single Zarr array (so
+`<root>/.zarray` exists) or a Zarr group with a `<root>/.zgroup` document. When
+a `<root>/.zattrs` is present, the reader uses the optional `variables` array to
+discover child arrays. Each child array lives at `<root>/<variable>/.zarray`
+with chunks under the same prefix. Path traversal sequences (`..`, backslashes,
+leading `/`) are rejected by the admin validator.
+
+### Deployment dependencies
+
+The Zarr reader is pure managed and ships with the server runtime. No native
+GDAL/Zarr binaries are required. Cloud reads reuse the shared S3 and Azure Blob
+range readers configured for COG, so any environment that already serves cloud
+COGs can register Zarr stores from the same buckets.
 
 ## CRS and georeferencing assumptions
 

--- a/src/Honua.Core/Features/Raster/Abstractions/IZarrMetadataReader.cs
+++ b/src/Honua.Core/Features/Raster/Abstractions/IZarrMetadataReader.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+
+namespace Honua.Core.Features.Raster.Abstractions;
+
+/// <summary>
+/// Reads Zarr store metadata (v2 .zarray / .zattrs / .zgroup JSON) via the
+/// shared <see cref="ICloudRangeReader"/> abstraction.
+/// </summary>
+public interface IZarrMetadataReader
+{
+    /// <summary>
+    /// Reads and parses Zarr store metadata starting at the supplied root path.
+    /// </summary>
+    /// <param name="reader">Cloud range reader for the backing object store.</param>
+    /// <param name="bucket">Bucket or container name.</param>
+    /// <param name="rootPath">Root key/prefix containing the .zgroup or .zarray document.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Parsed store metadata describing every array discovered under the root.</returns>
+    Task<ZarrStoreMetadata> ReadMetadataAsync(
+        ICloudRangeReader reader,
+        string bucket,
+        string rootPath,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Raster/Abstractions/IZarrStore.cs
+++ b/src/Honua.Core/Features/Raster/Abstractions/IZarrStore.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Raster.Domain;
+
+namespace Honua.Core.Features.Raster.Abstractions;
+
+/// <summary>
+/// Catalog CRUD for registered Zarr stores. Persistence backend is provider-specific;
+/// the default in-memory implementation is sufficient for the MVP read-only flow.
+/// </summary>
+public interface IZarrStore
+{
+    /// <summary>
+    /// Gets a Zarr registration by ID.
+    /// </summary>
+    Task<ZarrRegistration?> GetAsync(long id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Registers a new Zarr store.
+    /// </summary>
+    Task<ZarrRegistration> RegisterAsync(ZarrRegistrationRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a Zarr registration.
+    /// </summary>
+    Task<bool> UnregisterAsync(long id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all Zarr registrations for a layer.
+    /// </summary>
+    Task<ZarrRegistration[]> ListByLayerAsync(int layerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the cached metadata for a registration after a metadata scan.
+    /// </summary>
+    Task UpdateMetadataAsync(long id, ZarrStoreMetadata metadata, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Raster/Abstractions/IZarrSubsetReader.cs
+++ b/src/Honua.Core/Features/Raster/Abstractions/IZarrSubsetReader.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+
+namespace Honua.Core.Features.Raster.Abstractions;
+
+/// <summary>
+/// Reads bounded chunk-aligned subsets from a Zarr store.
+/// </summary>
+public interface IZarrSubsetReader
+{
+    /// <summary>
+    /// Reads a bounded subset of a single Zarr array variable.
+    /// </summary>
+    /// <param name="reader">Cloud range reader for the backing object store.</param>
+    /// <param name="bucket">Bucket or container name.</param>
+    /// <param name="rootPath">Root key/prefix containing the array metadata.</param>
+    /// <param name="metadata">Previously discovered store metadata.</param>
+    /// <param name="request">Subset request expressed as inclusive start / exclusive stop per dimension.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Subset payload as a contiguous little-endian buffer.</returns>
+    Task<ZarrSubsetResult> ReadSubsetAsync(
+        ICloudRangeReader reader,
+        string bucket,
+        string rootPath,
+        ZarrStoreMetadata metadata,
+        ZarrSubsetRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Raster/Domain/SupportedRasterFormat.cs
+++ b/src/Honua.Core/Features/Raster/Domain/SupportedRasterFormat.cs
@@ -29,5 +29,10 @@ public enum SupportedRasterFormat
     /// <summary>
     /// Cloud-Optimized GeoTIFF (.tif, .tiff) with internal tiling and overview IFDs.
     /// </summary>
-    CloudOptimizedGeoTiff
+    CloudOptimizedGeoTiff,
+
+    /// <summary>
+    /// Zarr v2 store hosted locally or in object storage. Read-only.
+    /// </summary>
+    Zarr
 }

--- a/src/Honua.Core/Features/Raster/Domain/ZarrModels.cs
+++ b/src/Honua.Core/Features/Raster/Domain/ZarrModels.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Domain;
+
+namespace Honua.Core.Features.Raster.Domain;
+
+/// <summary>
+/// Supported Zarr storage specification versions.
+/// </summary>
+public enum ZarrFormatVersion
+{
+    /// <summary>
+    /// Zarr v2 specification.
+    /// </summary>
+    V2 = 2,
+
+    /// <summary>
+    /// Zarr v3 specification (read-only support deferred).
+    /// </summary>
+    V3 = 3
+}
+
+/// <summary>
+/// Parsed metadata for a single Zarr array (variable).
+/// </summary>
+/// <param name="Name">Logical variable name (last path segment for single-array stores).</param>
+/// <param name="ZarrFormat">Detected Zarr format version.</param>
+/// <param name="RelativePath">Path under the store root where chunks and <c>.zarray</c> live. Empty for single-array stores.</param>
+/// <param name="Shape">Per-dimension array shape.</param>
+/// <param name="Chunks">Per-dimension chunk shape.</param>
+/// <param name="DataType">numpy-style dtype string (e.g. <c>&lt;f4</c>).</param>
+/// <param name="Order">Memory layout order (<c>C</c> or <c>F</c>).</param>
+/// <param name="Compressor">Compressor codec id (e.g. <c>zlib</c>); null when uncompressed.</param>
+/// <param name="FillValue">Fill value or null when unset.</param>
+/// <param name="DimensionNames">CF-style dimension names from <c>_ARRAY_DIMENSIONS</c> when present.</param>
+public sealed record ZarrArrayMetadata(
+    string Name,
+    ZarrFormatVersion ZarrFormat,
+    string RelativePath,
+    int[] Shape,
+    int[] Chunks,
+    string DataType,
+    string Order,
+    string? Compressor,
+    object? FillValue,
+    string[] DimensionNames);
+
+/// <summary>
+/// Parsed Zarr store metadata covering one or more arrays.
+/// </summary>
+public sealed record ZarrStoreMetadata(
+    ZarrFormatVersion ZarrFormat,
+    int Srid,
+    RasterExtent Extent,
+    ZarrArrayMetadata[] Arrays,
+    string? PrimaryVariable,
+    string? SpatialXDimension,
+    string? SpatialYDimension,
+    string? TemporalDimension);
+
+/// <summary>
+/// Persisted catalog entry for a registered Zarr store.
+/// </summary>
+public sealed record ZarrRegistration
+{
+    /// <summary>
+    /// Unique registration identifier.
+    /// </summary>
+    public required long Id { get; init; }
+
+    /// <summary>
+    /// Layer this Zarr store is associated with.
+    /// </summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>
+    /// Human-readable name for the registration.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Optional description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Cloud storage provider hosting the Zarr store.
+    /// </summary>
+    public required CloudStorageProvider Provider { get; init; }
+
+    /// <summary>
+    /// Bucket or container name.
+    /// </summary>
+    public required string Bucket { get; init; }
+
+    /// <summary>
+    /// Root key/prefix for the Zarr store.
+    /// </summary>
+    public required string RootPath { get; init; }
+
+    /// <summary>
+    /// Parsed Zarr metadata (null if scan has not completed).
+    /// </summary>
+    public ZarrStoreMetadata? Metadata { get; init; }
+
+    /// <summary>
+    /// When metadata was last scanned from the backing store.
+    /// </summary>
+    public DateTimeOffset? MetadataScannedAt { get; init; }
+
+    /// <summary>
+    /// Registration timestamp.
+    /// </summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+}
+
+/// <summary>
+/// Request to register a cloud-hosted or local Zarr store.
+/// </summary>
+public sealed record ZarrRegistrationRequest
+{
+    /// <summary>
+    /// Layer to associate the Zarr store with.
+    /// </summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>
+    /// Human-readable name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Optional description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Cloud storage provider.
+    /// </summary>
+    public required CloudStorageProvider Provider { get; init; }
+
+    /// <summary>
+    /// Bucket or container name.
+    /// </summary>
+    public required string Bucket { get; init; }
+
+    /// <summary>
+    /// Root key/prefix for the Zarr store.
+    /// </summary>
+    public required string RootPath { get; init; }
+}
+
+/// <summary>
+/// Bounded request for a Zarr subset read.
+/// </summary>
+public sealed record ZarrSubsetRequest
+{
+    /// <summary>
+    /// Variable (array name) to read.
+    /// </summary>
+    public required string Variable { get; init; }
+
+    /// <summary>
+    /// Inclusive start index per dimension (same order as the array shape).
+    /// </summary>
+    public required int[] Start { get; init; }
+
+    /// <summary>
+    /// Exclusive stop index per dimension.
+    /// </summary>
+    public required int[] Stop { get; init; }
+}
+
+/// <summary>
+/// Result of a Zarr subset read.
+/// </summary>
+public sealed record ZarrSubsetResult(
+    string Variable,
+    int[] Shape,
+    string DataType,
+    byte[] Data);

--- a/src/Honua.Core/Features/Raster/ZarrParser/ZarrMetadataExtractor.cs
+++ b/src/Honua.Core/Features/Raster/ZarrParser/ZarrMetadataExtractor.cs
@@ -225,6 +225,8 @@ public sealed class ZarrMetadataExtractor : IZarrMetadataReader
                 throw new InvalidDataException($"Zarr array '{name}' uses Fortran chunk order; only C order is supported by the MVP reader.");
             }
 
+            RejectUnsupportedFilters(root, name);
+
             var compressor = ResolveCompressorId(root);
 
             object? fillValue = null;
@@ -328,6 +330,15 @@ public sealed class ZarrMetadataExtractor : IZarrMetadataReader
             return idEl.GetString();
         }
         return null;
+    }
+
+    private static void RejectUnsupportedFilters(JsonElement root, string arrayName)
+    {
+        if (root.TryGetProperty("filters", out var filtersEl) &&
+            filtersEl.ValueKind != JsonValueKind.Null)
+        {
+            throw new InvalidDataException($"Zarr array '{arrayName}' declares filters, which are not supported by the MVP reader.");
+        }
     }
 
     private static string[]? ReadDimensionNamesFromAttrs(JsonElement root, int rank)

--- a/src/Honua.Core/Features/Raster/ZarrParser/ZarrMetadataExtractor.cs
+++ b/src/Honua.Core/Features/Raster/ZarrParser/ZarrMetadataExtractor.cs
@@ -1,0 +1,516 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Domain;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+
+namespace Honua.Core.Features.Raster.ZarrParser;
+
+/// <summary>
+/// AOT-safe Zarr v2 metadata reader. Discovers arrays under a root prefix by reading
+/// <c>.zgroup</c>, <c>.zattrs</c> (with an optional <c>variables</c> manifest), and
+/// <c>.zarray</c> JSON documents through <see cref="ICloudRangeReader"/>.
+/// </summary>
+public sealed class ZarrMetadataExtractor : IZarrMetadataReader
+{
+    private const int MaxMetadataBytes = 64 * 1024;
+    private const int MaxVariables = 64;
+
+    /// <inheritdoc />
+    public async Task<ZarrStoreMetadata> ReadMetadataAsync(
+        ICloudRangeReader reader,
+        string bucket,
+        string rootPath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentException.ThrowIfNullOrWhiteSpace(bucket);
+        ArgumentNullException.ThrowIfNull(rootPath);
+
+        var normalizedRoot = NormalizeRootPath(rootPath);
+        var groupDoc = await TryReadJsonDocumentAsync(reader, bucket, JoinKey(normalizedRoot, ".zgroup"), cancellationToken)
+            .ConfigureAwait(false);
+        var attrsDoc = await TryReadJsonDocumentAsync(reader, bucket, JoinKey(normalizedRoot, ".zattrs"), cancellationToken)
+            .ConfigureAwait(false);
+
+        var variables = ResolveVariables(groupDoc, attrsDoc, reader, bucket, normalizedRoot);
+
+        var arrays = new List<ZarrArrayMetadata>();
+        if (variables.Count == 0)
+        {
+            // Treat the root itself as a single-array store.
+            var rootArray = await ReadArrayAsync(
+                    reader,
+                    bucket,
+                    arrayPath: normalizedRoot,
+                    relativePath: string.Empty,
+                    name: ResolveSingleName(normalizedRoot),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            arrays.Add(rootArray);
+        }
+        else
+        {
+            foreach (var name in variables)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var arrayPath = JoinKey(normalizedRoot, name);
+                var arr = await ReadArrayAsync(reader, bucket, arrayPath, relativePath: name, name, cancellationToken)
+                    .ConfigureAwait(false);
+                arrays.Add(arr);
+            }
+        }
+
+        if (arrays.Count == 0)
+        {
+            throw new InvalidDataException("Zarr store contains no arrays.");
+        }
+
+        var (srid, extent, primary, xDim, yDim, tDim) = ResolveStoreGeoreferencing(attrsDoc, arrays);
+
+        return new ZarrStoreMetadata(
+            ZarrFormat: arrays[0].ZarrFormat,
+            Srid: srid,
+            Extent: extent,
+            Arrays: arrays.ToArray(),
+            PrimaryVariable: primary,
+            SpatialXDimension: xDim,
+            SpatialYDimension: yDim,
+            TemporalDimension: tDim);
+    }
+
+    private static string NormalizeRootPath(string rootPath)
+    {
+        var trimmed = rootPath.Trim();
+        while (trimmed.EndsWith('/'))
+        {
+            trimmed = trimmed[..^1];
+        }
+        return trimmed;
+    }
+
+    private static string JoinKey(string root, string segment)
+    {
+        if (string.IsNullOrEmpty(root))
+        {
+            return segment;
+        }
+        return root + "/" + segment;
+    }
+
+    private static string ResolveSingleName(string rootPath)
+    {
+        var lastSlash = rootPath.LastIndexOf('/');
+        return lastSlash >= 0 && lastSlash < rootPath.Length - 1
+            ? rootPath[(lastSlash + 1)..]
+            : "data";
+    }
+
+    private static List<string> ResolveVariables(
+        JsonDocument? groupDoc,
+        JsonDocument? attrsDoc,
+        ICloudRangeReader reader,
+        string bucket,
+        string rootPath)
+    {
+        _ = reader;
+        _ = bucket;
+        _ = rootPath;
+
+        var variables = new List<string>();
+        if (groupDoc is null)
+        {
+            return variables;
+        }
+
+        if (attrsDoc is not null &&
+            attrsDoc.RootElement.ValueKind == JsonValueKind.Object &&
+            attrsDoc.RootElement.TryGetProperty("variables", out var variablesElement) &&
+            variablesElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var entry in variablesElement.EnumerateArray())
+            {
+                if (variables.Count >= MaxVariables)
+                {
+                    throw new InvalidDataException($"Zarr store exposes more than {MaxVariables} variables; reduce the manifest or split the store.");
+                }
+                if (entry.ValueKind != JsonValueKind.String)
+                {
+                    continue;
+                }
+                var name = entry.GetString();
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    continue;
+                }
+                if (ContainsUnsafeSegment(name))
+                {
+                    throw new InvalidDataException($"Variable name '{name}' contains path traversal characters.");
+                }
+                variables.Add(name!);
+            }
+        }
+
+        return variables;
+    }
+
+    private static async Task<ZarrArrayMetadata> ReadArrayAsync(
+        ICloudRangeReader reader,
+        string bucket,
+        string arrayPath,
+        string relativePath,
+        string name,
+        CancellationToken cancellationToken)
+    {
+        var zarrayDoc = await TryReadJsonDocumentAsync(reader, bucket, JoinKey(arrayPath, ".zarray"), cancellationToken)
+            .ConfigureAwait(false);
+        if (zarrayDoc is null)
+        {
+            throw new InvalidDataException($"Zarr array '{name}' is missing a .zarray document at '{arrayPath}/.zarray'.");
+        }
+
+        var arrayAttrs = await TryReadJsonDocumentAsync(reader, bucket, JoinKey(arrayPath, ".zattrs"), cancellationToken)
+            .ConfigureAwait(false);
+
+        using (zarrayDoc)
+        using (arrayAttrs)
+        {
+            var root = zarrayDoc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                throw new InvalidDataException($"Zarr array '{name}' has a malformed .zarray document.");
+            }
+
+            var format = ResolveZarrFormat(root, name);
+            if (format != ZarrFormatVersion.V2)
+            {
+                throw new InvalidDataException($"Zarr v{(int)format} is not supported by the MVP reader; use a Zarr v2 store.");
+            }
+
+            var shape = ReadIntArray(root, "shape", name);
+            var chunks = ReadIntArray(root, "chunks", name);
+            if (shape.Length == 0 || shape.Length != chunks.Length)
+            {
+                throw new InvalidDataException($"Zarr array '{name}' has mismatched shape and chunk rank.");
+            }
+
+            foreach (var dim in shape)
+            {
+                if (dim <= 0)
+                {
+                    throw new InvalidDataException($"Zarr array '{name}' has non-positive shape entry.");
+                }
+            }
+
+            foreach (var chunk in chunks)
+            {
+                if (chunk <= 0)
+                {
+                    throw new InvalidDataException($"Zarr array '{name}' has non-positive chunk entry.");
+                }
+            }
+
+            var dtype = ReadRequiredString(root, "dtype", name);
+            var order = root.TryGetProperty("order", out var orderEl) && orderEl.ValueKind == JsonValueKind.String
+                ? orderEl.GetString() ?? "C"
+                : "C";
+            if (!string.Equals(order, "C", StringComparison.Ordinal))
+            {
+                throw new InvalidDataException($"Zarr array '{name}' uses Fortran chunk order; only C order is supported by the MVP reader.");
+            }
+
+            var compressor = ResolveCompressorId(root);
+
+            object? fillValue = null;
+            if (root.TryGetProperty("fill_value", out var fillEl))
+            {
+                fillValue = fillEl.ValueKind switch
+                {
+                    JsonValueKind.Number => fillEl.TryGetDouble(out var d) ? d : null,
+                    JsonValueKind.String => fillEl.GetString(),
+                    JsonValueKind.Null => null,
+                    _ => null
+                };
+            }
+
+            var dimNames = ReadDimensionNames(root, shape.Length);
+            if (arrayAttrs is not null)
+            {
+                var attrDims = ReadDimensionNamesFromAttrs(arrayAttrs.RootElement, shape.Length);
+                if (attrDims is not null)
+                {
+                    dimNames = attrDims;
+                }
+            }
+
+            return new ZarrArrayMetadata(
+                Name: name,
+                ZarrFormat: format,
+                RelativePath: relativePath,
+                Shape: shape,
+                Chunks: chunks,
+                DataType: dtype,
+                Order: order,
+                Compressor: compressor,
+                FillValue: fillValue,
+                DimensionNames: dimNames);
+        }
+    }
+
+    private static ZarrFormatVersion ResolveZarrFormat(JsonElement root, string arrayName)
+    {
+        if (!root.TryGetProperty("zarr_format", out var formatEl))
+        {
+            throw new InvalidDataException($"Zarr array '{arrayName}' is missing the zarr_format property.");
+        }
+
+        if (formatEl.ValueKind != JsonValueKind.Number || !formatEl.TryGetInt32(out var formatNumber))
+        {
+            throw new InvalidDataException($"Zarr array '{arrayName}' has a non-numeric zarr_format property.");
+        }
+
+        return formatNumber switch
+        {
+            2 => ZarrFormatVersion.V2,
+            3 => ZarrFormatVersion.V3,
+            _ => throw new InvalidDataException($"Zarr array '{arrayName}' declares unsupported zarr_format '{formatNumber}'.")
+        };
+    }
+
+    private static int[] ReadIntArray(JsonElement root, string property, string arrayName)
+    {
+        if (!root.TryGetProperty(property, out var element) || element.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidDataException($"Zarr array '{arrayName}' is missing required property '{property}'.");
+        }
+
+        var values = new List<int>();
+        foreach (var entry in element.EnumerateArray())
+        {
+            if (entry.ValueKind != JsonValueKind.Number || !entry.TryGetInt32(out var value))
+            {
+                throw new InvalidDataException($"Zarr array '{arrayName}' property '{property}' contains a non-integer entry.");
+            }
+            values.Add(value);
+        }
+        return values.ToArray();
+    }
+
+    private static string ReadRequiredString(JsonElement root, string property, string arrayName)
+    {
+        if (!root.TryGetProperty(property, out var element) || element.ValueKind != JsonValueKind.String)
+        {
+            throw new InvalidDataException($"Zarr array '{arrayName}' is missing required string property '{property}'.");
+        }
+        return element.GetString() ?? throw new InvalidDataException($"Zarr array '{arrayName}' has empty '{property}'.");
+    }
+
+    private static string? ResolveCompressorId(JsonElement root)
+    {
+        if (!root.TryGetProperty("compressor", out var element))
+        {
+            return null;
+        }
+        if (element.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+        if (element.ValueKind == JsonValueKind.Object &&
+            element.TryGetProperty("id", out var idEl) &&
+            idEl.ValueKind == JsonValueKind.String)
+        {
+            return idEl.GetString();
+        }
+        return null;
+    }
+
+    private static string[]? ReadDimensionNamesFromAttrs(JsonElement root, int rank)
+    {
+        if (root.ValueKind != JsonValueKind.Object ||
+            !root.TryGetProperty("_ARRAY_DIMENSIONS", out var dimsEl) ||
+            dimsEl.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var names = new List<string>();
+        foreach (var entry in dimsEl.EnumerateArray())
+        {
+            names.Add(entry.ValueKind == JsonValueKind.String ? entry.GetString() ?? string.Empty : string.Empty);
+        }
+        return names.Count == rank ? names.ToArray() : null;
+    }
+
+    private static string[] ReadDimensionNames(JsonElement root, int rank)
+    {
+        if (root.TryGetProperty("_ARRAY_DIMENSIONS", out var dimsEl) && dimsEl.ValueKind == JsonValueKind.Array)
+        {
+            var names = new List<string>();
+            foreach (var entry in dimsEl.EnumerateArray())
+            {
+                names.Add(entry.ValueKind == JsonValueKind.String ? entry.GetString() ?? string.Empty : string.Empty);
+            }
+            if (names.Count == rank)
+            {
+                return names.ToArray();
+            }
+        }
+
+        var fallback = new string[rank];
+        for (var i = 0; i < rank; i++)
+        {
+            fallback[i] = "dim_" + i.ToString(CultureInfo.InvariantCulture);
+        }
+        return fallback;
+    }
+
+    private static (int Srid, RasterExtent Extent, string? PrimaryVariable, string? XDim, string? YDim, string? TDim)
+        ResolveStoreGeoreferencing(JsonDocument? attrsDoc, List<ZarrArrayMetadata> arrays)
+    {
+        var srid = 0;
+        double xMin = 0, yMin = 0, xMax = 0, yMax = 0;
+        bool hasExtent = false;
+        string? primary = null;
+        string? xDim = null;
+        string? yDim = null;
+        string? tDim = null;
+
+        if (attrsDoc is not null && attrsDoc.RootElement.ValueKind == JsonValueKind.Object)
+        {
+            var root = attrsDoc.RootElement;
+            if (root.TryGetProperty("crs_wkid", out var crsEl) && crsEl.ValueKind == JsonValueKind.Number && crsEl.TryGetInt32(out var crsValue))
+            {
+                srid = crsValue;
+            }
+            else if (root.TryGetProperty("crs", out var crsStringEl) && crsStringEl.ValueKind == JsonValueKind.String)
+            {
+                if (TryParseEpsg(crsStringEl.GetString(), out var parsedSrid))
+                {
+                    srid = parsedSrid;
+                }
+            }
+
+            if (root.TryGetProperty("extent", out var extentEl) && extentEl.ValueKind == JsonValueKind.Array)
+            {
+                var coords = new List<double>();
+                foreach (var entry in extentEl.EnumerateArray())
+                {
+                    if (entry.ValueKind == JsonValueKind.Number && entry.TryGetDouble(out var d))
+                    {
+                        coords.Add(d);
+                    }
+                }
+                if (coords.Count == 4)
+                {
+                    xMin = coords[0];
+                    yMin = coords[1];
+                    xMax = coords[2];
+                    yMax = coords[3];
+                    hasExtent = true;
+                }
+            }
+
+            primary = ReadOptionalString(root, "primary_variable");
+            xDim = ReadOptionalString(root, "x_dimension");
+            yDim = ReadOptionalString(root, "y_dimension");
+            tDim = ReadOptionalString(root, "t_dimension");
+        }
+
+        if (string.IsNullOrEmpty(primary) && arrays.Count > 0)
+        {
+            primary = arrays[0].Name;
+        }
+
+        var extent = new RasterExtent
+        {
+            XMin = hasExtent ? xMin : 0,
+            YMin = hasExtent ? yMin : 0,
+            XMax = hasExtent ? xMax : (arrays.Count > 0 && arrays[0].Shape.Length >= 1 ? arrays[0].Shape[^1] : 0),
+            YMax = hasExtent ? yMax : (arrays.Count > 0 && arrays[0].Shape.Length >= 2 ? arrays[0].Shape[^2] : 0),
+            Srid = srid
+        };
+
+        return (srid, extent, primary, xDim, yDim, tDim);
+    }
+
+    private static string? ReadOptionalString(JsonElement root, string property)
+    {
+        return root.TryGetProperty(property, out var el) && el.ValueKind == JsonValueKind.String
+            ? el.GetString()
+            : null;
+    }
+
+    private static bool TryParseEpsg(string? value, out int srid)
+    {
+        srid = 0;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+        const string prefix = "EPSG:";
+        var span = value.AsSpan().Trim();
+        if (span.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            span = span[prefix.Length..];
+        }
+        return int.TryParse(span, NumberStyles.Integer, CultureInfo.InvariantCulture, out srid) && srid > 0;
+    }
+
+    internal static async Task<JsonDocument?> TryReadJsonDocumentAsync(
+        ICloudRangeReader reader,
+        string bucket,
+        string key,
+        CancellationToken cancellationToken)
+    {
+        byte[] payload;
+        try
+        {
+            payload = await reader.ReadRangeAsync(bucket, key, 0, MaxMetadataBytes, cancellationToken).ConfigureAwait(false);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return null;
+        }
+
+        if (payload.Length == 0)
+        {
+            return null;
+        }
+
+        var byteCount = payload.Length;
+        var buffer = ArrayPool<byte>.Shared.Rent(byteCount);
+        try
+        {
+            Buffer.BlockCopy(payload, 0, buffer, 0, byteCount);
+            // Ensure UTF-8 with no BOM consideration; Zarr metadata is JSON.
+            var text = Encoding.UTF8.GetString(buffer, 0, byteCount);
+            try
+            {
+                return JsonDocument.Parse(text);
+            }
+            catch (JsonException)
+            {
+                throw new InvalidDataException($"Zarr metadata at '{key}' is not valid JSON.");
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    internal static bool ContainsUnsafeSegment(string value)
+        => value.Contains("..", StringComparison.Ordinal) ||
+           value.Contains('\\', StringComparison.Ordinal) ||
+           value.StartsWith('/');
+}

--- a/src/Honua.Core/Features/Raster/ZarrParser/ZarrSubsetReader.cs
+++ b/src/Honua.Core/Features/Raster/ZarrParser/ZarrSubsetReader.cs
@@ -1,0 +1,476 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.IO.Compression;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+
+namespace Honua.Core.Features.Raster.ZarrParser;
+
+/// <summary>
+/// AOT-safe Zarr v2 subset reader. Supports the uncompressed and zlib codecs,
+/// C order, and per-dimension bounded reads. The result buffer is laid out in
+/// row-major order over the requested subset shape using the array's native dtype.
+/// </summary>
+public sealed class ZarrSubsetReader : IZarrSubsetReader
+{
+    private const int MaxChunksPerRequest = 4096;
+    private const long MaxBytesPerRequest = 256L * 1024L * 1024L; // 256 MiB
+
+    /// <inheritdoc />
+    public async Task<ZarrSubsetResult> ReadSubsetAsync(
+        ICloudRangeReader reader,
+        string bucket,
+        string rootPath,
+        ZarrStoreMetadata metadata,
+        ZarrSubsetRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(metadata);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var array = ResolveArray(metadata, request.Variable);
+        ValidateRequest(array, request);
+        ValidateCodec(array);
+
+        var rank = array.Shape.Length;
+        var subsetShape = new int[rank];
+        for (var i = 0; i < rank; i++)
+        {
+            subsetShape[i] = request.Stop[i] - request.Start[i];
+        }
+
+        var elementSize = ResolveElementSize(array.DataType);
+        var totalElements = 1L;
+        for (var i = 0; i < rank; i++)
+        {
+            totalElements *= subsetShape[i];
+        }
+
+        var totalBytes = checked(totalElements * elementSize);
+        if (totalBytes > MaxBytesPerRequest)
+        {
+            throw new InvalidOperationException(
+                $"Zarr subset would require {totalBytes:N0} bytes, exceeding the {MaxBytesPerRequest:N0} byte cap.");
+        }
+
+        var startChunk = new int[rank];
+        var stopChunk = new int[rank];
+        var chunkCount = 1L;
+        for (var i = 0; i < rank; i++)
+        {
+            startChunk[i] = request.Start[i] / array.Chunks[i];
+            stopChunk[i] = (request.Stop[i] - 1) / array.Chunks[i] + 1;
+            chunkCount = checked(chunkCount * (stopChunk[i] - startChunk[i]));
+            if (chunkCount > MaxChunksPerRequest)
+            {
+                throw new InvalidOperationException(
+                    $"Zarr subset would span more than {MaxChunksPerRequest} chunks; reduce the request bounds.");
+            }
+        }
+
+        var output = new byte[totalBytes];
+        var chunkIndex = new int[rank];
+        Array.Copy(startChunk, chunkIndex, rank);
+
+        var arrayPath = JoinKey(rootPath, array.RelativePath);
+
+        var done = false;
+        while (!done)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await CopyChunkIntoSubsetAsync(
+                    reader,
+                    bucket,
+                    arrayPath,
+                    array,
+                    request,
+                    subsetShape,
+                    elementSize,
+                    chunkIndex,
+                    output,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            // Increment chunkIndex within the [startChunk, stopChunk) range, row-major.
+            done = !TryIncrement(chunkIndex, startChunk, stopChunk);
+        }
+
+        return new ZarrSubsetResult(
+            Variable: array.Name,
+            Shape: subsetShape,
+            DataType: array.DataType,
+            Data: output);
+    }
+
+    private static ZarrArrayMetadata ResolveArray(ZarrStoreMetadata metadata, string variable)
+    {
+        foreach (var candidate in metadata.Arrays)
+        {
+            if (string.Equals(candidate.Name, variable, StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+        throw new InvalidOperationException($"Variable '{variable}' was not discovered in the Zarr store.");
+    }
+
+    private static void ValidateRequest(ZarrArrayMetadata array, ZarrSubsetRequest request)
+    {
+        if (request.Start.Length != array.Shape.Length || request.Stop.Length != array.Shape.Length)
+        {
+            throw new ArgumentException(
+                $"Zarr subset rank mismatch: array '{array.Name}' has rank {array.Shape.Length}.",
+                nameof(request));
+        }
+
+        for (var i = 0; i < array.Shape.Length; i++)
+        {
+            if (request.Start[i] < 0 || request.Stop[i] <= request.Start[i] || request.Stop[i] > array.Shape[i])
+            {
+                throw new ArgumentException(
+                    $"Zarr subset bounds [{request.Start[i]},{request.Stop[i]}) on dimension {i} are outside the array shape {array.Shape[i]}.",
+                    nameof(request));
+            }
+        }
+    }
+
+    private static void ValidateCodec(ZarrArrayMetadata array)
+    {
+        var compressor = array.Compressor;
+        if (compressor is null)
+        {
+            return;
+        }
+
+        if (string.Equals(compressor, "zlib", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Zarr compressor '{compressor}' is not supported by the MVP reader. Use uncompressed or zlib chunks.");
+    }
+
+    private static int ResolveElementSize(string dtype)
+    {
+        var span = dtype.AsSpan();
+        if (span.IsEmpty)
+        {
+            throw new InvalidDataException("Zarr dtype is empty.");
+        }
+
+        // dtype follows numpy convention: [<|>|=][kind][bytes], e.g. <f4, |u1, >i8.
+        var endian = span[0];
+        if (endian is not ('<' or '>' or '|' or '='))
+        {
+            throw new InvalidDataException($"Zarr dtype '{dtype}' has unrecognized byte-order prefix.");
+        }
+        if (endian == '>')
+        {
+            throw new InvalidOperationException($"Zarr dtype '{dtype}' is big-endian; only little-endian dtypes are supported by the MVP reader.");
+        }
+
+        if (span.Length < 3)
+        {
+            throw new InvalidDataException($"Zarr dtype '{dtype}' is too short to interpret.");
+        }
+
+        var kind = span[1];
+        if (kind is not ('f' or 'i' or 'u' or 'b'))
+        {
+            throw new InvalidOperationException($"Zarr dtype kind '{kind}' is not supported by the MVP reader (use f, i, u, or b).");
+        }
+
+        if (!int.TryParse(span[2..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var bytes) || bytes <= 0)
+        {
+            throw new InvalidDataException($"Zarr dtype '{dtype}' has an invalid element size suffix.");
+        }
+        return bytes;
+    }
+
+    private static async Task CopyChunkIntoSubsetAsync(
+        ICloudRangeReader reader,
+        string bucket,
+        string arrayPath,
+        ZarrArrayMetadata array,
+        ZarrSubsetRequest request,
+        int[] subsetShape,
+        int elementSize,
+        int[] chunkIndex,
+        byte[] output,
+        CancellationToken cancellationToken)
+    {
+        var rank = array.Shape.Length;
+        var chunkPath = JoinKey(arrayPath, BuildChunkKey(chunkIndex));
+        byte[]? raw;
+        try
+        {
+            raw = await reader.ReadRangeAsync(bucket, chunkPath, 0, int.MaxValue / 4, cancellationToken).ConfigureAwait(false);
+        }
+        catch (FileNotFoundException)
+        {
+            raw = null;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            raw = null;
+        }
+
+        var chunkBytes = ComputeChunkBytes(array, elementSize);
+        var chunkBuffer = new byte[chunkBytes];
+        if (raw is null || raw.Length == 0)
+        {
+            FillWithFillValue(chunkBuffer, array, elementSize);
+        }
+        else
+        {
+            DecompressChunk(raw, array.Compressor, chunkBuffer);
+        }
+
+        // For each cell in the chunk intersected with the request bounds, copy
+        // it to the appropriate output offset.
+        var chunkStart = new int[rank];
+        var chunkStop = new int[rank];
+        for (var i = 0; i < rank; i++)
+        {
+            chunkStart[i] = chunkIndex[i] * array.Chunks[i];
+            chunkStop[i] = Math.Min(chunkStart[i] + array.Chunks[i], array.Shape[i]);
+        }
+
+        var intersectStart = new int[rank];
+        var intersectStop = new int[rank];
+        for (var i = 0; i < rank; i++)
+        {
+            intersectStart[i] = Math.Max(chunkStart[i], request.Start[i]);
+            intersectStop[i] = Math.Min(chunkStop[i], request.Stop[i]);
+            if (intersectStop[i] <= intersectStart[i])
+            {
+                return;
+            }
+        }
+
+        // Iterate over all cells in the intersected region using row-major coordinates
+        // and copy contiguous innermost runs at a time.
+        var cursor = (int[])intersectStart.Clone();
+        var done = false;
+        while (!done)
+        {
+            // Copy a run on the last axis from cursor[rank-1] to intersectStop[rank-1].
+            var innerStart = intersectStart[rank - 1];
+            var innerStop = intersectStop[rank - 1];
+            var runLength = innerStop - innerStart;
+            cursor[rank - 1] = innerStart;
+
+            var srcOffset = checked((int)(ComputeChunkOffset(cursor, chunkStart, array.Chunks) * elementSize));
+            var dstOffset = checked((int)(ComputeSubsetOffset(cursor, request.Start, subsetShape) * elementSize));
+            Buffer.BlockCopy(chunkBuffer, srcOffset, output, dstOffset, runLength * elementSize);
+
+            done = !TryIncrementOuter(cursor, intersectStart, intersectStop);
+        }
+    }
+
+    private static long ComputeChunkBytes(ZarrArrayMetadata array, int elementSize)
+    {
+        long bytes = elementSize;
+        foreach (var c in array.Chunks)
+        {
+            bytes = checked(bytes * c);
+        }
+        return bytes;
+    }
+
+    private static void FillWithFillValue(byte[] buffer, ZarrArrayMetadata array, int elementSize)
+    {
+        if (array.FillValue is null)
+        {
+            return; // zero-filled by default.
+        }
+
+        // For MVP we only fill numeric fill values that round-trip to little-endian bytes.
+        // String fill values (e.g. NaN encoded as "NaN") are out of scope.
+        if (array.FillValue is double d)
+        {
+            WriteFillScalar(buffer, array.DataType, elementSize, d);
+        }
+    }
+
+    private static void WriteFillScalar(byte[] buffer, string dtype, int elementSize, double value)
+    {
+        // Best-effort fill for f4/f8/i*/u*; out-of-range values silently clamp to defaults.
+        Span<byte> scratch = stackalloc byte[8];
+        switch (dtype)
+        {
+            case "<f8":
+                BitConverter.TryWriteBytes(scratch, value);
+                break;
+            case "<f4":
+                BitConverter.TryWriteBytes(scratch, (float)value);
+                break;
+            case "<i4":
+            case "|i4":
+                BitConverter.TryWriteBytes(scratch, (int)value);
+                break;
+            case "<i2":
+            case "|i2":
+                BitConverter.TryWriteBytes(scratch, (short)value);
+                break;
+            case "|i1":
+            case "<i1":
+                scratch[0] = (byte)(sbyte)value;
+                break;
+            case "<u4":
+            case "|u4":
+                BitConverter.TryWriteBytes(scratch, (uint)value);
+                break;
+            case "<u2":
+            case "|u2":
+                BitConverter.TryWriteBytes(scratch, (ushort)value);
+                break;
+            case "|u1":
+            case "<u1":
+                scratch[0] = (byte)value;
+                break;
+            default:
+                return;
+        }
+
+        for (var offset = 0; offset + elementSize <= buffer.Length; offset += elementSize)
+        {
+            for (var k = 0; k < elementSize; k++)
+            {
+                buffer[offset + k] = scratch[k];
+            }
+        }
+    }
+
+    private static void DecompressChunk(byte[] raw, string? compressor, byte[] destination)
+    {
+        if (compressor is null)
+        {
+            if (raw.Length < destination.Length)
+            {
+                throw new InvalidDataException(
+                    $"Zarr chunk is {raw.Length} bytes but the array expects {destination.Length} uncompressed bytes.");
+            }
+            Buffer.BlockCopy(raw, 0, destination, 0, destination.Length);
+            return;
+        }
+
+        if (string.Equals(compressor, "zlib", StringComparison.Ordinal))
+        {
+            using var input = new MemoryStream(raw);
+            using var zlib = new ZLibStream(input, CompressionMode.Decompress);
+            var totalRead = 0;
+            while (totalRead < destination.Length)
+            {
+                var read = zlib.Read(destination, totalRead, destination.Length - totalRead);
+                if (read <= 0)
+                {
+                    break;
+                }
+                totalRead += read;
+            }
+            if (totalRead < destination.Length)
+            {
+                throw new InvalidDataException(
+                    $"Zarr zlib chunk decoded to {totalRead} bytes; expected {destination.Length}.");
+            }
+            return;
+        }
+
+        throw new InvalidOperationException($"Zarr compressor '{compressor}' is not supported.");
+    }
+
+    private static long ComputeChunkOffset(int[] cell, int[] chunkStart, int[] chunkShape)
+    {
+        long offset = 0;
+        long stride = 1;
+        for (var i = cell.Length - 1; i >= 0; i--)
+        {
+            var local = cell[i] - chunkStart[i];
+            offset += local * stride;
+            stride *= chunkShape[i];
+        }
+        return offset;
+    }
+
+    private static long ComputeSubsetOffset(int[] cell, int[] requestStart, int[] subsetShape)
+    {
+        long offset = 0;
+        long stride = 1;
+        for (var i = cell.Length - 1; i >= 0; i--)
+        {
+            var local = cell[i] - requestStart[i];
+            offset += local * stride;
+            stride *= subsetShape[i];
+        }
+        return offset;
+    }
+
+    private static bool TryIncrement(int[] cursor, int[] start, int[] stop)
+    {
+        for (var i = cursor.Length - 1; i >= 0; i--)
+        {
+            cursor[i]++;
+            if (cursor[i] < stop[i])
+            {
+                return true;
+            }
+            cursor[i] = start[i];
+        }
+        return false;
+    }
+
+    private static bool TryIncrementOuter(int[] cursor, int[] start, int[] stop)
+    {
+        // Increment all axes except the innermost (which the caller handled via run length).
+        for (var i = cursor.Length - 2; i >= 0; i--)
+        {
+            cursor[i]++;
+            if (cursor[i] < stop[i])
+            {
+                return true;
+            }
+            cursor[i] = start[i];
+        }
+        return false;
+    }
+
+    private static string BuildChunkKey(int[] chunkIndex)
+    {
+        // Zarr v2 default separator is '.'.
+        if (chunkIndex.Length == 0)
+        {
+            return "0";
+        }
+        var sb = new System.Text.StringBuilder();
+        for (var i = 0; i < chunkIndex.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append('.');
+            }
+            sb.Append(chunkIndex[i].ToString(CultureInfo.InvariantCulture));
+        }
+        return sb.ToString();
+    }
+
+    private static string JoinKey(string root, string segment)
+    {
+        if (string.IsNullOrEmpty(segment))
+        {
+            return root;
+        }
+        if (string.IsNullOrEmpty(root))
+        {
+            return segment;
+        }
+        return root + "/" + segment;
+    }
+
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -679,6 +679,13 @@ public static class EndpointRegistry
         new("DELETE", "/api/v1/admin/cloud-rasters/{id}"),
         new("POST", "/api/v1/admin/cloud-rasters/{id}/refresh"),
 
+        // Zarr admin endpoints (#1009)
+        new("POST", "/api/v1/admin/zarr-stores"),
+        new("GET", "/api/v1/admin/zarr-stores"),
+        new("GET", "/api/v1/admin/zarr-stores/{id}"),
+        new("DELETE", "/api/v1/admin/zarr-stores/{id}"),
+        new("POST", "/api/v1/admin/zarr-stores/{id}/refresh"),
+
         // STAC (SpatioTemporal Asset Catalog)
         new("GET", "/stac"),
         new("GET", "/stac/conformance"),

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -8,6 +8,7 @@ using Honua.Server.Features.Alerts;
 using Honua.Server.Features.CloudDemo;
 using Honua.Server.Features.Protocols.Cog;
 using Honua.Server.Features.Protocols.Coverages.Multidimensional;
+using Honua.Server.Features.Protocols.Zarr;
 using Honua.Server.Features.Protocols.GeoServices.FeatureServer;
 using Honua.Server.Features.Geocoding;
 using Honua.Server.Features.Grounding.Spec;
@@ -66,6 +67,7 @@ internal static class FeatureRegistrationExtensions
         services.AddGeocoding(configuration);
         services.AddCogServices(configuration);
         services.AddMultidimensionalCoverageServices();
+        services.AddZarrServices();
         services.AddImageServer();
         services.AddMapServer();
         services.AddOgcCoverages();
@@ -119,6 +121,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapGeocodingEndpoints();
         endpoints.MapCogEndpoints();
         endpoints.MapMultidimensionalCoverageEndpoints();
+        endpoints.MapZarrEndpoints();
         endpoints.MapGeoservicesCatalogEndpoints();
         endpoints.MapImageServerEndpoints();
         endpoints.MapMapServerEndpoints();

--- a/src/Honua.Server/Features/Protocols/Zarr/InMemoryZarrStore.cs
+++ b/src/Honua.Server/Features/Protocols/Zarr/InMemoryZarrStore.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+
+namespace Honua.Server.Features.Protocols.Zarr;
+
+/// <summary>
+/// MVP in-memory catalog for Zarr registrations. Persistent storage is deferred
+/// until a follow-on PR introduces a Postgres-backed catalog.
+/// </summary>
+internal sealed class InMemoryZarrStore : IZarrStore
+{
+    private readonly ConcurrentDictionary<long, ZarrRegistration> _registrations = new();
+    private readonly ConcurrentDictionary<string, long> _uniqueKeys = new(StringComparer.Ordinal);
+    private long _nextId;
+
+    public Task<ZarrRegistration?> GetAsync(long id, CancellationToken cancellationToken = default)
+    {
+        _registrations.TryGetValue(id, out var registration);
+        return Task.FromResult<ZarrRegistration?>(registration);
+    }
+
+    public Task<ZarrRegistration> RegisterAsync(ZarrRegistrationRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var key = BuildUniqueKey(request.LayerId, request.Provider.ToString(), request.Bucket, request.RootPath);
+        var id = Interlocked.Increment(ref _nextId);
+        if (!_uniqueKeys.TryAdd(key, id))
+        {
+            throw new InvalidOperationException(
+                $"A Zarr store is already registered for layer {request.LayerId} at {request.Provider}://{request.Bucket}/{request.RootPath}.");
+        }
+
+        var registration = new ZarrRegistration
+        {
+            Id = id,
+            LayerId = request.LayerId,
+            Name = request.Name,
+            Description = request.Description,
+            Provider = request.Provider,
+            Bucket = request.Bucket,
+            RootPath = request.RootPath,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        _registrations[id] = registration;
+        return Task.FromResult(registration);
+    }
+
+    public Task<bool> UnregisterAsync(long id, CancellationToken cancellationToken = default)
+    {
+        if (!_registrations.TryRemove(id, out var existing))
+        {
+            return Task.FromResult(false);
+        }
+        var key = BuildUniqueKey(existing.LayerId, existing.Provider.ToString(), existing.Bucket, existing.RootPath);
+        _uniqueKeys.TryRemove(key, out _);
+        return Task.FromResult(true);
+    }
+
+    public Task<ZarrRegistration[]> ListByLayerAsync(int layerId, CancellationToken cancellationToken = default)
+    {
+        var results = _registrations.Values
+            .Where(r => r.LayerId == layerId)
+            .OrderByDescending(r => r.CreatedAt)
+            .ToArray();
+        return Task.FromResult(results);
+    }
+
+    public Task UpdateMetadataAsync(long id, ZarrStoreMetadata metadata, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+        _registrations.AddOrUpdate(
+            id,
+            _ => throw new InvalidOperationException($"Zarr registration {id} does not exist."),
+            (_, existing) => existing with
+            {
+                Metadata = metadata,
+                MetadataScannedAt = DateTimeOffset.UtcNow
+            });
+        return Task.CompletedTask;
+    }
+
+    private static string BuildUniqueKey(int layerId, string provider, string bucket, string rootPath)
+        => layerId + "|" + provider + "|" + bucket + "|" + rootPath;
+}

--- a/src/Honua.Server/Features/Protocols/Zarr/Models/ZarrAdminModels.cs
+++ b/src/Honua.Server/Features/Protocols/Zarr/Models/ZarrAdminModels.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Domain;
+
+namespace Honua.Server.Features.Protocols.Zarr.Models;
+
+/// <summary>
+/// Request to register a Zarr store for read-only serving.
+/// </summary>
+internal sealed record RegisterZarrRequest
+{
+    /// <summary>
+    /// Layer to associate the Zarr store with.
+    /// </summary>
+    public int LayerId { get; init; }
+
+    /// <summary>
+    /// Human-readable name.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Cloud storage provider.
+    /// </summary>
+    public CloudStorageProvider Provider { get; init; }
+
+    /// <summary>
+    /// Bucket or container name.
+    /// </summary>
+    public string Bucket { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Root prefix within the bucket pointing at the Zarr store root.
+    /// </summary>
+    public string RootPath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Validates the request fields.
+    /// </summary>
+    public bool IsValid(out string error)
+    {
+        if (LayerId <= 0)
+        {
+            error = "LayerId must be a positive integer.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(Name))
+        {
+            error = "Name is required.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(Bucket))
+        {
+            error = "Bucket is required.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(RootPath))
+        {
+            error = "RootPath is required.";
+            return false;
+        }
+        if (RootPath.Contains("..", StringComparison.Ordinal) ||
+            RootPath.Contains('\\', StringComparison.Ordinal) ||
+            RootPath.StartsWith('/'))
+        {
+            error = "RootPath must be a relative object key with no traversal sequences.";
+            return false;
+        }
+        if (Bucket.Length > 255 || RootPath.Length > 1024)
+        {
+            error = "Bucket must be 255 characters or fewer and RootPath must be 1024 characters or fewer.";
+            return false;
+        }
+        if (!Enum.IsDefined(Provider))
+        {
+            error = "Provider must be one of: AwsS3, AzureBlob, Local.";
+            return false;
+        }
+        error = string.Empty;
+        return true;
+    }
+}
+
+/// <summary>
+/// Summary projection of a registered Zarr store.
+/// </summary>
+internal sealed record ZarrRegistrationResponse
+{
+    /// <summary>Registration identifier.</summary>
+    public long Id { get; init; }
+
+    /// <summary>Associated layer.</summary>
+    public int LayerId { get; init; }
+
+    /// <summary>Registration name.</summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Optional description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Cloud storage provider name.</summary>
+    public string Provider { get; init; } = string.Empty;
+
+    /// <summary>Bucket or container name.</summary>
+    public string Bucket { get; init; } = string.Empty;
+
+    /// <summary>Root key/prefix pointing at the Zarr store root.</summary>
+    public string RootPath { get; init; } = string.Empty;
+
+    /// <summary>Detected Zarr format version (2 or 3).</summary>
+    public int? ZarrFormat { get; init; }
+
+    /// <summary>Spatial reference identifier discovered during the metadata scan.</summary>
+    public int? Srid { get; init; }
+
+    /// <summary>Number of arrays/variables discovered in the store.</summary>
+    public int? VariableCount { get; init; }
+
+    /// <summary>Primary variable name when declared in the manifest.</summary>
+    public string? PrimaryVariable { get; init; }
+
+    /// <summary>Per-variable summaries.</summary>
+    public ZarrVariableSummary[]? Variables { get; init; }
+
+    /// <summary>When metadata was last scanned.</summary>
+    public DateTimeOffset? MetadataScannedAt { get; init; }
+
+    /// <summary>Registration timestamp.</summary>
+    public DateTimeOffset CreatedAt { get; init; }
+}
+
+/// <summary>
+/// Lightweight description of a single Zarr variable for admin responses.
+/// </summary>
+internal sealed record ZarrVariableSummary
+{
+    /// <summary>Variable name.</summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Per-dimension shape.</summary>
+    public int[] Shape { get; init; } = [];
+
+    /// <summary>Per-dimension chunk shape.</summary>
+    public int[] Chunks { get; init; } = [];
+
+    /// <summary>numpy-style dtype.</summary>
+    public string DataType { get; init; } = string.Empty;
+
+    /// <summary>Compressor codec id (e.g. <c>zlib</c>), or null when uncompressed.</summary>
+    public string? Compressor { get; init; }
+
+    /// <summary>Dimension names from <c>_ARRAY_DIMENSIONS</c> when present.</summary>
+    public string[] DimensionNames { get; init; } = [];
+}

--- a/src/Honua.Server/Features/Protocols/Zarr/ZarrEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Zarr/ZarrEndpoints.cs
@@ -1,0 +1,255 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Protocols.Zarr.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Protocols.Zarr;
+
+/// <summary>
+/// Log category for Zarr admin endpoints.
+/// </summary>
+internal sealed class ZarrEndpointsLog;
+
+/// <summary>
+/// Admin endpoints for Zarr store registration and metadata discovery.
+/// </summary>
+internal static class ZarrEndpoints
+{
+    private const string DuplicateRegistrationMessage =
+        "A Zarr store with the same layer, provider, bucket, and root path is already registered.";
+
+    /// <summary>
+    /// Maps Zarr admin endpoints.
+    /// </summary>
+    public static void MapZarrEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/zarr-stores")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Zarr Stores")
+            .RequireAdminAuthorization();
+
+        group.MapPost("/", HandleRegister)
+            .WithDisplayName("Register Zarr Store")
+            .WithSummary("Register a Zarr coverage store for read-only serving");
+
+        group.MapGet("/", HandleList)
+            .WithDisplayName("List Zarr Stores")
+            .WithSummary("List registered Zarr stores for a layer");
+
+        group.MapGet("/{id:long}", HandleGet)
+            .WithDisplayName("Get Zarr Store")
+            .WithSummary("Get registration details for a Zarr store");
+
+        group.MapDelete("/{id:long}", HandleDelete)
+            .WithDisplayName("Unregister Zarr Store")
+            .WithSummary("Unregister a Zarr store");
+
+        group.MapPost("/{id:long}/refresh", HandleRefresh)
+            .WithDisplayName("Refresh Zarr Metadata")
+            .WithSummary("Re-scan Zarr metadata from the backing store");
+    }
+
+    private static async Task<IResult> HandleRegister(
+        RegisterZarrRequest request,
+        [FromServices] ILayerCatalog layerCatalog,
+        [FromServices] IZarrStore store,
+        ILogger<ZarrEndpointsLog> logger,
+        CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return TypedResults.BadRequest("Request body is required.");
+        }
+        if (!request.IsValid(out var error))
+        {
+            return TypedResults.BadRequest(error);
+        }
+
+        if (!await layerCatalog.LayerExistsAsync(request.LayerId, cancellationToken).ConfigureAwait(false))
+        {
+            return TypedResults.NotFound("Layer not found.");
+        }
+
+        ZarrRegistration registration;
+        try
+        {
+            registration = await store.RegisterAsync(new ZarrRegistrationRequest
+            {
+                LayerId = request.LayerId,
+                Name = request.Name,
+                Description = request.Description,
+                Provider = request.Provider,
+                Bucket = request.Bucket,
+                RootPath = request.RootPath
+            }, cancellationToken).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("already registered", StringComparison.Ordinal))
+        {
+            return TypedResults.Conflict(DuplicateRegistrationMessage);
+        }
+
+        var providerName = registration.Provider.ToString();
+        ZarrLog.ZarrRegistered(
+            logger,
+            registration.Name,
+            registration.Id,
+            registration.LayerId,
+            providerName,
+            registration.Bucket,
+            registration.RootPath);
+
+        return Results.Json(ToResponse(registration), ZarrJsonContext.Default.ZarrRegistrationResponse, statusCode: 201);
+    }
+
+    private static async Task<IResult> HandleList(
+        [FromServices] IZarrStore store,
+        ILogger<ZarrEndpointsLog> logger,
+        int? layerId = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!layerId.HasValue)
+        {
+            return TypedResults.BadRequest("Query parameter 'layerId' is required.");
+        }
+
+        var registrations = await store.ListByLayerAsync(layerId.Value, cancellationToken).ConfigureAwait(false);
+        ZarrLog.ZarrListRetrieved(logger, registrations.Length);
+        var responses = registrations.Select(ToResponse).ToArray();
+        return Results.Json(responses, ZarrJsonContext.Default.ZarrRegistrationResponseArray);
+    }
+
+    private static async Task<IResult> HandleGet(
+        long id,
+        [FromServices] IZarrStore store,
+        CancellationToken cancellationToken)
+    {
+        var registration = await store.GetAsync(id, cancellationToken).ConfigureAwait(false);
+        if (registration is null)
+        {
+            return TypedResults.NotFound();
+        }
+        return Results.Json(ToResponse(registration), ZarrJsonContext.Default.ZarrRegistrationResponse);
+    }
+
+    private static async Task<IResult> HandleDelete(
+        long id,
+        [FromServices] IZarrStore store,
+        ILogger<ZarrEndpointsLog> logger,
+        CancellationToken cancellationToken)
+    {
+        var deleted = await store.UnregisterAsync(id, cancellationToken).ConfigureAwait(false);
+        if (!deleted)
+        {
+            return TypedResults.NotFound();
+        }
+        ZarrLog.ZarrUnregistered(logger, id);
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<IResult> HandleRefresh(
+        long id,
+        HttpContext context,
+        [FromServices] IZarrStore store,
+        [FromServices] IEnumerable<ICloudRangeReader> rangeReaders,
+        [FromServices] IZarrMetadataReader metadataReader,
+        ILogger<ZarrEndpointsLog> logger,
+        CancellationToken cancellationToken)
+    {
+        var registration = await store.GetAsync(id, cancellationToken).ConfigureAwait(false);
+        if (registration is null)
+        {
+            return TypedResults.NotFound();
+        }
+
+        var reader = rangeReaders.FirstOrDefault(r => r.Provider == registration.Provider);
+        if (reader is null)
+        {
+            return TypedResults.BadRequest($"No range reader configured for provider {registration.Provider}.");
+        }
+
+        var refreshProviderName = registration.Provider.ToString();
+        ZarrLog.MetadataScanStarted(
+            logger,
+            id,
+            refreshProviderName,
+            registration.Bucket,
+            registration.RootPath);
+
+        try
+        {
+            var metadata = await metadataReader
+                .ReadMetadataAsync(reader, registration.Bucket, registration.RootPath, cancellationToken)
+                .ConfigureAwait(false);
+            await store.UpdateMetadataAsync(id, metadata, cancellationToken).ConfigureAwait(false);
+
+            ZarrLog.MetadataScanCompleted(logger, id, metadata.Arrays.Length, metadata.Srid);
+
+            var updated = await store.GetAsync(id, cancellationToken).ConfigureAwait(false);
+            return Results.Json(ToResponse(updated!), ZarrJsonContext.Default.ZarrRegistrationResponse);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (InvalidDataException ex)
+        {
+            ZarrLog.MetadataScanFailed(logger, ex, id);
+            return TypedResults.BadRequest("Zarr metadata is invalid: " + ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            ZarrLog.MetadataScanFailed(logger, ex, id);
+            return TypedResults.BadRequest(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            ZarrLog.MetadataScanFailed(logger, ex, id);
+            return StandardErrorHelpers.CreateInternalServerError(context, "Metadata scan failed for the specified Zarr store.");
+        }
+    }
+
+    private static ZarrRegistrationResponse ToResponse(ZarrRegistration registration)
+    {
+        ZarrVariableSummary[]? variables = null;
+        if (registration.Metadata is { } metadata)
+        {
+            variables = metadata.Arrays.Select(a => new ZarrVariableSummary
+            {
+                Name = a.Name,
+                Shape = a.Shape,
+                Chunks = a.Chunks,
+                DataType = a.DataType,
+                Compressor = a.Compressor,
+                DimensionNames = a.DimensionNames
+            }).ToArray();
+        }
+
+        return new ZarrRegistrationResponse
+        {
+            Id = registration.Id,
+            LayerId = registration.LayerId,
+            Name = registration.Name,
+            Description = registration.Description,
+            Provider = registration.Provider.ToString(),
+            Bucket = registration.Bucket,
+            RootPath = registration.RootPath,
+            ZarrFormat = registration.Metadata is null ? null : (int)registration.Metadata.ZarrFormat,
+            Srid = registration.Metadata?.Srid,
+            VariableCount = registration.Metadata?.Arrays.Length,
+            PrimaryVariable = registration.Metadata?.PrimaryVariable,
+            Variables = variables,
+            MetadataScannedAt = registration.MetadataScannedAt,
+            CreatedAt = registration.CreatedAt
+        };
+    }
+}

--- a/src/Honua.Server/Features/Protocols/Zarr/ZarrJsonContext.cs
+++ b/src/Honua.Server/Features/Protocols/Zarr/ZarrJsonContext.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Server.Features.Protocols.Zarr.Models;
+
+namespace Honua.Server.Features.Protocols.Zarr;
+
+/// <summary>
+/// AOT-safe JSON serialization context for Zarr admin endpoints.
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(RegisterZarrRequest))]
+[JsonSerializable(typeof(ZarrRegistrationResponse))]
+[JsonSerializable(typeof(ZarrRegistrationResponse[]))]
+[JsonSerializable(typeof(ZarrVariableSummary))]
+[JsonSerializable(typeof(ZarrVariableSummary[]))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(long))]
+internal sealed partial class ZarrJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Protocols/Zarr/ZarrLog.cs
+++ b/src/Honua.Server/Features/Protocols/Zarr/ZarrLog.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Server.Features.Protocols.Zarr;
+
+/// <summary>
+/// Structured logging for Zarr admin operations. Event ID range: 7920-7939.
+/// </summary>
+internal static partial class ZarrLog
+{
+    [LoggerMessage(
+        EventId = 7920,
+        Level = LogLevel.Information,
+        Message = "Registered Zarr store '{Name}' (ID {RegistrationId}) for layer {LayerId}: {Provider}://{Bucket}/{RootPath}")]
+    public static partial void ZarrRegistered(ILogger logger, string name, long registrationId, int layerId, string provider, string bucket, string rootPath);
+
+    [LoggerMessage(
+        EventId = 7921,
+        Level = LogLevel.Information,
+        Message = "Unregistered Zarr store {RegistrationId}")]
+    public static partial void ZarrUnregistered(ILogger logger, long registrationId);
+
+    [LoggerMessage(
+        EventId = 7922,
+        Level = LogLevel.Information,
+        Message = "Listed {Count} Zarr registrations")]
+    public static partial void ZarrListRetrieved(ILogger logger, int count);
+
+    [LoggerMessage(
+        EventId = 7923,
+        Level = LogLevel.Information,
+        Message = "Zarr metadata scan started for {RegistrationId}: {Provider}://{Bucket}/{RootPath}")]
+    public static partial void MetadataScanStarted(ILogger logger, long registrationId, string provider, string bucket, string rootPath);
+
+    [LoggerMessage(
+        EventId = 7924,
+        Level = LogLevel.Information,
+        Message = "Zarr metadata scan completed for {RegistrationId}: {VariableCount} variables, SRID {Srid}")]
+    public static partial void MetadataScanCompleted(ILogger logger, long registrationId, int variableCount, int srid);
+
+    [LoggerMessage(
+        EventId = 7925,
+        Level = LogLevel.Error,
+        Message = "Zarr metadata scan failed for {RegistrationId}")]
+    public static partial void MetadataScanFailed(ILogger logger, Exception ex, long registrationId);
+}

--- a/src/Honua.Server/Features/Protocols/Zarr/ZarrServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Protocols/Zarr/ZarrServiceCollectionExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.ZarrParser;
+
+namespace Honua.Server.Features.Protocols.Zarr;
+
+/// <summary>
+/// Service collection extensions for the Zarr coverage feature.
+/// </summary>
+internal static class ZarrServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the AOT-safe Zarr metadata/subset readers and the in-memory catalog.
+    /// </summary>
+    public static IServiceCollection AddZarrServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<IZarrMetadataReader, ZarrMetadataExtractor>();
+        services.AddSingleton<IZarrSubsetReader, ZarrSubsetReader>();
+        services.AddSingleton<IZarrStore, InMemoryZarrStore>();
+        return services;
+    }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -866,6 +866,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Protocols.Stac.StacJsonContext.Default,
         Honua.Server.Features.Protocols.Cog.CogJsonContext.Default,
         Honua.Server.Features.Protocols.Coverages.Multidimensional.MultidimensionalCoverageJsonContext.Default,
+        Honua.Server.Features.Protocols.Zarr.ZarrJsonContext.Default,
         Honua.Server.Features.Protocols.SpatialAnalytics.Models.SpatialAnalyticsJsonContext.Default,
         Honua.Server.Features.Collaboration.Sessions.CollaborationSessionJsonContext.Default,
         Honua.Server.Features.Collaboration.FeatureLocks.FeatureLockJsonContext.Default,

--- a/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/InMemoryZarrRangeReader.cs
+++ b/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/InMemoryZarrRangeReader.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Domain;
+
+namespace Honua.Core.Tests.Raster.ZarrParser;
+
+/// <summary>
+/// Test double simulating an object store keyed by full path. Returns
+/// <see cref="FileNotFoundException"/> for missing keys so callers can probe.
+/// </summary>
+internal sealed class InMemoryZarrRangeReader : ICloudRangeReader
+{
+    private readonly Dictionary<string, byte[]> _objects;
+
+    public InMemoryZarrRangeReader(Dictionary<string, byte[]> objects)
+    {
+        _objects = objects;
+    }
+
+    public CloudStorageProvider Provider => CloudStorageProvider.AwsS3;
+
+    public Task<byte[]> ReadRangeAsync(string bucket, string key, long offset, int length, CancellationToken cancellationToken = default)
+    {
+        if (!_objects.TryGetValue(key, out var data))
+        {
+            throw new FileNotFoundException(key);
+        }
+
+        var startOffset = (int)offset;
+        var available = data.Length - startOffset;
+        if (available <= 0)
+        {
+            return Task.FromResult(System.Array.Empty<byte>());
+        }
+        var bytesToRead = System.Math.Min(length, available);
+        var slice = new byte[bytesToRead];
+        Buffer.BlockCopy(data, startOffset, slice, 0, bytesToRead);
+        return Task.FromResult(slice);
+    }
+
+    public Task<Stream> ReadRangeStreamAsync(string bucket, string key, long offset, int length, CancellationToken cancellationToken = default)
+    {
+        if (!_objects.TryGetValue(key, out var data))
+        {
+            throw new FileNotFoundException(key);
+        }
+        return Task.FromResult<Stream>(new MemoryStream(data, (int)offset, System.Math.Min(length, data.Length - (int)offset)));
+    }
+
+    public Task<long> GetObjectSizeAsync(string bucket, string key, CancellationToken cancellationToken = default)
+    {
+        if (!_objects.TryGetValue(key, out var data))
+        {
+            throw new FileNotFoundException(key);
+        }
+        return Task.FromResult((long)data.Length);
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrFixtureBuilder.cs
+++ b/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrFixtureBuilder.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace Honua.Core.Tests.Raster.ZarrParser;
+
+/// <summary>
+/// Builds synthetic Zarr v2 store layouts for tests. Each fixture is returned as
+/// a path-to-bytes dictionary suitable for <see cref="InMemoryZarrRangeReader"/>.
+/// </summary>
+internal static class ZarrFixtureBuilder
+{
+    public static Dictionary<string, byte[]> BuildSingleVariableUncompressed(
+        string root,
+        int rows,
+        int cols,
+        int chunkRows,
+        int chunkCols,
+        Func<int, int, float> sample)
+    {
+        var objects = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        var zarray = new StringBuilder();
+        zarray.Append('{')
+            .Append("\"chunks\":[").Append(chunkRows).Append(',').Append(chunkCols).Append("],")
+            .Append("\"compressor\":null,")
+            .Append("\"dtype\":\"<f4\",")
+            .Append("\"fill_value\":0,")
+            .Append("\"filters\":null,")
+            .Append("\"order\":\"C\",")
+            .Append("\"shape\":[").Append(rows).Append(',').Append(cols).Append("],")
+            .Append("\"zarr_format\":2}");
+        objects[root + "/.zarray"] = Encoding.UTF8.GetBytes(zarray.ToString());
+
+        AppendChunksFloat32(root, rows, cols, chunkRows, chunkCols, sample, compress: false, objects);
+        return objects;
+    }
+
+    public static Dictionary<string, byte[]> BuildGroupedZlib(
+        string root,
+        int rows,
+        int cols,
+        int chunkRows,
+        int chunkCols,
+        Func<int, int, float> sample,
+        int srid,
+        double xMin,
+        double yMin,
+        double xMax,
+        double yMax)
+    {
+        var objects = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        objects[root + "/.zgroup"] = Encoding.UTF8.GetBytes("{\"zarr_format\":2}");
+        var attrs = "{"
+            + "\"variables\":[\"temperature\"],"
+            + "\"primary_variable\":\"temperature\","
+            + "\"crs_wkid\":" + srid + ","
+            + "\"extent\":[" +
+                xMin.ToString("R", CultureInfo.InvariantCulture) + "," +
+                yMin.ToString("R", CultureInfo.InvariantCulture) + "," +
+                xMax.ToString("R", CultureInfo.InvariantCulture) + "," +
+                yMax.ToString("R", CultureInfo.InvariantCulture) + "],"
+            + "\"x_dimension\":\"x\","
+            + "\"y_dimension\":\"y\""
+            + "}";
+        objects[root + "/.zattrs"] = Encoding.UTF8.GetBytes(attrs);
+
+        var arrayRoot = root + "/temperature";
+        var zarray = "{"
+            + "\"chunks\":[" + chunkRows + "," + chunkCols + "],"
+            + "\"compressor\":{\"id\":\"zlib\",\"level\":1},"
+            + "\"dtype\":\"<f4\","
+            + "\"fill_value\":\"NaN\","
+            + "\"filters\":null,"
+            + "\"order\":\"C\","
+            + "\"shape\":[" + rows + "," + cols + "],"
+            + "\"zarr_format\":2}";
+        objects[arrayRoot + "/.zarray"] = Encoding.UTF8.GetBytes(zarray);
+        var arrayAttrs = "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"]}";
+        objects[arrayRoot + "/.zattrs"] = Encoding.UTF8.GetBytes(arrayAttrs);
+
+        AppendChunksFloat32(arrayRoot, rows, cols, chunkRows, chunkCols, sample, compress: true, objects);
+        return objects;
+    }
+
+    public static Dictionary<string, byte[]> BuildInvalidJson(string root)
+    {
+        var objects = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        objects[root + "/.zarray"] = Encoding.UTF8.GetBytes("{not-json");
+        return objects;
+    }
+
+    public static Dictionary<string, byte[]> BuildUnsupportedV3(string root)
+    {
+        var objects = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        objects[root + "/.zarray"] = Encoding.UTF8.GetBytes("{\"chunks\":[1],\"shape\":[1],\"dtype\":\"<f4\",\"order\":\"C\",\"compressor\":null,\"fill_value\":0,\"zarr_format\":3}");
+        return objects;
+    }
+
+    public static Dictionary<string, byte[]> BuildFortranOrder(string root)
+    {
+        var objects = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        objects[root + "/.zarray"] = Encoding.UTF8.GetBytes("{\"chunks\":[1],\"shape\":[1],\"dtype\":\"<f4\",\"order\":\"F\",\"compressor\":null,\"fill_value\":0,\"zarr_format\":2}");
+        return objects;
+    }
+
+    private static void AppendChunksFloat32(
+        string arrayRoot,
+        int rows,
+        int cols,
+        int chunkRows,
+        int chunkCols,
+        Func<int, int, float> sample,
+        bool compress,
+        Dictionary<string, byte[]> objects)
+    {
+        var chunkRowCount = (rows + chunkRows - 1) / chunkRows;
+        var chunkColCount = (cols + chunkCols - 1) / chunkCols;
+        for (var cr = 0; cr < chunkRowCount; cr++)
+        {
+            for (var cc = 0; cc < chunkColCount; cc++)
+            {
+                var startRow = cr * chunkRows;
+                var startCol = cc * chunkCols;
+                var raw = new byte[chunkRows * chunkCols * sizeof(float)];
+                for (var r = 0; r < chunkRows; r++)
+                {
+                    for (var c = 0; c < chunkCols; c++)
+                    {
+                        var globalRow = startRow + r;
+                        var globalCol = startCol + c;
+                        var value = (globalRow < rows && globalCol < cols) ? sample(globalRow, globalCol) : 0f;
+                        var offset = (r * chunkCols + c) * sizeof(float);
+                        var bytes = BitConverter.GetBytes(value);
+                        Buffer.BlockCopy(bytes, 0, raw, offset, sizeof(float));
+                    }
+                }
+
+                var chunkKey = arrayRoot + "/" + cr.ToString(CultureInfo.InvariantCulture) + "." + cc.ToString(CultureInfo.InvariantCulture);
+                if (compress)
+                {
+                    using var output = new MemoryStream();
+                    using (var deflate = new ZLibStream(output, CompressionLevel.Optimal, leaveOpen: true))
+                    {
+                        deflate.Write(raw, 0, raw.Length);
+                    }
+                    objects[chunkKey] = output.ToArray();
+                }
+                else
+                {
+                    objects[chunkKey] = raw;
+                }
+            }
+        }
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrFixtureBuilder.cs
+++ b/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrFixtureBuilder.cs
@@ -109,6 +109,13 @@ internal static class ZarrFixtureBuilder
         return objects;
     }
 
+    public static Dictionary<string, byte[]> BuildFilteredArray(string root)
+    {
+        var objects = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        objects[root + "/.zarray"] = Encoding.UTF8.GetBytes("{\"chunks\":[1],\"shape\":[1],\"dtype\":\"<f4\",\"order\":\"C\",\"compressor\":null,\"fill_value\":0,\"filters\":[{\"id\":\"delta\",\"dtype\":\"<f4\"}],\"zarr_format\":2}");
+        return objects;
+    }
+
     private static void AppendChunksFloat32(
         string arrayRoot,
         int rows,

--- a/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrMetadataExtractorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrMetadataExtractorTests.cs
@@ -104,4 +104,16 @@ public class ZarrMetadataExtractorTests
 
         (await act.Should().ThrowAsync<InvalidDataException>()).WithMessage("*Fortran*");
     }
+
+    [Fact]
+    public async Task ReadMetadataAsync_NonNullFilters_Rejected()
+    {
+        var objects = ZarrFixtureBuilder.BuildFilteredArray("stores/filtered");
+        var reader = new InMemoryZarrRangeReader(objects);
+        var extractor = new ZarrMetadataExtractor();
+
+        var act = () => extractor.ReadMetadataAsync(reader, "bucket", "stores/filtered");
+
+        (await act.Should().ThrowAsync<InvalidDataException>()).WithMessage("*filters*not supported*");
+    }
 }

--- a/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrMetadataExtractorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrMetadataExtractorTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Raster.ZarrParser;
+using Xunit;
+
+namespace Honua.Core.Tests.Raster.ZarrParser;
+
+public class ZarrMetadataExtractorTests
+{
+    [Fact]
+    public async Task ReadMetadataAsync_SingleArrayUncompressed_DiscoversShapeAndDtype()
+    {
+        var objects = ZarrFixtureBuilder.BuildSingleVariableUncompressed(
+            root: "stores/example",
+            rows: 8,
+            cols: 8,
+            chunkRows: 4,
+            chunkCols: 4,
+            sample: (r, c) => r * 10 + c);
+        var reader = new InMemoryZarrRangeReader(objects);
+        var extractor = new ZarrMetadataExtractor();
+
+        var metadata = await extractor.ReadMetadataAsync(reader, "bucket", "stores/example");
+
+        metadata.Arrays.Should().HaveCount(1);
+        var array = metadata.Arrays[0];
+        array.Name.Should().Be("example");
+        array.RelativePath.Should().BeEmpty();
+        array.Shape.Should().Equal(8, 8);
+        array.Chunks.Should().Equal(4, 4);
+        array.DataType.Should().Be("<f4");
+        array.Compressor.Should().BeNull();
+        metadata.ZarrFormat.Should().Be(ZarrFormatVersion.V2);
+        metadata.PrimaryVariable.Should().Be("example");
+    }
+
+    [Fact]
+    public async Task ReadMetadataAsync_GroupWithCrsAndExtent_PopulatesGeoreferencing()
+    {
+        var objects = ZarrFixtureBuilder.BuildGroupedZlib(
+            root: "stores/grouped",
+            rows: 8,
+            cols: 8,
+            chunkRows: 4,
+            chunkCols: 4,
+            sample: (r, c) => r + c,
+            srid: 4326,
+            xMin: -180,
+            yMin: -90,
+            xMax: 180,
+            yMax: 90);
+        var reader = new InMemoryZarrRangeReader(objects);
+        var extractor = new ZarrMetadataExtractor();
+
+        var metadata = await extractor.ReadMetadataAsync(reader, "bucket", "stores/grouped");
+
+        metadata.Srid.Should().Be(4326);
+        metadata.Extent.XMin.Should().Be(-180);
+        metadata.Extent.YMax.Should().Be(90);
+        metadata.PrimaryVariable.Should().Be("temperature");
+        metadata.Arrays.Should().HaveCount(1);
+        metadata.Arrays[0].RelativePath.Should().Be("temperature");
+        metadata.Arrays[0].Compressor.Should().Be("zlib");
+        metadata.Arrays[0].DimensionNames.Should().Equal("y", "x");
+    }
+
+    [Fact]
+    public async Task ReadMetadataAsync_InvalidJson_ThrowsInvalidData()
+    {
+        var objects = ZarrFixtureBuilder.BuildInvalidJson("stores/broken");
+        var reader = new InMemoryZarrRangeReader(objects);
+        var extractor = new ZarrMetadataExtractor();
+
+        var act = () => extractor.ReadMetadataAsync(reader, "bucket", "stores/broken");
+
+        await act.Should().ThrowAsync<InvalidDataException>();
+    }
+
+    [Fact]
+    public async Task ReadMetadataAsync_UnsupportedV3_Rejected()
+    {
+        var objects = ZarrFixtureBuilder.BuildUnsupportedV3("stores/v3");
+        var reader = new InMemoryZarrRangeReader(objects);
+        var extractor = new ZarrMetadataExtractor();
+
+        var act = () => extractor.ReadMetadataAsync(reader, "bucket", "stores/v3");
+
+        (await act.Should().ThrowAsync<InvalidDataException>()).WithMessage("*v3*");
+    }
+
+    [Fact]
+    public async Task ReadMetadataAsync_FortranOrder_Rejected()
+    {
+        var objects = ZarrFixtureBuilder.BuildFortranOrder("stores/fortran");
+        var reader = new InMemoryZarrRangeReader(objects);
+        var extractor = new ZarrMetadataExtractor();
+
+        var act = () => extractor.ReadMetadataAsync(reader, "bucket", "stores/fortran");
+
+        (await act.Should().ThrowAsync<InvalidDataException>()).WithMessage("*Fortran*");
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrSubsetReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrSubsetReaderTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Raster.ZarrParser;
+using Xunit;
+
+namespace Honua.Core.Tests.Raster.ZarrParser;
+
+public class ZarrSubsetReaderTests
+{
+    [Fact]
+    public async Task ReadSubsetAsync_UncompressedSpansMultipleChunks_ReturnsContiguousRowMajor()
+    {
+        var objects = ZarrFixtureBuilder.BuildSingleVariableUncompressed(
+            root: "datasets/temp",
+            rows: 8,
+            cols: 8,
+            chunkRows: 4,
+            chunkCols: 4,
+            sample: (r, c) => r * 100 + c);
+        var reader = new InMemoryZarrRangeReader(objects);
+        var metadata = await new ZarrMetadataExtractor().ReadMetadataAsync(reader, "bucket", "datasets/temp");
+
+        var request = new ZarrSubsetRequest
+        {
+            Variable = "temp",
+            Start = new[] { 2, 2 },
+            Stop = new[] { 6, 6 }
+        };
+
+        var subset = await new ZarrSubsetReader().ReadSubsetAsync(reader, "bucket", "datasets/temp", metadata, request);
+
+        subset.Shape.Should().Equal(4, 4);
+        subset.DataType.Should().Be("<f4");
+        subset.Data.Length.Should().Be(4 * 4 * sizeof(float));
+        for (var r = 0; r < 4; r++)
+        {
+            for (var c = 0; c < 4; c++)
+            {
+                var globalRow = r + 2;
+                var globalCol = c + 2;
+                var expected = (float)(globalRow * 100 + globalCol);
+                var actual = BitConverter.ToSingle(subset.Data, (r * 4 + c) * sizeof(float));
+                actual.Should().Be(expected, $"cell ({r},{c}) should reflect global ({globalRow},{globalCol})");
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ReadSubsetAsync_ZlibCompressed_DecodesCorrectly()
+    {
+        var objects = ZarrFixtureBuilder.BuildGroupedZlib(
+            root: "datasets/grid",
+            rows: 8,
+            cols: 8,
+            chunkRows: 4,
+            chunkCols: 4,
+            sample: (r, c) => r + c * 0.5f,
+            srid: 4326,
+            xMin: 0,
+            yMin: 0,
+            xMax: 8,
+            yMax: 8);
+        var reader = new InMemoryZarrRangeReader(objects);
+        var metadata = await new ZarrMetadataExtractor().ReadMetadataAsync(reader, "bucket", "datasets/grid");
+
+        var request = new ZarrSubsetRequest
+        {
+            Variable = "temperature",
+            Start = new[] { 0, 0 },
+            Stop = new[] { 5, 5 }
+        };
+
+        var subset = await new ZarrSubsetReader().ReadSubsetAsync(reader, "bucket", "datasets/grid", metadata, request);
+
+        subset.Shape.Should().Equal(5, 5);
+        for (var r = 0; r < 5; r++)
+        {
+            for (var c = 0; c < 5; c++)
+            {
+                var expected = r + c * 0.5f;
+                var actual = BitConverter.ToSingle(subset.Data, (r * 5 + c) * sizeof(float));
+                actual.Should().Be(expected);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ReadSubsetAsync_OutOfBounds_Throws()
+    {
+        var objects = ZarrFixtureBuilder.BuildSingleVariableUncompressed(
+            root: "datasets/bounds",
+            rows: 4,
+            cols: 4,
+            chunkRows: 4,
+            chunkCols: 4,
+            sample: (r, c) => 0f);
+        var reader = new InMemoryZarrRangeReader(objects);
+        var metadata = await new ZarrMetadataExtractor().ReadMetadataAsync(reader, "bucket", "datasets/bounds");
+
+        var request = new ZarrSubsetRequest
+        {
+            Variable = "bounds",
+            Start = new[] { 0, 0 },
+            Stop = new[] { 5, 5 }
+        };
+
+        var act = () => new ZarrSubsetReader().ReadSubsetAsync(reader, "bucket", "datasets/bounds", metadata, request);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Coverages/Multidimensional/MultidimensionalCoverageEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Coverages/Multidimensional/MultidimensionalCoverageEndpointTests.cs
@@ -50,7 +50,7 @@ public class MultidimensionalCoverageEndpointTests : IAsyncLifetime
             variables = Array.Empty<string>()
         };
 
-        var response = await _client.PostAsJsonAsync(Route, request);
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/multidim-coverages", request);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
@@ -140,7 +140,7 @@ public class MultidimensionalCoverageEndpointTests : IAsyncLifetime
     [Endpoint("GET /api/v1/admin/multidim-coverages")]
     public async Task List_WithoutLayerId_Returns400()
     {
-        var response = await _client.GetAsync(Route);
+        var response = await _client.GetAsync("/api/v1/admin/multidim-coverages");
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
@@ -149,7 +149,7 @@ public class MultidimensionalCoverageEndpointTests : IAsyncLifetime
     [Endpoint("GET /api/v1/admin/multidim-coverages/{id}")]
     public async Task Get_WithNonexistentId_Returns404()
     {
-        var response = await _client.GetAsync($"{Route}/99999");
+        var response = await _client.GetAsync("/api/v1/admin/multidim-coverages/99999");
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
@@ -158,7 +158,7 @@ public class MultidimensionalCoverageEndpointTests : IAsyncLifetime
     [Endpoint("DELETE /api/v1/admin/multidim-coverages/{id}")]
     public async Task Delete_WithNonexistentId_Returns404()
     {
-        var response = await _client.DeleteAsync($"{Route}/99999");
+        var response = await _client.DeleteAsync("/api/v1/admin/multidim-coverages/99999");
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
@@ -251,7 +251,7 @@ public class MultidimensionalCoverageEndpointTests : IAsyncLifetime
     [Endpoint("POST /api/v1/admin/multidim-coverages/{id}/refresh")]
     public async Task Refresh_WithNonexistentId_Returns404()
     {
-        var response = await _client.PostAsync($"{Route}/99999/refresh", null);
+        var response = await _client.PostAsync("/api/v1/admin/multidim-coverages/99999/refresh", null);
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Zarr/ZarrEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Zarr/ZarrEndpointTests.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+
+namespace Honua.Server.Tests.Features.Protocols.Zarr;
+
+/// <summary>
+/// Integration tests for Zarr admin endpoints (#1009).
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Zarr)]
+[Operation(Operations.ZarrAdmin)]
+public class ZarrEndpointTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/zarr-stores")]
+    public async Task RegisterZarr_WithMissingName_Returns400()
+    {
+        var request = new
+        {
+            layerId = 1,
+            name = string.Empty,
+            provider = "AwsS3",
+            bucket = "test-bucket",
+            rootPath = "datasets/example"
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/zarr-stores", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/zarr-stores")]
+    public async Task RegisterZarr_WithTraversalRootPath_Returns400()
+    {
+        var request = new
+        {
+            layerId = 1,
+            name = "bad-path",
+            provider = "AwsS3",
+            bucket = "test-bucket",
+            rootPath = "../etc/passwd"
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/zarr-stores", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/zarr-stores")]
+    public async Task RegisterZarr_WithMissingLayer_Returns404()
+    {
+        var request = new
+        {
+            layerId = 99999,
+            name = "missing-layer-zarr",
+            provider = "AwsS3",
+            bucket = "test-bucket",
+            rootPath = "missing-layer.zarr"
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/zarr-stores", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/zarr-stores")]
+    public async Task ListZarr_WithoutLayerId_Returns400()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/zarr-stores");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/zarr-stores/{id}")]
+    public async Task GetZarr_WithNonexistentId_Returns404()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/zarr-stores/99999");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Endpoint("DELETE /api/v1/admin/zarr-stores/{id}")]
+    public async Task DeleteZarr_WithNonexistentId_Returns404()
+    {
+        var response = await _client.DeleteAsync("/api/v1/admin/zarr-stores/99999");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/zarr-stores/{id}/refresh")]
+    public async Task RefreshZarr_WithNonexistentId_Returns404()
+    {
+        var response = await _client.PostAsync("/api/v1/admin/zarr-stores/99999/refresh", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/zarr-stores")]
+    public async Task ZarrCrud_RegisterListGetDelete_Lifecycle()
+    {
+        var request = new
+        {
+            layerId = 1,
+            name = "lifecycle-test-zarr",
+            description = "Integration test Zarr store",
+            provider = "AwsS3",
+            bucket = "test-bucket",
+            rootPath = "datasets/lifecycle.zarr"
+        };
+
+        var createResponse = await _client.PostAsJsonAsync("/api/v1/admin/zarr-stores", request);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        using var createDoc = JsonDocument.Parse(await createResponse.Content.ReadAsStringAsync());
+        var id = createDoc.RootElement.GetProperty("id").GetInt64();
+        id.Should().BeGreaterThan(0);
+        createDoc.RootElement.GetProperty("name").GetString().Should().Be("lifecycle-test-zarr");
+        createDoc.RootElement.GetProperty("rootPath").GetString().Should().Be("datasets/lifecycle.zarr");
+
+        var listResponse = await _client.GetAsync("/api/v1/admin/zarr-stores?layerId=1");
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var listDoc = JsonDocument.Parse(await listResponse.Content.ReadAsStringAsync());
+        listDoc.RootElement.GetArrayLength().Should().BeGreaterOrEqualTo(1);
+        listDoc.RootElement.EnumerateArray()
+            .Should().Contain(e => e.GetProperty("id").GetInt64() == id);
+
+        var getResponse = await _client.GetAsync($"/api/v1/admin/zarr-stores/{id}");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var deleteResponse = await _client.DeleteAsync($"/api/v1/admin/zarr-stores/{id}");
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var afterDeleteResponse = await _client.GetAsync($"/api/v1/admin/zarr-stores/{id}");
+        afterDeleteResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Constants/Operations.cs
+++ b/tests/dotnet/Honua.TestKit/Constants/Operations.cs
@@ -157,6 +157,9 @@ public static class Operations
     // COG Operations
     public const string CogAdmin = "CogAdmin";
 
+    // Zarr Operations
+    public const string ZarrAdmin = "ZarrAdmin";
+
     // STAC Operations
     public const string StacCatalog = "StacCatalog";
     public const string StacSearch = "StacSearch";

--- a/tests/dotnet/Honua.TestKit/Constants/Protocols.cs
+++ b/tests/dotnet/Honua.TestKit/Constants/Protocols.cs
@@ -95,6 +95,11 @@ public static class Protocols
     public const string Cog = "Cog";
 
     /// <summary>
+    /// Zarr coverage registration and metadata endpoints.
+    /// </summary>
+    public const string Zarr = "Zarr";
+
+    /// <summary>
     /// Infrastructure and cross-cutting concerns.
     /// </summary>
     public const string Infrastructure = "Infrastructure";


### PR DESCRIPTION
## Issue Link
Fixes #1009

## Summary
Adds read-only Zarr v2 support through the shared raster/coverage pipeline rather than a protocol-local reader. Ships a pure-managed, AOT-safe metadata extractor and bounded chunk-aligned subset reader (uncompressed + zlib), wires `/api/v1/admin/zarr-stores` admin endpoints mirroring the COG surface, and documents the MVP support matrix in `docs/gis/raster-overview.md`.

## Changes Made
- Core domain models (`ZarrModels.cs`): format version, array/store metadata, registration records, subset request/result.
- `IZarrMetadataReader` + `ZarrMetadataExtractor`: pure-managed Zarr v2 reader driven by shared `ICloudRangeReader`; discovers single-array roots and grouped stores via a `variables` manifest, reads `.zarray`/`.zattrs`/`_ARRAY_DIMENSIONS` and georeferencing hints; rejects v3, big-endian, Fortran order, and structured dtypes.
- `IZarrSubsetReader` + `ZarrSubsetReader`: rank-aware bounded subset reads, chunk-aligned, uncompressed + zlib (`ZLibStream`), 4096-chunk / 256-MiB caps.
- `IZarrStore` + `InMemoryZarrStore`: catalog abstraction with uniqueness guard (Postgres persistence deferred).
- Admin endpoints `/api/v1/admin/zarr-stores` (POST/GET/GET-id/DELETE/POST-refresh) wired via `ZarrServiceCollectionExtensions` and `FeatureRegistrationExtensions`, registered in `EndpointRegistry`, structured logging (event IDs 7920-7925), AOT-safe `ZarrJsonContext`.
- Tests: synthetic Zarr fixtures + `InMemoryZarrRangeReader`; 8 core tests (metadata discovery, georeferencing, invalid JSON, v3 rejection, Fortran rejection, multi-chunk uncompressed subset, zlib subset, out-of-bounds) and 8 server integration tests (validation, traversal rejection, missing layer, lifecycle).
- Docs: `docs/gis/raster-overview.md` — status-table row plus Zarr section covering endpoints, support matrix, object-storage layout, deployment notes.

### Deferred (per issue split guidance)
- Postgres-backed `IZarrStore` persistence (today: in-memory).
- STAC / OGC API Coverages / Maps / Tiles / ImageServer surfacing of Zarr-backed layers.
- Additional codecs (`blosc`, `gzip`, `lz4`, `zstd`) and filter pipelines.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran \`scripts/ci/pre-pr-check.sh\` and all checks passed
- [x] Commit messages follow conventional format: \`type: description (#issue)\`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review