### PR TITLE
ci: narrow Core/Postgres shard routing

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -1,10 +1,20 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
-  "_comment": "Single source of truth for the Honua.Server.Tests shard matrix. Owned by ADR-0037. Each entry under `shards` carries both routing fields (`paths`) and matrix-runtime fields (`shard_name`, `artifact_suffix`, `log_name`, `timeout_minutes`, `test_timeout_minutes`, `max_cpu_count`, `upload_operator_eval_report`, `upload_odata_evidence`, `filter`). The `targeted-shards` job in ci.yml reads this file, runs scripts/ci/honua-server-targeted-tests.sh to pick the active shards for the diff, and emits a filtered `matrix_include` that ci.yml::server-tests consumes via `strategy.matrix.include: fromJson(...)`. `timeout_minutes` is the GitHub runner job cap; `test_timeout_minutes` is the inner dotnet-test cap used by scripts/ci/run-server-test-shard.sh so logs and timing artifacts are uploaded before the runner is cancelled. `infrastructure_paths` short-circuits to run_all on first match. `unmapped_source_run_all_prefixes` forces run_all when a changed file under one of those prefixes is not matched by any shard's `paths` — this prevents new feature directories from silently routing to the Core shard whose filter excludes Honua.Server.Tests.Features.*. `default_shards_when_no_match` is only consulted when no source code under those prefixes was touched (e.g. doc-only diffs).",
+  "_comment": "Single source of truth for the Honua.Server.Tests shard matrix. Owned by ADR-0037. Each entry under `shards` carries both routing fields (`paths`) and matrix-runtime fields (`shard_name`, `artifact_suffix`, `log_name`, `timeout_minutes`, `test_timeout_minutes`, `max_cpu_count`, `upload_operator_eval_report`, `upload_odata_evidence`, `filter`). The `targeted-shards` job in ci.yml reads this file, runs scripts/ci/honua-server-targeted-tests.sh to pick the active shards for the diff, and emits a filtered `matrix_include` that ci.yml::server-tests consumes via `strategy.matrix.include: fromJson(...)`. `timeout_minutes` is the GitHub runner job cap; `test_timeout_minutes` is the inner dotnet-test cap used by scripts/ci/run-server-test-shard.sh so logs and timing artifacts are uploaded before the runner is cancelled. `infrastructure_paths` short-circuits to run_all on first match. Keep infrastructure paths limited to shared CI/runtime wiring; feature-slice Core/Postgres paths should be mapped to shard `paths` instead of forcing run_all. `unmapped_source_run_all_prefixes` forces run_all when a changed file under one of those prefixes is not matched by any shard's `paths` — this prevents new feature directories from silently routing to the Core shard whose filter excludes Honua.Server.Tests.Features.*. `default_shards_when_no_match` is only consulted when no source code under those prefixes was touched (e.g. doc-only diffs).",
   "infrastructure_paths": [
     "tests/dotnet/Honua.TestKit/",
-    "src/Honua.Core/",
-    "src/Honua.Postgres/",
+    "src/Honua.Core/Honua.Core.csproj",
+    "src/Honua.Core/Configuration/",
+    "src/Honua.Core/Exceptions/",
+    "src/Honua.Core/Features/Infrastructure/",
+    "src/Honua.Core/Features/Shared/",
+    "src/Honua.Core/Models/",
+    "src/Honua.Core/Queries/",
+    "src/Honua.Postgres/Honua.Postgres.csproj",
+    "src/Honua.Postgres/ServiceCollectionExtensions.cs",
+    "src/Honua.Postgres/Features/Infrastructure/",
+    "src/Honua.Postgres/Migrations/",
+    "src/Honua.Postgres/Queries/",
     "src/Honua.ServiceDefaults/",
     "src/Honua.Server/Features/Infrastructure/",
     "Honua.sln",
@@ -12,6 +22,8 @@
     "scripts/ci/"
   ],
   "unmapped_source_run_all_prefixes": [
+    "src/Honua.Core/",
+    "src/Honua.Postgres/",
     "src/Honua.Server/",
     "src/Honua.DuckDB/",
     "tests/dotnet/Honua.Server.Tests/"
@@ -30,6 +42,8 @@
       "upload_odata_evidence": false,
       "filter": "FullyQualifiedName!~Honua.Server.Tests.Features.&FullyQualifiedName!~Honua.Server.Tests.Import.&FullyQualifiedName!~Honua.Server.Tests.Performance.&FullyQualifiedName!~Honua.Server.Tests.Comprehensive.&FullyQualifiedName!~Honua.Server.Tests.Admin.&FullyQualifiedName!~Honua.Server.Tests.Infrastructure.&FullyQualifiedName!~Honua.Server.Tests.Cloud.&FullyQualifiedName!~Honua.Server.Tests.Features.Protocols.Cog&FullyQualifiedName!~Honua.Server.Tests.Contract.&FullyQualifiedName!~Honua.Server.Tests.AdminEndpointTests",
       "paths": [
+        "src/Honua.Core/Features/Metadata/",
+        "src/Honua.Postgres/Features/Metadata/",
         "tests/dotnet/Honua.Server.Tests/Helpers/",
         "tests/dotnet/Honua.Server.Tests/TestData/",
         "tests/dotnet/Honua.Server.Tests/AdvancedSpatialQueryTests.cs",
@@ -64,6 +78,8 @@
       "upload_odata_evidence": false,
       "filter": "FullyQualifiedName~Honua.Server.Tests.Admin.|FullyQualifiedName~Honua.Server.Tests.Infrastructure.|FullyQualifiedName~Honua.Server.Tests.AdminEndpointTests",
       "paths": [
+        "src/Honua.Core/Features/Admin/",
+        "src/Honua.Postgres/Features/Admin/",
         "src/Honua.Server/Features/Admin/",
         "tests/dotnet/Honua.Server.Tests/Admin/",
         "tests/dotnet/Honua.Server.Tests/AdminEndpointTests.cs",
@@ -102,7 +118,11 @@
       "upload_odata_evidence": false,
       "filter": "FullyQualifiedName~Honua.Server.Tests.Import.",
       "paths": [
+        "src/Honua.Core/Features/Import/",
+        "src/Honua.Postgres/Features/Import/",
         "src/Honua.Server/Features/Import/",
+        "tests/dotnet/Honua.Core.Tests/Features/Import/",
+        "tests/dotnet/Honua.Postgres.Tests/Features/Import/",
         "tests/dotnet/Honua.Server.Tests/Import/"
       ]
     },

--- a/scripts/ci/honua-server-targeted-tests.sh
+++ b/scripts/ci/honua-server-targeted-tests.sh
@@ -8,9 +8,10 @@
 #      {"run_all": true, "reason": "no_changed_files"} so a manual replay still
 #      exercises the full matrix.
 #   2. When the diff touches a path under `infrastructure_paths` in
-#      ci-shards.json (TestKit, Honua.Core, Honua.Postgres,
-#      Honua.ServiceDefaults, src/Honua.Server/Features/Infrastructure/,
-#      Honua.sln, .github/, scripts/ci/), emit
+#      ci-shards.json (TestKit, Core/Postgres project and shared
+#      infrastructure paths, Honua.ServiceDefaults,
+#      src/Honua.Server/Features/Infrastructure/, Honua.sln, .github/,
+#      scripts/ci/), emit
 #      {"run_all": true, "reason": "infrastructure_change"}.
 #   3. Otherwise, walk every changed file, match it against shard `paths`
 #      prefixes, and union the shard names that claim it.


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1087

## Summary
Narrows targeted server-test routing so Core/Postgres feature-slice changes no longer force the full server shard matrix unless they touch shared infrastructure.

## Changes Made
- Replaced blanket Core/Postgres infrastructure prefixes with narrower shared infrastructure, project, and service-registration paths.
- Routed Core/Postgres import paths to the Import shard, admin publishing paths to Admin & Infrastructure, and metadata paths to Core.
- Updated targeted shard selector comments to match the new routing contract.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:
- `jq empty .github/ci-shards.json`
- `scripts/ci/honua-server-targeted-tests.sh --stdin` for Core Import, Postgres Import, Admin+Import mixed, Metadata V2, Core Shared, and unmapped Server feature paths
- `git diff --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Focused local validation completed; full `scripts/ci/pre-pr-check.sh` remains delegated to this PR CI because this PR changes CI routing.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
