### PR TITLE
feat: scaffold migration acceptance suite — artifact contracts (#1024 slice 1)

### DIFF
--- a/src/Honua.Core/Features/Import/Domain/MigrationCutoverReadinessAttestationArtifact.cs
+++ b/src/Honua.Core/Features/Import/Domain/MigrationCutoverReadinessAttestationArtifact.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Deterministic cutover-readiness attestation emitted by the migration
+/// acceptance evidence suite. One artifact is produced per fixture run and
+/// summarizes the fidelity classification counts the acceptance gate inspects
+/// before allowing a release-level migration claim.
+/// </summary>
+/// <remarks>
+/// This artifact is intentionally minimal. It is the contract that ties the
+/// release-gated workflow runs (see <c>migration-acceptance.yml</c>) back to
+/// the per-source artifact chain produced by the upstream import slices.
+/// Schema changes here are observed by the artifact schema stability test
+/// suite and must be co-ordinated with the workflow consumers.
+/// </remarks>
+public sealed record MigrationCutoverReadinessAttestationArtifact
+{
+    /// <summary>
+    /// Stable artifact kind identifier.
+    /// </summary>
+    public string ArtifactKind { get; init; } = "honua.migration.cutover-readiness-attestation";
+
+    /// <summary>
+    /// Artifact schema version.
+    /// </summary>
+    public string ArtifactVersion { get; init; } = "1.0";
+
+    /// <summary>
+    /// Stable run identifier supplied by the workflow or release gate
+    /// (for example a GitHub Actions <c>run_id</c>).
+    /// </summary>
+    public required string RunId { get; init; }
+
+    /// <summary>
+    /// Stable source identifier whose fidelity is being attested. This is
+    /// typically the source-inventory artifact's <c>source.displayName</c>
+    /// slug or a workflow-supplied identifier.
+    /// </summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>
+    /// Source kind identifier such as <c>geoserver-rest</c> or
+    /// <c>arcgis-geoservices-rest</c>.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Stable fixture identifier the attestation was generated against
+    /// (for example <c>geoserver-public-pilot</c> or
+    /// <c>arcgis-anonymous-baseline</c>).
+    /// </summary>
+    public required string FixtureName { get; init; }
+
+    /// <summary>
+    /// UTC timestamp the attestation was generated. Stored as a normalized
+    /// ISO-8601 string so the artifact remains stable across serializers.
+    /// </summary>
+    public required string GeneratedAtUtc { get; init; }
+
+    /// <summary>
+    /// Aggregate fidelity classification counts inspected by the acceptance
+    /// suite gate.
+    /// </summary>
+    public required MigrationCutoverReadinessClassificationCounts ClassificationCounts { get; init; }
+}
+
+/// <summary>
+/// Aggregate fidelity classification counts for a migration cutover-readiness
+/// attestation. Counts mirror the automation statuses defined by
+/// <see cref="MigrationFidelityAutomationStatuses"/>.
+/// </summary>
+public sealed record MigrationCutoverReadinessClassificationCounts
+{
+    /// <summary>
+    /// Number of source classifications that can be carried by the current
+    /// automated migration path.
+    /// </summary>
+    public int Automated { get; init; }
+
+    /// <summary>
+    /// Number of source classifications that need assisted operator input
+    /// after import.
+    /// </summary>
+    public int Assisted { get; init; }
+
+    /// <summary>
+    /// Number of source classifications captured only for explicit operator
+    /// review.
+    /// </summary>
+    public int ManualReview { get; init; }
+
+    /// <summary>
+    /// Number of source classifications that are unsupported by this
+    /// migration slice.
+    /// </summary>
+    public int Unsupported { get; init; }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationArtifactSchemaSnapshots/honua.migration.cutover-readiness-attestation.schema.json
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationArtifactSchemaSnapshots/honua.migration.cutover-readiness-attestation.schema.json
@@ -1,0 +1,106 @@
+{
+  "TypeName": "MigrationCutoverReadinessAttestationArtifact",
+  "Properties": [
+    {
+      "JsonName": "artifactKind",
+      "ClrName": "ArtifactKind",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": false,
+      "Nullable": false
+    },
+    {
+      "JsonName": "artifactVersion",
+      "ClrName": "ArtifactVersion",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": false,
+      "Nullable": false
+    },
+    {
+      "JsonName": "classificationCounts",
+      "ClrName": "ClassificationCounts",
+      "Container": "scalar",
+      "ElementType": "MigrationCutoverReadinessClassificationCounts",
+      "Required": true,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationCutoverReadinessClassificationCounts",
+        "Properties": [
+          {
+            "JsonName": "assisted",
+            "ClrName": "Assisted",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "automated",
+            "ClrName": "Automated",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "manualReview",
+            "ClrName": "ManualReview",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "unsupported",
+            "ClrName": "Unsupported",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "fixtureName",
+      "ClrName": "FixtureName",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": true,
+      "Nullable": false
+    },
+    {
+      "JsonName": "generatedAtUtc",
+      "ClrName": "GeneratedAtUtc",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": true,
+      "Nullable": false
+    },
+    {
+      "JsonName": "runId",
+      "ClrName": "RunId",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": true,
+      "Nullable": false
+    },
+    {
+      "JsonName": "sourceId",
+      "ClrName": "SourceId",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": true,
+      "Nullable": false
+    },
+    {
+      "JsonName": "sourceKind",
+      "ClrName": "SourceKind",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": true,
+      "Nullable": false
+    }
+  ]
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationArtifactSchemaSnapshots/honua.migration.manifest.schema.json
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationArtifactSchemaSnapshots/honua.migration.manifest.schema.json
@@ -1,0 +1,1090 @@
+{
+  "TypeName": "MigrationManifestArtifact",
+  "Properties": [
+    {
+      "JsonName": "artifactKind",
+      "ClrName": "ArtifactKind",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": false,
+      "Nullable": false
+    },
+    {
+      "JsonName": "artifactVersion",
+      "ClrName": "ArtifactVersion",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": false,
+      "Nullable": false
+    },
+    {
+      "JsonName": "fidelityMatrix",
+      "ClrName": "FidelityMatrix",
+      "Container": "scalar",
+      "ElementType": "MigrationFidelityMatrix",
+      "Required": false,
+      "Nullable": true,
+      "Schema": {
+        "TypeName": "MigrationFidelityMatrix",
+        "Properties": [
+          {
+            "JsonName": "cells",
+            "ClrName": "Cells",
+            "Container": "array",
+            "ElementType": "MigrationFidelityMatrixCell",
+            "Required": false,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationFidelityMatrixCell",
+              "Properties": [
+                {
+                  "JsonName": "automationStatus",
+                  "ClrName": "AutomationStatus",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "category",
+                  "ClrName": "Category",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "codes",
+                  "ClrName": "Codes",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "count",
+                  "ClrName": "Count",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "kinds",
+                  "ClrName": "Kinds",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "manualSteps",
+                  "ClrName": "ManualSteps",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "relatedIds",
+                  "ClrName": "RelatedIds",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "sourceIds",
+                  "ClrName": "SourceIds",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "targetIds",
+                  "ClrName": "TargetIds",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "summary",
+            "ClrName": "Summary",
+            "Container": "scalar",
+            "ElementType": "MigrationFidelityMatrixSummary",
+            "Required": false,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationFidelityMatrixSummary",
+              "Properties": [
+                {
+                  "JsonName": "assistedCount",
+                  "ClrName": "AssistedCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "automatedCount",
+                  "ClrName": "AutomatedCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "manualReviewCount",
+                  "ClrName": "ManualReviewCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "totalCount",
+                  "ClrName": "TotalCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "unsupportedCount",
+                  "ClrName": "UnsupportedCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": false
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "identityRemaps",
+      "ClrName": "IdentityRemaps",
+      "Container": "array",
+      "ElementType": "MigrationManifestIdentityRemap",
+      "Required": false,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationManifestIdentityRemap",
+        "Properties": [
+          {
+            "JsonName": "action",
+            "ClrName": "Action",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "sourceId",
+            "ClrName": "SourceId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "sourceKind",
+            "ClrName": "SourceKind",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "targetId",
+            "ClrName": "TargetId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "targetKind",
+            "ClrName": "TargetKind",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "targetName",
+            "ClrName": "TargetName",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "manualReviewItems",
+      "ClrName": "ManualReviewItems",
+      "Container": "array",
+      "ElementType": "MigrationManifestReviewItem",
+      "Required": false,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationManifestReviewItem",
+        "Properties": [
+          {
+            "JsonName": "code",
+            "ClrName": "Code",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "kind",
+            "ClrName": "Kind",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "manualSteps",
+            "ClrName": "ManualSteps",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "reason",
+            "ClrName": "Reason",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "severity",
+            "ClrName": "Severity",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "sourceId",
+            "ClrName": "SourceId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "warnings",
+            "ClrName": "Warnings",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "servicePlans",
+      "ClrName": "ServicePlans",
+      "Container": "array",
+      "ElementType": "MigrationManifestServicePlan",
+      "Required": false,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationManifestServicePlan",
+        "Properties": [
+          {
+            "JsonName": "action",
+            "ClrName": "Action",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "compatibility",
+            "ClrName": "Compatibility",
+            "Container": "scalar",
+            "ElementType": "MigrationCompatibilityAssessment",
+            "Required": true,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationCompatibilityAssessment",
+              "Properties": [
+                {
+                  "JsonName": "code",
+                  "ClrName": "Code",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "level",
+                  "ClrName": "Level",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "manualSteps",
+                  "ClrName": "ManualSteps",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "reason",
+                  "ClrName": "Reason",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "warnings",
+                  "ClrName": "Warnings",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "externalDependencyIds",
+            "ClrName": "ExternalDependencyIds",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "resourceIds",
+            "ClrName": "ResourceIds",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "serviceType",
+            "ClrName": "ServiceType",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "sourceContainerId",
+            "ClrName": "SourceContainerId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "sourceKind",
+            "ClrName": "SourceKind",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "styleIds",
+            "ClrName": "StyleIds",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "targetServiceName",
+            "ClrName": "TargetServiceName",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "source",
+      "ClrName": "Source",
+      "Container": "scalar",
+      "ElementType": "MigrationSourceIdentity",
+      "Required": true,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationSourceIdentity",
+        "Properties": [
+          {
+            "JsonName": "baseUrl",
+            "ClrName": "BaseUrl",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "build",
+            "ClrName": "Build",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "displayName",
+            "ClrName": "DisplayName",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "product",
+            "ClrName": "Product",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "serviceType",
+            "ClrName": "ServiceType",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "version",
+            "ClrName": "Version",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "sourceArtifactKind",
+      "ClrName": "SourceArtifactKind",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": false,
+      "Nullable": false
+    },
+    {
+      "JsonName": "sourceArtifactVersion",
+      "ClrName": "SourceArtifactVersion",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": false,
+      "Nullable": false
+    },
+    {
+      "JsonName": "sourceKind",
+      "ClrName": "SourceKind",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": true,
+      "Nullable": false
+    },
+    {
+      "JsonName": "styleActions",
+      "ClrName": "StyleActions",
+      "Container": "array",
+      "ElementType": "MigrationManifestStyleAction",
+      "Required": false,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationManifestStyleAction",
+        "Properties": [
+          {
+            "JsonName": "action",
+            "ClrName": "Action",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "compatibility",
+            "ClrName": "Compatibility",
+            "Container": "scalar",
+            "ElementType": "MigrationCompatibilityAssessment",
+            "Required": true,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationCompatibilityAssessment",
+              "Properties": [
+                {
+                  "JsonName": "code",
+                  "ClrName": "Code",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "level",
+                  "ClrName": "Level",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "manualSteps",
+                  "ClrName": "ManualSteps",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "reason",
+                  "ClrName": "Reason",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "warnings",
+                  "ClrName": "Warnings",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "externalDependencyIds",
+            "ClrName": "ExternalDependencyIds",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "format",
+            "ClrName": "Format",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "resourceIds",
+            "ClrName": "ResourceIds",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "sourceStyleId",
+            "ClrName": "SourceStyleId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "targetStyleId",
+            "ClrName": "TargetStyleId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "summary",
+      "ClrName": "Summary",
+      "Container": "scalar",
+      "ElementType": "MigrationManifestSummary",
+      "Required": true,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationManifestSummary",
+        "Properties": [
+          {
+            "JsonName": "manualReviewCount",
+            "ClrName": "ManualReviewCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "servicePlanCount",
+            "ClrName": "ServicePlanCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "sourceResourceCount",
+            "ClrName": "SourceResourceCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "styleActionCount",
+            "ClrName": "StyleActionCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "targetResourceCount",
+            "ClrName": "TargetResourceCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "unsupportedCount",
+            "ClrName": "UnsupportedCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "targetResources",
+      "ClrName": "TargetResources",
+      "Container": "array",
+      "ElementType": "MigrationManifestTargetResource",
+      "Required": false,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationManifestTargetResource",
+        "Properties": [
+          {
+            "JsonName": "action",
+            "ClrName": "Action",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "capabilities",
+            "ClrName": "Capabilities",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "compatibility",
+            "ClrName": "Compatibility",
+            "Container": "scalar",
+            "ElementType": "MigrationCompatibilityAssessment",
+            "Required": true,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationCompatibilityAssessment",
+              "Properties": [
+                {
+                  "JsonName": "code",
+                  "ClrName": "Code",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "level",
+                  "ClrName": "Level",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "manualSteps",
+                  "ClrName": "ManualSteps",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "reason",
+                  "ClrName": "Reason",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "warnings",
+                  "ClrName": "Warnings",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "externalDependencyIds",
+            "ClrName": "ExternalDependencyIds",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "fields",
+            "ClrName": "Fields",
+            "Container": "array",
+            "ElementType": "MigrationInventoryField",
+            "Required": false,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationInventoryField",
+              "Properties": [
+                {
+                  "JsonName": "alias",
+                  "ClrName": "Alias",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "domainName",
+                  "ClrName": "DomainName",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "domainType",
+                  "ClrName": "DomainType",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "domainValues",
+                  "ClrName": "DomainValues",
+                  "Container": "array",
+                  "ElementType": "MigrationInventoryCodedValue",
+                  "Required": false,
+                  "Nullable": true,
+                  "Schema": {
+                    "TypeName": "MigrationInventoryCodedValue",
+                    "Properties": [
+                      {
+                        "JsonName": "code",
+                        "ClrName": "Code",
+                        "Container": "scalar",
+                        "ElementType": "string",
+                        "Required": true,
+                        "Nullable": false
+                      },
+                      {
+                        "JsonName": "name",
+                        "ClrName": "Name",
+                        "Container": "scalar",
+                        "ElementType": "string",
+                        "Required": true,
+                        "Nullable": false
+                      }
+                    ]
+                  }
+                },
+                {
+                  "JsonName": "fieldType",
+                  "ClrName": "FieldType",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "name",
+                  "ClrName": "Name",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "nullable",
+                  "ClrName": "Nullable",
+                  "Container": "scalar",
+                  "ElementType": "bool",
+                  "Required": false,
+                  "Nullable": true
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "geometryType",
+            "ClrName": "GeometryType",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "migrationMode",
+            "ClrName": "MigrationMode",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "sourceKind",
+            "ClrName": "SourceKind",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "sourceProtocol",
+            "ClrName": "SourceProtocol",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "sourceResourceId",
+            "ClrName": "SourceResourceId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "spatialReferences",
+            "ClrName": "SpatialReferences",
+            "Container": "array",
+            "ElementType": "MigrationSpatialReferenceInfo",
+            "Required": false,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationSpatialReferenceInfo",
+              "Properties": [
+                {
+                  "JsonName": "axisOrder",
+                  "ClrName": "AxisOrder",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "crsUri",
+                  "ClrName": "CrsUri",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "datum",
+                  "ClrName": "Datum",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "isGeographic",
+                  "ClrName": "IsGeographic",
+                  "Container": "scalar",
+                  "ElementType": "bool",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "role",
+                  "ClrName": "Role",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "sourceValue",
+                  "ClrName": "SourceValue",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "srid",
+                  "ClrName": "Srid",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "unit",
+                  "ClrName": "Unit",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "styleIds",
+            "ClrName": "StyleIds",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "targetResourceId",
+            "ClrName": "TargetResourceId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "targetResourceName",
+            "ClrName": "TargetResourceName",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "targetServiceName",
+            "ClrName": "TargetServiceName",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "unsupportedItems",
+      "ClrName": "UnsupportedItems",
+      "Container": "array",
+      "ElementType": "MigrationManifestReviewItem",
+      "Required": false,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationManifestReviewItem",
+        "Properties": [
+          {
+            "JsonName": "code",
+            "ClrName": "Code",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "kind",
+            "ClrName": "Kind",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "manualSteps",
+            "ClrName": "ManualSteps",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "reason",
+            "ClrName": "Reason",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "severity",
+            "ClrName": "Severity",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "sourceId",
+            "ClrName": "SourceId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "warnings",
+            "ClrName": "Warnings",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationArtifactSchemaSnapshots/honua.migration.parity-evidence-pack.schema.json
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationArtifactSchemaSnapshots/honua.migration.parity-evidence-pack.schema.json
@@ -1,0 +1,557 @@
+{
+  "TypeName": "MigrationParityEvidenceArtifact",
+  "Properties": [
+    {
+      "JsonName": "artifactKind",
+      "ClrName": "ArtifactKind",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": false,
+      "Nullable": false
+    },
+    {
+      "JsonName": "artifactVersion",
+      "ClrName": "ArtifactVersion",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": false,
+      "Nullable": false
+    },
+    {
+      "JsonName": "cutoverReadiness",
+      "ClrName": "CutoverReadiness",
+      "Container": "scalar",
+      "ElementType": "MigrationCutoverReadinessSummary",
+      "Required": true,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationCutoverReadinessSummary",
+        "Properties": [
+          {
+            "JsonName": "items",
+            "ClrName": "Items",
+            "Container": "array",
+            "ElementType": "MigrationCutoverReadinessItem",
+            "Required": false,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationCutoverReadinessItem",
+              "Properties": [
+                {
+                  "JsonName": "evidence",
+                  "ClrName": "Evidence",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "id",
+                  "ClrName": "Id",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "owner",
+                  "ClrName": "Owner",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "remediation",
+                  "ClrName": "Remediation",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "state",
+                  "ClrName": "State",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "title",
+                  "ClrName": "Title",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "state",
+            "ClrName": "State",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "manifestAvailable",
+      "ClrName": "ManifestAvailable",
+      "Container": "scalar",
+      "ElementType": "bool",
+      "Required": false,
+      "Nullable": false
+    },
+    {
+      "JsonName": "overallState",
+      "ClrName": "OverallState",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": true,
+      "Nullable": false
+    },
+    {
+      "JsonName": "performanceCost",
+      "ClrName": "PerformanceCost",
+      "Container": "scalar",
+      "ElementType": "MigrationPerformanceCostEvidence",
+      "Required": false,
+      "Nullable": true,
+      "Schema": {
+        "TypeName": "MigrationPerformanceCostEvidence",
+        "Properties": [
+          {
+            "JsonName": "artifactKind",
+            "ClrName": "ArtifactKind",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "artifactVersion",
+            "ClrName": "ArtifactVersion",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "evidenceReferences",
+            "ClrName": "EvidenceReferences",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "measurementScope",
+            "ClrName": "MeasurementScope",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "operations",
+            "ClrName": "Operations",
+            "Container": "array",
+            "ElementType": "MigrationPerformanceCostOperation",
+            "Required": false,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationPerformanceCostOperation",
+              "Properties": [
+                {
+                  "JsonName": "artifactSizeBytes",
+                  "ClrName": "ArtifactSizeBytes",
+                  "Container": "scalar",
+                  "ElementType": "long",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "bytesRead",
+                  "ClrName": "BytesRead",
+                  "Container": "scalar",
+                  "ElementType": "long",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "bytesWritten",
+                  "ClrName": "BytesWritten",
+                  "Container": "scalar",
+                  "ElementType": "long",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "durationMilliseconds",
+                  "ClrName": "DurationMilliseconds",
+                  "Container": "scalar",
+                  "ElementType": "long",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "evidenceReferences",
+                  "ClrName": "EvidenceReferences",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "featureCount",
+                  "ClrName": "FeatureCount",
+                  "Container": "scalar",
+                  "ElementType": "long",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "id",
+                  "ClrName": "Id",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "manualReviewCount",
+                  "ClrName": "ManualReviewCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "resourceCount",
+                  "ClrName": "ResourceCount",
+                  "Container": "scalar",
+                  "ElementType": "long",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "retryCount",
+                  "ClrName": "RetryCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "sourceRequestCount",
+                  "ClrName": "SourceRequestCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "stage",
+                  "ClrName": "Stage",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "state",
+                  "ClrName": "State",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "state",
+            "ClrName": "State",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "summary",
+            "ClrName": "Summary",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "totals",
+            "ClrName": "Totals",
+            "Container": "scalar",
+            "ElementType": "MigrationPerformanceCostTotals",
+            "Required": true,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationPerformanceCostTotals",
+              "Properties": [
+                {
+                  "JsonName": "artifactSizeBytes",
+                  "ClrName": "ArtifactSizeBytes",
+                  "Container": "scalar",
+                  "ElementType": "long",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "bytesRead",
+                  "ClrName": "BytesRead",
+                  "Container": "scalar",
+                  "ElementType": "long",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "bytesWritten",
+                  "ClrName": "BytesWritten",
+                  "Container": "scalar",
+                  "ElementType": "long",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "durationMilliseconds",
+                  "ClrName": "DurationMilliseconds",
+                  "Container": "scalar",
+                  "ElementType": "long",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "featureCount",
+                  "ClrName": "FeatureCount",
+                  "Container": "scalar",
+                  "ElementType": "long",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "manualReviewCount",
+                  "ClrName": "ManualReviewCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "resourceCount",
+                  "ClrName": "ResourceCount",
+                  "Container": "scalar",
+                  "ElementType": "long",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "retryCount",
+                  "ClrName": "RetryCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "sourceRequestCount",
+                  "ClrName": "SourceRequestCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": true
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "sections",
+      "ClrName": "Sections",
+      "Container": "array",
+      "ElementType": "MigrationParityEvidenceSection",
+      "Required": false,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationParityEvidenceSection",
+        "Properties": [
+          {
+            "JsonName": "id",
+            "ClrName": "Id",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "items",
+            "ClrName": "Items",
+            "Container": "array",
+            "ElementType": "MigrationParityEvidenceItem",
+            "Required": false,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationParityEvidenceItem",
+              "Properties": [
+                {
+                  "JsonName": "evidence",
+                  "ClrName": "Evidence",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "id",
+                  "ClrName": "Id",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "relatedIds",
+                  "ClrName": "RelatedIds",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "remediation",
+                  "ClrName": "Remediation",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "state",
+                  "ClrName": "State",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "summary",
+                  "ClrName": "Summary",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "state",
+            "ClrName": "State",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "title",
+            "ClrName": "Title",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "source",
+      "ClrName": "Source",
+      "Container": "scalar",
+      "ElementType": "MigrationSourceIdentity",
+      "Required": true,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationSourceIdentity",
+        "Properties": [
+          {
+            "JsonName": "baseUrl",
+            "ClrName": "BaseUrl",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "build",
+            "ClrName": "Build",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "displayName",
+            "ClrName": "DisplayName",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "product",
+            "ClrName": "Product",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "serviceType",
+            "ClrName": "ServiceType",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "version",
+            "ClrName": "Version",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "sourceKind",
+      "ClrName": "SourceKind",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": true,
+      "Nullable": false
+    },
+    {
+      "JsonName": "summary",
+      "ClrName": "Summary",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": true,
+      "Nullable": false
+    }
+  ]
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationArtifactSchemaSnapshots/honua.migration.source-inventory.schema.json
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationArtifactSchemaSnapshots/honua.migration.source-inventory.schema.json
@@ -1,0 +1,1350 @@
+{
+  "TypeName": "MigrationSourceInventoryArtifact",
+  "Properties": [
+    {
+      "JsonName": "artifactKind",
+      "ClrName": "ArtifactKind",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": false,
+      "Nullable": false
+    },
+    {
+      "JsonName": "artifactVersion",
+      "ClrName": "ArtifactVersion",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": false,
+      "Nullable": false
+    },
+    {
+      "JsonName": "authPosture",
+      "ClrName": "AuthPosture",
+      "Container": "scalar",
+      "ElementType": "MigrationInventoryAuthPosture",
+      "Required": true,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationInventoryAuthPosture",
+        "Properties": [
+          {
+            "JsonName": "accessConfirmed",
+            "ClrName": "AccessConfirmed",
+            "Container": "scalar",
+            "ElementType": "bool",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "credentialsSupplied",
+            "ClrName": "CredentialsSupplied",
+            "Container": "scalar",
+            "ElementType": "bool",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "mode",
+            "ClrName": "Mode",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "notes",
+            "ClrName": "Notes",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "containers",
+      "ClrName": "Containers",
+      "Container": "array",
+      "ElementType": "MigrationInventoryContainer",
+      "Required": false,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationInventoryContainer",
+        "Properties": [
+          {
+            "JsonName": "compatibility",
+            "ClrName": "Compatibility",
+            "Container": "scalar",
+            "ElementType": "MigrationCompatibilityAssessment",
+            "Required": true,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationCompatibilityAssessment",
+              "Properties": [
+                {
+                  "JsonName": "code",
+                  "ClrName": "Code",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "level",
+                  "ClrName": "Level",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "manualSteps",
+                  "ClrName": "ManualSteps",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "reason",
+                  "ClrName": "Reason",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "warnings",
+                  "ClrName": "Warnings",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "description",
+            "ClrName": "Description",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "id",
+            "ClrName": "Id",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "isDefault",
+            "ClrName": "IsDefault",
+            "Container": "scalar",
+            "ElementType": "bool",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "kind",
+            "ClrName": "Kind",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "name",
+            "ClrName": "Name",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "title",
+            "ClrName": "Title",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "externalDependencies",
+      "ClrName": "ExternalDependencies",
+      "Container": "array",
+      "ElementType": "MigrationExternalDependency",
+      "Required": false,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationExternalDependency",
+        "Properties": [
+          {
+            "JsonName": "address",
+            "ClrName": "Address",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "compatibility",
+            "ClrName": "Compatibility",
+            "Container": "scalar",
+            "ElementType": "MigrationCompatibilityAssessment",
+            "Required": true,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationCompatibilityAssessment",
+              "Properties": [
+                {
+                  "JsonName": "code",
+                  "ClrName": "Code",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "level",
+                  "ClrName": "Level",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "manualSteps",
+                  "ClrName": "ManualSteps",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "reason",
+                  "ClrName": "Reason",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "warnings",
+                  "ClrName": "Warnings",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "containerId",
+            "ClrName": "ContainerId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "dependencyType",
+            "ClrName": "DependencyType",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "id",
+            "ClrName": "Id",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "kind",
+            "ClrName": "Kind",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "metadata",
+            "ClrName": "Metadata",
+            "Container": "map",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "name",
+            "ClrName": "Name",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "resourceId",
+            "ClrName": "ResourceId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "spatialReferences",
+            "ClrName": "SpatialReferences",
+            "Container": "array",
+            "ElementType": "MigrationSpatialReferenceInfo",
+            "Required": false,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationSpatialReferenceInfo",
+              "Properties": [
+                {
+                  "JsonName": "axisOrder",
+                  "ClrName": "AxisOrder",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "crsUri",
+                  "ClrName": "CrsUri",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "datum",
+                  "ClrName": "Datum",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "isGeographic",
+                  "ClrName": "IsGeographic",
+                  "Container": "scalar",
+                  "ElementType": "bool",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "role",
+                  "ClrName": "Role",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "sourceValue",
+                  "ClrName": "SourceValue",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "srid",
+                  "ClrName": "Srid",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "unit",
+                  "ClrName": "Unit",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "fidelityClassifications",
+      "ClrName": "FidelityClassifications",
+      "Container": "array",
+      "ElementType": "MigrationFidelityClassificationRecord",
+      "Required": false,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationFidelityClassificationRecord",
+        "Properties": [
+          {
+            "JsonName": "automationStatus",
+            "ClrName": "AutomationStatus",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "category",
+            "ClrName": "Category",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "code",
+            "ClrName": "Code",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "id",
+            "ClrName": "Id",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "kind",
+            "ClrName": "Kind",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "manualSteps",
+            "ClrName": "ManualSteps",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "metadata",
+            "ClrName": "Metadata",
+            "Container": "map",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "name",
+            "ClrName": "Name",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "reason",
+            "ClrName": "Reason",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "relatedIds",
+            "ClrName": "RelatedIds",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "sourceId",
+            "ClrName": "SourceId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "targetId",
+            "ClrName": "TargetId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "targetKind",
+            "ClrName": "TargetKind",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "targetName",
+            "ClrName": "TargetName",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "fidelityMatrix",
+      "ClrName": "FidelityMatrix",
+      "Container": "scalar",
+      "ElementType": "MigrationFidelityMatrix",
+      "Required": false,
+      "Nullable": true,
+      "Schema": {
+        "TypeName": "MigrationFidelityMatrix",
+        "Properties": [
+          {
+            "JsonName": "cells",
+            "ClrName": "Cells",
+            "Container": "array",
+            "ElementType": "MigrationFidelityMatrixCell",
+            "Required": false,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationFidelityMatrixCell",
+              "Properties": [
+                {
+                  "JsonName": "automationStatus",
+                  "ClrName": "AutomationStatus",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "category",
+                  "ClrName": "Category",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "codes",
+                  "ClrName": "Codes",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "count",
+                  "ClrName": "Count",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "kinds",
+                  "ClrName": "Kinds",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "manualSteps",
+                  "ClrName": "ManualSteps",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "relatedIds",
+                  "ClrName": "RelatedIds",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "sourceIds",
+                  "ClrName": "SourceIds",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "targetIds",
+                  "ClrName": "TargetIds",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "summary",
+            "ClrName": "Summary",
+            "Container": "scalar",
+            "ElementType": "MigrationFidelityMatrixSummary",
+            "Required": false,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationFidelityMatrixSummary",
+              "Properties": [
+                {
+                  "JsonName": "assistedCount",
+                  "ClrName": "AssistedCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "automatedCount",
+                  "ClrName": "AutomatedCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "manualReviewCount",
+                  "ClrName": "ManualReviewCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "totalCount",
+                  "ClrName": "TotalCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "unsupportedCount",
+                  "ClrName": "UnsupportedCount",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": false
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "overallCompatibility",
+      "ClrName": "OverallCompatibility",
+      "Container": "scalar",
+      "ElementType": "MigrationCompatibilityAssessment",
+      "Required": true,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationCompatibilityAssessment",
+        "Properties": [
+          {
+            "JsonName": "code",
+            "ClrName": "Code",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "level",
+            "ClrName": "Level",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "manualSteps",
+            "ClrName": "ManualSteps",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "reason",
+            "ClrName": "Reason",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "warnings",
+            "ClrName": "Warnings",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "resources",
+      "ClrName": "Resources",
+      "Container": "array",
+      "ElementType": "MigrationInventoryResource",
+      "Required": false,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationInventoryResource",
+        "Properties": [
+          {
+            "JsonName": "capabilities",
+            "ClrName": "Capabilities",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "compatibility",
+            "ClrName": "Compatibility",
+            "Container": "scalar",
+            "ElementType": "MigrationCompatibilityAssessment",
+            "Required": true,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationCompatibilityAssessment",
+              "Properties": [
+                {
+                  "JsonName": "code",
+                  "ClrName": "Code",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "level",
+                  "ClrName": "Level",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "manualSteps",
+                  "ClrName": "ManualSteps",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "reason",
+                  "ClrName": "Reason",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "warnings",
+                  "ClrName": "Warnings",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "containerId",
+            "ClrName": "ContainerId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "description",
+            "ClrName": "Description",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "externalDependencyIds",
+            "ClrName": "ExternalDependencyIds",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "featureCount",
+            "ClrName": "FeatureCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "fields",
+            "ClrName": "Fields",
+            "Container": "array",
+            "ElementType": "MigrationInventoryField",
+            "Required": false,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationInventoryField",
+              "Properties": [
+                {
+                  "JsonName": "alias",
+                  "ClrName": "Alias",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "domainName",
+                  "ClrName": "DomainName",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "domainType",
+                  "ClrName": "DomainType",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "domainValues",
+                  "ClrName": "DomainValues",
+                  "Container": "array",
+                  "ElementType": "MigrationInventoryCodedValue",
+                  "Required": false,
+                  "Nullable": true,
+                  "Schema": {
+                    "TypeName": "MigrationInventoryCodedValue",
+                    "Properties": [
+                      {
+                        "JsonName": "code",
+                        "ClrName": "Code",
+                        "Container": "scalar",
+                        "ElementType": "string",
+                        "Required": true,
+                        "Nullable": false
+                      },
+                      {
+                        "JsonName": "name",
+                        "ClrName": "Name",
+                        "Container": "scalar",
+                        "ElementType": "string",
+                        "Required": true,
+                        "Nullable": false
+                      }
+                    ]
+                  }
+                },
+                {
+                  "JsonName": "fieldType",
+                  "ClrName": "FieldType",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "name",
+                  "ClrName": "Name",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "nullable",
+                  "ClrName": "Nullable",
+                  "Container": "scalar",
+                  "ElementType": "bool",
+                  "Required": false,
+                  "Nullable": true
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "geometryType",
+            "ClrName": "GeometryType",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "hasAttachments",
+            "ClrName": "HasAttachments",
+            "Container": "scalar",
+            "ElementType": "bool",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "id",
+            "ClrName": "Id",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "kind",
+            "ClrName": "Kind",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "name",
+            "ClrName": "Name",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "spatialReferences",
+            "ClrName": "SpatialReferences",
+            "Container": "array",
+            "ElementType": "MigrationSpatialReferenceInfo",
+            "Required": false,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationSpatialReferenceInfo",
+              "Properties": [
+                {
+                  "JsonName": "axisOrder",
+                  "ClrName": "AxisOrder",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "crsUri",
+                  "ClrName": "CrsUri",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "datum",
+                  "ClrName": "Datum",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "isGeographic",
+                  "ClrName": "IsGeographic",
+                  "Container": "scalar",
+                  "ElementType": "bool",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "role",
+                  "ClrName": "Role",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "sourceValue",
+                  "ClrName": "SourceValue",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "srid",
+                  "ClrName": "Srid",
+                  "Container": "scalar",
+                  "ElementType": "int",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "unit",
+                  "ClrName": "Unit",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "styleIds",
+            "ClrName": "StyleIds",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "title",
+            "ClrName": "Title",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "scanCompleteness",
+      "ClrName": "ScanCompleteness",
+      "Container": "scalar",
+      "ElementType": "MigrationInventoryCompleteness",
+      "Required": true,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationInventoryCompleteness",
+        "Properties": [
+          {
+            "JsonName": "missingArtifacts",
+            "ClrName": "MissingArtifacts",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "status",
+            "ClrName": "Status",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "warnings",
+            "ClrName": "Warnings",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "source",
+      "ClrName": "Source",
+      "Container": "scalar",
+      "ElementType": "MigrationSourceIdentity",
+      "Required": true,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationSourceIdentity",
+        "Properties": [
+          {
+            "JsonName": "baseUrl",
+            "ClrName": "BaseUrl",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "build",
+            "ClrName": "Build",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "displayName",
+            "ClrName": "DisplayName",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "product",
+            "ClrName": "Product",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "serviceType",
+            "ClrName": "ServiceType",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "version",
+            "ClrName": "Version",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "sourceKind",
+      "ClrName": "SourceKind",
+      "Container": "scalar",
+      "ElementType": "string",
+      "Required": true,
+      "Nullable": false
+    },
+    {
+      "JsonName": "styles",
+      "ClrName": "Styles",
+      "Container": "array",
+      "ElementType": "MigrationInventoryStyle",
+      "Required": false,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationInventoryStyle",
+        "Properties": [
+          {
+            "JsonName": "compatibility",
+            "ClrName": "Compatibility",
+            "Container": "scalar",
+            "ElementType": "MigrationCompatibilityAssessment",
+            "Required": true,
+            "Nullable": false,
+            "Schema": {
+              "TypeName": "MigrationCompatibilityAssessment",
+              "Properties": [
+                {
+                  "JsonName": "code",
+                  "ClrName": "Code",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": true
+                },
+                {
+                  "JsonName": "level",
+                  "ClrName": "Level",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "manualSteps",
+                  "ClrName": "ManualSteps",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "reason",
+                  "ClrName": "Reason",
+                  "Container": "scalar",
+                  "ElementType": "string",
+                  "Required": true,
+                  "Nullable": false
+                },
+                {
+                  "JsonName": "warnings",
+                  "ClrName": "Warnings",
+                  "Container": "array",
+                  "ElementType": "string",
+                  "Required": false,
+                  "Nullable": false
+                }
+              ]
+            }
+          },
+          {
+            "JsonName": "containerId",
+            "ClrName": "ContainerId",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "externalDependencyIds",
+            "ClrName": "ExternalDependencyIds",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "format",
+            "ClrName": "Format",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": true
+          },
+          {
+            "JsonName": "id",
+            "ClrName": "Id",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "kind",
+            "ClrName": "Kind",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "metadata",
+            "ClrName": "Metadata",
+            "Container": "map",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "name",
+            "ClrName": "Name",
+            "Container": "scalar",
+            "ElementType": "string",
+            "Required": true,
+            "Nullable": false
+          },
+          {
+            "JsonName": "resourceIds",
+            "ClrName": "ResourceIds",
+            "Container": "array",
+            "ElementType": "string",
+            "Required": false,
+            "Nullable": false
+          }
+        ]
+      }
+    },
+    {
+      "JsonName": "summary",
+      "ClrName": "Summary",
+      "Container": "scalar",
+      "ElementType": "MigrationInventorySummary",
+      "Required": true,
+      "Nullable": false,
+      "Schema": {
+        "TypeName": "MigrationInventorySummary",
+        "Properties": [
+          {
+            "JsonName": "compatibleCount",
+            "ClrName": "CompatibleCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "containerCount",
+            "ClrName": "ContainerCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "externalDependencyCount",
+            "ClrName": "ExternalDependencyCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "incompatibleCount",
+            "ClrName": "IncompatibleCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "partiallyCompatibleCount",
+            "ClrName": "PartiallyCompatibleCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "resourceCount",
+            "ClrName": "ResourceCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          },
+          {
+            "JsonName": "styleCount",
+            "ClrName": "StyleCount",
+            "Container": "scalar",
+            "ElementType": "int",
+            "Required": false,
+            "Nullable": false
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationArtifactSchemaStabilityTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationArtifactSchemaStabilityTests.cs
@@ -1,0 +1,333 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Tests.Features.Import;
+
+/// <summary>
+/// Pins the public JSON shape of migration acceptance suite artifacts. When an
+/// upstream slice (issues #1015 / #1016 / #1017 / #1018 and friends) adds a
+/// field, the developer must regenerate the snapshot in
+/// <c>MigrationArtifactSchemaSnapshots/</c> alongside the change so the
+/// acceptance-suite contract is updated deliberately.
+/// </summary>
+public sealed class MigrationArtifactSchemaStabilityTests
+{
+    private static readonly JsonSerializerOptions SnapshotJsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    [Theory]
+    [InlineData(typeof(MigrationSourceInventoryArtifact), "honua.migration.source-inventory.schema.json")]
+    [InlineData(typeof(MigrationManifestArtifact), "honua.migration.manifest.schema.json")]
+    [InlineData(typeof(MigrationParityEvidenceArtifact), "honua.migration.parity-evidence-pack.schema.json")]
+    [InlineData(typeof(MigrationCutoverReadinessAttestationArtifact), "honua.migration.cutover-readiness-attestation.schema.json")]
+    public void Artifact_Schema_Matches_GoldenSnapshot(Type artifactType, string snapshotFileName)
+    {
+        var schema = MigrationArtifactSchemaSnapshot.Capture(artifactType);
+        var actual = JsonSerializer.Serialize(schema, SnapshotJsonOptions);
+
+        var snapshotPath = ResolveSnapshotPath(snapshotFileName);
+
+        if (Environment.GetEnvironmentVariable("HONUA_TEST_UPDATE_SNAPSHOTS") == "1")
+        {
+            var sourceSnapshotPath = ResolveSourceSnapshotPath(snapshotFileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(sourceSnapshotPath)!);
+            File.WriteAllText(sourceSnapshotPath, actual + "\n");
+            Directory.CreateDirectory(Path.GetDirectoryName(snapshotPath)!);
+            File.WriteAllText(snapshotPath, actual + "\n");
+        }
+
+        File.Exists(snapshotPath).Should().BeTrue(
+            $"snapshot file '{snapshotPath}' should exist. " +
+            "To accept a deliberate artifact shape change, regenerate it by " +
+            "rerunning the test with HONUA_TEST_UPDATE_SNAPSHOTS=1 and committing " +
+            "the updated golden file.");
+
+        var expected = File.ReadAllText(snapshotPath);
+        NormalizeForCompare(actual).Should().Be(
+            NormalizeForCompare(expected),
+            $"the JSON shape of {artifactType.Name} must remain stable. " +
+            $"If this change is intentional, update '{snapshotFileName}' and " +
+            "co-ordinate the migration acceptance workflow consumers.");
+    }
+
+    private static string ResolveSnapshotPath(string fileName)
+    {
+        var baseDir = AppContext.BaseDirectory;
+        return Path.Combine(
+            baseDir,
+            "Features",
+            "Import",
+            "MigrationArtifactSchemaSnapshots",
+            fileName);
+    }
+
+    private static string ResolveSourceSnapshotPath(string fileName)
+    {
+        // Walk up from the test assembly output (bin/<config>/<tfm>) to the
+        // project root so the regenerated snapshot lands in source control.
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && current.Name != "Honua.Core.Tests")
+        {
+            current = current.Parent;
+        }
+
+        if (current is null)
+        {
+            throw new InvalidOperationException(
+                "Unable to locate the Honua.Core.Tests project directory from the test runtime.");
+        }
+
+        return Path.Combine(
+            current.FullName,
+            "Features",
+            "Import",
+            "MigrationArtifactSchemaSnapshots",
+            fileName);
+    }
+
+    private static string NormalizeForCompare(string value) =>
+        value.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd('\n');
+}
+
+/// <summary>
+/// Walks the property graph of a migration artifact record and emits a
+/// deterministic shape representation used by the schema stability tests.
+/// </summary>
+internal static class MigrationArtifactSchemaSnapshot
+{
+    public static SchemaNode Capture(Type artifactType) => CaptureType(artifactType, new HashSet<Type>());
+
+    private static SchemaNode CaptureType(Type type, HashSet<Type> visiting)
+    {
+        var node = new SchemaNode
+        {
+            TypeName = FormatTypeName(type)
+        };
+
+        if (IsRecordObject(type) && visiting.Add(type))
+        {
+            try
+            {
+                foreach (var property in EnumerateProperties(type))
+                {
+                    node.Properties ??= [];
+                    node.Properties.Add(BuildProperty(property, visiting));
+                }
+            }
+            finally
+            {
+                visiting.Remove(type);
+            }
+        }
+
+        return node;
+    }
+
+    private static SchemaProperty BuildProperty(PropertyInfo property, HashSet<Type> visiting)
+    {
+        var propertyType = property.PropertyType;
+        var isNullable = IsNullable(property);
+        var underlying = Nullable.GetUnderlyingType(propertyType);
+        if (underlying is not null)
+        {
+            propertyType = underlying;
+            isNullable = true;
+        }
+
+        var (elementType, container) = DescribeContainer(propertyType);
+        var shape = new SchemaProperty
+        {
+            JsonName = ResolveJsonName(property),
+            ClrName = property.Name,
+            Container = container,
+            ElementType = FormatTypeName(elementType),
+            Required = IsRequired(property),
+            Nullable = isNullable
+        };
+
+        if (IsRecordObject(elementType))
+        {
+            shape.Schema = CaptureType(elementType, visiting);
+        }
+
+        return shape;
+    }
+
+    private static IEnumerable<PropertyInfo> EnumerateProperties(Type type) =>
+        type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetIndexParameters().Length == 0 && p.CanRead)
+            .Where(p => p.GetCustomAttribute<JsonIgnoreAttribute>() is null)
+            .OrderBy(p => p.Name, StringComparer.Ordinal);
+
+    private static (Type ElementType, string Container) DescribeContainer(Type type)
+    {
+        if (type == typeof(string))
+        {
+            return (type, "scalar");
+        }
+
+        if (type.IsArray)
+        {
+            return (type.GetElementType()!, "array");
+        }
+
+        if (type.IsGenericType)
+        {
+            var def = type.GetGenericTypeDefinition();
+            if (def == typeof(IReadOnlyList<>) || def == typeof(IList<>) || def == typeof(List<>) ||
+                def == typeof(IEnumerable<>) || def == typeof(IReadOnlyCollection<>) || def == typeof(ICollection<>))
+            {
+                return (type.GetGenericArguments()[0], "array");
+            }
+
+            if (def == typeof(Dictionary<,>) || def == typeof(IReadOnlyDictionary<,>) || def == typeof(IDictionary<,>))
+            {
+                return (type.GetGenericArguments()[1], "map");
+            }
+        }
+
+        if (typeof(IEnumerable).IsAssignableFrom(type) && type != typeof(string))
+        {
+            return (typeof(object), "array");
+        }
+
+        return (type, "scalar");
+    }
+
+    private static bool IsRecordObject(Type type)
+    {
+        if (!type.IsClass || type == typeof(string))
+        {
+            return false;
+        }
+
+        if (typeof(IEnumerable).IsAssignableFrom(type))
+        {
+            return false;
+        }
+
+        // Records emit a compiler-generated Clone method (<Clone>$).
+        return type.GetMethod("<Clone>$", BindingFlags.Public | BindingFlags.Instance) is not null;
+    }
+
+    private static bool IsRequired(PropertyInfo property) =>
+        property.GetCustomAttribute<RequiredMemberAttribute>() is not null;
+
+    private static bool IsNullable(PropertyInfo property)
+    {
+        var context = new NullabilityInfoContext();
+        var info = context.Create(property);
+        return info.ReadState == NullabilityState.Nullable;
+    }
+
+    private static string ResolveJsonName(PropertyInfo property)
+    {
+        var explicitName = property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name;
+        if (!string.IsNullOrEmpty(explicitName))
+        {
+            return explicitName;
+        }
+
+        return JsonNamingPolicy.CamelCase.ConvertName(property.Name);
+    }
+
+    private static string FormatTypeName(Type type)
+    {
+        if (type == typeof(string))
+        {
+            return "string";
+        }
+
+        if (type == typeof(int) || type == typeof(int?))
+        {
+            return "int";
+        }
+
+        if (type == typeof(long) || type == typeof(long?))
+        {
+            return "long";
+        }
+
+        if (type == typeof(bool) || type == typeof(bool?))
+        {
+            return "bool";
+        }
+
+        if (type == typeof(double) || type == typeof(double?))
+        {
+            return "double";
+        }
+
+        if (type == typeof(decimal) || type == typeof(decimal?))
+        {
+            return "decimal";
+        }
+
+        if (type == typeof(DateTime) || type == typeof(DateTime?))
+        {
+            return "DateTime";
+        }
+
+        if (type == typeof(DateTimeOffset) || type == typeof(DateTimeOffset?))
+        {
+            return "DateTimeOffset";
+        }
+
+        if (type == typeof(object))
+        {
+            return "object";
+        }
+
+        var underlying = Nullable.GetUnderlyingType(type);
+        if (underlying is not null)
+        {
+            return FormatTypeName(underlying);
+        }
+
+        return type.Name;
+    }
+}
+
+internal sealed class SchemaNode
+{
+    [JsonPropertyOrder(0)]
+    public string TypeName { get; set; } = string.Empty;
+
+    [JsonPropertyOrder(1)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<SchemaProperty>? Properties { get; set; }
+}
+
+internal sealed class SchemaProperty
+{
+    [JsonPropertyOrder(0)]
+    public string JsonName { get; set; } = string.Empty;
+
+    [JsonPropertyOrder(1)]
+    public string ClrName { get; set; } = string.Empty;
+
+    [JsonPropertyOrder(2)]
+    public string Container { get; set; } = string.Empty;
+
+    [JsonPropertyOrder(3)]
+    public string ElementType { get; set; } = string.Empty;
+
+    [JsonPropertyOrder(4)]
+    public bool Required { get; set; }
+
+    [JsonPropertyOrder(5)]
+    public bool Nullable { get; set; }
+
+    [JsonPropertyOrder(6)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public SchemaNode? Schema { get; set; }
+}

--- a/tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj
+++ b/tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj
@@ -16,6 +16,9 @@
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Features\Import\MigrationArtifactSchemaSnapshots\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Issue Link

Related to #1024 — this PR ships the artifact-contract half of slice 1. The placeholder workflow YAML is split out to a small follow-up.

## Summary

Adds `MigrationCutoverReadinessAttestationArtifact` and golden-file schema stability tests pinning the public JSON shape of all four migration artifacts. Future upstream PRs that add fields must deliberately re-snapshot, preventing accidental contract drift while migration coverage lands (#1015/#1016/#1017/#1018/#1029/#1030/#1031/#1033). Recovered from a worktree agent that died on a socket error mid-run.

## Changes Made

- New `MigrationCutoverReadinessAttestationArtifact` capturing: classification-counts {automated, assisted, manual-review, unsupported}, source-id, fixture-name, run-id, timestamp
- New `MigrationArtifactSchemaStabilityTests` with golden snapshots for `source-inventory`, `manifest`, `parity-evidence-pack`, and `cutover-readiness-attestation` artifacts
- Updated `Honua.Core.Tests.csproj` to include snapshot resources

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes

None.

## Deferred (#1024 follow-on)

- Placeholder `migration-acceptance` workflow with per-source-family jobs (slice 1b)
- Wiring real fixture jobs into the workflow placeholders as #1015/#1016/#1017/#1018 etc. complete

---

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
