### PR TITLE
feat: count REST requests at HTTP boundary (#1097)

### DIFF
--- a/src/Honua.Core/Features/Import/ServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Import/ServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class ServiceCollectionExtensions
     {
         services.TryAddScoped<IFileFormatDetectionService, FileFormatDetectionService>();
         services.TryAddSingleton<IImportSchemaSuggestionService, ImportSchemaSuggestionService>();
+        services.TryAddTransient<MigrationRequestCountingHandler>();
         services.AddResilientHttpClient<OgcApiFeaturesMigrationScanner>(
             "ogc-api-features-migration",
             HttpResiliencePolicies.SlowServiceDefaults,
@@ -31,7 +32,8 @@ public static class ServiceCollectionExtensions
                 client.DefaultRequestHeaders.Add("User-Agent", "HonuaServer/1.0");
                 client.Timeout = TimeSpan.FromMinutes(2);
             },
-            configureHandler: static () => OgcApiFeaturesMigrationScanner.CreatePinnedDnsHttpMessageHandler());
+            configureHandler: static () => OgcApiFeaturesMigrationScanner.CreatePinnedDnsHttpMessageHandler())
+            .AddHttpMessageHandler<MigrationRequestCountingHandler>();
         services.TryAddScoped<IOgcApiFeaturesMigrationScanner>(serviceProvider =>
             serviceProvider.GetRequiredService<OgcApiFeaturesMigrationScanner>());
 

--- a/src/Honua.Core/Features/Import/Services/MigrationRequestCountingHandler.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationRequestCountingHandler.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Ambient flow that lets per-request HTTP handlers locate the <see cref="MigrationRunMetricsRecorder"/>
+/// associated with the active migration run without threading the recorder through every API.
+/// </summary>
+/// <remarks>
+/// The recorder is stored in an <see cref="AsyncLocal{T}"/>, so it follows the logical call chain across
+/// async hops. Callers wrap a migration phase with <see cref="PushRecorder(MigrationRunMetricsRecorder)"/>
+/// and dispose the returned scope when the phase ends. HTTP message handlers read the ambient recorder
+/// via <see cref="Current"/>.
+/// </remarks>
+public static class MigrationMetricsAmbient
+{
+    private static readonly AsyncLocal<MigrationRunMetricsRecorder?> CurrentRecorder = new();
+
+    /// <summary>Returns the recorder currently associated with the executing logical call context, if any.</summary>
+    public static MigrationRunMetricsRecorder? Current => CurrentRecorder.Value;
+
+    /// <summary>
+    /// Associates <paramref name="recorder"/> with the current logical call context. Dispose the returned
+    /// scope to restore the previously active recorder.
+    /// </summary>
+    public static Scope PushRecorder(MigrationRunMetricsRecorder recorder)
+    {
+        ArgumentNullException.ThrowIfNull(recorder);
+        var previous = CurrentRecorder.Value;
+        CurrentRecorder.Value = recorder;
+        return new Scope(previous);
+    }
+
+    /// <summary>Disposable scope returned by <see cref="PushRecorder(MigrationRunMetricsRecorder)"/>.</summary>
+    public readonly struct Scope : IDisposable
+    {
+        private readonly MigrationRunMetricsRecorder? _previous;
+
+        internal Scope(MigrationRunMetricsRecorder? previous)
+        {
+            _previous = previous;
+        }
+
+        /// <summary>Restores the previously active recorder.</summary>
+        public void Dispose() => CurrentRecorder.Value = _previous;
+    }
+}
+
+/// <summary>
+/// <see cref="DelegatingHandler"/> that records one source request — and, when cheap to read, the response
+/// payload byte count — with the ambient <see cref="MigrationRunMetricsRecorder"/> for every HTTP call
+/// flowing through the GeoServer/ArcGIS migration clients.
+/// </summary>
+/// <remarks>
+/// Mounted via <c>AddHttpMessageHandler&lt;MigrationRequestCountingHandler&gt;()</c> so the resilience
+/// pipeline can retry the inner request as needed and each physical send is counted. When no recorder is
+/// currently active (e.g. health probes or out-of-band calls) the handler simply forwards the request.
+/// </remarks>
+public sealed partial class MigrationRequestCountingHandler : DelegatingHandler
+{
+    private readonly ILogger<MigrationRequestCountingHandler> _logger;
+
+    /// <summary>Initializes a new <see cref="MigrationRequestCountingHandler"/>.</summary>
+    public MigrationRequestCountingHandler(ILogger<MigrationRequestCountingHandler> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var recorder = MigrationMetricsAmbient.Current;
+        HttpResponseMessage response;
+        try
+        {
+            response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Count the request even when it failed at the transport layer — the source still saw the load.
+            recorder?.RecordSourceRequest();
+            throw;
+        }
+
+        if (recorder is null)
+        {
+            return response;
+        }
+
+        var bytesRead = TryReadContentLength(response);
+        try
+        {
+            recorder.RecordSourceRequest(count: 1, bytesRead: bytesRead);
+        }
+        catch (Exception ex)
+        {
+            // Metrics recording must never affect the live import path.
+            LogRecordFailure(_logger, ex);
+        }
+
+        return response;
+    }
+
+    private static long TryReadContentLength(HttpResponseMessage response)
+    {
+        if (response.Content is null) return 0;
+        var headerLength = response.Content.Headers.ContentLength;
+        return headerLength is { } value && value > 0 ? value : 0;
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Failed to record migration source request metric; continuing without metric attribution.")]
+    private static partial void LogRecordFailure(ILogger logger, Exception exception);
+}

--- a/src/Honua.Core/Features/Import/Services/MigrationRunMetricsRecorder.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationRunMetricsRecorder.cs
@@ -78,13 +78,28 @@ public sealed class MigrationRunMetricsRecorder
     }
 
     /// <summary>Records a source request (typically HTTP) issued during the run.</summary>
-    public void RecordSourceRequest(long count = 1)
+    /// <param name="count">Number of requests to add (defaults to 1).</param>
+    /// <param name="bytesRead">
+    /// Optional bytes-read attribution for the request (e.g. response Content-Length). When greater
+    /// than zero, also increments the <see cref="MigrationRunMetricsValues.BytesRead"/> total so the
+    /// HTTP boundary can attribute payload size without forcing the caller to buffer the response.
+    /// </param>
+    public void RecordSourceRequest(long count = 1, long bytesRead = 0)
     {
-        if (count <= 0) return;
+        if (count <= 0 && bytesRead <= 0) return;
         lock (_gate)
         {
-            _sourceRequestCount += count;
-            CurrentPhase()?.AddSourceRequest(count);
+            if (count > 0)
+            {
+                _sourceRequestCount += count;
+                CurrentPhase()?.AddSourceRequest(count);
+            }
+
+            if (bytesRead > 0)
+            {
+                _bytesRead += bytesRead;
+                CurrentPhase()?.AddBytesRead(bytesRead);
+            }
         }
     }
 

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -327,7 +327,8 @@ internal static class ServiceCollectionExtensions
                 client.DefaultRequestHeaders.Add("User-Agent", "HonuaServer/1.0");
                 client.Timeout = TimeSpan.FromMinutes(5);
             },
-            configureHandler: static () => ArcGisRestClient.CreatePinnedDnsHttpMessageHandler());
+            configureHandler: static () => ArcGisRestClient.CreatePinnedDnsHttpMessageHandler())
+            .AddHttpMessageHandler<MigrationRequestCountingHandler>();
 
         // Register Geoservices import service
         services.AddScoped<IGeoservicesImportService, GeoservicesImportService>();
@@ -337,6 +338,7 @@ internal static class ServiceCollectionExtensions
         services.AddAutoDocsCore();
 
         // Register GeoServer REST client for GeoServer migration imports with resilience
+        services.TryAddTransient<MigrationRequestCountingHandler>();
         services.AddResilientHttpClient<GeoServerRestClient>(
             "geoserver-rest",
             HttpResiliencePolicies.SlowServiceDefaults,
@@ -345,7 +347,8 @@ internal static class ServiceCollectionExtensions
                 client.DefaultRequestHeaders.Add("User-Agent", "HonuaServer/1.0");
                 client.Timeout = TimeSpan.FromMinutes(5);
             },
-            configureHandler: static () => GeoServerRestClient.CreatePinnedDnsHttpMessageHandler());
+            configureHandler: static () => GeoServerRestClient.CreatePinnedDnsHttpMessageHandler())
+            .AddHttpMessageHandler<MigrationRequestCountingHandler>();
 
         // Register migration catalog writer used by apply-mode imports.
         services.AddScoped<IMigrationCatalogWriter, PostgresMigrationCatalogWriter>();
@@ -362,7 +365,8 @@ internal static class ServiceCollectionExtensions
                 client.DefaultRequestHeaders.Add("User-Agent", "HonuaServer/1.0");
                 client.Timeout = TimeSpan.FromMinutes(2);
             },
-            configureHandler: static () => OgcServiceMigrationScanner.CreatePinnedDnsHttpMessageHandler());
+            configureHandler: static () => OgcServiceMigrationScanner.CreatePinnedDnsHttpMessageHandler())
+            .AddHttpMessageHandler<MigrationRequestCountingHandler>();
         services.AddScoped<IOgcServiceMigrationScanner>(serviceProvider =>
             serviceProvider.GetRequiredService<OgcServiceMigrationScanner>());
 

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationRequestCountingHandlerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationRequestCountingHandlerTests.cs
@@ -1,0 +1,264 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Core.Tests.Features.Import;
+
+public sealed class MigrationRequestCountingHandlerTests
+{
+    [Fact]
+    public async Task SendAsync_WithAmbientRecorder_IncrementsSourceRequestPerCall()
+    {
+        var recorder = new MigrationRunMetricsRecorder();
+        var counting = new MigrationRequestCountingHandler(NullLogger<MigrationRequestCountingHandler>.Instance)
+        {
+            InnerHandler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("ok", Encoding.UTF8, "text/plain")
+            })
+        };
+
+        using var client = new HttpClient(counting);
+
+        using (MigrationMetricsAmbient.PushRecorder(recorder))
+        {
+            for (var i = 0; i < 4; i++)
+            {
+                using var response = await client.GetAsync("https://example.com/" + i);
+                response.StatusCode.Should().Be(HttpStatusCode.OK);
+            }
+        }
+
+        var totals = recorder.SnapshotTotals();
+        totals.SourceRequestCount.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task SendAsync_WithContentLength_RecordsBytesRead()
+    {
+        var recorder = new MigrationRunMetricsRecorder();
+        var counting = new MigrationRequestCountingHandler(NullLogger<MigrationRequestCountingHandler>.Instance)
+        {
+            InnerHandler = new StubHandler(_ =>
+            {
+                var content = new StringContent("hello-bytes", Encoding.UTF8, "text/plain");
+                // StringContent surfaces ContentLength automatically from the encoded payload.
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+            })
+        };
+
+        using var client = new HttpClient(counting);
+
+        using (MigrationMetricsAmbient.PushRecorder(recorder))
+        {
+            using var response = await client.GetAsync("https://example.com/payload");
+            response.Content.Headers.ContentLength.Should().BeGreaterThan(0);
+        }
+
+        var totals = recorder.SnapshotTotals();
+        totals.SourceRequestCount.Should().Be(1);
+        totals.BytesRead.Should().Be(Encoding.UTF8.GetByteCount("hello-bytes"));
+    }
+
+    [Fact]
+    public async Task SendAsync_WithoutAmbientRecorder_DoesNotThrow()
+    {
+        var counting = new MigrationRequestCountingHandler(NullLogger<MigrationRequestCountingHandler>.Instance)
+        {
+            InnerHandler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK))
+        };
+
+        using var client = new HttpClient(counting);
+
+        var act = async () =>
+        {
+            using var response = await client.GetAsync("https://example.com/no-recorder");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        };
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenTransportFails_StillCountsRequest()
+    {
+        var recorder = new MigrationRunMetricsRecorder();
+        var counting = new MigrationRequestCountingHandler(NullLogger<MigrationRequestCountingHandler>.Instance)
+        {
+            InnerHandler = new StubHandler(_ => throw new HttpRequestException("boom"))
+        };
+
+        using var client = new HttpClient(counting);
+
+        using (MigrationMetricsAmbient.PushRecorder(recorder))
+        {
+            var act = async () => await client.GetAsync("https://example.com/fail");
+            await act.Should().ThrowAsync<HttpRequestException>();
+        }
+
+        recorder.SnapshotTotals().SourceRequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DiscoveryThroughGeoServerRestClient_RecordsMultipleSourceRequests()
+    {
+        var recorder = new MigrationRunMetricsRecorder();
+        var counting = new MigrationRequestCountingHandler(NullLogger<MigrationRequestCountingHandler>.Instance)
+        {
+            InnerHandler = new MultiCallGeoServerHandler()
+        };
+
+        using var httpClient = new HttpClient(counting);
+        var client = new GeoServerRestClient(
+            httpClient,
+            NullLogger<GeoServerRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+
+        using (MigrationMetricsAmbient.PushRecorder(recorder))
+        {
+            var info = await client.DiscoverServiceAsync(
+                "https://example.com/geoserver/rest",
+                username: null,
+                password: null,
+                includeCompatibilityAnalysis: false,
+                includeStyleContent: false,
+                timeoutSeconds: 5,
+                maxRetryAttempts: 0,
+                allowUnsafeLocalUrls: false,
+                CancellationToken.None);
+
+            info.Workspaces.Should().NotBeEmpty();
+        }
+
+        var totals = recorder.SnapshotTotals();
+        totals.SourceRequestCount.Should().NotBeNull();
+        // version, settings, workspaces, per-workspace metadata/datastores/coveragestores/layers/layergroups/styles,
+        // styles index + per-workspace styles entries. The exact count depends on discovery internals; assert >1
+        // to guarantee we are counting at the HTTP boundary (per request), not once for the whole discovery.
+        totals.SourceRequestCount!.Value.Should().BeGreaterThan(1);
+    }
+
+    [Fact]
+    public async Task SendAsync_PerRunScoping_RecordersDoNotShareCounts()
+    {
+        var runA = new MigrationRunMetricsRecorder();
+        var runB = new MigrationRunMetricsRecorder();
+        var counting = new MigrationRequestCountingHandler(NullLogger<MigrationRequestCountingHandler>.Instance)
+        {
+            InnerHandler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK))
+        };
+        using var client = new HttpClient(counting);
+
+        using (MigrationMetricsAmbient.PushRecorder(runA))
+        {
+            using var responseA1 = await client.GetAsync("https://example.com/a/1");
+            using var responseA2 = await client.GetAsync("https://example.com/a/2");
+        }
+
+        using (MigrationMetricsAmbient.PushRecorder(runB))
+        {
+            using var responseB1 = await client.GetAsync("https://example.com/b/1");
+        }
+
+        // No ambient recorder — requests must not leak into either run.
+        using var responseOrphan = await client.GetAsync("https://example.com/orphan");
+
+        runA.SnapshotTotals().SourceRequestCount.Should().Be(2);
+        runB.SnapshotTotals().SourceRequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SendAsync_NoAmbientRecorder_DoesNotLeakIntoPreviouslyActiveRecorder()
+    {
+        var recorder = new MigrationRunMetricsRecorder();
+        var counting = new MigrationRequestCountingHandler(NullLogger<MigrationRequestCountingHandler>.Instance)
+        {
+            InnerHandler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK))
+        };
+        using var client = new HttpClient(counting);
+
+        using (MigrationMetricsAmbient.PushRecorder(recorder))
+        {
+            using var counted = await client.GetAsync("https://example.com/counted");
+        }
+
+        // After the scope is disposed, additional calls must not be attributed to the recorder.
+        using var uncounted = await client.GetAsync("https://example.com/uncounted");
+
+        recorder.SnapshotTotals().SourceRequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void PushRecorder_NestedScopes_RestorePreviousRecorderOnDispose()
+    {
+        var outer = new MigrationRunMetricsRecorder();
+        var inner = new MigrationRunMetricsRecorder();
+
+        MigrationMetricsAmbient.Current.Should().BeNull();
+        using (MigrationMetricsAmbient.PushRecorder(outer))
+        {
+            MigrationMetricsAmbient.Current.Should().BeSameAs(outer);
+            using (MigrationMetricsAmbient.PushRecorder(inner))
+            {
+                MigrationMetricsAmbient.Current.Should().BeSameAs(inner);
+            }
+
+            MigrationMetricsAmbient.Current.Should().BeSameAs(outer);
+        }
+
+        MigrationMetricsAmbient.Current.Should().BeNull();
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _factory;
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> factory)
+        {
+            _factory = factory;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_factory(request));
+    }
+
+    private sealed class MultiCallGeoServerHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+            var (contentType, payload) = path switch
+            {
+                "/geoserver/rest/about/version.xml" => ("application/xml", """
+                    <about>
+                      <resource name="GeoServer">
+                        <Version>2.28.0</Version>
+                      </resource>
+                    </about>
+                    """),
+                "/geoserver/rest/settings.json" => ("application/json", """{"global":{}}"""),
+                "/geoserver/rest/workspaces.json" => ("application/json", """{"workspaces":{"workspace":[{"name":"demo"}]}}"""),
+                "/geoserver/rest/workspaces/demo.json" => ("application/json", """{"workspace":{"name":"demo"}}"""),
+                "/geoserver/rest/workspaces/demo/datastores.json" => ("application/json", """{"dataStores":{"dataStore":""}}"""),
+                "/geoserver/rest/workspaces/demo/coveragestores.json" => ("application/json", """{"coverageStores":{"coverageStore":""}}"""),
+                "/geoserver/rest/workspaces/demo/layers.json" => ("application/json", """{"layers":{"layer":""}}"""),
+                "/geoserver/rest/layergroups.json" => ("application/json", """{"layerGroups":{"layerGroup":""}}"""),
+                "/geoserver/rest/workspaces/demo/layergroups.json" => ("application/json", """{"layerGroups":{"layerGroup":""}}"""),
+                "/geoserver/rest/styles.json" => ("application/json", """{"styles":{"style":""}}"""),
+                "/geoserver/rest/workspaces/demo/styles.json" => ("application/json", """{"styles":{"style":""}}"""),
+                _ => throw new InvalidOperationException($"Unexpected GeoServer request path: {path}")
+            };
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(payload, Encoding.UTF8, contentType)
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Issue Link

Closes #1097 — adds the HTTP-boundary REST request counter that ties into the migration metric schema delivered in slice 1 of #1033 (#1092).

## Summary

Adds a `DelegatingHandler` that records one source request — and, when the response advertises `Content-Length`, the response payload byte count — on the ambient `MigrationRunMetricsRecorder` for every HTTP call flowing through the GeoServer, ArcGIS, OGC service migration scanner, and OGC API Features migration scanner clients. Counts increment even when the transport fails so retries and partial loads remain visible on the migration metric schema.

## Changes Made

- New `MigrationMetricsAmbient` `AsyncLocal` scope and `MigrationRequestCountingHandler` in `Honua.Core.Features.Import.Services`
- Extends `MigrationRunMetricsRecorder.RecordSourceRequest` with an optional `bytesRead` attribution so the HTTP boundary doesn't have to buffer the response
- Mounts the handler on all four migration `HttpClient` pipelines (`geoserver-rest`, `arcgis-rest`, `ogc-service-migration`, `ogc-api-features-migration`)
- Unit tests cover success/failure counting, bytes-read attribution, per-run scoping (recorders never share counts), no-recorder safety, ambient scope restoration, and an end-to-end GeoServer discovery walkthrough that proves counting happens per HTTP call rather than once per logical operation

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

`dotnet test tests/dotnet/Honua.Core.Tests` → 1620/1620 passing.
`dotnet test tests/dotnet/Honua.Postgres.Tests` → 426/426 passing.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes

None.

## Follow-on work

Importers (`GeoServerImportService`, `ArcGisRestClient` callers, `OgcServiceMigrationScanner`, `OgcApiFeaturesMigrationScanner`) still need to call `MigrationMetricsAmbient.PushRecorder` at the start of each run so the counter has a target recorder. The handler is a no-op when no ambient recorder is set, so this PR can ship safely ahead of that wiring.

---

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
