### PR TITLE
feat: GeoTIFF/COG coverage import (#1030 slice 2/N)

### DIFF
--- a/src/Honua.Core/Features/Import/Abstractions/IOgcCoverageImportService.cs
+++ b/src/Honua.Core/Features/Import/Abstractions/IOgcCoverageImportService.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Abstractions;
+
+/// <summary>
+/// Imports OGC WCS / OGC API Coverages GeoTIFF/COG coverages into Honua's raster store
+/// using a slice-1 migration source inventory as the deterministic selection contract.
+/// </summary>
+public interface IOgcCoverageImportService
+{
+    /// <summary>
+    /// Build a deterministic migration manifest for the selected coverages and,
+    /// when <see cref="OgcCoverageImportRequest.ApplyMode"/> is set, stream the
+    /// GeoTIFF or Cloud Optimized GeoTIFF bytes into the configured raster store.
+    /// </summary>
+    /// <param name="request">Import request containing inventory and selection.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<OgcCoverageImportResult> ImportAsync(
+        OgcCoverageImportRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Import/Abstractions/IOgcWcsImportService.cs
+++ b/src/Honua.Core/Features/Import/Abstractions/IOgcWcsImportService.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Abstractions;
+
+/// <summary>
+/// Imports coverages from a legacy OGC Web Coverage Service (WCS 1.x or 2.x)
+/// endpoint. WCS is the older XML-over-HTTP coverage protocol that many
+/// production stacks still expose alongside, or instead of, OGC API Coverages.
+/// </summary>
+/// <remarks>
+/// Slice 3 of issue #1030. The WCS service classifies the requested output
+/// format — <c>image/tiff</c> is the deterministic happy-path; any other
+/// format (NetCDF, HDF, GML coverage, vendor-specific) routes the coverage
+/// to manual review. The actual catalog ingestion is delegated to the
+/// slice-2 <see cref="IOgcCoverageImportService"/> so there is exactly one
+/// raster sink in the system.
+/// </remarks>
+public interface IOgcWcsImportService
+{
+    /// <summary>
+    /// Plan or apply a WCS coverage import using the slice-1 migration inventory
+    /// as the selection contract. When <see cref="OgcWcsImportRequest.ApplyMode"/>
+    /// is set the underlying coverage import service streams the GeoTIFF response
+    /// into the Honua raster store.
+    /// </summary>
+    /// <param name="request">WCS import request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<OgcWcsImportResult> ImportAsync(
+        OgcWcsImportRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Import/Domain/OgcCoverageImportRequest.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcCoverageImportRequest.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Request to import one or more coverages from an OGC WCS or OGC API Coverages source
+/// using the slice-1 migration inventory as the source-of-truth selection.
+/// </summary>
+public sealed record OgcCoverageImportRequest
+{
+    /// <summary>
+    /// Coverage protocol surface. Supported values are <c>WCS</c> and <c>OGC API Coverages</c>.
+    /// </summary>
+    public required string ServiceType { get; init; }
+
+    /// <summary>
+    /// Source service URL (capability or landing-page root).
+    /// </summary>
+    public required string ServiceUrl { get; init; }
+
+    /// <summary>
+    /// Optional service version to request.
+    /// </summary>
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// Inventory artifact produced by the slice-1 scanner. Required.
+    /// </summary>
+    public required MigrationSourceInventoryArtifact Inventory { get; init; }
+
+    /// <summary>
+    /// Coverage selection. When null or empty every coverage in the inventory is processed.
+    /// Entries should match either <see cref="MigrationInventoryResource.Id"/> or
+    /// <see cref="MigrationInventoryResource.Name"/>.
+    /// </summary>
+    public string[] CoverageSelection { get; init; } = [];
+
+    /// <summary>
+    /// Optional per-coverage import settings keyed by source coverage name or resource id.
+    /// </summary>
+    public IReadOnlyDictionary<string, OgcCoverageImportTarget> Targets { get; init; }
+        = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// When true the service performs the actual GeoTIFF/COG download and
+    /// registers the raster through <c>IRasterImportService</c>. When false
+    /// only a deterministic manifest is produced.
+    /// </summary>
+    public bool ApplyMode { get; init; }
+
+    /// <summary>
+    /// When true callers explicitly request a dry-run preview manifest only.
+    /// This is the safe default — applyMode must be true to mutate state.
+    /// </summary>
+    public bool DryRun { get; init; } = true;
+
+    /// <summary>
+    /// Optional target service name used when computing manifest target identities.
+    /// </summary>
+    public string? TargetServiceName { get; init; }
+
+    /// <summary>
+    /// Optional HTTP basic-auth username for protected coverage endpoints.
+    /// Never echoed back in manifest output.
+    /// </summary>
+    public string? Username { get; init; }
+
+    /// <summary>
+    /// Optional HTTP basic-auth password for protected coverage endpoints.
+    /// Never echoed back in manifest output.
+    /// </summary>
+    public string? Password { get; init; }
+
+    /// <summary>
+    /// Optional request timeout in seconds.
+    /// </summary>
+    public int TimeoutSeconds { get; init; } = 120;
+
+    /// <summary>
+    /// Whether to allow plain HTTP or local URLs (operator-controlled environments).
+    /// </summary>
+    public bool AllowUnsafeLocalUrls { get; init; }
+}
+
+/// <summary>
+/// Per-coverage import target options.
+/// </summary>
+public sealed record OgcCoverageImportTarget
+{
+    /// <summary>
+    /// Destination raster layer identifier in Honua. Required when applyMode is true.
+    /// </summary>
+    public int? LayerId { get; init; }
+
+    /// <summary>
+    /// Optional target raster display name. Defaults to the source coverage name.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Optional target raster description.
+    /// </summary>
+    public string? Description { get; init; }
+}

--- a/src/Honua.Core/Features/Import/Domain/OgcCoverageImportResult.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcCoverageImportResult.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Result of an OGC coverage GeoTIFF/COG import attempt.
+/// </summary>
+public sealed record OgcCoverageImportResult
+{
+    /// <summary>
+    /// Deterministic per-source migration manifest summarizing the import attempt.
+    /// </summary>
+    public required MigrationManifestArtifact Manifest { get; init; }
+
+    /// <summary>
+    /// Per-coverage execution records. Empty in dry-run mode.
+    /// </summary>
+    public OgcCoverageImportRecord[] Records { get; init; } = [];
+
+    /// <summary>
+    /// Whether the request ran in apply mode.
+    /// </summary>
+    public bool ApplyMode { get; init; }
+
+    /// <summary>
+    /// Whether the request was a dry-run preview.
+    /// </summary>
+    public bool DryRun { get; init; }
+}
+
+/// <summary>
+/// Outcome for a single coverage processed by the import service.
+/// </summary>
+public sealed record OgcCoverageImportRecord
+{
+    /// <summary>
+    /// Source coverage identifier.
+    /// </summary>
+    public required string SourceCoverageId { get; init; }
+
+    /// <summary>
+    /// Target raster name registered (or planned) in Honua.
+    /// </summary>
+    public required string TargetCoverageName { get; init; }
+
+    /// <summary>
+    /// Output format requested from the source service ( <c>GeoTIFF</c>, <c>CloudOptimizedGeoTIFF</c>, etc. ).
+    /// </summary>
+    public required string OutputFormat { get; init; }
+
+    /// <summary>
+    /// Inventory classification: <c>automated</c>, <c>manual-review</c>, or <c>unsupported</c>.
+    /// </summary>
+    public required string Classification { get; init; }
+
+    /// <summary>
+    /// Final action: <c>imported</c>, <c>planned</c>, <c>skipped</c>, <c>manual-review</c>, or <c>failed</c>.
+    /// </summary>
+    public required string Action { get; init; }
+
+    /// <summary>
+    /// Declared CRS values copied from the source coverage.
+    /// </summary>
+    public string[] DeclaredCrs { get; init; } = [];
+
+    /// <summary>
+    /// Declared range/band names copied from the source coverage.
+    /// </summary>
+    public string[] DeclaredBands { get; init; } = [];
+
+    /// <summary>
+    /// Number of bytes streamed from the source. Zero in dry-run and manual-review records.
+    /// </summary>
+    public long ByteCount { get; init; }
+
+    /// <summary>
+    /// Honua raster identifier when the import was registered.
+    /// </summary>
+    public long? RasterId { get; init; }
+
+    /// <summary>
+    /// Honua target layer identifier when applicable.
+    /// </summary>
+    public int? TargetLayerId { get; init; }
+
+    /// <summary>
+    /// Warnings emitted while processing this coverage.
+    /// </summary>
+    public string[] Warnings { get; init; } = [];
+
+    /// <summary>
+    /// Optional error message when <see cref="Action"/> is <c>failed</c>.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+}

--- a/src/Honua.Core/Features/Import/Domain/OgcWcsImportRequest.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcWcsImportRequest.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Request to import one or more coverages from a legacy OGC Web Coverage
+/// Service endpoint (WCS 1.x or 2.x). Slice 3 of issue #1030.
+/// </summary>
+public sealed record OgcWcsImportRequest
+{
+    /// <summary>
+    /// Source WCS service URL — the capabilities endpoint root. Per-coverage
+    /// <c>GetCoverage</c> requests are built relative to this URL.
+    /// </summary>
+    public required string ServiceUrl { get; init; }
+
+    /// <summary>
+    /// WCS protocol version to request. Defaults to <c>2.0.1</c> when not specified.
+    /// Accepted values include <c>1.0.0</c>, <c>1.1.1</c>, <c>2.0.1</c>.
+    /// </summary>
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// Inventory artifact produced by the slice-1 OGC coverage scanner. Required.
+    /// </summary>
+    public required MigrationSourceInventoryArtifact Inventory { get; init; }
+
+    /// <summary>
+    /// Requested output format. The deterministic happy-path is
+    /// <c>image/tiff</c>; any other value is classified as <c>manual-review</c>
+    /// because the slice-2 ingestion pipeline only consumes GeoTIFF/COG bytes.
+    /// Defaults to <c>image/tiff</c>.
+    /// </summary>
+    public string OutputFormat { get; init; } = "image/tiff";
+
+    /// <summary>
+    /// Coverage selection. When null or empty every coverage in the inventory is processed.
+    /// Entries should match either <see cref="MigrationInventoryResource.Id"/> or
+    /// <see cref="MigrationInventoryResource.Name"/>.
+    /// </summary>
+    public string[] CoverageSelection { get; init; } = [];
+
+    /// <summary>
+    /// Optional per-coverage import settings keyed by source coverage name or resource id.
+    /// </summary>
+    public IReadOnlyDictionary<string, OgcCoverageImportTarget> Targets { get; init; }
+        = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// When true the service performs the actual GeoTIFF download and registers
+    /// the raster through the slice-2 coverage import pipeline. When false only a
+    /// deterministic manifest is produced.
+    /// </summary>
+    public bool ApplyMode { get; init; }
+
+    /// <summary>
+    /// When true callers explicitly request a dry-run preview manifest only.
+    /// This is the safe default — <see cref="ApplyMode"/> must be true to mutate state.
+    /// </summary>
+    public bool DryRun { get; init; } = true;
+
+    /// <summary>
+    /// Optional target service name used when computing manifest target identities.
+    /// </summary>
+    public string? TargetServiceName { get; init; }
+
+    /// <summary>
+    /// Optional HTTP basic-auth username for protected WCS endpoints.
+    /// Never echoed back in manifest output.
+    /// </summary>
+    public string? Username { get; init; }
+
+    /// <summary>
+    /// Optional HTTP basic-auth password for protected WCS endpoints.
+    /// Never echoed back in manifest output.
+    /// </summary>
+    public string? Password { get; init; }
+
+    /// <summary>
+    /// Optional request timeout in seconds.
+    /// </summary>
+    public int TimeoutSeconds { get; init; } = 120;
+
+    /// <summary>
+    /// Whether to allow plain HTTP or local URLs (operator-controlled environments).
+    /// </summary>
+    public bool AllowUnsafeLocalUrls { get; init; }
+}

--- a/src/Honua.Core/Features/Import/Domain/OgcWcsImportResult.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcWcsImportResult.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Result of a legacy OGC WCS coverage import attempt. Slice 3 of issue #1030.
+/// </summary>
+/// <remarks>
+/// The WCS service delegates the actual catalog ingestion to the slice-2
+/// coverage import service, so this result wraps the underlying
+/// <see cref="OgcCoverageImportResult"/> and exposes the negotiated output
+/// format the WCS layer requested on the caller's behalf.
+/// </remarks>
+public sealed record OgcWcsImportResult
+{
+    /// <summary>
+    /// Deterministic migration manifest produced by the underlying coverage import.
+    /// </summary>
+    public required MigrationManifestArtifact Manifest { get; init; }
+
+    /// <summary>
+    /// Per-coverage execution records produced by the slice-2 ingestion pipeline.
+    /// </summary>
+    public OgcCoverageImportRecord[] Records { get; init; } = [];
+
+    /// <summary>
+    /// Output format the WCS layer requested from the source service
+    /// (e.g. <c>image/tiff</c>). Mirrored back so callers can confirm
+    /// the negotiation outcome without re-parsing per-record output formats.
+    /// </summary>
+    public required string RequestedOutputFormat { get; init; }
+
+    /// <summary>
+    /// WCS protocol version resolved for this request.
+    /// </summary>
+    public required string ResolvedVersion { get; init; }
+
+    /// <summary>
+    /// Whether the request ran in apply mode.
+    /// </summary>
+    public bool ApplyMode { get; init; }
+
+    /// <summary>
+    /// Whether the request was a dry-run preview.
+    /// </summary>
+    public bool DryRun { get; init; }
+}

--- a/src/Honua.Core/Features/Import/ServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Import/ServiceCollectionExtensions.cs
@@ -49,6 +49,12 @@ public static class ServiceCollectionExtensions
         services.TryAddScoped<IOgcCoverageImportService>(serviceProvider =>
             serviceProvider.GetRequiredService<OgcCoverageImportService>());
 
+        // Legacy WCS coverage import service (issue #1030 slice 3). The WCS
+        // service wraps the slice-2 coverage import pipeline — no separate
+        // HttpClient is needed because the underlying service handles all
+        // wire IO. Format negotiation and inventory downgrades happen in-process.
+        services.TryAddScoped<IOgcWcsImportService, OgcWcsImportService>();
+
         return services;
     }
 }

--- a/src/Honua.Core/Features/Import/ServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Import/ServiceCollectionExtensions.cs
@@ -35,6 +35,20 @@ public static class ServiceCollectionExtensions
         services.TryAddScoped<IOgcApiFeaturesMigrationScanner>(serviceProvider =>
             serviceProvider.GetRequiredService<OgcApiFeaturesMigrationScanner>());
 
+        // GeoTIFF / Cloud Optimized GeoTIFF coverage import service (issue #1030 slice 2).
+        // GetCoverage downloads can be large, so the HTTP client uses a long base timeout
+        // while the import service applies its own per-request budget from the payload.
+        services.AddResilientHttpClient<OgcCoverageImportService>(
+            "ogc-coverage-import",
+            HttpResiliencePolicies.SlowServiceDefaults,
+            configureClient: client =>
+            {
+                client.DefaultRequestHeaders.Add("User-Agent", "HonuaServer/1.0");
+                client.Timeout = TimeSpan.FromMinutes(10);
+            });
+        services.TryAddScoped<IOgcCoverageImportService>(serviceProvider =>
+            serviceProvider.GetRequiredService<OgcCoverageImportService>());
+
         return services;
     }
 }

--- a/src/Honua.Core/Features/Import/Services/OgcCoverageImportService.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcCoverageImportService.cs
@@ -1,0 +1,744 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http.Headers;
+using System.Text;
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Imports OGC WCS / OGC API Coverages GeoTIFF and Cloud Optimized GeoTIFF coverages
+/// into Honua's raster store using a slice-1 migration source inventory as the
+/// deterministic source-of-truth selection.
+/// </summary>
+public sealed partial class OgcCoverageImportService : IOgcCoverageImportService
+{
+    private const string GeoTiffFormat = "GeoTIFF";
+    private const string CogFormat = "CloudOptimizedGeoTIFF";
+
+    private readonly HttpClient _httpClient;
+    private readonly IRasterImportService _rasterImportService;
+    private readonly ILogger<OgcCoverageImportService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OgcCoverageImportService"/> class.
+    /// </summary>
+    public OgcCoverageImportService(
+        HttpClient httpClient,
+        IRasterImportService rasterImportService,
+        ILogger<OgcCoverageImportService> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _rasterImportService = rasterImportService ?? throw new ArgumentNullException(nameof(rasterImportService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<OgcCoverageImportResult> ImportAsync(
+        OgcCoverageImportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Inventory);
+
+        var serviceType = NormalizeServiceType(request.ServiceType);
+        var serviceUri = ValidateServiceUri(request.ServiceUrl, request.AllowUnsafeLocalUrls);
+        var applyMode = request.ApplyMode && !request.DryRun;
+
+        var inventoryResources = request.Inventory.Resources
+            .Where(static resource => string.Equals(resource.Kind, "coverage", StringComparison.Ordinal))
+            .ToArray();
+        var selectedResources = SelectResources(inventoryResources, request.CoverageSelection);
+
+        var targets = new List<MigrationManifestTargetResource>();
+        var manualReviewItems = new List<MigrationManifestReviewItem>();
+        var unsupportedItems = new List<MigrationManifestReviewItem>();
+        var identityRemaps = new List<MigrationManifestIdentityRemap>();
+        var records = new List<OgcCoverageImportRecord>();
+
+        var targetServiceName = NormalizeTargetServiceName(
+            request.TargetServiceName,
+            request.Inventory.Source.DisplayName);
+
+        foreach (var resource in selectedResources.OrderBy(static r => r.Id, StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var classification = ClassifyResource(resource);
+            var sourceCoverageId = resource.Name;
+            var target = LookupTarget(request.Targets, resource);
+            var targetName = NormalizeTargetName(
+                target?.Name,
+                resource.Title,
+                resource.Name);
+            var targetResourceId = $"target:{targetServiceName}:{ToStableId(targetName)}";
+            var declaredCrs = resource.SpatialReferences
+                .Select(static sr => sr.SourceValue ?? sr.CrsUri ?? (sr.Srid is { } srid ? $"EPSG:{srid}" : string.Empty))
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(static value => value, StringComparer.Ordinal)
+                .ToArray();
+            var declaredBands = resource.Fields
+                .Select(static field => field.Name)
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(static value => value, StringComparer.Ordinal)
+                .ToArray();
+
+            identityRemaps.Add(new MigrationManifestIdentityRemap
+            {
+                SourceId = resource.Id,
+                SourceKind = resource.Kind,
+                TargetId = targetResourceId,
+                TargetKind = "raster-coverage",
+                TargetName = targetName,
+                Action = classification.Action
+            });
+
+            if (!classification.IsAutomated)
+            {
+                var review = new MigrationManifestReviewItem
+                {
+                    SourceId = resource.Id,
+                    Kind = resource.Kind,
+                    Code = classification.Code,
+                    Severity = classification.Severity,
+                    Reason = classification.Reason,
+                    ManualSteps = classification.ManualSteps,
+                    Warnings = resource.Compatibility.Warnings
+                };
+
+                if (string.Equals(classification.Severity, "unsupported", StringComparison.Ordinal))
+                {
+                    unsupportedItems.Add(review);
+                }
+                else
+                {
+                    manualReviewItems.Add(review);
+                }
+
+                records.Add(new OgcCoverageImportRecord
+                {
+                    SourceCoverageId = sourceCoverageId,
+                    TargetCoverageName = targetName,
+                    OutputFormat = classification.OutputFormat,
+                    Classification = classification.Severity,
+                    Action = "manual-review",
+                    DeclaredCrs = declaredCrs,
+                    DeclaredBands = declaredBands,
+                    Warnings = classification.ManualSteps
+                });
+
+                targets.Add(new MigrationManifestTargetResource
+                {
+                    SourceResourceId = resource.Id,
+                    SourceKind = resource.Kind,
+                    Action = "manual-review",
+                    TargetResourceId = targetResourceId,
+                    TargetServiceName = targetServiceName,
+                    TargetResourceName = targetName,
+                    MigrationMode = "raster-coverage-import",
+                    SourceProtocol = serviceType,
+                    Capabilities = resource.Capabilities,
+                    SpatialReferences = resource.SpatialReferences,
+                    Fields = resource.Fields,
+                    ExternalDependencyIds = resource.ExternalDependencyIds,
+                    Compatibility = resource.Compatibility
+                });
+
+                continue;
+            }
+
+            // Automated path — GeoTIFF/COG.
+            var manifestTarget = new MigrationManifestTargetResource
+            {
+                SourceResourceId = resource.Id,
+                SourceKind = resource.Kind,
+                Action = applyMode ? "imported" : "planned",
+                TargetResourceId = targetResourceId,
+                TargetServiceName = targetServiceName,
+                TargetResourceName = targetName,
+                MigrationMode = "raster-coverage-import",
+                SourceProtocol = serviceType,
+                Capabilities = resource.Capabilities,
+                SpatialReferences = resource.SpatialReferences,
+                Fields = resource.Fields,
+                ExternalDependencyIds = resource.ExternalDependencyIds,
+                Compatibility = resource.Compatibility
+            };
+
+            if (!applyMode)
+            {
+                targets.Add(manifestTarget);
+                records.Add(new OgcCoverageImportRecord
+                {
+                    SourceCoverageId = sourceCoverageId,
+                    TargetCoverageName = targetName,
+                    OutputFormat = classification.OutputFormat,
+                    Classification = classification.Severity,
+                    Action = "planned",
+                    DeclaredCrs = declaredCrs,
+                    DeclaredBands = declaredBands,
+                    TargetLayerId = target?.LayerId
+                });
+                continue;
+            }
+
+            // Apply mode — actually download and import.
+            if (target?.LayerId == null)
+            {
+                var warning = $"Coverage {sourceCoverageId} cannot be imported: no target layer was supplied.";
+                manualReviewItems.Add(new MigrationManifestReviewItem
+                {
+                    SourceId = resource.Id,
+                    Kind = resource.Kind,
+                    Code = "OGC_COVERAGE_TARGET_LAYER_MISSING",
+                    Severity = "manual-review",
+                    Reason = warning,
+                    ManualSteps = ["Provide targets[<coverage>].layerId before applying this coverage import."]
+                });
+                records.Add(new OgcCoverageImportRecord
+                {
+                    SourceCoverageId = sourceCoverageId,
+                    TargetCoverageName = targetName,
+                    OutputFormat = classification.OutputFormat,
+                    Classification = classification.Severity,
+                    Action = "skipped",
+                    DeclaredCrs = declaredCrs,
+                    DeclaredBands = declaredBands,
+                    Warnings = [warning]
+                });
+                targets.Add(manifestTarget with { Action = "manual-review" });
+                continue;
+            }
+
+            var record = await DownloadAndImportAsync(
+                    request,
+                    serviceUri,
+                    serviceType,
+                    resource,
+                    classification,
+                    target,
+                    targetName,
+                    declaredCrs,
+                    declaredBands,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            records.Add(record);
+            targets.Add(manifestTarget with
+            {
+                Action = record.Action switch
+                {
+                    "imported" => "imported",
+                    "failed" => "failed",
+                    _ => manifestTarget.Action
+                }
+            });
+        }
+
+        var summary = new MigrationManifestSummary
+        {
+            SourceResourceCount = inventoryResources.Length,
+            TargetResourceCount = targets.Count,
+            ManualReviewCount = manualReviewItems.Count,
+            UnsupportedCount = unsupportedItems.Count
+        };
+
+        var manifest = new MigrationManifestArtifact
+        {
+            SourceKind = request.Inventory.SourceKind,
+            Source = new MigrationSourceIdentity
+            {
+                DisplayName = request.Inventory.Source.DisplayName,
+                BaseUrl = ToSafeUrl(serviceUri),
+                Product = request.Inventory.Source.Product,
+                Version = request.Inventory.Source.Version,
+                Build = request.Inventory.Source.Build,
+                ServiceType = request.Inventory.Source.ServiceType
+            },
+            Summary = summary,
+            TargetResources = targets
+                .OrderBy(static t => t.TargetResourceId, StringComparer.Ordinal)
+                .ToArray(),
+            IdentityRemaps = identityRemaps
+                .OrderBy(static remap => remap.SourceId, StringComparer.Ordinal)
+                .ToArray(),
+            ManualReviewItems = manualReviewItems
+                .OrderBy(static item => item.SourceId, StringComparer.Ordinal)
+                .ToArray(),
+            UnsupportedItems = unsupportedItems
+                .OrderBy(static item => item.SourceId, StringComparer.Ordinal)
+                .ToArray()
+        };
+
+        return new OgcCoverageImportResult
+        {
+            Manifest = manifest,
+            Records = records
+                .OrderBy(static record => record.SourceCoverageId, StringComparer.Ordinal)
+                .ToArray(),
+            ApplyMode = applyMode,
+            DryRun = !applyMode
+        };
+    }
+
+    private async Task<OgcCoverageImportRecord> DownloadAndImportAsync(
+        OgcCoverageImportRequest request,
+        Uri serviceUri,
+        string serviceType,
+        MigrationInventoryResource resource,
+        CoverageClassification classification,
+        OgcCoverageImportTarget target,
+        string targetName,
+        string[] declaredCrs,
+        string[] declaredBands,
+        CancellationToken cancellationToken)
+    {
+        var sourceCoverageId = resource.Name;
+        var layerId = target.LayerId!.Value;
+        var warnings = new List<string>();
+        string? stagedFile = null;
+
+        try
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, request.TimeoutSeconds)));
+
+            var coverageUri = BuildGetCoverageUri(serviceUri, serviceType, sourceCoverageId, request.Version, classification.OutputFormat);
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Get, coverageUri);
+            if (!string.IsNullOrWhiteSpace(request.Username))
+            {
+                var raw = $"{request.Username}:{request.Password ?? string.Empty}";
+                var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(raw));
+                httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Basic", encoded);
+            }
+
+            using var response = await _httpClient
+                .SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, timeout.Token)
+                .ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            stagedFile = await StageGeoTiffAsync(response, sourceCoverageId, timeout.Token).ConfigureAwait(false);
+            var byteCount = new FileInfo(stagedFile).Length;
+
+            var importRequest = new RasterImportRequest
+            {
+                LayerId = layerId,
+                Name = targetName,
+                Description = target.Description ?? resource.Description,
+                FilePath = stagedFile,
+                FileName = $"{ToStableId(targetName)}.tif",
+                Format = classification.OutputFormat == CogFormat
+                    ? SupportedRasterFormat.CloudOptimizedGeoTiff
+                    : SupportedRasterFormat.GeoTiff,
+                TileZoomLevels = []
+            };
+
+            var importResult = await _rasterImportService
+                .ImportAsync(importRequest, progress: null, timeout.Token)
+                .ConfigureAwait(false);
+
+            if (!importResult.Success)
+            {
+                return new OgcCoverageImportRecord
+                {
+                    SourceCoverageId = sourceCoverageId,
+                    TargetCoverageName = targetName,
+                    OutputFormat = classification.OutputFormat,
+                    Classification = classification.Severity,
+                    Action = "failed",
+                    DeclaredCrs = declaredCrs,
+                    DeclaredBands = declaredBands,
+                    ByteCount = byteCount,
+                    TargetLayerId = layerId,
+                    Warnings = importResult.Warnings.Concat(warnings).ToArray(),
+                    ErrorMessage = importResult.ErrorMessage
+                };
+            }
+
+            warnings.AddRange(importResult.Warnings);
+            return new OgcCoverageImportRecord
+            {
+                SourceCoverageId = sourceCoverageId,
+                TargetCoverageName = targetName,
+                OutputFormat = classification.OutputFormat,
+                Classification = classification.Severity,
+                Action = "imported",
+                DeclaredCrs = declaredCrs,
+                DeclaredBands = declaredBands,
+                ByteCount = byteCount,
+                RasterId = importResult.RasterId,
+                TargetLayerId = layerId,
+                Warnings = warnings.ToArray()
+            };
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or IOException or InvalidDataException)
+        {
+            Log.CoverageDownloadFailed(_logger, sourceCoverageId, ex);
+            return new OgcCoverageImportRecord
+            {
+                SourceCoverageId = sourceCoverageId,
+                TargetCoverageName = targetName,
+                OutputFormat = classification.OutputFormat,
+                Classification = classification.Severity,
+                Action = "failed",
+                DeclaredCrs = declaredCrs,
+                DeclaredBands = declaredBands,
+                TargetLayerId = layerId,
+                ErrorMessage = "Failed to download or import coverage."
+            };
+        }
+        finally
+        {
+            if (stagedFile != null)
+            {
+                TryDelete(stagedFile);
+            }
+        }
+    }
+
+    private static async Task<string> StageGeoTiffAsync(
+        HttpResponseMessage response,
+        string sourceCoverageId,
+        CancellationToken cancellationToken)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "honua-ogc-coverage-import");
+        Directory.CreateDirectory(tempDir);
+        var path = Path.Combine(tempDir, $"{Guid.NewGuid():N}.tif");
+        try
+        {
+            await using var source = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var destination = File.Create(path);
+            await source.CopyToAsync(destination, cancellationToken).ConfigureAwait(false);
+            await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
+            if (destination.Length == 0)
+            {
+                throw new InvalidDataException($"GetCoverage response was empty for {sourceCoverageId}.");
+            }
+        }
+        catch
+        {
+            TryDelete(path);
+            throw;
+        }
+
+        return path;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    private static MigrationInventoryResource[] SelectResources(
+        MigrationInventoryResource[] resources,
+        string[] selection)
+    {
+        if (selection.Length == 0)
+        {
+            return resources;
+        }
+
+        var normalized = new HashSet<string>(
+            selection.Where(static s => !string.IsNullOrWhiteSpace(s)).Select(static s => s.Trim()),
+            StringComparer.Ordinal);
+
+        return resources
+            .Where(resource => normalized.Contains(resource.Id) || normalized.Contains(resource.Name))
+            .ToArray();
+    }
+
+    private static OgcCoverageImportTarget? LookupTarget(
+        IReadOnlyDictionary<string, OgcCoverageImportTarget> targets,
+        MigrationInventoryResource resource)
+    {
+        if (targets.TryGetValue(resource.Name, out var target))
+        {
+            return target;
+        }
+
+        return targets.TryGetValue(resource.Id, out target) ? target : null;
+    }
+
+    private static string NormalizeTargetServiceName(string? candidate, string? fallback)
+        => ToStableId(candidate ?? fallback ?? "raster-coverages");
+
+    private static string NormalizeTargetName(string? explicitName, string? title, string fallback)
+        => ToStableId(explicitName ?? title ?? fallback);
+
+    private static CoverageClassification ClassifyResource(MigrationInventoryResource resource)
+    {
+        var code = resource.Compatibility.Code ?? OgcCoverageMigrationCompatibilityCodes.ManualReview;
+        return code switch
+        {
+            OgcCoverageMigrationCompatibilityCodes.CogSupported => new CoverageClassification(
+                IsAutomated: true,
+                Severity: "automated",
+                Action: "import",
+                OutputFormat: CogFormat,
+                Code: code,
+                Reason: resource.Compatibility.Reason,
+                ManualSteps: []),
+            OgcCoverageMigrationCompatibilityCodes.GeoTiffSupported => new CoverageClassification(
+                IsAutomated: true,
+                Severity: "automated",
+                Action: "import",
+                OutputFormat: GeoTiffFormat,
+                Code: code,
+                Reason: resource.Compatibility.Reason,
+                ManualSteps: []),
+            OgcCoverageMigrationCompatibilityCodes.NetCdfUnsupported
+                or OgcCoverageMigrationCompatibilityCodes.HdfUnsupported
+                or OgcCoverageMigrationCompatibilityCodes.ZarrUnsupported
+                or OgcCoverageMigrationCompatibilityCodes.ScientificFormatUnsupported => new CoverageClassification(
+                    IsAutomated: false,
+                    Severity: "unsupported",
+                    Action: "manual-review",
+                    OutputFormat: GuessFormatFromCode(code),
+                    Code: code,
+                    Reason: resource.Compatibility.Reason,
+                    ManualSteps: BuildManualSteps(code)),
+            _ => new CoverageClassification(
+                IsAutomated: false,
+                Severity: "manual-review",
+                Action: "manual-review",
+                OutputFormat: GeoTiffFormat,
+                Code: code,
+                Reason: resource.Compatibility.Reason,
+                ManualSteps: resource.Compatibility.ManualSteps.Length > 0
+                    ? resource.Compatibility.ManualSteps
+                    : ["Run pilot coverage import and verify metadata, CRS, and band parity before promotion."])
+        };
+    }
+
+    private static string GuessFormatFromCode(string code) => code switch
+    {
+        OgcCoverageMigrationCompatibilityCodes.NetCdfUnsupported => "NetCDF",
+        OgcCoverageMigrationCompatibilityCodes.HdfUnsupported => "HDF",
+        OgcCoverageMigrationCompatibilityCodes.ZarrUnsupported => "Zarr",
+        _ => "Unknown"
+    };
+
+    private static string[] BuildManualSteps(string code) => code switch
+    {
+        OgcCoverageMigrationCompatibilityCodes.NetCdfUnsupported =>
+        [
+            "NetCDF coverage import depends on multidimensional format support (issue #1010). Track that issue before automating this coverage."
+        ],
+        OgcCoverageMigrationCompatibilityCodes.HdfUnsupported =>
+        [
+            "HDF coverage import depends on multidimensional format support (issue #1010). Track that issue before automating this coverage."
+        ],
+        OgcCoverageMigrationCompatibilityCodes.ZarrUnsupported =>
+        [
+            "Zarr coverage import depends on the Zarr ingest pipeline (issue #1009). Track that issue before automating this coverage."
+        ],
+        _ =>
+        [
+            "Coverage output format is not supported by the slice-2 GeoTIFF/COG import path. Re-evaluate after additional format pipelines land."
+        ]
+    };
+
+    private static Uri BuildGetCoverageUri(
+        Uri serviceUri,
+        string serviceType,
+        string coverageId,
+        string? version,
+        string outputFormat)
+    {
+        if (string.Equals(serviceType, "OGC API Coverages", StringComparison.Ordinal))
+        {
+            var builder = new UriBuilder(serviceUri);
+            var basePath = builder.Path.TrimEnd('/');
+            if (basePath.EndsWith("/collections", StringComparison.OrdinalIgnoreCase))
+            {
+                basePath = basePath[..^"/collections".Length];
+            }
+
+            builder.Path = $"{basePath}/collections/{Uri.EscapeDataString(coverageId)}/coverage";
+            builder.Query = BuildQuery(
+                builder.Query,
+                new Dictionary<string, string?>
+                {
+                    ["f"] = outputFormat == CogFormat ? "tif" : "geotiff"
+                });
+            return builder.Uri;
+        }
+
+        // WCS path (1.x or 2.x). Default to 2.0.1 semantics when version is unknown.
+        var resolvedVersion = string.IsNullOrWhiteSpace(version) || version!.StartsWith("2.", StringComparison.Ordinal)
+            ? version ?? "2.0.1"
+            : version;
+        var isWcs2 = resolvedVersion.StartsWith("2.", StringComparison.Ordinal);
+        var wcsBuilder = new UriBuilder(serviceUri)
+        {
+            Query = BuildQuery(
+                serviceUri.Query,
+                new Dictionary<string, string?>
+                {
+                    ["service"] = "WCS",
+                    ["version"] = resolvedVersion,
+                    ["request"] = "GetCoverage",
+                    [isWcs2 ? "coverageId" : "coverage"] = coverageId,
+                    ["format"] = outputFormat == CogFormat ? "image/tiff;application=geotiff;profile=cloud-optimized" : "image/tiff"
+                })
+        };
+        return wcsBuilder.Uri;
+    }
+
+    private static string BuildQuery(string existingQuery, IReadOnlyDictionary<string, string?> values)
+    {
+        var pairs = new List<KeyValuePair<string, string>>();
+        var trimmed = existingQuery.TrimStart('?');
+        if (trimmed.Length > 0)
+        {
+            foreach (var part in trimmed.Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var separator = part.IndexOf('=', StringComparison.Ordinal);
+                var key = separator < 0 ? Uri.UnescapeDataString(part) : Uri.UnescapeDataString(part[..separator]);
+                if (values.Keys.Any(candidate => string.Equals(candidate, key, StringComparison.OrdinalIgnoreCase)))
+                {
+                    continue;
+                }
+
+                var value = separator < 0 ? string.Empty : Uri.UnescapeDataString(part[(separator + 1)..]);
+                pairs.Add(new KeyValuePair<string, string>(key, value));
+            }
+        }
+
+        foreach (var (key, value) in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                pairs.Add(new KeyValuePair<string, string>(key, value));
+            }
+        }
+
+        return string.Join("&", pairs.Select(static pair =>
+            $"{Uri.EscapeDataString(pair.Key)}={Uri.EscapeDataString(pair.Value)}"));
+    }
+
+    [SuppressMessage("Performance", "CA1308:Normalize strings to uppercase", Justification = "Stable ASCII slug for manifest target identities.")]
+    private static string ToStableId(string value)
+    {
+        var sb = new StringBuilder(value.Length);
+        var lastWasSeparator = false;
+        foreach (var ch in value.Trim())
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                sb.Append(char.ToLowerInvariant(ch));
+                lastWasSeparator = false;
+            }
+            else
+            {
+                if (sb.Length > 0 && !lastWasSeparator)
+                {
+                    sb.Append('-');
+                    lastWasSeparator = true;
+                }
+            }
+        }
+
+        while (sb.Length > 0 && sb[^1] == '-')
+        {
+            sb.Length--;
+        }
+
+        return sb.Length == 0 ? "coverage" : sb.ToString();
+    }
+
+    private static string NormalizeServiceType(string serviceType)
+    {
+        if (string.IsNullOrWhiteSpace(serviceType))
+        {
+            throw new ArgumentException("ServiceType is required.", nameof(serviceType));
+        }
+
+        var normalized = serviceType.Trim();
+        if (normalized.Equals("WCS", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("Web Coverage Service", StringComparison.OrdinalIgnoreCase))
+        {
+            return "WCS";
+        }
+
+        if (normalized.Equals("OGC API Coverages", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("OGC API - Coverages", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("Coverages", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("ogc-api-coverages", StringComparison.OrdinalIgnoreCase))
+        {
+            return "OGC API Coverages";
+        }
+
+        throw new ArgumentException($"Unsupported coverage service type: {serviceType}", nameof(serviceType));
+    }
+
+    private static Uri ValidateServiceUri(string serviceUrl, bool allowUnsafeLocalUrls)
+    {
+        if (!Uri.TryCreate(serviceUrl, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new ArgumentException("Coverage service URL must be an absolute HTTP or HTTPS URL.", nameof(serviceUrl));
+        }
+
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+        {
+            throw new ArgumentException("Coverage service URL must not include embedded credentials.", nameof(serviceUrl));
+        }
+
+        if (uri.Scheme == Uri.UriSchemeHttp && !allowUnsafeLocalUrls)
+        {
+            throw new ArgumentException("Coverage service URL must be HTTPS unless allowUnsafeLocalUrls is true.", nameof(serviceUrl));
+        }
+
+        return uri;
+    }
+
+    private static string ToSafeUrl(Uri uri)
+    {
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty
+        };
+        return builder.Uri.ToString();
+    }
+
+    private readonly record struct CoverageClassification(
+        bool IsAutomated,
+        string Severity,
+        string Action,
+        string OutputFormat,
+        string Code,
+        string Reason,
+        string[] ManualSteps);
+
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 8810,
+            Level = LogLevel.Warning,
+            Message = "OGC coverage import: failed to download or stage coverage {SourceCoverageId}.")]
+        public static partial void CoverageDownloadFailed(ILogger logger, string sourceCoverageId, Exception exception);
+    }
+}

--- a/src/Honua.Core/Features/Import/Services/OgcWcsImportService.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcWcsImportService.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Import.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Imports coverages from a legacy OGC Web Coverage Service endpoint by
+/// negotiating the requested output format and delegating the actual
+/// catalog ingestion to the slice-2 <see cref="IOgcCoverageImportService"/>.
+/// Slice 3 of issue #1030.
+/// </summary>
+/// <remarks>
+/// Format negotiation: <c>image/tiff</c> (and the GeoTIFF profile variants)
+/// flow through the GeoTIFF ingestion path; any other format — NetCDF, HDF,
+/// GML coverage, vendor-specific — is forced to the manual-review path
+/// before the underlying service is asked to download anything. This keeps
+/// the WCS service deterministic and avoids surfacing partial coverage
+/// blobs that the raster ingestion layer cannot consume.
+/// </remarks>
+public sealed partial class OgcWcsImportService : IOgcWcsImportService
+{
+    private const string DefaultOutputFormat = "image/tiff";
+    private const string DefaultVersion = "2.0.1";
+
+    private readonly IOgcCoverageImportService _coverageImportService;
+    private readonly ILogger<OgcWcsImportService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OgcWcsImportService"/> class.
+    /// </summary>
+    public OgcWcsImportService(
+        IOgcCoverageImportService coverageImportService,
+        ILogger<OgcWcsImportService> logger)
+    {
+        _coverageImportService = coverageImportService
+            ?? throw new ArgumentNullException(nameof(coverageImportService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<OgcWcsImportResult> ImportAsync(
+        OgcWcsImportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Inventory);
+
+        if (string.IsNullOrWhiteSpace(request.ServiceUrl))
+        {
+            throw new ArgumentException("ServiceUrl is required.", nameof(request));
+        }
+
+        var resolvedVersion = NormalizeVersion(request.Version);
+        var negotiatedFormat = NormalizeOutputFormat(request.OutputFormat);
+        var isAutomatedFormat = IsGeoTiffFormat(negotiatedFormat);
+
+        // When the caller requested a non-GeoTIFF output format we rewrite the
+        // inventory so every otherwise-automatable coverage is downgraded to
+        // manual-review. Slice-2 only knows how to ingest GeoTIFF/COG bytes.
+        var inventory = isAutomatedFormat
+            ? request.Inventory
+            : DowngradeAutomatedCoveragesToManualReview(request.Inventory, negotiatedFormat);
+
+        if (!isAutomatedFormat)
+        {
+            Log.NonGeoTiffFormatDowngraded(_logger, negotiatedFormat);
+        }
+
+        var coverageRequest = new OgcCoverageImportRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = request.ServiceUrl,
+            Version = resolvedVersion,
+            Inventory = inventory,
+            CoverageSelection = request.CoverageSelection,
+            Targets = request.Targets,
+            ApplyMode = request.ApplyMode,
+            DryRun = request.DryRun,
+            TargetServiceName = request.TargetServiceName,
+            Username = request.Username,
+            Password = request.Password,
+            TimeoutSeconds = request.TimeoutSeconds,
+            AllowUnsafeLocalUrls = request.AllowUnsafeLocalUrls
+        };
+
+        var coverageResult = await _coverageImportService
+            .ImportAsync(coverageRequest, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new OgcWcsImportResult
+        {
+            Manifest = coverageResult.Manifest,
+            Records = coverageResult.Records,
+            RequestedOutputFormat = negotiatedFormat,
+            ResolvedVersion = resolvedVersion,
+            ApplyMode = coverageResult.ApplyMode,
+            DryRun = coverageResult.DryRun
+        };
+    }
+
+    private static string NormalizeVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return DefaultVersion;
+        }
+
+        var trimmed = version.Trim();
+        if (!trimmed.StartsWith("1.", StringComparison.Ordinal) &&
+            !trimmed.StartsWith("2.", StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Unsupported WCS version: {version}. Expected 1.x or 2.x.",
+                nameof(version));
+        }
+
+        return trimmed;
+    }
+
+    private static string NormalizeOutputFormat(string? outputFormat)
+    {
+        if (string.IsNullOrWhiteSpace(outputFormat))
+        {
+            return DefaultOutputFormat;
+        }
+
+        return outputFormat.Trim();
+    }
+
+    private static bool IsGeoTiffFormat(string negotiatedFormat)
+    {
+        // Accept the common GeoTIFF MIME variants WCS servers advertise.
+        if (negotiatedFormat.Equals("image/tiff", StringComparison.OrdinalIgnoreCase) ||
+            negotiatedFormat.Equals("image/geotiff", StringComparison.OrdinalIgnoreCase) ||
+            negotiatedFormat.Equals("image/tiff;application=geotiff", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return negotiatedFormat.StartsWith("image/tiff;", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static MigrationSourceInventoryArtifact DowngradeAutomatedCoveragesToManualReview(
+        MigrationSourceInventoryArtifact inventory,
+        string requestedFormat)
+    {
+        var manualReason = $"WCS import requested output format '{requestedFormat}', which is not supported by the slice-2 GeoTIFF/COG ingestion pipeline. Resolve manually before promoting.";
+        var manualSteps = new[]
+        {
+            $"Output format '{requestedFormat}' is not currently ingestible. Convert the coverage to GeoTIFF before re-running the import, or request a GeoTIFF response from the WCS server.",
+            "Confirm the source service can serve image/tiff for this coverage and re-run with outputFormat=image/tiff."
+        };
+
+        var rewritten = inventory.Resources
+            .Select(resource =>
+            {
+                if (!string.Equals(resource.Kind, "coverage", StringComparison.Ordinal))
+                {
+                    return resource;
+                }
+
+                return resource with
+                {
+                    Compatibility = resource.Compatibility with
+                    {
+                        Level = "incompatible",
+                        Code = OgcCoverageMigrationCompatibilityCodes.ScientificFormatUnsupported,
+                        Reason = manualReason,
+                        ManualSteps = manualSteps
+                    }
+                };
+            })
+            .ToArray();
+
+        return inventory with { Resources = rewritten };
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 8820,
+            Level = LogLevel.Information,
+            Message = "WCS import: requested output format '{Format}' is not GeoTIFF; routing coverages to manual review.")]
+        public static partial void NonGeoTiffFormatDowngraded(ILogger logger, string format);
+    }
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -274,6 +274,9 @@ public static class EndpointRegistry
         new("POST", "/api/v1/admin/import/geoserver/jobs/{jobId}/cancel"),
         new("GET", "/api/v1/admin/import/geoserver/jobs"),
 
+        // v1 admin import endpoints (OGC Coverages - GeoTIFF/COG, issue #1030 slice 2)
+        new("POST", "/api/v1/admin/import/ogc/coverages/import"),
+
         // v1 admin operational monitoring endpoints (#512)
         new("GET", "/api/v1/admin/operations/cache/health"),
         new("GET", "/api/v1/admin/operations/cache/statistics"),

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -277,6 +277,9 @@ public static class EndpointRegistry
         // v1 admin import endpoints (OGC Coverages - GeoTIFF/COG, issue #1030 slice 2)
         new("POST", "/api/v1/admin/import/ogc/coverages/import"),
 
+        // v1 admin import endpoints (legacy OGC WCS, issue #1030 slice 3)
+        new("POST", "/api/v1/admin/import/ogc-wcs/import"),
+
         // v1 admin operational monitoring endpoints (#512)
         new("GET", "/api/v1/admin/operations/cache/health"),
         new("GET", "/api/v1/admin/operations/cache/statistics"),

--- a/src/Honua.Server/Features/Import/OgcCoverageImportEndpoints.cs
+++ b/src/Honua.Server/Features/Import/OgcCoverageImportEndpoints.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Helpers;
+
+namespace Honua.Server.Features.Import;
+
+/// <summary>
+/// API endpoints for OGC WCS / OGC API Coverages GeoTIFF and Cloud Optimized GeoTIFF
+/// coverage imports (issue #1030 slice 2).
+/// </summary>
+internal static class OgcCoverageImportEndpoints
+{
+    /// <summary>
+    /// Map OGC coverage import endpoints to the web application with formal API versioning.
+    /// </summary>
+    public static void MapOgcCoverageImportEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/v{version:apiVersion}/admin/import/ogc/coverages")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("OgcCoverageImport")
+            .RequireAdminAuthorization();
+
+        _ = group.MapPost("/import", HandleImportCoverages)
+            .WithName("ImportOgcCoverages")
+            .WithSummary("Plan or apply a GeoTIFF/COG coverage import using a slice-1 migration inventory");
+    }
+
+    private static async Task HandleImportCoverages(HttpContext context)
+    {
+        var cancellationToken = context.RequestAborted;
+
+        OgcCoverageImportApiRequest? request;
+        try
+        {
+            request = await context.Request.ReadFromJsonAsync(
+                OgcCoverageImportJsonContext.Default.OgcCoverageImportApiRequest,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Invalid request body", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (request == null)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Request body is required", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ServiceType))
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "ServiceType is required.", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ServiceUrl))
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "ServiceUrl is required.", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (request.Inventory == null)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Inventory is required.", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        // Safety gate mirrors GeoServer import: explicit applyMode=true required to mutate state.
+        var dryRun = request.DryRun ?? true;
+        var applyMode = request.ApplyMode ?? false;
+        if (!dryRun && !applyMode)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                "Non-dry-run OGC coverage imports require applyMode=true to acknowledge that GeoTIFF/COG coverage data will be written to the Honua raster store.",
+                StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var allowUnsafeLocalUrls = GeoServerImportExecutionSettings.ShouldAllowUnsafeLocalUrls(context.RequestServices);
+        var urlValidation = await OgcServiceUrlValidation.ValidateAsync(
+            request.ServiceUrl,
+            allowUnsafeLocalUrls,
+            cancellationToken).ConfigureAwait(false);
+        if (!urlValidation.IsValid)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                urlValidation.ErrorMessage!,
+                StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var importRequest = new OgcCoverageImportRequest
+        {
+            ServiceType = request.ServiceType,
+            ServiceUrl = request.ServiceUrl,
+            Version = request.Version,
+            Inventory = request.Inventory,
+            CoverageSelection = request.CoverageSelection ?? [],
+            Targets = request.Targets ?? new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal),
+            ApplyMode = applyMode,
+            DryRun = dryRun,
+            TargetServiceName = request.TargetServiceName,
+            Username = request.Username,
+            Password = request.Password,
+            TimeoutSeconds = request.TimeoutSeconds ?? 120,
+            AllowUnsafeLocalUrls = allowUnsafeLocalUrls
+        };
+
+        try
+        {
+            var service = context.RequestServices.GetRequiredService<IOgcCoverageImportService>();
+            var result = await service.ImportAsync(importRequest, cancellationToken).ConfigureAwait(false);
+
+            await Results.Json(result, OgcCoverageImportJsonContext.Default.OgcCoverageImportResult)
+                .ExecuteAsync(context).ConfigureAwait(false);
+        }
+        catch (ArgumentException ex)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, ex.Message, StatusCodes.Status400BadRequest);
+        }
+        catch (HttpRequestException)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                "Failed to connect to coverage source service.",
+                StatusCodes.Status502BadGateway);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                "Coverage import timed out.",
+                StatusCodes.Status504GatewayTimeout);
+        }
+    }
+}
+
+/// <summary>
+/// API request payload for OGC coverage import operations.
+/// </summary>
+internal sealed record OgcCoverageImportApiRequest
+{
+    /// <summary>
+    /// Coverage protocol surface. Accepted values are <c>WCS</c> and <c>OGC API Coverages</c>.
+    /// </summary>
+    public string? ServiceType { get; init; }
+
+    /// <summary>
+    /// Source coverage service URL.
+    /// </summary>
+    public string? ServiceUrl { get; init; }
+
+    /// <summary>
+    /// Optional source service version.
+    /// </summary>
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// Slice-1 migration inventory artifact identifying the coverages to plan or import.
+    /// </summary>
+    public MigrationSourceInventoryArtifact? Inventory { get; init; }
+
+    /// <summary>
+    /// Optional explicit coverage selection. When omitted every coverage in the inventory is processed.
+    /// </summary>
+    public string[]? CoverageSelection { get; init; }
+
+    /// <summary>
+    /// Optional per-coverage import targets keyed by source coverage name or resource id.
+    /// </summary>
+    public IReadOnlyDictionary<string, OgcCoverageImportTarget>? Targets { get; init; }
+
+    /// <summary>
+    /// Optional dry-run preview flag. Defaults to <c>true</c>.
+    /// </summary>
+    public bool? DryRun { get; init; }
+
+    /// <summary>
+    /// Apply-mode opt-in. Required (alongside <c>dryRun=false</c>) to mutate raster store state.
+    /// </summary>
+    public bool? ApplyMode { get; init; }
+
+    /// <summary>
+    /// Optional target service name used when computing manifest identities.
+    /// </summary>
+    public string? TargetServiceName { get; init; }
+
+    /// <summary>
+    /// Optional HTTP basic-auth username for protected coverage endpoints.
+    /// </summary>
+    public string? Username { get; init; }
+
+    /// <summary>
+    /// Optional HTTP basic-auth password for protected coverage endpoints.
+    /// </summary>
+    public string? Password { get; init; }
+
+    /// <summary>
+    /// Optional per-request timeout in seconds.
+    /// </summary>
+    public int? TimeoutSeconds { get; init; }
+}

--- a/src/Honua.Server/Features/Import/OgcCoverageImportJsonContext.cs
+++ b/src/Honua.Server/Features/Import/OgcCoverageImportJsonContext.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Server.Features.Import;
+
+/// <summary>
+/// Source-generated JSON serialization context for OGC coverage import endpoint payloads.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(OgcCoverageImportApiRequest))]
+[JsonSerializable(typeof(OgcCoverageImportRequest))]
+[JsonSerializable(typeof(OgcCoverageImportResult))]
+[JsonSerializable(typeof(OgcCoverageImportRecord))]
+[JsonSerializable(typeof(OgcCoverageImportRecord[]))]
+[JsonSerializable(typeof(OgcCoverageImportTarget))]
+[JsonSerializable(typeof(IReadOnlyDictionary<string, OgcCoverageImportTarget>))]
+[JsonSerializable(typeof(MigrationSourceInventoryArtifact))]
+[JsonSerializable(typeof(MigrationManifestArtifact))]
+internal sealed partial class OgcCoverageImportJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Import/OgcWcsImportEndpoints.cs
+++ b/src/Honua.Server/Features/Import/OgcWcsImportEndpoints.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Helpers;
+
+namespace Honua.Server.Features.Import;
+
+/// <summary>
+/// API endpoints for legacy OGC Web Coverage Service (WCS 1.x / 2.x) coverage
+/// imports. Issue #1030 slice 3 — the WCS counterpart to slice 2's
+/// OGC API Coverages import surface.
+/// </summary>
+internal static class OgcWcsImportEndpoints
+{
+    /// <summary>
+    /// Map OGC WCS import endpoints onto the web application with formal API versioning.
+    /// </summary>
+    public static void MapOgcWcsImportEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/v{version:apiVersion}/admin/import/ogc-wcs")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("OgcWcsImport")
+            .RequireAdminAuthorization();
+
+        _ = group.MapPost("/import", HandleImportCoverages)
+            .WithName("ImportOgcWcsCoverages")
+            .WithSummary("Plan or apply a legacy WCS coverage import using a slice-1 migration inventory");
+    }
+
+    private static async Task HandleImportCoverages(HttpContext context)
+    {
+        var cancellationToken = context.RequestAborted;
+
+        OgcWcsImportApiRequest? request;
+        try
+        {
+            request = await context.Request.ReadFromJsonAsync(
+                OgcWcsImportJsonContext.Default.OgcWcsImportApiRequest,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Invalid request body", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (request == null)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Request body is required", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ServiceUrl))
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "ServiceUrl is required.", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (request.Inventory == null)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Inventory is required.", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        // Safety gate: require explicit applyMode=true when dryRun=false. Matches the
+        // slice-2 coverage endpoint contract so operators must acknowledge state mutation.
+        var dryRun = request.DryRun ?? true;
+        var applyMode = request.ApplyMode ?? false;
+        if (!dryRun && !applyMode)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                "Non-dry-run WCS coverage imports require applyMode=true to acknowledge that coverage data will be written to the Honua raster store.",
+                StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var allowUnsafeLocalUrls = GeoServerImportExecutionSettings.ShouldAllowUnsafeLocalUrls(context.RequestServices);
+        var urlValidation = await OgcServiceUrlValidation.ValidateAsync(
+            request.ServiceUrl,
+            allowUnsafeLocalUrls,
+            cancellationToken).ConfigureAwait(false);
+        if (!urlValidation.IsValid)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                urlValidation.ErrorMessage!,
+                StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var importRequest = new OgcWcsImportRequest
+        {
+            ServiceUrl = request.ServiceUrl,
+            Version = request.Version,
+            Inventory = request.Inventory,
+            OutputFormat = string.IsNullOrWhiteSpace(request.OutputFormat) ? "image/tiff" : request.OutputFormat!,
+            CoverageSelection = request.CoverageSelection ?? [],
+            Targets = request.Targets ?? new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal),
+            ApplyMode = applyMode,
+            DryRun = dryRun,
+            TargetServiceName = request.TargetServiceName,
+            Username = request.Username,
+            Password = request.Password,
+            TimeoutSeconds = request.TimeoutSeconds ?? 120,
+            AllowUnsafeLocalUrls = allowUnsafeLocalUrls
+        };
+
+        try
+        {
+            var service = context.RequestServices.GetRequiredService<IOgcWcsImportService>();
+            var result = await service.ImportAsync(importRequest, cancellationToken).ConfigureAwait(false);
+
+            await Results.Json(result, OgcWcsImportJsonContext.Default.OgcWcsImportResult)
+                .ExecuteAsync(context).ConfigureAwait(false);
+        }
+        catch (ArgumentException ex)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, ex.Message, StatusCodes.Status400BadRequest);
+        }
+        catch (HttpRequestException)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                "Failed to connect to WCS source service.",
+                StatusCodes.Status502BadGateway);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                "WCS coverage import timed out.",
+                StatusCodes.Status504GatewayTimeout);
+        }
+    }
+}
+
+/// <summary>
+/// API request payload for legacy WCS coverage import operations.
+/// </summary>
+internal sealed record OgcWcsImportApiRequest
+{
+    /// <summary>
+    /// Source WCS service URL.
+    /// </summary>
+    public string? ServiceUrl { get; init; }
+
+    /// <summary>
+    /// Optional WCS protocol version (e.g. <c>1.1.1</c>, <c>2.0.1</c>).
+    /// </summary>
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// Requested output format. Defaults to <c>image/tiff</c>; other formats are
+    /// classified as manual-review.
+    /// </summary>
+    public string? OutputFormat { get; init; }
+
+    /// <summary>
+    /// Slice-1 migration inventory artifact identifying the coverages to plan or import.
+    /// </summary>
+    public MigrationSourceInventoryArtifact? Inventory { get; init; }
+
+    /// <summary>
+    /// Optional explicit coverage selection. When omitted every coverage in the inventory is processed.
+    /// </summary>
+    public string[]? CoverageSelection { get; init; }
+
+    /// <summary>
+    /// Optional per-coverage import targets keyed by source coverage name or resource id.
+    /// </summary>
+    public IReadOnlyDictionary<string, OgcCoverageImportTarget>? Targets { get; init; }
+
+    /// <summary>
+    /// Optional dry-run preview flag. Defaults to <c>true</c>.
+    /// </summary>
+    public bool? DryRun { get; init; }
+
+    /// <summary>
+    /// Apply-mode opt-in. Required (alongside <c>dryRun=false</c>) to mutate raster store state.
+    /// </summary>
+    public bool? ApplyMode { get; init; }
+
+    /// <summary>
+    /// Optional target service name used when computing manifest identities.
+    /// </summary>
+    public string? TargetServiceName { get; init; }
+
+    /// <summary>
+    /// Optional HTTP basic-auth username for protected WCS endpoints.
+    /// </summary>
+    public string? Username { get; init; }
+
+    /// <summary>
+    /// Optional HTTP basic-auth password for protected WCS endpoints.
+    /// </summary>
+    public string? Password { get; init; }
+
+    /// <summary>
+    /// Optional per-request timeout in seconds.
+    /// </summary>
+    public int? TimeoutSeconds { get; init; }
+}

--- a/src/Honua.Server/Features/Import/OgcWcsImportJsonContext.cs
+++ b/src/Honua.Server/Features/Import/OgcWcsImportJsonContext.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Server.Features.Import;
+
+/// <summary>
+/// Source-generated JSON serialization context for legacy OGC WCS coverage import payloads.
+/// Issue #1030 slice 3.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(OgcWcsImportApiRequest))]
+[JsonSerializable(typeof(OgcWcsImportRequest))]
+[JsonSerializable(typeof(OgcWcsImportResult))]
+[JsonSerializable(typeof(OgcCoverageImportRecord))]
+[JsonSerializable(typeof(OgcCoverageImportRecord[]))]
+[JsonSerializable(typeof(OgcCoverageImportTarget))]
+[JsonSerializable(typeof(IReadOnlyDictionary<string, OgcCoverageImportTarget>))]
+[JsonSerializable(typeof(MigrationSourceInventoryArtifact))]
+[JsonSerializable(typeof(MigrationManifestArtifact))]
+internal sealed partial class OgcWcsImportJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -819,6 +819,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Import.ImportJsonContext.Default,
         Honua.Server.Features.Import.RasterImportJsonContext.Default,
         Honua.Server.Features.Import.GeoservicesImportApiJsonContext.Default,
+        Honua.Server.Features.Import.OgcCoverageImportJsonContext.Default,
         Honua.Server.Features.Admin.OperationsProgressJsonContext.Default,
         Honua.Server.Features.Admin.FeatureEventReplayJsonContext.Default,
         Honua.Server.Features.Mobile.Auth.MobileAuthJsonContext.Default,
@@ -1223,6 +1224,9 @@ app.MapGeoservicesImportEndpoints();
 
 // Configure GeoServer import endpoints
 app.MapGeoServerImportEndpoints();
+
+// Configure OGC WCS / OGC API Coverages GeoTIFF/COG import endpoints (issue #1030 slice 2)
+app.MapOgcCoverageImportEndpoints();
 
 if (isTestEnvironment)
 {

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -820,6 +820,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Import.RasterImportJsonContext.Default,
         Honua.Server.Features.Import.GeoservicesImportApiJsonContext.Default,
         Honua.Server.Features.Import.OgcCoverageImportJsonContext.Default,
+        Honua.Server.Features.Import.OgcWcsImportJsonContext.Default,
         Honua.Server.Features.Admin.OperationsProgressJsonContext.Default,
         Honua.Server.Features.Admin.FeatureEventReplayJsonContext.Default,
         Honua.Server.Features.Mobile.Auth.MobileAuthJsonContext.Default,
@@ -1227,6 +1228,9 @@ app.MapGeoServerImportEndpoints();
 
 // Configure OGC WCS / OGC API Coverages GeoTIFF/COG import endpoints (issue #1030 slice 2)
 app.MapOgcCoverageImportEndpoints();
+
+// Configure legacy OGC WCS coverage import endpoints (issue #1030 slice 3)
+app.MapOgcWcsImportEndpoints();
 
 if (isTestEnvironment)
 {

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcCoverageImportServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcCoverageImportServiceTests.cs
@@ -1,0 +1,404 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Core.Tests.Features.Import;
+
+/// <summary>
+/// Service-level tests for <see cref="OgcCoverageImportService"/> (issue #1030 slice 2).
+/// Cover GeoTIFF / COG selection, dry-run vs apply, idempotency, and error propagation.
+/// </summary>
+public sealed class OgcCoverageImportServiceTests
+{
+    private const string ServiceUrl = "https://example.com/geoserver/wcs";
+
+    [Fact]
+    public async Task ImportAsync_DryRun_BuildsPlannedManifestWithoutDownloadingCoverage()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => throw new InvalidOperationException("Dry-run import must not call the source service."));
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var inventory = BuildInventory(BuildCogResource("dem-cog"), BuildGeoTiffResource("dem-tiff"));
+        var request = new OgcCoverageImportRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = ServiceUrl,
+            Inventory = inventory,
+            DryRun = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.DryRun.Should().BeTrue();
+        result.ApplyMode.Should().BeFalse();
+        result.Records.Should().HaveCount(2);
+        result.Records.Should().OnlyContain(record => record.Action == "planned");
+
+        var cog = result.Records.Single(record => record.SourceCoverageId == "dem-cog");
+        cog.OutputFormat.Should().Be("CloudOptimizedGeoTIFF");
+        cog.Classification.Should().Be("automated");
+
+        var tiff = result.Records.Single(record => record.SourceCoverageId == "dem-tiff");
+        tiff.OutputFormat.Should().Be("GeoTIFF");
+        tiff.Classification.Should().Be("automated");
+
+        result.Manifest.Summary.TargetResourceCount.Should().Be(2);
+        result.Manifest.TargetResources.Should().OnlyContain(target => target.Action == "planned");
+        handler.RequestCount.Should().Be(0);
+        rasterImportMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ImportAsync_ApplyMode_DownloadsGeoTiffAndRegistersRaster()
+    {
+        var capturedRequests = new List<RasterImportRequest>();
+        var rasterImportMock = new Mock<IRasterImportService>();
+        rasterImportMock
+            .Setup(static s => s.ImportAsync(It.IsAny<RasterImportRequest>(), null, It.IsAny<CancellationToken>()))
+            .Callback<RasterImportRequest, IProgress<RasterImportProgress>?, CancellationToken>((req, _, _) => capturedRequests.Add(req))
+            .ReturnsAsync((RasterImportRequest req, IProgress<RasterImportProgress>? _, CancellationToken _) =>
+                new RasterImportResult
+                {
+                    Success = true,
+                    RasterId = 4242,
+                    LayerId = req.LayerId,
+                    Name = req.Name,
+                    Format = req.Format
+                });
+
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcCoverageImportRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = ServiceUrl,
+            Version = "2.0.1",
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-tiff"] = new OgcCoverageImportTarget { LayerId = 7, Name = "Elevation" }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.ApplyMode.Should().BeTrue();
+        result.DryRun.Should().BeFalse();
+        var record = result.Records.Should().ContainSingle().Subject;
+        record.Action.Should().Be("imported");
+        record.RasterId.Should().Be(4242);
+        record.TargetLayerId.Should().Be(7);
+        record.ByteCount.Should().BeGreaterThan(0);
+        handler.RequestCount.Should().Be(1);
+        handler.LastRequest!.RequestUri!.Query.Should().Contain("request=GetCoverage");
+        handler.LastRequest!.RequestUri!.Query.Should().Contain("coverageId=dem-tiff");
+        capturedRequests.Should().ContainSingle();
+        capturedRequests[0].Format.Should().Be(SupportedRasterFormat.GeoTiff);
+    }
+
+    [Fact]
+    public async Task ImportAsync_ApplyMode_CogClassificationRequestsCloudOptimizedFormat()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>();
+        rasterImportMock
+            .Setup(static s => s.ImportAsync(It.IsAny<RasterImportRequest>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RasterImportRequest req, IProgress<RasterImportProgress>? _, CancellationToken _) =>
+                new RasterImportResult
+                {
+                    Success = true,
+                    RasterId = 99,
+                    LayerId = req.LayerId,
+                    Name = req.Name,
+                    Format = req.Format
+                });
+
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcCoverageImportRequest
+        {
+            ServiceType = "OGC API Coverages",
+            ServiceUrl = "https://example.com/ogc/collections",
+            Inventory = BuildInventory(BuildCogResource("dem-cog")),
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-cog"] = new OgcCoverageImportTarget { LayerId = 11 }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        var record = result.Records.Should().ContainSingle().Subject;
+        record.OutputFormat.Should().Be("CloudOptimizedGeoTIFF");
+        record.Action.Should().Be("imported");
+        handler.LastRequest!.RequestUri!.AbsolutePath.Should().EndWith("/collections/dem-cog/coverage");
+        handler.LastRequest!.RequestUri!.Query.Should().Contain("f=tif");
+    }
+
+    [Fact]
+    public async Task ImportAsync_ApplyMode_TwiceProducesIdenticalManifests()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>();
+        rasterImportMock
+            .Setup(static s => s.ImportAsync(It.IsAny<RasterImportRequest>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RasterImportRequest req, IProgress<RasterImportProgress>? _, CancellationToken _) =>
+                new RasterImportResult
+                {
+                    Success = true,
+                    RasterId = 100,
+                    LayerId = req.LayerId,
+                    Name = req.Name,
+                    Format = req.Format
+                });
+
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var inventory = BuildInventory(BuildGeoTiffResource("dem-tiff"));
+        var request = new OgcCoverageImportRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = ServiceUrl,
+            Inventory = inventory,
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-tiff"] = new OgcCoverageImportTarget { LayerId = 5 }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var first = await service.ImportAsync(request);
+        var second = await service.ImportAsync(request);
+
+        first.Manifest.Should().BeEquivalentTo(second.Manifest);
+        first.Records.Select(static r => r.SourceCoverageId)
+            .Should().BeEquivalentTo(second.Records.Select(static r => r.SourceCoverageId));
+        handler.RequestCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ImportAsync_ApplyMode_MissingLayerIdProducesManualReviewWithoutCallingSource()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => throw new InvalidOperationException("Source must not be called when layerId is missing."));
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcCoverageImportRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = ServiceUrl,
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        var record = result.Records.Should().ContainSingle().Subject;
+        record.Action.Should().Be("skipped");
+        record.Warnings.Should().ContainSingle()
+            .Which.Should().Contain("no target layer was supplied");
+        result.Manifest.ManualReviewItems.Should().ContainSingle()
+            .Which.Code.Should().Be("OGC_COVERAGE_TARGET_LAYER_MISSING");
+        handler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ImportAsync_ApplyMode_HttpFailurePropagatesAsFailedRecord()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcCoverageImportRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = ServiceUrl,
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-tiff"] = new OgcCoverageImportTarget { LayerId = 3 }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        var record = result.Records.Should().ContainSingle().Subject;
+        record.Action.Should().Be("failed");
+        record.ErrorMessage.Should().Be("Failed to download or import coverage.");
+        handler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ImportAsync_UnsupportedScientificFormat_ClassifiedAsManualReview()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => throw new InvalidOperationException("Unsupported coverages must not be downloaded."));
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcCoverageImportRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = ServiceUrl,
+            Inventory = BuildInventory(BuildResource(
+                "dem-netcdf",
+                OgcCoverageMigrationCompatibilityCodes.NetCdfUnsupported,
+                "incompatible")),
+            DryRun = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        var record = result.Records.Should().ContainSingle().Subject;
+        record.Action.Should().Be("manual-review");
+        record.OutputFormat.Should().Be("NetCDF");
+        record.Classification.Should().Be("unsupported");
+        result.Manifest.UnsupportedItems.Should().ContainSingle()
+            .Which.Code.Should().Be(OgcCoverageMigrationCompatibilityCodes.NetCdfUnsupported);
+        handler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ImportAsync_RejectsPlainHttpUrl_UnlessAllowUnsafeIsSet()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcCoverageImportRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = "http://example.com/wcs",
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            DryRun = true
+        };
+
+        var act = async () => await service.ImportAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    private static OgcCoverageImportService CreateService(
+        HttpMessageHandler handler,
+        IRasterImportService rasterImportService)
+    {
+        var httpClient = new HttpClient(handler);
+        return new OgcCoverageImportService(
+            httpClient,
+            rasterImportService,
+            NullLogger<OgcCoverageImportService>.Instance);
+    }
+
+    private static MigrationSourceInventoryArtifact BuildInventory(params MigrationInventoryResource[] resources)
+        => new()
+        {
+            SourceKind = "ogc-wcs",
+            Source = new MigrationSourceIdentity
+            {
+                DisplayName = "Example WCS",
+                BaseUrl = ServiceUrl,
+                ServiceType = "WCS"
+            },
+            AuthPosture = new MigrationInventoryAuthPosture { Mode = "anonymous" },
+            ScanCompleteness = new MigrationInventoryCompleteness { Status = "complete" },
+            Summary = new MigrationInventorySummary
+            {
+                ContainerCount = 1,
+                ResourceCount = resources.Length
+            },
+            OverallCompatibility = new MigrationCompatibilityAssessment
+            {
+                Level = "compatible",
+                Reason = "OGC coverage migration scan completed."
+            },
+            Resources = resources
+        };
+
+    private static MigrationInventoryResource BuildGeoTiffResource(string name)
+        => BuildResource(name, OgcCoverageMigrationCompatibilityCodes.GeoTiffSupported, "compatible");
+
+    private static MigrationInventoryResource BuildCogResource(string name)
+        => BuildResource(name, OgcCoverageMigrationCompatibilityCodes.CogSupported, "compatible");
+
+    private static MigrationInventoryResource BuildResource(string name, string compatibilityCode, string level)
+        => new()
+        {
+            Id = $"coverage:{name}",
+            ContainerId = "service:wcs",
+            Kind = "coverage",
+            Name = name,
+            Title = name,
+            SpatialReferences = [
+                new MigrationSpatialReferenceInfo
+                {
+                    Role = "native",
+                    Srid = 4326,
+                    SourceValue = "EPSG:4326"
+                }
+            ],
+            Compatibility = new MigrationCompatibilityAssessment
+            {
+                Level = level,
+                Code = compatibilityCode,
+                Reason = $"OGC coverage migration compatibility: {compatibilityCode}."
+            }
+        };
+
+    /// <summary>
+    /// Creates a minimal GeoTIFF response payload. Includes the classic GeoTIFF
+    /// little-endian header so anything sniffing the file can identify it.
+    /// </summary>
+    private static HttpResponseMessage CreateGeoTiffResponse()
+    {
+        // II*\0 = little-endian TIFF magic. Padding bytes simulate a small coverage body.
+        var bytes = new byte[]
+        {
+            0x49, 0x49, 0x2A, 0x00,
+            0x08, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0xDE, 0xAD, 0xBE, 0xEF
+        };
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(bytes)
+        };
+    }
+
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpResponseMessage> _factory;
+
+        public CountingHandler(Func<HttpResponseMessage> factory)
+        {
+            _factory = factory;
+        }
+
+        public int RequestCount { get; private set; }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            LastRequest = request;
+            return Task.FromResult(_factory());
+        }
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcWcsImportServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcWcsImportServiceTests.cs
@@ -1,0 +1,393 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Core.Tests.Features.Import;
+
+/// <summary>
+/// Service-level tests for <see cref="OgcWcsImportService"/> (issue #1030 slice 3).
+/// Exercises the WCS happy-path against captured GetCoverage responses, the
+/// non-GeoTIFF format downgrade, and error propagation from the underlying
+/// coverage import pipeline.
+/// </summary>
+public sealed class OgcWcsImportServiceTests
+{
+    private const string ServiceUrl = "https://example.com/geoserver/wcs";
+
+    [Fact]
+    public async Task ImportAsync_DryRun_BuildsPlannedManifestWithoutDownloadingCoverage()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => throw new InvalidOperationException("Dry-run import must not call the WCS source."));
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var inventory = BuildInventory(BuildGeoTiffResource("dem-tiff"));
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            Inventory = inventory,
+            DryRun = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.DryRun.Should().BeTrue();
+        result.ApplyMode.Should().BeFalse();
+        result.RequestedOutputFormat.Should().Be("image/tiff");
+        result.ResolvedVersion.Should().Be("2.0.1");
+        result.Records.Should().ContainSingle().Which.Action.Should().Be("planned");
+        result.Manifest.TargetResources.Should().OnlyContain(target => target.Action == "planned");
+        handler.RequestCount.Should().Be(0);
+        rasterImportMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ImportAsync_ApplyMode_DownloadsGeoTiffAndIssuesWcsGetCoverageRequest()
+    {
+        var capturedRequests = new List<RasterImportRequest>();
+        var rasterImportMock = new Mock<IRasterImportService>();
+        rasterImportMock
+            .Setup(static s => s.ImportAsync(It.IsAny<RasterImportRequest>(), null, It.IsAny<CancellationToken>()))
+            .Callback<RasterImportRequest, IProgress<RasterImportProgress>?, CancellationToken>((req, _, _) => capturedRequests.Add(req))
+            .ReturnsAsync((RasterImportRequest req, IProgress<RasterImportProgress>? _, CancellationToken _) =>
+                new RasterImportResult
+                {
+                    Success = true,
+                    RasterId = 7777,
+                    LayerId = req.LayerId,
+                    Name = req.Name,
+                    Format = req.Format
+                });
+
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            Version = "2.0.1",
+            OutputFormat = "image/tiff",
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-tiff"] = new OgcCoverageImportTarget { LayerId = 9, Name = "Elevation" }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.ApplyMode.Should().BeTrue();
+        result.DryRun.Should().BeFalse();
+        result.ResolvedVersion.Should().Be("2.0.1");
+        var record = result.Records.Should().ContainSingle().Subject;
+        record.Action.Should().Be("imported");
+        record.RasterId.Should().Be(7777);
+        record.TargetLayerId.Should().Be(9);
+        record.OutputFormat.Should().Be("GeoTIFF");
+        handler.RequestCount.Should().Be(1);
+        var query = handler.LastRequest!.RequestUri!.Query;
+        query.Should().Contain("service=WCS");
+        query.Should().Contain("request=GetCoverage");
+        query.Should().Contain("coverageId=dem-tiff");
+        query.Should().Contain("version=2.0.1");
+        capturedRequests.Should().ContainSingle();
+        capturedRequests[0].Format.Should().Be(SupportedRasterFormat.GeoTiff);
+    }
+
+    [Fact]
+    public async Task ImportAsync_NonGeoTiffFormat_DowngradesEveryCoverageToManualReview()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => throw new InvalidOperationException("Non-GeoTIFF formats must not call the WCS source."));
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            OutputFormat = "application/x-netcdf",
+            Inventory = BuildInventory(
+                BuildGeoTiffResource("dem-tiff"),
+                BuildGeoTiffResource("ortho-tiff")),
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-tiff"] = new OgcCoverageImportTarget { LayerId = 1 },
+                ["ortho-tiff"] = new OgcCoverageImportTarget { LayerId = 2 }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.RequestedOutputFormat.Should().Be("application/x-netcdf");
+        result.Records.Should().HaveCount(2);
+        result.Records.Should().OnlyContain(record => record.Action == "manual-review");
+        result.Manifest.UnsupportedItems.Should().HaveCount(2);
+        result.Manifest.UnsupportedItems.Should().OnlyContain(item =>
+            item.Code == OgcCoverageMigrationCompatibilityCodes.ScientificFormatUnsupported);
+        handler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ImportAsync_GeoTiffMimeVariant_IsTreatedAsAutomatedFormat()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>();
+        rasterImportMock
+            .Setup(static s => s.ImportAsync(It.IsAny<RasterImportRequest>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RasterImportRequest req, IProgress<RasterImportProgress>? _, CancellationToken _) =>
+                new RasterImportResult
+                {
+                    Success = true,
+                    RasterId = 333,
+                    LayerId = req.LayerId,
+                    Name = req.Name,
+                    Format = req.Format
+                });
+
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            OutputFormat = "image/tiff;application=geotiff",
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-tiff"] = new OgcCoverageImportTarget { LayerId = 4 }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.RequestedOutputFormat.Should().Be("image/tiff;application=geotiff");
+        result.Records.Should().ContainSingle().Which.Action.Should().Be("imported");
+        handler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ImportAsync_Wcs1xVersion_PropagatesLegacyCoverageParameter()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>();
+        rasterImportMock
+            .Setup(static s => s.ImportAsync(It.IsAny<RasterImportRequest>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RasterImportRequest req, IProgress<RasterImportProgress>? _, CancellationToken _) =>
+                new RasterImportResult
+                {
+                    Success = true,
+                    RasterId = 1,
+                    LayerId = req.LayerId,
+                    Name = req.Name,
+                    Format = req.Format
+                });
+
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            Version = "1.1.1",
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-tiff"] = new OgcCoverageImportTarget { LayerId = 6 }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.ResolvedVersion.Should().Be("1.1.1");
+        var query = handler.LastRequest!.RequestUri!.Query;
+        query.Should().Contain("version=1.1.1");
+        // WCS 1.x uses "coverage" rather than "coverageId" for the layer identifier.
+        query.Should().Contain("coverage=dem-tiff");
+        query.Should().NotContain("coverageId=");
+    }
+
+    [Fact]
+    public async Task ImportAsync_HttpFailurePropagatesAsFailedRecord()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-tiff"] = new OgcCoverageImportTarget { LayerId = 3 }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        var record = result.Records.Should().ContainSingle().Subject;
+        record.Action.Should().Be("failed");
+        record.ErrorMessage.Should().Be("Failed to download or import coverage.");
+        handler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ImportAsync_RejectsUnknownVersion()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            Version = "9.9.9",
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            DryRun = true
+        };
+
+        var act = async () => await service.ImportAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .Where(static ex => ex.Message.Contains("Unsupported WCS version"));
+        handler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ImportAsync_MissingServiceUrl_ThrowsArgumentException()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = "   ",
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff"))
+        };
+
+        var act = async () => await service.ImportAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .Where(static ex => ex.Message.Contains("ServiceUrl is required"));
+    }
+
+    private static OgcWcsImportService CreateService(
+        HttpMessageHandler handler,
+        IRasterImportService rasterImportService)
+    {
+        var httpClient = new HttpClient(handler);
+        var coverageService = new OgcCoverageImportService(
+            httpClient,
+            rasterImportService,
+            NullLogger<OgcCoverageImportService>.Instance);
+        return new OgcWcsImportService(
+            coverageService,
+            NullLogger<OgcWcsImportService>.Instance);
+    }
+
+    private static MigrationSourceInventoryArtifact BuildInventory(params MigrationInventoryResource[] resources)
+        => new()
+        {
+            SourceKind = "ogc-wcs",
+            Source = new MigrationSourceIdentity
+            {
+                DisplayName = "Example WCS",
+                BaseUrl = ServiceUrl,
+                ServiceType = "WCS"
+            },
+            AuthPosture = new MigrationInventoryAuthPosture { Mode = "anonymous" },
+            ScanCompleteness = new MigrationInventoryCompleteness { Status = "complete" },
+            Summary = new MigrationInventorySummary
+            {
+                ContainerCount = 1,
+                ResourceCount = resources.Length
+            },
+            OverallCompatibility = new MigrationCompatibilityAssessment
+            {
+                Level = "compatible",
+                Reason = "WCS coverage migration scan completed."
+            },
+            Resources = resources
+        };
+
+    private static MigrationInventoryResource BuildGeoTiffResource(string name)
+        => new()
+        {
+            Id = $"coverage:{name}",
+            ContainerId = "service:wcs",
+            Kind = "coverage",
+            Name = name,
+            Title = name,
+            SpatialReferences = [
+                new MigrationSpatialReferenceInfo
+                {
+                    Role = "native",
+                    Srid = 4326,
+                    SourceValue = "EPSG:4326"
+                }
+            ],
+            Compatibility = new MigrationCompatibilityAssessment
+            {
+                Level = "compatible",
+                Code = OgcCoverageMigrationCompatibilityCodes.GeoTiffSupported,
+                Reason = "WCS GeoTIFF coverage."
+            }
+        };
+
+    /// <summary>
+    /// Builds a minimal GeoTIFF response body. WCS 2.x servers return image/tiff
+    /// directly from GetCoverage; we mimic that shape with the canonical TIFF magic.
+    /// </summary>
+    private static HttpResponseMessage CreateGeoTiffResponse()
+    {
+        // II*\0 = little-endian TIFF magic. Padding bytes simulate the coverage body.
+        var bytes = new byte[]
+        {
+            0x49, 0x49, 0x2A, 0x00,
+            0x08, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0xDE, 0xAD, 0xBE, 0xEF
+        };
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(bytes)
+        };
+    }
+
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpResponseMessage> _factory;
+
+        public CountingHandler(Func<HttpResponseMessage> factory)
+        {
+            _factory = factory;
+        }
+
+        public int RequestCount { get; private set; }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            LastRequest = request;
+            return Task.FromResult(_factory());
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Import/OgcCoverageImportEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/OgcCoverageImportEndpointTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Import;
+
+/// <summary>
+/// Integration tests for OGC coverage import endpoints.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Import)]
+public sealed class OgcCoverageImportEndpointTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/ogc/coverages/import")]
+    public async Task Import_WithMissingServiceType_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/import/ogc/coverages/import", new
+        {
+            ServiceUrl = "https://example.com/ogc/coverages"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("ServiceType is required.");
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Import/OgcWcsImportEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/OgcWcsImportEndpointTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Import;
+
+/// <summary>
+/// Integration tests for legacy OGC WCS coverage import endpoints (issue #1030 slice 3).
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Import)]
+public sealed class OgcWcsImportEndpointTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/ogc-wcs/import")]
+    public async Task Import_WithMissingServiceUrl_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/import/ogc-wcs/import", new
+        {
+            Version = "2.0.1"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("ServiceUrl is required.");
+    }
+}


### PR DESCRIPTION
## Issue Link

Closes #1030 — slice 2/N (follows the migration scan path from #1081).

## Summary

- Add OGC coverage import abstraction + Core service that pulls GeoTIFF/COG coverages from an OGC API Coverages source
- Add Postgres-bound endpoints + JSON source-gen context for the new request/result shapes
- Wire DI registrations and Program.cs endpoint mapping

## Changes Made

- `src/Honua.Core/Features/Import/Abstractions/IOgcCoverageImportService.cs` — new abstraction
- `src/Honua.Core/Features/Import/Domain/OgcCoverageImportRequest.cs` and `OgcCoverageImportResult.cs` — request/result domain types
- `src/Honua.Core/Features/Import/Services/OgcCoverageImportService.cs` — Core service implementation
- `src/Honua.Core/Features/Import/ServiceCollectionExtensions.cs` — DI registration
- `src/Honua.Server/Features/Import/OgcCoverageImportEndpoints.cs` and `OgcCoverageImportJsonContext.cs` — server endpoints + JSON source-gen
- `src/Honua.Server/Program.cs` — endpoint mapping
- `tests/dotnet/Honua.Core.Tests/Features/Import/OgcCoverageImportServiceTests.cs` — new test coverage

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

- `dotnet build` clean
- New `OgcCoverageImportServiceTests` pass
- Reviewer: confirm endpoint mapping shape matches sibling import endpoints

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes

None.

---

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
