### PR TITLE
feat: drive migration apply stage on fixture sources (#1024 slice 3/N)

### DIFF
--- a/src/Honua.Core/Features/Import/Domain/MigrationApplyStageReport.cs
+++ b/src/Honua.Core/Features/Import/Domain/MigrationApplyStageReport.cs
@@ -1,0 +1,234 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Deterministic envelope produced by the migration acceptance apply stage. Aggregates per-source
+/// <see cref="MigrationManifestArtifact"/> outputs (and an apply-plan replay token) into a single
+/// artifact suitable for downstream publish, parity, and readiness stages of the acceptance suite.
+/// </summary>
+/// <remarks>
+/// The apply stage is the second pipeline stage emitted by the migration acceptance suite described
+/// in issue #1024 (scan -> manifest -> apply/dry-run -> publish -> parity -> readiness). When the
+/// upstream source family does not yet support a non-destructive apply against the fixture target,
+/// the runner falls back to the deterministic <see cref="MigrationApplyPlanArtifact"/> dry-run path.
+/// Either way the per-source outcome on this report pins the manifest artifact and a replay token so
+/// later stages can re-derive their work deterministically from the same source set.
+/// </remarks>
+public sealed record MigrationApplyStageReport
+{
+    /// <summary>
+    /// Stable artifact kind identifier.
+    /// </summary>
+    public string ArtifactKind { get; init; } = "honua.migration.apply-stage-report";
+
+    /// <summary>
+    /// Artifact schema version.
+    /// </summary>
+    public string ArtifactVersion { get; init; } = "1.0";
+
+    /// <summary>
+    /// Stable identifier for the acceptance run that produced this report. Callers supply a
+    /// deterministic value (e.g. a fixture set name) so the report can be diffed across runs.
+    /// </summary>
+    public required string RunId { get; init; }
+
+    /// <summary>
+    /// Stable identifier for the upstream scan stage report this apply stage was derived from.
+    /// </summary>
+    public required string ScanRunId { get; init; }
+
+    /// <summary>
+    /// Aggregate counts across all per-source apply outcomes.
+    /// </summary>
+    public required MigrationApplyStageSummary Summary { get; init; }
+
+    /// <summary>
+    /// Per-source apply stage entries, ordered deterministically by
+    /// <see cref="MigrationApplyStageEntry.FixtureId"/>.
+    /// </summary>
+    public MigrationApplyStageEntry[] Sources { get; init; } = [];
+}
+
+/// <summary>
+/// One per-source entry in a <see cref="MigrationApplyStageReport"/>.
+/// </summary>
+public sealed record MigrationApplyStageEntry
+{
+    /// <summary>
+    /// Stable fixture identifier (e.g. <c>arcgis-mapserver-mixed-renderers</c>). Used to order
+    /// entries and to cross-reference upstream scan and downstream parity artifacts.
+    /// </summary>
+    public required string FixtureId { get; init; }
+
+    /// <summary>
+    /// Source kind such as <c>arcgis-geoservices-rest</c>, <c>geoserver-rest</c>, or
+    /// <c>ogc-api-features</c>. Mirrors <see cref="MigrationManifestArtifact.SourceKind"/>.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Apply mode used for the fixture. <c>apply</c> indicates a real apply against the fixture
+    /// target was executed; <c>dry-run</c> indicates the deterministic
+    /// <see cref="MigrationApplyPlanArtifact"/> dry-run path was used instead (the source family
+    /// does not yet support fixture-driven apply, or the fixture explicitly opts into dry-run for
+    /// release gates).
+    /// </summary>
+    public required string ApplyMode { get; init; }
+
+    /// <summary>
+    /// Per-source apply outcome — items applied, manual-review entries, diagnostics, and the
+    /// deterministic manifest the apply stage emitted for downstream consumers.
+    /// </summary>
+    public required MigrationApplyStageOutcome Outcome { get; init; }
+}
+
+/// <summary>
+/// Per-source apply outcome rolled up into a <see cref="MigrationApplyStageEntry"/>.
+/// </summary>
+public sealed record MigrationApplyStageOutcome
+{
+    /// <summary>
+    /// Deterministic manifest artifact produced for this fixture.
+    /// </summary>
+    public required MigrationManifestArtifact Manifest { get; init; }
+
+    /// <summary>
+    /// Stable replay token (SHA-256 fingerprint) over the apply-plan payload. Identical across
+    /// re-runs of the same fixture set.
+    /// </summary>
+    public required string ReplayToken { get; init; }
+
+    /// <summary>
+    /// Number of manifest items the apply stage was able to stage automatically (i.e. apply-plan
+    /// steps with disposition <c>ready</c>).
+    /// </summary>
+    public int AppliedItemCount { get; init; }
+
+    /// <summary>
+    /// Number of manifest items routed to operator review (i.e. apply-plan steps with disposition
+    /// <c>manual-review</c>).
+    /// </summary>
+    public int ManualReviewItemCount { get; init; }
+
+    /// <summary>
+    /// Number of manifest items that this apply path does not support (i.e. apply-plan steps with
+    /// disposition <c>unsupported</c>).
+    /// </summary>
+    public int UnsupportedItemCount { get; init; }
+
+    /// <summary>
+    /// Per-item classifications recorded by the apply stage. Ordered deterministically by
+    /// <see cref="MigrationApplyStageItemClassification.SourceId"/>.
+    /// </summary>
+    public MigrationApplyStageItemClassification[] Classifications { get; init; } = [];
+
+    /// <summary>
+    /// Manual-review entries copied from the manifest for fixture-level review. Ordered by
+    /// <see cref="MigrationManifestReviewItem.SourceId"/> then <see cref="MigrationManifestReviewItem.Code"/>.
+    /// </summary>
+    public MigrationManifestReviewItem[] ManualReviewItems { get; init; } = [];
+
+    /// <summary>
+    /// Apply-stage diagnostics. These are operator-facing notes that surface non-fatal issues that
+    /// did not prevent the manifest from being emitted (e.g. a style format that requires manual
+    /// review, an unsupported renderer that was deliberately not auto-migrated).
+    /// </summary>
+    public MigrationApplyStageDiagnostic[] Diagnostics { get; init; } = [];
+}
+
+/// <summary>
+/// One per-item classification recorded by the apply stage.
+/// </summary>
+public sealed record MigrationApplyStageItemClassification
+{
+    /// <summary>
+    /// Source manifest item identifier.
+    /// </summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>
+    /// Source item kind such as <c>feature-layer</c> or <c>style</c>.
+    /// </summary>
+    public required string Kind { get; init; }
+
+    /// <summary>
+    /// Disposition assigned by the apply stage: <c>applied</c>, <c>manual-review</c>, or
+    /// <c>unsupported</c>.
+    /// </summary>
+    public required string Disposition { get; init; }
+
+    /// <summary>
+    /// Apply-stage action recorded for the item, such as <c>stage-catalog-resource</c>,
+    /// <c>stage-style</c>, <c>manual-review</c>, or <c>unsupported</c>.
+    /// </summary>
+    public required string Action { get; init; }
+}
+
+/// <summary>
+/// Apply-stage diagnostic note surfaced to operators.
+/// </summary>
+public sealed record MigrationApplyStageDiagnostic
+{
+    /// <summary>
+    /// Stable machine-readable diagnostic code.
+    /// </summary>
+    public required string Code { get; init; }
+
+    /// <summary>
+    /// Diagnostic severity such as <c>info</c>, <c>manual-review</c>, or <c>unsupported</c>.
+    /// </summary>
+    public required string Severity { get; init; }
+
+    /// <summary>
+    /// Source manifest item identifier the diagnostic refers to.
+    /// </summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>
+    /// Human-readable diagnostic message. Must not contain credentials or other secrets.
+    /// </summary>
+    public required string Message { get; init; }
+}
+
+/// <summary>
+/// Aggregate counts rolled up across all apply-stage entries in a report.
+/// </summary>
+public sealed record MigrationApplyStageSummary
+{
+    /// <summary>
+    /// Total number of fixture sources processed by the apply stage.
+    /// </summary>
+    public int SourceCount { get; init; }
+
+    /// <summary>
+    /// Number of sources that ran in <c>apply</c> mode.
+    /// </summary>
+    public int AppliedSourceCount { get; init; }
+
+    /// <summary>
+    /// Number of sources that ran in <c>dry-run</c> mode.
+    /// </summary>
+    public int DryRunSourceCount { get; init; }
+
+    /// <summary>
+    /// Total number of manifest items applied across all sources.
+    /// </summary>
+    public int AppliedItemCount { get; init; }
+
+    /// <summary>
+    /// Total number of manifest items routed to operator review across all sources.
+    /// </summary>
+    public int ManualReviewItemCount { get; init; }
+
+    /// <summary>
+    /// Total number of manifest items rejected as unsupported across all sources.
+    /// </summary>
+    public int UnsupportedItemCount { get; init; }
+
+    /// <summary>
+    /// Total number of apply-stage diagnostics emitted across all sources.
+    /// </summary>
+    public int DiagnosticCount { get; init; }
+}

--- a/src/Honua.Core/Features/Import/Services/MigrationAcceptanceApplyStageRunner.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationAcceptanceApplyStageRunner.cs
@@ -1,0 +1,289 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Drives the apply stage of the migration acceptance suite by translating per-source
+/// <see cref="MigrationSourceInventoryArtifact"/> inputs into deterministic
+/// <see cref="MigrationManifestArtifact"/> outputs and rolling them into a
+/// <see cref="MigrationApplyStageReport"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This runner is import-service-agnostic: it relies on the existing
+/// <see cref="MigrationManifestTranslator"/> to translate the slice-2 inventory output into a
+/// target manifest, and on <see cref="MigrationApplyPlanBuilder"/> to derive a deterministic
+/// apply-plan replay token plus per-item dispositions. The runner does not reimplement apply,
+/// does not introduce additional protocol surface, and does not require a database connection
+/// or live HTTP target.
+/// </para>
+/// <para>
+/// Fixture sources whose source family does not yet support a non-destructive apply against the
+/// fixture target run in <c>dry-run</c> mode; the runner still emits the
+/// <see cref="MigrationManifestArtifact"/> and classifies items deterministically so downstream
+/// publish, parity, and readiness stages can replay from the same source set. Callers can opt a
+/// fixture into <c>apply</c> mode by setting
+/// <see cref="MigrationAcceptanceApplyStageInput.ApplyMode"/> when the upstream import service
+/// has already produced an apply outcome.
+/// </para>
+/// </remarks>
+public static class MigrationAcceptanceApplyStageRunner
+{
+    /// <summary>
+    /// Default apply mode used when a fixture does not explicitly opt into a real apply.
+    /// </summary>
+    public const string DryRunMode = "dry-run";
+
+    /// <summary>
+    /// Apply mode indicating the upstream import service performed a real apply for the fixture
+    /// target.
+    /// </summary>
+    public const string ApplyMode = "apply";
+
+    private const string AppliedDisposition = "applied";
+    private const string ManualReviewDisposition = "manual-review";
+    private const string UnsupportedDisposition = "unsupported";
+    private const string ReadyApplyPlanDisposition = "ready";
+
+    /// <summary>
+    /// Build a deterministic apply stage report from the supplied per-source inventories.
+    /// </summary>
+    /// <param name="runId">Stable identifier for this acceptance apply run (e.g. fixture set name).</param>
+    /// <param name="scanRunId">Identifier of the upstream scan stage report.</param>
+    /// <param name="inputs">Per-fixture apply inputs.</param>
+    /// <returns>Aggregate report pinning the apply stage outputs.</returns>
+    public static MigrationApplyStageReport BuildReport(
+        string runId,
+        string scanRunId,
+        IEnumerable<MigrationAcceptanceApplyStageInput> inputs)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scanRunId);
+        ArgumentNullException.ThrowIfNull(inputs);
+
+        var entries = inputs
+            .Select(input =>
+            {
+                ArgumentNullException.ThrowIfNull(input);
+                if (string.IsNullOrWhiteSpace(input.FixtureId))
+                {
+                    throw new ArgumentException(
+                        "Apply stage inputs must supply a non-empty fixture identifier.",
+                        nameof(inputs));
+                }
+
+                if (input.Inventory is null)
+                {
+                    throw new ArgumentException(
+                        $"Apply stage input for fixture '{input.FixtureId}' is missing its inventory artifact.",
+                        nameof(inputs));
+                }
+
+                var manifest = input.Manifest
+                    ?? MigrationManifestTranslator.Translate(input.Inventory, input.ManifestOptions);
+                var applyPlan = MigrationApplyPlanBuilder.Build(manifest);
+                var outcome = BuildOutcome(manifest, applyPlan);
+                var applyMode = NormalizeApplyMode(input.ApplyMode);
+
+                return new MigrationApplyStageEntry
+                {
+                    FixtureId = input.FixtureId,
+                    SourceKind = manifest.SourceKind,
+                    ApplyMode = applyMode,
+                    Outcome = outcome
+                };
+            })
+            .OrderBy(static entry => entry.FixtureId, StringComparer.Ordinal)
+            .ToArray();
+
+        return new MigrationApplyStageReport
+        {
+            RunId = runId,
+            ScanRunId = scanRunId,
+            Summary = BuildSummary(entries),
+            Sources = entries
+        };
+    }
+
+    /// <summary>
+    /// Build a deterministic per-source apply outcome from a translated manifest. Exposed for
+    /// callers (and tests) that drive the apply stage one fixture at a time.
+    /// </summary>
+    /// <param name="manifest">Translated manifest artifact for the source.</param>
+    /// <returns>Deterministic per-source outcome.</returns>
+    public static MigrationApplyStageOutcome BuildOutcome(MigrationManifestArtifact manifest)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        return BuildOutcome(manifest, MigrationApplyPlanBuilder.Build(manifest));
+    }
+
+    private static MigrationApplyStageOutcome BuildOutcome(
+        MigrationManifestArtifact manifest,
+        MigrationApplyPlanArtifact applyPlan)
+    {
+        var classifications = applyPlan.Steps
+            .Select(step => new MigrationApplyStageItemClassification
+            {
+                SourceId = step.SourceId,
+                Kind = step.Kind,
+                Disposition = MapStepDisposition(step.Disposition),
+                Action = step.Action
+            })
+            .OrderBy(static item => item.SourceId, StringComparer.Ordinal)
+            .ThenBy(static item => item.Kind, StringComparer.Ordinal)
+            .ToArray();
+
+        var diagnostics = BuildDiagnostics(manifest);
+
+        return new MigrationApplyStageOutcome
+        {
+            Manifest = manifest,
+            ReplayToken = applyPlan.ReplayToken,
+            AppliedItemCount = applyPlan.Summary.ReadyStepCount,
+            ManualReviewItemCount = applyPlan.Summary.ManualReviewStepCount,
+            UnsupportedItemCount = applyPlan.Summary.UnsupportedStepCount,
+            Classifications = classifications,
+            ManualReviewItems = manifest.ManualReviewItems
+                .OrderBy(static item => item.SourceId, StringComparer.Ordinal)
+                .ThenBy(static item => item.Code, StringComparer.Ordinal)
+                .ToArray(),
+            Diagnostics = diagnostics
+        };
+    }
+
+    private static MigrationApplyStageDiagnostic[] BuildDiagnostics(MigrationManifestArtifact manifest)
+    {
+        var diagnostics = new List<MigrationApplyStageDiagnostic>();
+
+        foreach (var item in manifest.ManualReviewItems)
+        {
+            diagnostics.Add(new MigrationApplyStageDiagnostic
+            {
+                Code = item.Code,
+                Severity = "manual-review",
+                SourceId = item.SourceId,
+                Message = item.Reason
+            });
+        }
+
+        foreach (var item in manifest.UnsupportedItems)
+        {
+            diagnostics.Add(new MigrationApplyStageDiagnostic
+            {
+                Code = item.Code,
+                Severity = "unsupported",
+                SourceId = item.SourceId,
+                Message = item.Reason
+            });
+        }
+
+        return diagnostics
+            .OrderBy(static item => item.SourceId, StringComparer.Ordinal)
+            .ThenBy(static item => item.Severity, StringComparer.Ordinal)
+            .ThenBy(static item => item.Code, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string MapStepDisposition(string disposition)
+        => disposition switch
+        {
+            ReadyApplyPlanDisposition => AppliedDisposition,
+            UnsupportedDisposition => UnsupportedDisposition,
+            _ => ManualReviewDisposition
+        };
+
+    private static string NormalizeApplyMode(string? applyMode)
+    {
+        if (string.IsNullOrWhiteSpace(applyMode))
+        {
+            return DryRunMode;
+        }
+
+        var trimmed = applyMode.Trim();
+        return trimmed switch
+        {
+            ApplyMode => ApplyMode,
+            DryRunMode => DryRunMode,
+            _ => throw new ArgumentException(
+                $"Apply mode must be either '{ApplyMode}' or '{DryRunMode}' (received '{applyMode}').",
+                nameof(applyMode))
+        };
+    }
+
+    private static MigrationApplyStageSummary BuildSummary(MigrationApplyStageEntry[] entries)
+    {
+        var appliedSources = 0;
+        var dryRunSources = 0;
+        var appliedItems = 0;
+        var manualReviewItems = 0;
+        var unsupportedItems = 0;
+        var diagnosticCount = 0;
+
+        foreach (var entry in entries)
+        {
+            if (string.Equals(entry.ApplyMode, ApplyMode, StringComparison.Ordinal))
+            {
+                appliedSources++;
+            }
+            else
+            {
+                dryRunSources++;
+            }
+
+            appliedItems += entry.Outcome.AppliedItemCount;
+            manualReviewItems += entry.Outcome.ManualReviewItemCount;
+            unsupportedItems += entry.Outcome.UnsupportedItemCount;
+            diagnosticCount += entry.Outcome.Diagnostics.Length;
+        }
+
+        return new MigrationApplyStageSummary
+        {
+            SourceCount = entries.Length,
+            AppliedSourceCount = appliedSources,
+            DryRunSourceCount = dryRunSources,
+            AppliedItemCount = appliedItems,
+            ManualReviewItemCount = manualReviewItems,
+            UnsupportedItemCount = unsupportedItems,
+            DiagnosticCount = diagnosticCount
+        };
+    }
+}
+
+/// <summary>
+/// One per-fixture input to <see cref="MigrationAcceptanceApplyStageRunner.BuildReport"/>.
+/// </summary>
+public sealed record MigrationAcceptanceApplyStageInput
+{
+    /// <summary>
+    /// Stable fixture identifier (e.g. <c>arcgis-mapserver-mixed-renderers</c>).
+    /// </summary>
+    public required string FixtureId { get; init; }
+
+    /// <summary>
+    /// Inventory artifact produced by the upstream scan stage for this fixture.
+    /// </summary>
+    public required MigrationSourceInventoryArtifact Inventory { get; init; }
+
+    /// <summary>
+    /// Optional pre-built manifest artifact. When supplied the runner skips translation and uses
+    /// the supplied manifest directly. When omitted the runner translates the inventory with
+    /// <see cref="MigrationManifestTranslator"/>.
+    /// </summary>
+    public MigrationManifestArtifact? Manifest { get; init; }
+
+    /// <summary>
+    /// Optional manifest translation options. Ignored when <see cref="Manifest"/> is supplied.
+    /// </summary>
+    public MigrationManifestTranslationOptions? ManifestOptions { get; init; }
+
+    /// <summary>
+    /// Apply mode for the fixture. Defaults to
+    /// <see cref="MigrationAcceptanceApplyStageRunner.DryRunMode"/>. Set to
+    /// <see cref="MigrationAcceptanceApplyStageRunner.ApplyMode"/> when the upstream import
+    /// service has performed a real apply against the fixture target.
+    /// </summary>
+    public string? ApplyMode { get; init; }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/MigrationAcceptanceApplyStageTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/MigrationAcceptanceApplyStageTests.cs
@@ -1,0 +1,433 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Shared.Models;
+using Honua.Postgres.Features.Import;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+/// <summary>
+/// Drives the migration acceptance suite apply stage end-to-end across the same fixture set used by
+/// <see cref="MigrationAcceptanceScanStageTests"/>: one ArcGIS GeoServices REST fixture, one
+/// GeoServer REST fixture, and one OGC API Features snapshot fixture. The apply stage runs scan ->
+/// manifest -> apply (dry-run for fixtures whose apply path is not yet supported against the
+/// fixture target) and asserts that the slice-3 <see cref="MigrationApplyStageReport"/> emits the
+/// <see cref="MigrationManifestArtifact"/> per fixture deterministically while preserving the
+/// slice-1 redaction and manual-review-classification contracts.
+/// </summary>
+public sealed class MigrationAcceptanceApplyStageTests
+{
+    private static readonly JsonSerializerOptions ArtifactJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
+    [Fact]
+    public async Task ApplyStage_AcrossArcGisGeoServerAndOgcApiFeatures_ProducesDeterministicReport()
+    {
+        var first = await BuildReportAsync();
+        var second = await BuildReportAsync();
+
+        first.RunId.Should().Be("acceptance-apply-stage:slice-3");
+        first.ScanRunId.Should().Be("acceptance-scan-stage:slice-2");
+        first.ArtifactKind.Should().Be("honua.migration.apply-stage-report");
+        first.ArtifactVersion.Should().Be("1.0");
+
+        var firstJson = JsonSerializer.Serialize(first, ArtifactJsonOptions);
+        var secondJson = JsonSerializer.Serialize(second, ArtifactJsonOptions);
+        secondJson.Should().Be(firstJson, "the apply stage must be deterministic across re-runs of the same fixture set.");
+
+        foreach (var entry in first.Sources)
+        {
+            entry.Outcome.ReplayToken.Should().StartWith("sha256:");
+        }
+    }
+
+    [Fact]
+    public async Task ApplyStage_EmitsOneManifestArtifactPerFixtureSource()
+    {
+        var report = await BuildReportAsync();
+
+        report.Sources.Should().HaveCount(3);
+        report.Summary.SourceCount.Should().Be(3);
+        // All three fixture families currently use the deterministic dry-run path: none of the
+        // import services exposed here can drive a non-destructive apply against the fixture
+        // target without a live database connection, so the slice gates the apply stage on the
+        // apply-plan replay token. The dry-run path still emits the full manifest contract.
+        report.Summary.DryRunSourceCount.Should().Be(3);
+        report.Summary.AppliedSourceCount.Should().Be(0);
+
+        report.Sources.Select(entry => entry.FixtureId)
+            .Should().BeInAscendingOrder(StringComparer.Ordinal)
+            .And.Equal(
+                "arcgis-mapserver-mixed-renderers",
+                "geoserver-mixed-catalog",
+                "ogc-api-features-demo");
+
+        report.Sources.Select(entry => entry.SourceKind)
+            .Should().Equal(
+                "arcgis-geoservices-rest",
+                "geoserver-rest",
+                "ogc-api-features");
+
+        foreach (var entry in report.Sources)
+        {
+            entry.Outcome.Manifest.Should().NotBeNull();
+            entry.Outcome.Manifest.ArtifactKind.Should().Be("honua.migration.manifest");
+            entry.Outcome.Manifest.ArtifactVersion.Should().Be("1.0");
+            entry.Outcome.Manifest.SourceKind.Should().Be(entry.SourceKind);
+        }
+    }
+
+    [Fact]
+    public async Task ApplyStage_ChainsScanThenApply_ForSingleFixture()
+    {
+        // A single test that drives scan -> apply for one fixture and asserts both artifacts emit
+        // deterministically — exercising the per-fixture path through the acceptance suite.
+        var inventory = ScanOgcApiFeatures();
+
+        var scanReport = MigrationAcceptanceScanStageRunner.BuildReport(
+            "acceptance-scan-stage:slice-2:ogc-only",
+            [
+                new MigrationAcceptanceScanStageInput
+                {
+                    FixtureId = "ogc-api-features-demo",
+                    Inventory = inventory
+                }
+            ]);
+
+        var applyReport = MigrationAcceptanceApplyStageRunner.BuildReport(
+            "acceptance-apply-stage:slice-3:ogc-only",
+            scanReport.RunId,
+            [
+                new MigrationAcceptanceApplyStageInput
+                {
+                    FixtureId = "ogc-api-features-demo",
+                    Inventory = scanReport.Sources.Single().Inventory
+                }
+            ]);
+
+        scanReport.Sources.Should().ContainSingle();
+        applyReport.Sources.Should().ContainSingle();
+        applyReport.Sources.Single().FixtureId.Should().Be(scanReport.Sources.Single().FixtureId);
+        applyReport.Sources.Single().Outcome.Manifest.SourceKind
+            .Should().Be(scanReport.Sources.Single().SourceKind);
+
+        var replayed = MigrationAcceptanceApplyStageRunner.BuildReport(
+            applyReport.RunId,
+            applyReport.ScanRunId,
+            [
+                new MigrationAcceptanceApplyStageInput
+                {
+                    FixtureId = "ogc-api-features-demo",
+                    Inventory = scanReport.Sources.Single().Inventory
+                }
+            ]);
+
+        var first = JsonSerializer.Serialize(applyReport, ArtifactJsonOptions);
+        var second = JsonSerializer.Serialize(replayed, ArtifactJsonOptions);
+        second.Should().Be(first, "scan -> apply for a single fixture must replay deterministically.");
+    }
+
+    [Fact]
+    public async Task ApplyStage_ClassifiesManualReviewAndUnsupportedItems_AcrossSources()
+    {
+        var report = await BuildReportAsync();
+
+        // The ArcGIS MapServer-MixedRenderers fixture intentionally exercises an unsupported
+        // renderer (heatmap). The apply stage must classify the offending source item as
+        // manual-review or unsupported instead of silently auto-staging it.
+        var arcgisEntry = report.Sources.Single(entry => entry.FixtureId == "arcgis-mapserver-mixed-renderers");
+        arcgisEntry.Outcome.UnsupportedItemCount.Should().BeGreaterThan(0,
+            "the MapServer-MixedRenderers fixture intentionally includes an unsupported renderer.");
+        arcgisEntry.Outcome.Classifications
+            .Should().Contain(classification => classification.Disposition == "unsupported");
+        arcgisEntry.Outcome.Diagnostics
+            .Should().Contain(diagnostic => diagnostic.Severity == "unsupported");
+
+        // The GeoServer MixedCatalog fixture has a manual-review coverage store. The apply stage
+        // must route those items through the manual-review classification path so they are not
+        // auto-applied.
+        var geoServerEntry = report.Sources.Single(entry => entry.FixtureId == "geoserver-mixed-catalog");
+        (geoServerEntry.Outcome.ManualReviewItemCount + geoServerEntry.Outcome.UnsupportedItemCount)
+            .Should().BeGreaterThan(0, "the MixedCatalog fixture intentionally includes non-automated items.");
+        geoServerEntry.Outcome.Diagnostics.Should().NotBeEmpty();
+        geoServerEntry.Outcome.ManualReviewItems
+            .Should().BeInAscendingOrder(item => item.SourceId, StringComparer.Ordinal);
+
+        // Summary counts must match the per-source rollups exactly.
+        report.Summary.AppliedItemCount.Should()
+            .Be(report.Sources.Sum(entry => entry.Outcome.AppliedItemCount));
+        report.Summary.ManualReviewItemCount.Should()
+            .Be(report.Sources.Sum(entry => entry.Outcome.ManualReviewItemCount));
+        report.Summary.UnsupportedItemCount.Should()
+            .Be(report.Sources.Sum(entry => entry.Outcome.UnsupportedItemCount));
+        report.Summary.DiagnosticCount.Should()
+            .Be(report.Sources.Sum(entry => entry.Outcome.Diagnostics.Length));
+    }
+
+    [Fact]
+    public async Task ApplyStage_RedactsCredentials_FromArtifactOutput()
+    {
+        var report = await BuildReportAsync();
+
+        var json = JsonSerializer.Serialize(report, ArtifactJsonOptions);
+
+        json.Should().NotContain("super-secret-token",
+            "the apply stage manifest must never echo back the supplied ArcGIS token.");
+        json.Should().NotContain("Authorization",
+            "the apply stage manifest must not surface raw HTTP authorization headers.");
+        json.Should().NotContain("password",
+            "the apply stage manifest must not surface password values from the source.");
+        json.Should().NotContain("Basic ",
+            "the apply stage manifest must not surface raw Basic auth values from the source.");
+    }
+
+    [Fact]
+    public async Task ApplyStage_DeterministicReapply_MatchesReplayToken_PerSource()
+    {
+        var first = await BuildReportAsync();
+        var second = await BuildReportAsync();
+
+        first.Sources.Should().HaveSameCount(second.Sources);
+        foreach (var (left, right) in first.Sources.Zip(second.Sources))
+        {
+            left.FixtureId.Should().Be(right.FixtureId);
+            left.Outcome.ReplayToken.Should().Be(right.Outcome.ReplayToken,
+                $"the apply stage replay token for fixture '{left.FixtureId}' must be stable across re-runs.");
+        }
+    }
+
+    private static async Task<MigrationApplyStageReport> BuildReportAsync()
+    {
+        var arcgisInventory = await ScanArcGisAsync();
+        var geoServerInventory = await ScanGeoServerAsync();
+        var ogcInventory = ScanOgcApiFeatures();
+
+        return MigrationAcceptanceApplyStageRunner.BuildReport(
+            "acceptance-apply-stage:slice-3",
+            "acceptance-scan-stage:slice-2",
+            [
+                new MigrationAcceptanceApplyStageInput
+                {
+                    FixtureId = "arcgis-mapserver-mixed-renderers",
+                    Inventory = arcgisInventory
+                },
+                new MigrationAcceptanceApplyStageInput
+                {
+                    FixtureId = "geoserver-mixed-catalog",
+                    Inventory = geoServerInventory
+                },
+                new MigrationAcceptanceApplyStageInput
+                {
+                    FixtureId = "ogc-api-features-demo",
+                    Inventory = ogcInventory
+                }
+            ]);
+    }
+
+    private static async Task<MigrationSourceInventoryArtifact> ScanArcGisAsync()
+    {
+        var fixture = LoadFixture("ArcGis", "MapServer-MixedRenderers");
+        var service = CreateGeoservicesService(new FixtureHttpHandler(fixture.Responses));
+
+        return await service.ScanSourceAsync(new GeoservicesDiscoveryRequest
+        {
+            ServiceUrl = fixture.ServiceUrl,
+            TimeoutSeconds = 5
+        });
+    }
+
+    private static async Task<MigrationSourceInventoryArtifact> ScanGeoServerAsync()
+    {
+        var fixture = LoadFixture("GeoServer", "MixedCatalog");
+        var service = CreateGeoServerService(new FixtureHttpHandler(fixture.Responses));
+
+        return await service.ScanSourceAsync(new GeoServerDiscoveryRequest
+        {
+            GeoServerRestUrl = fixture.ServiceUrl,
+            IncludeCompatibilityAnalysis = true,
+            IncludeStyleContent = true,
+            TimeoutSeconds = 5
+        });
+    }
+
+    private static MigrationSourceInventoryArtifact ScanOgcApiFeatures()
+    {
+        var snapshot = new OgcApiFeaturesMigrationSourceSnapshot
+        {
+            BaseUrl = "https://demo.example/ogcapi/",
+            Title = "Demo OGC API Features",
+            Version = "1.0",
+            LandingPageLinks =
+            [
+                Link("service-desc", "https://demo.example/ogcapi/openapi", "application/vnd.oai.openapi+json;version=3.0"),
+                Link("conformance", "https://demo.example/ogcapi/conformance", "application/json"),
+                Link("data", "https://demo.example/ogcapi/collections", "application/json")
+            ],
+            ConformanceClasses =
+            [
+                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+                "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables"
+            ],
+            Collections =
+            [
+                new OgcApiFeaturesCollectionSnapshot
+                {
+                    Id = "roads",
+                    Title = "Roads",
+                    GeometryType = "LineString",
+                    FeatureCount = 125,
+                    Links =
+                    [
+                        Link("items", "https://demo.example/ogcapi/collections/roads/items", "application/geo+json"),
+                        Link("http://www.opengis.net/def/rel/ogc/1.0/queryables", "https://demo.example/ogcapi/collections/roads/queryables", "application/schema+json")
+                    ],
+                    CrsDeclarations =
+                    [
+                        Crs("storage", "http://www.opengis.net/def/crs/OGC/1.3/CRS84"),
+                        Crs("supported", "http://www.opengis.net/def/crs/EPSG/0/4326")
+                    ],
+                    ItemEncodings = ["application/geo+json"],
+                    Fields =
+                    [
+                        new MigrationInventoryField
+                        {
+                            Name = "name",
+                            Alias = "Road name",
+                            FieldType = "string",
+                            Nullable = false
+                        }
+                    ]
+                }
+            ]
+        };
+
+        return OgcApiFeaturesMigrationInventoryScanner.BuildInventory(snapshot);
+    }
+
+    private static OgcApiFeaturesLink Link(string rel, string href, string? type = null) =>
+        new() { Rel = rel, Href = href, Type = type };
+
+    private static OgcApiFeaturesCrsDeclaration Crs(string role, string value) =>
+        new() { Role = role, Value = value };
+
+    private static FixtureScenario LoadFixture(string family, string scenario)
+    {
+        var fixturePath = Path.Combine(
+            AppContext.BaseDirectory,
+            "Features",
+            "Import",
+            "Fixtures",
+            family,
+            $"{scenario}.json");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(fixturePath));
+        var root = document.RootElement;
+        var serviceUrl = root.GetProperty("serviceUrl").GetString()
+            ?? throw new InvalidDataException($"Fixture {scenario} is missing serviceUrl.");
+        var responses = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var entry in root.GetProperty("responses").EnumerateObject())
+        {
+            responses[entry.Name] = entry.Value.ValueKind == JsonValueKind.String
+                ? entry.Value.GetString() ?? string.Empty
+                : entry.Value.GetRawText();
+        }
+
+        return new FixtureScenario(serviceUrl, responses);
+    }
+
+    private static GeoservicesImportService CreateGeoservicesService(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler);
+        var restClient = new ArcGisRestClient(
+            httpClient,
+            NullLogger<ArcGisRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+        var connectionProvider = new Mock<IDatabaseConnectionProvider>(MockBehavior.Strict);
+        var crsRegistry = CreateCrsRegistry();
+
+        return new GeoservicesImportService(
+            restClient,
+            connectionProvider.Object,
+            crsRegistry,
+            NullLogger<GeoservicesImportService>.Instance);
+    }
+
+    private static GeoServerImportService CreateGeoServerService(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler);
+        var restClient = new GeoServerRestClient(
+            httpClient,
+            NullLogger<GeoServerRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+        var connectionProvider = new Mock<IDatabaseConnectionProvider>(MockBehavior.Strict);
+        var crsRegistry = CreateCrsRegistry();
+
+        return new GeoServerImportService(
+            restClient,
+            connectionProvider.Object,
+            crsRegistry,
+            NullLogger<GeoServerImportService>.Instance);
+    }
+
+    private static ICrsRegistry CreateCrsRegistry()
+    {
+        var registry = new Mock<ICrsRegistry>(MockBehavior.Strict);
+        registry.Setup(r => r.ResolveBySridAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns((int srid, CancellationToken _) => new ValueTask<CrsDefinition?>(
+                srid switch
+                {
+                    3857 => new CrsDefinition("http://www.opengis.net/def/crs/EPSG/0/3857", 3857, AxisOrder.EastNorth, false),
+                    4326 => new CrsDefinition("http://www.opengis.net/def/crs/EPSG/0/4326", 4326, AxisOrder.EastNorth, true),
+                    _ => null
+                }));
+        return registry.Object;
+    }
+
+    private sealed record FixtureScenario(string ServiceUrl, IReadOnlyDictionary<string, string> Responses);
+
+    private sealed class FixtureHttpHandler : HttpMessageHandler
+    {
+        private readonly IReadOnlyDictionary<string, string> _responses;
+
+        public FixtureHttpHandler(IReadOnlyDictionary<string, string> responses)
+        {
+            _responses = responses;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var pathAndQuery = request.RequestUri?.PathAndQuery ?? string.Empty;
+            if (!_responses.TryGetValue(pathAndQuery, out var body))
+            {
+                throw new InvalidOperationException(
+                    $"Fixture has no response for {pathAndQuery}. Add it to the fixture JSON or correct the request path.");
+            }
+
+            var contentType = pathAndQuery.EndsWith(".xml", StringComparison.Ordinal)
+                ? "application/xml"
+                : pathAndQuery.EndsWith(".sld", StringComparison.Ordinal)
+                    ? "application/vnd.ogc.sld+xml"
+                    : "application/json";
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, contentType)
+            });
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1024 — slice 3 of the migration acceptance suite, stacked on top of #1108 (slice 2 / `codex/issue-1024-acceptance-suite-next`), which built on the slice-1 artifact contracts in #1093.

## Summary
Drive a real migration apply stage against the same deterministic fixture sources used by the slice-2 scan stage so the acceptance suite emits its first `MigrationManifestArtifact` per fixture. Per-fixture apply runs in `dry-run` mode when the source family does not yet support a non-destructive apply against the fixture target — the runner still produces the manifest and an apply-plan replay token so downstream publish, parity, and readiness stages can replay deterministically from the same source set. No new protocol surface is introduced; the runner composes the existing `MigrationManifestTranslator` and `MigrationApplyPlanBuilder`.

## Changes Made
- New `MigrationApplyStageReport` in `Honua.Core.Features.Import.Domain` capturing the per-source apply outcome (manifest artifact, replay token, classifications, manual-review entries, diagnostics) and a deterministic envelope summary.
- New `MigrationAcceptanceApplyStageRunner` in `Honua.Core.Features.Import.Services` that translates inventory inputs into manifests and emits the per-fixture apply outcome without reimplementing apply or requiring a live database/HTTP target.
- Integration tests in `MigrationAcceptanceApplyStageTests` covering schema stability, deterministic re-apply (same fixture set → same artifact + per-source replay token), single-fixture scan→apply chaining, credential-safe redaction, and manual-review/unsupported classification rollups.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)