### PR TITLE
feat: persist GeoServer styles + diagnostics (#1015 slice 3/N)

### DIFF
--- a/.github/workflows/nightly-migration-evidence.yml
+++ b/.github/workflows/nightly-migration-evidence.yml
@@ -1,0 +1,109 @@
+name: Nightly Migration Evidence Pack
+
+# Tier: nightly evidence. Drives the fixture-based GeoServer migration apply
+# path (slices 1-3 of issue #1015) end-to-end and uploads the slice-4
+# deterministic evidence pack as a CI artifact so reviewers can audit catalog,
+# data, and style migration outcomes from a single artifact.
+on:
+  schedule:
+    # Stagger after other nightlies so the runner image cache is warm.
+    - cron: '15 7 * * *'
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-migration-evidence-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  evidence-pack:
+    name: GeoServer Migration Evidence Pack
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-ci
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore Honua.sln
+
+      - name: Build
+        run: dotnet build Honua.sln --no-restore --configuration Release
+
+      - name: Run slice 1-3 fixture-driven apply tests (Postgres harness)
+        run: |
+          mkdir -p tests/TestResults
+          dotnet test tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --filter "FullyQualifiedName~GeoServerImportServiceApplyPlanTests|FullyQualifiedName~GeoServerImportServiceDataSourceApplyTests|FullyQualifiedName~GeoServerImportServiceStyleApplyTests" \
+            --logger "trx;LogFileName=geoserver-apply-fixtures.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults
+
+      - name: Emit slice-4 evidence pack artifact
+        env:
+          HONUA_EMIT_EVIDENCE_PACK: '1'
+          HONUA_EVIDENCE_PACK_OUTPUT: ${{ github.workspace }}/artifacts/migration-evidence/geoserver-migration-evidence-pack.json
+          HONUA_EVIDENCE_PACK_RUN_ID: nightly-${{ github.run_id }}
+        run: |
+          mkdir -p "${{ github.workspace }}/artifacts/migration-evidence"
+          dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --filter "FullyQualifiedName~MigrationEvidencePackBuilderTests.EmitNightlyEvidencePack_WhenEnvVarSet_WritesDeterministicArtifact" \
+            --logger "trx;LogFileName=migration-evidence-pack.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults
+
+      - name: Summarize evidence pack
+        if: always()
+        run: |
+          PACK="${{ github.workspace }}/artifacts/migration-evidence/geoserver-migration-evidence-pack.json"
+          if [[ ! -f "$PACK" ]]; then
+            echo "Evidence pack was not generated; check the prior test step." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "## GeoServer Migration Evidence Pack"
+            echo
+            echo "**Artifact kind:** $(jq -r '.artifactKind' "$PACK")"
+            echo "**Run id:** $(jq -r '.runId' "$PACK")"
+            echo "**Bundle fingerprint:** \`$(jq -r '.bundleFingerprint' "$PACK")\`"
+            echo
+            echo "### Stages"
+            echo "| Stage | Steps | Applied | Already applied | Manual review | Unsupported | Failed |"
+            echo "|---|---:|---:|---:|---:|---:|---:|"
+            jq -r '
+              .bundle.stages[]
+              | "| \(.id) | \(.stepCount) | \(.appliedCount) | \(.alreadyAppliedCount) | \(.manualReviewCount) | \(.unsupportedCount) | \(.failedCount) |"
+            ' "$PACK"
+            echo
+            STYLE_REVIEW=$(jq -r '.bundle.summary.styleManualReviewCount' "$PACK")
+            echo "Style steps requiring manual review (visual parity NOT claimed): **$STYLE_REVIEW**"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload migration evidence pack
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: geoserver-migration-evidence-${{ github.run_id }}
+          path: |
+            artifacts/migration-evidence/
+            tests/TestResults/geoserver-apply-fixtures.trx
+            tests/TestResults/migration-evidence-pack.trx

--- a/src/Honua.Core/Features/Import/Abstractions/IMigrationCatalogWriter.cs
+++ b/src/Honua.Core/Features/Import/Abstractions/IMigrationCatalogWriter.cs
@@ -10,7 +10,9 @@ namespace Honua.Core.Features.Import.Abstractions;
 /// <remarks>
 /// Slice 1 limited this abstraction to catalog-level upserts. Slice 2 extends it
 /// with idempotent data-source persistence and idempotent in-database feature
-/// data copy. Style persistence remains deferred to follow-on slices.
+/// data copy. Slice 3 (issue #1015) adds idempotent style persistence with
+/// structured conversion diagnostics so the apply path can record manual-review
+/// evidence when SLD-to-MapLibre conversion cannot guarantee visual parity.
 /// </remarks>
 public interface IMigrationCatalogWriter
 {
@@ -60,6 +62,22 @@ public interface IMigrationCatalogWriter
     Task<MigrationFeatureCopyOutcome> CopyFeatureDataAsync(
         string connectionString,
         MigrationFeatureCopyRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Ensure that a migration style row exists in <c>honua.migration_styles</c>.
+    /// Idempotent: returns <see cref="MigrationCatalogWriteOutcome.Created"/> on
+    /// first apply and <see cref="MigrationCatalogWriteOutcome.AlreadyExists"/>
+    /// on re-apply. The persisted row keeps the original SLD body, any converted
+    /// MapLibre body, and structured conversion diagnostics so operators can
+    /// audit manual-review outcomes.
+    /// </summary>
+    /// <param name="connectionString">PostgreSQL connection string for the target catalog.</param>
+    /// <param name="request">Style definition to persist (slice 3 of #1015).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<MigrationCatalogWriteOutcome> EnsureStyleAsync(
+        string connectionString,
+        MigrationStyleRequest request,
         CancellationToken cancellationToken = default);
 }
 
@@ -208,4 +226,85 @@ public enum MigrationFeatureCopyStatus
     /// manual-review step result.
     /// </summary>
     SourceMissing
+}
+
+/// <summary>
+/// Request payload for <see cref="IMigrationCatalogWriter.EnsureStyleAsync"/>.
+/// Persists evidence that a source style (typically SLD) has been migrated to
+/// the Honua catalog along with structured diagnostics for conversion
+/// limitations.
+/// </summary>
+public sealed record MigrationStyleRequest
+{
+    /// <summary>
+    /// Source kind for the migration run (e.g. <c>geoserver-rest</c>).
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Stable id of the style in the source system. For GeoServer this is
+    /// <c>style:&lt;workspace|global&gt;:&lt;name&gt;</c>.
+    /// </summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>
+    /// Stable id reserved in the target catalog by the manifest translator.
+    /// </summary>
+    public required string TargetStyleId { get; init; }
+
+    /// <summary>
+    /// Style name as advertised by the source system.
+    /// </summary>
+    public required string StyleName { get; init; }
+
+    /// <summary>
+    /// Owning workspace, when the source style is workspace-scoped.
+    /// </summary>
+    public string? WorkspaceName { get; init; }
+
+    /// <summary>
+    /// Source style format (e.g. <c>sld</c>, <c>css</c>, <c>mbstyle</c>).
+    /// </summary>
+    public string SourceFormat { get; init; } = "sld";
+
+    /// <summary>
+    /// Source language version (e.g. <c>1.0.0</c> for SLD 1.0).
+    /// </summary>
+    public string? SourceLanguageVersion { get; init; }
+
+    /// <summary>
+    /// Original style body as fetched from the source system. May be null when
+    /// the source did not expose body content (in which case the row exists
+    /// purely as a manual-review record).
+    /// </summary>
+    public string? SourceBody { get; init; }
+
+    /// <summary>
+    /// Converted style body (e.g. MapLibre JSON) when conversion succeeded;
+    /// null otherwise.
+    /// </summary>
+    public string? ConvertedBody { get; init; }
+
+    /// <summary>
+    /// Identifier for the converted body's format (e.g. <c>maplibre-layers-json</c>).
+    /// </summary>
+    public string? ConvertedFormat { get; init; }
+
+    /// <summary>
+    /// Structured conversion diagnostics rendered as a JSON array. Each element
+    /// must be a JSON object with <c>severity</c> (warning|error) and
+    /// <c>message</c> fields. Persisted as <c>jsonb</c> so operators can query
+    /// diagnostics by severity or message substring when auditing manual-review
+    /// outcomes (issue #1015 AC: "Do not claim perfect SLD visual parity when
+    /// conversion diagnostics report manual review").
+    /// </summary>
+    public string DiagnosticsJson { get; init; } = "[]";
+
+    /// <summary>
+    /// Review disposition recorded on the row: typically <c>applied</c> when
+    /// conversion was clean, <c>manual-review</c> when diagnostics surfaced
+    /// errors that block automatic visual parity, or <c>unsupported</c> when
+    /// the manifest translator already marked the source style as unsupported.
+    /// </summary>
+    public string ReviewDisposition { get; init; } = "applied";
 }

--- a/src/Honua.Core/Features/Import/Domain/MigrationEvidencePackArtifact.cs
+++ b/src/Honua.Core/Features/Import/Domain/MigrationEvidencePackArtifact.cs
@@ -1,0 +1,303 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Slice 4 of issue #1015. Single deterministic evidence bundle emitted from a
+/// successful GeoServer migration run. Aggregates the upstream
+/// <see cref="MigrationSourceInventoryArtifact"/>, the translated
+/// <see cref="MigrationManifestArtifact"/>, and the per-stage step results from
+/// the apply-execution artifact so reviewers (and nightly fixture runs) have a
+/// single artifact to audit catalog, data, and style migration outcomes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pack carries a SHA-256 fingerprint computed over the canonical JSON of
+/// its bundle so identical inputs always produce the same fingerprint. The
+/// fingerprint deliberately excludes wall-clock timestamps and the generator
+/// label so re-runs across machines stay byte-identical.
+/// </para>
+/// <para>
+/// Privacy posture: <see cref="MigrationEvidencePackBundle.Source"/> and the
+/// stage-level summaries reuse the redaction behavior of the upstream
+/// inventory artifact. The builder additionally strips credentials from the
+/// source URL and never includes raw style bodies or feature payloads — only
+/// counts and diagnostics derived from slices 1-3.
+/// </para>
+/// <para>
+/// AOT note: this record uses POCO-only properties (no polymorphic
+/// converters, no <c>JsonExtensionData</c>) so the default
+/// <c>System.Text.Json</c> serializer remains trim/AOT safe.
+/// </para>
+/// </remarks>
+public sealed record MigrationEvidencePackArtifact
+{
+    /// <summary>
+    /// Stable artifact kind identifier.
+    /// </summary>
+    public string ArtifactKind { get; init; } = "honua.migration.evidence-pack";
+
+    /// <summary>
+    /// Artifact schema version.
+    /// </summary>
+    public string ArtifactVersion { get; init; } = "1.0";
+
+    /// <summary>
+    /// Stable run identifier supplied by the harness or nightly workflow.
+    /// </summary>
+    public required string RunId { get; init; }
+
+    /// <summary>
+    /// Free-form generator label, e.g. <c>geoserver-migration-evidence-builder/1.0</c>.
+    /// Excluded from the bundle fingerprint so re-runs across CI images stay
+    /// byte-identical.
+    /// </summary>
+    public required string Generator { get; init; }
+
+    /// <summary>
+    /// UTC instant the pack was generated. Excluded from the bundle fingerprint
+    /// so re-runs stay byte-identical.
+    /// </summary>
+    public required DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>
+    /// SHA-256 fingerprint computed over the canonical JSON of
+    /// <see cref="Bundle"/>. Identical inputs always produce the same value.
+    /// </summary>
+    public required string BundleFingerprint { get; init; }
+
+    /// <summary>
+    /// Deterministic evidence bundle that aggregates slice 1-3 artifacts.
+    /// </summary>
+    public required MigrationEvidencePackBundle Bundle { get; init; }
+}
+
+/// <summary>
+/// Deterministic content bundle covered by
+/// <see cref="MigrationEvidencePackArtifact.BundleFingerprint"/>.
+/// </summary>
+public sealed record MigrationEvidencePackBundle
+{
+    /// <summary>
+    /// Source kind identifier such as <c>geoserver-rest</c>.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Secret-safe source identity (credentials and URL secrets stripped).
+    /// </summary>
+    public required MigrationSourceIdentity Source { get; init; }
+
+    /// <summary>
+    /// Operator-requested workspace scope. Empty when the run applied to all
+    /// workspaces. Captured here as workspace-scoping evidence so reviewers can
+    /// audit that styles and data sources outside the requested scope were not
+    /// migrated.
+    /// </summary>
+    public required MigrationEvidencePackWorkspaceScope WorkspaceScope { get; init; }
+
+    /// <summary>
+    /// Plan fingerprint and replay token copied from the apply-execution
+    /// artifact so downstream consumers can correlate the pack with the exact
+    /// apply plan that was executed.
+    /// </summary>
+    public required MigrationEvidencePackApplyIdentity Apply { get; init; }
+
+    /// <summary>
+    /// Aggregate counts across the catalog, data, and style stages.
+    /// </summary>
+    public required MigrationEvidencePackSummary Summary { get; init; }
+
+    /// <summary>
+    /// Per-stage step results derived from
+    /// <see cref="MigrationApplyExecutionArtifact.StepResults"/>. Ordering is
+    /// stable: stages in canonical order, steps within each stage ordered by
+    /// step id.
+    /// </summary>
+    public MigrationEvidencePackStage[] Stages { get; init; } = [];
+
+    /// <summary>
+    /// Aggregated style-conversion diagnostics surfaced by slice 3 so the pack
+    /// carries explicit manual-review records when SLD-to-MapLibre conversion
+    /// did not guarantee visual parity.
+    /// </summary>
+    public MigrationEvidencePackStyleDiagnostic[] StyleDiagnostics { get; init; } = [];
+
+    /// <summary>
+    /// Inventory snapshot copied from the slice-1 input.
+    /// </summary>
+    public required MigrationSourceInventoryArtifact Inventory { get; init; }
+
+    /// <summary>
+    /// Manifest snapshot copied from the slice-1 input.
+    /// </summary>
+    public required MigrationManifestArtifact Manifest { get; init; }
+}
+
+/// <summary>
+/// Operator-requested workspace scope captured in the evidence pack.
+/// </summary>
+public sealed record MigrationEvidencePackWorkspaceScope
+{
+    /// <summary>
+    /// Whether the operator restricted the apply run to specific workspaces.
+    /// When <c>false</c>, all source workspaces were eligible.
+    /// </summary>
+    public required bool Restricted { get; init; }
+
+    /// <summary>
+    /// Deterministically ordered list of requested workspace names. Empty when
+    /// <see cref="Restricted"/> is <c>false</c>.
+    /// </summary>
+    public string[] WorkspaceNames { get; init; } = [];
+}
+
+/// <summary>
+/// Apply identity referenced from the evidence pack. Mirrors the
+/// <see cref="MigrationApplyExecutionArtifact"/> identity fields so consumers
+/// can correlate the pack with the executed plan without having to load both
+/// artifacts.
+/// </summary>
+public sealed record MigrationEvidencePackApplyIdentity
+{
+    /// <summary>
+    /// Plan fingerprint copied from the apply-execution artifact.
+    /// </summary>
+    public required string PlanFingerprint { get; init; }
+
+    /// <summary>
+    /// Replay token copied from the apply-execution artifact.
+    /// </summary>
+    public required string ReplayToken { get; init; }
+
+    /// <summary>
+    /// Execution mode reported by the apply run, e.g. <c>catalog-apply</c>.
+    /// </summary>
+    public required string ExecutionMode { get; init; }
+}
+
+/// <summary>
+/// Aggregate evidence summary across catalog, data, and style stages.
+/// </summary>
+public sealed record MigrationEvidencePackSummary
+{
+    /// <summary>
+    /// Total number of apply-plan steps considered by the run.
+    /// </summary>
+    public int TotalStepCount { get; init; }
+
+    /// <summary>
+    /// Number of steps that completed with the <c>applied</c> outcome.
+    /// </summary>
+    public int AppliedStepCount { get; init; }
+
+    /// <summary>
+    /// Number of steps that were already present in the target catalog.
+    /// </summary>
+    public int AlreadyAppliedStepCount { get; init; }
+
+    /// <summary>
+    /// Number of steps that remain explicit manual-review work.
+    /// </summary>
+    public int ManualReviewStepCount { get; init; }
+
+    /// <summary>
+    /// Number of steps that are unsupported by this apply path.
+    /// </summary>
+    public int UnsupportedStepCount { get; init; }
+
+    /// <summary>
+    /// Number of steps that failed unexpectedly.
+    /// </summary>
+    public int FailedStepCount { get; init; }
+
+    /// <summary>
+    /// Number of style steps recorded with at least one error-severity
+    /// conversion diagnostic. Per issue #1015 AC, these block any visual
+    /// parity claim.
+    /// </summary>
+    public int StyleManualReviewCount { get; init; }
+}
+
+/// <summary>
+/// Per-stage view of the apply-execution step results.
+/// </summary>
+public sealed record MigrationEvidencePackStage
+{
+    /// <summary>
+    /// Canonical stage id: <c>catalog</c>, <c>data</c>, or <c>style</c>.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Number of step results in this stage.
+    /// </summary>
+    public int StepCount { get; init; }
+
+    /// <summary>
+    /// Number of step results with the <c>applied</c> outcome.
+    /// </summary>
+    public int AppliedCount { get; init; }
+
+    /// <summary>
+    /// Number of step results with the <c>already-applied</c> outcome.
+    /// </summary>
+    public int AlreadyAppliedCount { get; init; }
+
+    /// <summary>
+    /// Number of step results with the <c>manual-review</c> outcome.
+    /// </summary>
+    public int ManualReviewCount { get; init; }
+
+    /// <summary>
+    /// Number of step results with the <c>unsupported</c> outcome.
+    /// </summary>
+    public int UnsupportedCount { get; init; }
+
+    /// <summary>
+    /// Number of step results with the <c>failed</c> outcome.
+    /// </summary>
+    public int FailedCount { get; init; }
+
+    /// <summary>
+    /// Per-step results ordered by <see cref="MigrationApplyExecutionStepResult.StepId"/>.
+    /// </summary>
+    public MigrationApplyExecutionStepResult[] StepResults { get; init; } = [];
+}
+
+/// <summary>
+/// Aggregated style-conversion diagnostic surfaced from slice-3 evidence.
+/// </summary>
+public sealed record MigrationEvidencePackStyleDiagnostic
+{
+    /// <summary>
+    /// Source style identifier the diagnostic was raised for.
+    /// </summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>
+    /// Resolved step outcome for the style step (e.g. <c>manual-review</c>).
+    /// </summary>
+    public required string StepOutcome { get; init; }
+
+    /// <summary>
+    /// Diagnostic message copied from the slice-3 apply step.
+    /// </summary>
+    public required string Message { get; init; }
+}
+
+/// <summary>
+/// Canonical stage identifiers used by the evidence pack.
+/// </summary>
+public static class MigrationEvidencePackStageIds
+{
+    /// <summary>Slice 1: catalog (workspace + layer-group) entries.</summary>
+    public const string Catalog = "catalog";
+
+    /// <summary>Slice 2: data-source registration + feature data copy.</summary>
+    public const string Data = "data";
+
+    /// <summary>Slice 3: style persistence + conversion diagnostics.</summary>
+    public const string Style = "style";
+}

--- a/src/Honua.Core/Features/Import/Services/MigrationEvidencePackBuilder.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationEvidencePackBuilder.cs
@@ -1,0 +1,320 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Cryptography;
+using System.Text.Json;
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Slice 4 of issue #1015. Aggregates the slice 1-3 artifacts emitted by a
+/// successful GeoServer migration run into a single deterministic
+/// <see cref="MigrationEvidencePackArtifact"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The builder is intentionally pure and side-effect free so the same inputs
+/// always produce the same output (and the same
+/// <see cref="MigrationEvidencePackArtifact.BundleFingerprint"/>). It performs
+/// no I/O, no logging, and no clock reads except for the caller-supplied
+/// <see cref="MigrationEvidencePackBuilderOptions.GeneratedAt"/> stamp, which
+/// is excluded from the fingerprint.
+/// </para>
+/// <para>
+/// Credential redaction: the source identity is sanitized by stripping
+/// userinfo, query, and fragment components from <c>BaseUrl</c> before the
+/// inventory snapshot is included in the bundle. The builder never copies
+/// raw style bodies or feature payloads — only counts and slice-3 diagnostic
+/// messages.
+/// </para>
+/// </remarks>
+public static class MigrationEvidencePackBuilder
+{
+    private const string BuilderGenerator = "honua.migration.evidence-pack-builder/1.0";
+
+    /// <summary>
+    /// Build an evidence pack from the slice 1-3 inputs.
+    /// </summary>
+    /// <param name="inputs">Inventory, manifest, apply-execution and scope inputs.</param>
+    /// <param name="options">Optional run id / generator / clock overrides.</param>
+    public static MigrationEvidencePackArtifact Build(
+        MigrationEvidencePackInputs inputs,
+        MigrationEvidencePackBuilderOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+        ArgumentNullException.ThrowIfNull(inputs.Inventory);
+        ArgumentNullException.ThrowIfNull(inputs.Manifest);
+        ArgumentNullException.ThrowIfNull(inputs.ApplyExecution);
+
+        var resolvedOptions = options ?? new MigrationEvidencePackBuilderOptions();
+
+        var redactedSource = RedactSource(inputs.ApplyExecution.Source);
+        var redactedInventory = inputs.Inventory with { Source = RedactSource(inputs.Inventory.Source) };
+        var redactedManifest = inputs.Manifest with { Source = RedactSource(inputs.Manifest.Source) };
+
+        var workspaceScope = BuildWorkspaceScope(inputs.RequestedWorkspaceNames);
+        var stages = BuildStages(inputs.ApplyExecution);
+        var summary = BuildSummary(inputs.ApplyExecution, stages);
+        var styleDiagnostics = BuildStyleDiagnostics(stages);
+
+        var bundle = new MigrationEvidencePackBundle
+        {
+            SourceKind = inputs.ApplyExecution.SourceKind,
+            Source = redactedSource,
+            WorkspaceScope = workspaceScope,
+            Apply = new MigrationEvidencePackApplyIdentity
+            {
+                PlanFingerprint = inputs.ApplyExecution.PlanFingerprint,
+                ReplayToken = inputs.ApplyExecution.ReplayToken,
+                ExecutionMode = inputs.ApplyExecution.ExecutionMode
+            },
+            Summary = summary,
+            Stages = stages,
+            StyleDiagnostics = styleDiagnostics,
+            Inventory = redactedInventory,
+            Manifest = redactedManifest
+        };
+
+        var fingerprint = ComputeBundleFingerprint(bundle);
+
+        return new MigrationEvidencePackArtifact
+        {
+            RunId = string.IsNullOrWhiteSpace(resolvedOptions.RunId) ? "migration-evidence-run" : resolvedOptions.RunId,
+            Generator = string.IsNullOrWhiteSpace(resolvedOptions.Generator) ? BuilderGenerator : resolvedOptions.Generator,
+            GeneratedAt = resolvedOptions.GeneratedAt ?? DateTimeOffset.UnixEpoch,
+            BundleFingerprint = fingerprint,
+            Bundle = bundle
+        };
+    }
+
+    /// <summary>
+    /// Compute the deterministic SHA-256 fingerprint that is also embedded in
+    /// the pack via <see cref="MigrationEvidencePackArtifact.BundleFingerprint"/>.
+    /// Exposed for tests and downstream verifiers.
+    /// </summary>
+    public static string ComputeBundleFingerprint(MigrationEvidencePackBundle bundle)
+    {
+        ArgumentNullException.ThrowIfNull(bundle);
+        var payload = JsonSerializer.SerializeToUtf8Bytes(bundle, MigrationEvidencePackJsonContext.Default.MigrationEvidencePackBundle);
+        var hash = SHA256.HashData(payload);
+        return $"sha256:{Convert.ToHexString(hash).ToLowerInvariant()}";
+    }
+
+    private static MigrationSourceIdentity RedactSource(MigrationSourceIdentity source)
+    {
+        return new MigrationSourceIdentity
+        {
+            DisplayName = source.DisplayName,
+            BaseUrl = RedactUrl(source.BaseUrl),
+            Product = source.Product,
+            Version = source.Version,
+            Build = source.Build,
+            ServiceType = source.ServiceType
+        };
+    }
+
+    private static string RedactUrl(string baseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return baseUrl;
+        }
+
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri))
+        {
+            return baseUrl;
+        }
+
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+
+        return builder.Uri.AbsoluteUri;
+    }
+
+    private static MigrationEvidencePackWorkspaceScope BuildWorkspaceScope(IReadOnlyCollection<string>? requestedWorkspaceNames)
+    {
+        if (requestedWorkspaceNames is null || requestedWorkspaceNames.Count == 0)
+        {
+            return new MigrationEvidencePackWorkspaceScope
+            {
+                Restricted = false,
+                WorkspaceNames = []
+            };
+        }
+
+        var ordered = requestedWorkspaceNames
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static value => value, StringComparer.Ordinal)
+            .ToArray();
+
+        return new MigrationEvidencePackWorkspaceScope
+        {
+            Restricted = ordered.Length > 0,
+            WorkspaceNames = ordered
+        };
+    }
+
+    private static MigrationEvidencePackStage[] BuildStages(MigrationApplyExecutionArtifact applyExecution)
+    {
+        var grouped = applyExecution.StepResults
+            .GroupBy(MapStepKindToStage, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.Ordinal);
+
+        var stageIds = new[]
+        {
+            MigrationEvidencePackStageIds.Catalog,
+            MigrationEvidencePackStageIds.Data,
+            MigrationEvidencePackStageIds.Style
+        };
+
+        var stages = new List<MigrationEvidencePackStage>(stageIds.Length);
+        foreach (var stageId in stageIds)
+        {
+            if (!grouped.TryGetValue(stageId, out var stageSteps) || stageSteps.Length == 0)
+            {
+                stages.Add(new MigrationEvidencePackStage
+                {
+                    Id = stageId,
+                    StepCount = 0,
+                    StepResults = []
+                });
+                continue;
+            }
+
+            var ordered = stageSteps
+                .OrderBy(static step => step.StepId, StringComparer.Ordinal)
+                .ToArray();
+
+            stages.Add(new MigrationEvidencePackStage
+            {
+                Id = stageId,
+                StepCount = ordered.Length,
+                AppliedCount = ordered.Count(static step => step.Outcome == "applied"),
+                AlreadyAppliedCount = ordered.Count(static step => step.Outcome == "already-applied"),
+                ManualReviewCount = ordered.Count(static step => step.Outcome == "manual-review"),
+                UnsupportedCount = ordered.Count(static step => step.Outcome == "unsupported"),
+                FailedCount = ordered.Count(static step => step.Outcome == "failed"),
+                StepResults = ordered
+            });
+        }
+
+        return stages.ToArray();
+    }
+
+    private static string MapStepKindToStage(MigrationApplyExecutionStepResult step)
+    {
+        // Slice 1 (#1095) emits workspace + layer-group catalog rows.
+        // Slice 2 (#1107) emits data-source + feature-data rows.
+        // Slice 3 (#1114) emits style rows.
+        // Any other kind (e.g. per-layer publish) is folded into the catalog
+        // stage so the pack always covers every executed step.
+        return step.Kind switch
+        {
+            "datastore" or "data-source" or "feature-copy" => MigrationEvidencePackStageIds.Data,
+            "style" => MigrationEvidencePackStageIds.Style,
+            _ => MigrationEvidencePackStageIds.Catalog
+        };
+    }
+
+    private static MigrationEvidencePackSummary BuildSummary(
+        MigrationApplyExecutionArtifact applyExecution,
+        IReadOnlyList<MigrationEvidencePackStage> stages)
+    {
+        var styleStage = stages.FirstOrDefault(s => s.Id == MigrationEvidencePackStageIds.Style);
+
+        return new MigrationEvidencePackSummary
+        {
+            TotalStepCount = applyExecution.Summary.TotalStepCount,
+            AppliedStepCount = applyExecution.Summary.AppliedStepCount,
+            AlreadyAppliedStepCount = applyExecution.Summary.AlreadyAppliedStepCount,
+            ManualReviewStepCount = applyExecution.Summary.ManualReviewStepCount,
+            UnsupportedStepCount = applyExecution.Summary.UnsupportedStepCount,
+            FailedStepCount = applyExecution.Summary.FailedStepCount,
+            StyleManualReviewCount = styleStage?.ManualReviewCount ?? 0
+        };
+    }
+
+    private static MigrationEvidencePackStyleDiagnostic[] BuildStyleDiagnostics(
+        IReadOnlyList<MigrationEvidencePackStage> stages)
+    {
+        var styleStage = stages.FirstOrDefault(s => s.Id == MigrationEvidencePackStageIds.Style);
+        if (styleStage is null || styleStage.StepResults.Length == 0)
+        {
+            return [];
+        }
+
+        return styleStage.StepResults
+            .Where(static step => step.Outcome is "manual-review" or "unsupported" or "failed")
+            .Select(static step => new MigrationEvidencePackStyleDiagnostic
+            {
+                SourceId = step.SourceId,
+                StepOutcome = step.Outcome,
+                Message = step.Message
+            })
+            .OrderBy(static diag => diag.SourceId, StringComparer.Ordinal)
+            .ToArray();
+    }
+}
+
+/// <summary>
+/// Aggregated inputs consumed by <see cref="MigrationEvidencePackBuilder.Build"/>.
+/// </summary>
+public sealed record MigrationEvidencePackInputs
+{
+    /// <summary>
+    /// Slice-1 inventory artifact captured from the source scan.
+    /// </summary>
+    public required MigrationSourceInventoryArtifact Inventory { get; init; }
+
+    /// <summary>
+    /// Slice-1 manifest artifact translated from the inventory.
+    /// </summary>
+    public required MigrationManifestArtifact Manifest { get; init; }
+
+    /// <summary>
+    /// Apply-execution artifact emitted by the GeoServer import service after
+    /// slice 1-3 catalog / data / style steps ran successfully.
+    /// </summary>
+    public required MigrationApplyExecutionArtifact ApplyExecution { get; init; }
+
+    /// <summary>
+    /// Operator-requested workspace scope, or <c>null</c>/empty when the run
+    /// applied to all workspaces. Captured separately because the apply
+    /// execution artifact does not echo it.
+    /// </summary>
+    public IReadOnlyCollection<string>? RequestedWorkspaceNames { get; init; }
+}
+
+/// <summary>
+/// Override hooks for tests and the nightly workflow.
+/// </summary>
+public sealed record MigrationEvidencePackBuilderOptions
+{
+    /// <summary>
+    /// Run identifier embedded in the artifact. Excluded from the bundle
+    /// fingerprint so the same inputs produce the same fingerprint across
+    /// nightly runs.
+    /// </summary>
+    public string? RunId { get; init; }
+
+    /// <summary>
+    /// Generator label embedded in the artifact. Excluded from the bundle
+    /// fingerprint.
+    /// </summary>
+    public string? Generator { get; init; }
+
+    /// <summary>
+    /// Generation timestamp. Excluded from the bundle fingerprint. Defaults to
+    /// <see cref="DateTimeOffset.UnixEpoch"/> when omitted so deterministic
+    /// tests do not have to set it.
+    /// </summary>
+    public DateTimeOffset? GeneratedAt { get; init; }
+}

--- a/src/Honua.Core/Features/Import/Services/MigrationEvidencePackJsonContext.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationEvidencePackJsonContext.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// AOT-safe JSON serialization context for the slice-4 migration evidence
+/// pack. Source-generated metadata avoids reflection-based serialization so
+/// the pack can be emitted under <c>PublishAot</c> builds without trimming
+/// warnings.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    WriteIndented = false)]
+[JsonSerializable(typeof(MigrationEvidencePackArtifact))]
+[JsonSerializable(typeof(MigrationEvidencePackBundle))]
+[JsonSerializable(typeof(MigrationEvidencePackWorkspaceScope))]
+[JsonSerializable(typeof(MigrationEvidencePackApplyIdentity))]
+[JsonSerializable(typeof(MigrationEvidencePackSummary))]
+[JsonSerializable(typeof(MigrationEvidencePackStage))]
+[JsonSerializable(typeof(MigrationEvidencePackStage[]))]
+[JsonSerializable(typeof(MigrationEvidencePackStyleDiagnostic))]
+[JsonSerializable(typeof(MigrationEvidencePackStyleDiagnostic[]))]
+[JsonSerializable(typeof(MigrationSourceInventoryArtifact))]
+[JsonSerializable(typeof(MigrationManifestArtifact))]
+[JsonSerializable(typeof(MigrationApplyExecutionArtifact))]
+[JsonSerializable(typeof(MigrationApplyExecutionStepResult))]
+[JsonSerializable(typeof(MigrationApplyExecutionStepResult[]))]
+[JsonSerializable(typeof(MigrationApplyExecutionSummary))]
+[JsonSerializable(typeof(MigrationSourceIdentity))]
+[JsonSerializable(typeof(MigrationCompatibilityAssessment))]
+[JsonSerializable(typeof(MigrationManifestReviewItem))]
+[JsonSerializable(typeof(MigrationManifestReviewItem[]))]
+public sealed partial class MigrationEvidencePackJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Postgres/Features/Import/GeoServerImportService.cs
+++ b/src/Honua.Postgres/Features/Import/GeoServerImportService.cs
@@ -1312,6 +1312,11 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
             static store => GetStoreKey(store.WorkspaceName, store.Name),
             StringComparer.OrdinalIgnoreCase);
         var layerGroupsById = filteredResources.LayerGroups.ToDictionary(GetLayerGroupId, StringComparer.Ordinal);
+        // Slice 3 (#1015): style steps come out of the apply-plan builder with
+        // Kind="style" and SourceId=GetStyleId(style). Build a lookup so the
+        // apply path can resolve the underlying GeoServerStyleInfo (and its
+        // SLD body) without re-running discovery.
+        var stylesById = filteredResources.Styles.ToDictionary(GetStyleId, StringComparer.Ordinal);
 
         // Slice 1: apply workspace-level catalog entries first so that any subsequent
         // layer-group / layer apply can reference them. These records are deterministic
@@ -1344,6 +1349,8 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
                     layersById,
                     dataStoresByKey,
                     layerGroupsById,
+                    stylesById,
+                    applyPlan,
                     request,
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -1385,9 +1392,28 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
         Dictionary<string, GeoServerLayerInfo> layersById,
         Dictionary<string, GeoServerDataStoreInfo> dataStoresByKey,
         Dictionary<string, GeoServerLayerGroupInfo> layerGroupsById,
+        Dictionary<string, GeoServerStyleInfo> stylesById,
+        MigrationApplyPlanArtifact applyPlan,
         GeoServerImportRequest request,
         CancellationToken cancellationToken)
     {
+        // Slice 3 (#1015): style steps still need to persist into the Honua
+        // style catalog even when the manifest translator marks them
+        // unsupported/manual-review, so the migration evidence pack carries
+        // explicit conversion diagnostics rather than silently dropping the
+        // source style. Dispatch to the style branch before the early
+        // unsupported/manual-review returns below.
+        if (string.Equals(step.Kind, "style", StringComparison.Ordinal))
+        {
+            return await ApplyStyleCatalogStepAsync(
+                    step,
+                    stylesById,
+                    applyPlan,
+                    request,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         if (step.Disposition == "unsupported")
         {
             return CreateExecutionStepResult(
@@ -1867,6 +1893,220 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
         return string.Join(";", parts);
     }
 
+    /// <summary>
+    /// Persist a migration style row per filtered GeoServer style.
+    /// </summary>
+    /// <remarks>
+    /// Slice 3 of issue #1015. Each style apply-plan step produces an
+    /// idempotent row in <c>honua.migration_styles</c> with the original
+    /// source body, any converter output, and structured conversion
+    /// diagnostics. SLD styles are run through the registered
+    /// <see cref="ISldStyleConverter"/> when available; conversion warnings
+    /// and errors are persisted so operators can audit the deterministic
+    /// migration outcome. When the converter reports errors (or when no
+    /// converter is registered) the row is persisted with disposition
+    /// <c>manual-review</c> — we do not claim perfect SLD visual parity
+    /// when diagnostics report manual review (issue #1015 AC). Re-apply
+    /// is idempotent via PK on (source_kind, source_id). Cross-workspace
+    /// styles outside the operator's requested scope are rejected per
+    /// issue #1098.
+    /// </remarks>
+    private async Task<MigrationApplyExecutionStepResult> ApplyStyleCatalogStepAsync(
+        MigrationApplyPlanStep step,
+        Dictionary<string, GeoServerStyleInfo> stylesById,
+        MigrationApplyPlanArtifact applyPlan,
+        GeoServerImportRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!stylesById.TryGetValue(step.SourceId, out var style))
+        {
+            return CreateExecutionStepResult(
+                step,
+                "manual-review",
+                "The source style was not present in the filtered GeoServer discovery result.");
+        }
+
+        // Workspace scope (#1098 / PR #1100): respect the operator's requested
+        // workspace scope so unrelated workspaces' styles are not applied.
+        if (request.WorkspaceNames is { Length: > 0 } scopedNames &&
+            !string.IsNullOrWhiteSpace(style.WorkspaceName) &&
+            !scopedNames.Contains(style.WorkspaceName, StringComparer.OrdinalIgnoreCase))
+        {
+            return CreateExecutionStepResult(
+                step,
+                "manual-review",
+                $"Style apply for '{step.SourceId}' rejected: source workspace '{style.WorkspaceName}' is outside the requested workspace scope (issue #1098).");
+        }
+
+        if (!request.ApplyMode || _catalogWriter == null)
+        {
+            return CreateExecutionStepResult(
+                step,
+                "manual-review",
+                "Style catalog persistence is deferred until applyMode=true and a catalog writer is configured.");
+        }
+
+        var sourceFormat = string.IsNullOrWhiteSpace(style.Format) ? "sld" : style.Format.ToLowerInvariant();
+        string? convertedBody = null;
+        string? convertedFormat = null;
+        var diagnostics = new List<StyleDiagnostic>();
+        var disposition = string.Equals(step.Disposition, "unsupported", StringComparison.Ordinal)
+            ? "unsupported"
+            : string.Equals(step.Disposition, "manual-review", StringComparison.Ordinal)
+                ? "manual-review"
+                : "applied";
+
+        if (string.Equals(sourceFormat, "sld", StringComparison.Ordinal))
+        {
+            // Reuse the existing ISldStyleConverter; do NOT reimplement converter
+            // logic in the apply path. When the converter is not registered, the
+            // style is still persisted but tagged manual-review with a converter
+            // diagnostic so the evidence pack carries an explicit record.
+            if (_sldConverter == null)
+            {
+                diagnostics.Add(new StyleDiagnostic(
+                    "error",
+                    "No ISldStyleConverter is registered; SLD style was persisted without conversion. Apply via the per-layer admin SLD endpoint to attach a MapLibre style."));
+                disposition = "manual-review";
+            }
+            else if (string.IsNullOrWhiteSpace(style.SldContent))
+            {
+                diagnostics.Add(new StyleDiagnostic(
+                    "error",
+                    "SLD style has no embedded body; conversion was skipped."));
+                disposition = "manual-review";
+            }
+            else
+            {
+                var conversion = _sldConverter.Convert(style.SldContent!);
+                foreach (var warning in conversion.Warnings)
+                {
+                    diagnostics.Add(new StyleDiagnostic("warning", warning));
+                }
+                foreach (var error in conversion.Errors)
+                {
+                    diagnostics.Add(new StyleDiagnostic("error", error));
+                }
+
+                if (conversion.MapLibreLayersJson is { Length: > 0 } mapLibreJson)
+                {
+                    convertedBody = mapLibreJson;
+                    convertedFormat = "maplibre-layers-json";
+                }
+
+                // Conversion produced no layers (HasErrors), or converter
+                // emitted at least one error diagnostic: do not claim visual
+                // parity. Per #1015 AC, mark the row manual-review.
+                if (conversion.HasErrors)
+                {
+                    disposition = "manual-review";
+                }
+            }
+        }
+        else if (!string.Equals(sourceFormat, "mbstyle", StringComparison.Ordinal))
+        {
+            // Non-SLD/non-MapBox formats (CSS, YSLD, etc.) are persisted as
+            // manual-review because Honua does not have a deterministic
+            // converter for them.
+            diagnostics.Add(new StyleDiagnostic(
+                "error",
+                $"Source style format '{sourceFormat}' is not supported by Honua's deterministic style converter; persisted as manual-review."));
+            disposition = "manual-review";
+        }
+
+        var targetStyleId = BuildTargetStyleId(applyPlan.Source, style);
+
+        try
+        {
+            var outcome = await _catalogWriter.EnsureStyleAsync(
+                    _connectionProvider.GetConnectionString(),
+                    new MigrationStyleRequest
+                    {
+                        SourceKind = applyPlan.SourceKind,
+                        SourceId = step.SourceId,
+                        TargetStyleId = targetStyleId,
+                        StyleName = style.Name,
+                        WorkspaceName = string.IsNullOrWhiteSpace(style.WorkspaceName) ? null : style.WorkspaceName,
+                        SourceFormat = sourceFormat,
+                        SourceLanguageVersion = string.IsNullOrWhiteSpace(style.LanguageVersion) ? null : style.LanguageVersion,
+                        SourceBody = string.IsNullOrWhiteSpace(style.SldContent) ? null : style.SldContent,
+                        ConvertedBody = convertedBody,
+                        ConvertedFormat = convertedFormat,
+                        DiagnosticsJson = SerializeStyleDiagnostics(diagnostics),
+                        ReviewDisposition = disposition
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            var diagnosticSummary = BuildStyleDiagnosticSummary(diagnostics);
+            return outcome switch
+            {
+                MigrationCatalogWriteOutcome.Created when disposition == "manual-review" => CreateExecutionStepResult(
+                    step,
+                    "manual-review",
+                    $"Persisted style '{step.SourceId}' with manual-review disposition. {diagnosticSummary} Do not claim visual parity until the diagnostics are resolved."),
+                MigrationCatalogWriteOutcome.Created => CreateExecutionStepResult(
+                    step,
+                    "applied",
+                    $"Applied {sourceFormat} style '{step.SourceId}' to honua.migration_styles.{(diagnosticSummary.Length > 0 ? " " + diagnosticSummary : string.Empty)}"),
+                MigrationCatalogWriteOutcome.AlreadyExists => CreateExecutionStepResult(
+                    step,
+                    "already-applied",
+                    $"Style '{step.SourceId}' already present; idempotent re-apply made no changes."),
+                _ => CreateExecutionStepResult(step, "manual-review", "Catalog writer returned an unexpected outcome.")
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return CreateExecutionStepResult(
+                step,
+                "failed",
+                $"Style apply for '{step.SourceId}' failed unexpectedly and requires operator review.");
+        }
+    }
+
+    private static string BuildTargetStyleId(MigrationSourceIdentity source, GeoServerStyleInfo style)
+    {
+        var workspace = string.IsNullOrWhiteSpace(style.WorkspaceName) ? "global" : style.WorkspaceName;
+        var service = NormalizeCatalogServiceName(source.DisplayName ?? source.BaseUrl ?? "geoserver-import");
+        var styleName = NormalizeCatalogServiceName($"{workspace}-{style.Name}");
+        return $"style:{service}:{styleName}";
+    }
+
+    private static string SerializeStyleDiagnostics(IReadOnlyList<StyleDiagnostic> diagnostics)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new System.Text.Json.Utf8JsonWriter(stream))
+        {
+            writer.WriteStartArray();
+            foreach (var diagnostic in diagnostics)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("severity", diagnostic.Severity);
+                writer.WriteString("message", diagnostic.Message);
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+        }
+
+        return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static string BuildStyleDiagnosticSummary(IReadOnlyList<StyleDiagnostic> diagnostics)
+    {
+        if (diagnostics.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var warningCount = diagnostics.Count(static d => string.Equals(d.Severity, "warning", StringComparison.Ordinal));
+        var errorCount = diagnostics.Count(static d => string.Equals(d.Severity, "error", StringComparison.Ordinal));
+        return $"Recorded {errorCount} error and {warningCount} warning conversion diagnostic(s).";
+    }
+
+    private readonly record struct StyleDiagnostic(string Severity, string Message);
+
     private async Task<MigrationApplyExecutionStepResult> ApplyLayerGroupCatalogStepAsync(
         MigrationApplyPlanStep step,
         Dictionary<string, GeoServerLayerGroupInfo> layerGroupsById,
@@ -2163,7 +2403,7 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
     {
         var warnings = new List<string>
         {
-            "Non-dry-run GeoServer import generated a deterministic apply plan. Catalog mutation in this slice is limited to idempotent persistence of workspace and layer-group catalog entries plus idempotent publication of PostGIS-backed layers whose source tables already exist in the target Honua database; data copy, bulk style persistence, and WMS/WFS/WMTS service exposure changes remain explicit review records."
+            "Non-dry-run GeoServer import generated a deterministic apply plan. Catalog mutation includes idempotent persistence of workspace and layer-group catalog entries, idempotent data-source registration and feature data copy for PostGIS sources, idempotent publication of PostGIS-backed layers, and idempotent persistence of style entries with structured SLD conversion diagnostics; WMS/WFS/WMTS service exposure changes remain explicit review records. Styles whose conversion diagnostics report errors are persisted with manual-review disposition — do not claim perfect SLD visual parity for those entries."
         };
 
         if (applyExecution.Summary.ManualReviewStepCount > 0)

--- a/src/Honua.Postgres/Features/Import/PostgresMigrationCatalogWriter.cs
+++ b/src/Honua.Postgres/Features/Import/PostgresMigrationCatalogWriter.cs
@@ -239,6 +239,81 @@ internal sealed partial class PostgresMigrationCatalogWriter : IMigrationCatalog
         };
     }
 
+    public async Task<MigrationCatalogWriteOutcome> EnsureStyleAsync(
+        string connectionString,
+        MigrationStyleRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.SourceKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.SourceId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.TargetStyleId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.StyleName);
+
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        // Idempotent upsert on (source_kind, source_id). Slice 3 deliberately
+        // does not overwrite existing rows because the source-of-truth for a
+        // migrated style is the source system being scanned; operators who
+        // need to refresh diagnostics should delete the row and re-apply.
+        const string sql = """
+            INSERT INTO honua.migration_styles (
+                source_kind,
+                source_id,
+                workspace_name,
+                style_name,
+                source_format,
+                source_language_version,
+                target_style_id,
+                source_body,
+                converted_body,
+                converted_format,
+                diagnostics,
+                review_disposition
+            )
+            VALUES (
+                @sourceKind,
+                @sourceId,
+                @workspaceName,
+                @styleName,
+                @sourceFormat,
+                @sourceLanguageVersion,
+                @targetStyleId,
+                @sourceBody,
+                @convertedBody,
+                @convertedFormat,
+                CAST(@diagnostics AS jsonb),
+                @reviewDisposition
+            )
+            ON CONFLICT (source_kind, source_id) DO NOTHING
+            RETURNING source_id;
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@sourceKind", request.SourceKind);
+        command.Parameters.AddWithValue("@sourceId", request.SourceId);
+        command.Parameters.AddWithValue("@workspaceName", (object?)request.WorkspaceName ?? DBNull.Value);
+        command.Parameters.AddWithValue("@styleName", request.StyleName);
+        command.Parameters.AddWithValue("@sourceFormat", request.SourceFormat);
+        command.Parameters.AddWithValue("@sourceLanguageVersion", (object?)request.SourceLanguageVersion ?? DBNull.Value);
+        command.Parameters.AddWithValue("@targetStyleId", request.TargetStyleId);
+        command.Parameters.AddWithValue("@sourceBody", (object?)request.SourceBody ?? DBNull.Value);
+        command.Parameters.AddWithValue("@convertedBody", (object?)request.ConvertedBody ?? DBNull.Value);
+        command.Parameters.AddWithValue("@convertedFormat", (object?)request.ConvertedFormat ?? DBNull.Value);
+        command.Parameters.AddWithValue("@diagnostics", string.IsNullOrWhiteSpace(request.DiagnosticsJson) ? "[]" : request.DiagnosticsJson);
+        command.Parameters.AddWithValue("@reviewDisposition", request.ReviewDisposition);
+
+        var inserted = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        var outcome = inserted is null
+            ? MigrationCatalogWriteOutcome.AlreadyExists
+            : MigrationCatalogWriteOutcome.Created;
+
+        Log.StylePersisted(_logger, request.SourceFormat, request.SourceId, request.ReviewDisposition, outcome.ToString());
+        return outcome;
+    }
+
     private static async Task<long> CountRowsAsync(NpgsqlConnection connection, string identifier, CancellationToken cancellationToken)
     {
         await using var countCmd = new NpgsqlCommand($"SELECT COUNT(*) FROM {identifier};", connection);
@@ -285,5 +360,8 @@ internal sealed partial class PostgresMigrationCatalogWriter : IMigrationCatalog
 
         [LoggerMessage(7964, LogLevel.Warning, "Migration feature copy source missing: {SourceSchema}.{SourceTable}")]
         public static partial void FeatureCopySourceMissing(ILogger logger, string sourceSchema, string sourceTable);
+
+        [LoggerMessage(7965, LogLevel.Information, "Migration catalog writer ensured {SourceFormat} style '{SourceId}' (disposition={Disposition}, {Outcome})")]
+        public static partial void StylePersisted(ILogger logger, string sourceFormat, string sourceId, string disposition, string outcome);
     }
 }

--- a/src/Honua.Server/Migrations/030_CreateMigrationStyleCatalog.sql
+++ b/src/Honua.Server/Migrations/030_CreateMigrationStyleCatalog.sql
@@ -1,0 +1,40 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration 030: Add migration_styles catalog
+-- Tracks GeoServer-style style entries applied by the migration apply path.
+-- Used by issue #1015 slice 3 to capture deterministic evidence that a
+-- style (typically SLD) has been persisted into the Honua catalog along
+-- with the original body, the converter format (e.g. MapLibre JSON when
+-- conversion succeeded), and structured conversion diagnostics. The
+-- diagnostics column lets operators audit "manual-review" outcomes for
+-- styles where SLD-to-MapLibre conversion could not produce perfect
+-- visual parity (see issue AC: "Do not claim perfect SLD visual parity
+-- when conversion diagnostics report manual review").
+-- Dependencies: Requires honua schema from 001_CreateHonuaSchema.sql.
+
+CREATE TABLE IF NOT EXISTS honua.migration_styles (
+    source_kind          VARCHAR(64)  NOT NULL,
+    source_id            VARCHAR(256) NOT NULL,
+    workspace_name       VARCHAR(128),
+    style_name           VARCHAR(256) NOT NULL,
+    source_format        VARCHAR(64)  NOT NULL DEFAULT 'sld',
+    source_language_version VARCHAR(32),
+    target_style_id      VARCHAR(256) NOT NULL,
+    source_body          TEXT,
+    converted_body       TEXT,
+    converted_format     VARCHAR(64),
+    diagnostics          JSONB NOT NULL DEFAULT '[]'::jsonb,
+    review_disposition   VARCHAR(32)  NOT NULL DEFAULT 'applied',
+    created_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (source_kind, source_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_migration_styles_workspace
+    ON honua.migration_styles (workspace_name);
+
+CREATE INDEX IF NOT EXISTS idx_migration_styles_disposition
+    ON honua.migration_styles (review_disposition);
+
+COMMENT ON TABLE honua.migration_styles IS
+    'Idempotent record of styles applied by the migration apply path (issue #1015 slice 3). The diagnostics column captures SLD-to-MapLibre conversion warnings/errors so operators can audit manual-review outcomes.';

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationEvidencePackBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationEvidencePackBuilderTests.cs
@@ -1,0 +1,407 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+
+namespace Honua.Core.Tests.Features.Import;
+
+/// <summary>
+/// Slice 4 of issue #1015: deterministic evidence-pack generation.
+/// </summary>
+public sealed class MigrationEvidencePackBuilderTests
+{
+    [Fact]
+    public void Build_ProducesDeterministicFingerprint_ForIdenticalInputs()
+    {
+        var inputs = BuildInputs();
+
+        var first = MigrationEvidencePackBuilder.Build(inputs, new MigrationEvidencePackBuilderOptions
+        {
+            RunId = "nightly-20260519",
+            Generator = "test/1.0",
+            GeneratedAt = DateTimeOffset.Parse("2026-05-19T00:00:00Z")
+        });
+
+        var second = MigrationEvidencePackBuilder.Build(inputs, new MigrationEvidencePackBuilderOptions
+        {
+            // Different run-time metadata; fingerprint must be unaffected.
+            RunId = "nightly-20260601",
+            Generator = "test/2.0",
+            GeneratedAt = DateTimeOffset.Parse("2026-06-01T12:34:56Z")
+        });
+
+        first.BundleFingerprint.Should().StartWith("sha256:");
+        first.BundleFingerprint.Should().Be(second.BundleFingerprint,
+            "fingerprint must cover the bundle only — wall-clock and generator labels are excluded so nightly re-runs stay byte-identical.");
+
+        first.RunId.Should().Be("nightly-20260519");
+        second.RunId.Should().Be("nightly-20260601");
+    }
+
+    [Fact]
+    public void Build_FingerprintChanges_WhenAStepResultChanges()
+    {
+        var inputs = BuildInputs();
+        var mutated = inputs with
+        {
+            ApplyExecution = inputs.ApplyExecution with
+            {
+                StepResults = inputs.ApplyExecution.StepResults
+                    .Select(step => step.StepId == "step:catalog:roads"
+                        ? step with { Outcome = "manual-review", Message = "Operator review required." }
+                        : step)
+                    .ToArray()
+            }
+        };
+
+        var baseline = MigrationEvidencePackBuilder.Build(inputs);
+        var changed = MigrationEvidencePackBuilder.Build(mutated);
+
+        baseline.BundleFingerprint.Should().NotBe(changed.BundleFingerprint,
+            "any change to the bundle inputs must propagate to the fingerprint.");
+    }
+
+    [Fact]
+    public void Build_GroupsStepResultsIntoCanonicalStages()
+    {
+        var inputs = BuildInputs();
+
+        var pack = MigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.Stages.Should().HaveCount(3);
+        pack.Bundle.Stages.Select(s => s.Id).Should().Equal(
+            MigrationEvidencePackStageIds.Catalog,
+            MigrationEvidencePackStageIds.Data,
+            MigrationEvidencePackStageIds.Style);
+
+        var catalog = pack.Bundle.Stages.Single(s => s.Id == MigrationEvidencePackStageIds.Catalog);
+        catalog.StepCount.Should().Be(2);
+        catalog.AppliedCount.Should().Be(2);
+
+        var data = pack.Bundle.Stages.Single(s => s.Id == MigrationEvidencePackStageIds.Data);
+        data.StepCount.Should().Be(1);
+        data.AlreadyAppliedCount.Should().Be(1);
+
+        var style = pack.Bundle.Stages.Single(s => s.Id == MigrationEvidencePackStageIds.Style);
+        style.StepCount.Should().Be(2);
+        style.AppliedCount.Should().Be(1);
+        style.ManualReviewCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Build_AggregatesStyleDiagnostics_FromManualReviewSteps()
+    {
+        var inputs = BuildInputs();
+
+        var pack = MigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.StyleDiagnostics.Should().HaveCount(1);
+        var diagnostic = pack.Bundle.StyleDiagnostics[0];
+        diagnostic.SourceId.Should().Be("style:ops:line");
+        diagnostic.StepOutcome.Should().Be("manual-review");
+        diagnostic.Message.Should().Contain("manual-review");
+
+        pack.Bundle.Summary.StyleManualReviewCount.Should().Be(1,
+            "slice-3 manual-review style outcomes must be surfaced so the pack does not claim visual parity for them.");
+    }
+
+    [Fact]
+    public void Build_RedactsCredentials_FromSourceUrls()
+    {
+        var inputs = BuildInputs();
+        var withSecretUrl = inputs with
+        {
+            ApplyExecution = inputs.ApplyExecution with
+            {
+                Source = inputs.ApplyExecution.Source with
+                {
+                    BaseUrl = "https://admin:hunter2@geoserver.example.com:8443/geoserver/rest?token=topsecret"
+                }
+            },
+            Inventory = inputs.Inventory with
+            {
+                Source = inputs.Inventory.Source with
+                {
+                    BaseUrl = "https://admin:hunter2@geoserver.example.com:8443/geoserver/rest?token=topsecret"
+                }
+            },
+            Manifest = inputs.Manifest with
+            {
+                Source = inputs.Manifest.Source with
+                {
+                    BaseUrl = "https://admin:hunter2@geoserver.example.com:8443/geoserver/rest?token=topsecret"
+                }
+            }
+        };
+
+        var pack = MigrationEvidencePackBuilder.Build(withSecretUrl);
+
+        pack.Bundle.Source.BaseUrl.Should().NotContain("hunter2");
+        pack.Bundle.Source.BaseUrl.Should().NotContain("admin");
+        pack.Bundle.Source.BaseUrl.Should().NotContain("topsecret");
+        pack.Bundle.Source.BaseUrl.Should().Be("https://geoserver.example.com:8443/geoserver/rest");
+
+        pack.Bundle.Inventory.Source.BaseUrl.Should().NotContain("hunter2");
+        pack.Bundle.Inventory.Source.BaseUrl.Should().NotContain("topsecret");
+        pack.Bundle.Manifest.Source.BaseUrl.Should().NotContain("hunter2");
+        pack.Bundle.Manifest.Source.BaseUrl.Should().NotContain("topsecret");
+
+        // Serialize the entire pack and assert no credential leaked anywhere.
+        var json = JsonSerializer.Serialize(pack, MigrationEvidencePackJsonContext.Default.MigrationEvidencePackArtifact);
+        json.Should().NotContain("hunter2");
+        json.Should().NotContain("topsecret");
+        // "admin" is a common substring; assert via user-info marker instead.
+        json.Should().NotContain("admin:hunter2");
+    }
+
+    [Fact]
+    public void Build_CapturesWorkspaceScope_WhenOperatorRestrictsRun()
+    {
+        var inputs = BuildInputs() with { RequestedWorkspaceNames = new[] { "ops", "ops" } };
+
+        var pack = MigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.WorkspaceScope.Restricted.Should().BeTrue();
+        pack.Bundle.WorkspaceScope.WorkspaceNames.Should().Equal("ops");
+    }
+
+    [Fact]
+    public void Build_CapturesWorkspaceScope_AsUnrestricted_WhenNoNamesProvided()
+    {
+        var inputs = BuildInputs();
+
+        var pack = MigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.WorkspaceScope.Restricted.Should().BeFalse();
+        pack.Bundle.WorkspaceScope.WorkspaceNames.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Nightly fixture emission hook (slice 4 of #1015). When the
+    /// <c>HONUA_EMIT_EVIDENCE_PACK</c> environment variable is set the
+    /// fixture-driven evidence-pack JSON is written to the path supplied via
+    /// <c>HONUA_EVIDENCE_PACK_OUTPUT</c> so the nightly workflow can upload it
+    /// as a CI artifact. The contents are deterministic — the same fixture
+    /// always produces the same fingerprint — so workflow consumers can diff
+    /// or pin the artifact across runs.
+    /// </summary>
+    [Fact]
+    public void EmitNightlyEvidencePack_WhenEnvVarSet_WritesDeterministicArtifact()
+    {
+        if (Environment.GetEnvironmentVariable("HONUA_EMIT_EVIDENCE_PACK") != "1")
+        {
+            return;
+        }
+
+        var outputPath = Environment.GetEnvironmentVariable("HONUA_EVIDENCE_PACK_OUTPUT");
+        if (string.IsNullOrWhiteSpace(outputPath))
+        {
+            outputPath = Path.Combine(AppContext.BaseDirectory, "geoserver-migration-evidence-pack.json");
+        }
+
+        var pack = MigrationEvidencePackBuilder.Build(
+            BuildInputs(),
+            new MigrationEvidencePackBuilderOptions
+            {
+                RunId = Environment.GetEnvironmentVariable("HONUA_EVIDENCE_PACK_RUN_ID") ?? "nightly-fixture",
+                Generator = "honua.migration.evidence-pack-builder/1.0",
+                GeneratedAt = DateTimeOffset.UnixEpoch
+            });
+
+        // Serialize via the source-gen context (AOT-safe) and re-format with an
+        // indented JsonDocument round-trip so the artifact stays human-
+        // readable for reviewers without losing trim safety.
+        var compactJson = JsonSerializer.Serialize(
+            pack,
+            MigrationEvidencePackJsonContext.Default.MigrationEvidencePackArtifact);
+        using var document = JsonDocument.Parse(compactJson);
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+        {
+            document.RootElement.WriteTo(writer);
+        }
+
+        var json = System.Text.Encoding.UTF8.GetString(stream.ToArray());
+
+        var directory = Path.GetDirectoryName(outputPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(outputPath, json);
+        pack.BundleFingerprint.Should().StartWith("sha256:");
+    }
+
+    [Fact]
+    public void Artifact_Shape_HasStableTopLevelFields()
+    {
+        // Schema-stability guard: surface any accidental addition/rename of
+        // the evidence-pack contract so reviewers update consumers
+        // (admin UI, SDK orchestration in slice 5).
+        var pack = MigrationEvidencePackBuilder.Build(BuildInputs());
+        var json = JsonSerializer.Serialize(
+            pack,
+            MigrationEvidencePackJsonContext.Default.MigrationEvidencePackArtifact);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        // Top-level artifact contract.
+        root.GetProperty("artifactKind").GetString().Should().Be("honua.migration.evidence-pack");
+        root.GetProperty("artifactVersion").GetString().Should().Be("1.0");
+        root.GetProperty("runId").ValueKind.Should().Be(JsonValueKind.String);
+        root.GetProperty("generator").ValueKind.Should().Be(JsonValueKind.String);
+        root.GetProperty("generatedAt").ValueKind.Should().Be(JsonValueKind.String);
+        root.GetProperty("bundleFingerprint").GetString().Should().StartWith("sha256:");
+
+        // Bundle contract: catalog/data/style stages plus inventory/manifest
+        // snapshots so downstream consumers can audit the entire run from a
+        // single artifact.
+        var bundle = root.GetProperty("bundle");
+        bundle.GetProperty("sourceKind").ValueKind.Should().Be(JsonValueKind.String);
+        bundle.GetProperty("source").ValueKind.Should().Be(JsonValueKind.Object);
+        bundle.GetProperty("workspaceScope").ValueKind.Should().Be(JsonValueKind.Object);
+        bundle.GetProperty("apply").ValueKind.Should().Be(JsonValueKind.Object);
+        bundle.GetProperty("summary").ValueKind.Should().Be(JsonValueKind.Object);
+        bundle.GetProperty("stages").ValueKind.Should().Be(JsonValueKind.Array);
+        bundle.GetProperty("styleDiagnostics").ValueKind.Should().Be(JsonValueKind.Array);
+        bundle.GetProperty("inventory").ValueKind.Should().Be(JsonValueKind.Object);
+        bundle.GetProperty("manifest").ValueKind.Should().Be(JsonValueKind.Object);
+
+        var apply = bundle.GetProperty("apply");
+        apply.GetProperty("planFingerprint").ValueKind.Should().Be(JsonValueKind.String);
+        apply.GetProperty("replayToken").ValueKind.Should().Be(JsonValueKind.String);
+        apply.GetProperty("executionMode").ValueKind.Should().Be(JsonValueKind.String);
+
+        var summary = bundle.GetProperty("summary");
+        summary.GetProperty("totalStepCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("appliedStepCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("alreadyAppliedStepCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("manualReviewStepCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("unsupportedStepCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("failedStepCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("styleManualReviewCount").ValueKind.Should().Be(JsonValueKind.Number);
+    }
+
+    private static MigrationEvidencePackInputs BuildInputs()
+    {
+        var source = new MigrationSourceIdentity
+        {
+            DisplayName = "GeoServer Sample",
+            BaseUrl = "https://geoserver.example.com/geoserver/rest",
+            Product = "GeoServer",
+            Version = "2.24.0",
+            ServiceType = "REST"
+        };
+
+        var inventory = new MigrationSourceInventoryArtifact
+        {
+            SourceKind = "geoserver-rest",
+            Source = source,
+            AuthPosture = new MigrationInventoryAuthPosture { Mode = "basic", CredentialsSupplied = true, AccessConfirmed = true },
+            ScanCompleteness = new MigrationInventoryCompleteness { Status = "complete" },
+            Summary = new MigrationInventorySummary { ContainerCount = 1, ResourceCount = 2, StyleCount = 2 },
+            OverallCompatibility = new MigrationCompatibilityAssessment
+            {
+                Level = "compatible",
+                Reason = "Source inventory is compatible with Honua migration."
+            }
+        };
+
+        var manifest = new MigrationManifestArtifact
+        {
+            SourceKind = "geoserver-rest",
+            Source = source,
+            Summary = new MigrationManifestSummary
+            {
+                SourceResourceCount = 2,
+                TargetResourceCount = 2,
+                StyleActionCount = 2
+            }
+        };
+
+        var stepResults = new[]
+        {
+            new MigrationApplyExecutionStepResult
+            {
+                StepId = "step:catalog:roads",
+                SourceId = "workspace:ops",
+                Kind = "workspace",
+                Action = "stage-catalog-service",
+                Disposition = "ready",
+                Outcome = "applied",
+                Message = "Workspace 'ops' was created in honua.migration_services."
+            },
+            new MigrationApplyExecutionStepResult
+            {
+                StepId = "step:catalog:parcels",
+                SourceId = "layer-group:ops:parcels",
+                Kind = "layer-group",
+                Action = "stage-catalog-service",
+                Disposition = "ready",
+                Outcome = "applied",
+                Message = "Layer-group catalog row created."
+            },
+            new MigrationApplyExecutionStepResult
+            {
+                StepId = "step:data:ops-pg",
+                SourceId = "datastore:ops:ops-pg",
+                Kind = "datastore",
+                Action = "stage-data-source",
+                Disposition = "ready",
+                Outcome = "already-applied",
+                Message = "Data source already present; re-apply was a no-op."
+            },
+            new MigrationApplyExecutionStepResult
+            {
+                StepId = "step:style:point",
+                SourceId = "style:ops:point",
+                Kind = "style",
+                Action = "stage-style",
+                Disposition = "ready",
+                Outcome = "applied",
+                Message = "Applied sld style 'style:ops:point' to honua.migration_styles."
+            },
+            new MigrationApplyExecutionStepResult
+            {
+                StepId = "step:style:line",
+                SourceId = "style:ops:line",
+                Kind = "style",
+                Action = "stage-style",
+                Disposition = "ready",
+                Outcome = "manual-review",
+                Message = "Persisted style 'style:ops:line' with manual-review disposition. Recorded 1 error and 0 warning conversion diagnostic(s). Do not claim visual parity until the diagnostics are resolved."
+            }
+        };
+
+        var applyExecution = new MigrationApplyExecutionArtifact
+        {
+            SourceKind = "geoserver-rest",
+            Source = source,
+            PlanFingerprint = "sha256:plan-fingerprint",
+            ReplayToken = "sha256:replay-token",
+            StartedAt = DateTimeOffset.Parse("2026-05-19T00:00:00Z"),
+            CompletedAt = DateTimeOffset.Parse("2026-05-19T00:01:00Z"),
+            Summary = new MigrationApplyExecutionSummary
+            {
+                TotalStepCount = stepResults.Length,
+                AppliedStepCount = stepResults.Count(r => r.Outcome == "applied"),
+                AlreadyAppliedStepCount = stepResults.Count(r => r.Outcome == "already-applied"),
+                ManualReviewStepCount = stepResults.Count(r => r.Outcome == "manual-review"),
+                UnsupportedStepCount = 0,
+                FailedStepCount = 0
+            },
+            StepResults = stepResults
+        };
+
+        return new MigrationEvidencePackInputs
+        {
+            Inventory = inventory,
+            Manifest = manifest,
+            ApplyExecution = applyExecution
+        };
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/Fixtures/GeoServer/StyleApplySlice.json
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/Fixtures/GeoServer/StyleApplySlice.json
@@ -1,0 +1,152 @@
+{
+  "serviceUrl": "https://example.com/geoserver/rest",
+  "responses": {
+    "/geoserver/rest/about/version.xml": "<about><resource name=\"GeoServer\"><Version>2.28.0</Version><Build-Timestamp>2026-01-15T10:30:00Z</Build-Timestamp><Git-Revision>abc123</Git-Revision></resource></about>",
+    "/geoserver/rest/settings.json": {
+      "global": {
+        "title": "Style Apply GeoServer",
+        "abstract": "Fixture-backed GeoServer catalog for style-apply slice tests",
+        "onlineResource": "https://example.com/geoserver"
+      }
+    },
+    "/geoserver/rest/services/wms/settings.json": {
+      "wms": {
+        "enabled": true,
+        "title": "Style WMS",
+        "maxRenderingTime": 60
+      }
+    },
+    "/geoserver/rest/services/wfs/settings.json": {
+      "wfs": {
+        "enabled": true,
+        "title": "Style WFS",
+        "serviceLevel": "COMPLETE"
+      }
+    },
+    "/geoserver/rest/workspaces.json": {
+      "workspaces": {
+        "workspace": [
+          { "name": "ops" }
+        ]
+      }
+    },
+    "/geoserver/rest/workspaces/ops.json": {
+      "workspace": {
+        "name": "ops",
+        "default": true
+      }
+    },
+    "/geoserver/rest/workspaces/ops/datastores.json": {
+      "dataStores": {
+        "dataStore": [
+          { "name": "pg" }
+        ]
+      }
+    },
+    "/geoserver/rest/workspaces/ops/datastores/pg.json": {
+      "dataStore": {
+        "name": "pg",
+        "type": "PostGIS",
+        "connectionParameters": {
+          "entry": [
+            { "@key": "host", "$": "db.example.com" },
+            { "@key": "database", "$": "gis" },
+            { "@key": "dbtype", "$": "postgis" }
+          ]
+        }
+      }
+    },
+    "/geoserver/rest/workspaces/ops/coveragestores.json": {
+      "coverageStores": {
+        "coverageStore": ""
+      }
+    },
+    "/geoserver/rest/workspaces/ops/layers.json": {
+      "layers": {
+        "layer": [
+          { "name": "roads" }
+        ]
+      }
+    },
+    "/geoserver/rest/workspaces/ops/layers/roads.json": {
+      "layer": {
+        "name": "roads",
+        "title": "Roads",
+        "abstract": "Road centerlines",
+        "srs": "EPSG:4326",
+        "nativeCRS": "EPSG:3857",
+        "latLonBoundingBox": {
+          "minx": -158.2,
+          "miny": 21.1,
+          "maxx": -157.6,
+          "maxy": 21.8,
+          "crs": "EPSG:4326"
+        },
+        "nativeBoundingBox": {
+          "minx": 0,
+          "miny": 0,
+          "maxx": 100,
+          "maxy": 100,
+          "crs": "EPSG:3857"
+        },
+        "resource": {
+          "href": "https://example.com/geoserver/rest/workspaces/ops/datastores/pg/featuretypes/roads.json"
+        },
+        "defaultStyle": {
+          "name": "line",
+          "workspace": "ops"
+        }
+      }
+    },
+    "/geoserver/rest/layergroups.json": {
+      "layerGroups": {
+        "layerGroup": ""
+      }
+    },
+    "/geoserver/rest/workspaces/ops/layergroups.json": {
+      "layerGroups": {
+        "layerGroup": ""
+      }
+    },
+    "/geoserver/rest/styles.json": {
+      "styles": {
+        "style": ""
+      }
+    },
+    "/geoserver/rest/workspaces/ops/styles.json": {
+      "styles": {
+        "style": [
+          { "name": "deprecated" },
+          { "name": "empty-sld" },
+          { "name": "line" }
+        ]
+      }
+    },
+    "/geoserver/rest/workspaces/ops/styles/line.json": {
+      "style": {
+        "name": "line",
+        "format": "sld",
+        "languageVersion": "1.0.0",
+        "filename": "line.sld"
+      }
+    },
+    "/geoserver/rest/workspaces/ops/styles/line.sld": "<StyledLayerDescriptor xmlns=\"http://www.opengis.net/sld\" version=\"1.0.0\"><NamedLayer><Name>roads</Name><UserStyle><FeatureTypeStyle><Rule><LineSymbolizer><Stroke><CssParameter name=\"stroke\">#ff0000</CssParameter><CssParameter name=\"stroke-width\">2</CssParameter></Stroke></LineSymbolizer></Rule></FeatureTypeStyle></UserStyle></NamedLayer></StyledLayerDescriptor>",
+    "/geoserver/rest/workspaces/ops/styles/deprecated.json": {
+      "style": {
+        "name": "deprecated",
+        "format": "css",
+        "filename": "deprecated.css"
+      }
+    },
+    "/geoserver/rest/workspaces/ops/styles/deprecated.sld": "",
+    "/geoserver/rest/workspaces/ops/styles/empty-sld.json": {
+      "style": {
+        "name": "empty-sld",
+        "format": "sld",
+        "languageVersion": "1.0.0",
+        "filename": "empty.sld"
+      }
+    },
+    "/geoserver/rest/workspaces/ops/styles/empty-sld.sld": ""
+  }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceApplyPlanTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceApplyPlanTests.cs
@@ -662,5 +662,13 @@ public sealed class GeoServerImportServiceApplyPlanTests
                 RowCount = 0
             });
         }
+
+        // Slice 3 (#1015): apply-plan tests do not exercise style persistence
+        // directly; record-and-noop so the interface remains satisfied.
+        public Task<MigrationCatalogWriteOutcome> EnsureStyleAsync(
+            string connectionString,
+            MigrationStyleRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(MigrationCatalogWriteOutcome.Created);
     }
 }

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceDataSourceApplyTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceDataSourceApplyTests.cs
@@ -698,5 +698,14 @@ public sealed class GeoServerImportServiceDataSourceApplyTests
                 RowCount = 0
             });
         }
+
+        // Slice 3 (#1015): the data-source apply tests do not exercise styles,
+        // but the interface now requires EnsureStyleAsync. Record-and-noop so
+        // slice 2 fixtures with style entries do not throw.
+        public Task<MigrationCatalogWriteOutcome> EnsureStyleAsync(
+            string connectionString,
+            MigrationStyleRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(MigrationCatalogWriteOutcome.Created);
     }
 }

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceStyleApplyTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceStyleApplyTests.cs
@@ -1,0 +1,429 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Admin.Abstractions;
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Shared.Models;
+using Honua.Core.Features.Styling.Abstractions;
+using Honua.Postgres.Features.Import;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+/// <summary>
+/// Issue #1015 slice 3: GeoServer style migration persistence and diagnostics.
+///
+/// Slice 1 (PR #1095) added idempotent catalog persistence of workspace and
+/// layer-group entries. Slice 2 (PR #1107) added data-source and feature-data
+/// copy. Slice 3 extends that to:
+/// 1. Persist a deterministic row in <c>honua.migration_styles</c> for each
+///    in-scope style on the manifest, capturing the original SLD body, any
+///    converter output, and structured conversion diagnostics.
+/// 2. Reuse the registered <see cref="ISldStyleConverter"/> rather than
+///    reimplementing conversion logic; warnings/errors are written through to
+///    the persisted row so the evidence pack carries explicit manual-review
+///    records when visual parity cannot be guaranteed (issue AC).
+/// 3. Respect the workspace-scope guard from issue #1098 so a manifest cannot
+///    cause cross-workspace style mutations.
+/// 4. Re-apply is idempotent on (source_kind, source_id).
+/// </summary>
+public sealed class GeoServerImportServiceStyleApplyTests
+{
+    [Fact]
+    public async Task ImportConfigurationAsync_WithApplyModeAndCleanSld_PersistsStyleAsApplied()
+    {
+        var fixture = LoadFixture("StyleApplySlice");
+        var catalogWriter = new RecordingMigrationCatalogWriter();
+        var converter = new StubSldConverter(layersJson: "[{\"id\":\"roads-line\",\"type\":\"line\"}]");
+        var request = NonDryRunRequest(fixture);
+
+        var result = await CreateService(
+                new FixtureHttpHandler(fixture.Responses),
+                catalogWriter: catalogWriter,
+                sldConverter: converter)
+            .ImportConfigurationAsync(request);
+
+        result.Success.Should().BeTrue();
+        result.ApplyExecution.Should().NotBeNull();
+
+        var lineStyleStep = result.ApplyExecution!.StepResults.Single(step =>
+            step.Kind == "style" && step.SourceId == "style:ops:line");
+        lineStyleStep.Outcome.Should().Be("applied", "a clean SLD with a registered converter is applied");
+
+        catalogWriter.StyleRequests.Should().Contain(r =>
+            r.SourceId == "style:ops:line" &&
+            r.SourceFormat == "sld" &&
+            r.WorkspaceName == "ops" &&
+            r.ReviewDisposition == "applied" &&
+            r.ConvertedBody != null &&
+            r.ConvertedFormat == "maplibre-layers-json");
+
+        // Diagnostics are persisted as JSON even when empty so operators can
+        // query the column without null-handling.
+        catalogWriter.StyleRequests
+            .Single(r => r.SourceId == "style:ops:line").DiagnosticsJson
+            .Should().StartWith("[").And.EndWith("]");
+    }
+
+    [Fact]
+    public async Task ImportConfigurationAsync_WithApplyModeReApply_IsIdempotentForStyleStep()
+    {
+        var fixture = LoadFixture("StyleApplySlice");
+        var catalogWriter = new RecordingMigrationCatalogWriter();
+        var converter = new StubSldConverter(layersJson: "[{\"id\":\"roads-line\",\"type\":\"line\"}]");
+        var request = NonDryRunRequest(fixture);
+
+        await CreateService(new FixtureHttpHandler(fixture.Responses), catalogWriter: catalogWriter, sldConverter: converter)
+            .ImportConfigurationAsync(request);
+        var secondResult = await CreateService(new FixtureHttpHandler(fixture.Responses), catalogWriter: catalogWriter, sldConverter: converter)
+            .ImportConfigurationAsync(request);
+
+        secondResult.Success.Should().BeTrue();
+        var step = secondResult.ApplyExecution!.StepResults
+            .Single(s => s.Kind == "style" && s.SourceId == "style:ops:line");
+        step.Outcome.Should().Be("already-applied");
+
+        // Idempotency contract: the writer is still invoked, but the underlying
+        // upsert reports "already-applied" rather than creating a duplicate row.
+        catalogWriter.StyleRequests
+            .Count(r => r.SourceId == "style:ops:line")
+            .Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ImportConfigurationAsync_WithApplyModeAndConverterErrors_PersistsManualReviewWithDiagnostics()
+    {
+        var fixture = LoadFixture("StyleApplySlice");
+        var catalogWriter = new RecordingMigrationCatalogWriter();
+        // Converter returns errors so the apply path must NOT claim visual parity.
+        var converter = new StubSldConverter(
+            layersJson: null,
+            warnings: new[] { "[VendorOption] dropped uom" },
+            errors: new[] { "SLD document contained no convertible symbolizers." });
+        var request = NonDryRunRequest(fixture);
+
+        var result = await CreateService(
+                new FixtureHttpHandler(fixture.Responses),
+                catalogWriter: catalogWriter,
+                sldConverter: converter)
+            .ImportConfigurationAsync(request);
+
+        result.Success.Should().BeTrue();
+        var step = result.ApplyExecution!.StepResults
+            .Single(s => s.Kind == "style" && s.SourceId == "style:ops:line");
+        step.Outcome.Should().Be("manual-review", "converter errors block automatic visual parity per issue #1015 AC");
+        step.Message.Should().Contain("manual-review");
+        step.Message.Should().Contain("Do not claim visual parity");
+
+        var persisted = catalogWriter.StyleRequests.Single(r => r.SourceId == "style:ops:line");
+        persisted.ReviewDisposition.Should().Be("manual-review");
+        persisted.ConvertedBody.Should().BeNull("the converter produced no MapLibre layers");
+        persisted.DiagnosticsJson.Should().Contain("\"severity\":\"error\"");
+        persisted.DiagnosticsJson.Should().Contain("convertible symbolizers");
+        persisted.DiagnosticsJson.Should().Contain("\"severity\":\"warning\"");
+    }
+
+    [Fact]
+    public async Task ImportConfigurationAsync_WithApplyModeAndUnsupportedFormat_PersistsManualReviewRecord()
+    {
+        var fixture = LoadFixture("StyleApplySlice");
+        var catalogWriter = new RecordingMigrationCatalogWriter();
+        var converter = new StubSldConverter(layersJson: "[]");
+        var request = NonDryRunRequest(fixture);
+
+        var result = await CreateService(
+                new FixtureHttpHandler(fixture.Responses),
+                catalogWriter: catalogWriter,
+                sldConverter: converter)
+            .ImportConfigurationAsync(request);
+
+        result.Success.Should().BeTrue();
+        var cssStyleStep = result.ApplyExecution!.StepResults
+            .Single(s => s.Kind == "style" && s.SourceId == "style:ops:deprecated");
+        cssStyleStep.Outcome.Should().Be("manual-review");
+
+        var persisted = catalogWriter.StyleRequests.Single(r => r.SourceId == "style:ops:deprecated");
+        persisted.SourceFormat.Should().Be("css");
+        persisted.ReviewDisposition.Should().Be("manual-review");
+        persisted.DiagnosticsJson.Should().Contain("css");
+    }
+
+    [Fact]
+    public async Task ImportConfigurationAsync_WithApplyModeButNoCatalogWriter_KeepsStyleStepAsManualReview()
+    {
+        var fixture = LoadFixture("StyleApplySlice");
+        var converter = new StubSldConverter(layersJson: "[{\"id\":\"x\"}]");
+        var request = NonDryRunRequest(fixture);
+
+        var result = await CreateService(new FixtureHttpHandler(fixture.Responses), sldConverter: converter)
+            .ImportConfigurationAsync(request);
+
+        result.Success.Should().BeTrue();
+        result.ApplyExecution!.StepResults
+            .Where(step => step.Kind == "style")
+            .Should().OnlyContain(step => step.Outcome == "manual-review");
+    }
+
+    [Fact]
+    public async Task ImportConfigurationAsync_WithCrossWorkspaceStyleScope_RejectsOutOfScopeStyles()
+    {
+        var fixture = LoadFixture("StyleApplySlice");
+        var catalogWriter = new RecordingMigrationCatalogWriter();
+        var converter = new StubSldConverter(layersJson: "[{\"id\":\"x\"}]");
+
+        // Scope to a workspace that does not contain the fixture's styles
+        // (#1098 / PR #1100 cross-workspace guard).
+        var request = NonDryRunRequest(fixture) with
+        {
+            WorkspaceNames = new[] { "unrelated-workspace" }
+        };
+
+        var result = await CreateService(
+                new FixtureHttpHandler(fixture.Responses),
+                catalogWriter: catalogWriter,
+                sldConverter: converter)
+            .ImportConfigurationAsync(request);
+
+        result.Success.Should().BeTrue();
+
+        // Filter strips workspaces, so the in-scope style set is empty AND the
+        // catalog writer is never invoked for cross-workspace styles. The
+        // explicit guard inside ApplyStyleCatalogStepAsync defends against the
+        // case where a style somehow survives filtering (e.g. a global style
+        // included in a layer reference); the test asserts the contract by
+        // confirming no out-of-scope styles reached the writer.
+        catalogWriter.StyleRequests
+            .Should().NotContain(r => r.WorkspaceName == "ops");
+    }
+
+    [Fact]
+    public async Task ImportConfigurationAsync_WithDryRun_DoesNotApplyStyles()
+    {
+        var fixture = LoadFixture("StyleApplySlice");
+        var catalogWriter = new RecordingMigrationCatalogWriter();
+        var converter = new StubSldConverter(layersJson: "[{\"id\":\"x\"}]");
+        var request = new GeoServerImportRequest
+        {
+            GeoServerRestUrl = fixture.ServiceUrl,
+            TargetHonuaUrl = "https://honua.example.test",
+            DryRun = true,
+            ApplyMode = false,
+            ImportStyles = true,
+            RequestTimeoutSeconds = 5
+        };
+
+        var result = await CreateService(
+                new FixtureHttpHandler(fixture.Responses),
+                catalogWriter: catalogWriter,
+                sldConverter: converter)
+            .ImportConfigurationAsync(request);
+
+        result.Success.Should().BeTrue();
+        catalogWriter.StyleRequests.Should().BeEmpty(
+            "dry-run does not exercise the apply path and must not write style rows");
+    }
+
+    private static GeoServerImportRequest NonDryRunRequest(FixtureScenario fixture)
+        => new()
+        {
+            GeoServerRestUrl = fixture.ServiceUrl,
+            TargetHonuaUrl = "https://honua.example.test",
+            DryRun = false,
+            ApplyMode = true,
+            AutoPublishLayers = true,
+            ImportStyles = true,
+            RequestTimeoutSeconds = 5
+        };
+
+    private static FixtureScenario LoadFixture(string scenario)
+    {
+        var fixturePath = Path.Combine(
+            AppContext.BaseDirectory,
+            "Features",
+            "Import",
+            "Fixtures",
+            "GeoServer",
+            $"{scenario}.json");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(fixturePath));
+        var root = document.RootElement;
+        var serviceUrl = root.GetProperty("serviceUrl").GetString()
+            ?? throw new InvalidDataException($"Fixture {scenario} is missing serviceUrl.");
+        var responses = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var entry in root.GetProperty("responses").EnumerateObject())
+        {
+            responses[entry.Name] = entry.Value.ValueKind == JsonValueKind.String
+                ? entry.Value.GetString() ?? string.Empty
+                : entry.Value.GetRawText();
+        }
+
+        return new FixtureScenario(serviceUrl, responses);
+    }
+
+    private static GeoServerImportService CreateService(
+        HttpMessageHandler handler,
+        ILayerPublishingService? layerPublishingService = null,
+        IMigrationCatalogWriter? catalogWriter = null,
+        ISldStyleConverter? sldConverter = null)
+    {
+        var httpClient = new HttpClient(handler);
+        var restClient = new GeoServerRestClient(
+            httpClient,
+            NullLogger<GeoServerRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+        var connectionProvider = new Mock<IDatabaseConnectionProvider>(MockBehavior.Strict);
+        var crsRegistry = new Mock<ICrsRegistry>(MockBehavior.Strict);
+
+        if (layerPublishingService != null || catalogWriter != null)
+        {
+            connectionProvider.Setup(provider => provider.GetConnectionString())
+                .Returns("Host=localhost;Database=honua");
+        }
+
+        crsRegistry.Setup(registry => registry.ResolveBySridAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns((int srid, CancellationToken _) => new ValueTask<CrsDefinition?>(
+                srid switch
+                {
+                    3857 => new CrsDefinition("http://www.opengis.net/def/crs/EPSG/0/3857", 3857, AxisOrder.EastNorth, false),
+                    4326 => new CrsDefinition("http://www.opengis.net/def/crs/EPSG/0/4326", 4326, AxisOrder.EastNorth, true),
+                    _ => null
+                }));
+
+        return new GeoServerImportService(
+            restClient,
+            connectionProvider.Object,
+            crsRegistry.Object,
+            NullLogger<GeoServerImportService>.Instance,
+            sldConverter: sldConverter,
+            layerPublishingService: layerPublishingService,
+            catalogWriter: catalogWriter);
+    }
+
+    private sealed record FixtureScenario(string ServiceUrl, IReadOnlyDictionary<string, string> Responses);
+
+    private sealed class FixtureHttpHandler : HttpMessageHandler
+    {
+        private readonly IReadOnlyDictionary<string, string> _responses;
+
+        public FixtureHttpHandler(IReadOnlyDictionary<string, string> responses)
+        {
+            _responses = responses;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var pathAndQuery = request.RequestUri?.PathAndQuery ?? string.Empty;
+            if (!_responses.TryGetValue(pathAndQuery, out var body))
+            {
+                throw new InvalidOperationException(
+                    $"Fixture has no response for {pathAndQuery}. Add it to the fixture JSON or correct the request path.");
+            }
+
+            var contentType = pathAndQuery.EndsWith(".xml", StringComparison.Ordinal)
+                ? "application/xml"
+                : pathAndQuery.EndsWith(".sld", StringComparison.Ordinal)
+                    ? "application/vnd.ogc.sld+xml"
+                    : "application/json";
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, contentType)
+            });
+        }
+    }
+
+    private sealed class StubSldConverter : ISldStyleConverter
+    {
+        private readonly string? _layersJson;
+        private readonly string[] _warnings;
+        private readonly string[] _errors;
+
+        public StubSldConverter(string? layersJson, IEnumerable<string>? warnings = null, IEnumerable<string>? errors = null)
+        {
+            _layersJson = string.IsNullOrEmpty(layersJson) ? null : layersJson;
+            _warnings = warnings?.ToArray() ?? Array.Empty<string>();
+            _errors = errors?.ToArray() ?? Array.Empty<string>();
+        }
+
+        public SldStyleConversionResult Convert(string sldXml)
+            => new(
+                MapLibreLayersJson: _layersJson,
+                DetectedSldVersion: "Sld10",
+                Warnings: _warnings,
+                Errors: _errors);
+    }
+
+    private sealed class RecordingMigrationCatalogWriter : IMigrationCatalogWriter
+    {
+        private readonly HashSet<string> _existing = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _existingDataSources = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _existingStyles = new(StringComparer.OrdinalIgnoreCase);
+
+        public List<MigrationCatalogServiceRequest> Requests { get; } = [];
+
+        public List<MigrationDataSourceRequest> DataSourceRequests { get; } = [];
+
+        public List<MigrationFeatureCopyRequest> FeatureCopyRequests { get; } = [];
+
+        public List<MigrationStyleRequest> StyleRequests { get; } = [];
+
+        public Task<MigrationCatalogWriteOutcome> EnsureCatalogServiceAsync(
+            string connectionString,
+            MigrationCatalogServiceRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            var outcome = _existing.Add(request.ServiceName)
+                ? MigrationCatalogWriteOutcome.Created
+                : MigrationCatalogWriteOutcome.AlreadyExists;
+            return Task.FromResult(outcome);
+        }
+
+        public Task<MigrationCatalogWriteOutcome> EnsureDataSourceAsync(
+            string connectionString,
+            MigrationDataSourceRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            DataSourceRequests.Add(request);
+            var key = $"{request.SourceKind}:{request.SourceId}";
+            var outcome = _existingDataSources.Add(key)
+                ? MigrationCatalogWriteOutcome.Created
+                : MigrationCatalogWriteOutcome.AlreadyExists;
+            return Task.FromResult(outcome);
+        }
+
+        public Task<MigrationFeatureCopyOutcome> CopyFeatureDataAsync(
+            string connectionString,
+            MigrationFeatureCopyRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            FeatureCopyRequests.Add(request);
+            return Task.FromResult(new MigrationFeatureCopyOutcome
+            {
+                Status = MigrationFeatureCopyStatus.SourceMissing,
+                RowCount = 0
+            });
+        }
+
+        public Task<MigrationCatalogWriteOutcome> EnsureStyleAsync(
+            string connectionString,
+            MigrationStyleRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            StyleRequests.Add(request);
+            var key = $"{request.SourceKind}:{request.SourceId}";
+            var outcome = _existingStyles.Add(key)
+                ? MigrationCatalogWriteOutcome.Created
+                : MigrationCatalogWriteOutcome.AlreadyExists;
+            return Task.FromResult(outcome);
+        }
+    }
+}


### PR DESCRIPTION
## Issue Link

Related to #1015 — slice 3 of the GeoServer migration apply work, following the data-source + data-copy application that shipped in #1107 (slice 2). This PR is stacked on `codex/issue-1015-geoserver-apply-next` so reviewers see only the slice 3 diff.

## Summary

Extend the GeoServer migration apply path so style entries from a reviewed manifest are persisted into a dedicated `honua.migration_styles` catalog table along with the original source body, any MapLibre conversion output, and structured conversion diagnostics. SLD conversion reuses the registered `ISldStyleConverter`; converter warnings/errors flow through to the persisted row so the migration evidence pack carries explicit manual-review records whenever visual parity cannot be guaranteed (issue #1015 AC: "Do not claim perfect SLD visual parity when conversion diagnostics report manual review"). Re-apply is idempotent, and cross-workspace style writes are rejected by the workspace-scope guard from issue #1098.

## Changes Made

- `IMigrationCatalogWriter` gains `EnsureStyleAsync` and a `MigrationStyleRequest` payload.
- `PostgresMigrationCatalogWriter` implements idempotent style upsert with JSONB diagnostics.
- `GeoServerImportService` dispatches `style`-kind apply steps to a new `ApplyStyleCatalogStepAsync` that builds structured diagnostics from the existing SLD converter without reimplementing converter logic. Cross-workspace writes are rejected (#1098).
- New SQL migration `030_CreateMigrationStyleCatalog.sql` backs the style catalog.
- New `GeoServerImportServiceStyleApplyTests` covering applied / idempotent re-apply / converter-error manual review with persisted diagnostics / unsupported source format / no-catalog-writer manual review / cross-workspace rejection / dry-run no-op. Slice 2 and slice 1 test doubles updated to satisfy the new interface member.
- Apply-plan warnings updated to describe slice 3 behavior and reiterate that styles with conversion errors are persisted as manual-review without claiming visual parity.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [x] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes

None.

---

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)