### PR TITLE
feat: drive migration parity stage on fixture sources (#1024 slice 4/N)

### DIFF
--- a/src/Honua.Core/Features/Import/Domain/MigrationParityStageReport.cs
+++ b/src/Honua.Core/Features/Import/Domain/MigrationParityStageReport.cs
@@ -1,0 +1,398 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Deterministic envelope produced by the migration acceptance parity stage. Aggregates per-source
+/// parity outcomes (feature-count match, schema-field-name match, bbox-overlap check) into a single
+/// artifact suitable for downstream readiness gates of the acceptance suite.
+/// </summary>
+/// <remarks>
+/// The parity stage is the third pipeline stage emitted by the migration acceptance suite described
+/// in issue #1024 (scan -> manifest -> apply/dry-run -> publish -> parity -> readiness). Parity
+/// probes compare the applied target state (carried on the slice-3
+/// <see cref="MigrationManifestArtifact"/> output of the apply stage) against the original
+/// <see cref="MigrationSourceInventoryArtifact"/>. Slice 4 keeps the probe set deliberately small —
+/// feature count, schema field-name set, and an axis-aligned bbox overlap — so the parity stage can
+/// classify fixture sources deterministically without depending on heavyweight per-feature checks.
+/// Geometry hashing, attribute distribution, and live target probing belong in later slices.
+/// </remarks>
+public sealed record MigrationParityStageReport
+{
+    /// <summary>
+    /// Stable artifact kind identifier.
+    /// </summary>
+    public string ArtifactKind { get; init; } = "honua.migration.parity-stage-report";
+
+    /// <summary>
+    /// Artifact schema version.
+    /// </summary>
+    public string ArtifactVersion { get; init; } = "1.0";
+
+    /// <summary>
+    /// Stable identifier for the acceptance run that produced this report. Callers supply a
+    /// deterministic value (e.g. a fixture set name) so the report can be diffed across runs.
+    /// </summary>
+    public required string RunId { get; init; }
+
+    /// <summary>
+    /// Stable identifier for the upstream apply stage report this parity stage was derived from.
+    /// </summary>
+    public required string ApplyRunId { get; init; }
+
+    /// <summary>
+    /// Aggregate counts across all per-source parity outcomes.
+    /// </summary>
+    public required MigrationParityStageSummary Summary { get; init; }
+
+    /// <summary>
+    /// Per-source parity stage entries, ordered deterministically by
+    /// <see cref="MigrationParityStageEntry.FixtureId"/>.
+    /// </summary>
+    public MigrationParityStageEntry[] Sources { get; init; } = [];
+}
+
+/// <summary>
+/// One per-source entry in a <see cref="MigrationParityStageReport"/>.
+/// </summary>
+public sealed record MigrationParityStageEntry
+{
+    /// <summary>
+    /// Stable fixture identifier (e.g. <c>arcgis-mapserver-mixed-renderers</c>). Used to order
+    /// entries and to cross-reference upstream scan/apply artifacts.
+    /// </summary>
+    public required string FixtureId { get; init; }
+
+    /// <summary>
+    /// Source kind such as <c>arcgis-geoservices-rest</c>, <c>geoserver-rest</c>, or
+    /// <c>ogc-api-features</c>. Mirrors <see cref="MigrationManifestArtifact.SourceKind"/>.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Aggregate parity classification for the fixture: <c>pass</c>, <c>warn</c>,
+    /// <c>fail</c>, or <c>manual-review</c>. Mirrors the per-section thresholds rolled up by
+    /// <see cref="MigrationAcceptanceParityStageRunner"/>.
+    /// </summary>
+    public required string Classification { get; init; }
+
+    /// <summary>
+    /// Per-source parity outcome — counts, schema diffs, extent diffs, and the parity evidence
+    /// artifact produced for downstream readiness consumers.
+    /// </summary>
+    public required MigrationParityStageOutcome Outcome { get; init; }
+}
+
+/// <summary>
+/// Per-source parity outcome rolled up into a <see cref="MigrationParityStageEntry"/>.
+/// </summary>
+public sealed record MigrationParityStageOutcome
+{
+    /// <summary>
+    /// Deterministic parity evidence artifact produced for this fixture by the parity stage.
+    /// </summary>
+    public required MigrationParityEvidenceArtifact Evidence { get; init; }
+
+    /// <summary>
+    /// Stable replay token (SHA-256 fingerprint) over the parity probe payload. Identical across
+    /// re-runs of the same fixture set.
+    /// </summary>
+    public required string ReplayToken { get; init; }
+
+    /// <summary>
+    /// Number of source resources the parity stage compared.
+    /// </summary>
+    public int ResourceCount { get; init; }
+
+    /// <summary>
+    /// Number of resources whose feature counts matched the manifest target state.
+    /// </summary>
+    public int FeatureCountMatchCount { get; init; }
+
+    /// <summary>
+    /// Number of resources whose feature counts diverged between source and target.
+    /// </summary>
+    public int FeatureCountMismatchCount { get; init; }
+
+    /// <summary>
+    /// Number of resources whose schema field-name set matched the manifest target state.
+    /// </summary>
+    public int SchemaMatchCount { get; init; }
+
+    /// <summary>
+    /// Number of resources whose schema field-name set diverged.
+    /// </summary>
+    public int SchemaMismatchCount { get; init; }
+
+    /// <summary>
+    /// Number of resources whose bbox overlap probe passed.
+    /// </summary>
+    public int BboxOverlapMatchCount { get; init; }
+
+    /// <summary>
+    /// Number of resources whose bbox overlap probe failed (disjoint envelopes).
+    /// </summary>
+    public int BboxOverlapMismatchCount { get; init; }
+
+    /// <summary>
+    /// Number of probes that were not applicable (e.g. the source did not advertise a
+    /// feature count or extent metadata for the resource).
+    /// </summary>
+    public int NotApplicableProbeCount { get; init; }
+
+    /// <summary>
+    /// Number of resources routed to manual review (e.g. manifest disposition was
+    /// <c>manual-review</c> or <c>unsupported</c> so no target observation is available).
+    /// </summary>
+    public int ManualReviewResourceCount { get; init; }
+
+    /// <summary>
+    /// Per-resource parity probes recorded by the parity stage. Ordered deterministically by
+    /// <see cref="MigrationParityResourceProbe.SourceResourceId"/>.
+    /// </summary>
+    public MigrationParityResourceProbe[] ResourceProbes { get; init; } = [];
+
+    /// <summary>
+    /// Parity-stage diagnostics. Operator-facing notes that surface non-fatal issues such as
+    /// missing extent metadata or partially captured schemas.
+    /// </summary>
+    public MigrationParityStageDiagnostic[] Diagnostics { get; init; } = [];
+}
+
+/// <summary>
+/// One per-resource parity probe recorded by the parity stage.
+/// </summary>
+public sealed record MigrationParityResourceProbe
+{
+    /// <summary>
+    /// Source inventory resource identifier.
+    /// </summary>
+    public required string SourceResourceId { get; init; }
+
+    /// <summary>
+    /// Target manifest resource identifier, when the apply stage emitted one.
+    /// </summary>
+    public string? TargetResourceId { get; init; }
+
+    /// <summary>
+    /// Manifest action recorded for the resource (e.g. <c>publish</c>, <c>manual-review</c>).
+    /// </summary>
+    public required string ManifestAction { get; init; }
+
+    /// <summary>
+    /// Aggregate per-resource classification: <c>pass</c>, <c>warn</c>, <c>fail</c>, or
+    /// <c>manual-review</c>.
+    /// </summary>
+    public required string Classification { get; init; }
+
+    /// <summary>
+    /// Feature-count probe outcome.
+    /// </summary>
+    public required MigrationParityProbeResult FeatureCount { get; init; }
+
+    /// <summary>
+    /// Schema field-name probe outcome.
+    /// </summary>
+    public required MigrationParityProbeResult Schema { get; init; }
+
+    /// <summary>
+    /// Bbox overlap probe outcome.
+    /// </summary>
+    public required MigrationParityProbeResult BboxOverlap { get; init; }
+}
+
+/// <summary>
+/// One per-probe result captured by the parity stage.
+/// </summary>
+public sealed record MigrationParityProbeResult
+{
+    /// <summary>
+    /// Stable probe identifier such as <c>feature-count</c>, <c>schema-field-names</c>, or
+    /// <c>bbox-overlap</c>.
+    /// </summary>
+    public required string ProbeId { get; init; }
+
+    /// <summary>
+    /// Probe state: <c>pass</c>, <c>warn</c>, <c>fail</c>, <c>manual-review</c>, or
+    /// <c>not-applicable</c>.
+    /// </summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// Human-readable summary suitable for operator review. Must not contain credentials.
+    /// </summary>
+    public required string Summary { get; init; }
+
+    /// <summary>
+    /// Optional observed value from the source side (e.g. source feature count).
+    /// </summary>
+    public string? Expected { get; init; }
+
+    /// <summary>
+    /// Optional observed value from the target side (e.g. target feature count).
+    /// </summary>
+    public string? Observed { get; init; }
+
+    /// <summary>
+    /// Optional deterministic difference description (e.g. field-name set diff or extent diff).
+    /// </summary>
+    public string[] Differences { get; init; } = [];
+}
+
+/// <summary>
+/// Parity-stage diagnostic note surfaced to operators.
+/// </summary>
+public sealed record MigrationParityStageDiagnostic
+{
+    /// <summary>
+    /// Stable machine-readable diagnostic code such as <c>parity.feature-count.mismatch</c>,
+    /// <c>parity.schema.mismatch</c>, or <c>parity.bbox.disjoint</c>.
+    /// </summary>
+    public required string Code { get; init; }
+
+    /// <summary>
+    /// Diagnostic severity such as <c>warn</c>, <c>fail</c>, or <c>manual-review</c>.
+    /// </summary>
+    public required string Severity { get; init; }
+
+    /// <summary>
+    /// Source manifest item identifier the diagnostic refers to.
+    /// </summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>
+    /// Human-readable diagnostic message. Must not contain credentials or other secrets.
+    /// </summary>
+    public required string Message { get; init; }
+}
+
+/// <summary>
+/// Aggregate counts rolled up across all parity-stage entries in a report.
+/// </summary>
+public sealed record MigrationParityStageSummary
+{
+    /// <summary>
+    /// Total number of fixture sources processed by the parity stage.
+    /// </summary>
+    public int SourceCount { get; init; }
+
+    /// <summary>
+    /// Number of fixture sources classified as <c>pass</c>.
+    /// </summary>
+    public int PassSourceCount { get; init; }
+
+    /// <summary>
+    /// Number of fixture sources classified as <c>warn</c>.
+    /// </summary>
+    public int WarnSourceCount { get; init; }
+
+    /// <summary>
+    /// Number of fixture sources classified as <c>fail</c>.
+    /// </summary>
+    public int FailSourceCount { get; init; }
+
+    /// <summary>
+    /// Number of fixture sources classified as <c>manual-review</c>.
+    /// </summary>
+    public int ManualReviewSourceCount { get; init; }
+
+    /// <summary>
+    /// Total number of source resources compared across all fixture sources.
+    /// </summary>
+    public int ResourceCount { get; init; }
+
+    /// <summary>
+    /// Total number of feature-count probe matches across all sources.
+    /// </summary>
+    public int FeatureCountMatchCount { get; init; }
+
+    /// <summary>
+    /// Total number of feature-count probe mismatches across all sources.
+    /// </summary>
+    public int FeatureCountMismatchCount { get; init; }
+
+    /// <summary>
+    /// Total number of schema probe matches across all sources.
+    /// </summary>
+    public int SchemaMatchCount { get; init; }
+
+    /// <summary>
+    /// Total number of schema probe mismatches across all sources.
+    /// </summary>
+    public int SchemaMismatchCount { get; init; }
+
+    /// <summary>
+    /// Total number of bbox overlap probe matches across all sources.
+    /// </summary>
+    public int BboxOverlapMatchCount { get; init; }
+
+    /// <summary>
+    /// Total number of bbox overlap probe mismatches across all sources.
+    /// </summary>
+    public int BboxOverlapMismatchCount { get; init; }
+
+    /// <summary>
+    /// Total number of parity-stage diagnostics emitted across all sources.
+    /// </summary>
+    public int DiagnosticCount { get; init; }
+}
+
+/// <summary>
+/// Optional per-resource observation from the actual target after apply. When supplied, the parity
+/// runner uses these observations as the target side of each probe; otherwise it derives the target
+/// observation deterministically from the manifest (which mirrors the source inventory by
+/// construction for fixture-driven dry-run apply).
+/// </summary>
+public sealed record MigrationParityTargetObservation
+{
+    /// <summary>
+    /// Source resource identifier the observation refers to.
+    /// </summary>
+    public required string SourceResourceId { get; init; }
+
+    /// <summary>
+    /// Observed feature count on the target after apply. <c>null</c> when not measured.
+    /// </summary>
+    public long? FeatureCount { get; init; }
+
+    /// <summary>
+    /// Observed schema field-name set on the target after apply. <c>null</c> when not measured.
+    /// </summary>
+    public string[]? FieldNames { get; init; }
+
+    /// <summary>
+    /// Observed axis-aligned bbox on the target after apply, in source CRS, as
+    /// <c>[minX, minY, maxX, maxY]</c>. <c>null</c> when not measured.
+    /// </summary>
+    public double[]? Bbox { get; init; }
+}
+
+/// <summary>
+/// Optional per-resource observation from the source side. When supplied, overrides the source
+/// inventory's reported counts/fields/bbox for the parity probe (used by callers that have probed
+/// the live source after the inventory was captured).
+/// </summary>
+public sealed record MigrationParitySourceObservation
+{
+    /// <summary>
+    /// Source resource identifier the observation refers to.
+    /// </summary>
+    public required string SourceResourceId { get; init; }
+
+    /// <summary>
+    /// Observed feature count on the source. <c>null</c> falls back to the inventory value.
+    /// </summary>
+    public long? FeatureCount { get; init; }
+
+    /// <summary>
+    /// Observed schema field-name set on the source. <c>null</c> falls back to the inventory value.
+    /// </summary>
+    public string[]? FieldNames { get; init; }
+
+    /// <summary>
+    /// Observed axis-aligned bbox on the source, in source CRS, as
+    /// <c>[minX, minY, maxX, maxY]</c>. <c>null</c> falls back to inventory metadata when present.
+    /// </summary>
+    public double[]? Bbox { get; init; }
+}

--- a/src/Honua.Core/Features/Import/Services/MigrationAcceptanceParityStageRunner.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationAcceptanceParityStageRunner.cs
@@ -1,0 +1,718 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Cryptography;
+using System.Text.Json;
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Drives the parity stage of the migration acceptance suite by running a small, deterministic
+/// probe set (feature count, schema field-names, axis-aligned bbox overlap) over each
+/// per-source <see cref="MigrationManifestArtifact"/> emitted by the slice-3 apply stage and the
+/// original <see cref="MigrationSourceInventoryArtifact"/> from the slice-2 scan stage.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The parity stage is intentionally light in slice 4: it does not hash geometries, sample
+/// attribute distributions, or talk to a live target. The slice composes the existing parity
+/// evidence generator (<see cref="MigrationParityEvidenceGenerator"/>) for the per-source
+/// <see cref="MigrationParityEvidenceArtifact"/> and adds the deterministic probe roll-up. Heavier
+/// probes belong in later slices once a target observation contract is wired up.
+/// </para>
+/// <para>
+/// When the upstream apply stage ran in dry-run mode the per-resource target observation is
+/// derived from the manifest itself: the manifest copies the source field set and (by
+/// construction) advertises the same feature count and bbox the source declared. Callers driving
+/// the parity stage against a real apply outcome can supply explicit per-resource
+/// <see cref="MigrationParityTargetObservation"/> values to override this fallback.
+/// </para>
+/// </remarks>
+public static class MigrationAcceptanceParityStageRunner
+{
+    /// <summary>Aggregate classification when every probe in scope passed.</summary>
+    public const string PassClassification = "pass";
+
+    /// <summary>Aggregate classification when at least one probe warned but none failed.</summary>
+    public const string WarnClassification = "warn";
+
+    /// <summary>Aggregate classification when at least one probe failed.</summary>
+    public const string FailClassification = "fail";
+
+    /// <summary>
+    /// Aggregate classification when no automated probes were applicable because all resources
+    /// were routed to manual review or were unsupported by the apply stage.
+    /// </summary>
+    public const string ManualReviewClassification = "manual-review";
+
+    private const string FeatureCountProbeId = "feature-count";
+    private const string SchemaProbeId = "schema-field-names";
+    private const string BboxProbeId = "bbox-overlap";
+
+    private const string PassState = "pass";
+    private const string WarnState = "warn";
+    private const string FailState = "fail";
+    private const string NotApplicableState = "not-applicable";
+    private const string ManualReviewState = "manual-review";
+
+    private const string PublishAction = "publish";
+    private const string ManualReviewAction = "manual-review";
+    private const string UnsupportedAction = "unsupported";
+
+    /// <summary>
+    /// Build a deterministic parity stage report from the supplied per-source apply outputs and
+    /// inventories.
+    /// </summary>
+    /// <param name="runId">Stable identifier for this acceptance parity run (e.g. fixture set name).</param>
+    /// <param name="applyRunId">Identifier of the upstream apply stage report.</param>
+    /// <param name="inputs">Per-fixture parity inputs.</param>
+    /// <returns>Aggregate report pinning the parity stage outputs.</returns>
+    public static MigrationParityStageReport BuildReport(
+        string runId,
+        string applyRunId,
+        IEnumerable<MigrationAcceptanceParityStageInput> inputs)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(applyRunId);
+        ArgumentNullException.ThrowIfNull(inputs);
+
+        var entries = inputs
+            .Select(input =>
+            {
+                ArgumentNullException.ThrowIfNull(input);
+                if (string.IsNullOrWhiteSpace(input.FixtureId))
+                {
+                    throw new ArgumentException(
+                        "Parity stage inputs must supply a non-empty fixture identifier.",
+                        nameof(inputs));
+                }
+
+                if (input.Inventory is null)
+                {
+                    throw new ArgumentException(
+                        $"Parity stage input for fixture '{input.FixtureId}' is missing its inventory artifact.",
+                        nameof(inputs));
+                }
+
+                if (input.Manifest is null)
+                {
+                    throw new ArgumentException(
+                        $"Parity stage input for fixture '{input.FixtureId}' is missing its manifest artifact.",
+                        nameof(inputs));
+                }
+
+                var outcome = BuildOutcome(
+                    input.Inventory,
+                    input.Manifest,
+                    input.SourceObservations,
+                    input.TargetObservations,
+                    input.Attestation);
+
+                var classification = ClassifyOutcome(outcome);
+
+                return new MigrationParityStageEntry
+                {
+                    FixtureId = input.FixtureId,
+                    SourceKind = input.Manifest.SourceKind,
+                    Classification = classification,
+                    Outcome = outcome
+                };
+            })
+            .OrderBy(static entry => entry.FixtureId, StringComparer.Ordinal)
+            .ToArray();
+
+        return new MigrationParityStageReport
+        {
+            RunId = runId,
+            ApplyRunId = applyRunId,
+            Summary = BuildSummary(entries),
+            Sources = entries
+        };
+    }
+
+    /// <summary>
+    /// Build a deterministic per-source parity outcome. Exposed for callers (and tests) that
+    /// drive the parity stage one fixture at a time.
+    /// </summary>
+    /// <param name="inventory">Source inventory artifact for the fixture.</param>
+    /// <param name="manifest">Manifest artifact emitted by the apply stage for the fixture.</param>
+    /// <param name="sourceObservations">Optional per-resource source observations.</param>
+    /// <param name="targetObservations">Optional per-resource target observations.</param>
+    /// <param name="attestation">Optional operator-supplied readiness attestation forwarded to the parity evidence pack.</param>
+    /// <returns>Deterministic per-source parity outcome.</returns>
+    public static MigrationParityStageOutcome BuildOutcome(
+        MigrationSourceInventoryArtifact inventory,
+        MigrationManifestArtifact manifest,
+        IEnumerable<MigrationParitySourceObservation>? sourceObservations = null,
+        IEnumerable<MigrationParityTargetObservation>? targetObservations = null,
+        MigrationReadinessAttestation? attestation = null)
+    {
+        ArgumentNullException.ThrowIfNull(inventory);
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        var sourceObs = (sourceObservations ?? Array.Empty<MigrationParitySourceObservation>())
+            .Where(static item => item is not null)
+            .GroupBy(static item => item.SourceResourceId, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+
+        var targetObs = (targetObservations ?? Array.Empty<MigrationParityTargetObservation>())
+            .Where(static item => item is not null)
+            .GroupBy(static item => item.SourceResourceId, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+
+        var manifestBySourceId = manifest.TargetResources
+            .GroupBy(static item => item.SourceResourceId, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+
+        var probes = new List<MigrationParityResourceProbe>(inventory.Resources.Length);
+        var diagnostics = new List<MigrationParityStageDiagnostic>();
+
+        foreach (var resource in inventory.Resources)
+        {
+            manifestBySourceId.TryGetValue(resource.Id, out var target);
+            sourceObs.TryGetValue(resource.Id, out var sourceObservation);
+            targetObs.TryGetValue(resource.Id, out var targetObservation);
+
+            var probe = BuildResourceProbe(resource, target, sourceObservation, targetObservation);
+            probes.Add(probe);
+            CollectDiagnostics(probe, diagnostics);
+        }
+
+        var orderedProbes = probes
+            .OrderBy(static item => item.SourceResourceId, StringComparer.Ordinal)
+            .ToArray();
+
+        var orderedDiagnostics = diagnostics
+            .OrderBy(static item => item.SourceId, StringComparer.Ordinal)
+            .ThenBy(static item => item.Severity, StringComparer.Ordinal)
+            .ThenBy(static item => item.Code, StringComparer.Ordinal)
+            .ToArray();
+
+        var evidence = MigrationParityEvidenceGenerator.Generate(inventory, manifest, attestation);
+        var replayToken = ComputeReplayToken(manifest.SourceKind, orderedProbes);
+
+        return new MigrationParityStageOutcome
+        {
+            Evidence = evidence,
+            ReplayToken = replayToken,
+            ResourceCount = orderedProbes.Length,
+            FeatureCountMatchCount = orderedProbes.Count(static probe => probe.FeatureCount.State == PassState),
+            FeatureCountMismatchCount = orderedProbes.Count(static probe => probe.FeatureCount.State is FailState or WarnState),
+            SchemaMatchCount = orderedProbes.Count(static probe => probe.Schema.State == PassState),
+            SchemaMismatchCount = orderedProbes.Count(static probe => probe.Schema.State is FailState or WarnState),
+            BboxOverlapMatchCount = orderedProbes.Count(static probe => probe.BboxOverlap.State == PassState),
+            BboxOverlapMismatchCount = orderedProbes.Count(static probe => probe.BboxOverlap.State is FailState or WarnState),
+            NotApplicableProbeCount = orderedProbes.Sum(static probe => CountNotApplicable(probe)),
+            ManualReviewResourceCount = orderedProbes.Count(static probe => probe.Classification == ManualReviewClassification),
+            ResourceProbes = orderedProbes,
+            Diagnostics = orderedDiagnostics
+        };
+    }
+
+    private static MigrationParityResourceProbe BuildResourceProbe(
+        MigrationInventoryResource resource,
+        MigrationManifestTargetResource? target,
+        MigrationParitySourceObservation? sourceObservation,
+        MigrationParityTargetObservation? targetObservation)
+    {
+        var manifestAction = NormalizeAction(target?.Action);
+        var isManualReview = manifestAction is ManualReviewAction or UnsupportedAction || target is null;
+
+        var featureCountProbe = BuildFeatureCountProbe(resource, target, sourceObservation, targetObservation, isManualReview);
+        var schemaProbe = BuildSchemaProbe(resource, target, sourceObservation, targetObservation, isManualReview);
+        var bboxProbe = BuildBboxProbe(resource, sourceObservation, targetObservation, isManualReview);
+
+        var classification = ClassifyResourceProbe(isManualReview, featureCountProbe, schemaProbe, bboxProbe);
+
+        return new MigrationParityResourceProbe
+        {
+            SourceResourceId = resource.Id,
+            TargetResourceId = target?.TargetResourceId,
+            ManifestAction = manifestAction,
+            Classification = classification,
+            FeatureCount = featureCountProbe,
+            Schema = schemaProbe,
+            BboxOverlap = bboxProbe
+        };
+    }
+
+    private static MigrationParityProbeResult BuildFeatureCountProbe(
+        MigrationInventoryResource resource,
+        MigrationManifestTargetResource? target,
+        MigrationParitySourceObservation? sourceObservation,
+        MigrationParityTargetObservation? targetObservation,
+        bool isManualReview)
+    {
+        var expectedCount = sourceObservation?.FeatureCount
+            ?? (resource.FeatureCount.HasValue ? (long?)resource.FeatureCount.Value : null);
+
+        if (!expectedCount.HasValue)
+        {
+            return new MigrationParityProbeResult
+            {
+                ProbeId = FeatureCountProbeId,
+                State = NotApplicableState,
+                Summary = "Source inventory did not advertise a feature count for this resource."
+            };
+        }
+
+        if (isManualReview)
+        {
+            return new MigrationParityProbeResult
+            {
+                ProbeId = FeatureCountProbeId,
+                State = ManualReviewState,
+                Summary = "Resource routed to manual review; feature count parity must be verified by an operator.",
+                Expected = expectedCount.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            };
+        }
+
+        // When no live target observation is supplied the manifest mirrors the source by
+        // construction, so the parity probe asserts the count is preserved.
+        var observedCount = targetObservation?.FeatureCount ?? expectedCount.Value;
+
+        if (observedCount == expectedCount.Value)
+        {
+            return new MigrationParityProbeResult
+            {
+                ProbeId = FeatureCountProbeId,
+                State = PassState,
+                Summary = "Source feature count matched the target feature count.",
+                Expected = expectedCount.Value.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                Observed = observedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            };
+        }
+
+        var delta = observedCount - expectedCount.Value;
+        var severity = Math.Abs(delta) <= Math.Max(1, expectedCount.Value / 100) ? WarnState : FailState;
+        return new MigrationParityProbeResult
+        {
+            ProbeId = FeatureCountProbeId,
+            State = severity,
+            Summary = severity == WarnState
+                ? "Source and target feature counts differ within the 1% warning threshold."
+                : "Source and target feature counts diverged beyond the 1% warning threshold.",
+            Expected = expectedCount.Value.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            Observed = observedCount.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            Differences =
+            [
+                $"delta={delta.ToString(System.Globalization.CultureInfo.InvariantCulture)}"
+            ]
+        };
+    }
+
+    private static MigrationParityProbeResult BuildSchemaProbe(
+        MigrationInventoryResource resource,
+        MigrationManifestTargetResource? target,
+        MigrationParitySourceObservation? sourceObservation,
+        MigrationParityTargetObservation? targetObservation,
+        bool isManualReview)
+    {
+        var expectedFields = NormalizeFieldNames(
+            sourceObservation?.FieldNames
+            ?? resource.Fields.Select(static field => field.Name));
+
+        if (expectedFields.Length == 0 && target is null)
+        {
+            return new MigrationParityProbeResult
+            {
+                ProbeId = SchemaProbeId,
+                State = NotApplicableState,
+                Summary = "Source inventory did not advertise a field schema for this resource."
+            };
+        }
+
+        if (isManualReview)
+        {
+            return new MigrationParityProbeResult
+            {
+                ProbeId = SchemaProbeId,
+                State = ManualReviewState,
+                Summary = "Resource routed to manual review; schema parity must be verified by an operator.",
+                Expected = JoinPreview(expectedFields)
+            };
+        }
+
+        var observedFields = NormalizeFieldNames(
+            targetObservation?.FieldNames
+            ?? target!.Fields.Select(static field => field.Name));
+
+        if (expectedFields.SequenceEqual(observedFields, StringComparer.Ordinal))
+        {
+            return new MigrationParityProbeResult
+            {
+                ProbeId = SchemaProbeId,
+                State = PassState,
+                Summary = "Source and target schema field names matched.",
+                Expected = JoinPreview(expectedFields),
+                Observed = JoinPreview(observedFields)
+            };
+        }
+
+        var missingOnTarget = expectedFields.Except(observedFields, StringComparer.Ordinal).ToArray();
+        var extraOnTarget = observedFields.Except(expectedFields, StringComparer.Ordinal).ToArray();
+        var differences = new List<string>(missingOnTarget.Length + extraOnTarget.Length);
+        foreach (var name in missingOnTarget)
+        {
+            differences.Add($"missing-on-target={name}");
+        }
+        foreach (var name in extraOnTarget)
+        {
+            differences.Add($"extra-on-target={name}");
+        }
+
+        return new MigrationParityProbeResult
+        {
+            ProbeId = SchemaProbeId,
+            State = FailState,
+            Summary = "Source and target schema field-name sets diverged.",
+            Expected = JoinPreview(expectedFields),
+            Observed = JoinPreview(observedFields),
+            Differences = differences.ToArray()
+        };
+    }
+
+    private static MigrationParityProbeResult BuildBboxProbe(
+        MigrationInventoryResource resource,
+        MigrationParitySourceObservation? sourceObservation,
+        MigrationParityTargetObservation? targetObservation,
+        bool isManualReview)
+    {
+        var expectedBbox = NormalizeBbox(sourceObservation?.Bbox);
+        var observedBbox = NormalizeBbox(targetObservation?.Bbox);
+
+        if (expectedBbox is null && observedBbox is null)
+        {
+            return new MigrationParityProbeResult
+            {
+                ProbeId = BboxProbeId,
+                State = NotApplicableState,
+                Summary = "Neither source inventory nor target observation supplied a bbox for this resource."
+            };
+        }
+
+        if (isManualReview)
+        {
+            return new MigrationParityProbeResult
+            {
+                ProbeId = BboxProbeId,
+                State = ManualReviewState,
+                Summary = "Resource routed to manual review; spatial extent parity must be verified by an operator.",
+                Expected = expectedBbox is null ? null : FormatBbox(expectedBbox)
+            };
+        }
+
+        if (expectedBbox is null)
+        {
+            return new MigrationParityProbeResult
+            {
+                ProbeId = BboxProbeId,
+                State = WarnState,
+                Summary = "Target advertised a bbox but the source did not; cannot verify overlap.",
+                Observed = FormatBbox(observedBbox!)
+            };
+        }
+
+        if (observedBbox is null)
+        {
+            // Mirror the source bbox onto the target by construction when no live observation
+            // was supplied so the deterministic dry-run path still classifies as pass.
+            observedBbox = expectedBbox;
+        }
+
+        if (BboxesOverlap(expectedBbox, observedBbox))
+        {
+            return new MigrationParityProbeResult
+            {
+                ProbeId = BboxProbeId,
+                State = PassState,
+                Summary = "Source and target axis-aligned bboxes overlap.",
+                Expected = FormatBbox(expectedBbox),
+                Observed = FormatBbox(observedBbox)
+            };
+        }
+
+        return new MigrationParityProbeResult
+        {
+            ProbeId = BboxProbeId,
+            State = FailState,
+            Summary = "Source and target axis-aligned bboxes are disjoint.",
+            Expected = FormatBbox(expectedBbox),
+            Observed = FormatBbox(observedBbox),
+            Differences =
+            [
+                $"source-min=[{expectedBbox[0].ToString(System.Globalization.CultureInfo.InvariantCulture)},{expectedBbox[1].ToString(System.Globalization.CultureInfo.InvariantCulture)}]",
+                $"target-min=[{observedBbox[0].ToString(System.Globalization.CultureInfo.InvariantCulture)},{observedBbox[1].ToString(System.Globalization.CultureInfo.InvariantCulture)}]"
+            ]
+        };
+    }
+
+    private static string ClassifyResourceProbe(
+        bool isManualReview,
+        MigrationParityProbeResult featureCount,
+        MigrationParityProbeResult schema,
+        MigrationParityProbeResult bbox)
+    {
+        if (isManualReview)
+        {
+            return ManualReviewClassification;
+        }
+
+        var states = new[] { featureCount.State, schema.State, bbox.State };
+        if (states.Any(static state => state == FailState))
+        {
+            return FailClassification;
+        }
+        if (states.Any(static state => state == WarnState))
+        {
+            return WarnClassification;
+        }
+        return PassClassification;
+    }
+
+    private static string ClassifyOutcome(MigrationParityStageOutcome outcome)
+    {
+        if (outcome.ResourceProbes.Length == 0)
+        {
+            return ManualReviewClassification;
+        }
+
+        var hasFail = outcome.ResourceProbes.Any(static probe => probe.Classification == FailClassification);
+        if (hasFail)
+        {
+            return FailClassification;
+        }
+
+        var hasWarn = outcome.ResourceProbes.Any(static probe => probe.Classification == WarnClassification);
+        if (hasWarn)
+        {
+            return WarnClassification;
+        }
+
+        var hasPass = outcome.ResourceProbes.Any(static probe => probe.Classification == PassClassification);
+        return hasPass ? PassClassification : ManualReviewClassification;
+    }
+
+    private static void CollectDiagnostics(MigrationParityResourceProbe probe, List<MigrationParityStageDiagnostic> diagnostics)
+    {
+        foreach (var result in new[] { probe.FeatureCount, probe.Schema, probe.BboxOverlap })
+        {
+            if (result.State is PassState or NotApplicableState)
+            {
+                continue;
+            }
+
+            diagnostics.Add(new MigrationParityStageDiagnostic
+            {
+                Code = $"parity.{result.ProbeId}.{result.State}",
+                Severity = result.State == ManualReviewState ? ManualReviewState : result.State,
+                SourceId = probe.SourceResourceId,
+                Message = result.Summary
+            });
+        }
+    }
+
+    private static MigrationParityStageSummary BuildSummary(MigrationParityStageEntry[] entries)
+    {
+        var pass = 0;
+        var warn = 0;
+        var fail = 0;
+        var manualReview = 0;
+        var resources = 0;
+        var fcMatch = 0;
+        var fcMismatch = 0;
+        var schemaMatch = 0;
+        var schemaMismatch = 0;
+        var bboxMatch = 0;
+        var bboxMismatch = 0;
+        var diagnostics = 0;
+
+        foreach (var entry in entries)
+        {
+            switch (entry.Classification)
+            {
+                case PassClassification: pass++; break;
+                case WarnClassification: warn++; break;
+                case FailClassification: fail++; break;
+                default: manualReview++; break;
+            }
+
+            resources += entry.Outcome.ResourceCount;
+            fcMatch += entry.Outcome.FeatureCountMatchCount;
+            fcMismatch += entry.Outcome.FeatureCountMismatchCount;
+            schemaMatch += entry.Outcome.SchemaMatchCount;
+            schemaMismatch += entry.Outcome.SchemaMismatchCount;
+            bboxMatch += entry.Outcome.BboxOverlapMatchCount;
+            bboxMismatch += entry.Outcome.BboxOverlapMismatchCount;
+            diagnostics += entry.Outcome.Diagnostics.Length;
+        }
+
+        return new MigrationParityStageSummary
+        {
+            SourceCount = entries.Length,
+            PassSourceCount = pass,
+            WarnSourceCount = warn,
+            FailSourceCount = fail,
+            ManualReviewSourceCount = manualReview,
+            ResourceCount = resources,
+            FeatureCountMatchCount = fcMatch,
+            FeatureCountMismatchCount = fcMismatch,
+            SchemaMatchCount = schemaMatch,
+            SchemaMismatchCount = schemaMismatch,
+            BboxOverlapMatchCount = bboxMatch,
+            BboxOverlapMismatchCount = bboxMismatch,
+            DiagnosticCount = diagnostics
+        };
+    }
+
+    private static int CountNotApplicable(MigrationParityResourceProbe probe)
+    {
+        var count = 0;
+        if (probe.FeatureCount.State == NotApplicableState) count++;
+        if (probe.Schema.State == NotApplicableState) count++;
+        if (probe.BboxOverlap.State == NotApplicableState) count++;
+        return count;
+    }
+
+    private static string NormalizeAction(string? action)
+    {
+        if (string.IsNullOrWhiteSpace(action))
+        {
+            return ManualReviewAction;
+        }
+        var trimmed = action.Trim();
+        return trimmed switch
+        {
+            PublishAction => PublishAction,
+            ManualReviewAction => ManualReviewAction,
+            UnsupportedAction => UnsupportedAction,
+            _ => trimmed
+        };
+    }
+
+    private static string[] NormalizeFieldNames(IEnumerable<string>? names)
+        => (names ?? Array.Empty<string>())
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Select(static name => name.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+
+    private static double[]? NormalizeBbox(double[]? bbox)
+    {
+        if (bbox is null || bbox.Length != 4)
+        {
+            return null;
+        }
+        var minX = Math.Min(bbox[0], bbox[2]);
+        var minY = Math.Min(bbox[1], bbox[3]);
+        var maxX = Math.Max(bbox[0], bbox[2]);
+        var maxY = Math.Max(bbox[1], bbox[3]);
+        return [minX, minY, maxX, maxY];
+    }
+
+    private static bool BboxesOverlap(double[] a, double[] b)
+        => a[0] <= b[2] && a[2] >= b[0] && a[1] <= b[3] && a[3] >= b[1];
+
+    private static string FormatBbox(double[] bbox)
+        => string.Create(System.Globalization.CultureInfo.InvariantCulture,
+            $"[{bbox[0]},{bbox[1]},{bbox[2]},{bbox[3]}]");
+
+    private static string JoinPreview(string[] values)
+        => values.Length == 0 ? string.Empty : string.Join(",", values);
+
+    private static string ComputeReplayToken(string sourceKind, MigrationParityResourceProbe[] probes)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("sourceKind", sourceKind);
+            writer.WriteStartArray("probes");
+            foreach (var probe in probes)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("sourceResourceId", probe.SourceResourceId);
+                if (probe.TargetResourceId is not null)
+                {
+                    writer.WriteString("targetResourceId", probe.TargetResourceId);
+                }
+                writer.WriteString("manifestAction", probe.ManifestAction);
+                writer.WriteString("classification", probe.Classification);
+                WriteProbe(writer, "featureCount", probe.FeatureCount);
+                WriteProbe(writer, "schema", probe.Schema);
+                WriteProbe(writer, "bboxOverlap", probe.BboxOverlap);
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        var hash = SHA256.HashData(stream.ToArray());
+        return $"sha256:{Convert.ToHexString(hash).ToLowerInvariant()}";
+    }
+
+    private static void WriteProbe(Utf8JsonWriter writer, string propertyName, MigrationParityProbeResult result)
+    {
+        writer.WriteStartObject(propertyName);
+        writer.WriteString("probeId", result.ProbeId);
+        writer.WriteString("state", result.State);
+        writer.WriteString("summary", result.Summary);
+        if (result.Expected is not null)
+        {
+            writer.WriteString("expected", result.Expected);
+        }
+        if (result.Observed is not null)
+        {
+            writer.WriteString("observed", result.Observed);
+        }
+        if (result.Differences.Length > 0)
+        {
+            writer.WriteStartArray("differences");
+            foreach (var difference in result.Differences)
+            {
+                writer.WriteStringValue(difference);
+            }
+            writer.WriteEndArray();
+        }
+        writer.WriteEndObject();
+    }
+}
+
+/// <summary>
+/// One per-fixture input to <see cref="MigrationAcceptanceParityStageRunner.BuildReport"/>.
+/// </summary>
+public sealed record MigrationAcceptanceParityStageInput
+{
+    /// <summary>
+    /// Stable fixture identifier (e.g. <c>arcgis-mapserver-mixed-renderers</c>).
+    /// </summary>
+    public required string FixtureId { get; init; }
+
+    /// <summary>
+    /// Inventory artifact produced by the upstream scan stage for this fixture.
+    /// </summary>
+    public required MigrationSourceInventoryArtifact Inventory { get; init; }
+
+    /// <summary>
+    /// Manifest artifact emitted by the upstream apply stage for this fixture (the deterministic
+    /// "applied target state" the parity stage probes against).
+    /// </summary>
+    public required MigrationManifestArtifact Manifest { get; init; }
+
+    /// <summary>
+    /// Optional per-resource source observations that override values pulled from the inventory.
+    /// </summary>
+    public IEnumerable<MigrationParitySourceObservation>? SourceObservations { get; init; }
+
+    /// <summary>
+    /// Optional per-resource target observations recorded after a real apply.
+    /// </summary>
+    public IEnumerable<MigrationParityTargetObservation>? TargetObservations { get; init; }
+
+    /// <summary>
+    /// Optional operator-supplied readiness attestation forwarded to the parity evidence pack.
+    /// </summary>
+    public MigrationReadinessAttestation? Attestation { get; init; }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/MigrationAcceptanceParityStageTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/MigrationAcceptanceParityStageTests.cs
@@ -1,0 +1,600 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Shared.Models;
+using Honua.Postgres.Features.Import;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+/// <summary>
+/// Drives the migration acceptance suite parity stage end-to-end across the same fixture set used
+/// by <see cref="MigrationAcceptanceScanStageTests"/> and <see cref="MigrationAcceptanceApplyStageTests"/>:
+/// one ArcGIS GeoServices REST fixture, one GeoServer REST fixture, and one OGC API Features
+/// snapshot fixture. The parity stage runs scan -> manifest -> apply -> parity probes (feature
+/// count, schema field-names, axis-aligned bbox overlap) and asserts that the slice-4
+/// <see cref="MigrationParityStageReport"/> emits the <see cref="MigrationParityEvidenceArtifact"/>
+/// per fixture deterministically while routing manual-review resources through the manual-review
+/// classification path.
+/// </summary>
+public sealed class MigrationAcceptanceParityStageTests
+{
+    private static readonly JsonSerializerOptions ArtifactJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
+    [Fact]
+    public async Task ParityStage_AcrossArcGisGeoServerAndOgcApiFeatures_ProducesDeterministicReport()
+    {
+        var first = await BuildReportAsync();
+        var second = await BuildReportAsync();
+
+        first.RunId.Should().Be("acceptance-parity-stage:slice-4");
+        first.ApplyRunId.Should().Be("acceptance-apply-stage:slice-3");
+        first.ArtifactKind.Should().Be("honua.migration.parity-stage-report");
+        first.ArtifactVersion.Should().Be("1.0");
+
+        var firstJson = JsonSerializer.Serialize(first, ArtifactJsonOptions);
+        var secondJson = JsonSerializer.Serialize(second, ArtifactJsonOptions);
+        secondJson.Should().Be(firstJson, "the parity stage must be deterministic across re-runs of the same fixture set.");
+
+        foreach (var entry in first.Sources)
+        {
+            entry.Outcome.ReplayToken.Should().StartWith("sha256:");
+        }
+    }
+
+    [Fact]
+    public async Task ParityStage_EmitsOneEvidenceArtifactPerFixtureSource()
+    {
+        var report = await BuildReportAsync();
+
+        report.Sources.Should().HaveCount(3);
+        report.Summary.SourceCount.Should().Be(3);
+
+        report.Sources.Select(entry => entry.FixtureId)
+            .Should().BeInAscendingOrder(StringComparer.Ordinal)
+            .And.Equal(
+                "arcgis-mapserver-mixed-renderers",
+                "geoserver-mixed-catalog",
+                "ogc-api-features-demo");
+
+        report.Sources.Select(entry => entry.SourceKind)
+            .Should().Equal(
+                "arcgis-geoservices-rest",
+                "geoserver-rest",
+                "ogc-api-features");
+
+        foreach (var entry in report.Sources)
+        {
+            entry.Outcome.Evidence.Should().NotBeNull();
+            entry.Outcome.Evidence.ArtifactKind.Should().Be("honua.migration.parity-evidence-pack");
+            entry.Outcome.Evidence.ArtifactVersion.Should().Be("1.0");
+            entry.Outcome.Evidence.SourceKind.Should().Be(entry.SourceKind);
+            entry.Outcome.Evidence.ManifestAvailable.Should().BeTrue();
+        }
+    }
+
+    [Fact]
+    public async Task ParityStage_ChainsScanApplyParity_ForSingleFixture()
+    {
+        // A single test that drives scan -> apply -> parity for one fixture and asserts all three
+        // artifacts emit deterministically — exercising the per-fixture path through the
+        // acceptance suite.
+        var inventory = ScanOgcApiFeatures();
+
+        var scanReport = MigrationAcceptanceScanStageRunner.BuildReport(
+            "acceptance-scan-stage:slice-2:ogc-only",
+            [
+                new MigrationAcceptanceScanStageInput
+                {
+                    FixtureId = "ogc-api-features-demo",
+                    Inventory = inventory
+                }
+            ]);
+
+        var applyReport = MigrationAcceptanceApplyStageRunner.BuildReport(
+            "acceptance-apply-stage:slice-3:ogc-only",
+            scanReport.RunId,
+            [
+                new MigrationAcceptanceApplyStageInput
+                {
+                    FixtureId = "ogc-api-features-demo",
+                    Inventory = scanReport.Sources.Single().Inventory
+                }
+            ]);
+
+        var parityReport = MigrationAcceptanceParityStageRunner.BuildReport(
+            "acceptance-parity-stage:slice-4:ogc-only",
+            applyReport.RunId,
+            [
+                new MigrationAcceptanceParityStageInput
+                {
+                    FixtureId = "ogc-api-features-demo",
+                    Inventory = scanReport.Sources.Single().Inventory,
+                    Manifest = applyReport.Sources.Single().Outcome.Manifest
+                }
+            ]);
+
+        scanReport.Sources.Should().ContainSingle();
+        applyReport.Sources.Should().ContainSingle();
+        parityReport.Sources.Should().ContainSingle();
+        parityReport.Sources.Single().FixtureId.Should().Be(scanReport.Sources.Single().FixtureId);
+        parityReport.Sources.Single().SourceKind.Should().Be(applyReport.Sources.Single().SourceKind);
+        parityReport.Sources.Single().Outcome.Evidence.SourceKind
+            .Should().Be(scanReport.Sources.Single().SourceKind);
+
+        var replayed = MigrationAcceptanceParityStageRunner.BuildReport(
+            parityReport.RunId,
+            parityReport.ApplyRunId,
+            [
+                new MigrationAcceptanceParityStageInput
+                {
+                    FixtureId = "ogc-api-features-demo",
+                    Inventory = scanReport.Sources.Single().Inventory,
+                    Manifest = applyReport.Sources.Single().Outcome.Manifest
+                }
+            ]);
+
+        var first = JsonSerializer.Serialize(parityReport, ArtifactJsonOptions);
+        var second = JsonSerializer.Serialize(replayed, ArtifactJsonOptions);
+        second.Should().Be(first, "scan -> apply -> parity for a single fixture must replay deterministically.");
+    }
+
+    [Fact]
+    public async Task ParityStage_DeterministicReapply_MatchesReplayToken_PerSource()
+    {
+        var first = await BuildReportAsync();
+        var second = await BuildReportAsync();
+
+        first.Sources.Should().HaveSameCount(second.Sources);
+        foreach (var (left, right) in first.Sources.Zip(second.Sources))
+        {
+            left.FixtureId.Should().Be(right.FixtureId);
+            left.Outcome.ReplayToken.Should().Be(right.Outcome.ReplayToken,
+                $"the parity stage replay token for fixture '{left.FixtureId}' must be stable across re-runs.");
+        }
+    }
+
+    [Fact]
+    public async Task ParityStage_RoutesManualReview_ForResourcesWithoutPublishableTarget()
+    {
+        // Drive the parity runner with a synthetic manifest whose target resource is routed to
+        // manual-review so the per-resource classification path is exercised independently of
+        // upstream scanner heuristics. This keeps the test asserting the runner contract rather
+        // than a particular scanner's compatibility classifier.
+        var inventory = ScanOgcApiFeatures();
+        var manifest = MigrationManifestTranslator.Translate(inventory);
+        var manualReviewManifest = manifest with
+        {
+            TargetResources = manifest.TargetResources
+                .Select(resource => resource with { Action = "manual-review" })
+                .ToArray()
+        };
+
+        var manualReport = MigrationAcceptanceParityStageRunner.BuildReport(
+            "acceptance-parity-stage:slice-4:manual-review",
+            "acceptance-apply-stage:slice-3:manual-review",
+            [
+                new MigrationAcceptanceParityStageInput
+                {
+                    FixtureId = "ogc-api-features-demo",
+                    Inventory = inventory,
+                    Manifest = manualReviewManifest
+                }
+            ]);
+
+        var entry = manualReport.Sources.Single();
+        entry.Classification.Should().Be("manual-review",
+            "a manifest that routes every target resource to manual review must roll up to the manual-review classification.");
+        entry.Outcome.ManualReviewResourceCount.Should().BeGreaterThan(0);
+        entry.Outcome.ResourceProbes
+            .Should().OnlyContain(probe => probe.Classification == "manual-review");
+        entry.Outcome.Diagnostics
+            .Should().OnlyContain(diagnostic => diagnostic.Severity == "manual-review");
+
+        // The full fixture-set report must still keep its summary counts coherent.
+        var report = await BuildReportAsync();
+
+        // Summary counts must match the per-source rollups exactly.
+        report.Summary.ResourceCount.Should()
+            .Be(report.Sources.Sum(entry => entry.Outcome.ResourceCount));
+        report.Summary.FeatureCountMatchCount.Should()
+            .Be(report.Sources.Sum(entry => entry.Outcome.FeatureCountMatchCount));
+        report.Summary.SchemaMatchCount.Should()
+            .Be(report.Sources.Sum(entry => entry.Outcome.SchemaMatchCount));
+        report.Summary.DiagnosticCount.Should()
+            .Be(report.Sources.Sum(entry => entry.Outcome.Diagnostics.Length));
+        (report.Summary.PassSourceCount
+            + report.Summary.WarnSourceCount
+            + report.Summary.FailSourceCount
+            + report.Summary.ManualReviewSourceCount).Should().Be(report.Summary.SourceCount);
+    }
+
+    [Fact]
+    public async Task ParityStage_PassWarnFail_ThresholdsReachTheArtifact()
+    {
+        // Drive the parity runner directly with synthetic target observations so all three
+        // classification thresholds (pass, warn, fail) are exercised on the per-resource probe and
+        // surface to the aggregate fixture classification on the artifact.
+        var inventory = await ScanArcGisAsync();
+        var manifest = MigrationManifestTranslator.Translate(inventory);
+        var publishableResources = manifest.TargetResources
+            .Where(resource => resource.Action == "publish")
+            .ToArray();
+        publishableResources.Should().NotBeEmpty(
+            "the ArcGIS MapServer-MixedRenderers fixture must expose at least one publishable resource for the threshold probe.");
+
+        // Pass case: target observation exactly matches the source.
+        var passInventory = inventory;
+        var passManifest = manifest;
+        var passReport = MigrationAcceptanceParityStageRunner.BuildReport(
+            "acceptance-parity-stage:slice-4:threshold-pass",
+            "acceptance-apply-stage:slice-3:threshold",
+            [
+                new MigrationAcceptanceParityStageInput
+                {
+                    FixtureId = "arcgis-mapserver-mixed-renderers",
+                    Inventory = passInventory,
+                    Manifest = passManifest,
+                    SourceObservations = publishableResources
+                        .Select(resource => new MigrationParitySourceObservation
+                        {
+                            SourceResourceId = resource.SourceResourceId,
+                            FeatureCount = 1000,
+                            Bbox = [0, 0, 10, 10]
+                        })
+                        .ToArray(),
+                    TargetObservations = publishableResources
+                        .Select(resource => new MigrationParityTargetObservation
+                        {
+                            SourceResourceId = resource.SourceResourceId,
+                            FeatureCount = 1000,
+                            Bbox = [0, 0, 10, 10]
+                        })
+                        .ToArray()
+                }
+            ]);
+        var passEntry = passReport.Sources.Single();
+        passEntry.Outcome.ResourceProbes
+            .Where(probe => probe.Classification != "manual-review")
+            .Should().OnlyContain(probe => probe.Classification == "pass");
+
+        // Warn case: target feature count differs by 1 — within the 1% warn threshold for 1000.
+        var warnReport = MigrationAcceptanceParityStageRunner.BuildReport(
+            "acceptance-parity-stage:slice-4:threshold-warn",
+            "acceptance-apply-stage:slice-3:threshold",
+            [
+                new MigrationAcceptanceParityStageInput
+                {
+                    FixtureId = "arcgis-mapserver-mixed-renderers",
+                    Inventory = inventory,
+                    Manifest = manifest,
+                    SourceObservations = publishableResources
+                        .Select(resource => new MigrationParitySourceObservation
+                        {
+                            SourceResourceId = resource.SourceResourceId,
+                            FeatureCount = 1000
+                        })
+                        .ToArray(),
+                    TargetObservations = publishableResources
+                        .Select(resource => new MigrationParityTargetObservation
+                        {
+                            SourceResourceId = resource.SourceResourceId,
+                            FeatureCount = 999
+                        })
+                        .ToArray()
+                }
+            ]);
+        var warnEntry = warnReport.Sources.Single();
+        warnEntry.Classification.Should().Be("warn",
+            "a 1-feature drift on a 1000-feature resource must roll up to the warn classification.");
+        warnEntry.Outcome.ResourceProbes
+            .Where(probe => probe.Classification != "manual-review")
+            .Should().Contain(probe => probe.FeatureCount.State == "warn");
+        warnEntry.Outcome.Diagnostics
+            .Should().Contain(diagnostic => diagnostic.Code == "parity.feature-count.warn");
+
+        // Fail case: bbox is disjoint — must fail the bbox-overlap probe and roll up to fail.
+        var failReport = MigrationAcceptanceParityStageRunner.BuildReport(
+            "acceptance-parity-stage:slice-4:threshold-fail",
+            "acceptance-apply-stage:slice-3:threshold",
+            [
+                new MigrationAcceptanceParityStageInput
+                {
+                    FixtureId = "arcgis-mapserver-mixed-renderers",
+                    Inventory = inventory,
+                    Manifest = manifest,
+                    SourceObservations = publishableResources
+                        .Select(resource => new MigrationParitySourceObservation
+                        {
+                            SourceResourceId = resource.SourceResourceId,
+                            FeatureCount = 1000,
+                            Bbox = [0, 0, 10, 10]
+                        })
+                        .ToArray(),
+                    TargetObservations = publishableResources
+                        .Select(resource => new MigrationParityTargetObservation
+                        {
+                            SourceResourceId = resource.SourceResourceId,
+                            FeatureCount = 1000,
+                            Bbox = [100, 100, 110, 110]
+                        })
+                        .ToArray()
+                }
+            ]);
+        var failEntry = failReport.Sources.Single();
+        failEntry.Classification.Should().Be("fail",
+            "a disjoint bbox observation must roll up to the fail classification.");
+        failEntry.Outcome.BboxOverlapMismatchCount.Should().BeGreaterThan(0);
+        failEntry.Outcome.Diagnostics
+            .Should().Contain(diagnostic => diagnostic.Code == "parity.bbox-overlap.fail");
+    }
+
+    [Fact]
+    public async Task ParityStage_RedactsCredentials_FromArtifactOutput()
+    {
+        var report = await BuildReportAsync();
+
+        var json = JsonSerializer.Serialize(report, ArtifactJsonOptions);
+
+        json.Should().NotContain("super-secret-token",
+            "the parity stage evidence must never echo back the supplied ArcGIS token.");
+        json.Should().NotContain("Authorization",
+            "the parity stage evidence must not surface raw HTTP authorization headers.");
+        json.Should().NotContain("password",
+            "the parity stage evidence must not surface password values from the source.");
+        json.Should().NotContain("Basic ",
+            "the parity stage evidence must not surface raw Basic auth values from the source.");
+    }
+
+    private static async Task<MigrationParityStageReport> BuildReportAsync()
+    {
+        var arcgisInventory = await ScanArcGisAsync();
+        var geoServerInventory = await ScanGeoServerAsync();
+        var ogcInventory = ScanOgcApiFeatures();
+
+        var applyReport = MigrationAcceptanceApplyStageRunner.BuildReport(
+            "acceptance-apply-stage:slice-3",
+            "acceptance-scan-stage:slice-2",
+            [
+                new MigrationAcceptanceApplyStageInput
+                {
+                    FixtureId = "arcgis-mapserver-mixed-renderers",
+                    Inventory = arcgisInventory
+                },
+                new MigrationAcceptanceApplyStageInput
+                {
+                    FixtureId = "geoserver-mixed-catalog",
+                    Inventory = geoServerInventory
+                },
+                new MigrationAcceptanceApplyStageInput
+                {
+                    FixtureId = "ogc-api-features-demo",
+                    Inventory = ogcInventory
+                }
+            ]);
+
+        var inventoryByFixture = new Dictionary<string, MigrationSourceInventoryArtifact>(StringComparer.Ordinal)
+        {
+            ["arcgis-mapserver-mixed-renderers"] = arcgisInventory,
+            ["geoserver-mixed-catalog"] = geoServerInventory,
+            ["ogc-api-features-demo"] = ogcInventory
+        };
+
+        return MigrationAcceptanceParityStageRunner.BuildReport(
+            "acceptance-parity-stage:slice-4",
+            applyReport.RunId,
+            applyReport.Sources.Select(entry => new MigrationAcceptanceParityStageInput
+            {
+                FixtureId = entry.FixtureId,
+                Inventory = inventoryByFixture[entry.FixtureId],
+                Manifest = entry.Outcome.Manifest
+            }).ToArray());
+    }
+
+    private static async Task<MigrationSourceInventoryArtifact> ScanArcGisAsync()
+    {
+        var fixture = LoadFixture("ArcGis", "MapServer-MixedRenderers");
+        var service = CreateGeoservicesService(new FixtureHttpHandler(fixture.Responses));
+
+        return await service.ScanSourceAsync(new GeoservicesDiscoveryRequest
+        {
+            ServiceUrl = fixture.ServiceUrl,
+            TimeoutSeconds = 5
+        });
+    }
+
+    private static async Task<MigrationSourceInventoryArtifact> ScanGeoServerAsync()
+    {
+        var fixture = LoadFixture("GeoServer", "MixedCatalog");
+        var service = CreateGeoServerService(new FixtureHttpHandler(fixture.Responses));
+
+        return await service.ScanSourceAsync(new GeoServerDiscoveryRequest
+        {
+            GeoServerRestUrl = fixture.ServiceUrl,
+            IncludeCompatibilityAnalysis = true,
+            IncludeStyleContent = true,
+            TimeoutSeconds = 5
+        });
+    }
+
+    private static MigrationSourceInventoryArtifact ScanOgcApiFeatures()
+    {
+        var snapshot = new OgcApiFeaturesMigrationSourceSnapshot
+        {
+            BaseUrl = "https://demo.example/ogcapi/",
+            Title = "Demo OGC API Features",
+            Version = "1.0",
+            LandingPageLinks =
+            [
+                Link("service-desc", "https://demo.example/ogcapi/openapi", "application/vnd.oai.openapi+json;version=3.0"),
+                Link("conformance", "https://demo.example/ogcapi/conformance", "application/json"),
+                Link("data", "https://demo.example/ogcapi/collections", "application/json")
+            ],
+            ConformanceClasses =
+            [
+                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+                "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables"
+            ],
+            Collections =
+            [
+                new OgcApiFeaturesCollectionSnapshot
+                {
+                    Id = "roads",
+                    Title = "Roads",
+                    GeometryType = "LineString",
+                    FeatureCount = 125,
+                    Links =
+                    [
+                        Link("items", "https://demo.example/ogcapi/collections/roads/items", "application/geo+json"),
+                        Link("http://www.opengis.net/def/rel/ogc/1.0/queryables", "https://demo.example/ogcapi/collections/roads/queryables", "application/schema+json")
+                    ],
+                    CrsDeclarations =
+                    [
+                        Crs("storage", "http://www.opengis.net/def/crs/OGC/1.3/CRS84"),
+                        Crs("supported", "http://www.opengis.net/def/crs/EPSG/0/4326")
+                    ],
+                    ItemEncodings = ["application/geo+json"],
+                    Fields =
+                    [
+                        new MigrationInventoryField
+                        {
+                            Name = "name",
+                            Alias = "Road name",
+                            FieldType = "string",
+                            Nullable = false
+                        }
+                    ]
+                }
+            ]
+        };
+
+        return OgcApiFeaturesMigrationInventoryScanner.BuildInventory(snapshot);
+    }
+
+    private static OgcApiFeaturesLink Link(string rel, string href, string? type = null) =>
+        new() { Rel = rel, Href = href, Type = type };
+
+    private static OgcApiFeaturesCrsDeclaration Crs(string role, string value) =>
+        new() { Role = role, Value = value };
+
+    private static FixtureScenario LoadFixture(string family, string scenario)
+    {
+        var fixturePath = Path.Combine(
+            AppContext.BaseDirectory,
+            "Features",
+            "Import",
+            "Fixtures",
+            family,
+            $"{scenario}.json");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(fixturePath));
+        var root = document.RootElement;
+        var serviceUrl = root.GetProperty("serviceUrl").GetString()
+            ?? throw new InvalidDataException($"Fixture {scenario} is missing serviceUrl.");
+        var responses = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var entry in root.GetProperty("responses").EnumerateObject())
+        {
+            responses[entry.Name] = entry.Value.ValueKind == JsonValueKind.String
+                ? entry.Value.GetString() ?? string.Empty
+                : entry.Value.GetRawText();
+        }
+
+        return new FixtureScenario(serviceUrl, responses);
+    }
+
+    private static GeoservicesImportService CreateGeoservicesService(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler);
+        var restClient = new ArcGisRestClient(
+            httpClient,
+            NullLogger<ArcGisRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+        var connectionProvider = new Mock<IDatabaseConnectionProvider>(MockBehavior.Strict);
+        var crsRegistry = CreateCrsRegistry();
+
+        return new GeoservicesImportService(
+            restClient,
+            connectionProvider.Object,
+            crsRegistry,
+            NullLogger<GeoservicesImportService>.Instance);
+    }
+
+    private static GeoServerImportService CreateGeoServerService(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler);
+        var restClient = new GeoServerRestClient(
+            httpClient,
+            NullLogger<GeoServerRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+        var connectionProvider = new Mock<IDatabaseConnectionProvider>(MockBehavior.Strict);
+        var crsRegistry = CreateCrsRegistry();
+
+        return new GeoServerImportService(
+            restClient,
+            connectionProvider.Object,
+            crsRegistry,
+            NullLogger<GeoServerImportService>.Instance);
+    }
+
+    private static ICrsRegistry CreateCrsRegistry()
+    {
+        var registry = new Mock<ICrsRegistry>(MockBehavior.Strict);
+        registry.Setup(r => r.ResolveBySridAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns((int srid, CancellationToken _) => new ValueTask<CrsDefinition?>(
+                srid switch
+                {
+                    3857 => new CrsDefinition("http://www.opengis.net/def/crs/EPSG/0/3857", 3857, AxisOrder.EastNorth, false),
+                    4326 => new CrsDefinition("http://www.opengis.net/def/crs/EPSG/0/4326", 4326, AxisOrder.EastNorth, true),
+                    _ => null
+                }));
+        return registry.Object;
+    }
+
+    private sealed record FixtureScenario(string ServiceUrl, IReadOnlyDictionary<string, string> Responses);
+
+    private sealed class FixtureHttpHandler : HttpMessageHandler
+    {
+        private readonly IReadOnlyDictionary<string, string> _responses;
+
+        public FixtureHttpHandler(IReadOnlyDictionary<string, string> responses)
+        {
+            _responses = responses;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var pathAndQuery = request.RequestUri?.PathAndQuery ?? string.Empty;
+            if (!_responses.TryGetValue(pathAndQuery, out var body))
+            {
+                throw new InvalidOperationException(
+                    $"Fixture has no response for {pathAndQuery}. Add it to the fixture JSON or correct the request path.");
+            }
+
+            var contentType = pathAndQuery.EndsWith(".xml", StringComparison.Ordinal)
+                ? "application/xml"
+                : pathAndQuery.EndsWith(".sld", StringComparison.Ordinal)
+                    ? "application/vnd.ogc.sld+xml"
+                    : "application/json";
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, contentType)
+            });
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1024 — slice 4 of the migration acceptance suite, stacked on top of #1111 (slice 3 / `codex/issue-1024-apply-stage`), which built on the slice-2 scan stage in #1108 and the slice-1 artifact contracts in #1093.

## Summary
Drive a real migration parity stage against the same deterministic fixture sources used by the slice-2 scan stage and slice-3 apply stage so the acceptance suite emits its first `MigrationParityEvidenceArtifact` per fixture, alongside a deterministic stage-level report. Parity probes in slice 4 are intentionally small — feature count, schema field-name set, and axis-aligned bbox overlap — so the parity stage can classify fixture sources deterministically without depending on heavyweight per-feature checks. Heavier probes (geometry hashing, attribute distribution, live target probing) remain out of scope and belong in later slices once a target observation contract is wired up. No new protocol surface is introduced; the runner composes the existing `MigrationParityEvidenceGenerator` for the per-source evidence artifact and rolls per-resource probes into a stage report with a SHA-256 replay token.

## Changes Made
- New `MigrationParityStageReport` in `Honua.Core.Features.Import.Domain` capturing the per-source parity outcome (parity evidence artifact, replay token, per-resource probes, manual-review counts, diagnostics) and a deterministic envelope summary.
- New `MigrationAcceptanceParityStageRunner` in `Honua.Core.Features.Import.Services` that takes per-fixture inventory + manifest inputs (optionally observed source/target counts, field-names, bboxes), runs the three slice-4 probes, classifies pass/warn/fail/manual-review per resource, and rolls up the fixture-level classification without reimplementing parity or requiring a live target.
- Integration tests in `MigrationAcceptanceParityStageTests` covering schema stability, deterministic re-parity (same fixture set → same artifact + per-source replay token), single-fixture scan→apply→parity chaining, pass/warn/fail threshold coverage, manual-review classification on the artifact, and credential-safe redaction across the full report.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)