### PR TITLE
feat: GeoServer migration evidence pack + nightly fixture (#1015 slice 4/5)

### DIFF
--- a/.github/workflows/nightly-migration-evidence.yml
+++ b/.github/workflows/nightly-migration-evidence.yml
@@ -1,0 +1,109 @@
+name: Nightly Migration Evidence Pack
+
+# Tier: nightly evidence. Drives the fixture-based GeoServer migration apply
+# path (slices 1-3 of issue #1015) end-to-end and uploads the slice-4
+# deterministic evidence pack as a CI artifact so reviewers can audit catalog,
+# data, and style migration outcomes from a single artifact.
+on:
+  schedule:
+    # Stagger after other nightlies so the runner image cache is warm.
+    - cron: '15 7 * * *'
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-migration-evidence-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  evidence-pack:
+    name: GeoServer Migration Evidence Pack
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-ci
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore Honua.sln
+
+      - name: Build
+        run: dotnet build Honua.sln --no-restore --configuration Release
+
+      - name: Run slice 1-3 fixture-driven apply tests (Postgres harness)
+        run: |
+          mkdir -p tests/TestResults
+          dotnet test tests/dotnet/Honua.Postgres.Tests/Honua.Postgres.Tests.csproj \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --filter "FullyQualifiedName~GeoServerImportServiceApplyPlanTests|FullyQualifiedName~GeoServerImportServiceDataSourceApplyTests|FullyQualifiedName~GeoServerImportServiceStyleApplyTests" \
+            --logger "trx;LogFileName=geoserver-apply-fixtures.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults
+
+      - name: Emit slice-4 evidence pack artifact
+        env:
+          HONUA_EMIT_EVIDENCE_PACK: '1'
+          HONUA_EVIDENCE_PACK_OUTPUT: ${{ github.workspace }}/artifacts/migration-evidence/geoserver-migration-evidence-pack.json
+          HONUA_EVIDENCE_PACK_RUN_ID: nightly-${{ github.run_id }}
+        run: |
+          mkdir -p "${{ github.workspace }}/artifacts/migration-evidence"
+          dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --filter "FullyQualifiedName~MigrationEvidencePackBuilderTests.EmitNightlyEvidencePack_WhenEnvVarSet_WritesDeterministicArtifact" \
+            --logger "trx;LogFileName=migration-evidence-pack.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults
+
+      - name: Summarize evidence pack
+        if: always()
+        run: |
+          PACK="${{ github.workspace }}/artifacts/migration-evidence/geoserver-migration-evidence-pack.json"
+          if [[ ! -f "$PACK" ]]; then
+            echo "Evidence pack was not generated; check the prior test step." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "## GeoServer Migration Evidence Pack"
+            echo
+            echo "**Artifact kind:** $(jq -r '.artifactKind' "$PACK")"
+            echo "**Run id:** $(jq -r '.runId' "$PACK")"
+            echo "**Bundle fingerprint:** \`$(jq -r '.bundleFingerprint' "$PACK")\`"
+            echo
+            echo "### Stages"
+            echo "| Stage | Steps | Applied | Already applied | Manual review | Unsupported | Failed |"
+            echo "|---|---:|---:|---:|---:|---:|---:|"
+            jq -r '
+              .bundle.stages[]
+              | "| \(.id) | \(.stepCount) | \(.appliedCount) | \(.alreadyAppliedCount) | \(.manualReviewCount) | \(.unsupportedCount) | \(.failedCount) |"
+            ' "$PACK"
+            echo
+            STYLE_REVIEW=$(jq -r '.bundle.summary.styleManualReviewCount' "$PACK")
+            echo "Style steps requiring manual review (visual parity NOT claimed): **$STYLE_REVIEW**"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload migration evidence pack
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: geoserver-migration-evidence-${{ github.run_id }}
+          path: |
+            artifacts/migration-evidence/
+            tests/TestResults/geoserver-apply-fixtures.trx
+            tests/TestResults/migration-evidence-pack.trx

--- a/src/Honua.Core/Features/Import/Domain/MigrationEvidencePackArtifact.cs
+++ b/src/Honua.Core/Features/Import/Domain/MigrationEvidencePackArtifact.cs
@@ -1,0 +1,303 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Slice 4 of issue #1015. Single deterministic evidence bundle emitted from a
+/// successful GeoServer migration run. Aggregates the upstream
+/// <see cref="MigrationSourceInventoryArtifact"/>, the translated
+/// <see cref="MigrationManifestArtifact"/>, and the per-stage step results from
+/// the apply-execution artifact so reviewers (and nightly fixture runs) have a
+/// single artifact to audit catalog, data, and style migration outcomes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pack carries a SHA-256 fingerprint computed over the canonical JSON of
+/// its bundle so identical inputs always produce the same fingerprint. The
+/// fingerprint deliberately excludes wall-clock timestamps and the generator
+/// label so re-runs across machines stay byte-identical.
+/// </para>
+/// <para>
+/// Privacy posture: <see cref="MigrationEvidencePackBundle.Source"/> and the
+/// stage-level summaries reuse the redaction behavior of the upstream
+/// inventory artifact. The builder additionally strips credentials from the
+/// source URL and never includes raw style bodies or feature payloads — only
+/// counts and diagnostics derived from slices 1-3.
+/// </para>
+/// <para>
+/// AOT note: this record uses POCO-only properties (no polymorphic
+/// converters, no <c>JsonExtensionData</c>) so the default
+/// <c>System.Text.Json</c> serializer remains trim/AOT safe.
+/// </para>
+/// </remarks>
+public sealed record MigrationEvidencePackArtifact
+{
+    /// <summary>
+    /// Stable artifact kind identifier.
+    /// </summary>
+    public string ArtifactKind { get; init; } = "honua.migration.evidence-pack";
+
+    /// <summary>
+    /// Artifact schema version.
+    /// </summary>
+    public string ArtifactVersion { get; init; } = "1.0";
+
+    /// <summary>
+    /// Stable run identifier supplied by the harness or nightly workflow.
+    /// </summary>
+    public required string RunId { get; init; }
+
+    /// <summary>
+    /// Free-form generator label, e.g. <c>geoserver-migration-evidence-builder/1.0</c>.
+    /// Excluded from the bundle fingerprint so re-runs across CI images stay
+    /// byte-identical.
+    /// </summary>
+    public required string Generator { get; init; }
+
+    /// <summary>
+    /// UTC instant the pack was generated. Excluded from the bundle fingerprint
+    /// so re-runs stay byte-identical.
+    /// </summary>
+    public required DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>
+    /// SHA-256 fingerprint computed over the canonical JSON of
+    /// <see cref="Bundle"/>. Identical inputs always produce the same value.
+    /// </summary>
+    public required string BundleFingerprint { get; init; }
+
+    /// <summary>
+    /// Deterministic evidence bundle that aggregates slice 1-3 artifacts.
+    /// </summary>
+    public required MigrationEvidencePackBundle Bundle { get; init; }
+}
+
+/// <summary>
+/// Deterministic content bundle covered by
+/// <see cref="MigrationEvidencePackArtifact.BundleFingerprint"/>.
+/// </summary>
+public sealed record MigrationEvidencePackBundle
+{
+    /// <summary>
+    /// Source kind identifier such as <c>geoserver-rest</c>.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Secret-safe source identity (credentials and URL secrets stripped).
+    /// </summary>
+    public required MigrationSourceIdentity Source { get; init; }
+
+    /// <summary>
+    /// Operator-requested workspace scope. Empty when the run applied to all
+    /// workspaces. Captured here as workspace-scoping evidence so reviewers can
+    /// audit that styles and data sources outside the requested scope were not
+    /// migrated.
+    /// </summary>
+    public required MigrationEvidencePackWorkspaceScope WorkspaceScope { get; init; }
+
+    /// <summary>
+    /// Plan fingerprint and replay token copied from the apply-execution
+    /// artifact so downstream consumers can correlate the pack with the exact
+    /// apply plan that was executed.
+    /// </summary>
+    public required MigrationEvidencePackApplyIdentity Apply { get; init; }
+
+    /// <summary>
+    /// Aggregate counts across the catalog, data, and style stages.
+    /// </summary>
+    public required MigrationEvidencePackSummary Summary { get; init; }
+
+    /// <summary>
+    /// Per-stage step results derived from
+    /// <see cref="MigrationApplyExecutionArtifact.StepResults"/>. Ordering is
+    /// stable: stages in canonical order, steps within each stage ordered by
+    /// step id.
+    /// </summary>
+    public MigrationEvidencePackStage[] Stages { get; init; } = [];
+
+    /// <summary>
+    /// Aggregated style-conversion diagnostics surfaced by slice 3 so the pack
+    /// carries explicit manual-review records when SLD-to-MapLibre conversion
+    /// did not guarantee visual parity.
+    /// </summary>
+    public MigrationEvidencePackStyleDiagnostic[] StyleDiagnostics { get; init; } = [];
+
+    /// <summary>
+    /// Inventory snapshot copied from the slice-1 input.
+    /// </summary>
+    public required MigrationSourceInventoryArtifact Inventory { get; init; }
+
+    /// <summary>
+    /// Manifest snapshot copied from the slice-1 input.
+    /// </summary>
+    public required MigrationManifestArtifact Manifest { get; init; }
+}
+
+/// <summary>
+/// Operator-requested workspace scope captured in the evidence pack.
+/// </summary>
+public sealed record MigrationEvidencePackWorkspaceScope
+{
+    /// <summary>
+    /// Whether the operator restricted the apply run to specific workspaces.
+    /// When <c>false</c>, all source workspaces were eligible.
+    /// </summary>
+    public required bool Restricted { get; init; }
+
+    /// <summary>
+    /// Deterministically ordered list of requested workspace names. Empty when
+    /// <see cref="Restricted"/> is <c>false</c>.
+    /// </summary>
+    public string[] WorkspaceNames { get; init; } = [];
+}
+
+/// <summary>
+/// Apply identity referenced from the evidence pack. Mirrors the
+/// <see cref="MigrationApplyExecutionArtifact"/> identity fields so consumers
+/// can correlate the pack with the executed plan without having to load both
+/// artifacts.
+/// </summary>
+public sealed record MigrationEvidencePackApplyIdentity
+{
+    /// <summary>
+    /// Plan fingerprint copied from the apply-execution artifact.
+    /// </summary>
+    public required string PlanFingerprint { get; init; }
+
+    /// <summary>
+    /// Replay token copied from the apply-execution artifact.
+    /// </summary>
+    public required string ReplayToken { get; init; }
+
+    /// <summary>
+    /// Execution mode reported by the apply run, e.g. <c>catalog-apply</c>.
+    /// </summary>
+    public required string ExecutionMode { get; init; }
+}
+
+/// <summary>
+/// Aggregate evidence summary across catalog, data, and style stages.
+/// </summary>
+public sealed record MigrationEvidencePackSummary
+{
+    /// <summary>
+    /// Total number of apply-plan steps considered by the run.
+    /// </summary>
+    public int TotalStepCount { get; init; }
+
+    /// <summary>
+    /// Number of steps that completed with the <c>applied</c> outcome.
+    /// </summary>
+    public int AppliedStepCount { get; init; }
+
+    /// <summary>
+    /// Number of steps that were already present in the target catalog.
+    /// </summary>
+    public int AlreadyAppliedStepCount { get; init; }
+
+    /// <summary>
+    /// Number of steps that remain explicit manual-review work.
+    /// </summary>
+    public int ManualReviewStepCount { get; init; }
+
+    /// <summary>
+    /// Number of steps that are unsupported by this apply path.
+    /// </summary>
+    public int UnsupportedStepCount { get; init; }
+
+    /// <summary>
+    /// Number of steps that failed unexpectedly.
+    /// </summary>
+    public int FailedStepCount { get; init; }
+
+    /// <summary>
+    /// Number of style steps recorded with at least one error-severity
+    /// conversion diagnostic. Per issue #1015 AC, these block any visual
+    /// parity claim.
+    /// </summary>
+    public int StyleManualReviewCount { get; init; }
+}
+
+/// <summary>
+/// Per-stage view of the apply-execution step results.
+/// </summary>
+public sealed record MigrationEvidencePackStage
+{
+    /// <summary>
+    /// Canonical stage id: <c>catalog</c>, <c>data</c>, or <c>style</c>.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Number of step results in this stage.
+    /// </summary>
+    public int StepCount { get; init; }
+
+    /// <summary>
+    /// Number of step results with the <c>applied</c> outcome.
+    /// </summary>
+    public int AppliedCount { get; init; }
+
+    /// <summary>
+    /// Number of step results with the <c>already-applied</c> outcome.
+    /// </summary>
+    public int AlreadyAppliedCount { get; init; }
+
+    /// <summary>
+    /// Number of step results with the <c>manual-review</c> outcome.
+    /// </summary>
+    public int ManualReviewCount { get; init; }
+
+    /// <summary>
+    /// Number of step results with the <c>unsupported</c> outcome.
+    /// </summary>
+    public int UnsupportedCount { get; init; }
+
+    /// <summary>
+    /// Number of step results with the <c>failed</c> outcome.
+    /// </summary>
+    public int FailedCount { get; init; }
+
+    /// <summary>
+    /// Per-step results ordered by <see cref="MigrationApplyExecutionStepResult.StepId"/>.
+    /// </summary>
+    public MigrationApplyExecutionStepResult[] StepResults { get; init; } = [];
+}
+
+/// <summary>
+/// Aggregated style-conversion diagnostic surfaced from slice-3 evidence.
+/// </summary>
+public sealed record MigrationEvidencePackStyleDiagnostic
+{
+    /// <summary>
+    /// Source style identifier the diagnostic was raised for.
+    /// </summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>
+    /// Resolved step outcome for the style step (e.g. <c>manual-review</c>).
+    /// </summary>
+    public required string StepOutcome { get; init; }
+
+    /// <summary>
+    /// Diagnostic message copied from the slice-3 apply step.
+    /// </summary>
+    public required string Message { get; init; }
+}
+
+/// <summary>
+/// Canonical stage identifiers used by the evidence pack.
+/// </summary>
+public static class MigrationEvidencePackStageIds
+{
+    /// <summary>Slice 1: catalog (workspace + layer-group) entries.</summary>
+    public const string Catalog = "catalog";
+
+    /// <summary>Slice 2: data-source registration + feature data copy.</summary>
+    public const string Data = "data";
+
+    /// <summary>Slice 3: style persistence + conversion diagnostics.</summary>
+    public const string Style = "style";
+}

--- a/src/Honua.Core/Features/Import/Services/MigrationEvidencePackBuilder.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationEvidencePackBuilder.cs
@@ -1,0 +1,320 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Cryptography;
+using System.Text.Json;
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Slice 4 of issue #1015. Aggregates the slice 1-3 artifacts emitted by a
+/// successful GeoServer migration run into a single deterministic
+/// <see cref="MigrationEvidencePackArtifact"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The builder is intentionally pure and side-effect free so the same inputs
+/// always produce the same output (and the same
+/// <see cref="MigrationEvidencePackArtifact.BundleFingerprint"/>). It performs
+/// no I/O, no logging, and no clock reads except for the caller-supplied
+/// <see cref="MigrationEvidencePackBuilderOptions.GeneratedAt"/> stamp, which
+/// is excluded from the fingerprint.
+/// </para>
+/// <para>
+/// Credential redaction: the source identity is sanitized by stripping
+/// userinfo, query, and fragment components from <c>BaseUrl</c> before the
+/// inventory snapshot is included in the bundle. The builder never copies
+/// raw style bodies or feature payloads — only counts and slice-3 diagnostic
+/// messages.
+/// </para>
+/// </remarks>
+public static class MigrationEvidencePackBuilder
+{
+    private const string BuilderGenerator = "honua.migration.evidence-pack-builder/1.0";
+
+    /// <summary>
+    /// Build an evidence pack from the slice 1-3 inputs.
+    /// </summary>
+    /// <param name="inputs">Inventory, manifest, apply-execution and scope inputs.</param>
+    /// <param name="options">Optional run id / generator / clock overrides.</param>
+    public static MigrationEvidencePackArtifact Build(
+        MigrationEvidencePackInputs inputs,
+        MigrationEvidencePackBuilderOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+        ArgumentNullException.ThrowIfNull(inputs.Inventory);
+        ArgumentNullException.ThrowIfNull(inputs.Manifest);
+        ArgumentNullException.ThrowIfNull(inputs.ApplyExecution);
+
+        var resolvedOptions = options ?? new MigrationEvidencePackBuilderOptions();
+
+        var redactedSource = RedactSource(inputs.ApplyExecution.Source);
+        var redactedInventory = inputs.Inventory with { Source = RedactSource(inputs.Inventory.Source) };
+        var redactedManifest = inputs.Manifest with { Source = RedactSource(inputs.Manifest.Source) };
+
+        var workspaceScope = BuildWorkspaceScope(inputs.RequestedWorkspaceNames);
+        var stages = BuildStages(inputs.ApplyExecution);
+        var summary = BuildSummary(inputs.ApplyExecution, stages);
+        var styleDiagnostics = BuildStyleDiagnostics(stages);
+
+        var bundle = new MigrationEvidencePackBundle
+        {
+            SourceKind = inputs.ApplyExecution.SourceKind,
+            Source = redactedSource,
+            WorkspaceScope = workspaceScope,
+            Apply = new MigrationEvidencePackApplyIdentity
+            {
+                PlanFingerprint = inputs.ApplyExecution.PlanFingerprint,
+                ReplayToken = inputs.ApplyExecution.ReplayToken,
+                ExecutionMode = inputs.ApplyExecution.ExecutionMode
+            },
+            Summary = summary,
+            Stages = stages,
+            StyleDiagnostics = styleDiagnostics,
+            Inventory = redactedInventory,
+            Manifest = redactedManifest
+        };
+
+        var fingerprint = ComputeBundleFingerprint(bundle);
+
+        return new MigrationEvidencePackArtifact
+        {
+            RunId = string.IsNullOrWhiteSpace(resolvedOptions.RunId) ? "migration-evidence-run" : resolvedOptions.RunId,
+            Generator = string.IsNullOrWhiteSpace(resolvedOptions.Generator) ? BuilderGenerator : resolvedOptions.Generator,
+            GeneratedAt = resolvedOptions.GeneratedAt ?? DateTimeOffset.UnixEpoch,
+            BundleFingerprint = fingerprint,
+            Bundle = bundle
+        };
+    }
+
+    /// <summary>
+    /// Compute the deterministic SHA-256 fingerprint that is also embedded in
+    /// the pack via <see cref="MigrationEvidencePackArtifact.BundleFingerprint"/>.
+    /// Exposed for tests and downstream verifiers.
+    /// </summary>
+    public static string ComputeBundleFingerprint(MigrationEvidencePackBundle bundle)
+    {
+        ArgumentNullException.ThrowIfNull(bundle);
+        var payload = JsonSerializer.SerializeToUtf8Bytes(bundle, MigrationEvidencePackJsonContext.Default.MigrationEvidencePackBundle);
+        var hash = SHA256.HashData(payload);
+        return $"sha256:{Convert.ToHexString(hash).ToLowerInvariant()}";
+    }
+
+    private static MigrationSourceIdentity RedactSource(MigrationSourceIdentity source)
+    {
+        return new MigrationSourceIdentity
+        {
+            DisplayName = source.DisplayName,
+            BaseUrl = RedactUrl(source.BaseUrl),
+            Product = source.Product,
+            Version = source.Version,
+            Build = source.Build,
+            ServiceType = source.ServiceType
+        };
+    }
+
+    private static string RedactUrl(string baseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return baseUrl;
+        }
+
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri))
+        {
+            return baseUrl;
+        }
+
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+
+        return builder.Uri.AbsoluteUri;
+    }
+
+    private static MigrationEvidencePackWorkspaceScope BuildWorkspaceScope(IReadOnlyCollection<string>? requestedWorkspaceNames)
+    {
+        if (requestedWorkspaceNames is null || requestedWorkspaceNames.Count == 0)
+        {
+            return new MigrationEvidencePackWorkspaceScope
+            {
+                Restricted = false,
+                WorkspaceNames = []
+            };
+        }
+
+        var ordered = requestedWorkspaceNames
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static value => value, StringComparer.Ordinal)
+            .ToArray();
+
+        return new MigrationEvidencePackWorkspaceScope
+        {
+            Restricted = ordered.Length > 0,
+            WorkspaceNames = ordered
+        };
+    }
+
+    private static MigrationEvidencePackStage[] BuildStages(MigrationApplyExecutionArtifact applyExecution)
+    {
+        var grouped = applyExecution.StepResults
+            .GroupBy(MapStepKindToStage, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.Ordinal);
+
+        var stageIds = new[]
+        {
+            MigrationEvidencePackStageIds.Catalog,
+            MigrationEvidencePackStageIds.Data,
+            MigrationEvidencePackStageIds.Style
+        };
+
+        var stages = new List<MigrationEvidencePackStage>(stageIds.Length);
+        foreach (var stageId in stageIds)
+        {
+            if (!grouped.TryGetValue(stageId, out var stageSteps) || stageSteps.Length == 0)
+            {
+                stages.Add(new MigrationEvidencePackStage
+                {
+                    Id = stageId,
+                    StepCount = 0,
+                    StepResults = []
+                });
+                continue;
+            }
+
+            var ordered = stageSteps
+                .OrderBy(static step => step.StepId, StringComparer.Ordinal)
+                .ToArray();
+
+            stages.Add(new MigrationEvidencePackStage
+            {
+                Id = stageId,
+                StepCount = ordered.Length,
+                AppliedCount = ordered.Count(static step => step.Outcome == "applied"),
+                AlreadyAppliedCount = ordered.Count(static step => step.Outcome == "already-applied"),
+                ManualReviewCount = ordered.Count(static step => step.Outcome == "manual-review"),
+                UnsupportedCount = ordered.Count(static step => step.Outcome == "unsupported"),
+                FailedCount = ordered.Count(static step => step.Outcome == "failed"),
+                StepResults = ordered
+            });
+        }
+
+        return stages.ToArray();
+    }
+
+    private static string MapStepKindToStage(MigrationApplyExecutionStepResult step)
+    {
+        // Slice 1 (#1095) emits workspace + layer-group catalog rows.
+        // Slice 2 (#1107) emits data-source + feature-data rows.
+        // Slice 3 (#1114) emits style rows.
+        // Any other kind (e.g. per-layer publish) is folded into the catalog
+        // stage so the pack always covers every executed step.
+        return step.Kind switch
+        {
+            "datastore" or "data-source" or "feature-copy" => MigrationEvidencePackStageIds.Data,
+            "style" => MigrationEvidencePackStageIds.Style,
+            _ => MigrationEvidencePackStageIds.Catalog
+        };
+    }
+
+    private static MigrationEvidencePackSummary BuildSummary(
+        MigrationApplyExecutionArtifact applyExecution,
+        IReadOnlyList<MigrationEvidencePackStage> stages)
+    {
+        var styleStage = stages.FirstOrDefault(s => s.Id == MigrationEvidencePackStageIds.Style);
+
+        return new MigrationEvidencePackSummary
+        {
+            TotalStepCount = applyExecution.Summary.TotalStepCount,
+            AppliedStepCount = applyExecution.Summary.AppliedStepCount,
+            AlreadyAppliedStepCount = applyExecution.Summary.AlreadyAppliedStepCount,
+            ManualReviewStepCount = applyExecution.Summary.ManualReviewStepCount,
+            UnsupportedStepCount = applyExecution.Summary.UnsupportedStepCount,
+            FailedStepCount = applyExecution.Summary.FailedStepCount,
+            StyleManualReviewCount = styleStage?.ManualReviewCount ?? 0
+        };
+    }
+
+    private static MigrationEvidencePackStyleDiagnostic[] BuildStyleDiagnostics(
+        IReadOnlyList<MigrationEvidencePackStage> stages)
+    {
+        var styleStage = stages.FirstOrDefault(s => s.Id == MigrationEvidencePackStageIds.Style);
+        if (styleStage is null || styleStage.StepResults.Length == 0)
+        {
+            return [];
+        }
+
+        return styleStage.StepResults
+            .Where(static step => step.Outcome is "manual-review" or "unsupported" or "failed")
+            .Select(static step => new MigrationEvidencePackStyleDiagnostic
+            {
+                SourceId = step.SourceId,
+                StepOutcome = step.Outcome,
+                Message = step.Message
+            })
+            .OrderBy(static diag => diag.SourceId, StringComparer.Ordinal)
+            .ToArray();
+    }
+}
+
+/// <summary>
+/// Aggregated inputs consumed by <see cref="MigrationEvidencePackBuilder.Build"/>.
+/// </summary>
+public sealed record MigrationEvidencePackInputs
+{
+    /// <summary>
+    /// Slice-1 inventory artifact captured from the source scan.
+    /// </summary>
+    public required MigrationSourceInventoryArtifact Inventory { get; init; }
+
+    /// <summary>
+    /// Slice-1 manifest artifact translated from the inventory.
+    /// </summary>
+    public required MigrationManifestArtifact Manifest { get; init; }
+
+    /// <summary>
+    /// Apply-execution artifact emitted by the GeoServer import service after
+    /// slice 1-3 catalog / data / style steps ran successfully.
+    /// </summary>
+    public required MigrationApplyExecutionArtifact ApplyExecution { get; init; }
+
+    /// <summary>
+    /// Operator-requested workspace scope, or <c>null</c>/empty when the run
+    /// applied to all workspaces. Captured separately because the apply
+    /// execution artifact does not echo it.
+    /// </summary>
+    public IReadOnlyCollection<string>? RequestedWorkspaceNames { get; init; }
+}
+
+/// <summary>
+/// Override hooks for tests and the nightly workflow.
+/// </summary>
+public sealed record MigrationEvidencePackBuilderOptions
+{
+    /// <summary>
+    /// Run identifier embedded in the artifact. Excluded from the bundle
+    /// fingerprint so the same inputs produce the same fingerprint across
+    /// nightly runs.
+    /// </summary>
+    public string? RunId { get; init; }
+
+    /// <summary>
+    /// Generator label embedded in the artifact. Excluded from the bundle
+    /// fingerprint.
+    /// </summary>
+    public string? Generator { get; init; }
+
+    /// <summary>
+    /// Generation timestamp. Excluded from the bundle fingerprint. Defaults to
+    /// <see cref="DateTimeOffset.UnixEpoch"/> when omitted so deterministic
+    /// tests do not have to set it.
+    /// </summary>
+    public DateTimeOffset? GeneratedAt { get; init; }
+}

--- a/src/Honua.Core/Features/Import/Services/MigrationEvidencePackJsonContext.cs
+++ b/src/Honua.Core/Features/Import/Services/MigrationEvidencePackJsonContext.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// AOT-safe JSON serialization context for the slice-4 migration evidence
+/// pack. Source-generated metadata avoids reflection-based serialization so
+/// the pack can be emitted under <c>PublishAot</c> builds without trimming
+/// warnings.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    WriteIndented = false)]
+[JsonSerializable(typeof(MigrationEvidencePackArtifact))]
+[JsonSerializable(typeof(MigrationEvidencePackBundle))]
+[JsonSerializable(typeof(MigrationEvidencePackWorkspaceScope))]
+[JsonSerializable(typeof(MigrationEvidencePackApplyIdentity))]
+[JsonSerializable(typeof(MigrationEvidencePackSummary))]
+[JsonSerializable(typeof(MigrationEvidencePackStage))]
+[JsonSerializable(typeof(MigrationEvidencePackStage[]))]
+[JsonSerializable(typeof(MigrationEvidencePackStyleDiagnostic))]
+[JsonSerializable(typeof(MigrationEvidencePackStyleDiagnostic[]))]
+[JsonSerializable(typeof(MigrationSourceInventoryArtifact))]
+[JsonSerializable(typeof(MigrationManifestArtifact))]
+[JsonSerializable(typeof(MigrationApplyExecutionArtifact))]
+[JsonSerializable(typeof(MigrationApplyExecutionStepResult))]
+[JsonSerializable(typeof(MigrationApplyExecutionStepResult[]))]
+[JsonSerializable(typeof(MigrationApplyExecutionSummary))]
+[JsonSerializable(typeof(MigrationSourceIdentity))]
+[JsonSerializable(typeof(MigrationCompatibilityAssessment))]
+[JsonSerializable(typeof(MigrationManifestReviewItem))]
+[JsonSerializable(typeof(MigrationManifestReviewItem[]))]
+public sealed partial class MigrationEvidencePackJsonContext : JsonSerializerContext
+{
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationEvidencePackBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/MigrationEvidencePackBuilderTests.cs
@@ -1,0 +1,407 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+
+namespace Honua.Core.Tests.Features.Import;
+
+/// <summary>
+/// Slice 4 of issue #1015: deterministic evidence-pack generation.
+/// </summary>
+public sealed class MigrationEvidencePackBuilderTests
+{
+    [Fact]
+    public void Build_ProducesDeterministicFingerprint_ForIdenticalInputs()
+    {
+        var inputs = BuildInputs();
+
+        var first = MigrationEvidencePackBuilder.Build(inputs, new MigrationEvidencePackBuilderOptions
+        {
+            RunId = "nightly-20260519",
+            Generator = "test/1.0",
+            GeneratedAt = DateTimeOffset.Parse("2026-05-19T00:00:00Z")
+        });
+
+        var second = MigrationEvidencePackBuilder.Build(inputs, new MigrationEvidencePackBuilderOptions
+        {
+            // Different run-time metadata; fingerprint must be unaffected.
+            RunId = "nightly-20260601",
+            Generator = "test/2.0",
+            GeneratedAt = DateTimeOffset.Parse("2026-06-01T12:34:56Z")
+        });
+
+        first.BundleFingerprint.Should().StartWith("sha256:");
+        first.BundleFingerprint.Should().Be(second.BundleFingerprint,
+            "fingerprint must cover the bundle only — wall-clock and generator labels are excluded so nightly re-runs stay byte-identical.");
+
+        first.RunId.Should().Be("nightly-20260519");
+        second.RunId.Should().Be("nightly-20260601");
+    }
+
+    [Fact]
+    public void Build_FingerprintChanges_WhenAStepResultChanges()
+    {
+        var inputs = BuildInputs();
+        var mutated = inputs with
+        {
+            ApplyExecution = inputs.ApplyExecution with
+            {
+                StepResults = inputs.ApplyExecution.StepResults
+                    .Select(step => step.StepId == "step:catalog:roads"
+                        ? step with { Outcome = "manual-review", Message = "Operator review required." }
+                        : step)
+                    .ToArray()
+            }
+        };
+
+        var baseline = MigrationEvidencePackBuilder.Build(inputs);
+        var changed = MigrationEvidencePackBuilder.Build(mutated);
+
+        baseline.BundleFingerprint.Should().NotBe(changed.BundleFingerprint,
+            "any change to the bundle inputs must propagate to the fingerprint.");
+    }
+
+    [Fact]
+    public void Build_GroupsStepResultsIntoCanonicalStages()
+    {
+        var inputs = BuildInputs();
+
+        var pack = MigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.Stages.Should().HaveCount(3);
+        pack.Bundle.Stages.Select(s => s.Id).Should().Equal(
+            MigrationEvidencePackStageIds.Catalog,
+            MigrationEvidencePackStageIds.Data,
+            MigrationEvidencePackStageIds.Style);
+
+        var catalog = pack.Bundle.Stages.Single(s => s.Id == MigrationEvidencePackStageIds.Catalog);
+        catalog.StepCount.Should().Be(2);
+        catalog.AppliedCount.Should().Be(2);
+
+        var data = pack.Bundle.Stages.Single(s => s.Id == MigrationEvidencePackStageIds.Data);
+        data.StepCount.Should().Be(1);
+        data.AlreadyAppliedCount.Should().Be(1);
+
+        var style = pack.Bundle.Stages.Single(s => s.Id == MigrationEvidencePackStageIds.Style);
+        style.StepCount.Should().Be(2);
+        style.AppliedCount.Should().Be(1);
+        style.ManualReviewCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Build_AggregatesStyleDiagnostics_FromManualReviewSteps()
+    {
+        var inputs = BuildInputs();
+
+        var pack = MigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.StyleDiagnostics.Should().HaveCount(1);
+        var diagnostic = pack.Bundle.StyleDiagnostics[0];
+        diagnostic.SourceId.Should().Be("style:ops:line");
+        diagnostic.StepOutcome.Should().Be("manual-review");
+        diagnostic.Message.Should().Contain("manual-review");
+
+        pack.Bundle.Summary.StyleManualReviewCount.Should().Be(1,
+            "slice-3 manual-review style outcomes must be surfaced so the pack does not claim visual parity for them.");
+    }
+
+    [Fact]
+    public void Build_RedactsCredentials_FromSourceUrls()
+    {
+        var inputs = BuildInputs();
+        var withSecretUrl = inputs with
+        {
+            ApplyExecution = inputs.ApplyExecution with
+            {
+                Source = inputs.ApplyExecution.Source with
+                {
+                    BaseUrl = "https://admin:hunter2@geoserver.example.com:8443/geoserver/rest?token=topsecret"
+                }
+            },
+            Inventory = inputs.Inventory with
+            {
+                Source = inputs.Inventory.Source with
+                {
+                    BaseUrl = "https://admin:hunter2@geoserver.example.com:8443/geoserver/rest?token=topsecret"
+                }
+            },
+            Manifest = inputs.Manifest with
+            {
+                Source = inputs.Manifest.Source with
+                {
+                    BaseUrl = "https://admin:hunter2@geoserver.example.com:8443/geoserver/rest?token=topsecret"
+                }
+            }
+        };
+
+        var pack = MigrationEvidencePackBuilder.Build(withSecretUrl);
+
+        pack.Bundle.Source.BaseUrl.Should().NotContain("hunter2");
+        pack.Bundle.Source.BaseUrl.Should().NotContain("admin");
+        pack.Bundle.Source.BaseUrl.Should().NotContain("topsecret");
+        pack.Bundle.Source.BaseUrl.Should().Be("https://geoserver.example.com:8443/geoserver/rest");
+
+        pack.Bundle.Inventory.Source.BaseUrl.Should().NotContain("hunter2");
+        pack.Bundle.Inventory.Source.BaseUrl.Should().NotContain("topsecret");
+        pack.Bundle.Manifest.Source.BaseUrl.Should().NotContain("hunter2");
+        pack.Bundle.Manifest.Source.BaseUrl.Should().NotContain("topsecret");
+
+        // Serialize the entire pack and assert no credential leaked anywhere.
+        var json = JsonSerializer.Serialize(pack, MigrationEvidencePackJsonContext.Default.MigrationEvidencePackArtifact);
+        json.Should().NotContain("hunter2");
+        json.Should().NotContain("topsecret");
+        // "admin" is a common substring; assert via user-info marker instead.
+        json.Should().NotContain("admin:hunter2");
+    }
+
+    [Fact]
+    public void Build_CapturesWorkspaceScope_WhenOperatorRestrictsRun()
+    {
+        var inputs = BuildInputs() with { RequestedWorkspaceNames = new[] { "ops", "ops" } };
+
+        var pack = MigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.WorkspaceScope.Restricted.Should().BeTrue();
+        pack.Bundle.WorkspaceScope.WorkspaceNames.Should().Equal("ops");
+    }
+
+    [Fact]
+    public void Build_CapturesWorkspaceScope_AsUnrestricted_WhenNoNamesProvided()
+    {
+        var inputs = BuildInputs();
+
+        var pack = MigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.WorkspaceScope.Restricted.Should().BeFalse();
+        pack.Bundle.WorkspaceScope.WorkspaceNames.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Nightly fixture emission hook (slice 4 of #1015). When the
+    /// <c>HONUA_EMIT_EVIDENCE_PACK</c> environment variable is set the
+    /// fixture-driven evidence-pack JSON is written to the path supplied via
+    /// <c>HONUA_EVIDENCE_PACK_OUTPUT</c> so the nightly workflow can upload it
+    /// as a CI artifact. The contents are deterministic — the same fixture
+    /// always produces the same fingerprint — so workflow consumers can diff
+    /// or pin the artifact across runs.
+    /// </summary>
+    [Fact]
+    public void EmitNightlyEvidencePack_WhenEnvVarSet_WritesDeterministicArtifact()
+    {
+        if (Environment.GetEnvironmentVariable("HONUA_EMIT_EVIDENCE_PACK") != "1")
+        {
+            return;
+        }
+
+        var outputPath = Environment.GetEnvironmentVariable("HONUA_EVIDENCE_PACK_OUTPUT");
+        if (string.IsNullOrWhiteSpace(outputPath))
+        {
+            outputPath = Path.Combine(AppContext.BaseDirectory, "geoserver-migration-evidence-pack.json");
+        }
+
+        var pack = MigrationEvidencePackBuilder.Build(
+            BuildInputs(),
+            new MigrationEvidencePackBuilderOptions
+            {
+                RunId = Environment.GetEnvironmentVariable("HONUA_EVIDENCE_PACK_RUN_ID") ?? "nightly-fixture",
+                Generator = "honua.migration.evidence-pack-builder/1.0",
+                GeneratedAt = DateTimeOffset.UnixEpoch
+            });
+
+        // Serialize via the source-gen context (AOT-safe) and re-format with an
+        // indented JsonDocument round-trip so the artifact stays human-
+        // readable for reviewers without losing trim safety.
+        var compactJson = JsonSerializer.Serialize(
+            pack,
+            MigrationEvidencePackJsonContext.Default.MigrationEvidencePackArtifact);
+        using var document = JsonDocument.Parse(compactJson);
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+        {
+            document.RootElement.WriteTo(writer);
+        }
+
+        var json = System.Text.Encoding.UTF8.GetString(stream.ToArray());
+
+        var directory = Path.GetDirectoryName(outputPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(outputPath, json);
+        pack.BundleFingerprint.Should().StartWith("sha256:");
+    }
+
+    [Fact]
+    public void Artifact_Shape_HasStableTopLevelFields()
+    {
+        // Schema-stability guard: surface any accidental addition/rename of
+        // the evidence-pack contract so reviewers update consumers
+        // (admin UI, SDK orchestration in slice 5).
+        var pack = MigrationEvidencePackBuilder.Build(BuildInputs());
+        var json = JsonSerializer.Serialize(
+            pack,
+            MigrationEvidencePackJsonContext.Default.MigrationEvidencePackArtifact);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        // Top-level artifact contract.
+        root.GetProperty("artifactKind").GetString().Should().Be("honua.migration.evidence-pack");
+        root.GetProperty("artifactVersion").GetString().Should().Be("1.0");
+        root.GetProperty("runId").ValueKind.Should().Be(JsonValueKind.String);
+        root.GetProperty("generator").ValueKind.Should().Be(JsonValueKind.String);
+        root.GetProperty("generatedAt").ValueKind.Should().Be(JsonValueKind.String);
+        root.GetProperty("bundleFingerprint").GetString().Should().StartWith("sha256:");
+
+        // Bundle contract: catalog/data/style stages plus inventory/manifest
+        // snapshots so downstream consumers can audit the entire run from a
+        // single artifact.
+        var bundle = root.GetProperty("bundle");
+        bundle.GetProperty("sourceKind").ValueKind.Should().Be(JsonValueKind.String);
+        bundle.GetProperty("source").ValueKind.Should().Be(JsonValueKind.Object);
+        bundle.GetProperty("workspaceScope").ValueKind.Should().Be(JsonValueKind.Object);
+        bundle.GetProperty("apply").ValueKind.Should().Be(JsonValueKind.Object);
+        bundle.GetProperty("summary").ValueKind.Should().Be(JsonValueKind.Object);
+        bundle.GetProperty("stages").ValueKind.Should().Be(JsonValueKind.Array);
+        bundle.GetProperty("styleDiagnostics").ValueKind.Should().Be(JsonValueKind.Array);
+        bundle.GetProperty("inventory").ValueKind.Should().Be(JsonValueKind.Object);
+        bundle.GetProperty("manifest").ValueKind.Should().Be(JsonValueKind.Object);
+
+        var apply = bundle.GetProperty("apply");
+        apply.GetProperty("planFingerprint").ValueKind.Should().Be(JsonValueKind.String);
+        apply.GetProperty("replayToken").ValueKind.Should().Be(JsonValueKind.String);
+        apply.GetProperty("executionMode").ValueKind.Should().Be(JsonValueKind.String);
+
+        var summary = bundle.GetProperty("summary");
+        summary.GetProperty("totalStepCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("appliedStepCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("alreadyAppliedStepCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("manualReviewStepCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("unsupportedStepCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("failedStepCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("styleManualReviewCount").ValueKind.Should().Be(JsonValueKind.Number);
+    }
+
+    private static MigrationEvidencePackInputs BuildInputs()
+    {
+        var source = new MigrationSourceIdentity
+        {
+            DisplayName = "GeoServer Sample",
+            BaseUrl = "https://geoserver.example.com/geoserver/rest",
+            Product = "GeoServer",
+            Version = "2.24.0",
+            ServiceType = "REST"
+        };
+
+        var inventory = new MigrationSourceInventoryArtifact
+        {
+            SourceKind = "geoserver-rest",
+            Source = source,
+            AuthPosture = new MigrationInventoryAuthPosture { Mode = "basic", CredentialsSupplied = true, AccessConfirmed = true },
+            ScanCompleteness = new MigrationInventoryCompleteness { Status = "complete" },
+            Summary = new MigrationInventorySummary { ContainerCount = 1, ResourceCount = 2, StyleCount = 2 },
+            OverallCompatibility = new MigrationCompatibilityAssessment
+            {
+                Level = "compatible",
+                Reason = "Source inventory is compatible with Honua migration."
+            }
+        };
+
+        var manifest = new MigrationManifestArtifact
+        {
+            SourceKind = "geoserver-rest",
+            Source = source,
+            Summary = new MigrationManifestSummary
+            {
+                SourceResourceCount = 2,
+                TargetResourceCount = 2,
+                StyleActionCount = 2
+            }
+        };
+
+        var stepResults = new[]
+        {
+            new MigrationApplyExecutionStepResult
+            {
+                StepId = "step:catalog:roads",
+                SourceId = "workspace:ops",
+                Kind = "workspace",
+                Action = "stage-catalog-service",
+                Disposition = "ready",
+                Outcome = "applied",
+                Message = "Workspace 'ops' was created in honua.migration_services."
+            },
+            new MigrationApplyExecutionStepResult
+            {
+                StepId = "step:catalog:parcels",
+                SourceId = "layer-group:ops:parcels",
+                Kind = "layer-group",
+                Action = "stage-catalog-service",
+                Disposition = "ready",
+                Outcome = "applied",
+                Message = "Layer-group catalog row created."
+            },
+            new MigrationApplyExecutionStepResult
+            {
+                StepId = "step:data:ops-pg",
+                SourceId = "datastore:ops:ops-pg",
+                Kind = "datastore",
+                Action = "stage-data-source",
+                Disposition = "ready",
+                Outcome = "already-applied",
+                Message = "Data source already present; re-apply was a no-op."
+            },
+            new MigrationApplyExecutionStepResult
+            {
+                StepId = "step:style:point",
+                SourceId = "style:ops:point",
+                Kind = "style",
+                Action = "stage-style",
+                Disposition = "ready",
+                Outcome = "applied",
+                Message = "Applied sld style 'style:ops:point' to honua.migration_styles."
+            },
+            new MigrationApplyExecutionStepResult
+            {
+                StepId = "step:style:line",
+                SourceId = "style:ops:line",
+                Kind = "style",
+                Action = "stage-style",
+                Disposition = "ready",
+                Outcome = "manual-review",
+                Message = "Persisted style 'style:ops:line' with manual-review disposition. Recorded 1 error and 0 warning conversion diagnostic(s). Do not claim visual parity until the diagnostics are resolved."
+            }
+        };
+
+        var applyExecution = new MigrationApplyExecutionArtifact
+        {
+            SourceKind = "geoserver-rest",
+            Source = source,
+            PlanFingerprint = "sha256:plan-fingerprint",
+            ReplayToken = "sha256:replay-token",
+            StartedAt = DateTimeOffset.Parse("2026-05-19T00:00:00Z"),
+            CompletedAt = DateTimeOffset.Parse("2026-05-19T00:01:00Z"),
+            Summary = new MigrationApplyExecutionSummary
+            {
+                TotalStepCount = stepResults.Length,
+                AppliedStepCount = stepResults.Count(r => r.Outcome == "applied"),
+                AlreadyAppliedStepCount = stepResults.Count(r => r.Outcome == "already-applied"),
+                ManualReviewStepCount = stepResults.Count(r => r.Outcome == "manual-review"),
+                UnsupportedStepCount = 0,
+                FailedStepCount = 0
+            },
+            StepResults = stepResults
+        };
+
+        return new MigrationEvidencePackInputs
+        {
+            Inventory = inventory,
+            Manifest = manifest,
+            ApplyExecution = applyExecution
+        };
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link

Related to #1015 — slice 4 of the GeoServer migration apply work, stacked on slice 3 (PR #1114 / `codex/issue-1015-styles`) so reviewers see only the slice 4 diff. Slice 5 (admin UI + SDK orchestration) is left for a follow-on PR per the issue's split guidance.

## Summary

Aggregate the slice 1-3 GeoServer migration artifacts (catalog inventory + manifest + per-stage apply execution + slice-3 style diagnostics) into a single deterministic **evidence pack** so reviewers — and the new nightly fixture run — can audit catalog, data, and style migration outcomes from one artifact. The pack carries a SHA-256 fingerprint over the bundle payload (run id, generator label, and wall-clock timestamps are excluded so nightly re-runs stay byte-identical) and is emitted from a fixture-driven CI workflow that uploads it as an artifact.

## Changes Made

- New `MigrationEvidencePackArtifact` + bundle records in `Honua.Core.Features.Import.Domain`. Workspace-scoping evidence, apply plan fingerprint/replay token, per-stage step results (`catalog` / `data` / `style`), and slice-3 style-conversion diagnostics are surfaced alongside the original inventory + manifest snapshots.
- New `MigrationEvidencePackBuilder` in `Honua.Core.Features.Import.Services` composes inventory + manifest + apply-execution into the bundle, groups step results into canonical stages, and **redacts userinfo / query / fragment from the source base URL** before any secret-bearing field is embedded in the pack.
- New AOT-safe `MigrationEvidencePackJsonContext` (source-generated `System.Text.Json` context) so the pack can be emitted under trim/AOT builds.
- New `.github/workflows/nightly-migration-evidence.yml` drives the existing slice 1-3 fixture-based GeoServer apply tests (workspace + data + style) and then invokes the slice-4 emission hook to write the evidence pack JSON to `artifacts/migration-evidence/` for upload as a CI artifact. Job summary includes per-stage counts and the style-manual-review count so reviewers can see at a glance which outcomes block visual-parity claims.
- New `MigrationEvidencePackBuilderTests` cover: deterministic fingerprint output across identical inputs (and stability under run-id / generator / timestamp changes), fingerprint sensitivity to step-result mutations, canonical stage grouping, style-diagnostic aggregation from slice-3 manual-review outcomes, credential redaction in embedded inventory / manifest / source URLs, workspace-scope capture (restricted + unrestricted), a schema-stability guard on the top-level shape, and a CI-gated nightly emission hook.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact

- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes

None — the evidence pack is a brand-new artifact; no existing artifact contract changes.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review