### PR TITLE
feat: register centroid/length/convex-hull executors (#1031 slice 4/N)

### DIFF
--- a/src/Honua.Server/Features/Geoprocessing/BuiltInProcessCatalog.cs
+++ b/src/Honua.Server/Features/Geoprocessing/BuiltInProcessCatalog.cs
@@ -43,7 +43,7 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
     private static ProcessDefinition[] BuildDefinitions() =>
     [
         // -----------------------------------------------------------------------
-        // Geometry operations (10)
+        // Geometry operations (12)
         // -----------------------------------------------------------------------
         new ProcessDefinition
         {
@@ -181,6 +181,32 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
                 Param("srid", "Spatial Reference", "SRID of the input geometry.", ProcessParameterValueType.Srid, required: true),
             ],
             OutputArtifactKinds = [ArtifactKind.Scalar]
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "geometry.centroid",
+            Title = "Centroid",
+            Description = "Computes the centroid point of the input geometry. For collections the centroid is computed over all member vertices.",
+            Category = "geometry",
+            Parameters =
+            [
+                Param("wkb", "Input Geometry", "Geometry as base64-encoded WKB.", ProcessParameterValueType.Wkb, required: true),
+                Param("srid", "Spatial Reference", "SRID of the input geometry.", ProcessParameterValueType.Srid, required: true),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer]
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "geometry.convex-hull",
+            Title = "Convex Hull",
+            Description = "Computes the convex hull of the input geometry. For collections the hull is computed over all member vertices, matching PostGIS ST_ConvexHull semantics.",
+            Category = "geometry",
+            Parameters =
+            [
+                Param("wkb", "Input Geometry", "Geometry as base64-encoded WKB.", ProcessParameterValueType.Wkb, required: true),
+                Param("srid", "Spatial Reference", "SRID of the input geometry.", ProcessParameterValueType.Srid, required: true),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer]
         },
 
         // -----------------------------------------------------------------------

--- a/src/Honua.Server/Features/Geoprocessing/Execution/GeometryCentroidJobExecutor.cs
+++ b/src/Honua.Server/Features/Geoprocessing/Execution/GeometryCentroidJobExecutor.cs
@@ -1,0 +1,212 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace Honua.Server.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Production <see cref="IJobExecutor"/> for the <c>geometry.centroid</c>
+/// process. Slice 4 of #1031 — extends the buffer / clip / intersect /
+/// project / area / union set with a per-feature centroid output.
+///
+/// Computes the centroid of the supplied geometry using NetTopologySuite's
+/// <see cref="Geometry.Centroid"/> primitive — a deterministic, robust
+/// centroid that handles point / line / polygon inputs uniformly — and
+/// publishes the result as a single GeoJSON Point Feature on the
+/// <c>outputFeatureLayer</c> slot. The output is always a point regardless
+/// of the input geometry type, matching the long-standing GeoServices and
+/// PostGIS <c>ST_Centroid</c> semantics.
+/// </summary>
+internal sealed partial class GeometryCentroidJobExecutor : IJobExecutor
+{
+    /// <summary>
+    /// The single process id this executor handles. Matches the catalog
+    /// entry in <see cref="BuiltInProcessCatalog"/>.
+    /// </summary>
+    internal const string HandledProcessId = "geometry.centroid";
+
+    private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options;
+    private readonly ILogger<GeometryCentroidJobExecutor> _logger;
+
+    public GeometryCentroidJobExecutor(
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<GeometryCentroidJobExecutor> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GeoprocessingDispatchHelper.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(_logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the geometry.centroid executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing centroid inputs", cancellationToken).ConfigureAwait(false);
+
+        if (!TryReadInputs(parameters, out var inputs, out var inputError))
+        {
+            Log.InvalidInputs(_logger, job.OperationId, inputError);
+            return JobExecutionResult.Failed($"Invalid centroid inputs: {inputError}");
+        }
+
+        Geometry geometry;
+        try
+        {
+            var reader = new WKBReader { HandleSRID = true };
+            geometry = reader.Read(inputs.WkbBytes);
+        }
+        catch (Exception ex) when (ex is ParseException or ArgumentException or IndexOutOfRangeException)
+        {
+            Log.InvalidWkb(_logger, job.OperationId, ex.Message);
+            return JobExecutionResult.Failed("Invalid centroid inputs: WKB payload could not be decoded.");
+        }
+
+        if (geometry == null || geometry.IsEmpty)
+        {
+            return JobExecutionResult.Failed("Invalid centroid inputs: geometry is empty.");
+        }
+
+        geometry.SRID = inputs.Srid;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(50, "Computing centroid", cancellationToken).ConfigureAwait(false);
+
+        Geometry centroid;
+        try
+        {
+            centroid = geometry.Centroid;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.CentroidComputationFailed(_logger, job.OperationId, ex);
+            return JobExecutionResult.Failed($"Centroid computation failed: {ex.GetType().Name}.");
+        }
+
+        if (centroid == null || centroid.IsEmpty)
+        {
+            return JobExecutionResult.Failed(
+                "Centroid computation produced an empty geometry; verify the input geometry.");
+        }
+
+        centroid.SRID = inputs.Srid;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(75, "Encoding centroid artifact", cancellationToken).ConfigureAwait(false);
+
+        var payload = GeometryFeatureWriter.WriteFeature(
+            centroid,
+            HandledProcessId,
+            new[]
+            {
+                ("inputSrid", (object)inputs.Srid),
+                ("inputGeometryType", (object)geometry.GeometryType),
+            });
+
+        var maxBytes = _options.CurrentValue.MaxArtifactBytes;
+        if (payload.Length > maxBytes)
+        {
+            Log.ArtifactTooLarge(_logger, job.OperationId, payload.Length, maxBytes);
+            return JobExecutionResult.Failed(
+                $"Centroid artifact size {payload.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}.");
+        }
+
+        var artifactUri = GeometryFeatureWriter.BuildDataUri(payload);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+        await context.ReportProgressAsync(100, "Centroid completed", cancellationToken).ConfigureAwait(false);
+
+        return JobExecutionResult.Succeeded();
+    }
+
+    private static bool TryReadInputs(
+        IReadOnlyDictionary<string, string> parameters,
+        out CentroidInputs inputs,
+        out string error)
+    {
+        inputs = default;
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+
+        if (!parameters.TryGetValue(prefix + "wkb", out var wkb) || string.IsNullOrWhiteSpace(wkb))
+        {
+            error = "missing required input 'wkb'";
+            return false;
+        }
+
+        if (!parameters.TryGetValue(prefix + "srid", out var sridRaw)
+            || !int.TryParse(sridRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var srid)
+            || srid <= 0)
+        {
+            error = "missing or invalid input 'srid'; expected a positive integer";
+            return false;
+        }
+
+        byte[] wkbBytes;
+        try
+        {
+            wkbBytes = Convert.FromBase64String(wkb);
+        }
+        catch (FormatException)
+        {
+            error = "input 'wkb' is not valid base64";
+            return false;
+        }
+
+        if (wkbBytes.Length == 0)
+        {
+            error = "input 'wkb' decoded to zero bytes";
+            return false;
+        }
+
+        inputs = new CentroidInputs(wkbBytes, srid);
+        error = "";
+        return true;
+    }
+
+    private readonly record struct CentroidInputs(byte[] WkbBytes, int Srid);
+
+    private static partial class Log
+    {
+        [LoggerMessage(9150, LogLevel.Warning,
+            "Geometry centroid executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9151, LogLevel.Warning,
+            "Geometry centroid executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9152, LogLevel.Warning,
+            "Geometry centroid executor rejected job {OperationId}: WKB decode failed: {Reason}")]
+        public static partial void InvalidWkb(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9153, LogLevel.Error,
+            "Geometry centroid executor failed job {OperationId} during centroid computation")]
+        public static partial void CentroidComputationFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9154, LogLevel.Warning,
+            "Geometry centroid executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+    }
+}

--- a/src/Honua.Server/Features/Geoprocessing/Execution/GeometryConvexHullJobExecutor.cs
+++ b/src/Honua.Server/Features/Geoprocessing/Execution/GeometryConvexHullJobExecutor.cs
@@ -1,0 +1,218 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace Honua.Server.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Production <see cref="IJobExecutor"/> for the <c>geometry.convex-hull</c>
+/// process. Slice 4 of #1031 — completes the per-feature geometry-output
+/// trio alongside <see cref="GeometryCentroidJobExecutor"/> and
+/// <see cref="GeometryLengthJobExecutor"/>.
+///
+/// Computes the convex hull of the supplied geometry using
+/// <see cref="Geometry.ConvexHull"/> — NetTopologySuite's Graham-scan based
+/// implementation — and publishes the result as a single GeoJSON Feature on
+/// the <c>outputFeatureLayer</c> slot. For a single point the hull is the
+/// point; for two distinct points it is the connecting line; for three or
+/// more non-collinear points it is the bounding polygon. Geometry
+/// collections / multi-geometries are accepted: NTS treats the hull as the
+/// hull over all member vertices, which is the canonical "hull of the
+/// union" behavior used by PostGIS <c>ST_ConvexHull</c>.
+/// </summary>
+internal sealed partial class GeometryConvexHullJobExecutor : IJobExecutor
+{
+    /// <summary>
+    /// The single process id this executor handles. Matches the catalog
+    /// entry in <see cref="BuiltInProcessCatalog"/>.
+    /// </summary>
+    internal const string HandledProcessId = "geometry.convex-hull";
+
+    private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options;
+    private readonly ILogger<GeometryConvexHullJobExecutor> _logger;
+
+    public GeometryConvexHullJobExecutor(
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<GeometryConvexHullJobExecutor> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GeoprocessingDispatchHelper.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(_logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the geometry.convex-hull executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing convex-hull inputs", cancellationToken).ConfigureAwait(false);
+
+        if (!TryReadInputs(parameters, out var inputs, out var inputError))
+        {
+            Log.InvalidInputs(_logger, job.OperationId, inputError);
+            return JobExecutionResult.Failed($"Invalid convex-hull inputs: {inputError}");
+        }
+
+        Geometry geometry;
+        try
+        {
+            var reader = new WKBReader { HandleSRID = true };
+            geometry = reader.Read(inputs.WkbBytes);
+        }
+        catch (Exception ex) when (ex is ParseException or ArgumentException or IndexOutOfRangeException)
+        {
+            Log.InvalidWkb(_logger, job.OperationId, ex.Message);
+            return JobExecutionResult.Failed("Invalid convex-hull inputs: WKB payload could not be decoded.");
+        }
+
+        if (geometry == null || geometry.IsEmpty)
+        {
+            return JobExecutionResult.Failed("Invalid convex-hull inputs: geometry is empty.");
+        }
+
+        geometry.SRID = inputs.Srid;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(50, "Computing convex hull", cancellationToken).ConfigureAwait(false);
+
+        Geometry hull;
+        try
+        {
+            // NTS ConvexHull handles all geometry types uniformly: for
+            // collections / multi-geometries it produces the hull over all
+            // member vertices, matching PostGIS ST_ConvexHull semantics.
+            hull = geometry.ConvexHull();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.HullComputationFailed(_logger, job.OperationId, ex);
+            return JobExecutionResult.Failed($"Convex-hull computation failed: {ex.GetType().Name}.");
+        }
+
+        if (hull == null || hull.IsEmpty)
+        {
+            return JobExecutionResult.Failed(
+                "Convex-hull computation produced an empty geometry; verify the input geometry.");
+        }
+
+        hull.SRID = inputs.Srid;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(75, "Encoding convex-hull artifact", cancellationToken).ConfigureAwait(false);
+
+        var payload = GeometryFeatureWriter.WriteFeature(
+            hull,
+            HandledProcessId,
+            new[]
+            {
+                ("inputSrid", (object)inputs.Srid),
+                ("inputGeometryType", (object)geometry.GeometryType),
+            });
+
+        var maxBytes = _options.CurrentValue.MaxArtifactBytes;
+        if (payload.Length > maxBytes)
+        {
+            Log.ArtifactTooLarge(_logger, job.OperationId, payload.Length, maxBytes);
+            return JobExecutionResult.Failed(
+                $"Convex-hull artifact size {payload.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}.");
+        }
+
+        var artifactUri = GeometryFeatureWriter.BuildDataUri(payload);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+        await context.ReportProgressAsync(100, "Convex-hull completed", cancellationToken).ConfigureAwait(false);
+
+        return JobExecutionResult.Succeeded();
+    }
+
+    private static bool TryReadInputs(
+        IReadOnlyDictionary<string, string> parameters,
+        out HullInputs inputs,
+        out string error)
+    {
+        inputs = default;
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+
+        if (!parameters.TryGetValue(prefix + "wkb", out var wkb) || string.IsNullOrWhiteSpace(wkb))
+        {
+            error = "missing required input 'wkb'";
+            return false;
+        }
+
+        if (!parameters.TryGetValue(prefix + "srid", out var sridRaw)
+            || !int.TryParse(sridRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var srid)
+            || srid <= 0)
+        {
+            error = "missing or invalid input 'srid'; expected a positive integer";
+            return false;
+        }
+
+        byte[] wkbBytes;
+        try
+        {
+            wkbBytes = Convert.FromBase64String(wkb);
+        }
+        catch (FormatException)
+        {
+            error = "input 'wkb' is not valid base64";
+            return false;
+        }
+
+        if (wkbBytes.Length == 0)
+        {
+            error = "input 'wkb' decoded to zero bytes";
+            return false;
+        }
+
+        inputs = new HullInputs(wkbBytes, srid);
+        error = "";
+        return true;
+    }
+
+    private readonly record struct HullInputs(byte[] WkbBytes, int Srid);
+
+    private static partial class Log
+    {
+        [LoggerMessage(9170, LogLevel.Warning,
+            "Geometry convex-hull executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9171, LogLevel.Warning,
+            "Geometry convex-hull executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9172, LogLevel.Warning,
+            "Geometry convex-hull executor rejected job {OperationId}: WKB decode failed: {Reason}")]
+        public static partial void InvalidWkb(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9173, LogLevel.Error,
+            "Geometry convex-hull executor failed job {OperationId} during hull computation")]
+        public static partial void HullComputationFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9174, LogLevel.Warning,
+            "Geometry convex-hull executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+    }
+}

--- a/src/Honua.Server/Features/Geoprocessing/Execution/GeometryLengthJobExecutor.cs
+++ b/src/Honua.Server/Features/Geoprocessing/Execution/GeometryLengthJobExecutor.cs
@@ -1,0 +1,237 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace Honua.Server.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Production <see cref="IJobExecutor"/> for the <c>geometry.length</c>
+/// process. Slice 4 of #1031 — companion to <see cref="GeometryAreaJobExecutor"/>
+/// for one-dimensional measure outputs.
+///
+/// Computes the planar (Cartesian) length of the supplied geometry in
+/// input-CRS units and publishes a single canonical <c>MeasureResult</c>
+/// document on the <c>outputScalar</c> slot. Geodesic length (meters on the
+/// WGS 84 ellipsoid) is catalog-documented but deferred to the geodesic
+/// measure slice, mirroring how <see cref="GeometryAreaJobExecutor"/>
+/// rejects geodesic until that follow-on lands. Returns the
+/// <see cref="Geometry.Length"/> for line geometries; for polygons NTS
+/// returns the perimeter, which is consistent with the catalog description.
+/// </summary>
+internal sealed partial class GeometryLengthJobExecutor : IJobExecutor
+{
+    /// <summary>
+    /// The single process id this executor handles. Matches the catalog
+    /// entry in <see cref="BuiltInProcessCatalog"/>.
+    /// </summary>
+    internal const string HandledProcessId = "geometry.length";
+
+    private const string ScalarDataUriPrefix = "data:application/json;base64,";
+
+    private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options;
+    private readonly ILogger<GeometryLengthJobExecutor> _logger;
+
+    public GeometryLengthJobExecutor(
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<GeometryLengthJobExecutor> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GeoprocessingDispatchHelper.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(_logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the geometry.length executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing length inputs", cancellationToken).ConfigureAwait(false);
+
+        if (!TryReadInputs(parameters, out var inputs, out var inputError))
+        {
+            Log.InvalidInputs(_logger, job.OperationId, inputError);
+            return JobExecutionResult.Failed($"Invalid length inputs: {inputError}");
+        }
+
+        Geometry geometry;
+        try
+        {
+            var reader = new WKBReader { HandleSRID = true };
+            geometry = reader.Read(inputs.WkbBytes);
+        }
+        catch (Exception ex) when (ex is ParseException or ArgumentException or IndexOutOfRangeException)
+        {
+            Log.InvalidWkb(_logger, job.OperationId, ex.Message);
+            return JobExecutionResult.Failed("Invalid length inputs: WKB payload could not be decoded.");
+        }
+
+        if (geometry == null || geometry.IsEmpty)
+        {
+            return JobExecutionResult.Failed("Invalid length inputs: geometry is empty.");
+        }
+
+        geometry.SRID = inputs.Srid;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(50, "Computing length", cancellationToken).ConfigureAwait(false);
+
+        double length;
+        try
+        {
+            // First-slice executor computes planar length in input-CRS units.
+            // Geodesic length is documented in the catalog but deferred to
+            // the geodesic measure slice, matching geometry.area's policy.
+            length = geometry.Length;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.LengthComputationFailed(_logger, job.OperationId, ex);
+            return JobExecutionResult.Failed($"Length computation failed: {ex.GetType().Name}.");
+        }
+
+        if (double.IsNaN(length) || double.IsInfinity(length))
+        {
+            return JobExecutionResult.Failed(
+                "Length computation produced a non-finite value; verify the input geometry coordinates.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(75, "Encoding length artifact", cancellationToken).ConfigureAwait(false);
+
+        var payload = BuildMeasurePayload(length, geometry, inputs);
+        var maxBytes = _options.CurrentValue.MaxArtifactBytes;
+        if (payload.Length > maxBytes)
+        {
+            Log.ArtifactTooLarge(_logger, job.OperationId, payload.Length, maxBytes);
+            return JobExecutionResult.Failed(
+                $"Length artifact size {payload.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}.");
+        }
+
+        var artifactUri = BuildDataUri(payload);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+        await context.ReportProgressAsync(100, "Length completed", cancellationToken).ConfigureAwait(false);
+
+        return JobExecutionResult.Succeeded();
+    }
+
+    private static bool TryReadInputs(
+        IReadOnlyDictionary<string, string> parameters,
+        out LengthInputs inputs,
+        out string error)
+    {
+        inputs = default;
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+
+        if (!parameters.TryGetValue(prefix + "wkb", out var wkb) || string.IsNullOrWhiteSpace(wkb))
+        {
+            error = "missing required input 'wkb'";
+            return false;
+        }
+
+        if (!parameters.TryGetValue(prefix + "srid", out var sridRaw)
+            || !int.TryParse(sridRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var srid)
+            || srid <= 0)
+        {
+            error = "missing or invalid input 'srid'; expected a positive integer";
+            return false;
+        }
+
+        byte[] wkbBytes;
+        try
+        {
+            wkbBytes = Convert.FromBase64String(wkb);
+        }
+        catch (FormatException)
+        {
+            error = "input 'wkb' is not valid base64";
+            return false;
+        }
+
+        if (wkbBytes.Length == 0)
+        {
+            error = "input 'wkb' decoded to zero bytes";
+            return false;
+        }
+
+        inputs = new LengthInputs(wkbBytes, srid);
+        error = "";
+        return true;
+    }
+
+    private static byte[] BuildMeasurePayload(double length, Geometry geometry, LengthInputs inputs)
+    {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "MeasureResult");
+            writer.WriteString("processId", HandledProcessId);
+            writer.WriteString("measure", "length");
+            writer.WriteNumber("value", length);
+            writer.WriteString("unit", "input-crs-units");
+            writer.WriteNumber("inputSrid", inputs.Srid);
+            writer.WriteString("inputGeometryType", geometry.GeometryType);
+            writer.WriteEndObject();
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static string BuildDataUri(byte[] payload)
+    {
+        var sb = new StringBuilder(payload.Length * 2 + ScalarDataUriPrefix.Length);
+        sb.Append(ScalarDataUriPrefix);
+        sb.Append(Convert.ToBase64String(payload));
+        return sb.ToString();
+    }
+
+    private readonly record struct LengthInputs(byte[] WkbBytes, int Srid);
+
+    private static partial class Log
+    {
+        [LoggerMessage(9160, LogLevel.Warning,
+            "Geometry length executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9161, LogLevel.Warning,
+            "Geometry length executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9162, LogLevel.Warning,
+            "Geometry length executor rejected job {OperationId}: WKB decode failed: {Reason}")]
+        public static partial void InvalidWkb(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9163, LogLevel.Error,
+            "Geometry length executor failed job {OperationId} during length computation")]
+        public static partial void LengthComputationFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9164, LogLevel.Warning,
+            "Geometry length executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+    }
+}

--- a/src/Honua.Server/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
+++ b/src/Honua.Server/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
@@ -17,11 +17,13 @@ namespace Honua.Server.Features.Geoprocessing.Execution;
 /// Slice 1 (#1031) introduced <see cref="GeometryBufferJobExecutor"/> as the
 /// only registered executor; submitting any other process id surfaced the
 /// "first-slice geoprocessing runtime" error from inside that class. Slice 2
-/// adds <c>geometry.clip</c>, <c>geometry.intersect</c>, and
+/// added <c>geometry.clip</c>, <c>geometry.intersect</c>, and
 /// <c>geometry.project</c> as additional per-process executors. Slice 3
-/// adds <c>geometry.area</c> (per-feature measure) and <c>geometry.union</c>
-/// (collection aggregation) — completing the measure + aggregate shapes
-/// before later slices tackle the heavyweight raster / surface ops. This
+/// added <c>geometry.area</c> (per-feature measure) and <c>geometry.union</c>
+/// (collection aggregation). Slice 4 adds <c>geometry.centroid</c>,
+/// <c>geometry.length</c>, and <c>geometry.convex-hull</c> — finishing the
+/// deterministic single-feature vector set before later slices tackle
+/// simplify/dissolve and the heavyweight raster / surface ops. This
 /// dispatcher routes between them and emits a single, consistent
 /// "unsupported process id" error for everything outside the current
 /// supported set.
@@ -38,6 +40,9 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
         GeometryProjectJobExecutor project,
         GeometryAreaJobExecutor area,
         GeometryUnionJobExecutor union,
+        GeometryCentroidJobExecutor centroid,
+        GeometryLengthJobExecutor length,
+        GeometryConvexHullJobExecutor convexHull,
         ILogger<GeoprocessingDispatchJobExecutor> logger)
     {
         ArgumentNullException.ThrowIfNull(buffer);
@@ -46,6 +51,9 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
         ArgumentNullException.ThrowIfNull(project);
         ArgumentNullException.ThrowIfNull(area);
         ArgumentNullException.ThrowIfNull(union);
+        ArgumentNullException.ThrowIfNull(centroid);
+        ArgumentNullException.ThrowIfNull(length);
+        ArgumentNullException.ThrowIfNull(convexHull);
         ArgumentNullException.ThrowIfNull(logger);
 
         _handlers = new Dictionary<string, IJobExecutor>(StringComparer.Ordinal)
@@ -56,6 +64,9 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
             [GeometryProjectJobExecutor.HandledProcessId] = project,
             [GeometryAreaJobExecutor.HandledProcessId] = area,
             [GeometryUnionJobExecutor.HandledProcessId] = union,
+            [GeometryCentroidJobExecutor.HandledProcessId] = centroid,
+            [GeometryLengthJobExecutor.HandledProcessId] = length,
+            [GeometryConvexHullJobExecutor.HandledProcessId] = convexHull,
         }.ToFrozenDictionary(StringComparer.Ordinal);
 
         _logger = logger;

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -94,10 +94,13 @@ internal static class GeoprocessingServiceCollectionExtensions
 
         // Built-in production executors (ticket #1031). Slice 1 introduced the
         // first concrete executor (geometry.buffer); slice 2 added geometry.clip,
-        // geometry.intersect, and geometry.project; slice 3 adds geometry.area
-        // (per-feature measure) and geometry.union (collection aggregation).
-        // The worker host keys executors by ExecutionJobKind, so the
-        // per-process executors are composed behind
+        // geometry.intersect, and geometry.project; slice 3 added geometry.area
+        // (per-feature measure) and geometry.union (collection aggregation);
+        // slice 4 adds geometry.centroid, geometry.length, and
+        // geometry.convex-hull — rounding out the deterministic single-feature
+        // vector set before later slices tackle simplify/dissolve and the
+        // heavyweight raster family. The worker host keys executors by
+        // ExecutionJobKind, so the per-process executors are composed behind
         // GeoprocessingDispatchJobExecutor — the single IJobExecutor registered
         // for ExecutionJobKind.Geoprocessing — which routes claimed jobs to
         // the matching handler.
@@ -107,6 +110,9 @@ internal static class GeoprocessingServiceCollectionExtensions
         services.TryAddSingleton<GeometryProjectJobExecutor>();
         services.TryAddSingleton<GeometryAreaJobExecutor>();
         services.TryAddSingleton<GeometryUnionJobExecutor>();
+        services.TryAddSingleton<GeometryCentroidJobExecutor>();
+        services.TryAddSingleton<GeometryLengthJobExecutor>();
+        services.TryAddSingleton<GeometryConvexHullJobExecutor>();
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IJobExecutor, GeoprocessingDispatchJobExecutor>());
 

--- a/src/Honua.Server/Features/Geoprocessing/ProcessMigrationEvidenceClassifier.cs
+++ b/src/Honua.Server/Features/Geoprocessing/ProcessMigrationEvidenceClassifier.cs
@@ -24,6 +24,8 @@ internal static class ProcessMigrationEvidenceClassifier
             "geometry.difference",
             "geometry.area",
             "geometry.length",
+            "geometry.centroid",
+            "geometry.convex-hull",
             "analytics.buffer-aggregate",
             "analytics.spatial-join",
             "analytics.density",

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeometryCentroidJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeometryCentroidJobExecutorTests.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Geoprocessing;
+using Honua.Server.Features.Geoprocessing.Execution;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Unit coverage of the slice-4 <c>geometry.centroid</c> executor. Pins the
+/// same failure surfaces slice 1/2/3 introduced (unsupported process id,
+/// malformed inputs, oversized artifact guardrail) plus the happy-path
+/// GeoJSON Point Feature shape produced over a polygon input.
+/// </summary>
+public sealed class GeometryCentroidJobExecutorTests
+{
+    private const string FeatureDataUriPrefix = "data:application/geo+json;base64,";
+
+    [UnitTest]
+    public async Task ExecuteAsync_UnsupportedProcessId_FailsWithClassifiedMessage()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-test");
+
+        var record = CreateJobRecord(processId: "geometry.buffer", includeInputs: false);
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("geometry.centroid");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_HappyPath_PublishesCentroidPointFeature()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-centroid");
+
+        string? publishedUri = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedUri = call.ArgAt<string>(0));
+
+        // Centroid of a 10x10 box anchored at (0,0) is the geometric center (5,5).
+        var box = WkbBase64(BuildBoxPolygon(0, 0, 10, 10));
+        var record = CreateJobRecord(
+            processId: GeometryCentroidJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: box);
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        publishedUri.Should().NotBeNull();
+        publishedUri!.Should().StartWith(FeatureDataUriPrefix);
+
+        var bytes = Convert.FromBase64String(publishedUri[FeatureDataUriPrefix.Length..]);
+        using var doc = JsonDocument.Parse(bytes);
+        doc.RootElement.GetProperty("type").GetString().Should().Be("Feature");
+        var properties = doc.RootElement.GetProperty("properties");
+        properties.GetProperty("processId").GetString().Should().Be("geometry.centroid");
+        properties.GetProperty("inputSrid").GetInt32().Should().Be(4326);
+        properties.GetProperty("inputGeometryType").GetString().Should().Be("Polygon");
+
+        var geometry = new GeoJsonReader().Read<Geometry>(
+            doc.RootElement.GetProperty("geometry").GetRawText());
+        geometry.Should().BeOfType<Point>();
+        var point = (Point)geometry;
+        point.X.Should().BeApproximately(5.0, 1e-9);
+        point.Y.Should().BeApproximately(5.0, 1e-9);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_MissingWkb_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-missing");
+
+        var record = CreateJobRecord(
+            processId: GeometryCentroidJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: null);
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("'wkb'");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_InvalidSrid_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-srid");
+
+        var record = CreateJobRecord(
+            processId: GeometryCentroidJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(BuildBoxPolygon(0, 0, 10, 10)),
+            srid: "not-an-int");
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("'srid'");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_PayloadExceedsMaxArtifactBytes_FailsWithGuardrail()
+    {
+        var executor = CreateExecutor(maxArtifactBytes: 8);
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-too-big");
+
+        var record = CreateJobRecord(
+            processId: GeometryCentroidJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(BuildBoxPolygon(0, 0, 10, 10)));
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("MaxArtifactBytes");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static GeometryCentroidJobExecutor CreateExecutor(long maxArtifactBytes = 50L * 1024L * 1024L)
+    {
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = maxArtifactBytes,
+            ResultRetention = TimeSpan.FromDays(7)
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+        return new GeometryCentroidJobExecutor(monitor, NullLogger<GeometryCentroidJobExecutor>.Instance);
+    }
+
+    private static Polygon BuildBoxPolygon(double minX, double minY, double maxX, double maxY)
+    {
+        var factory = NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory();
+        return factory.CreatePolygon(new[]
+        {
+            new Coordinate(minX, minY),
+            new Coordinate(maxX, minY),
+            new Coordinate(maxX, maxY),
+            new Coordinate(minX, maxY),
+            new Coordinate(minX, minY),
+        });
+    }
+
+    private static string WkbBase64(Geometry geometry)
+        => Convert.ToBase64String(new WKBWriter().Write(geometry));
+
+    private static ExecutionJobRecord CreateJobRecord(
+        string? processId,
+        bool includeInputs,
+        string? wkb = null,
+        string? srid = "4326")
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (!string.IsNullOrEmpty(processId))
+        {
+            parameters[ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId;
+            parameters["protocolProcessId"] = processId;
+        }
+
+        if (includeInputs)
+        {
+            var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+            if (wkb != null)
+            {
+                parameters[prefix + "wkb"] = wkb;
+            }
+            parameters[prefix + "srid"] = srid ?? "4326";
+        }
+
+        return new ExecutionJobRecord
+        {
+            OperationId = "op-test",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:test",
+                Parameters = parameters
+            }
+        };
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeometryConvexHullJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeometryConvexHullJobExecutorTests.cs
@@ -1,0 +1,218 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Geoprocessing;
+using Honua.Server.Features.Geoprocessing.Execution;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Unit coverage of the slice-4 <c>geometry.convex-hull</c> executor. Pins
+/// the same failure surfaces as the earlier vector executors plus the
+/// happy-path GeoJSON Polygon Feature shape produced over a MultiPoint
+/// collection: the hull of five points (four corners of a 10x10 box plus
+/// the centroid) is the 10x10 box itself, area 100.
+/// </summary>
+public sealed class GeometryConvexHullJobExecutorTests
+{
+    private const string FeatureDataUriPrefix = "data:application/geo+json;base64,";
+
+    [UnitTest]
+    public async Task ExecuteAsync_UnsupportedProcessId_FailsWithClassifiedMessage()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-test");
+
+        var record = CreateJobRecord(processId: "geometry.buffer", includeInputs: false);
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("geometry.convex-hull");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_HappyPath_PublishesHullPolygonFeature()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-hull");
+
+        string? publishedUri = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedUri = call.ArgAt<string>(0));
+
+        // MultiPoint with four corners of a 10x10 box plus the centroid (5,5).
+        // Convex hull is the bounding 10x10 box itself with area 100 — the
+        // interior point does not extend the hull.
+        var multipoint = WkbBase64(BuildMultiPoint(
+            new Coordinate(0, 0),
+            new Coordinate(10, 0),
+            new Coordinate(10, 10),
+            new Coordinate(0, 10),
+            new Coordinate(5, 5)));
+        var record = CreateJobRecord(
+            processId: GeometryConvexHullJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: multipoint);
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        publishedUri.Should().NotBeNull();
+        publishedUri!.Should().StartWith(FeatureDataUriPrefix);
+
+        var bytes = Convert.FromBase64String(publishedUri[FeatureDataUriPrefix.Length..]);
+        using var doc = JsonDocument.Parse(bytes);
+        doc.RootElement.GetProperty("type").GetString().Should().Be("Feature");
+        var properties = doc.RootElement.GetProperty("properties");
+        properties.GetProperty("processId").GetString().Should().Be("geometry.convex-hull");
+        properties.GetProperty("inputSrid").GetInt32().Should().Be(4326);
+        properties.GetProperty("inputGeometryType").GetString().Should().Be("MultiPoint");
+
+        var geometry = new GeoJsonReader().Read<Geometry>(
+            doc.RootElement.GetProperty("geometry").GetRawText());
+        geometry.Area.Should().BeApproximately(100.0, 1e-6,
+            "hull of the four corners of a 10x10 box + centroid is the 10x10 box itself");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_MissingWkb_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-missing");
+
+        var record = CreateJobRecord(
+            processId: GeometryConvexHullJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: null);
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("'wkb'");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_InvalidSrid_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-srid");
+
+        var record = CreateJobRecord(
+            processId: GeometryConvexHullJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(BuildMultiPoint(new Coordinate(0, 0), new Coordinate(1, 1))),
+            srid: "not-an-int");
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("'srid'");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_PayloadExceedsMaxArtifactBytes_FailsWithGuardrail()
+    {
+        var executor = CreateExecutor(maxArtifactBytes: 8);
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-too-big");
+
+        var record = CreateJobRecord(
+            processId: GeometryConvexHullJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(BuildMultiPoint(
+                new Coordinate(0, 0),
+                new Coordinate(10, 0),
+                new Coordinate(10, 10),
+                new Coordinate(0, 10))));
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("MaxArtifactBytes");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static GeometryConvexHullJobExecutor CreateExecutor(long maxArtifactBytes = 50L * 1024L * 1024L)
+    {
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = maxArtifactBytes,
+            ResultRetention = TimeSpan.FromDays(7)
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+        return new GeometryConvexHullJobExecutor(monitor, NullLogger<GeometryConvexHullJobExecutor>.Instance);
+    }
+
+    private static MultiPoint BuildMultiPoint(params Coordinate[] coordinates)
+    {
+        var factory = NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory();
+        var points = coordinates.Select(c => factory.CreatePoint(c)).ToArray();
+        return factory.CreateMultiPoint(points);
+    }
+
+    private static string WkbBase64(Geometry geometry)
+        => Convert.ToBase64String(new WKBWriter().Write(geometry));
+
+    private static ExecutionJobRecord CreateJobRecord(
+        string? processId,
+        bool includeInputs,
+        string? wkb = null,
+        string? srid = "4326")
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (!string.IsNullOrEmpty(processId))
+        {
+            parameters[ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId;
+            parameters["protocolProcessId"] = processId;
+        }
+
+        if (includeInputs)
+        {
+            var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+            if (wkb != null)
+            {
+                parameters[prefix + "wkb"] = wkb;
+            }
+            parameters[prefix + "srid"] = srid ?? "4326";
+        }
+
+        return new ExecutionJobRecord
+        {
+            OperationId = "op-test",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:test",
+                Parameters = parameters
+            }
+        };
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeometryLengthJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeometryLengthJobExecutorTests.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Geoprocessing;
+using Honua.Server.Features.Geoprocessing.Execution;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Unit coverage of the slice-4 <c>geometry.length</c> executor. Pins the
+/// same failure surfaces as the slice-3 area executor (unsupported process
+/// id, malformed inputs, oversized artifact guardrail) plus the happy-path
+/// scalar measure payload shape for a deterministic 3-4-5 right-triangle
+/// linestring with total length 7.
+/// </summary>
+public sealed class GeometryLengthJobExecutorTests
+{
+    private const string ScalarDataUriPrefix = "data:application/json;base64,";
+
+    [UnitTest]
+    public async Task ExecuteAsync_UnsupportedProcessId_FailsWithClassifiedMessage()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-test");
+
+        var record = CreateJobRecord(processId: "geometry.buffer", includeInputs: false);
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("geometry.length");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_HappyPath_PublishesMeasureResult()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-length");
+
+        string? publishedUri = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedUri = call.ArgAt<string>(0));
+
+        // LINESTRING(0 0, 3 0, 3 4) has total planar length 3 + 4 = 7.
+        var line = WkbBase64(BuildLineString(
+            new Coordinate(0, 0),
+            new Coordinate(3, 0),
+            new Coordinate(3, 4)));
+        var record = CreateJobRecord(
+            processId: GeometryLengthJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: line);
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        publishedUri.Should().NotBeNull();
+        publishedUri!.Should().StartWith(ScalarDataUriPrefix);
+
+        var bytes = Convert.FromBase64String(publishedUri[ScalarDataUriPrefix.Length..]);
+        using var doc = JsonDocument.Parse(bytes);
+        var root = doc.RootElement;
+        root.GetProperty("type").GetString().Should().Be("MeasureResult");
+        root.GetProperty("processId").GetString().Should().Be("geometry.length");
+        root.GetProperty("measure").GetString().Should().Be("length");
+        root.GetProperty("value").GetDouble().Should().BeApproximately(7.0, 1e-9);
+        root.GetProperty("unit").GetString().Should().Be("input-crs-units");
+        root.GetProperty("inputSrid").GetInt32().Should().Be(4326);
+        root.GetProperty("inputGeometryType").GetString().Should().Be("LineString");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_MissingWkb_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-missing");
+
+        var record = CreateJobRecord(
+            processId: GeometryLengthJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: null);
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("'wkb'");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_InvalidSrid_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-srid");
+
+        var record = CreateJobRecord(
+            processId: GeometryLengthJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(BuildLineString(new Coordinate(0, 0), new Coordinate(1, 0))),
+            srid: "not-an-int");
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("'srid'");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_PayloadExceedsMaxArtifactBytes_FailsWithGuardrail()
+    {
+        var executor = CreateExecutor(maxArtifactBytes: 8);
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-too-big");
+
+        var record = CreateJobRecord(
+            processId: GeometryLengthJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(BuildLineString(new Coordinate(0, 0), new Coordinate(1, 0))));
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("MaxArtifactBytes");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static GeometryLengthJobExecutor CreateExecutor(long maxArtifactBytes = 50L * 1024L * 1024L)
+    {
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = maxArtifactBytes,
+            ResultRetention = TimeSpan.FromDays(7)
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+        return new GeometryLengthJobExecutor(monitor, NullLogger<GeometryLengthJobExecutor>.Instance);
+    }
+
+    private static LineString BuildLineString(params Coordinate[] coordinates)
+    {
+        var factory = NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory();
+        return factory.CreateLineString(coordinates);
+    }
+
+    private static string WkbBase64(Geometry geometry)
+        => Convert.ToBase64String(new WKBWriter().Write(geometry));
+
+    private static ExecutionJobRecord CreateJobRecord(
+        string? processId,
+        bool includeInputs,
+        string? wkb = null,
+        string? srid = "4326")
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (!string.IsNullOrEmpty(processId))
+        {
+            parameters[ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId;
+            parameters["protocolProcessId"] = processId;
+        }
+
+        if (includeInputs)
+        {
+            var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+            if (wkb != null)
+            {
+                parameters[prefix + "wkb"] = wkb;
+            }
+            parameters[prefix + "srid"] = srid ?? "4326";
+        }
+
+        return new ExecutionJobRecord
+        {
+            OperationId = "op-test",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:test",
+                Parameters = parameters
+            }
+        };
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
@@ -18,9 +18,10 @@ namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
 /// Unit coverage for the dispatcher that routes claimed geoprocessing jobs
 /// to the correct per-process executor. The dispatcher is the single
 /// IJobExecutor registered for ExecutionJobKind.Geoprocessing after slice 2;
-/// slice 3 extends it with geometry.area + geometry.union. This test pins
-/// the routing contract so unknown process ids never reach a per-process
-/// executor by accident.
+/// slice 3 extended it with geometry.area + geometry.union; slice 4 adds
+/// geometry.centroid + geometry.length + geometry.convex-hull. This test
+/// pins the routing contract so unknown process ids never reach a
+/// per-process executor by accident.
 /// </summary>
 public sealed class GeoprocessingDispatchJobExecutorTests
 {
@@ -43,6 +44,9 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         result.ErrorMessage.Should().Contain("geometry.project");
         result.ErrorMessage.Should().Contain("geometry.area");
         result.ErrorMessage.Should().Contain("geometry.union");
+        result.ErrorMessage.Should().Contain("geometry.centroid");
+        result.ErrorMessage.Should().Contain("geometry.length");
+        result.ErrorMessage.Should().Contain("geometry.convex-hull");
     }
 
     [UnitTest]
@@ -60,7 +64,7 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         result.ErrorMessage.Should().Contain("<none>");
     }
 
-    private static readonly string[] SliceThreeProcessIds =
+    private static readonly string[] SliceFourProcessIds =
     {
         "geometry.buffer",
         "geometry.clip",
@@ -68,13 +72,16 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         "geometry.project",
         "geometry.area",
         "geometry.union",
+        "geometry.centroid",
+        "geometry.length",
+        "geometry.convex-hull",
     };
 
     [UnitTest]
-    public void SupportedProcessIds_ListsSliceThreeExecutors()
+    public void SupportedProcessIds_ListsSliceFourExecutors()
     {
         var dispatcher = CreateDispatcher();
-        dispatcher.SupportedProcessIds.Should().BeEquivalentTo(SliceThreeProcessIds);
+        dispatcher.SupportedProcessIds.Should().BeEquivalentTo(SliceFourProcessIds);
     }
 
     [UnitTest]
@@ -101,6 +108,9 @@ public sealed class GeoprocessingDispatchJobExecutorTests
             new GeometryProjectJobExecutor(monitor, NullLogger<GeometryProjectJobExecutor>.Instance),
             new GeometryAreaJobExecutor(monitor, NullLogger<GeometryAreaJobExecutor>.Instance),
             new GeometryUnionJobExecutor(monitor, NullLogger<GeometryUnionJobExecutor>.Instance),
+            new GeometryCentroidJobExecutor(monitor, NullLogger<GeometryCentroidJobExecutor>.Instance),
+            new GeometryLengthJobExecutor(monitor, NullLogger<GeometryLengthJobExecutor>.Instance),
+            new GeometryConvexHullJobExecutor(monitor, NullLogger<GeometryConvexHullJobExecutor>.Instance),
             NullLogger<GeoprocessingDispatchJobExecutor>.Instance);
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/VectorProcessParityIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/VectorProcessParityIntegrationTests.cs
@@ -25,15 +25,15 @@ using StackExchange.Redis;
 namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
 
 /// <summary>
-/// End-to-end parity coverage for the slice-2 / slice-3 vector executors.
-/// Each test submits a process through the OGC API Processes execute
-/// endpoint, polls the durable runtime until the job reaches a terminal
-/// status, retrieves the result document, and compares the published
-/// GeoJSON Feature (FeatureLayer outputs) or measure-result document
-/// (Scalar outputs) against a golden expectation (geometry type, feature
-/// count, area / coordinate position, measure value). Mirrors the slice-1
-/// buffer integration test shape so the new processes pin the same
-/// evidence contract.
+/// End-to-end parity coverage for the slice-2 / slice-3 / slice-4 vector
+/// executors. Each test submits a process through the OGC API Processes
+/// execute endpoint, polls the durable runtime until the job reaches a
+/// terminal status, retrieves the result document, and compares the
+/// published GeoJSON Feature (FeatureLayer outputs) or measure-result
+/// document (Scalar outputs) against a golden expectation (geometry type,
+/// feature count, area / coordinate position, measure value). Mirrors the
+/// slice-1 buffer integration test shape so the new processes pin the
+/// same evidence contract.
 /// </summary>
 [Collection("Redis")]
 [Protocol(TestProtocols.OgcApiProcesses)]
@@ -286,6 +286,179 @@ public sealed class VectorProcessParityIntegrationTests(RedisFixture redis)
         }
     }
 
+    [IntegrationTest]
+    [Operation(Operations.ProcessExecution)]
+    [Endpoint("POST /ogc/processes/processes/{processId}/execution")]
+    [Endpoint("GET /ogc/processes/jobs/{jobId}/results")]
+    public async Task CentroidProcess_CompletesAndReturnsCenterPoint()
+    {
+        await DeleteControlPlaneKeysAsync(redis.ConnectionString);
+
+        var fixture = BuildFixture();
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateAdminClient();
+            client.Timeout = TimeSpan.FromSeconds(30);
+
+            // Centroid of a 10x10 box anchored at (0,0) is (5,5).
+            var polygon = BuildBoxPolygon(0, 0, 10, 10);
+            var body = string.Format(
+                CultureInfo.InvariantCulture,
+                "{{\"response\":\"document\",\"inputs\":{{\"wkb\":\"{0}\",\"srid\":4326}}}}",
+                WkbBase64(polygon));
+
+            var jobId = await SubmitJobAsync(client, "geometry.centroid", body);
+
+            using var terminal = await PollUntilTerminalAsync(client, jobId);
+            terminal.RootElement.GetProperty("status").GetString().Should().Be("successful");
+
+            using var resultsDoc = await GetResultsAsync(client, jobId);
+            var feature = DecodeOutputFeature(resultsDoc, "geometry.centroid");
+
+            feature.GetProperty("properties").GetProperty("inputSrid").GetInt32().Should().Be(4326);
+            feature.GetProperty("properties").GetProperty("inputGeometryType").GetString().Should().Be("Polygon");
+
+            var geometry = ReadGeometry(feature.GetProperty("geometry"));
+            geometry.Should().BeOfType<Point>();
+            var point = (Point)geometry;
+            point.X.Should().BeApproximately(5.0, 1e-9);
+            point.Y.Should().BeApproximately(5.0, 1e-9);
+
+            var resultStore = fixture.GetService<IGeoprocessingResultPackageStore>();
+            var package = await resultStore.GetAsync(jobId);
+            package.Should().NotBeNull();
+            package!.Status.Should().Be(GeoprocessingWorkflowStatus.Completed);
+            package.Artifacts.Should().ContainSingle();
+            package.Artifacts[0].Uri.Should().StartWith(DataUriPrefix);
+            package.Artifacts[0].Label.Should().Be("outputFeatureLayer");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+            await DeleteControlPlaneKeysAsync(redis.ConnectionString);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ProcessExecution)]
+    [Endpoint("POST /ogc/processes/processes/{processId}/execution")]
+    [Endpoint("GET /ogc/processes/jobs/{jobId}/results")]
+    public async Task LengthProcess_CompletesAndReturnsPlanarMeasure()
+    {
+        await DeleteControlPlaneKeysAsync(redis.ConnectionString);
+
+        var fixture = BuildFixture();
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateAdminClient();
+            client.Timeout = TimeSpan.FromSeconds(30);
+
+            // LINESTRING(0 0, 3 0, 3 4) — 3-4-5 right-triangle linestring with planar length 7.
+            var factory = NetTopologySuite.NtsGeometryServices.Instance
+                .CreateGeometryFactory(srid: 4326);
+            var line = factory.CreateLineString(new[]
+            {
+                new Coordinate(0, 0),
+                new Coordinate(3, 0),
+                new Coordinate(3, 4),
+            });
+            var body = string.Format(
+                CultureInfo.InvariantCulture,
+                "{{\"response\":\"document\",\"inputs\":{{\"wkb\":\"{0}\",\"srid\":4326}}}}",
+                WkbBase64(line));
+
+            var jobId = await SubmitJobAsync(client, "geometry.length", body);
+
+            using var terminal = await PollUntilTerminalAsync(client, jobId);
+            terminal.RootElement.GetProperty("status").GetString().Should().Be("successful");
+
+            using var resultsDoc = await GetResultsAsync(client, jobId);
+            var measure = DecodeScalarMeasure(resultsDoc, "geometry.length");
+            measure.GetProperty("measure").GetString().Should().Be("length");
+            measure.GetProperty("value").GetDouble().Should().BeApproximately(7.0, 1e-9);
+            measure.GetProperty("unit").GetString().Should().Be("input-crs-units");
+            measure.GetProperty("inputSrid").GetInt32().Should().Be(4326);
+            measure.GetProperty("inputGeometryType").GetString().Should().Be("LineString");
+
+            var resultStore = fixture.GetService<IGeoprocessingResultPackageStore>();
+            var package = await resultStore.GetAsync(jobId);
+            package.Should().NotBeNull();
+            package!.Status.Should().Be(GeoprocessingWorkflowStatus.Completed);
+            package.Artifacts.Should().ContainSingle();
+            package.Artifacts[0].Uri.Should().StartWith("data:application/json;base64,");
+            package.Artifacts[0].Label.Should().Be("outputScalar");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+            await DeleteControlPlaneKeysAsync(redis.ConnectionString);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ProcessExecution)]
+    [Endpoint("POST /ogc/processes/processes/{processId}/execution")]
+    [Endpoint("GET /ogc/processes/jobs/{jobId}/results")]
+    public async Task ConvexHullProcess_CompletesAndReturnsBoundingPolygon()
+    {
+        await DeleteControlPlaneKeysAsync(redis.ConnectionString);
+
+        var fixture = BuildFixture();
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateAdminClient();
+            client.Timeout = TimeSpan.FromSeconds(30);
+
+            // MultiPoint with four corners of a 10x10 box plus the centroid.
+            // Hull is the bounding 10x10 box itself with area 100.
+            var factory = NetTopologySuite.NtsGeometryServices.Instance
+                .CreateGeometryFactory(srid: 4326);
+            var multipoint = factory.CreateMultiPoint(new[]
+            {
+                factory.CreatePoint(new Coordinate(0, 0)),
+                factory.CreatePoint(new Coordinate(10, 0)),
+                factory.CreatePoint(new Coordinate(10, 10)),
+                factory.CreatePoint(new Coordinate(0, 10)),
+                factory.CreatePoint(new Coordinate(5, 5)),
+            });
+            var body = string.Format(
+                CultureInfo.InvariantCulture,
+                "{{\"response\":\"document\",\"inputs\":{{\"wkb\":\"{0}\",\"srid\":4326}}}}",
+                WkbBase64(multipoint));
+
+            var jobId = await SubmitJobAsync(client, "geometry.convex-hull", body);
+
+            using var terminal = await PollUntilTerminalAsync(client, jobId);
+            terminal.RootElement.GetProperty("status").GetString().Should().Be("successful");
+
+            using var resultsDoc = await GetResultsAsync(client, jobId);
+            var feature = DecodeOutputFeature(resultsDoc, "geometry.convex-hull");
+
+            feature.GetProperty("properties").GetProperty("inputSrid").GetInt32().Should().Be(4326);
+            feature.GetProperty("properties").GetProperty("inputGeometryType").GetString().Should().Be("MultiPoint");
+
+            var geometry = ReadGeometry(feature.GetProperty("geometry"));
+            geometry.Area.Should().BeApproximately(100.0, 1e-6,
+                "hull of four corners of a 10x10 box plus the centroid is the 10x10 box itself");
+
+            var resultStore = fixture.GetService<IGeoprocessingResultPackageStore>();
+            var package = await resultStore.GetAsync(jobId);
+            package.Should().NotBeNull();
+            package!.Status.Should().Be(GeoprocessingWorkflowStatus.Completed);
+            package.Artifacts.Should().ContainSingle();
+            package.Artifacts[0].Uri.Should().StartWith(DataUriPrefix);
+            package.Artifacts[0].Label.Should().Be("outputFeatureLayer");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+            await DeleteControlPlaneKeysAsync(redis.ConnectionString);
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
@@ -340,9 +513,10 @@ public sealed class VectorProcessParityIntegrationTests(RedisFixture redis)
 
         // Activate the worker host. The production dispatcher registered by
         // AddGeoprocessing routes the geometry.clip / geometry.intersect /
-        // geometry.project / geometry.area / geometry.union ids to their
-        // per-process executors — that's the system-under-test for this
-        // parity suite.
+        // geometry.project / geometry.area / geometry.union /
+        // geometry.centroid / geometry.length / geometry.convex-hull ids to
+        // their per-process executors — that's the system-under-test for
+        // this parity suite.
         services.AddJobWorker();
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
@@ -35,22 +35,22 @@ public sealed class ProcessCatalogTests
     [UnitTest]
     [Operation(Operations.Query)]
     [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
-    public void Catalog_ListProcesses_ReturnsExactly34BuiltIns()
+    public void Catalog_ListProcesses_ReturnsExactly36BuiltIns()
     {
         var all = _catalog.ListProcesses();
 
-        all.Should().HaveCount(34);
+        all.Should().HaveCount(36);
         all.Select(p => p.ProcessId).Should().OnlyHaveUniqueItems();
     }
 
     [UnitTest]
     [Operation(Operations.Query)]
     [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
-    public void Catalog_GeometryCategory_Returns10Processes()
+    public void Catalog_GeometryCategory_Returns12Processes()
     {
         var geometry = _catalog.GetProcessesByCategory("geometry");
 
-        geometry.Should().HaveCount(10);
+        geometry.Should().HaveCount(12);
         geometry.Should().AllSatisfy(p => p.Category.Should().Be("geometry"));
     }
 
@@ -211,7 +211,8 @@ public sealed class ProcessCatalogTests
             "geometry.buffer", "geometry.simplify", "geometry.project",
             "geometry.make-valid", "geometry.union", "geometry.intersect",
             "geometry.clip", "geometry.difference", "geometry.area",
-            "geometry.length", "analytics.cluster", "analytics.spatial-join",
+            "geometry.length", "geometry.centroid", "geometry.convex-hull",
+            "analytics.cluster", "analytics.spatial-join",
             "analytics.buffer-aggregate", "analytics.density",
             "surface.slope", "surface.aspect", "surface.hillshade",
             "surface.rugosity-tri", "surface.rugosity-tpi", "surface.roughness",

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessMigrationEvidenceFixtureTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessMigrationEvidenceFixtureTests.cs
@@ -41,7 +41,10 @@ public sealed class ProcessMigrationEvidenceFixtureTests
             "geometry.intersect",
             "geometry.project",
             "geometry.area",
-            "geometry.union"
+            "geometry.union",
+            "geometry.centroid",
+            "geometry.length",
+            "geometry.convex-hull"
         ]);
 
         foreach (var processId in processIds)

--- a/tests/fixtures/process-migration/vector-process-parity-fixture.json
+++ b/tests/fixtures/process-migration/vector-process-parity-fixture.json
@@ -12,7 +12,10 @@
     "geometry.intersect",
     "geometry.project",
     "geometry.area",
-    "geometry.union"
+    "geometry.union",
+    "geometry.centroid",
+    "geometry.length",
+    "geometry.convex-hull"
   ],
   "cases": [
     {
@@ -135,6 +138,54 @@
         "geometryType": "Polygon",
         "featureCount": 1,
         "areaApprox": 175.0
+      }
+    },
+    {
+      "caseId": "centroid-10x10-box",
+      "processId": "geometry.centroid",
+      "description": "Slice 4: centroid of a 10x10 axis-aligned box anchored at (0,0) is the geometric center (5,5). Output is always a Point Feature regardless of input geometry type.",
+      "inputsWkt": {
+        "wkt": "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
+        "srid": "4326"
+      },
+      "expected": {
+        "outputParameter": "outputFeatureLayer",
+        "artifactKind": "FeatureLayer",
+        "geometryType": "Point",
+        "featureCount": 1,
+        "coordinate": [5.0, 5.0]
+      }
+    },
+    {
+      "caseId": "length-3-4-5-triangle-line",
+      "processId": "geometry.length",
+      "description": "Slice 4: planar length of a 3-4-5 right-triangle linestring (LINESTRING(0 0, 3 0, 3 4)) is 7. Catalog documents geodesic length but the first-slice executor returns planar length; geodesic measure is tracked as a follow-on slice alongside geometry.area.",
+      "inputsWkt": {
+        "wkt": "LINESTRING(0 0, 3 0, 3 4)",
+        "srid": "4326"
+      },
+      "expected": {
+        "outputParameter": "outputScalar",
+        "artifactKind": "Scalar",
+        "measure": "length",
+        "value": 7.0,
+        "unit": "input-crs-units"
+      }
+    },
+    {
+      "caseId": "convex-hull-five-points",
+      "processId": "geometry.convex-hull",
+      "description": "Slice 4: convex hull of five points (four corners of a 10x10 box plus the centroid) is the 10x10 box itself with area 100. Mirrors the PostGIS ST_ConvexHull semantics where the interior point does not extend the hull.",
+      "inputsWkt": {
+        "wkt": "MULTIPOINT((0 0), (10 0), (10 10), (0 10), (5 5))",
+        "srid": "4326"
+      },
+      "expected": {
+        "outputParameter": "outputFeatureLayer",
+        "artifactKind": "FeatureLayer",
+        "geometryType": "Polygon",
+        "featureCount": 1,
+        "areaApprox": 100.0
       }
     }
   ],


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1031 (stacked on PR #1113, slice 3)

## Summary
Slice 4 of #1031 finishes the deterministic single-feature vector executor set, adding `geometry.centroid`, `geometry.length`, and `geometry.convex-hull`. With these three the dispatcher covers the full per-feature geometry/measure shape (Point, MeasureResult, Polygon) before later slices tackle simplify/dissolve and the heavyweight raster/surface family. Stacks on PR #1113; base branch is `codex/issue-1031-area-union`.

## Changes Made
- Adds `GeometryCentroidJobExecutor` — `Geometry.Centroid` per feature, published as a GeoJSON Point Feature via the `outputFeatureLayer` slot with `inputSrid` + `inputGeometryType` metadata.
- Adds `GeometryLengthJobExecutor` — planar length in input-CRS units, published as a canonical `MeasureResult` JSON document via the `outputScalar` slot. Geodesic length is documented in the catalog but deferred to the geodesic measure slice, mirroring `geometry.area`'s policy.
- Adds `GeometryConvexHullJobExecutor` — `Geometry.ConvexHull` per feature, published as a GeoJSON Feature. Collections/multi-geometries take the hull over all member vertices, matching PostGIS `ST_ConvexHull` semantics ("hull of the union" for aggregate inputs).
- Adds `geometry.centroid` and `geometry.convex-hull` to `BuiltInProcessCatalog` (geometry now declares 12 processes; total 36). `geometry.length` already existed in the catalog.
- Registers all three in `GeoprocessingServiceCollectionExtensions` and wires them into `GeoprocessingDispatchJobExecutor` (constructor + handler map) alongside the existing slice-1/2/3 executors; renames the dispatcher supported-set test array to `SliceFourProcessIds`.
- Extends `ProcessMigrationEvidenceClassifier` so the three new ids classify as `Automated` and projected through OGC API Processes; updates `ProcessMigrationEvidenceFixtureTests` and the parity fixture's `supportedProcessIds`.
- Extends `tests/fixtures/process-migration/vector-process-parity-fixture.json` with golden entries for `centroid-10x10-box` (Point at (5,5)), `length-3-4-5-triangle-line` (planar length 7), and `convex-hull-five-points` (10x10 box hull, area 100).
- Per-executor unit tests covering unsupported process id, happy path, missing/invalid inputs, and oversized-artifact guardrail.
- Extends `VectorProcessParityIntegrationTests` with end-to-end `CentroidProcess`, `LengthProcess`, and `ConvexHullProcess` cases that submit through OGC API Processes execute, poll for terminal status, and verify the result document shape.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None — additive registration in the geoprocessing dispatcher and two new catalog entries; existing slice-1/2/3 executors are unchanged.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
