### PR TITLE
feat: legacy WCS coverage source import (#1030 slice 3/N)

### DIFF
--- a/src/Honua.Core/Features/Import/Abstractions/IOgcWcsImportService.cs
+++ b/src/Honua.Core/Features/Import/Abstractions/IOgcWcsImportService.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Abstractions;
+
+/// <summary>
+/// Imports coverages from a legacy OGC Web Coverage Service (WCS 1.x or 2.x)
+/// endpoint. WCS is the older XML-over-HTTP coverage protocol that many
+/// production stacks still expose alongside, or instead of, OGC API Coverages.
+/// </summary>
+/// <remarks>
+/// Slice 3 of issue #1030. The WCS service classifies the requested output
+/// format — <c>image/tiff</c> is the deterministic happy-path; any other
+/// format (NetCDF, HDF, GML coverage, vendor-specific) routes the coverage
+/// to manual review. The actual catalog ingestion is delegated to the
+/// slice-2 <see cref="IOgcCoverageImportService"/> so there is exactly one
+/// raster sink in the system.
+/// </remarks>
+public interface IOgcWcsImportService
+{
+    /// <summary>
+    /// Plan or apply a WCS coverage import using the slice-1 migration inventory
+    /// as the selection contract. When <see cref="OgcWcsImportRequest.ApplyMode"/>
+    /// is set the underlying coverage import service streams the GeoTIFF response
+    /// into the Honua raster store.
+    /// </summary>
+    /// <param name="request">WCS import request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<OgcWcsImportResult> ImportAsync(
+        OgcWcsImportRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Import/Domain/OgcWcsImportRequest.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcWcsImportRequest.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Request to import one or more coverages from a legacy OGC Web Coverage
+/// Service endpoint (WCS 1.x or 2.x). Slice 3 of issue #1030.
+/// </summary>
+public sealed record OgcWcsImportRequest
+{
+    /// <summary>
+    /// Source WCS service URL — the capabilities endpoint root. Per-coverage
+    /// <c>GetCoverage</c> requests are built relative to this URL.
+    /// </summary>
+    public required string ServiceUrl { get; init; }
+
+    /// <summary>
+    /// WCS protocol version to request. Defaults to <c>2.0.1</c> when not specified.
+    /// Accepted values include <c>1.0.0</c>, <c>1.1.1</c>, <c>2.0.1</c>.
+    /// </summary>
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// Inventory artifact produced by the slice-1 OGC coverage scanner. Required.
+    /// </summary>
+    public required MigrationSourceInventoryArtifact Inventory { get; init; }
+
+    /// <summary>
+    /// Requested output format. The deterministic happy-path is
+    /// <c>image/tiff</c>; any other value is classified as <c>manual-review</c>
+    /// because the slice-2 ingestion pipeline only consumes GeoTIFF/COG bytes.
+    /// Defaults to <c>image/tiff</c>.
+    /// </summary>
+    public string OutputFormat { get; init; } = "image/tiff";
+
+    /// <summary>
+    /// Coverage selection. When null or empty every coverage in the inventory is processed.
+    /// Entries should match either <see cref="MigrationInventoryResource.Id"/> or
+    /// <see cref="MigrationInventoryResource.Name"/>.
+    /// </summary>
+    public string[] CoverageSelection { get; init; } = [];
+
+    /// <summary>
+    /// Optional per-coverage import settings keyed by source coverage name or resource id.
+    /// </summary>
+    public IReadOnlyDictionary<string, OgcCoverageImportTarget> Targets { get; init; }
+        = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// When true the service performs the actual GeoTIFF download and registers
+    /// the raster through the slice-2 coverage import pipeline. When false only a
+    /// deterministic manifest is produced.
+    /// </summary>
+    public bool ApplyMode { get; init; }
+
+    /// <summary>
+    /// When true callers explicitly request a dry-run preview manifest only.
+    /// This is the safe default — <see cref="ApplyMode"/> must be true to mutate state.
+    /// </summary>
+    public bool DryRun { get; init; } = true;
+
+    /// <summary>
+    /// Optional target service name used when computing manifest target identities.
+    /// </summary>
+    public string? TargetServiceName { get; init; }
+
+    /// <summary>
+    /// Optional HTTP basic-auth username for protected WCS endpoints.
+    /// Never echoed back in manifest output.
+    /// </summary>
+    public string? Username { get; init; }
+
+    /// <summary>
+    /// Optional HTTP basic-auth password for protected WCS endpoints.
+    /// Never echoed back in manifest output.
+    /// </summary>
+    public string? Password { get; init; }
+
+    /// <summary>
+    /// Optional request timeout in seconds.
+    /// </summary>
+    public int TimeoutSeconds { get; init; } = 120;
+
+    /// <summary>
+    /// Whether to allow plain HTTP or local URLs (operator-controlled environments).
+    /// </summary>
+    public bool AllowUnsafeLocalUrls { get; init; }
+}

--- a/src/Honua.Core/Features/Import/Domain/OgcWcsImportResult.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcWcsImportResult.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Result of a legacy OGC WCS coverage import attempt. Slice 3 of issue #1030.
+/// </summary>
+/// <remarks>
+/// The WCS service delegates the actual catalog ingestion to the slice-2
+/// coverage import service, so this result wraps the underlying
+/// <see cref="OgcCoverageImportResult"/> and exposes the negotiated output
+/// format the WCS layer requested on the caller's behalf.
+/// </remarks>
+public sealed record OgcWcsImportResult
+{
+    /// <summary>
+    /// Deterministic migration manifest produced by the underlying coverage import.
+    /// </summary>
+    public required MigrationManifestArtifact Manifest { get; init; }
+
+    /// <summary>
+    /// Per-coverage execution records produced by the slice-2 ingestion pipeline.
+    /// </summary>
+    public OgcCoverageImportRecord[] Records { get; init; } = [];
+
+    /// <summary>
+    /// Output format the WCS layer requested from the source service
+    /// (e.g. <c>image/tiff</c>). Mirrored back so callers can confirm
+    /// the negotiation outcome without re-parsing per-record output formats.
+    /// </summary>
+    public required string RequestedOutputFormat { get; init; }
+
+    /// <summary>
+    /// WCS protocol version resolved for this request.
+    /// </summary>
+    public required string ResolvedVersion { get; init; }
+
+    /// <summary>
+    /// Whether the request ran in apply mode.
+    /// </summary>
+    public bool ApplyMode { get; init; }
+
+    /// <summary>
+    /// Whether the request was a dry-run preview.
+    /// </summary>
+    public bool DryRun { get; init; }
+}

--- a/src/Honua.Core/Features/Import/ServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Import/ServiceCollectionExtensions.cs
@@ -49,6 +49,12 @@ public static class ServiceCollectionExtensions
         services.TryAddScoped<IOgcCoverageImportService>(serviceProvider =>
             serviceProvider.GetRequiredService<OgcCoverageImportService>());
 
+        // Legacy WCS coverage import service (issue #1030 slice 3). The WCS
+        // service wraps the slice-2 coverage import pipeline — no separate
+        // HttpClient is needed because the underlying service handles all
+        // wire IO. Format negotiation and inventory downgrades happen in-process.
+        services.TryAddScoped<IOgcWcsImportService, OgcWcsImportService>();
+
         return services;
     }
 }

--- a/src/Honua.Core/Features/Import/Services/OgcWcsImportService.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcWcsImportService.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Import.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Imports coverages from a legacy OGC Web Coverage Service endpoint by
+/// negotiating the requested output format and delegating the actual
+/// catalog ingestion to the slice-2 <see cref="IOgcCoverageImportService"/>.
+/// Slice 3 of issue #1030.
+/// </summary>
+/// <remarks>
+/// Format negotiation: <c>image/tiff</c> (and the GeoTIFF profile variants)
+/// flow through the GeoTIFF ingestion path; any other format — NetCDF, HDF,
+/// GML coverage, vendor-specific — is forced to the manual-review path
+/// before the underlying service is asked to download anything. This keeps
+/// the WCS service deterministic and avoids surfacing partial coverage
+/// blobs that the raster ingestion layer cannot consume.
+/// </remarks>
+public sealed partial class OgcWcsImportService : IOgcWcsImportService
+{
+    private const string DefaultOutputFormat = "image/tiff";
+    private const string DefaultVersion = "2.0.1";
+
+    private readonly IOgcCoverageImportService _coverageImportService;
+    private readonly ILogger<OgcWcsImportService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OgcWcsImportService"/> class.
+    /// </summary>
+    public OgcWcsImportService(
+        IOgcCoverageImportService coverageImportService,
+        ILogger<OgcWcsImportService> logger)
+    {
+        _coverageImportService = coverageImportService
+            ?? throw new ArgumentNullException(nameof(coverageImportService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<OgcWcsImportResult> ImportAsync(
+        OgcWcsImportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Inventory);
+
+        if (string.IsNullOrWhiteSpace(request.ServiceUrl))
+        {
+            throw new ArgumentException("ServiceUrl is required.", nameof(request));
+        }
+
+        var resolvedVersion = NormalizeVersion(request.Version);
+        var negotiatedFormat = NormalizeOutputFormat(request.OutputFormat);
+        var isAutomatedFormat = IsGeoTiffFormat(negotiatedFormat);
+
+        // When the caller requested a non-GeoTIFF output format we rewrite the
+        // inventory so every otherwise-automatable coverage is downgraded to
+        // manual-review. Slice-2 only knows how to ingest GeoTIFF/COG bytes.
+        var inventory = isAutomatedFormat
+            ? request.Inventory
+            : DowngradeAutomatedCoveragesToManualReview(request.Inventory, negotiatedFormat);
+
+        if (!isAutomatedFormat)
+        {
+            Log.NonGeoTiffFormatDowngraded(_logger, negotiatedFormat);
+        }
+
+        var coverageRequest = new OgcCoverageImportRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = request.ServiceUrl,
+            Version = resolvedVersion,
+            Inventory = inventory,
+            CoverageSelection = request.CoverageSelection,
+            Targets = request.Targets,
+            ApplyMode = request.ApplyMode,
+            DryRun = request.DryRun,
+            TargetServiceName = request.TargetServiceName,
+            Username = request.Username,
+            Password = request.Password,
+            TimeoutSeconds = request.TimeoutSeconds,
+            AllowUnsafeLocalUrls = request.AllowUnsafeLocalUrls
+        };
+
+        var coverageResult = await _coverageImportService
+            .ImportAsync(coverageRequest, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new OgcWcsImportResult
+        {
+            Manifest = coverageResult.Manifest,
+            Records = coverageResult.Records,
+            RequestedOutputFormat = negotiatedFormat,
+            ResolvedVersion = resolvedVersion,
+            ApplyMode = coverageResult.ApplyMode,
+            DryRun = coverageResult.DryRun
+        };
+    }
+
+    private static string NormalizeVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return DefaultVersion;
+        }
+
+        var trimmed = version.Trim();
+        if (!trimmed.StartsWith("1.", StringComparison.Ordinal) &&
+            !trimmed.StartsWith("2.", StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Unsupported WCS version: {version}. Expected 1.x or 2.x.",
+                nameof(version));
+        }
+
+        return trimmed;
+    }
+
+    private static string NormalizeOutputFormat(string? outputFormat)
+    {
+        if (string.IsNullOrWhiteSpace(outputFormat))
+        {
+            return DefaultOutputFormat;
+        }
+
+        return outputFormat.Trim();
+    }
+
+    private static bool IsGeoTiffFormat(string negotiatedFormat)
+    {
+        // Accept the common GeoTIFF MIME variants WCS servers advertise.
+        if (negotiatedFormat.Equals("image/tiff", StringComparison.OrdinalIgnoreCase) ||
+            negotiatedFormat.Equals("image/geotiff", StringComparison.OrdinalIgnoreCase) ||
+            negotiatedFormat.Equals("image/tiff;application=geotiff", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return negotiatedFormat.StartsWith("image/tiff;", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static MigrationSourceInventoryArtifact DowngradeAutomatedCoveragesToManualReview(
+        MigrationSourceInventoryArtifact inventory,
+        string requestedFormat)
+    {
+        var manualReason = $"WCS import requested output format '{requestedFormat}', which is not supported by the slice-2 GeoTIFF/COG ingestion pipeline. Resolve manually before promoting.";
+        var manualSteps = new[]
+        {
+            $"Output format '{requestedFormat}' is not currently ingestible. Convert the coverage to GeoTIFF before re-running the import, or request a GeoTIFF response from the WCS server.",
+            "Confirm the source service can serve image/tiff for this coverage and re-run with outputFormat=image/tiff."
+        };
+
+        var rewritten = inventory.Resources
+            .Select(resource =>
+            {
+                if (!string.Equals(resource.Kind, "coverage", StringComparison.Ordinal))
+                {
+                    return resource;
+                }
+
+                return resource with
+                {
+                    Compatibility = resource.Compatibility with
+                    {
+                        Level = "incompatible",
+                        Code = OgcCoverageMigrationCompatibilityCodes.ScientificFormatUnsupported,
+                        Reason = manualReason,
+                        ManualSteps = manualSteps
+                    }
+                };
+            })
+            .ToArray();
+
+        return inventory with { Resources = rewritten };
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 8820,
+            Level = LogLevel.Information,
+            Message = "WCS import: requested output format '{Format}' is not GeoTIFF; routing coverages to manual review.")]
+        public static partial void NonGeoTiffFormatDowngraded(ILogger logger, string format);
+    }
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -277,6 +277,9 @@ public static class EndpointRegistry
         // v1 admin import endpoints (OGC Coverages - GeoTIFF/COG, issue #1030 slice 2)
         new("POST", "/api/v1/admin/import/ogc/coverages/import"),
 
+        // v1 admin import endpoints (legacy OGC WCS, issue #1030 slice 3)
+        new("POST", "/api/v1/admin/import/ogc-wcs/import"),
+
         // v1 admin operational monitoring endpoints (#512)
         new("GET", "/api/v1/admin/operations/cache/health"),
         new("GET", "/api/v1/admin/operations/cache/statistics"),

--- a/src/Honua.Server/Features/Import/OgcWcsImportEndpoints.cs
+++ b/src/Honua.Server/Features/Import/OgcWcsImportEndpoints.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Helpers;
+
+namespace Honua.Server.Features.Import;
+
+/// <summary>
+/// API endpoints for legacy OGC Web Coverage Service (WCS 1.x / 2.x) coverage
+/// imports. Issue #1030 slice 3 — the WCS counterpart to slice 2's
+/// OGC API Coverages import surface.
+/// </summary>
+internal static class OgcWcsImportEndpoints
+{
+    /// <summary>
+    /// Map OGC WCS import endpoints onto the web application with formal API versioning.
+    /// </summary>
+    public static void MapOgcWcsImportEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/v{version:apiVersion}/admin/import/ogc-wcs")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("OgcWcsImport")
+            .RequireAdminAuthorization();
+
+        _ = group.MapPost("/import", HandleImportCoverages)
+            .WithName("ImportOgcWcsCoverages")
+            .WithSummary("Plan or apply a legacy WCS coverage import using a slice-1 migration inventory");
+    }
+
+    private static async Task HandleImportCoverages(HttpContext context)
+    {
+        var cancellationToken = context.RequestAborted;
+
+        OgcWcsImportApiRequest? request;
+        try
+        {
+            request = await context.Request.ReadFromJsonAsync(
+                OgcWcsImportJsonContext.Default.OgcWcsImportApiRequest,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Invalid request body", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (request == null)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Request body is required", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ServiceUrl))
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "ServiceUrl is required.", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (request.Inventory == null)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Inventory is required.", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        // Safety gate: require explicit applyMode=true when dryRun=false. Matches the
+        // slice-2 coverage endpoint contract so operators must acknowledge state mutation.
+        var dryRun = request.DryRun ?? true;
+        var applyMode = request.ApplyMode ?? false;
+        if (!dryRun && !applyMode)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                "Non-dry-run WCS coverage imports require applyMode=true to acknowledge that coverage data will be written to the Honua raster store.",
+                StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var allowUnsafeLocalUrls = GeoServerImportExecutionSettings.ShouldAllowUnsafeLocalUrls(context.RequestServices);
+        var urlValidation = await OgcServiceUrlValidation.ValidateAsync(
+            request.ServiceUrl,
+            allowUnsafeLocalUrls,
+            cancellationToken).ConfigureAwait(false);
+        if (!urlValidation.IsValid)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                urlValidation.ErrorMessage!,
+                StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var importRequest = new OgcWcsImportRequest
+        {
+            ServiceUrl = request.ServiceUrl,
+            Version = request.Version,
+            Inventory = request.Inventory,
+            OutputFormat = string.IsNullOrWhiteSpace(request.OutputFormat) ? "image/tiff" : request.OutputFormat!,
+            CoverageSelection = request.CoverageSelection ?? [],
+            Targets = request.Targets ?? new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal),
+            ApplyMode = applyMode,
+            DryRun = dryRun,
+            TargetServiceName = request.TargetServiceName,
+            Username = request.Username,
+            Password = request.Password,
+            TimeoutSeconds = request.TimeoutSeconds ?? 120,
+            AllowUnsafeLocalUrls = allowUnsafeLocalUrls
+        };
+
+        try
+        {
+            var service = context.RequestServices.GetRequiredService<IOgcWcsImportService>();
+            var result = await service.ImportAsync(importRequest, cancellationToken).ConfigureAwait(false);
+
+            await Results.Json(result, OgcWcsImportJsonContext.Default.OgcWcsImportResult)
+                .ExecuteAsync(context).ConfigureAwait(false);
+        }
+        catch (ArgumentException ex)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, ex.Message, StatusCodes.Status400BadRequest);
+        }
+        catch (HttpRequestException)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                "Failed to connect to WCS source service.",
+                StatusCodes.Status502BadGateway);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                "WCS coverage import timed out.",
+                StatusCodes.Status504GatewayTimeout);
+        }
+    }
+}
+
+/// <summary>
+/// API request payload for legacy WCS coverage import operations.
+/// </summary>
+internal sealed record OgcWcsImportApiRequest
+{
+    /// <summary>
+    /// Source WCS service URL.
+    /// </summary>
+    public string? ServiceUrl { get; init; }
+
+    /// <summary>
+    /// Optional WCS protocol version (e.g. <c>1.1.1</c>, <c>2.0.1</c>).
+    /// </summary>
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// Requested output format. Defaults to <c>image/tiff</c>; other formats are
+    /// classified as manual-review.
+    /// </summary>
+    public string? OutputFormat { get; init; }
+
+    /// <summary>
+    /// Slice-1 migration inventory artifact identifying the coverages to plan or import.
+    /// </summary>
+    public MigrationSourceInventoryArtifact? Inventory { get; init; }
+
+    /// <summary>
+    /// Optional explicit coverage selection. When omitted every coverage in the inventory is processed.
+    /// </summary>
+    public string[]? CoverageSelection { get; init; }
+
+    /// <summary>
+    /// Optional per-coverage import targets keyed by source coverage name or resource id.
+    /// </summary>
+    public IReadOnlyDictionary<string, OgcCoverageImportTarget>? Targets { get; init; }
+
+    /// <summary>
+    /// Optional dry-run preview flag. Defaults to <c>true</c>.
+    /// </summary>
+    public bool? DryRun { get; init; }
+
+    /// <summary>
+    /// Apply-mode opt-in. Required (alongside <c>dryRun=false</c>) to mutate raster store state.
+    /// </summary>
+    public bool? ApplyMode { get; init; }
+
+    /// <summary>
+    /// Optional target service name used when computing manifest identities.
+    /// </summary>
+    public string? TargetServiceName { get; init; }
+
+    /// <summary>
+    /// Optional HTTP basic-auth username for protected WCS endpoints.
+    /// </summary>
+    public string? Username { get; init; }
+
+    /// <summary>
+    /// Optional HTTP basic-auth password for protected WCS endpoints.
+    /// </summary>
+    public string? Password { get; init; }
+
+    /// <summary>
+    /// Optional per-request timeout in seconds.
+    /// </summary>
+    public int? TimeoutSeconds { get; init; }
+}

--- a/src/Honua.Server/Features/Import/OgcWcsImportJsonContext.cs
+++ b/src/Honua.Server/Features/Import/OgcWcsImportJsonContext.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Server.Features.Import;
+
+/// <summary>
+/// Source-generated JSON serialization context for legacy OGC WCS coverage import payloads.
+/// Issue #1030 slice 3.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(OgcWcsImportApiRequest))]
+[JsonSerializable(typeof(OgcWcsImportRequest))]
+[JsonSerializable(typeof(OgcWcsImportResult))]
+[JsonSerializable(typeof(OgcCoverageImportRecord))]
+[JsonSerializable(typeof(OgcCoverageImportRecord[]))]
+[JsonSerializable(typeof(OgcCoverageImportTarget))]
+[JsonSerializable(typeof(IReadOnlyDictionary<string, OgcCoverageImportTarget>))]
+[JsonSerializable(typeof(MigrationSourceInventoryArtifact))]
+[JsonSerializable(typeof(MigrationManifestArtifact))]
+internal sealed partial class OgcWcsImportJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -820,6 +820,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Import.RasterImportJsonContext.Default,
         Honua.Server.Features.Import.GeoservicesImportApiJsonContext.Default,
         Honua.Server.Features.Import.OgcCoverageImportJsonContext.Default,
+        Honua.Server.Features.Import.OgcWcsImportJsonContext.Default,
         Honua.Server.Features.Admin.OperationsProgressJsonContext.Default,
         Honua.Server.Features.Admin.FeatureEventReplayJsonContext.Default,
         Honua.Server.Features.Mobile.Auth.MobileAuthJsonContext.Default,
@@ -1227,6 +1228,9 @@ app.MapGeoServerImportEndpoints();
 
 // Configure OGC WCS / OGC API Coverages GeoTIFF/COG import endpoints (issue #1030 slice 2)
 app.MapOgcCoverageImportEndpoints();
+
+// Configure legacy OGC WCS coverage import endpoints (issue #1030 slice 3)
+app.MapOgcWcsImportEndpoints();
 
 if (isTestEnvironment)
 {

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcWcsImportServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcWcsImportServiceTests.cs
@@ -1,0 +1,393 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Core.Tests.Features.Import;
+
+/// <summary>
+/// Service-level tests for <see cref="OgcWcsImportService"/> (issue #1030 slice 3).
+/// Exercises the WCS happy-path against captured GetCoverage responses, the
+/// non-GeoTIFF format downgrade, and error propagation from the underlying
+/// coverage import pipeline.
+/// </summary>
+public sealed class OgcWcsImportServiceTests
+{
+    private const string ServiceUrl = "https://example.com/geoserver/wcs";
+
+    [Fact]
+    public async Task ImportAsync_DryRun_BuildsPlannedManifestWithoutDownloadingCoverage()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => throw new InvalidOperationException("Dry-run import must not call the WCS source."));
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var inventory = BuildInventory(BuildGeoTiffResource("dem-tiff"));
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            Inventory = inventory,
+            DryRun = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.DryRun.Should().BeTrue();
+        result.ApplyMode.Should().BeFalse();
+        result.RequestedOutputFormat.Should().Be("image/tiff");
+        result.ResolvedVersion.Should().Be("2.0.1");
+        result.Records.Should().ContainSingle().Which.Action.Should().Be("planned");
+        result.Manifest.TargetResources.Should().OnlyContain(target => target.Action == "planned");
+        handler.RequestCount.Should().Be(0);
+        rasterImportMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ImportAsync_ApplyMode_DownloadsGeoTiffAndIssuesWcsGetCoverageRequest()
+    {
+        var capturedRequests = new List<RasterImportRequest>();
+        var rasterImportMock = new Mock<IRasterImportService>();
+        rasterImportMock
+            .Setup(static s => s.ImportAsync(It.IsAny<RasterImportRequest>(), null, It.IsAny<CancellationToken>()))
+            .Callback<RasterImportRequest, IProgress<RasterImportProgress>?, CancellationToken>((req, _, _) => capturedRequests.Add(req))
+            .ReturnsAsync((RasterImportRequest req, IProgress<RasterImportProgress>? _, CancellationToken _) =>
+                new RasterImportResult
+                {
+                    Success = true,
+                    RasterId = 7777,
+                    LayerId = req.LayerId,
+                    Name = req.Name,
+                    Format = req.Format
+                });
+
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            Version = "2.0.1",
+            OutputFormat = "image/tiff",
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-tiff"] = new OgcCoverageImportTarget { LayerId = 9, Name = "Elevation" }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.ApplyMode.Should().BeTrue();
+        result.DryRun.Should().BeFalse();
+        result.ResolvedVersion.Should().Be("2.0.1");
+        var record = result.Records.Should().ContainSingle().Subject;
+        record.Action.Should().Be("imported");
+        record.RasterId.Should().Be(7777);
+        record.TargetLayerId.Should().Be(9);
+        record.OutputFormat.Should().Be("GeoTIFF");
+        handler.RequestCount.Should().Be(1);
+        var query = handler.LastRequest!.RequestUri!.Query;
+        query.Should().Contain("service=WCS");
+        query.Should().Contain("request=GetCoverage");
+        query.Should().Contain("coverageId=dem-tiff");
+        query.Should().Contain("version=2.0.1");
+        capturedRequests.Should().ContainSingle();
+        capturedRequests[0].Format.Should().Be(SupportedRasterFormat.GeoTiff);
+    }
+
+    [Fact]
+    public async Task ImportAsync_NonGeoTiffFormat_DowngradesEveryCoverageToManualReview()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => throw new InvalidOperationException("Non-GeoTIFF formats must not call the WCS source."));
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            OutputFormat = "application/x-netcdf",
+            Inventory = BuildInventory(
+                BuildGeoTiffResource("dem-tiff"),
+                BuildGeoTiffResource("ortho-tiff")),
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-tiff"] = new OgcCoverageImportTarget { LayerId = 1 },
+                ["ortho-tiff"] = new OgcCoverageImportTarget { LayerId = 2 }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.RequestedOutputFormat.Should().Be("application/x-netcdf");
+        result.Records.Should().HaveCount(2);
+        result.Records.Should().OnlyContain(record => record.Action == "manual-review");
+        result.Manifest.UnsupportedItems.Should().HaveCount(2);
+        result.Manifest.UnsupportedItems.Should().OnlyContain(item =>
+            item.Code == OgcCoverageMigrationCompatibilityCodes.ScientificFormatUnsupported);
+        handler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ImportAsync_GeoTiffMimeVariant_IsTreatedAsAutomatedFormat()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>();
+        rasterImportMock
+            .Setup(static s => s.ImportAsync(It.IsAny<RasterImportRequest>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RasterImportRequest req, IProgress<RasterImportProgress>? _, CancellationToken _) =>
+                new RasterImportResult
+                {
+                    Success = true,
+                    RasterId = 333,
+                    LayerId = req.LayerId,
+                    Name = req.Name,
+                    Format = req.Format
+                });
+
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            OutputFormat = "image/tiff;application=geotiff",
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-tiff"] = new OgcCoverageImportTarget { LayerId = 4 }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.RequestedOutputFormat.Should().Be("image/tiff;application=geotiff");
+        result.Records.Should().ContainSingle().Which.Action.Should().Be("imported");
+        handler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ImportAsync_Wcs1xVersion_PropagatesLegacyCoverageParameter()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>();
+        rasterImportMock
+            .Setup(static s => s.ImportAsync(It.IsAny<RasterImportRequest>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RasterImportRequest req, IProgress<RasterImportProgress>? _, CancellationToken _) =>
+                new RasterImportResult
+                {
+                    Success = true,
+                    RasterId = 1,
+                    LayerId = req.LayerId,
+                    Name = req.Name,
+                    Format = req.Format
+                });
+
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            Version = "1.1.1",
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-tiff"] = new OgcCoverageImportTarget { LayerId = 6 }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.ResolvedVersion.Should().Be("1.1.1");
+        var query = handler.LastRequest!.RequestUri!.Query;
+        query.Should().Contain("version=1.1.1");
+        // WCS 1.x uses "coverage" rather than "coverageId" for the layer identifier.
+        query.Should().Contain("coverage=dem-tiff");
+        query.Should().NotContain("coverageId=");
+    }
+
+    [Fact]
+    public async Task ImportAsync_HttpFailurePropagatesAsFailedRecord()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            Targets = new Dictionary<string, OgcCoverageImportTarget>(StringComparer.Ordinal)
+            {
+                ["dem-tiff"] = new OgcCoverageImportTarget { LayerId = 3 }
+            },
+            DryRun = false,
+            ApplyMode = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        var record = result.Records.Should().ContainSingle().Subject;
+        record.Action.Should().Be("failed");
+        record.ErrorMessage.Should().Be("Failed to download or import coverage.");
+        handler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ImportAsync_RejectsUnknownVersion()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            Version = "9.9.9",
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff")),
+            DryRun = true
+        };
+
+        var act = async () => await service.ImportAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .Where(static ex => ex.Message.Contains("Unsupported WCS version"));
+        handler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ImportAsync_MissingServiceUrl_ThrowsArgumentException()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => CreateGeoTiffResponse());
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = "   ",
+            Inventory = BuildInventory(BuildGeoTiffResource("dem-tiff"))
+        };
+
+        var act = async () => await service.ImportAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .Where(static ex => ex.Message.Contains("ServiceUrl is required"));
+    }
+
+    private static OgcWcsImportService CreateService(
+        HttpMessageHandler handler,
+        IRasterImportService rasterImportService)
+    {
+        var httpClient = new HttpClient(handler);
+        var coverageService = new OgcCoverageImportService(
+            httpClient,
+            rasterImportService,
+            NullLogger<OgcCoverageImportService>.Instance);
+        return new OgcWcsImportService(
+            coverageService,
+            NullLogger<OgcWcsImportService>.Instance);
+    }
+
+    private static MigrationSourceInventoryArtifact BuildInventory(params MigrationInventoryResource[] resources)
+        => new()
+        {
+            SourceKind = "ogc-wcs",
+            Source = new MigrationSourceIdentity
+            {
+                DisplayName = "Example WCS",
+                BaseUrl = ServiceUrl,
+                ServiceType = "WCS"
+            },
+            AuthPosture = new MigrationInventoryAuthPosture { Mode = "anonymous" },
+            ScanCompleteness = new MigrationInventoryCompleteness { Status = "complete" },
+            Summary = new MigrationInventorySummary
+            {
+                ContainerCount = 1,
+                ResourceCount = resources.Length
+            },
+            OverallCompatibility = new MigrationCompatibilityAssessment
+            {
+                Level = "compatible",
+                Reason = "WCS coverage migration scan completed."
+            },
+            Resources = resources
+        };
+
+    private static MigrationInventoryResource BuildGeoTiffResource(string name)
+        => new()
+        {
+            Id = $"coverage:{name}",
+            ContainerId = "service:wcs",
+            Kind = "coverage",
+            Name = name,
+            Title = name,
+            SpatialReferences = [
+                new MigrationSpatialReferenceInfo
+                {
+                    Role = "native",
+                    Srid = 4326,
+                    SourceValue = "EPSG:4326"
+                }
+            ],
+            Compatibility = new MigrationCompatibilityAssessment
+            {
+                Level = "compatible",
+                Code = OgcCoverageMigrationCompatibilityCodes.GeoTiffSupported,
+                Reason = "WCS GeoTIFF coverage."
+            }
+        };
+
+    /// <summary>
+    /// Builds a minimal GeoTIFF response body. WCS 2.x servers return image/tiff
+    /// directly from GetCoverage; we mimic that shape with the canonical TIFF magic.
+    /// </summary>
+    private static HttpResponseMessage CreateGeoTiffResponse()
+    {
+        // II*\0 = little-endian TIFF magic. Padding bytes simulate the coverage body.
+        var bytes = new byte[]
+        {
+            0x49, 0x49, 0x2A, 0x00,
+            0x08, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0xDE, 0xAD, 0xBE, 0xEF
+        };
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(bytes)
+        };
+    }
+
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpResponseMessage> _factory;
+
+        public CountingHandler(Func<HttpResponseMessage> factory)
+        {
+            _factory = factory;
+        }
+
+        public int RequestCount { get; private set; }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            LastRequest = request;
+            return Task.FromResult(_factory());
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Import/OgcWcsImportEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/OgcWcsImportEndpointTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Import;
+
+/// <summary>
+/// Integration tests for legacy OGC WCS coverage import endpoints (issue #1030 slice 3).
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Import)]
+public sealed class OgcWcsImportEndpointTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/ogc-wcs/import")]
+    public async Task Import_WithMissingServiceUrl_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/import/ogc-wcs/import", new
+        {
+            Version = "2.0.1"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("ServiceUrl is required.");
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1030 (slice 3 of N — stacked on #1101)

## Summary
Adds the legacy OGC Web Coverage Service (WCS 1.x / 2.x) source import path. Many production stacks still serve coverages over WCS rather than the newer OGC API Coverages, so the migration story for #1030 must cover both. This slice introduces a dedicated `IOgcWcsImportService` that sits on top of the slice-2 coverage ingestion pipeline and handles WCS-specific format negotiation before delegating the actual GetCoverage download and raster store registration.

`image/tiff` (and the common GeoTIFF MIME variants) is the deterministic happy-path. Any other requested format — NetCDF, HDF, GML coverage, vendor-specific — is downgraded to manual-review before the source service is contacted, so the WCS layer never asks the slice-2 ingest pipeline to consume bytes it cannot interpret.

## Changes Made
- New core service `IOgcWcsImportService` + `OgcWcsImportService` (delegates to slice-2 `IOgcCoverageImportService` — no duplicate ingest logic).
- New domain types `OgcWcsImportRequest` and `OgcWcsImportResult`.
- New admin endpoint `POST /api/v1/admin/import/ogc-wcs/import` with the same dry-run / explicit-apply contract slice 2 established.
- DI registration in `Features/Import/ServiceCollectionExtensions`.
- `Program.cs`, `EndpointRegistry.cs`, and a source-gen JSON context (`OgcWcsImportJsonContext`) registered with the server's JSON registry.
- Service tests cover dry-run, apply-mode GeoTIFF happy-path, non-GeoTIFF downgrade, GeoTIFF MIME variant acceptance, WCS 1.x legacy `coverage=` parameter routing, HTTP failure propagation, and version/URL validation.
- Endpoint integration test satisfies the `AllRegisteredEndpoints_HaveIntegrationTests` architecture gate.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None — new endpoint and services; nothing existing changes shape.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review