### PR TITLE
feat: coverage style migration diagnostics (#1030 slice 4/N)

### DIFF
--- a/src/Honua.Core/Features/Import/Domain/MigrationCoverageStyleDiagnostic.cs
+++ b/src/Honua.Core/Features/Import/Domain/MigrationCoverageStyleDiagnostic.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Diagnostic emitted by the OGC coverage import pipeline describing a coverage
+/// style hint (color map, band statistics, NoData marker, transparency preset,
+/// legend, or rendering hint) that could not be transferred verbatim with the
+/// raw pixels. Slice 4 of issue #1030.
+/// </summary>
+/// <remarks>
+/// Coverage *style* migration is deliberately separate from coverage *data*
+/// migration: pixels can be downloaded and re-registered, but per-band lookup
+/// tables, NoData markers, legend swatches and renderer-specific transforms
+/// have to be recreated against the target rendering pipeline. These records
+/// surface every hint discovered from the source so operators can decide which
+/// to recreate automatically, which to copy verbatim, and which to rebuild by
+/// hand.
+/// </remarks>
+public sealed record MigrationCoverageStyleDiagnostic
+{
+    /// <summary>
+    /// Style kind. One of: <c>colorMap</c>, <c>bandStatistics</c>,
+    /// <c>noDataValue</c>, <c>transparency</c>, <c>legend</c>, <c>renderingHint</c>.
+    /// </summary>
+    public required string Kind { get; init; }
+
+    /// <summary>
+    /// Migration classification: <c>automated</c>, <c>assisted</c>, or
+    /// <c>manual-review</c>. Determines how the diagnostic must be acted on
+    /// in the downstream apply stage.
+    /// </summary>
+    public required string Classification { get; init; }
+
+    /// <summary>
+    /// Source coverage identifier the diagnostic applies to.
+    /// </summary>
+    public required string SourceCoverageId { get; init; }
+
+    /// <summary>
+    /// Optional source style identifier (for example a GeoServer SLD name or
+    /// an OGC API Coverages <c>/styles/{styleId}</c> document) when the
+    /// diagnostic was derived from a named style entry.
+    /// </summary>
+    public string? SourceStyleId { get; init; }
+
+    /// <summary>
+    /// Human-readable reason describing why the diagnostic was emitted.
+    /// </summary>
+    public required string Reason { get; init; }
+
+    /// <summary>
+    /// Stable suggestion for the target style identifier when the diagnostic
+    /// classifier could match the source hint to an existing Honua style
+    /// preset (e.g. <c>grayscale-linear-stretch</c>). Null when no preset
+    /// match is available and operators must author a target style manually.
+    /// </summary>
+    public string? SuggestedTargetStyleId { get; init; }
+
+    /// <summary>
+    /// Vendor name for vendor-specific extensions (e.g. <c>Esri</c>,
+    /// <c>GeoServer</c>). Null when the diagnostic does not originate from a
+    /// recognised vendor extension marker.
+    /// </summary>
+    public string? VendorName { get; init; }
+
+    /// <summary>
+    /// Manual steps an operator must perform to reconcile this style hint
+    /// against the target. Empty for fully automated diagnostics.
+    /// </summary>
+    public string[] ManualSteps { get; init; } = [];
+}

--- a/src/Honua.Core/Features/Import/Domain/OgcCoverageImportResult.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcCoverageImportResult.cs
@@ -27,6 +27,15 @@ public sealed record OgcCoverageImportResult
     /// Whether the request was a dry-run preview.
     /// </summary>
     public bool DryRun { get; init; }
+
+    /// <summary>
+    /// Coverage-style migration diagnostics emitted while inspecting source
+    /// coverage style hints. Empty when no inventoried coverage advertised a
+    /// color map, band statistics, NoData marker, transparency preset, legend,
+    /// or rendering hint that required separate operator attention.
+    /// Slice 4 of issue #1030.
+    /// </summary>
+    public MigrationCoverageStyleDiagnostic[] StyleDiagnostics { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Import/Domain/OgcWcsImportResult.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcWcsImportResult.cs
@@ -45,4 +45,10 @@ public sealed record OgcWcsImportResult
     /// Whether the request was a dry-run preview.
     /// </summary>
     public bool DryRun { get; init; }
+
+    /// <summary>
+    /// Coverage-style migration diagnostics surfaced by the underlying coverage
+    /// import service. Slice 4 of issue #1030.
+    /// </summary>
+    public MigrationCoverageStyleDiagnostic[] StyleDiagnostics { get; init; } = [];
 }

--- a/src/Honua.Core/Features/Import/Services/CoverageStyleDiagnosticBuilder.cs
+++ b/src/Honua.Core/Features/Import/Services/CoverageStyleDiagnosticBuilder.cs
@@ -1,0 +1,409 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Inspects <see cref="MigrationInventoryResource"/> coverage records and emits
+/// <see cref="MigrationCoverageStyleDiagnostic"/> entries describing per-style
+/// hints (color maps, band statistics, NoData markers, transparency presets,
+/// legends, vendor-specific rendering hints) that need separate operator
+/// attention when migrating to Honua. Slice 4 of issue #1030.
+/// </summary>
+/// <remarks>
+/// Classification rules:
+/// <list type="bullet">
+///   <item><description>Single-band grayscale with stats → automated; suggests
+///   <c>grayscale-linear-stretch</c>.</description></item>
+///   <item><description>Indexed color tables (≤256 entries) → assisted; preserves
+///   the source table and emits an informational diagnostic so it can be
+///   transferred verbatim.</description></item>
+///   <item><description>Continuous color ramps with formulas or unresolved color
+///   tables → manual-review; the raw style is preserved but a warning is
+///   raised.</description></item>
+///   <item><description>Vendor-specific extension markers (Esri, GeoServer, etc.)
+///   → manual-review with the vendor name surfaced so operators know which
+///   product authored the style.</description></item>
+/// </list>
+/// The builder is deterministic: it ignores input ordering and emits records
+/// sorted by source coverage id, kind, then source style id.
+/// </remarks>
+internal static class CoverageStyleDiagnosticBuilder
+{
+    private const string KindColorMap = "colorMap";
+    private const string KindBandStatistics = "bandStatistics";
+    private const string KindNoDataValue = "noDataValue";
+    private const string KindTransparency = "transparency";
+    private const string KindLegend = "legend";
+    private const string KindRenderingHint = "renderingHint";
+
+    private const string ClassificationAutomated = "automated";
+    private const string ClassificationAssisted = "assisted";
+    private const string ClassificationManualReview = "manual-review";
+
+    private const string SuggestedGrayscaleLinearStretch = "grayscale-linear-stretch";
+    private const string SuggestedIndexedColor = "indexed-color-table";
+
+    /// <summary>
+    /// Builds the deterministic ordered diagnostic collection for the supplied
+    /// inventory coverage resources.
+    /// </summary>
+    /// <param name="resources">Coverage resources from the source migration inventory.</param>
+    /// <returns>Empty array when no style hints were discovered.</returns>
+    public static MigrationCoverageStyleDiagnostic[] Build(IEnumerable<MigrationInventoryResource> resources)
+    {
+        ArgumentNullException.ThrowIfNull(resources);
+
+        var diagnostics = new List<MigrationCoverageStyleDiagnostic>();
+        foreach (var resource in resources)
+        {
+            if (resource is null ||
+                !string.Equals(resource.Kind, "coverage", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            BuildForResource(resource, diagnostics);
+        }
+
+        return diagnostics
+            .OrderBy(static d => d.SourceCoverageId, StringComparer.Ordinal)
+            .ThenBy(static d => d.Kind, StringComparer.Ordinal)
+            .ThenBy(static d => d.SourceStyleId ?? string.Empty, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static void BuildForResource(
+        MigrationInventoryResource resource,
+        ICollection<MigrationCoverageStyleDiagnostic> sink)
+    {
+        var coverageId = resource.Name;
+
+        // Band statistics + grayscale stretch preset.
+        var bandCount = resource.Fields.Length;
+        if (bandCount > 0)
+        {
+            var firstBand = resource.Fields[0];
+            var hasStats = LooksLikeNumeric(firstBand.FieldType);
+
+            if (bandCount == 1 && hasStats)
+            {
+                sink.Add(new MigrationCoverageStyleDiagnostic
+                {
+                    Kind = KindBandStatistics,
+                    Classification = ClassificationAutomated,
+                    SourceCoverageId = coverageId,
+                    SourceStyleId = firstBand.Name,
+                    Reason = $"Single-band grayscale coverage ({firstBand.FieldType}) detected; a linear stretch preset can be auto-applied at apply time.",
+                    SuggestedTargetStyleId = SuggestedGrayscaleLinearStretch
+                });
+            }
+            else if (bandCount > 1)
+            {
+                sink.Add(new MigrationCoverageStyleDiagnostic
+                {
+                    Kind = KindBandStatistics,
+                    Classification = ClassificationAssisted,
+                    SourceCoverageId = coverageId,
+                    Reason = $"Multi-band coverage ({bandCount} bands) requires per-band statistics to recreate the source rendering; preserve the source band metadata when authoring the target style.",
+                    ManualSteps =
+                    [
+                        "Capture per-band min/max/mean/stddev from the source service before promoting the target style.",
+                        "Pick a multi-band renderer (RGB, false-color, multispectral composite) on the target layer and bind it to the imported raster."
+                    ]
+                });
+            }
+        }
+
+        // NoData values surfaced via field DomainName (range unit) or capability marker.
+        foreach (var field in resource.Fields)
+        {
+            if (HasNoDataMarker(field))
+            {
+                sink.Add(new MigrationCoverageStyleDiagnostic
+                {
+                    Kind = KindNoDataValue,
+                    Classification = ClassificationAutomated,
+                    SourceCoverageId = coverageId,
+                    SourceStyleId = field.Name,
+                    Reason = $"NoData marker advertised for band {field.Name}; the slice-2 GeoTIFF import preserves NoData verbatim, but the target style must mask matching pixels."
+                });
+            }
+        }
+
+        // StyleIds → color maps / vendor markers / continuous ramps.
+        foreach (var styleId in resource.StyleIds)
+        {
+            if (string.IsNullOrWhiteSpace(styleId))
+            {
+                continue;
+            }
+
+            var classified = ClassifyStyleId(styleId, coverageId);
+            if (classified is not null)
+            {
+                sink.Add(classified);
+            }
+        }
+
+        // Capabilities / warning markers — transparency presets and rendering hints.
+        foreach (var capability in resource.Capabilities)
+        {
+            if (string.IsNullOrWhiteSpace(capability))
+            {
+                continue;
+            }
+
+            var diagnostic = ClassifyCapability(capability, coverageId);
+            if (diagnostic is not null)
+            {
+                sink.Add(diagnostic);
+            }
+        }
+
+        // Compatibility warnings → legend / rendering hint surfaces.
+        foreach (var warning in resource.Compatibility.Warnings)
+        {
+            if (string.IsNullOrWhiteSpace(warning))
+            {
+                continue;
+            }
+
+            var diagnostic = ClassifyWarning(warning, coverageId);
+            if (diagnostic is not null)
+            {
+                sink.Add(diagnostic);
+            }
+        }
+    }
+
+    private static bool LooksLikeNumeric(string? fieldType)
+    {
+        if (string.IsNullOrWhiteSpace(fieldType))
+        {
+            return false;
+        }
+
+        var lower = fieldType.ToLower(CultureInfo.InvariantCulture);
+        return lower.Contains("int", StringComparison.Ordinal) ||
+            lower.Contains("float", StringComparison.Ordinal) ||
+            lower.Contains("double", StringComparison.Ordinal) ||
+            lower.Contains("byte", StringComparison.Ordinal) ||
+            lower.Contains("real", StringComparison.Ordinal) ||
+            lower.Contains("numeric", StringComparison.Ordinal);
+    }
+
+    private static bool HasNoDataMarker(MigrationInventoryField field)
+    {
+        if (field is null)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(field.DomainName) &&
+            field.DomainName.Contains("nodata", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(field.DomainType) &&
+            field.DomainType.Contains("nodata", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static MigrationCoverageStyleDiagnostic? ClassifyStyleId(string styleId, string coverageId)
+    {
+        var trimmed = styleId.Trim();
+        var lower = trimmed.ToLower(CultureInfo.InvariantCulture);
+
+        // Vendor markers first — these dominate the classification.
+        var vendor = DetectVendor(lower);
+        if (vendor is not null)
+        {
+            return new MigrationCoverageStyleDiagnostic
+            {
+                Kind = KindRenderingHint,
+                Classification = ClassificationManualReview,
+                SourceCoverageId = coverageId,
+                SourceStyleId = trimmed,
+                VendorName = vendor,
+                Reason = $"Vendor-specific {vendor} style extension '{trimmed}' cannot be migrated automatically; recreate the equivalent renderer in Honua.",
+                ManualSteps =
+                [
+                    $"Export the source {vendor} style definition for reference.",
+                    "Author an equivalent renderer in Honua and bind it to the imported coverage."
+                ]
+            };
+        }
+
+        // Continuous ramp / formula markers → manual review.
+        if (LooksLikeContinuousRamp(lower))
+        {
+            return new MigrationCoverageStyleDiagnostic
+            {
+                Kind = KindColorMap,
+                Classification = ClassificationManualReview,
+                SourceCoverageId = coverageId,
+                SourceStyleId = trimmed,
+                Reason = $"Continuous color ramp '{trimmed}' uses a formula-based interpolation; preserve the source style document and rebuild the equivalent ramp on the target.",
+                ManualSteps =
+                [
+                    "Export the source style document (SLD, GDAL color table, or OGC API styles JSON) and store it alongside the migration manifest.",
+                    "Recreate the continuous ramp renderer on the Honua target layer."
+                ]
+            };
+        }
+
+        // Indexed color map → assisted.
+        if (LooksLikeIndexedColor(lower))
+        {
+            return new MigrationCoverageStyleDiagnostic
+            {
+                Kind = KindColorMap,
+                Classification = ClassificationAssisted,
+                SourceCoverageId = coverageId,
+                SourceStyleId = trimmed,
+                SuggestedTargetStyleId = SuggestedIndexedColor,
+                Reason = $"Indexed color table '{trimmed}' (≤256 entries) can be transferred verbatim; preserve the source palette when registering the target style."
+            };
+        }
+
+        if (lower.Contains("legend", StringComparison.Ordinal))
+        {
+            return new MigrationCoverageStyleDiagnostic
+            {
+                Kind = KindLegend,
+                Classification = ClassificationManualReview,
+                SourceCoverageId = coverageId,
+                SourceStyleId = trimmed,
+                Reason = $"Legend hint '{trimmed}' must be regenerated against the target rendering pipeline; the source legend graphic is not transferable.",
+                ManualSteps = ["Generate a fresh legend graphic after the target style is published."]
+            };
+        }
+
+        if (lower.Contains("transparen", StringComparison.Ordinal) ||
+            lower.Contains("alpha", StringComparison.Ordinal))
+        {
+            return new MigrationCoverageStyleDiagnostic
+            {
+                Kind = KindTransparency,
+                Classification = ClassificationAssisted,
+                SourceCoverageId = coverageId,
+                SourceStyleId = trimmed,
+                Reason = $"Transparency preset '{trimmed}' detected; mirror the opacity on the target style after import."
+            };
+        }
+
+        // Unknown but present style id → record as rendering hint manual-review so it isn't silently dropped.
+        return new MigrationCoverageStyleDiagnostic
+        {
+            Kind = KindRenderingHint,
+            Classification = ClassificationManualReview,
+            SourceCoverageId = coverageId,
+            SourceStyleId = trimmed,
+            Reason = $"Source style '{trimmed}' could not be classified automatically; review and recreate on the target.",
+            ManualSteps = ["Fetch the source style document and decide whether to import verbatim, adapt, or skip."]
+        };
+    }
+
+    private static MigrationCoverageStyleDiagnostic? ClassifyCapability(string capability, string coverageId)
+    {
+        var lower = capability.Trim().ToLower(CultureInfo.InvariantCulture);
+        if (lower.Contains("transparen", StringComparison.Ordinal) || lower.Contains("alpha", StringComparison.Ordinal))
+        {
+            return new MigrationCoverageStyleDiagnostic
+            {
+                Kind = KindTransparency,
+                Classification = ClassificationAssisted,
+                SourceCoverageId = coverageId,
+                Reason = $"Coverage advertises a transparency capability ('{capability}'); confirm the matching alpha treatment on the target style."
+            };
+        }
+
+        return null;
+    }
+
+    private static MigrationCoverageStyleDiagnostic? ClassifyWarning(string warning, string coverageId)
+    {
+        var lower = warning.ToLower(CultureInfo.InvariantCulture);
+        if (lower.Contains("legend", StringComparison.Ordinal))
+        {
+            return new MigrationCoverageStyleDiagnostic
+            {
+                Kind = KindLegend,
+                Classification = ClassificationManualReview,
+                SourceCoverageId = coverageId,
+                Reason = $"Coverage scan flagged legend hint: {warning}.",
+                ManualSteps = ["Inspect the source legend artifact and regenerate it on the target."]
+            };
+        }
+
+        if (lower.Contains("color") || lower.Contains("renderer") || lower.Contains("rendering"))
+        {
+            return new MigrationCoverageStyleDiagnostic
+            {
+                Kind = KindRenderingHint,
+                Classification = ClassificationManualReview,
+                SourceCoverageId = coverageId,
+                Reason = $"Coverage scan flagged rendering hint: {warning}.",
+                ManualSteps = ["Review the rendering hint and reproduce the equivalent treatment on the target style."]
+            };
+        }
+
+        return null;
+    }
+
+    private static string? DetectVendor(string lower)
+    {
+        if (lower.Contains("esri", StringComparison.Ordinal) ||
+            lower.StartsWith("arcgis", StringComparison.Ordinal) ||
+            lower.Contains("arcmap", StringComparison.Ordinal))
+        {
+            return "Esri";
+        }
+
+        if (lower.Contains("geoserver", StringComparison.Ordinal) ||
+            lower.Contains("gs:", StringComparison.Ordinal) ||
+            lower.StartsWith("sld_", StringComparison.Ordinal))
+        {
+            return "GeoServer";
+        }
+
+        if (lower.Contains("mapinfo", StringComparison.Ordinal))
+        {
+            return "MapInfo";
+        }
+
+        if (lower.Contains("hexagon", StringComparison.Ordinal) ||
+            lower.Contains("erdas", StringComparison.Ordinal))
+        {
+            return "Hexagon";
+        }
+
+        return null;
+    }
+
+    private static bool LooksLikeContinuousRamp(string lower)
+        => lower.Contains("ramp", StringComparison.Ordinal) ||
+           lower.Contains("continuous", StringComparison.Ordinal) ||
+           lower.Contains("gradient", StringComparison.Ordinal) ||
+           lower.Contains("interpolat", StringComparison.Ordinal) ||
+           lower.Contains("formula", StringComparison.Ordinal);
+
+    private static bool LooksLikeIndexedColor(string lower)
+        => lower.Contains("indexed", StringComparison.Ordinal) ||
+           lower.Contains("palette", StringComparison.Ordinal) ||
+           lower.Contains("colormap", StringComparison.Ordinal) ||
+           lower.Contains("color-map", StringComparison.Ordinal) ||
+           lower.Contains("colortable", StringComparison.Ordinal) ||
+           lower.Contains("color-table", StringComparison.Ordinal) ||
+           lower.Contains("lookup", StringComparison.Ordinal) ||
+           lower.Contains("classified", StringComparison.Ordinal);
+}

--- a/src/Honua.Core/Features/Import/Services/OgcCoverageImportService.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcCoverageImportService.cs
@@ -55,6 +55,7 @@ public sealed partial class OgcCoverageImportService : IOgcCoverageImportService
             .Where(static resource => string.Equals(resource.Kind, "coverage", StringComparison.Ordinal))
             .ToArray();
         var selectedResources = SelectResources(inventoryResources, request.CoverageSelection);
+        var styleDiagnostics = CoverageStyleDiagnosticBuilder.Build(selectedResources);
 
         var targets = new List<MigrationManifestTargetResource>();
         var manualReviewItems = new List<MigrationManifestReviewItem>();
@@ -284,7 +285,8 @@ public sealed partial class OgcCoverageImportService : IOgcCoverageImportService
                 .OrderBy(static record => record.SourceCoverageId, StringComparer.Ordinal)
                 .ToArray(),
             ApplyMode = applyMode,
-            DryRun = !applyMode
+            DryRun = !applyMode,
+            StyleDiagnostics = styleDiagnostics
         };
     }
 

--- a/src/Honua.Core/Features/Import/Services/OgcWcsImportService.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcWcsImportService.cs
@@ -98,7 +98,8 @@ public sealed partial class OgcWcsImportService : IOgcWcsImportService
             RequestedOutputFormat = negotiatedFormat,
             ResolvedVersion = resolvedVersion,
             ApplyMode = coverageResult.ApplyMode,
-            DryRun = coverageResult.DryRun
+            DryRun = coverageResult.DryRun,
+            StyleDiagnostics = coverageResult.StyleDiagnostics
         };
     }
 

--- a/src/Honua.Server/Features/Import/OgcCoverageImportJsonContext.cs
+++ b/src/Honua.Server/Features/Import/OgcCoverageImportJsonContext.cs
@@ -17,6 +17,8 @@ namespace Honua.Server.Features.Import;
 [JsonSerializable(typeof(OgcCoverageImportResult))]
 [JsonSerializable(typeof(OgcCoverageImportRecord))]
 [JsonSerializable(typeof(OgcCoverageImportRecord[]))]
+[JsonSerializable(typeof(MigrationCoverageStyleDiagnostic))]
+[JsonSerializable(typeof(MigrationCoverageStyleDiagnostic[]))]
 [JsonSerializable(typeof(OgcCoverageImportTarget))]
 [JsonSerializable(typeof(IReadOnlyDictionary<string, OgcCoverageImportTarget>))]
 [JsonSerializable(typeof(MigrationSourceInventoryArtifact))]

--- a/src/Honua.Server/Features/Import/OgcWcsImportJsonContext.cs
+++ b/src/Honua.Server/Features/Import/OgcWcsImportJsonContext.cs
@@ -18,6 +18,8 @@ namespace Honua.Server.Features.Import;
 [JsonSerializable(typeof(OgcWcsImportResult))]
 [JsonSerializable(typeof(OgcCoverageImportRecord))]
 [JsonSerializable(typeof(OgcCoverageImportRecord[]))]
+[JsonSerializable(typeof(MigrationCoverageStyleDiagnostic))]
+[JsonSerializable(typeof(MigrationCoverageStyleDiagnostic[]))]
 [JsonSerializable(typeof(OgcCoverageImportTarget))]
 [JsonSerializable(typeof(IReadOnlyDictionary<string, OgcCoverageImportTarget>))]
 [JsonSerializable(typeof(MigrationSourceInventoryArtifact))]

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/CoverageStyleDiagnosticBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/CoverageStyleDiagnosticBuilderTests.cs
@@ -1,0 +1,247 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+
+namespace Honua.Core.Tests.Features.Import;
+
+/// <summary>
+/// Coverage-style migration diagnostic tests for the slice-4 builder
+/// (<see cref="CoverageStyleDiagnosticBuilder"/>) of issue #1030.
+/// Each fact targets one of the four documented classification rules plus
+/// JSON round-trip stability.
+/// </summary>
+public sealed class CoverageStyleDiagnosticBuilderTests
+{
+    [Fact]
+    public void Build_SingleBandGrayscaleWithStats_EmitsAutomatedLinearStretch()
+    {
+        var resource = BuildResource(
+            "dem-tiff",
+            fields: [
+                new MigrationInventoryField { Name = "elevation", FieldType = "Float32" }
+            ]);
+
+        var diagnostics = CoverageStyleDiagnosticBuilder.Build([resource]);
+
+        var bandStats = diagnostics.Should()
+            .ContainSingle(d => d.Kind == "bandStatistics").Subject;
+        bandStats.Classification.Should().Be("automated");
+        bandStats.SourceCoverageId.Should().Be("dem-tiff");
+        bandStats.SourceStyleId.Should().Be("elevation");
+        bandStats.SuggestedTargetStyleId.Should().Be("grayscale-linear-stretch");
+        bandStats.ManualSteps.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Build_IndexedColorTable_EmitsAssistedColorMapWithPreservedPalette()
+    {
+        var resource = BuildResource(
+            "landcover",
+            styleIds: ["landcover-palette"]);
+
+        var diagnostics = CoverageStyleDiagnosticBuilder.Build([resource]);
+
+        var colorMap = diagnostics.Should()
+            .ContainSingle(d => d.Kind == "colorMap").Subject;
+        colorMap.Classification.Should().Be("assisted");
+        colorMap.SourceStyleId.Should().Be("landcover-palette");
+        colorMap.SuggestedTargetStyleId.Should().Be("indexed-color-table");
+        colorMap.Reason.Should().Contain("transferred verbatim");
+    }
+
+    [Fact]
+    public void Build_ContinuousColorRamp_EmitsManualReviewWithGuidance()
+    {
+        var resource = BuildResource(
+            "ndvi-monthly",
+            styleIds: ["ndvi-continuous-ramp"]);
+
+        var diagnostics = CoverageStyleDiagnosticBuilder.Build([resource]);
+
+        var colorMap = diagnostics.Should()
+            .ContainSingle(d => d.Kind == "colorMap").Subject;
+        colorMap.Classification.Should().Be("manual-review");
+        colorMap.SuggestedTargetStyleId.Should().BeNull();
+        colorMap.ManualSteps.Should().NotBeEmpty();
+        colorMap.ManualSteps[0].Should().Contain("Export the source style document");
+    }
+
+    [Fact]
+    public void Build_VendorMarker_EsriExtension_EmitsManualReviewWithVendorName()
+    {
+        var resource = BuildResource(
+            "imagery",
+            styleIds: ["esri:rendering:stretchedRaster"]);
+
+        var diagnostics = CoverageStyleDiagnosticBuilder.Build([resource]);
+
+        var hint = diagnostics.Should()
+            .ContainSingle(d => d.Kind == "renderingHint").Subject;
+        hint.Classification.Should().Be("manual-review");
+        hint.VendorName.Should().Be("Esri");
+        hint.SourceStyleId.Should().Be("esri:rendering:stretchedRaster");
+        hint.ManualSteps.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Build_VendorMarker_GeoServerSld_EmitsManualReviewWithGeoServerVendor()
+    {
+        var resource = BuildResource(
+            "ortho",
+            styleIds: ["gs:rgb-stretch"]);
+
+        var diagnostics = CoverageStyleDiagnosticBuilder.Build([resource]);
+
+        diagnostics.Should().ContainSingle()
+            .Which.VendorName.Should().Be("GeoServer");
+    }
+
+    [Fact]
+    public void Build_NoDataMarker_EmitsAutomatedDiagnostic()
+    {
+        var resource = BuildResource(
+            "dem-tiff",
+            fields: [
+                new MigrationInventoryField
+                {
+                    Name = "elevation",
+                    FieldType = "Float32",
+                    DomainName = "NoData=-9999"
+                }
+            ]);
+
+        var diagnostics = CoverageStyleDiagnosticBuilder.Build([resource]);
+
+        var nodata = diagnostics.Should()
+            .ContainSingle(d => d.Kind == "noDataValue").Subject;
+        nodata.Classification.Should().Be("automated");
+        nodata.SourceStyleId.Should().Be("elevation");
+    }
+
+    [Fact]
+    public void Build_TransparencyCapability_EmitsAssistedDiagnostic()
+    {
+        var resource = BuildResource(
+            "satellite",
+            capabilities: ["transparency"]);
+
+        var diagnostics = CoverageStyleDiagnosticBuilder.Build([resource]);
+
+        diagnostics.Should().ContainSingle(d => d.Kind == "transparency")
+            .Which.Classification.Should().Be("assisted");
+    }
+
+    [Fact]
+    public void Build_MultiBandCoverage_EmitsAssistedBandStatisticsDiagnostic()
+    {
+        var resource = BuildResource(
+            "rgb-ortho",
+            fields: [
+                new MigrationInventoryField { Name = "red", FieldType = "UInt8" },
+                new MigrationInventoryField { Name = "green", FieldType = "UInt8" },
+                new MigrationInventoryField { Name = "blue", FieldType = "UInt8" }
+            ]);
+
+        var diagnostics = CoverageStyleDiagnosticBuilder.Build([resource]);
+
+        var bandStats = diagnostics.Should()
+            .ContainSingle(d => d.Kind == "bandStatistics").Subject;
+        bandStats.Classification.Should().Be("assisted");
+        bandStats.SuggestedTargetStyleId.Should().BeNull();
+        bandStats.ManualSteps.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Build_NonCoverageResources_Ignored()
+    {
+        var resource = BuildResource(
+            "feature-set",
+            kind: "feature",
+            styleIds: ["any-style"]);
+
+        var diagnostics = CoverageStyleDiagnosticBuilder.Build([resource]);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Build_Ordering_IsDeterministic()
+    {
+        var first = BuildResource(
+            "z-coverage",
+            styleIds: ["z-palette"]);
+        var second = BuildResource(
+            "a-coverage",
+            styleIds: ["a-palette"]);
+        var third = BuildResource(
+            "m-coverage",
+            styleIds: ["m-ramp"]);
+
+        var diagnostics = CoverageStyleDiagnosticBuilder.Build([first, second, third]);
+
+        diagnostics.Select(d => d.SourceCoverageId)
+            .Should().ContainInOrder("a-coverage", "m-coverage", "z-coverage");
+    }
+
+    [Fact]
+    public void Diagnostic_JsonRoundTrip_PreservesAllFields()
+    {
+        var resource = BuildResource(
+            "ndvi",
+            fields: [
+                new MigrationInventoryField
+                {
+                    Name = "ndvi",
+                    FieldType = "Float32",
+                    DomainName = "NoData=-9999"
+                }
+            ],
+            styleIds: ["ndvi-continuous-ramp", "esri:colorizer"],
+            capabilities: ["transparency"]);
+
+        var diagnostics = CoverageStyleDiagnosticBuilder.Build([resource]);
+        diagnostics.Should().NotBeEmpty();
+
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+
+        var json = JsonSerializer.Serialize(diagnostics, options);
+        var round = JsonSerializer.Deserialize<MigrationCoverageStyleDiagnostic[]>(json, options);
+
+        round.Should().BeEquivalentTo(diagnostics);
+        json.Should().Contain("\"classification\":");
+        json.Should().Contain("\"kind\":");
+        json.Should().Contain("\"reason\":");
+    }
+
+    private static MigrationInventoryResource BuildResource(
+        string name,
+        string kind = "coverage",
+        MigrationInventoryField[]? fields = null,
+        string[]? styleIds = null,
+        string[]? capabilities = null)
+        => new()
+        {
+            Id = $"{kind}:{name}",
+            ContainerId = "service:wcs",
+            Kind = kind,
+            Name = name,
+            Title = name,
+            Fields = fields ?? [],
+            StyleIds = styleIds ?? [],
+            Capabilities = capabilities ?? [],
+            Compatibility = new MigrationCompatibilityAssessment
+            {
+                Level = "compatible",
+                Code = OgcCoverageMigrationCompatibilityCodes.GeoTiffSupported,
+                Reason = "test fixture"
+            }
+        };
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcCoverageImportServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcCoverageImportServiceTests.cs
@@ -276,6 +276,32 @@ public sealed class OgcCoverageImportServiceTests
     }
 
     [Fact]
+    public async Task ImportAsync_PopulatesStyleDiagnosticsFromInventoryStyleIds()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => throw new InvalidOperationException("Dry-run import must not call the source service."));
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var resource = BuildGeoTiffResource("ndvi-monthly") with
+        {
+            StyleIds = ["ndvi-continuous-ramp", "esri:rendering:stretchedRaster"]
+        };
+        var request = new OgcCoverageImportRequest
+        {
+            ServiceType = "WCS",
+            ServiceUrl = ServiceUrl,
+            Inventory = BuildInventory(resource),
+            DryRun = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.StyleDiagnostics.Should().HaveCountGreaterThan(0);
+        result.StyleDiagnostics.Should().Contain(d => d.Kind == "colorMap" && d.Classification == "manual-review");
+        result.StyleDiagnostics.Should().Contain(d => d.VendorName == "Esri");
+    }
+
+    [Fact]
     public async Task ImportAsync_RejectsPlainHttpUrl_UnlessAllowUnsafeIsSet()
     {
         var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcWcsImportServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcWcsImportServiceTests.cs
@@ -269,6 +269,31 @@ public sealed class OgcWcsImportServiceTests
     }
 
     [Fact]
+    public async Task ImportAsync_PropagatesStyleDiagnosticsFromUnderlyingCoverageService()
+    {
+        var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);
+        var handler = new CountingHandler(() => throw new InvalidOperationException("Dry-run must not call the WCS source."));
+        var service = CreateService(handler, rasterImportMock.Object);
+
+        var resource = BuildGeoTiffResource("ndvi") with
+        {
+            StyleIds = ["esri:colorizer"]
+        };
+        var request = new OgcWcsImportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            Inventory = BuildInventory(resource),
+            DryRun = true
+        };
+
+        var result = await service.ImportAsync(request);
+
+        result.StyleDiagnostics.Should().ContainSingle();
+        result.StyleDiagnostics[0].VendorName.Should().Be("Esri");
+        result.StyleDiagnostics[0].Classification.Should().Be("manual-review");
+    }
+
+    [Fact]
     public async Task ImportAsync_MissingServiceUrl_ThrowsArgumentException()
     {
         var rasterImportMock = new Mock<IRasterImportService>(MockBehavior.Strict);


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1030

## Summary
Slice 4 of the OGC coverage migration epic. Coverage *style* — color maps, band statistics, NoData markers, transparency presets, legends, vendor-specific renderer hints — does not transfer with the raw pixels. Emit a deterministic `MigrationCoverageStyleDiagnostic` collection from the OGC coverage import service (and propagate it through the legacy WCS service) so operators can decide what to recreate on the target.

Stacked on `codex/issue-1030-wcs-import` (slice 3, PR #1121).

## Changes Made
- Add `MigrationCoverageStyleDiagnostic` domain record with `Kind`, `Classification`, `Reason`, optional `SuggestedTargetStyleId`, optional `VendorName`, and `ManualSteps`.
- Add `CoverageStyleDiagnosticBuilder` that classifies each selected coverage's `Fields`, `StyleIds`, `Capabilities`, and warnings into the four documented categories (automated grayscale stretch, assisted indexed color table, manual-review continuous ramps, manual-review vendor markers).
- Extend `OgcCoverageImportResult` and `OgcWcsImportResult` additively with a `StyleDiagnostics` collection.
- Wire the builder into `OgcCoverageImportService.ImportAsync` (runs after selection, before manifest assembly) and propagate the diagnostics through `OgcWcsImportService`.
- Register `MigrationCoverageStyleDiagnostic` in both `OgcCoverageImportJsonContext` and `OgcWcsImportJsonContext` so the API response surface stays additive.
- Tests under `tests/dotnet/Honua.Core.Tests/Features/Import/CoverageStyleDiagnosticBuilderTests.cs` covering each classification rule, NoData markers, transparency capability, multi-band assisted path, non-coverage resources being ignored, deterministic ordering, and JSON round-trip; service-level smoke tests in the existing coverage/WCS test files confirm propagation.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None — the new `StyleDiagnostics` collection defaults to an empty array on both result records, so existing callers stay binary-compatible.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>