### PR TITLE
feat: register dissolve/simplify/snap executors (#1031 slice 5/N)

### DIFF
--- a/src/Honua.Server/Features/Geoprocessing/BuiltInProcessCatalog.cs
+++ b/src/Honua.Server/Features/Geoprocessing/BuiltInProcessCatalog.cs
@@ -43,7 +43,7 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
     private static ProcessDefinition[] BuildDefinitions() =>
     [
         // -----------------------------------------------------------------------
-        // Geometry operations (12)
+        // Geometry operations (14)
         // -----------------------------------------------------------------------
         new ProcessDefinition
         {
@@ -64,13 +64,14 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
         {
             ProcessId = "geometry.simplify",
             Title = "Simplify",
-            Description = "Generalizes geometries by removing vertices within the given tolerance, optionally preserving topology.",
+            Description = "Generalizes a geometry by removing vertices within the given tolerance using the Douglas-Peucker algorithm. By default uses topology-preserving simplification (ST_SimplifyPreserveTopology); setting preserveTopology=false enables the faster plain Douglas-Peucker walk.",
             Category = "geometry",
             Parameters =
             [
                 Param("wkb", "Input Geometry", "Geometry to simplify as base64-encoded WKB.", ProcessParameterValueType.Wkb, required: true),
-                Param("tolerance", "Tolerance", "Simplification tolerance in spatial reference units.", ProcessParameterValueType.FloatingPoint, required: true),
-                Param("preserveTopology", "Preserve Topology", "Use topology-preserving simplification.", ProcessParameterValueType.Flag, defaultValue: "true"),
+                Param("srid", "Spatial Reference", "SRID of the input geometry.", ProcessParameterValueType.Srid, required: true),
+                Param("tolerance", "Tolerance", "Simplification tolerance in spatial reference units; vertices within the tolerance of the simplified path are removed.", ProcessParameterValueType.FloatingPoint, required: true),
+                Param("preserveTopology", "Preserve Topology", "Use topology-preserving simplification to avoid introducing self-intersections.", ProcessParameterValueType.Flag, defaultValue: "true"),
             ],
             OutputArtifactKinds = [ArtifactKind.FeatureLayer]
         },
@@ -205,6 +206,35 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
             [
                 Param("wkb", "Input Geometry", "Geometry as base64-encoded WKB.", ProcessParameterValueType.Wkb, required: true),
                 Param("srid", "Spatial Reference", "SRID of the input geometry.", ProcessParameterValueType.Srid, required: true),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer]
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "geometry.dissolve",
+            Title = "Dissolve",
+            Description = "Collapses adjacent same-attribute geometries into one feature per group. Each input geometry is paired with an optional groupKeys entry; geometries sharing a key are unioned. When groupKeys is omitted every input collapses into a single feature, mirroring geometry.union but emitting a FeatureCollection envelope so downstream consumers can rely on the same shape regardless of group cardinality.",
+            Category = "geometry",
+            Parameters =
+            [
+                Param("wkbs", "Input Geometries", "Array of geometries to dissolve as base64-encoded WKB strings.", ProcessParameterValueType.WkbArray, required: true),
+                Param("srid", "Spatial Reference", "SRID of the input geometries.", ProcessParameterValueType.Srid, required: true),
+                Param("groupKeys", "Group Keys", "Optional JSON array of attribute keys parallel to 'wkbs'; geometries sharing a key dissolve together. When omitted all inputs collapse into a single feature.", ProcessParameterValueType.Text),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer]
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "geometry.snap",
+            Title = "Snap",
+            Description = "Snaps the vertices of an input geometry to those of a reference geometry whenever the distance between two candidates falls within the supplied tolerance, using the NetTopologySuite GeometrySnapper. Useful for aligning adjacent dataset boundaries before overlay operations that would otherwise produce sliver polygons.",
+            Category = "geometry",
+            Parameters =
+            [
+                Param("wkb", "Input Geometry", "Geometry whose vertices will be snapped, as base64-encoded WKB.", ProcessParameterValueType.Wkb, required: true),
+                Param("referenceWkb", "Reference Geometry", "Reference geometry whose vertices are the snap targets, as base64-encoded WKB.", ProcessParameterValueType.Wkb, required: true),
+                Param("srid", "Spatial Reference", "SRID of both geometries.", ProcessParameterValueType.Srid, required: true),
+                Param("tolerance", "Tolerance", "Snap tolerance in spatial reference units; input vertices within this distance of a reference vertex are pulled onto it.", ProcessParameterValueType.FloatingPoint, required: true),
             ],
             OutputArtifactKinds = [ArtifactKind.FeatureLayer]
         },

--- a/src/Honua.Server/Features/Geoprocessing/Execution/GeometryDissolveJobExecutor.cs
+++ b/src/Honua.Server/Features/Geoprocessing/Execution/GeometryDissolveJobExecutor.cs
@@ -1,0 +1,392 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NetTopologySuite.Operation.Union;
+
+namespace Honua.Server.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Production <see cref="IJobExecutor"/> for the <c>geometry.dissolve</c>
+/// process. Slice 5 of #1031 — extends the prior aggregate-output set
+/// (geometry.union) with a group-aware dissolve that collapses adjacent
+/// same-attribute geometries into one feature per group.
+///
+/// Where <see cref="GeometryUnionJobExecutor"/> always emits a single
+/// merged Feature, dissolve preserves grouping: callers supply a parallel
+/// <c>groupKeys</c> array (one key per input WKB) and the executor unions
+/// the geometries within each group, publishing a GeoJSON
+/// <c>FeatureCollection</c> with one Feature per distinct key. When
+/// <c>groupKeys</c> is omitted, every input collapses into a single
+/// group ("__all__") — the same behavior as a plain union but routed
+/// through the dissolve artifact shape so downstream consumers can rely
+/// on the FeatureCollection envelope.
+/// </summary>
+internal sealed partial class GeometryDissolveJobExecutor : IJobExecutor
+{
+    private const string FeatureCollectionDataUriPrefix = "data:application/geo+json;base64,";
+    private const string DefaultGroupKey = "__all__";
+
+    /// <summary>
+    /// The single process id this executor handles. Matches the catalog
+    /// entry in <see cref="BuiltInProcessCatalog"/>.
+    /// </summary>
+    internal const string HandledProcessId = "geometry.dissolve";
+
+    private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options;
+    private readonly ILogger<GeometryDissolveJobExecutor> _logger;
+
+    public GeometryDissolveJobExecutor(
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<GeometryDissolveJobExecutor> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GeoprocessingDispatchHelper.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(_logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the geometry.dissolve executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing dissolve inputs", cancellationToken).ConfigureAwait(false);
+
+        if (!TryReadInputs(parameters, out var inputs, out var inputError))
+        {
+            Log.InvalidInputs(_logger, job.OperationId, inputError);
+            return JobExecutionResult.Failed($"Invalid dissolve inputs: {inputError}");
+        }
+
+        var reader = new WKBReader { HandleSRID = true };
+        var groupedGeometries = new Dictionary<string, List<Geometry>>(StringComparer.Ordinal);
+        var orderedKeys = new List<string>();
+
+        for (var i = 0; i < inputs.WkbItems.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            byte[] bytes;
+            try
+            {
+                bytes = Convert.FromBase64String(inputs.WkbItems[i]);
+            }
+            catch (FormatException)
+            {
+                Log.InvalidWkb(_logger, job.OperationId, i, "is not valid base64");
+                return JobExecutionResult.Failed(
+                    $"Invalid dissolve inputs: wkbs[{i}] is not valid base64.");
+            }
+
+            if (bytes.Length == 0)
+            {
+                Log.InvalidWkb(_logger, job.OperationId, i, "decoded to zero bytes");
+                return JobExecutionResult.Failed(
+                    $"Invalid dissolve inputs: wkbs[{i}] decoded to zero bytes.");
+            }
+
+            Geometry geometry;
+            try
+            {
+                geometry = reader.Read(bytes);
+            }
+            catch (Exception ex) when (ex is ParseException or ArgumentException or IndexOutOfRangeException)
+            {
+                Log.InvalidWkb(_logger, job.OperationId, i, $"could not be decoded ({ex.GetType().Name})");
+                return JobExecutionResult.Failed(
+                    $"Invalid dissolve inputs: wkbs[{i}] could not be decoded.");
+            }
+
+            if (geometry == null || geometry.IsEmpty)
+            {
+                Log.InvalidWkb(_logger, job.OperationId, i, "decoded to an empty geometry");
+                return JobExecutionResult.Failed(
+                    $"Invalid dissolve inputs: wkbs[{i}] decoded to an empty geometry.");
+            }
+
+            geometry.SRID = inputs.Srid;
+
+            var key = inputs.GroupKeys?[i] ?? DefaultGroupKey;
+            if (!groupedGeometries.TryGetValue(key, out var bucket))
+            {
+                bucket = new List<Geometry>();
+                groupedGeometries[key] = bucket;
+                orderedKeys.Add(key);
+            }
+
+            bucket.Add(geometry);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(45, "Dissolving grouped geometries", cancellationToken).ConfigureAwait(false);
+
+        var dissolved = new List<(string Key, Geometry Geometry)>(orderedKeys.Count);
+        foreach (var key in orderedKeys)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Geometry unioned;
+            try
+            {
+                // UnaryUnionOp handles mixed geometry types and avoids the
+                // O(N) pairwise Union calls that amplify floating-point error
+                // across larger collections — matching the union executor.
+                unioned = UnaryUnionOp.Union(groupedGeometries[key]);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Log.DissolveComputationFailed(_logger, job.OperationId, key, ex);
+                return JobExecutionResult.Failed(
+                    $"Dissolve computation failed for group '{key}': {ex.GetType().Name}.");
+            }
+
+            if (unioned == null || unioned.IsEmpty)
+            {
+                return JobExecutionResult.Failed(
+                    $"Dissolve computation produced an empty geometry for group '{key}'.");
+            }
+
+            unioned.SRID = inputs.Srid;
+            dissolved.Add((key, unioned));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(75, "Encoding dissolve artifact", cancellationToken).ConfigureAwait(false);
+
+        var payload = WriteFeatureCollection(dissolved, inputs.Srid, inputs.WkbItems.Count);
+
+        var maxBytes = _options.CurrentValue.MaxArtifactBytes;
+        if (payload.Length > maxBytes)
+        {
+            Log.ArtifactTooLarge(_logger, job.OperationId, payload.Length, maxBytes);
+            return JobExecutionResult.Failed(
+                $"Dissolve artifact size {payload.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}. " +
+                "Reduce the input collection size or simplify the inputs before dissolving.");
+        }
+
+        var artifactUri = BuildDataUri(payload);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+        await context.ReportProgressAsync(100, "Dissolve completed", cancellationToken).ConfigureAwait(false);
+
+        return JobExecutionResult.Succeeded();
+    }
+
+    private static byte[] WriteFeatureCollection(
+        IReadOnlyList<(string Key, Geometry Geometry)> dissolved,
+        int srid,
+        int inputCount)
+    {
+        var writer = new GeoJsonWriter();
+
+        using var buffer = new MemoryStream();
+        using (var jsonWriter = new Utf8JsonWriter(buffer))
+        {
+            jsonWriter.WriteStartObject();
+            jsonWriter.WriteString("type", "FeatureCollection");
+            jsonWriter.WriteString("processId", HandledProcessId);
+            jsonWriter.WriteNumber("inputSrid", srid);
+            jsonWriter.WriteNumber("inputCount", inputCount);
+            jsonWriter.WriteNumber("groupCount", dissolved.Count);
+
+            jsonWriter.WritePropertyName("features");
+            jsonWriter.WriteStartArray();
+            foreach (var (key, geometry) in dissolved)
+            {
+                jsonWriter.WriteStartObject();
+                jsonWriter.WriteString("type", "Feature");
+
+                jsonWriter.WritePropertyName("geometry");
+                using (var doc = JsonDocument.Parse(writer.Write(geometry)))
+                {
+                    doc.RootElement.WriteTo(jsonWriter);
+                }
+
+                jsonWriter.WritePropertyName("properties");
+                jsonWriter.WriteStartObject();
+                jsonWriter.WriteString("processId", HandledProcessId);
+                jsonWriter.WriteString("groupKey", key);
+                jsonWriter.WriteNumber("inputSrid", srid);
+                jsonWriter.WriteEndObject();
+
+                jsonWriter.WriteEndObject();
+            }
+            jsonWriter.WriteEndArray();
+
+            jsonWriter.WriteEndObject();
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static string BuildDataUri(byte[] payload)
+    {
+        var sb = new StringBuilder(payload.Length * 2 + FeatureCollectionDataUriPrefix.Length);
+        sb.Append(FeatureCollectionDataUriPrefix);
+        sb.Append(Convert.ToBase64String(payload));
+        return sb.ToString();
+    }
+
+    private static bool TryReadInputs(
+        IReadOnlyDictionary<string, string> parameters,
+        out DissolveInputs inputs,
+        out string error)
+    {
+        inputs = default;
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+
+        if (!parameters.TryGetValue(prefix + "wkbs", out var wkbsRaw) || string.IsNullOrWhiteSpace(wkbsRaw))
+        {
+            error = "missing required input 'wkbs'";
+            return false;
+        }
+
+        if (!parameters.TryGetValue(prefix + "srid", out var sridRaw)
+            || !int.TryParse(sridRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var srid)
+            || srid <= 0)
+        {
+            error = "missing or invalid input 'srid'; expected a positive integer";
+            return false;
+        }
+
+        if (!TryParseStringArray(wkbsRaw, "wkbs", out var wkbItems, out error))
+        {
+            return false;
+        }
+
+        if (wkbItems.Count == 0)
+        {
+            error = "input 'wkbs' must contain at least one geometry";
+            return false;
+        }
+
+        List<string>? groupKeys = null;
+        if (parameters.TryGetValue(prefix + "groupKeys", out var groupKeysRaw)
+            && !string.IsNullOrWhiteSpace(groupKeysRaw))
+        {
+            if (!TryParseStringArray(groupKeysRaw, "groupKeys", out groupKeys, out error))
+            {
+                return false;
+            }
+
+            if (groupKeys.Count != wkbItems.Count)
+            {
+                error = $"input 'groupKeys' length ({groupKeys.Count}) must match 'wkbs' length ({wkbItems.Count})";
+                return false;
+            }
+        }
+
+        inputs = new DissolveInputs(wkbItems, groupKeys, srid);
+        error = "";
+        return true;
+    }
+
+    private static bool TryParseStringArray(
+        string raw,
+        string fieldName,
+        out List<string> values,
+        out string error)
+    {
+        values = new List<string>();
+        try
+        {
+            using var doc = JsonDocument.Parse(raw);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            {
+                error = $"input '{fieldName}' must be a JSON array";
+                return false;
+            }
+
+            values.Capacity = doc.RootElement.GetArrayLength();
+            var index = 0;
+            foreach (var element in doc.RootElement.EnumerateArray())
+            {
+                if (element.ValueKind != JsonValueKind.String)
+                {
+                    error = $"input '{fieldName}' element at index {index} is not a string";
+                    return false;
+                }
+
+                var value = element.GetString();
+                if (value == null)
+                {
+                    error = $"input '{fieldName}' element at index {index} is null";
+                    return false;
+                }
+
+                // For wkbs we additionally require non-whitespace; for
+                // groupKeys we accept the empty string as a legitimate key
+                // (canonical "no attribute" bucket). The empty-base64 check
+                // below catches degenerate WKB payloads regardless.
+                if (string.Equals(fieldName, "wkbs", StringComparison.Ordinal)
+                    && string.IsNullOrWhiteSpace(value))
+                {
+                    error = $"input '{fieldName}' element at index {index} is empty";
+                    return false;
+                }
+
+                values.Add(value);
+                index++;
+            }
+        }
+        catch (JsonException)
+        {
+            error = $"input '{fieldName}' is not valid JSON";
+            return false;
+        }
+
+        error = "";
+        return true;
+    }
+
+    private readonly record struct DissolveInputs(
+        IReadOnlyList<string> WkbItems,
+        IReadOnlyList<string>? GroupKeys,
+        int Srid);
+
+    private static partial class Log
+    {
+        [LoggerMessage(9200, LogLevel.Warning,
+            "Geometry dissolve executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9201, LogLevel.Warning,
+            "Geometry dissolve executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9202, LogLevel.Warning,
+            "Geometry dissolve executor rejected job {OperationId}: WKB decode failed at index {Index}: {Reason}")]
+        public static partial void InvalidWkb(ILogger logger, string operationId, int index, string reason);
+
+        [LoggerMessage(9203, LogLevel.Error,
+            "Geometry dissolve executor failed job {OperationId} during dissolve computation for group {GroupKey}")]
+        public static partial void DissolveComputationFailed(ILogger logger, string operationId, string groupKey, Exception exception);
+
+        [LoggerMessage(9204, LogLevel.Warning,
+            "Geometry dissolve executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+    }
+}

--- a/src/Honua.Server/Features/Geoprocessing/Execution/GeometrySimplifyJobExecutor.cs
+++ b/src/Honua.Server/Features/Geoprocessing/Execution/GeometrySimplifyJobExecutor.cs
@@ -1,0 +1,247 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NetTopologySuite.Simplify;
+
+namespace Honua.Server.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Production <see cref="IJobExecutor"/> for the <c>geometry.simplify</c>
+/// process. Slice 5 of #1031 — completes the per-feature vector "shape
+/// transform" set alongside <see cref="GeometryDissolveJobExecutor"/> and
+/// <see cref="GeometrySnapJobExecutor"/> by exposing the deterministic
+/// Douglas-Peucker simplification primitive.
+///
+/// Reduces vertex count by collapsing points within the supplied tolerance
+/// in the input CRS units. By default the executor uses NetTopologySuite's
+/// <see cref="TopologyPreservingSimplifier"/> — the same algorithm
+/// surfaced by PostGIS <c>ST_SimplifyPreserveTopology</c> — which avoids
+/// introducing self-intersections on collapsed rings. Callers may opt in
+/// to the faster, non-topology-preserving <see cref="DouglasPeuckerSimplifier"/>
+/// by setting <c>preserveTopology=false</c>; that path matches plain
+/// <c>ST_Simplify</c> and can produce invalid geometries on near-tolerance
+/// vertices, which is why preservation is the default.
+/// </summary>
+internal sealed partial class GeometrySimplifyJobExecutor : IJobExecutor
+{
+    /// <summary>
+    /// The single process id this executor handles. Matches the catalog
+    /// entry in <see cref="BuiltInProcessCatalog"/>.
+    /// </summary>
+    internal const string HandledProcessId = "geometry.simplify";
+
+    private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options;
+    private readonly ILogger<GeometrySimplifyJobExecutor> _logger;
+
+    public GeometrySimplifyJobExecutor(
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<GeometrySimplifyJobExecutor> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GeoprocessingDispatchHelper.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(_logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the geometry.simplify executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing simplify inputs", cancellationToken).ConfigureAwait(false);
+
+        if (!TryReadInputs(parameters, out var inputs, out var inputError))
+        {
+            Log.InvalidInputs(_logger, job.OperationId, inputError);
+            return JobExecutionResult.Failed($"Invalid simplify inputs: {inputError}");
+        }
+
+        Geometry geometry;
+        try
+        {
+            var reader = new WKBReader { HandleSRID = true };
+            geometry = reader.Read(inputs.WkbBytes);
+        }
+        catch (Exception ex) when (ex is ParseException or ArgumentException or IndexOutOfRangeException)
+        {
+            Log.InvalidWkb(_logger, job.OperationId, ex.Message);
+            return JobExecutionResult.Failed("Invalid simplify inputs: WKB payload could not be decoded.");
+        }
+
+        if (geometry == null || geometry.IsEmpty)
+        {
+            return JobExecutionResult.Failed("Invalid simplify inputs: geometry is empty.");
+        }
+
+        geometry.SRID = inputs.Srid;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(50, "Simplifying geometry", cancellationToken).ConfigureAwait(false);
+
+        Geometry simplified;
+        try
+        {
+            // Topology-preserving simplification is the safer default because it
+            // refuses to collapse rings that would self-intersect at the chosen
+            // tolerance — matching ST_SimplifyPreserveTopology. The faster
+            // Douglas-Peucker path is exposed via preserveTopology=false for
+            // callers who already validate their inputs and want the cheaper
+            // walk.
+            simplified = inputs.PreserveTopology
+                ? TopologyPreservingSimplifier.Simplify(geometry, inputs.Tolerance)
+                : DouglasPeuckerSimplifier.Simplify(geometry, inputs.Tolerance);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.SimplifyComputationFailed(_logger, job.OperationId, ex);
+            return JobExecutionResult.Failed($"Simplify computation failed: {ex.GetType().Name}.");
+        }
+
+        if (simplified == null || simplified.IsEmpty)
+        {
+            return JobExecutionResult.Failed(
+                "Simplify computation produced an empty geometry; reduce the tolerance or verify the input geometry.");
+        }
+
+        simplified.SRID = inputs.Srid;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(75, "Encoding simplify artifact", cancellationToken).ConfigureAwait(false);
+
+        var payload = GeometryFeatureWriter.WriteFeature(
+            simplified,
+            HandledProcessId,
+            new[]
+            {
+                ("inputSrid", (object)inputs.Srid),
+                ("tolerance", (object)inputs.Tolerance),
+                ("preserveTopology", (object)inputs.PreserveTopology),
+                ("inputGeometryType", (object)geometry.GeometryType),
+            });
+
+        var maxBytes = _options.CurrentValue.MaxArtifactBytes;
+        if (payload.Length > maxBytes)
+        {
+            Log.ArtifactTooLarge(_logger, job.OperationId, payload.Length, maxBytes);
+            return JobExecutionResult.Failed(
+                $"Simplify artifact size {payload.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}. " +
+                "Increase the simplification tolerance or pre-clip the input geometry.");
+        }
+
+        var artifactUri = GeometryFeatureWriter.BuildDataUri(payload);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+        await context.ReportProgressAsync(100, "Simplify completed", cancellationToken).ConfigureAwait(false);
+
+        return JobExecutionResult.Succeeded();
+    }
+
+    private static bool TryReadInputs(
+        IReadOnlyDictionary<string, string> parameters,
+        out SimplifyInputs inputs,
+        out string error)
+    {
+        inputs = default;
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+
+        if (!parameters.TryGetValue(prefix + "wkb", out var wkb) || string.IsNullOrWhiteSpace(wkb))
+        {
+            error = "missing required input 'wkb'";
+            return false;
+        }
+
+        if (!parameters.TryGetValue(prefix + "srid", out var sridRaw)
+            || !int.TryParse(sridRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var srid)
+            || srid <= 0)
+        {
+            error = "missing or invalid input 'srid'; expected a positive integer";
+            return false;
+        }
+
+        if (!parameters.TryGetValue(prefix + "tolerance", out var toleranceRaw)
+            || !double.TryParse(toleranceRaw, NumberStyles.Float, CultureInfo.InvariantCulture, out var tolerance)
+            || double.IsNaN(tolerance) || double.IsInfinity(tolerance) || tolerance < 0.0)
+        {
+            error = "missing or invalid input 'tolerance'; expected a finite non-negative number";
+            return false;
+        }
+
+        // preserveTopology defaults to true to match ST_SimplifyPreserveTopology
+        // and the catalog default.
+        var preserveTopology = true;
+        if (parameters.TryGetValue(prefix + "preserveTopology", out var preserveRaw)
+            && !string.IsNullOrWhiteSpace(preserveRaw)
+            && !bool.TryParse(preserveRaw, out preserveTopology))
+        {
+            error = "invalid input 'preserveTopology'; expected boolean";
+            return false;
+        }
+
+        byte[] wkbBytes;
+        try
+        {
+            wkbBytes = Convert.FromBase64String(wkb);
+        }
+        catch (FormatException)
+        {
+            error = "input 'wkb' is not valid base64";
+            return false;
+        }
+
+        if (wkbBytes.Length == 0)
+        {
+            error = "input 'wkb' decoded to zero bytes";
+            return false;
+        }
+
+        inputs = new SimplifyInputs(wkbBytes, srid, tolerance, preserveTopology);
+        error = "";
+        return true;
+    }
+
+    private readonly record struct SimplifyInputs(byte[] WkbBytes, int Srid, double Tolerance, bool PreserveTopology);
+
+    private static partial class Log
+    {
+        [LoggerMessage(9180, LogLevel.Warning,
+            "Geometry simplify executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9181, LogLevel.Warning,
+            "Geometry simplify executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9182, LogLevel.Warning,
+            "Geometry simplify executor rejected job {OperationId}: WKB decode failed: {Reason}")]
+        public static partial void InvalidWkb(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9183, LogLevel.Error,
+            "Geometry simplify executor failed job {OperationId} during simplify computation")]
+        public static partial void SimplifyComputationFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9184, LogLevel.Warning,
+            "Geometry simplify executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+    }
+}

--- a/src/Honua.Server/Features/Geoprocessing/Execution/GeometrySnapJobExecutor.cs
+++ b/src/Honua.Server/Features/Geoprocessing/Execution/GeometrySnapJobExecutor.cs
@@ -1,0 +1,277 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NetTopologySuite.Operation.Overlay.Snap;
+
+namespace Honua.Server.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Production <see cref="IJobExecutor"/> for the <c>geometry.snap</c>
+/// process. Slice 5 of #1031 — completes the vertex-conditioning trio
+/// alongside <see cref="GeometrySimplifyJobExecutor"/> and
+/// <see cref="GeometryDissolveJobExecutor"/>.
+///
+/// Snaps the vertices of the input geometry to those of a reference
+/// geometry whenever the distance between two candidates falls within the
+/// supplied tolerance, using NetTopologySuite's
+/// <see cref="GeometrySnapper.SnapTo(Geometry, double)"/>. The classic use
+/// case is reconciling adjacent dataset boundaries (e.g., aligning a
+/// freshly-digitized parcel with the authoritative cadaster) before
+/// running overlay operations that would otherwise produce sliver
+/// polygons. The reference geometry is consumed for vertex
+/// reference only; only the input geometry's coordinates are mutated.
+/// </summary>
+internal sealed partial class GeometrySnapJobExecutor : IJobExecutor
+{
+    /// <summary>
+    /// The single process id this executor handles. Matches the catalog
+    /// entry in <see cref="BuiltInProcessCatalog"/>.
+    /// </summary>
+    internal const string HandledProcessId = "geometry.snap";
+
+    private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options;
+    private readonly ILogger<GeometrySnapJobExecutor> _logger;
+
+    public GeometrySnapJobExecutor(
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<GeometrySnapJobExecutor> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GeoprocessingDispatchHelper.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(_logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the geometry.snap executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing snap inputs", cancellationToken).ConfigureAwait(false);
+
+        if (!TryReadInputs(parameters, out var inputs, out var inputError))
+        {
+            Log.InvalidInputs(_logger, job.OperationId, inputError);
+            return JobExecutionResult.Failed($"Invalid snap inputs: {inputError}");
+        }
+
+        var reader = new WKBReader { HandleSRID = true };
+
+        Geometry input;
+        try
+        {
+            input = reader.Read(inputs.WkbBytes);
+        }
+        catch (Exception ex) when (ex is ParseException or ArgumentException or IndexOutOfRangeException)
+        {
+            Log.InvalidWkb(_logger, job.OperationId, "wkb", ex.Message);
+            return JobExecutionResult.Failed("Invalid snap inputs: WKB payload could not be decoded.");
+        }
+
+        if (input == null || input.IsEmpty)
+        {
+            return JobExecutionResult.Failed("Invalid snap inputs: input geometry is empty.");
+        }
+
+        Geometry reference;
+        try
+        {
+            reference = reader.Read(inputs.ReferenceWkbBytes);
+        }
+        catch (Exception ex) when (ex is ParseException or ArgumentException or IndexOutOfRangeException)
+        {
+            Log.InvalidWkb(_logger, job.OperationId, "referenceWkb", ex.Message);
+            return JobExecutionResult.Failed("Invalid snap inputs: reference WKB payload could not be decoded.");
+        }
+
+        if (reference == null || reference.IsEmpty)
+        {
+            return JobExecutionResult.Failed("Invalid snap inputs: reference geometry is empty.");
+        }
+
+        input.SRID = inputs.Srid;
+        reference.SRID = inputs.Srid;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(50, "Snapping geometry to reference", cancellationToken).ConfigureAwait(false);
+
+        Geometry snapped;
+        try
+        {
+            // GeometrySnapper.SnapTo walks every vertex of the input and
+            // pulls coordinates within tolerance onto the matching vertex
+            // of the reference geometry. It returns a new Geometry; the
+            // input is not mutated in place.
+            var snapper = new GeometrySnapper(input);
+            snapped = snapper.SnapTo(reference, inputs.Tolerance);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.SnapComputationFailed(_logger, job.OperationId, ex);
+            return JobExecutionResult.Failed($"Snap computation failed: {ex.GetType().Name}.");
+        }
+
+        if (snapped == null || snapped.IsEmpty)
+        {
+            return JobExecutionResult.Failed(
+                "Snap computation produced an empty geometry; reduce the tolerance or verify the inputs.");
+        }
+
+        snapped.SRID = inputs.Srid;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(75, "Encoding snap artifact", cancellationToken).ConfigureAwait(false);
+
+        var payload = GeometryFeatureWriter.WriteFeature(
+            snapped,
+            HandledProcessId,
+            new[]
+            {
+                ("inputSrid", (object)inputs.Srid),
+                ("tolerance", (object)inputs.Tolerance),
+                ("inputGeometryType", (object)input.GeometryType),
+                ("referenceGeometryType", (object)reference.GeometryType),
+            });
+
+        var maxBytes = _options.CurrentValue.MaxArtifactBytes;
+        if (payload.Length > maxBytes)
+        {
+            Log.ArtifactTooLarge(_logger, job.OperationId, payload.Length, maxBytes);
+            return JobExecutionResult.Failed(
+                $"Snap artifact size {payload.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}.");
+        }
+
+        var artifactUri = GeometryFeatureWriter.BuildDataUri(payload);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+        await context.ReportProgressAsync(100, "Snap completed", cancellationToken).ConfigureAwait(false);
+
+        return JobExecutionResult.Succeeded();
+    }
+
+    private static bool TryReadInputs(
+        IReadOnlyDictionary<string, string> parameters,
+        out SnapInputs inputs,
+        out string error)
+    {
+        inputs = default;
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+
+        if (!parameters.TryGetValue(prefix + "wkb", out var wkb) || string.IsNullOrWhiteSpace(wkb))
+        {
+            error = "missing required input 'wkb'";
+            return false;
+        }
+
+        if (!parameters.TryGetValue(prefix + "referenceWkb", out var referenceWkb)
+            || string.IsNullOrWhiteSpace(referenceWkb))
+        {
+            error = "missing required input 'referenceWkb'";
+            return false;
+        }
+
+        if (!parameters.TryGetValue(prefix + "srid", out var sridRaw)
+            || !int.TryParse(sridRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var srid)
+            || srid <= 0)
+        {
+            error = "missing or invalid input 'srid'; expected a positive integer";
+            return false;
+        }
+
+        if (!parameters.TryGetValue(prefix + "tolerance", out var toleranceRaw)
+            || !double.TryParse(toleranceRaw, NumberStyles.Float, CultureInfo.InvariantCulture, out var tolerance)
+            || double.IsNaN(tolerance) || double.IsInfinity(tolerance) || tolerance < 0.0)
+        {
+            error = "missing or invalid input 'tolerance'; expected a finite non-negative number";
+            return false;
+        }
+
+        byte[] wkbBytes;
+        try
+        {
+            wkbBytes = Convert.FromBase64String(wkb);
+        }
+        catch (FormatException)
+        {
+            error = "input 'wkb' is not valid base64";
+            return false;
+        }
+
+        if (wkbBytes.Length == 0)
+        {
+            error = "input 'wkb' decoded to zero bytes";
+            return false;
+        }
+
+        byte[] referenceWkbBytes;
+        try
+        {
+            referenceWkbBytes = Convert.FromBase64String(referenceWkb);
+        }
+        catch (FormatException)
+        {
+            error = "input 'referenceWkb' is not valid base64";
+            return false;
+        }
+
+        if (referenceWkbBytes.Length == 0)
+        {
+            error = "input 'referenceWkb' decoded to zero bytes";
+            return false;
+        }
+
+        inputs = new SnapInputs(wkbBytes, referenceWkbBytes, srid, tolerance);
+        error = "";
+        return true;
+    }
+
+    private readonly record struct SnapInputs(
+        byte[] WkbBytes,
+        byte[] ReferenceWkbBytes,
+        int Srid,
+        double Tolerance);
+
+    private static partial class Log
+    {
+        [LoggerMessage(9190, LogLevel.Warning,
+            "Geometry snap executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9191, LogLevel.Warning,
+            "Geometry snap executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9192, LogLevel.Warning,
+            "Geometry snap executor rejected job {OperationId}: WKB decode failed for {Field}: {Reason}")]
+        public static partial void InvalidWkb(ILogger logger, string operationId, string field, string reason);
+
+        [LoggerMessage(9193, LogLevel.Error,
+            "Geometry snap executor failed job {OperationId} during snap computation")]
+        public static partial void SnapComputationFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9194, LogLevel.Warning,
+            "Geometry snap executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+    }
+}

--- a/src/Honua.Server/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
+++ b/src/Honua.Server/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
@@ -20,13 +20,15 @@ namespace Honua.Server.Features.Geoprocessing.Execution;
 /// added <c>geometry.clip</c>, <c>geometry.intersect</c>, and
 /// <c>geometry.project</c> as additional per-process executors. Slice 3
 /// added <c>geometry.area</c> (per-feature measure) and <c>geometry.union</c>
-/// (collection aggregation). Slice 4 adds <c>geometry.centroid</c>,
+/// (collection aggregation). Slice 4 added <c>geometry.centroid</c>,
 /// <c>geometry.length</c>, and <c>geometry.convex-hull</c> — finishing the
-/// deterministic single-feature vector set before later slices tackle
-/// simplify/dissolve and the heavyweight raster / surface ops. This
-/// dispatcher routes between them and emits a single, consistent
-/// "unsupported process id" error for everything outside the current
-/// supported set.
+/// deterministic single-feature vector set. Slice 5 rounds out the
+/// migration-priority vector ops with <c>geometry.dissolve</c>
+/// (group-aware aggregate), <c>geometry.simplify</c> (Douglas-Peucker),
+/// and <c>geometry.snap</c> (vertex conditioning to a reference
+/// geometry). This dispatcher routes between them and emits a single,
+/// consistent "unsupported process id" error for everything outside the
+/// current supported set.
 /// </summary>
 internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
 {
@@ -43,6 +45,9 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
         GeometryCentroidJobExecutor centroid,
         GeometryLengthJobExecutor length,
         GeometryConvexHullJobExecutor convexHull,
+        GeometryDissolveJobExecutor dissolve,
+        GeometrySimplifyJobExecutor simplify,
+        GeometrySnapJobExecutor snap,
         ILogger<GeoprocessingDispatchJobExecutor> logger)
     {
         ArgumentNullException.ThrowIfNull(buffer);
@@ -54,6 +59,9 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
         ArgumentNullException.ThrowIfNull(centroid);
         ArgumentNullException.ThrowIfNull(length);
         ArgumentNullException.ThrowIfNull(convexHull);
+        ArgumentNullException.ThrowIfNull(dissolve);
+        ArgumentNullException.ThrowIfNull(simplify);
+        ArgumentNullException.ThrowIfNull(snap);
         ArgumentNullException.ThrowIfNull(logger);
 
         _handlers = new Dictionary<string, IJobExecutor>(StringComparer.Ordinal)
@@ -67,6 +75,9 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
             [GeometryCentroidJobExecutor.HandledProcessId] = centroid,
             [GeometryLengthJobExecutor.HandledProcessId] = length,
             [GeometryConvexHullJobExecutor.HandledProcessId] = convexHull,
+            [GeometryDissolveJobExecutor.HandledProcessId] = dissolve,
+            [GeometrySimplifyJobExecutor.HandledProcessId] = simplify,
+            [GeometrySnapJobExecutor.HandledProcessId] = snap,
         }.ToFrozenDictionary(StringComparer.Ordinal);
 
         _logger = logger;

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -96,14 +96,17 @@ internal static class GeoprocessingServiceCollectionExtensions
         // first concrete executor (geometry.buffer); slice 2 added geometry.clip,
         // geometry.intersect, and geometry.project; slice 3 added geometry.area
         // (per-feature measure) and geometry.union (collection aggregation);
-        // slice 4 adds geometry.centroid, geometry.length, and
+        // slice 4 added geometry.centroid, geometry.length, and
         // geometry.convex-hull — rounding out the deterministic single-feature
-        // vector set before later slices tackle simplify/dissolve and the
-        // heavyweight raster family. The worker host keys executors by
-        // ExecutionJobKind, so the per-process executors are composed behind
-        // GeoprocessingDispatchJobExecutor — the single IJobExecutor registered
-        // for ExecutionJobKind.Geoprocessing — which routes claimed jobs to
-        // the matching handler.
+        // vector set; slice 5 lands the migration-priority shape transforms
+        // geometry.dissolve (group-aware aggregate), geometry.simplify
+        // (Douglas-Peucker), and geometry.snap (vertex conditioning) so the
+        // workspace covers the common parity targets before later slices
+        // tackle the heavyweight raster / surface families. The worker host
+        // keys executors by ExecutionJobKind, so the per-process executors
+        // are composed behind GeoprocessingDispatchJobExecutor — the single
+        // IJobExecutor registered for ExecutionJobKind.Geoprocessing — which
+        // routes claimed jobs to the matching handler.
         services.TryAddSingleton<GeometryBufferJobExecutor>();
         services.TryAddSingleton<GeometryClipJobExecutor>();
         services.TryAddSingleton<GeometryIntersectJobExecutor>();
@@ -113,6 +116,9 @@ internal static class GeoprocessingServiceCollectionExtensions
         services.TryAddSingleton<GeometryCentroidJobExecutor>();
         services.TryAddSingleton<GeometryLengthJobExecutor>();
         services.TryAddSingleton<GeometryConvexHullJobExecutor>();
+        services.TryAddSingleton<GeometryDissolveJobExecutor>();
+        services.TryAddSingleton<GeometrySimplifyJobExecutor>();
+        services.TryAddSingleton<GeometrySnapJobExecutor>();
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IJobExecutor, GeoprocessingDispatchJobExecutor>());
 

--- a/src/Honua.Server/Features/Geoprocessing/ProcessMigrationEvidenceClassifier.cs
+++ b/src/Honua.Server/Features/Geoprocessing/ProcessMigrationEvidenceClassifier.cs
@@ -19,6 +19,8 @@ internal static class ProcessMigrationEvidenceClassifier
             "geometry.intersect",
             "geometry.project",
             "geometry.simplify",
+            "geometry.snap",
+            "geometry.dissolve",
             "geometry.make-valid",
             "geometry.union",
             "geometry.difference",

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeometryDissolveJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeometryDissolveJobExecutorTests.cs
@@ -1,0 +1,334 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Geoprocessing;
+using Honua.Server.Features.Geoprocessing.Execution;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Unit coverage of the slice-5 <c>geometry.dissolve</c> executor. Mirrors
+/// the failure surfaces the union executor pins (since dissolve uses the
+/// same WkbArray input contract) plus the new group-aware behavior: two
+/// overlapping boxes tagged with the same key collapse into one feature,
+/// while two distinct keys yield a FeatureCollection with one feature per
+/// group.
+/// </summary>
+public sealed class GeometryDissolveJobExecutorTests
+{
+    private const string FeatureDataUriPrefix = "data:application/geo+json;base64,";
+
+    [UnitTest]
+    public async Task ExecuteAsync_UnsupportedProcessId_FailsWithClassifiedMessage()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-test");
+
+        var record = CreateJobRecord(processId: "geometry.buffer", includeInputs: false);
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("geometry.dissolve");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_SingleGroup_CollapsesIntoOneFeature()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-one-group");
+
+        string? publishedUri = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedUri = call.ArgAt<string>(0));
+
+        // Two overlapping 10x10 boxes share the same group key -> union area 175.
+        var wkbs = BuildWkbsJson(
+            BuildBox(0, 0, 10, 10),
+            BuildBox(5, 5, 15, 15));
+        var keys = JsonSerializer.Serialize(new[] { "a", "a" });
+
+        var record = CreateJobRecord(
+            processId: GeometryDissolveJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkbsJson: wkbs,
+            groupKeysJson: keys);
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        publishedUri.Should().NotBeNull();
+        publishedUri!.Should().StartWith(FeatureDataUriPrefix);
+
+        var bytes = Convert.FromBase64String(publishedUri[FeatureDataUriPrefix.Length..]);
+        using var doc = JsonDocument.Parse(bytes);
+        doc.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        doc.RootElement.GetProperty("processId").GetString().Should().Be("geometry.dissolve");
+        doc.RootElement.GetProperty("inputSrid").GetInt32().Should().Be(4326);
+        doc.RootElement.GetProperty("inputCount").GetInt32().Should().Be(2);
+        doc.RootElement.GetProperty("groupCount").GetInt32().Should().Be(1);
+
+        var features = doc.RootElement.GetProperty("features");
+        features.GetArrayLength().Should().Be(1);
+
+        var feature = features[0];
+        feature.GetProperty("properties").GetProperty("groupKey").GetString().Should().Be("a");
+        var geometry = new GeoJsonReader().Read<Geometry>(
+            feature.GetProperty("geometry").GetRawText());
+        geometry.Area.Should().BeApproximately(175.0, 1e-6,
+            "two overlapping 10x10 boxes under one group dissolve to an L with area 175");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_TwoGroups_EmitsFeaturePerGroup()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-two-groups");
+
+        string? publishedUri = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedUri = call.ArgAt<string>(0));
+
+        // Two non-overlapping boxes with distinct keys -> two features of
+        // area 100 each, in input order ("a" then "b").
+        var wkbs = BuildWkbsJson(
+            BuildBox(0, 0, 10, 10),
+            BuildBox(20, 20, 30, 30));
+        var keys = JsonSerializer.Serialize(new[] { "a", "b" });
+
+        var record = CreateJobRecord(
+            processId: GeometryDissolveJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkbsJson: wkbs,
+            groupKeysJson: keys);
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        publishedUri.Should().NotBeNull();
+
+        var bytes = Convert.FromBase64String(publishedUri!["data:application/geo+json;base64,".Length..]);
+        using var doc = JsonDocument.Parse(bytes);
+        doc.RootElement.GetProperty("groupCount").GetInt32().Should().Be(2);
+        var features = doc.RootElement.GetProperty("features");
+        features.GetArrayLength().Should().Be(2);
+
+        var keys0 = features[0].GetProperty("properties").GetProperty("groupKey").GetString();
+        var keys1 = features[1].GetProperty("properties").GetProperty("groupKey").GetString();
+        new[] { keys0, keys1 }.Should().BeEquivalentTo(new[] { "a", "b" });
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_WithoutGroupKeys_CollapsesAllToSingleFeature()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-no-keys");
+
+        string? publishedUri = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedUri = call.ArgAt<string>(0));
+
+        var wkbs = BuildWkbsJson(
+            BuildBox(0, 0, 10, 10),
+            BuildBox(5, 5, 15, 15));
+
+        var record = CreateJobRecord(
+            processId: GeometryDissolveJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkbsJson: wkbs,
+            groupKeysJson: null);
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+
+        var bytes = Convert.FromBase64String(publishedUri!["data:application/geo+json;base64,".Length..]);
+        using var doc = JsonDocument.Parse(bytes);
+        doc.RootElement.GetProperty("groupCount").GetInt32().Should().Be(1);
+        var feature = doc.RootElement.GetProperty("features")[0];
+        feature.GetProperty("properties").GetProperty("groupKey").GetString().Should().Be("__all__");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_GroupKeysLengthMismatch_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-mismatch");
+
+        var wkbs = BuildWkbsJson(
+            BuildBox(0, 0, 10, 10),
+            BuildBox(5, 5, 15, 15));
+        var keys = JsonSerializer.Serialize(new[] { "only-one" });
+
+        var record = CreateJobRecord(
+            processId: GeometryDissolveJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkbsJson: wkbs,
+            groupKeysJson: keys);
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("groupKeys");
+        result.ErrorMessage.Should().Contain("length");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_MissingWkbs_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-missing");
+
+        var record = CreateJobRecord(
+            processId: GeometryDissolveJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkbsJson: null);
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("'wkbs'");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_EmptyArray_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-empty");
+
+        var record = CreateJobRecord(
+            processId: GeometryDissolveJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkbsJson: "[]");
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("at least one");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_PayloadExceedsMaxArtifactBytes_FailsWithGuardrail()
+    {
+        var executor = CreateExecutor(maxArtifactBytes: 32);
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-too-big");
+
+        var wkbs = BuildWkbsJson(
+            BuildBox(0, 0, 10, 10),
+            BuildBox(5, 5, 15, 15));
+
+        var record = CreateJobRecord(
+            processId: GeometryDissolveJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkbsJson: wkbs);
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("MaxArtifactBytes");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static GeometryDissolveJobExecutor CreateExecutor(long maxArtifactBytes = 50L * 1024L * 1024L)
+    {
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = maxArtifactBytes,
+            ResultRetention = TimeSpan.FromDays(7)
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+        return new GeometryDissolveJobExecutor(monitor, NullLogger<GeometryDissolveJobExecutor>.Instance);
+    }
+
+    private static Polygon BuildBox(double minX, double minY, double maxX, double maxY)
+    {
+        var factory = NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory();
+        return factory.CreatePolygon(new[]
+        {
+            new Coordinate(minX, minY),
+            new Coordinate(maxX, minY),
+            new Coordinate(maxX, maxY),
+            new Coordinate(minX, maxY),
+            new Coordinate(minX, minY),
+        });
+    }
+
+    private static string BuildWkbsJson(params Geometry[] geometries)
+    {
+        var writer = new WKBWriter();
+        var items = geometries.Select(g => Convert.ToBase64String(writer.Write(g)));
+        return JsonSerializer.Serialize(items);
+    }
+
+    private static ExecutionJobRecord CreateJobRecord(
+        string? processId,
+        bool includeInputs,
+        string? wkbsJson = null,
+        string? srid = "4326",
+        string? groupKeysJson = null)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (!string.IsNullOrEmpty(processId))
+        {
+            parameters[ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId;
+            parameters["protocolProcessId"] = processId;
+        }
+
+        if (includeInputs)
+        {
+            var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+            if (wkbsJson != null)
+            {
+                parameters[prefix + "wkbs"] = wkbsJson;
+            }
+            parameters[prefix + "srid"] = srid ?? "4326";
+            if (groupKeysJson != null)
+            {
+                parameters[prefix + "groupKeys"] = groupKeysJson;
+            }
+        }
+
+        return new ExecutionJobRecord
+        {
+            OperationId = "op-test",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:test",
+                Parameters = parameters
+            }
+        };
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeometrySimplifyJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeometrySimplifyJobExecutorTests.cs
@@ -1,0 +1,250 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Geoprocessing;
+using Honua.Server.Features.Geoprocessing.Execution;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Unit coverage of the slice-5 <c>geometry.simplify</c> executor. Pins
+/// the same failure surfaces as the earlier vector executors plus the
+/// happy-path GeoJSON Feature shape: a near-straight zig-zag line with a
+/// 0.001-unit perturbation collapses to the two-vertex segment under a
+/// tolerance of 1.0 (Douglas-Peucker removes the below-tolerance vertex).
+/// </summary>
+public sealed class GeometrySimplifyJobExecutorTests
+{
+    private const string FeatureDataUriPrefix = "data:application/geo+json;base64,";
+
+    [UnitTest]
+    public async Task ExecuteAsync_UnsupportedProcessId_FailsWithClassifiedMessage()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-test");
+
+        var record = CreateJobRecord(processId: "geometry.buffer", includeInputs: false);
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("geometry.simplify");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_HappyPath_CollapsesBelowToleranceVertex()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-simplify");
+
+        string? publishedUri = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedUri = call.ArgAt<string>(0));
+
+        // LINESTRING(0 0, 5 0.001, 10 0) — the midpoint sits 0.001 units off
+        // the (0,0)-(10,0) baseline. Under tolerance 1.0 the Douglas-Peucker
+        // walk drops it, leaving the two-vertex segment.
+        var line = BuildLineString(
+            new Coordinate(0, 0),
+            new Coordinate(5, 0.001),
+            new Coordinate(10, 0));
+
+        var record = CreateJobRecord(
+            processId: GeometrySimplifyJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(line),
+            tolerance: "1.0");
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        publishedUri.Should().NotBeNull();
+        publishedUri!.Should().StartWith(FeatureDataUriPrefix);
+
+        var bytes = Convert.FromBase64String(publishedUri[FeatureDataUriPrefix.Length..]);
+        using var doc = JsonDocument.Parse(bytes);
+        doc.RootElement.GetProperty("type").GetString().Should().Be("Feature");
+        var properties = doc.RootElement.GetProperty("properties");
+        properties.GetProperty("processId").GetString().Should().Be("geometry.simplify");
+        properties.GetProperty("inputSrid").GetInt32().Should().Be(4326);
+        properties.GetProperty("tolerance").GetDouble().Should().Be(1.0);
+        properties.GetProperty("preserveTopology").GetBoolean().Should().BeTrue();
+        properties.GetProperty("inputGeometryType").GetString().Should().Be("LineString");
+
+        var geometry = new GeoJsonReader().Read<Geometry>(
+            doc.RootElement.GetProperty("geometry").GetRawText());
+        geometry.Should().BeOfType<LineString>();
+        ((LineString)geometry).NumPoints.Should().Be(2,
+            "the 0.001-offset midpoint is well below the 1.0 tolerance and should collapse");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_MissingTolerance_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-missing-tol");
+
+        var record = CreateJobRecord(
+            processId: GeometrySimplifyJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(BuildLineString(new Coordinate(0, 0), new Coordinate(1, 1))),
+            tolerance: null);
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("'tolerance'");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_NegativeTolerance_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-neg-tol");
+
+        var record = CreateJobRecord(
+            processId: GeometrySimplifyJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(BuildLineString(new Coordinate(0, 0), new Coordinate(1, 1))),
+            tolerance: "-0.5");
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("'tolerance'");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_MissingWkb_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-missing-wkb");
+
+        var record = CreateJobRecord(
+            processId: GeometrySimplifyJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: null,
+            tolerance: "1.0");
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("'wkb'");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_PayloadExceedsMaxArtifactBytes_FailsWithGuardrail()
+    {
+        var executor = CreateExecutor(maxArtifactBytes: 8);
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-too-big");
+
+        var record = CreateJobRecord(
+            processId: GeometrySimplifyJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(BuildLineString(
+                new Coordinate(0, 0),
+                new Coordinate(10, 0),
+                new Coordinate(20, 5),
+                new Coordinate(30, 0))),
+            tolerance: "0.1");
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("MaxArtifactBytes");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static GeometrySimplifyJobExecutor CreateExecutor(long maxArtifactBytes = 50L * 1024L * 1024L)
+    {
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = maxArtifactBytes,
+            ResultRetention = TimeSpan.FromDays(7)
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+        return new GeometrySimplifyJobExecutor(monitor, NullLogger<GeometrySimplifyJobExecutor>.Instance);
+    }
+
+    private static LineString BuildLineString(params Coordinate[] coordinates)
+    {
+        var factory = NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory();
+        return factory.CreateLineString(coordinates);
+    }
+
+    private static string WkbBase64(Geometry geometry)
+        => Convert.ToBase64String(new WKBWriter().Write(geometry));
+
+    private static ExecutionJobRecord CreateJobRecord(
+        string? processId,
+        bool includeInputs,
+        string? wkb = null,
+        string? srid = "4326",
+        string? tolerance = "1.0",
+        string? preserveTopology = null)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (!string.IsNullOrEmpty(processId))
+        {
+            parameters[ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId;
+            parameters["protocolProcessId"] = processId;
+        }
+
+        if (includeInputs)
+        {
+            var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+            if (wkb != null)
+            {
+                parameters[prefix + "wkb"] = wkb;
+            }
+            parameters[prefix + "srid"] = srid ?? "4326";
+            if (tolerance != null)
+            {
+                parameters[prefix + "tolerance"] = tolerance;
+            }
+            if (preserveTopology != null)
+            {
+                parameters[prefix + "preserveTopology"] = preserveTopology;
+            }
+        }
+
+        return new ExecutionJobRecord
+        {
+            OperationId = "op-test",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:test",
+                Parameters = parameters
+            }
+        };
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeometrySnapJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeometrySnapJobExecutorTests.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Server.Features.Geoprocessing;
+using Honua.Server.Features.Geoprocessing.Execution;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Unit coverage of the slice-5 <c>geometry.snap</c> executor. Pins the
+/// failure surfaces shared by the other vector executors (unsupported
+/// process id, missing inputs, oversized artifact) and the happy path:
+/// a near-coincident input point is pulled onto the reference origin
+/// when the tolerance exceeds their separation, matching the behavior
+/// of NetTopologySuite's <c>GeometrySnapper.SnapTo</c>.
+/// </summary>
+public sealed class GeometrySnapJobExecutorTests
+{
+    private const string FeatureDataUriPrefix = "data:application/geo+json;base64,";
+
+    [UnitTest]
+    public async Task ExecuteAsync_UnsupportedProcessId_FailsWithClassifiedMessage()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-test");
+
+        var record = CreateJobRecord(processId: "geometry.buffer", includeInputs: false);
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("geometry.snap");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_HappyPath_SnapsPointToReferenceVertex()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-snap");
+
+        string? publishedUri = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedUri = call.ArgAt<string>(0));
+
+        // Input POINT(0.1 0.1) is 0.14-ish from POINT(0 0); a tolerance of
+        // 0.5 covers the gap so the snapper pulls the input onto the
+        // reference vertex.
+        var input = BuildPoint(0.1, 0.1);
+        var reference = BuildPoint(0, 0);
+
+        var record = CreateJobRecord(
+            processId: GeometrySnapJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(input),
+            referenceWkb: WkbBase64(reference),
+            tolerance: "0.5");
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        publishedUri.Should().NotBeNull();
+        publishedUri!.Should().StartWith(FeatureDataUriPrefix);
+
+        var bytes = Convert.FromBase64String(publishedUri[FeatureDataUriPrefix.Length..]);
+        using var doc = JsonDocument.Parse(bytes);
+        doc.RootElement.GetProperty("type").GetString().Should().Be("Feature");
+        var properties = doc.RootElement.GetProperty("properties");
+        properties.GetProperty("processId").GetString().Should().Be("geometry.snap");
+        properties.GetProperty("inputSrid").GetInt32().Should().Be(4326);
+        properties.GetProperty("tolerance").GetDouble().Should().Be(0.5);
+        properties.GetProperty("inputGeometryType").GetString().Should().Be("Point");
+        properties.GetProperty("referenceGeometryType").GetString().Should().Be("Point");
+
+        var geometry = new GeoJsonReader().Read<Geometry>(
+            doc.RootElement.GetProperty("geometry").GetRawText());
+        geometry.Should().BeOfType<Point>();
+        var snapped = (Point)geometry;
+        snapped.X.Should().BeApproximately(0.0, 1e-9, "input should be pulled onto the reference vertex");
+        snapped.Y.Should().BeApproximately(0.0, 1e-9);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_BeyondTolerance_LeavesGeometryUnchanged()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-no-snap");
+
+        string? publishedUri = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedUri = call.ArgAt<string>(0));
+
+        // Input is 1.0 unit away from reference; tolerance 0.1 is too small
+        // to trigger snapping, so the executor must succeed but leave the
+        // input coordinates intact.
+        var input = BuildPoint(1.0, 0.0);
+        var reference = BuildPoint(0, 0);
+
+        var record = CreateJobRecord(
+            processId: GeometrySnapJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(input),
+            referenceWkb: WkbBase64(reference),
+            tolerance: "0.1");
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        publishedUri.Should().NotBeNull();
+
+        var bytes = Convert.FromBase64String(publishedUri!["data:application/geo+json;base64,".Length..]);
+        using var doc = JsonDocument.Parse(bytes);
+        var geometry = new GeoJsonReader().Read<Geometry>(
+            doc.RootElement.GetProperty("geometry").GetRawText());
+        ((Point)geometry).X.Should().BeApproximately(1.0, 1e-9);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_MissingReferenceWkb_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-missing-ref");
+
+        var record = CreateJobRecord(
+            processId: GeometrySnapJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(BuildPoint(0, 0)),
+            referenceWkb: null,
+            tolerance: "0.5");
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("'referenceWkb'");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_InvalidTolerance_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-bad-tol");
+
+        var record = CreateJobRecord(
+            processId: GeometrySnapJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(BuildPoint(0, 0)),
+            referenceWkb: WkbBase64(BuildPoint(1, 1)),
+            tolerance: "not-a-number");
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("'tolerance'");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_PayloadExceedsMaxArtifactBytes_FailsWithGuardrail()
+    {
+        var executor = CreateExecutor(maxArtifactBytes: 8);
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-too-big");
+
+        var record = CreateJobRecord(
+            processId: GeometrySnapJobExecutor.HandledProcessId,
+            includeInputs: true,
+            wkb: WkbBase64(BuildPoint(0.1, 0.1)),
+            referenceWkb: WkbBase64(BuildPoint(0, 0)),
+            tolerance: "0.5");
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("MaxArtifactBytes");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static GeometrySnapJobExecutor CreateExecutor(long maxArtifactBytes = 50L * 1024L * 1024L)
+    {
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = maxArtifactBytes,
+            ResultRetention = TimeSpan.FromDays(7)
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+        return new GeometrySnapJobExecutor(monitor, NullLogger<GeometrySnapJobExecutor>.Instance);
+    }
+
+    private static Point BuildPoint(double x, double y)
+    {
+        var factory = NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory();
+        return factory.CreatePoint(new Coordinate(x, y));
+    }
+
+    private static string WkbBase64(Geometry geometry)
+        => Convert.ToBase64String(new WKBWriter().Write(geometry));
+
+    private static ExecutionJobRecord CreateJobRecord(
+        string? processId,
+        bool includeInputs,
+        string? wkb = null,
+        string? referenceWkb = null,
+        string? srid = "4326",
+        string? tolerance = "0.5")
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (!string.IsNullOrEmpty(processId))
+        {
+            parameters[ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId;
+            parameters["protocolProcessId"] = processId;
+        }
+
+        if (includeInputs)
+        {
+            var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+            if (wkb != null)
+            {
+                parameters[prefix + "wkb"] = wkb;
+            }
+            if (referenceWkb != null)
+            {
+                parameters[prefix + "referenceWkb"] = referenceWkb;
+            }
+            parameters[prefix + "srid"] = srid ?? "4326";
+            if (tolerance != null)
+            {
+                parameters[prefix + "tolerance"] = tolerance;
+            }
+        }
+
+        return new ExecutionJobRecord
+        {
+            OperationId = "op-test",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:test",
+                Parameters = parameters
+            }
+        };
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
@@ -18,10 +18,11 @@ namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
 /// Unit coverage for the dispatcher that routes claimed geoprocessing jobs
 /// to the correct per-process executor. The dispatcher is the single
 /// IJobExecutor registered for ExecutionJobKind.Geoprocessing after slice 2;
-/// slice 3 extended it with geometry.area + geometry.union; slice 4 adds
-/// geometry.centroid + geometry.length + geometry.convex-hull. This test
-/// pins the routing contract so unknown process ids never reach a
-/// per-process executor by accident.
+/// slice 3 extended it with geometry.area + geometry.union; slice 4 added
+/// geometry.centroid + geometry.length + geometry.convex-hull; slice 5 adds
+/// geometry.dissolve + geometry.simplify + geometry.snap. This test pins
+/// the routing contract so unknown process ids never reach a per-process
+/// executor by accident.
 /// </summary>
 public sealed class GeoprocessingDispatchJobExecutorTests
 {
@@ -32,12 +33,15 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         var context = Substitute.For<IJobExecutionContext>();
         context.OperationId.Returns("op-unknown");
 
-        var record = CreateJobRecord("geometry.simplify");
+        // geometry.difference is still catalog-only after slice 5 — pick it
+        // for the unknown-id smoke so the assertion stays meaningful as the
+        // slice adds geometry.simplify / geometry.dissolve / geometry.snap.
+        var record = CreateJobRecord("geometry.difference");
 
         var result = await dispatcher.ExecuteAsync(record, context, CancellationToken.None);
 
         result.Status.Should().Be(ExecutionJobStatus.Failed);
-        result.ErrorMessage.Should().Contain("geometry.simplify");
+        result.ErrorMessage.Should().Contain("geometry.difference");
         result.ErrorMessage.Should().Contain("geometry.buffer");
         result.ErrorMessage.Should().Contain("geometry.clip");
         result.ErrorMessage.Should().Contain("geometry.intersect");
@@ -47,6 +51,9 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         result.ErrorMessage.Should().Contain("geometry.centroid");
         result.ErrorMessage.Should().Contain("geometry.length");
         result.ErrorMessage.Should().Contain("geometry.convex-hull");
+        result.ErrorMessage.Should().Contain("geometry.dissolve");
+        result.ErrorMessage.Should().Contain("geometry.simplify");
+        result.ErrorMessage.Should().Contain("geometry.snap");
     }
 
     [UnitTest]
@@ -64,7 +71,7 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         result.ErrorMessage.Should().Contain("<none>");
     }
 
-    private static readonly string[] SliceFourProcessIds =
+    private static readonly string[] SliceFiveProcessIds =
     {
         "geometry.buffer",
         "geometry.clip",
@@ -75,13 +82,16 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         "geometry.centroid",
         "geometry.length",
         "geometry.convex-hull",
+        "geometry.dissolve",
+        "geometry.simplify",
+        "geometry.snap",
     };
 
     [UnitTest]
-    public void SupportedProcessIds_ListsSliceFourExecutors()
+    public void SupportedProcessIds_ListsSliceFiveExecutors()
     {
         var dispatcher = CreateDispatcher();
-        dispatcher.SupportedProcessIds.Should().BeEquivalentTo(SliceFourProcessIds);
+        dispatcher.SupportedProcessIds.Should().BeEquivalentTo(SliceFiveProcessIds);
     }
 
     [UnitTest]
@@ -111,6 +121,9 @@ public sealed class GeoprocessingDispatchJobExecutorTests
             new GeometryCentroidJobExecutor(monitor, NullLogger<GeometryCentroidJobExecutor>.Instance),
             new GeometryLengthJobExecutor(monitor, NullLogger<GeometryLengthJobExecutor>.Instance),
             new GeometryConvexHullJobExecutor(monitor, NullLogger<GeometryConvexHullJobExecutor>.Instance),
+            new GeometryDissolveJobExecutor(monitor, NullLogger<GeometryDissolveJobExecutor>.Instance),
+            new GeometrySimplifyJobExecutor(monitor, NullLogger<GeometrySimplifyJobExecutor>.Instance),
+            new GeometrySnapJobExecutor(monitor, NullLogger<GeometrySnapJobExecutor>.Instance),
             NullLogger<GeoprocessingDispatchJobExecutor>.Instance);
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/VectorProcessParityIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/VectorProcessParityIntegrationTests.cs
@@ -25,15 +25,16 @@ using StackExchange.Redis;
 namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
 
 /// <summary>
-/// End-to-end parity coverage for the slice-2 / slice-3 / slice-4 vector
+/// End-to-end parity coverage for the slice-2 through slice-5 vector
 /// executors. Each test submits a process through the OGC API Processes
 /// execute endpoint, polls the durable runtime until the job reaches a
 /// terminal status, retrieves the result document, and compares the
-/// published GeoJSON Feature (FeatureLayer outputs) or measure-result
-/// document (Scalar outputs) against a golden expectation (geometry type,
-/// feature count, area / coordinate position, measure value). Mirrors the
-/// slice-1 buffer integration test shape so the new processes pin the
-/// same evidence contract.
+/// published GeoJSON Feature (FeatureLayer outputs), FeatureCollection
+/// (geometry.dissolve), or measure-result document (Scalar outputs)
+/// against a golden expectation (geometry type, feature count, area /
+/// coordinate position, measure value). Mirrors the slice-1 buffer
+/// integration test shape so the new processes pin the same evidence
+/// contract.
 /// </summary>
 [Collection("Redis")]
 [Protocol(TestProtocols.OgcApiProcesses)]
@@ -459,6 +460,188 @@ public sealed class VectorProcessParityIntegrationTests(RedisFixture redis)
         }
     }
 
+    [IntegrationTest]
+    [Operation(Operations.ProcessExecution)]
+    [Endpoint("POST /ogc/processes/processes/{processId}/execution")]
+    [Endpoint("GET /ogc/processes/jobs/{jobId}/results")]
+    public async Task DissolveProcess_CompletesAndReturnsFeatureCollectionPerGroup()
+    {
+        await DeleteControlPlaneKeysAsync(redis.ConnectionString);
+
+        var fixture = BuildFixture();
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateAdminClient();
+            client.Timeout = TimeSpan.FromSeconds(30);
+
+            // Two overlapping 10x10 boxes share a single group key → one
+            // feature with union area 100 + 100 - 25 = 175.
+            var first = BuildBoxPolygon(0, 0, 10, 10);
+            var second = BuildBoxPolygon(5, 5, 15, 15);
+            var body = string.Format(
+                CultureInfo.InvariantCulture,
+                "{{\"response\":\"document\",\"inputs\":{{\"wkbs\":[\"{0}\",\"{1}\"],\"groupKeys\":[\"a\",\"a\"],\"srid\":4326}}}}",
+                WkbBase64(first),
+                WkbBase64(second));
+
+            var jobId = await SubmitJobAsync(client, "geometry.dissolve", body);
+
+            using var terminal = await PollUntilTerminalAsync(client, jobId);
+            terminal.RootElement.GetProperty("status").GetString().Should().Be("successful");
+
+            using var resultsDoc = await GetResultsAsync(client, jobId);
+            var collection = DecodeOutputFeatureCollection(resultsDoc, "geometry.dissolve");
+            collection.GetProperty("groupCount").GetInt32().Should().Be(1);
+            collection.GetProperty("inputCount").GetInt32().Should().Be(2);
+
+            var features = collection.GetProperty("features");
+            features.GetArrayLength().Should().Be(1);
+            var feature = features[0];
+            feature.GetProperty("properties").GetProperty("groupKey").GetString().Should().Be("a");
+
+            var geometry = ReadGeometry(feature.GetProperty("geometry"));
+            geometry.Area.Should().BeApproximately(175.0, 1e-6,
+                "two overlapping 10x10 boxes under one group dissolve to area 175");
+
+            var resultStore = fixture.GetService<IGeoprocessingResultPackageStore>();
+            var package = await resultStore.GetAsync(jobId);
+            package.Should().NotBeNull();
+            package!.Status.Should().Be(GeoprocessingWorkflowStatus.Completed);
+            package.Artifacts.Should().ContainSingle();
+            package.Artifacts[0].Uri.Should().StartWith(DataUriPrefix);
+            package.Artifacts[0].Label.Should().Be("outputFeatureLayer");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+            await DeleteControlPlaneKeysAsync(redis.ConnectionString);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ProcessExecution)]
+    [Endpoint("POST /ogc/processes/processes/{processId}/execution")]
+    [Endpoint("GET /ogc/processes/jobs/{jobId}/results")]
+    public async Task SimplifyProcess_CollapsesBelowToleranceVertices()
+    {
+        await DeleteControlPlaneKeysAsync(redis.ConnectionString);
+
+        var fixture = BuildFixture();
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateAdminClient();
+            client.Timeout = TimeSpan.FromSeconds(30);
+
+            // LINESTRING(0 0, 5 0.001, 10 0) simplified at tolerance 1.0
+            // collapses to LINESTRING(0 0, 10 0).
+            var factory = NetTopologySuite.NtsGeometryServices.Instance
+                .CreateGeometryFactory(srid: 4326);
+            var line = factory.CreateLineString(new[]
+            {
+                new Coordinate(0, 0),
+                new Coordinate(5, 0.001),
+                new Coordinate(10, 0),
+            });
+            var body = string.Format(
+                CultureInfo.InvariantCulture,
+                "{{\"response\":\"document\",\"inputs\":{{\"wkb\":\"{0}\",\"srid\":4326,\"tolerance\":1.0}}}}",
+                WkbBase64(line));
+
+            var jobId = await SubmitJobAsync(client, "geometry.simplify", body);
+
+            using var terminal = await PollUntilTerminalAsync(client, jobId);
+            terminal.RootElement.GetProperty("status").GetString().Should().Be("successful");
+
+            using var resultsDoc = await GetResultsAsync(client, jobId);
+            var feature = DecodeOutputFeature(resultsDoc, "geometry.simplify");
+
+            feature.GetProperty("properties").GetProperty("inputSrid").GetInt32().Should().Be(4326);
+            feature.GetProperty("properties").GetProperty("tolerance").GetDouble().Should().Be(1.0);
+            feature.GetProperty("properties").GetProperty("inputGeometryType").GetString().Should().Be("LineString");
+
+            var geometry = ReadGeometry(feature.GetProperty("geometry"));
+            geometry.Should().BeOfType<LineString>();
+            ((LineString)geometry).NumPoints.Should().Be(2,
+                "tolerance 1.0 collapses the 0.001-offset midpoint");
+
+            var resultStore = fixture.GetService<IGeoprocessingResultPackageStore>();
+            var package = await resultStore.GetAsync(jobId);
+            package.Should().NotBeNull();
+            package!.Status.Should().Be(GeoprocessingWorkflowStatus.Completed);
+            package.Artifacts.Should().ContainSingle();
+            package.Artifacts[0].Uri.Should().StartWith(DataUriPrefix);
+            package.Artifacts[0].Label.Should().Be("outputFeatureLayer");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+            await DeleteControlPlaneKeysAsync(redis.ConnectionString);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ProcessExecution)]
+    [Endpoint("POST /ogc/processes/processes/{processId}/execution")]
+    [Endpoint("GET /ogc/processes/jobs/{jobId}/results")]
+    public async Task SnapProcess_PullsInputOntoReferenceVertex()
+    {
+        await DeleteControlPlaneKeysAsync(redis.ConnectionString);
+
+        var fixture = BuildFixture();
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateAdminClient();
+            client.Timeout = TimeSpan.FromSeconds(30);
+
+            // Input POINT(0.1 0.1) snapped to reference POINT(0 0) at
+            // tolerance 0.5 lands on the reference origin.
+            var factory = NetTopologySuite.NtsGeometryServices.Instance
+                .CreateGeometryFactory(srid: 4326);
+            var input = factory.CreatePoint(new Coordinate(0.1, 0.1));
+            var reference = factory.CreatePoint(new Coordinate(0, 0));
+
+            var body = string.Format(
+                CultureInfo.InvariantCulture,
+                "{{\"response\":\"document\",\"inputs\":{{\"wkb\":\"{0}\",\"referenceWkb\":\"{1}\",\"srid\":4326,\"tolerance\":0.5}}}}",
+                WkbBase64(input),
+                WkbBase64(reference));
+
+            var jobId = await SubmitJobAsync(client, "geometry.snap", body);
+
+            using var terminal = await PollUntilTerminalAsync(client, jobId);
+            terminal.RootElement.GetProperty("status").GetString().Should().Be("successful");
+
+            using var resultsDoc = await GetResultsAsync(client, jobId);
+            var feature = DecodeOutputFeature(resultsDoc, "geometry.snap");
+
+            feature.GetProperty("properties").GetProperty("inputSrid").GetInt32().Should().Be(4326);
+            feature.GetProperty("properties").GetProperty("tolerance").GetDouble().Should().Be(0.5);
+            feature.GetProperty("properties").GetProperty("inputGeometryType").GetString().Should().Be("Point");
+
+            var geometry = ReadGeometry(feature.GetProperty("geometry"));
+            geometry.Should().BeOfType<Point>();
+            var snapped = (Point)geometry;
+            snapped.X.Should().BeApproximately(0.0, 1e-9);
+            snapped.Y.Should().BeApproximately(0.0, 1e-9);
+
+            var resultStore = fixture.GetService<IGeoprocessingResultPackageStore>();
+            var package = await resultStore.GetAsync(jobId);
+            package.Should().NotBeNull();
+            package!.Status.Should().Be(GeoprocessingWorkflowStatus.Completed);
+            package.Artifacts.Should().ContainSingle();
+            package.Artifacts[0].Uri.Should().StartWith(DataUriPrefix);
+            package.Artifacts[0].Label.Should().Be("outputFeatureLayer");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+            await DeleteControlPlaneKeysAsync(redis.ConnectionString);
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
@@ -512,9 +695,10 @@ public sealed class VectorProcessParityIntegrationTests(RedisFixture redis)
                 sp.GetRequiredService<ILogger<RedisExecutionLogStore>>()));
 
         // Activate the worker host. The production dispatcher registered by
-        // AddGeoprocessing routes the geometry.clip / geometry.intersect /
+        // AddGeoprocessing routes geometry.clip / geometry.intersect /
         // geometry.project / geometry.area / geometry.union /
-        // geometry.centroid / geometry.length / geometry.convex-hull ids to
+        // geometry.centroid / geometry.length / geometry.convex-hull /
+        // geometry.dissolve / geometry.simplify / geometry.snap ids to
         // their per-process executors — that's the system-under-test for
         // this parity suite.
         services.AddJobWorker();
@@ -598,6 +782,25 @@ public sealed class VectorProcessParityIntegrationTests(RedisFixture redis)
         feature.GetProperty("properties").GetProperty("processId").GetString()
             .Should().Be(expectedProcessId);
         return feature;
+    }
+
+    private static JsonElement DecodeOutputFeatureCollection(JsonDocument resultsDoc, string expectedProcessId)
+    {
+        var output = resultsDoc.RootElement.GetProperty("outputFeatureLayer");
+        output.GetProperty("kind").GetString().Should().Be("FeatureLayer");
+        output.GetProperty("type").GetString().Should().Be("application/geo+json");
+
+        var href = output.GetProperty("href").GetString();
+        href.Should().NotBeNull();
+        href!.Should().StartWith(DataUriPrefix);
+
+        var base64 = href[DataUriPrefix.Length..];
+        var bytes = Convert.FromBase64String(base64);
+        var doc = JsonDocument.Parse(bytes);
+        var collection = doc.RootElement.Clone();
+        collection.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        collection.GetProperty("processId").GetString().Should().Be(expectedProcessId);
+        return collection;
     }
 
     private static Geometry ReadGeometry(JsonElement geometryElement)

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
@@ -35,22 +35,22 @@ public sealed class ProcessCatalogTests
     [UnitTest]
     [Operation(Operations.Query)]
     [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
-    public void Catalog_ListProcesses_ReturnsExactly36BuiltIns()
+    public void Catalog_ListProcesses_ReturnsExactly38BuiltIns()
     {
         var all = _catalog.ListProcesses();
 
-        all.Should().HaveCount(36);
+        all.Should().HaveCount(38);
         all.Select(p => p.ProcessId).Should().OnlyHaveUniqueItems();
     }
 
     [UnitTest]
     [Operation(Operations.Query)]
     [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
-    public void Catalog_GeometryCategory_Returns12Processes()
+    public void Catalog_GeometryCategory_Returns14Processes()
     {
         var geometry = _catalog.GetProcessesByCategory("geometry");
 
-        geometry.Should().HaveCount(12);
+        geometry.Should().HaveCount(14);
         geometry.Should().AllSatisfy(p => p.Category.Should().Be("geometry"));
     }
 
@@ -212,6 +212,7 @@ public sealed class ProcessCatalogTests
             "geometry.make-valid", "geometry.union", "geometry.intersect",
             "geometry.clip", "geometry.difference", "geometry.area",
             "geometry.length", "geometry.centroid", "geometry.convex-hull",
+            "geometry.dissolve", "geometry.snap",
             "analytics.cluster", "analytics.spatial-join",
             "analytics.buffer-aggregate", "analytics.density",
             "surface.slope", "surface.aspect", "surface.hillshade",

--- a/tests/fixtures/process-migration/vector-process-parity-fixture.json
+++ b/tests/fixtures/process-migration/vector-process-parity-fixture.json
@@ -15,7 +15,10 @@
     "geometry.union",
     "geometry.centroid",
     "geometry.length",
-    "geometry.convex-hull"
+    "geometry.convex-hull",
+    "geometry.dissolve",
+    "geometry.simplify",
+    "geometry.snap"
   ],
   "cases": [
     {
@@ -186,6 +189,62 @@
         "geometryType": "Polygon",
         "featureCount": 1,
         "areaApprox": 100.0
+      }
+    },
+    {
+      "caseId": "dissolve-two-overlapping-boxes-by-group",
+      "processId": "geometry.dissolve",
+      "description": "Slice 5: dissolving two overlapping 10x10 boxes (offset by (5,5)) under a single group key collapses them into one feature whose union area is 175 (100 + 100 - 25 overlap). Output is a FeatureCollection envelope with one feature per group.",
+      "inputsWkt": {
+        "wkts": [
+          "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
+          "POLYGON((5 5, 15 5, 15 15, 5 15, 5 5))"
+        ],
+        "groupKeys": ["a", "a"],
+        "srid": "4326"
+      },
+      "expected": {
+        "outputParameter": "outputFeatureLayer",
+        "artifactKind": "FeatureLayer",
+        "documentType": "FeatureCollection",
+        "groupCount": 1,
+        "featureCount": 1,
+        "areaApprox": 175.0
+      }
+    },
+    {
+      "caseId": "simplify-zigzag-collapses-to-segment",
+      "processId": "geometry.simplify",
+      "description": "Slice 5: a near-straight line with a tiny midpoint perturbation (LINESTRING(0 0, 5 0.001, 10 0)) simplifies under a tolerance of 1.0 to the two-vertex segment LINESTRING(0 0, 10 0). Validates Douglas-Peucker collapses below-tolerance vertices.",
+      "inputsWkt": {
+        "wkt": "LINESTRING(0 0, 5 0.001, 10 0)",
+        "srid": "4326",
+        "tolerance": "1.0"
+      },
+      "expected": {
+        "outputParameter": "outputFeatureLayer",
+        "artifactKind": "FeatureLayer",
+        "geometryType": "LineString",
+        "featureCount": 1,
+        "vertexCount": 2
+      }
+    },
+    {
+      "caseId": "snap-near-coincident-point-to-reference",
+      "processId": "geometry.snap",
+      "description": "Slice 5: an input POINT(0.1 0.1) snapped to reference POINT(0 0) under tolerance 0.5 is pulled onto (0,0). Demonstrates that NetTopologySuite GeometrySnapper.SnapTo aligns within-tolerance vertices to the reference coordinate.",
+      "inputsWkt": {
+        "wkt": "POINT(0.1 0.1)",
+        "referenceWkt": "POINT(0 0)",
+        "srid": "4326",
+        "tolerance": "0.5"
+      },
+      "expected": {
+        "outputParameter": "outputFeatureLayer",
+        "artifactKind": "FeatureLayer",
+        "geometryType": "Point",
+        "featureCount": 1,
+        "coordinate": [0.0, 0.0]
       }
     }
   ],


### PR DESCRIPTION
## Issue Link
Fixes #1031 (slice 5/N — stacked on #1118)

## Summary
Slice 5 of #1031 rounds out the migration-priority vector op set with three commonly-needed shape-transform executors: `geometry.dissolve` (group-aware aggregate), `geometry.simplify` (Douglas-Peucker), and `geometry.snap` (vertex conditioning to a reference geometry). With this slice the workspace covers the common parity targets before later slices tackle the heavyweight raster / surface families.

## Changes Made
- `GeometryDissolveJobExecutor` — group-aware aggregate; takes a parallel `groupKeys` array alongside `wkbs` and emits a GeoJSON `FeatureCollection` with one Feature per dissolved group, defaulting all inputs into the `__all__` bucket when keys are omitted.
- `GeometrySimplifyJobExecutor` — Douglas-Peucker simplification with configurable tolerance; defaults to `TopologyPreservingSimplifier` (ST_SimplifyPreserveTopology) with an opt-in plain Douglas-Peucker path via `preserveTopology=false`.
- `GeometrySnapJobExecutor` — snaps input vertices to a reference geometry within a tolerance using NetTopologySuite `GeometrySnapper`.
- Wires all three into `GeoprocessingDispatchJobExecutor` + DI registration. Renames the dispatcher supported-set fixture array to `SliceFiveProcessIds` and shifts the unknown-id smoke from `geometry.simplify` (now supported) to `geometry.difference` (still catalog-only).
- Adds `geometry.dissolve` and `geometry.snap` catalog entries and tightens the existing `geometry.simplify` entry to require `srid`; bumps the catalog counts (14 geometry processes / 38 total) and the expected-id list.
- Extends `ProcessMigrationEvidenceClassifier` so `dissolve` and `snap` join the first-slice automated vector set (`simplify` was already there).
- Adds golden fixture entries for `dissolve-two-overlapping-boxes-by-group`, `simplify-zigzag-collapses-to-segment`, and `snap-near-coincident-point-to-reference`; expands the fixture's `supportedProcessIds`.
- Per-executor unit tests and three new end-to-end cases in `VectorProcessParityIntegrationTests` that submit through OGC API Processes execute and verify the published artifact (Feature or FeatureCollection) shape.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
The existing `geometry.simplify` catalog entry now declares `srid` as a required parameter (was not previously required). Callers that already supply `srid` for the other geometry executors are unaffected; bare simplify submissions that omitted SRID will now surface `MISSING_REQUIRED_PARAMETER` during validation instead of running with an unspecified spatial reference.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)