### PR TITLE
feat: export XYZ/TMS tile caches from migration plans (#1016 slice 4/N)

### DIFF
--- a/src/Honua.Core/Features/Import/Abstractions/IOgcTileCacheExportService.cs
+++ b/src/Honua.Core/Features/Import/Abstractions/IOgcTileCacheExportService.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Abstractions;
+
+/// <summary>
+/// Exports XYZ/TMS tile caches from an OGC WMTS source for plan entries
+/// classified as <c>automated</c> by the slice-3 WMTS migration planner.
+/// </summary>
+public interface IOgcTileCacheExportService
+{
+    /// <summary>
+    /// Resolve the migration manifest for the requested source, then walk the
+    /// classified WMTS tile-set plan entries and fetch the configured
+    /// zoom-level window into Honua's tile catalog through the registered
+    /// <see cref="IOgcTileCacheSink"/>. The operation is idempotent: tiles
+    /// already present in the sink are left untouched.
+    /// </summary>
+    /// <param name="request">Tile cache export request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Per-tile-set outcomes plus the migration manifest the export was derived from.</returns>
+    Task<OgcTileCacheExportResult> ExportAsync(
+        OgcTileCacheExportRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Import/Abstractions/IOgcTileCacheSink.cs
+++ b/src/Honua.Core/Features/Import/Abstractions/IOgcTileCacheSink.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Abstractions;
+
+/// <summary>
+/// Idempotent sink for tile records emitted by
+/// <see cref="IOgcTileCacheExportService"/>. Implementations persist tile
+/// bytes into Honua's tile catalog. Repeated writes for the same
+/// (cache, z, x, y) tuple must leave existing rows untouched.
+/// </summary>
+public interface IOgcTileCacheSink
+{
+    /// <summary>
+    /// Ensure a tile-cache catalog row exists for the supplied descriptor.
+    /// Implementations must return the stable target identifier they will
+    /// use for tile rows referencing this cache.
+    /// </summary>
+    /// <param name="descriptor">Tile-cache descriptor.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Stable target tile-cache identifier.</returns>
+    Task<string> EnsureTileCacheAsync(
+        OgcTileCacheDescriptor descriptor,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Write a single tile record into the cache. Implementations must be
+    /// idempotent: a repeated write for the same (cache, z, x, y) tuple
+    /// returns <see cref="OgcTileCacheWriteStatus.AlreadyPresent"/> and does
+    /// not overwrite the existing row.
+    /// </summary>
+    /// <param name="record">Tile record to persist.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Whether the record was inserted or skipped as already present.</returns>
+    Task<OgcTileCacheWriteStatus> WriteTileAsync(
+        OgcTileCacheRecord record,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Stable descriptor for a tile cache.
+/// </summary>
+public sealed record OgcTileCacheDescriptor
+{
+    /// <summary>Source WMTS layer identifier.</summary>
+    public required string LayerIdentifier { get; init; }
+
+    /// <summary>Source WMTS tile-matrix-set identifier.</summary>
+    public required string TileMatrixSetIdentifier { get; init; }
+
+    /// <summary>Sanitized source service URL the export ran against.</summary>
+    public required string SourceServiceUrl { get; init; }
+
+    /// <summary>Tile format such as <c>image/png</c>.</summary>
+    public required string TileFormat { get; init; }
+
+    /// <summary>WMTS style identifier the export was fetched with.</summary>
+    public required string StyleIdentifier { get; init; }
+
+    /// <summary>Resolved minimum zoom level included in the export.</summary>
+    public required int MinZoom { get; init; }
+
+    /// <summary>Resolved maximum zoom level included in the export.</summary>
+    public required int MaxZoom { get; init; }
+}
+
+/// <summary>
+/// One tile-cache row.
+/// </summary>
+public sealed record OgcTileCacheRecord
+{
+    /// <summary>Target tile-cache identifier this tile belongs to.</summary>
+    public required string TileCacheId { get; init; }
+
+    /// <summary>Zoom level.</summary>
+    public required int Z { get; init; }
+
+    /// <summary>Tile column.</summary>
+    public required int X { get; init; }
+
+    /// <summary>Tile row.</summary>
+    public required int Y { get; init; }
+
+    /// <summary>Tile content type, such as <c>image/png</c>.</summary>
+    public required string ContentType { get; init; }
+
+    /// <summary>Tile content bytes.</summary>
+    public required byte[] Content { get; init; }
+
+    /// <summary>Sanitized source URL the tile was fetched from.</summary>
+    public required string SourceUrl { get; init; }
+}
+
+/// <summary>
+/// Outcome of a tile-cache write.
+/// </summary>
+public enum OgcTileCacheWriteStatus
+{
+    /// <summary>The tile was inserted into the cache.</summary>
+    Inserted = 0,
+
+    /// <summary>A tile already existed at this coordinate; no write occurred.</summary>
+    AlreadyPresent = 1
+}

--- a/src/Honua.Core/Features/Import/Domain/ImportCompatibilityCodes.cs
+++ b/src/Honua.Core/Features/Import/Domain/ImportCompatibilityCodes.cs
@@ -135,4 +135,16 @@ public static class ImportCompatibilityCodes
 
     /// <summary>WMS/WMTS render or tile endpoint captured for downstream service migration planning.</summary>
     public const string OgcRenderEndpointPlanned = "OGC_RENDER_ENDPOINT_PLANNED";
+
+    /// <summary>WMTS tile-set export ran successfully for an automated XYZ/TMS plan entry.</summary>
+    public const string OgcWmtsTileCacheExported = "OGC_WMTS_TILE_CACHE_EXPORTED";
+
+    /// <summary>WMTS tile-set export was deferred because the requested zoom range exceeds the slice-4 safety threshold.</summary>
+    public const string OgcWmtsTileCacheZoomThresholdExceeded = "OGC_WMTS_TILE_CACHE_ZOOM_THRESHOLD_EXCEEDED";
+
+    /// <summary>WMTS tile-set export was skipped because the planner did not classify the tile-set as automated XYZ/TMS.</summary>
+    public const string OgcWmtsTileCacheSkippedManualReview = "OGC_WMTS_TILE_CACHE_SKIPPED_MANUAL_REVIEW";
+
+    /// <summary>WMTS tile-set export failed because a tile fetch returned an error.</summary>
+    public const string OgcWmtsTileCacheFetchFailed = "OGC_WMTS_TILE_CACHE_FETCH_FAILED";
 }

--- a/src/Honua.Core/Features/Import/Domain/OgcTileCacheExportRequest.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcTileCacheExportRequest.cs
@@ -1,0 +1,232 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Request to export a deterministic XYZ/TMS tile cache from a slice-3 WMTS
+/// migration plan entry classified as automated. The export fetches the
+/// configured zoom-level window from the source WMTS endpoint and persists
+/// the bytes through an <see cref="Abstractions.IOgcTileCacheSink"/>.
+/// </summary>
+public sealed record OgcTileCacheExportRequest
+{
+    /// <summary>
+    /// Optional job identifier used for log correlation.
+    /// </summary>
+    public string? JobId { get; init; }
+
+    /// <summary>
+    /// WMTS service URL. May be a service root or an existing
+    /// <c>GetCapabilities</c> URL. Used by the inventory scanner when no
+    /// pre-built manifest is supplied.
+    /// </summary>
+    public required string ServiceUrl { get; init; }
+
+    /// <summary>
+    /// Optional WMTS version. When omitted, the version advertised by the
+    /// source is used.
+    /// </summary>
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// Optional list of source WMTS layer identifiers to export. When omitted,
+    /// every automated tile-set plan entry is exported.
+    /// </summary>
+    public string[]? LayerIdentifiers { get; init; }
+
+    /// <summary>
+    /// Optional tile-matrix-set identifiers to restrict the export to. When
+    /// omitted, every automated tile-matrix-set plan entry is exported.
+    /// </summary>
+    public string[]? TileMatrixSetIdentifiers { get; init; }
+
+    /// <summary>
+    /// Output tile format the source should be asked for, such as
+    /// <c>image/png</c>. Defaults to <c>image/png</c>.
+    /// </summary>
+    public string? TileFormat { get; init; }
+
+    /// <summary>
+    /// Optional WMTS style identifier to fetch tiles with. Defaults to
+    /// <c>default</c>.
+    /// </summary>
+    public string? StyleIdentifier { get; init; }
+
+    /// <summary>
+    /// Minimum zoom level (inclusive). Defaults to 0.
+    /// </summary>
+    public int MinZoom { get; init; } = OgcTileCacheExportSafetyLimits.DefaultMinZoom;
+
+    /// <summary>
+    /// Maximum zoom level (inclusive). Defaults to
+    /// <see cref="OgcTileCacheExportSafetyLimits.DefaultMaxZoom"/>.
+    /// </summary>
+    public int MaxZoom { get; init; } = OgcTileCacheExportSafetyLimits.DefaultMaxZoom;
+
+    /// <summary>
+    /// Optional column window (inclusive) per zoom level. When omitted, the
+    /// full grid for the zoom level is exported up to the tile-count safety cap.
+    /// </summary>
+    public OgcTileCacheTileWindow? Window { get; init; }
+
+    /// <summary>
+    /// Whether to perform a dry run that resolves the plan and tile URLs but
+    /// does not fetch tile bytes or write to the sink.
+    /// </summary>
+    public bool DryRun { get; init; }
+
+    /// <summary>
+    /// Explicit operator opt-in for catalog mutation. When <see cref="DryRun"/>
+    /// is <c>false</c>, the import endpoint rejects the request unless
+    /// <c>ApplyMode</c> is <c>true</c>.
+    /// </summary>
+    public bool ApplyMode { get; init; }
+
+    /// <summary>
+    /// Per-tile HTTP timeout in seconds. Defaults to 30 seconds.
+    /// </summary>
+    public int RequestTimeoutSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// Whether HTTP and local URLs are allowed for test or controlled operator
+    /// environments.
+    /// </summary>
+    public bool AllowUnsafeLocalUrls { get; init; }
+}
+
+/// <summary>
+/// Inclusive (z, x, y) tile window. The window applies uniformly per zoom; if
+/// the requested column or row exceeds the grid extent for a zoom, the export
+/// clamps to the valid range.
+/// </summary>
+public sealed record OgcTileCacheTileWindow
+{
+    /// <summary>Inclusive minimum tile column.</summary>
+    public required int MinColumn { get; init; }
+
+    /// <summary>Inclusive maximum tile column.</summary>
+    public required int MaxColumn { get; init; }
+
+    /// <summary>Inclusive minimum tile row.</summary>
+    public required int MinRow { get; init; }
+
+    /// <summary>Inclusive maximum tile row.</summary>
+    public required int MaxRow { get; init; }
+}
+
+/// <summary>
+/// Safety thresholds applied by <see cref="Abstractions.IOgcTileCacheExportService"/>.
+/// </summary>
+public static class OgcTileCacheExportSafetyLimits
+{
+    /// <summary>Default minimum zoom level for slice-4 automated tile exports.</summary>
+    public const int DefaultMinZoom = 0;
+
+    /// <summary>
+    /// Default maximum zoom level for slice-4 automated tile exports. Chosen
+    /// to keep export fixtures bounded. Operators may opt in to a larger
+    /// window per request, subject to <see cref="MaxAutomatedZoomLevel"/>.
+    /// </summary>
+    public const int DefaultMaxZoom = 2;
+
+    /// <summary>
+    /// Hard upper bound on the per-request maximum zoom level. Beyond this
+    /// the tile-set is reclassified as <c>manual-review</c> because automated
+    /// export would request too many tiles for a single migration run.
+    /// </summary>
+    public const int MaxAutomatedZoomLevel = 6;
+
+    /// <summary>
+    /// Hard upper bound on the per-request total tile count. Beyond this the
+    /// tile-set is reclassified as <c>manual-review</c>.
+    /// </summary>
+    public const int MaxAutomatedTileCount = 1024;
+}
+
+/// <summary>
+/// Result of a tile-cache export operation.
+/// </summary>
+public sealed record OgcTileCacheExportResult
+{
+    /// <summary>Whether the export completed without a top-level error.</summary>
+    public required bool Success { get; init; }
+
+    /// <summary>Whether this was a dry run (no tile bytes were written).</summary>
+    public bool WasDryRun { get; init; }
+
+    /// <summary>Source WMTS URL the export ran against.</summary>
+    public required string SourceServiceUrl { get; init; }
+
+    /// <summary>Number of tile-set plan entries considered for export.</summary>
+    public int TileSetsPlanned { get; init; }
+
+    /// <summary>Number of tile-set plan entries exported (or that would have exported in a dry run).</summary>
+    public int TileSetsExported { get; init; }
+
+    /// <summary>Number of tile-set plan entries skipped (manual-review, threshold exceeded, or error).</summary>
+    public int TileSetsSkipped { get; init; }
+
+    /// <summary>Total number of tile records persisted across all tile-sets.</summary>
+    public int TilesPersisted { get; init; }
+
+    /// <summary>Total number of tile records skipped because they already existed in the sink.</summary>
+    public int TilesAlreadyPresent { get; init; }
+
+    /// <summary>Total number of tile records that failed to fetch or persist.</summary>
+    public int TilesFailed { get; init; }
+
+    /// <summary>Per-tile-set outcome records.</summary>
+    public IReadOnlyList<OgcTileCacheExportedTileSet> TileSets { get; init; } = [];
+
+    /// <summary>Top-level warnings encountered during the export.</summary>
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+
+    /// <summary>Top-level error message when <see cref="Success"/> is <c>false</c>.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Migration manifest the export was derived from.</summary>
+    public required MigrationManifestArtifact Manifest { get; init; }
+
+    /// <summary>Export duration.</summary>
+    public TimeSpan Duration { get; init; }
+}
+
+/// <summary>
+/// Per-tile-set record describing one tile-cache export outcome.
+/// </summary>
+public sealed record OgcTileCacheExportedTileSet
+{
+    /// <summary>Source WMTS layer identifier.</summary>
+    public required string LayerIdentifier { get; init; }
+
+    /// <summary>Source WMTS tile-matrix-set identifier.</summary>
+    public required string TileMatrixSetIdentifier { get; init; }
+
+    /// <summary>Stable target tile-cache identifier persisted into the catalog.</summary>
+    public string? TargetTileCacheId { get; init; }
+
+    /// <summary>Resolved minimum zoom level for the export.</summary>
+    public int MinZoom { get; init; }
+
+    /// <summary>Resolved maximum zoom level for the export.</summary>
+    public int MaxZoom { get; init; }
+
+    /// <summary>Number of tiles persisted by this export.</summary>
+    public int TilesPersisted { get; init; }
+
+    /// <summary>Number of tiles that already existed in the sink and were left untouched.</summary>
+    public int TilesAlreadyPresent { get; init; }
+
+    /// <summary>Number of tiles that failed to fetch or persist.</summary>
+    public int TilesFailed { get; init; }
+
+    /// <summary>Fidelity classification, one of <see cref="MigrationFidelityAutomationStatuses"/>.</summary>
+    public required string Classification { get; init; }
+
+    /// <summary>Stable machine-readable code summarising the export outcome.</summary>
+    public required string Code { get; init; }
+
+    /// <summary>Per-tile-set warnings.</summary>
+    public string[] Warnings { get; init; } = [];
+}

--- a/src/Honua.Core/Features/Import/Services/OgcTileCacheExportService.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcTileCacheExportService.cs
@@ -1,0 +1,663 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Net.Http.Headers;
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Import.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Deterministic XYZ/TMS tile cache exporter for WMTS sources whose slice-3
+/// plan entry classified the tile-set as <c>automated</c>. Fetches tiles
+/// within a bounded zoom and tile-count window and hands them to an
+/// <see cref="IOgcTileCacheSink"/>. Re-runs are idempotent because the sink
+/// reports already-present tiles instead of overwriting them.
+/// </summary>
+public sealed partial class OgcTileCacheExportService : IOgcTileCacheExportService
+{
+    /// <summary>
+    /// Named <see cref="IHttpClientFactory"/> identifier for the WMTS tile
+    /// fetch client.
+    /// </summary>
+    public const string HttpClientName = "ogc-tile-cache-export";
+
+    private const string SourceKindOgcWmts = "ogc-wmts";
+    private const string DefaultTileFormat = "image/png";
+    private const string DefaultStyle = "default";
+    private const int MaxTileBytes = 4 * 1024 * 1024;
+
+    private readonly IOgcServiceMigrationScanner _scanner;
+    private readonly IOgcTileCacheSink _sink;
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<OgcTileCacheExportService> _logger;
+
+    /// <summary>
+    /// Initializes a new <see cref="OgcTileCacheExportService"/>.
+    /// </summary>
+    /// <param name="scanner">OGC service migration scanner used to resolve the manifest.</param>
+    /// <param name="sink">Tile cache sink used to persist tile bytes.</param>
+    /// <param name="httpClient">HTTP client used to fetch WMTS tiles.</param>
+    /// <param name="logger">Logger.</param>
+    public OgcTileCacheExportService(
+        IOgcServiceMigrationScanner scanner,
+        IOgcTileCacheSink sink,
+        HttpClient httpClient,
+        ILogger<OgcTileCacheExportService> logger)
+    {
+        _scanner = scanner ?? throw new ArgumentNullException(nameof(scanner));
+        _sink = sink ?? throw new ArgumentNullException(nameof(sink));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<OgcTileCacheExportResult> ExportAsync(
+        OgcTileCacheExportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.ServiceUrl))
+        {
+            throw new ArgumentException("ServiceUrl is required.", nameof(request));
+        }
+
+        if (request.MinZoom < 0 || request.MaxZoom < 0 || request.MaxZoom < request.MinZoom)
+        {
+            throw new ArgumentException("MinZoom/MaxZoom must form a non-negative inclusive range.", nameof(request));
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        var jobId = string.IsNullOrWhiteSpace(request.JobId)
+            ? Guid.NewGuid().ToString("N")[..8]
+            : request.JobId;
+        var safeSourceUrl = ToSafeSourceUrl(request.ServiceUrl);
+        var tileFormat = string.IsNullOrWhiteSpace(request.TileFormat) ? DefaultTileFormat : request.TileFormat;
+        var styleIdentifier = string.IsNullOrWhiteSpace(request.StyleIdentifier) ? DefaultStyle : request.StyleIdentifier;
+
+        Log.ExportStarting(_logger, safeSourceUrl, jobId, request.DryRun);
+
+        MigrationSourceInventoryArtifact inventory;
+        try
+        {
+            inventory = await _scanner.ScanSourceAsync(
+                new OgcServiceScanRequest
+                {
+                    ServiceType = "WMTS",
+                    ServiceUrl = request.ServiceUrl,
+                    Version = request.Version,
+                    TimeoutSeconds = request.RequestTimeoutSeconds,
+                    AllowUnsafeLocalUrls = request.AllowUnsafeLocalUrls
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Log.InventoryScanFailed(_logger, safeSourceUrl, ex);
+            return CreateFailureResult(request, safeSourceUrl, "Failed to scan WMTS source for tile-cache export.", stopwatch.Elapsed);
+        }
+
+        if (!string.Equals(inventory.SourceKind, SourceKindOgcWmts, StringComparison.OrdinalIgnoreCase))
+        {
+            return CreateFailureResult(request, safeSourceUrl, "Source URL did not resolve to a WMTS endpoint.", stopwatch.Elapsed, inventory);
+        }
+
+        if (string.Equals(inventory.ScanCompleteness.Status, "failed", StringComparison.OrdinalIgnoreCase))
+        {
+            var reason = inventory.ScanCompleteness.Warnings.FirstOrDefault() ?? "WMTS source scan failed.";
+            return CreateFailureResult(request, safeSourceUrl, reason, stopwatch.Elapsed, inventory);
+        }
+
+        var manifest = MigrationManifestTranslator.Translate(inventory);
+        var plans = ResolveWmtsPlans(manifest);
+
+        var perTileSet = new List<OgcTileCacheExportedTileSet>();
+        var topLevelWarnings = new List<string>();
+        var tileSetsPlanned = 0;
+        var tileSetsExported = 0;
+        var tileSetsSkipped = 0;
+        var tilesPersisted = 0;
+        var tilesAlreadyPresent = 0;
+        var tilesFailed = 0;
+
+        var requestedLayers = ToOrdinalSet(request.LayerIdentifiers);
+        var requestedTileMatrixSets = ToOrdinalSet(request.TileMatrixSetIdentifiers);
+
+        foreach (var plan in plans)
+        {
+            var tileSetEntries = plan.PlanEntries
+                .Where(entry => string.Equals(entry.Category, "tile-set", StringComparison.Ordinal))
+                .OrderBy(static entry => entry.Id, StringComparer.Ordinal)
+                .ToArray();
+
+            var layerEntries = plan.PlanEntries
+                .Where(entry => string.Equals(entry.Category, "layer-metadata", StringComparison.Ordinal))
+                .OrderBy(static entry => entry.Id, StringComparer.Ordinal)
+                .ToArray();
+
+            foreach (var layerEntry in layerEntries)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (requestedLayers != null && !requestedLayers.Contains(layerEntry.SourceId))
+                {
+                    continue;
+                }
+
+                var layerResource = inventory.Resources.FirstOrDefault(resource =>
+                    string.Equals(resource.Id, layerEntry.SourceId, StringComparison.Ordinal));
+                if (layerResource == null)
+                {
+                    continue;
+                }
+
+                var layerTileMatrixSetIds = new HashSet<string>(layerResource.ExternalDependencyIds, StringComparer.Ordinal);
+
+                foreach (var tileSetEntry in tileSetEntries)
+                {
+                    if (!layerTileMatrixSetIds.Contains(tileSetEntry.SourceId))
+                    {
+                        continue;
+                    }
+
+                    if (requestedTileMatrixSets != null && !requestedTileMatrixSets.Contains(tileSetEntry.SourceId))
+                    {
+                        continue;
+                    }
+
+                    tileSetsPlanned++;
+
+                    if (!string.Equals(tileSetEntry.AutomationStatus, MigrationFidelityAutomationStatuses.Automated, StringComparison.Ordinal))
+                    {
+                        perTileSet.Add(new OgcTileCacheExportedTileSet
+                        {
+                            LayerIdentifier = layerResource.Name,
+                            TileMatrixSetIdentifier = tileSetEntry.Name ?? tileSetEntry.SourceId,
+                            MinZoom = request.MinZoom,
+                            MaxZoom = request.MaxZoom,
+                            Classification = MigrationFidelityAutomationStatuses.ManualReview,
+                            Code = ImportCompatibilityCodes.OgcWmtsTileCacheSkippedManualReview,
+                            Warnings = ["Slice-3 plan entry was not classified as automated; tile-set export skipped."]
+                        });
+                        tileSetsSkipped++;
+                        continue;
+                    }
+
+                    if (request.MaxZoom > OgcTileCacheExportSafetyLimits.MaxAutomatedZoomLevel)
+                    {
+                        perTileSet.Add(new OgcTileCacheExportedTileSet
+                        {
+                            LayerIdentifier = layerResource.Name,
+                            TileMatrixSetIdentifier = tileSetEntry.Name ?? tileSetEntry.SourceId,
+                            MinZoom = request.MinZoom,
+                            MaxZoom = request.MaxZoom,
+                            Classification = MigrationFidelityAutomationStatuses.ManualReview,
+                            Code = ImportCompatibilityCodes.OgcWmtsTileCacheZoomThresholdExceeded,
+                            Warnings =
+                            [
+                                string.Create(CultureInfo.InvariantCulture,
+                                    $"Requested max zoom {request.MaxZoom} exceeds the slice-4 safety threshold of {OgcTileCacheExportSafetyLimits.MaxAutomatedZoomLevel}; reclassify as manual review.")
+                            ]
+                        });
+                        tileSetsSkipped++;
+                        continue;
+                    }
+
+                    var projectedTileCount = ProjectTileCount(request);
+                    if (projectedTileCount > OgcTileCacheExportSafetyLimits.MaxAutomatedTileCount)
+                    {
+                        perTileSet.Add(new OgcTileCacheExportedTileSet
+                        {
+                            LayerIdentifier = layerResource.Name,
+                            TileMatrixSetIdentifier = tileSetEntry.Name ?? tileSetEntry.SourceId,
+                            MinZoom = request.MinZoom,
+                            MaxZoom = request.MaxZoom,
+                            Classification = MigrationFidelityAutomationStatuses.ManualReview,
+                            Code = ImportCompatibilityCodes.OgcWmtsTileCacheZoomThresholdExceeded,
+                            Warnings =
+                            [
+                                string.Create(CultureInfo.InvariantCulture,
+                                    $"Projected tile count {projectedTileCount} exceeds the slice-4 safety cap of {OgcTileCacheExportSafetyLimits.MaxAutomatedTileCount}; reclassify as manual review.")
+                            ]
+                        });
+                        tileSetsSkipped++;
+                        continue;
+                    }
+
+                    OgcTileCacheExportedTileSet outcome;
+                    try
+                    {
+                        outcome = await ExportTileSetAsync(
+                            request,
+                            inventory,
+                            layerResource,
+                            tileSetEntry,
+                            tileFormat,
+                            styleIdentifier,
+                            safeSourceUrl,
+                            cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.TileSetExportFailed(_logger, layerResource.Name, tileSetEntry.SourceId, ex);
+                        outcome = new OgcTileCacheExportedTileSet
+                        {
+                            LayerIdentifier = layerResource.Name,
+                            TileMatrixSetIdentifier = tileSetEntry.Name ?? tileSetEntry.SourceId,
+                            MinZoom = request.MinZoom,
+                            MaxZoom = request.MaxZoom,
+                            Classification = MigrationFidelityAutomationStatuses.ManualReview,
+                            Code = ImportCompatibilityCodes.OgcWmtsTileCacheFetchFailed,
+                            Warnings = [ToSafeFailureReason(ex)]
+                        };
+                    }
+
+                    perTileSet.Add(outcome);
+                    tilesPersisted += outcome.TilesPersisted;
+                    tilesAlreadyPresent += outcome.TilesAlreadyPresent;
+                    tilesFailed += outcome.TilesFailed;
+
+                    if (string.Equals(outcome.Classification, MigrationFidelityAutomationStatuses.Automated, StringComparison.Ordinal))
+                    {
+                        tileSetsExported++;
+                    }
+                    else
+                    {
+                        tileSetsSkipped++;
+                    }
+                }
+            }
+        }
+
+        stopwatch.Stop();
+        Log.ExportCompleted(_logger, safeSourceUrl, tileSetsExported, tileSetsSkipped, tilesPersisted, tilesAlreadyPresent, tilesFailed, stopwatch.Elapsed.TotalSeconds);
+
+        return new OgcTileCacheExportResult
+        {
+            Success = true,
+            WasDryRun = request.DryRun,
+            SourceServiceUrl = safeSourceUrl,
+            TileSetsPlanned = tileSetsPlanned,
+            TileSetsExported = tileSetsExported,
+            TileSetsSkipped = tileSetsSkipped,
+            TilesPersisted = tilesPersisted,
+            TilesAlreadyPresent = tilesAlreadyPresent,
+            TilesFailed = tilesFailed,
+            TileSets = perTileSet,
+            Warnings = topLevelWarnings,
+            Manifest = manifest,
+            Duration = stopwatch.Elapsed
+        };
+    }
+
+    private async Task<OgcTileCacheExportedTileSet> ExportTileSetAsync(
+        OgcTileCacheExportRequest request,
+        MigrationSourceInventoryArtifact inventory,
+        MigrationInventoryResource layerResource,
+        MigrationManifestPlanEntry tileSetEntry,
+        string tileFormat,
+        string styleIdentifier,
+        string safeSourceUrl,
+        CancellationToken cancellationToken)
+    {
+        var warnings = new List<string>();
+        var template = ResolveTileTemplate(inventory, layerResource, tileFormat);
+        var descriptor = new OgcTileCacheDescriptor
+        {
+            LayerIdentifier = layerResource.Name,
+            TileMatrixSetIdentifier = tileSetEntry.Name ?? tileSetEntry.SourceId,
+            SourceServiceUrl = safeSourceUrl,
+            TileFormat = tileFormat,
+            StyleIdentifier = styleIdentifier,
+            MinZoom = request.MinZoom,
+            MaxZoom = request.MaxZoom
+        };
+
+        string? targetTileCacheId = null;
+        if (!request.DryRun)
+        {
+            targetTileCacheId = await _sink.EnsureTileCacheAsync(descriptor, cancellationToken).ConfigureAwait(false);
+        }
+
+        var serviceUri = new Uri(request.ServiceUrl, UriKind.Absolute);
+        var inserted = 0;
+        var alreadyPresent = 0;
+        var failed = 0;
+
+        for (var z = request.MinZoom; z <= request.MaxZoom; z++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var (minCol, maxCol, minRow, maxRow) = ResolveWindow(request.Window, z);
+            for (var x = minCol; x <= maxCol; x++)
+            {
+                for (var y = minRow; y <= maxRow; y++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var tileUri = BuildTileUri(template, serviceUri, layerResource.Name, descriptor.TileMatrixSetIdentifier, styleIdentifier, tileFormat, z, x, y);
+
+                    if (request.DryRun)
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        var bytes = await FetchTileAsync(tileUri, request.RequestTimeoutSeconds, cancellationToken).ConfigureAwait(false);
+                        var status = await _sink.WriteTileAsync(new OgcTileCacheRecord
+                        {
+                            TileCacheId = targetTileCacheId!,
+                            Z = z,
+                            X = x,
+                            Y = y,
+                            ContentType = tileFormat,
+                            Content = bytes,
+                            SourceUrl = ToSafeSourceUrl(tileUri.AbsoluteUri)
+                        }, cancellationToken).ConfigureAwait(false);
+
+                        if (status == OgcTileCacheWriteStatus.Inserted)
+                        {
+                            inserted++;
+                        }
+                        else
+                        {
+                            alreadyPresent++;
+                        }
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.TileFetchFailed(_logger, layerResource.Name, z, x, y, ex);
+                        if (warnings.Count == 0)
+                        {
+                            warnings.Add($"Tile fetch failed (z={z},x={x},y={y}): {ToSafeFailureReason(ex)}");
+                        }
+
+                        failed++;
+                    }
+                }
+            }
+        }
+
+        var classification = failed == 0
+            ? MigrationFidelityAutomationStatuses.Automated
+            : MigrationFidelityAutomationStatuses.ManualReview;
+        var code = failed == 0
+            ? ImportCompatibilityCodes.OgcWmtsTileCacheExported
+            : ImportCompatibilityCodes.OgcWmtsTileCacheFetchFailed;
+
+        return new OgcTileCacheExportedTileSet
+        {
+            LayerIdentifier = layerResource.Name,
+            TileMatrixSetIdentifier = descriptor.TileMatrixSetIdentifier,
+            TargetTileCacheId = targetTileCacheId,
+            MinZoom = request.MinZoom,
+            MaxZoom = request.MaxZoom,
+            TilesPersisted = inserted,
+            TilesAlreadyPresent = alreadyPresent,
+            TilesFailed = failed,
+            Classification = classification,
+            Code = code,
+            Warnings = [.. warnings]
+        };
+    }
+
+    private async Task<byte[]> FetchTileAsync(Uri tileUri, int timeoutSeconds, CancellationToken cancellationToken)
+    {
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, tileUri);
+        requestMessage.Headers.Accept.Clear();
+        requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("image/*"));
+        requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/octet-stream"));
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds <= 0 ? 30 : timeoutSeconds));
+
+        using var response = await _httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, timeout.Token).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(timeout.Token).ConfigureAwait(false);
+        using var buffer = new MemoryStream();
+        var totalRead = 0;
+        var pool = new byte[8192];
+        int read;
+        while ((read = await stream.ReadAsync(pool.AsMemory(0, pool.Length), timeout.Token).ConfigureAwait(false)) > 0)
+        {
+            totalRead += read;
+            if (totalRead > MaxTileBytes)
+            {
+                throw new InvalidOperationException(
+                    $"Tile response exceeded the slice-4 maximum tile size of {MaxTileBytes} bytes.");
+            }
+
+            await buffer.WriteAsync(pool.AsMemory(0, read), timeout.Token).ConfigureAwait(false);
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static (int MinCol, int MaxCol, int MinRow, int MaxRow) ResolveWindow(OgcTileCacheTileWindow? window, int z)
+    {
+        var grid = checked(1 << z);
+        if (window == null)
+        {
+            return (0, grid - 1, 0, grid - 1);
+        }
+
+        var minCol = Math.Clamp(window.MinColumn, 0, grid - 1);
+        var maxCol = Math.Clamp(window.MaxColumn, 0, grid - 1);
+        var minRow = Math.Clamp(window.MinRow, 0, grid - 1);
+        var maxRow = Math.Clamp(window.MaxRow, 0, grid - 1);
+        return (Math.Min(minCol, maxCol), Math.Max(minCol, maxCol), Math.Min(minRow, maxRow), Math.Max(minRow, maxRow));
+    }
+
+    private static int ProjectTileCount(OgcTileCacheExportRequest request)
+    {
+        long total = 0;
+        for (var z = request.MinZoom; z <= request.MaxZoom; z++)
+        {
+            var (minCol, maxCol, minRow, maxRow) = ResolveWindow(request.Window, z);
+            total += checked((long)(maxCol - minCol + 1) * (maxRow - minRow + 1));
+            if (total > int.MaxValue)
+            {
+                return int.MaxValue;
+            }
+        }
+
+        return (int)total;
+    }
+
+    private static string? ResolveTileTemplate(
+        MigrationSourceInventoryArtifact inventory,
+        MigrationInventoryResource layerResource,
+        string tileFormat)
+    {
+        foreach (var dependency in inventory.ExternalDependencies)
+        {
+            if (!string.Equals(dependency.ResourceId, layerResource.Id, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!string.Equals(dependency.Kind, "ogc-endpoint", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!dependency.Metadata.TryGetValue("operation", out var operation) ||
+                !string.Equals(operation, "ResourceURL", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (dependency.Metadata.TryGetValue("format", out var format) &&
+                !string.IsNullOrWhiteSpace(format) &&
+                !string.Equals(format, tileFormat, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(dependency.Address))
+            {
+                return dependency.Address;
+            }
+        }
+
+        return null;
+    }
+
+    private static Uri BuildTileUri(
+        string? template,
+        Uri serviceUri,
+        string layerIdentifier,
+        string tileMatrixSetIdentifier,
+        string styleIdentifier,
+        string tileFormat,
+        int z,
+        int x,
+        int y)
+    {
+        if (!string.IsNullOrWhiteSpace(template))
+        {
+            var resolved = template
+                .Replace("{TileMatrixSet}", tileMatrixSetIdentifier, StringComparison.Ordinal)
+                .Replace("{TileMatrix}", z.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)
+                .Replace("{TileCol}", x.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)
+                .Replace("{TileRow}", y.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)
+                .Replace("{Style}", styleIdentifier, StringComparison.Ordinal)
+                .Replace("{Layer}", layerIdentifier, StringComparison.Ordinal);
+            if (Uri.TryCreate(resolved, UriKind.Absolute, out var templateUri))
+            {
+                return templateUri;
+            }
+        }
+
+        var query = string.Create(CultureInfo.InvariantCulture,
+            $"service=WMTS&version=1.0.0&request=GetTile&layer={Uri.EscapeDataString(layerIdentifier)}&style={Uri.EscapeDataString(styleIdentifier)}&tilematrixset={Uri.EscapeDataString(tileMatrixSetIdentifier)}&tilematrix={z}&tilerow={y}&tilecol={x}&format={Uri.EscapeDataString(tileFormat)}");
+        var builder = new UriBuilder(serviceUri) { Query = query };
+        return builder.Uri;
+    }
+
+    private static IReadOnlySet<string>? ToOrdinalSet(string[]? values)
+    {
+        if (values == null || values.Length == 0)
+        {
+            return null;
+        }
+
+        return new HashSet<string>(values, StringComparer.Ordinal);
+    }
+
+    private static IReadOnlyList<MigrationManifestServicePlan> ResolveWmtsPlans(MigrationManifestArtifact manifest)
+        => manifest.ServicePlans
+            .Where(plan => string.Equals(plan.ServiceType, "WMTS", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(static plan => plan.SourceContainerId, StringComparer.Ordinal)
+            .ToArray();
+
+    private static OgcTileCacheExportResult CreateFailureResult(
+        OgcTileCacheExportRequest request,
+        string safeSourceUrl,
+        string errorMessage,
+        TimeSpan duration,
+        MigrationSourceInventoryArtifact? inventory = null)
+    {
+        inventory ??= new MigrationSourceInventoryArtifact
+        {
+            SourceKind = SourceKindOgcWmts,
+            Source = new MigrationSourceIdentity
+            {
+                DisplayName = "WMTS",
+                BaseUrl = safeSourceUrl,
+                Product = "OGC Web Map Tile Service",
+                ServiceType = "WMTS"
+            },
+            AuthPosture = new MigrationInventoryAuthPosture { Mode = "anonymous" },
+            ScanCompleteness = new MigrationInventoryCompleteness
+            {
+                Status = "failed",
+                Warnings = [errorMessage]
+            },
+            Summary = new MigrationInventorySummary(),
+            OverallCompatibility = new MigrationCompatibilityAssessment
+            {
+                Level = "incompatible",
+                Reason = errorMessage
+            }
+        };
+
+        var manifest = MigrationManifestTranslator.Translate(inventory);
+        return new OgcTileCacheExportResult
+        {
+            Success = false,
+            WasDryRun = request.DryRun,
+            SourceServiceUrl = safeSourceUrl,
+            ErrorMessage = errorMessage,
+            TileSets = [],
+            Warnings = [errorMessage],
+            Manifest = manifest,
+            Duration = duration
+        };
+    }
+
+    private static string ToSafeSourceUrl(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return url;
+        }
+
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Fragment = string.Empty
+        };
+        return builder.Uri.AbsoluteUri;
+    }
+
+    private static string ToSafeFailureReason(Exception ex)
+        => ex switch
+        {
+            HttpRequestException => "WMTS tile endpoint could not be reached or returned an error response.",
+            TaskCanceledException => "WMTS tile request timed out.",
+            InvalidOperationException io => io.Message,
+            _ => "WMTS tile fetch failed."
+        };
+
+    private static partial class Log
+    {
+        [LoggerMessage(7950, LogLevel.Information,
+            "Starting WMTS tile-cache export from {SafeUrl} (job {JobId}, dryRun {DryRun})")]
+        public static partial void ExportStarting(ILogger logger, string safeUrl, string jobId, bool dryRun);
+
+        [LoggerMessage(7951, LogLevel.Information,
+            "WMTS tile-cache export complete for {SafeUrl}: exported {Exported}, skipped {Skipped}, tiles inserted {Inserted}, already-present {AlreadyPresent}, failed {Failed} in {ElapsedSeconds:F1}s")]
+        public static partial void ExportCompleted(ILogger logger, string safeUrl, int exported, int skipped, int inserted, int alreadyPresent, int failed, double elapsedSeconds);
+
+        [LoggerMessage(7952, LogLevel.Warning, "WMTS tile-cache inventory scan failed for {SafeUrl}")]
+        public static partial void InventoryScanFailed(ILogger logger, string safeUrl, Exception exception);
+
+        [LoggerMessage(7953, LogLevel.Warning,
+            "WMTS tile-set export failed for layer {Layer} tile-matrix-set {TileMatrixSet}")]
+        public static partial void TileSetExportFailed(ILogger logger, string layer, string tileMatrixSet, Exception exception);
+
+        [LoggerMessage(7954, LogLevel.Warning,
+            "WMTS tile fetch failed for layer {Layer} z={Zoom} x={Col} y={Row}")]
+        public static partial void TileFetchFailed(ILogger logger, string layer, int zoom, int col, int row, Exception exception);
+    }
+}

--- a/src/Honua.Postgres/Features/Import/PostgresOgcTileCacheSink.cs
+++ b/src/Honua.Postgres/Features/Import/PostgresOgcTileCacheSink.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.Import;
+
+/// <summary>
+/// Idempotent Postgres-backed sink for the WMTS tile-cache exporter
+/// (#1016 slice 4). Writes tile bytes into <c>honua.tile_caches</c> and
+/// <c>honua.tile_cache_entries</c>, deriving stable cache identifiers from
+/// the descriptor so repeated exports converge on the same row set.
+/// </summary>
+internal sealed partial class PostgresOgcTileCacheSink : IOgcTileCacheSink
+{
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly ILogger<PostgresOgcTileCacheSink> _logger;
+
+    public PostgresOgcTileCacheSink(
+        IDatabaseConnectionProvider connectionProvider,
+        ILogger<PostgresOgcTileCacheSink> logger)
+    {
+        _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<string> EnsureTileCacheAsync(
+        OgcTileCacheDescriptor descriptor,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        var cacheId = BuildTileCacheId(descriptor);
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var cmd = lease.Connection.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO honua.tile_caches (
+                tile_cache_id,
+                layer_identifier,
+                tile_matrix_set,
+                source_service_url,
+                tile_format,
+                style_identifier,
+                min_zoom,
+                max_zoom)
+            VALUES (
+                @tile_cache_id,
+                @layer_identifier,
+                @tile_matrix_set,
+                @source_service_url,
+                @tile_format,
+                @style_identifier,
+                @min_zoom,
+                @max_zoom)
+            ON CONFLICT (tile_cache_id) DO UPDATE
+                SET min_zoom   = LEAST(honua.tile_caches.min_zoom, EXCLUDED.min_zoom),
+                    max_zoom   = GREATEST(honua.tile_caches.max_zoom, EXCLUDED.max_zoom),
+                    updated_at = NOW();
+            """;
+        cmd.Parameters.AddWithValue("tile_cache_id", cacheId);
+        cmd.Parameters.AddWithValue("layer_identifier", descriptor.LayerIdentifier);
+        cmd.Parameters.AddWithValue("tile_matrix_set", descriptor.TileMatrixSetIdentifier);
+        cmd.Parameters.AddWithValue("source_service_url", descriptor.SourceServiceUrl);
+        cmd.Parameters.AddWithValue("tile_format", descriptor.TileFormat);
+        cmd.Parameters.AddWithValue("style_identifier", descriptor.StyleIdentifier);
+        cmd.Parameters.AddWithValue("min_zoom", descriptor.MinZoom);
+        cmd.Parameters.AddWithValue("max_zoom", descriptor.MaxZoom);
+
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        Log.CacheEnsured(_logger, cacheId, descriptor.LayerIdentifier, descriptor.TileMatrixSetIdentifier);
+
+        return cacheId;
+    }
+
+    /// <inheritdoc />
+    public async Task<OgcTileCacheWriteStatus> WriteTileAsync(
+        OgcTileCacheRecord record,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var cmd = lease.Connection.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO honua.tile_cache_entries (
+                tile_cache_id,
+                zoom_level,
+                tile_column,
+                tile_row,
+                content_type,
+                content,
+                source_url)
+            VALUES (
+                @tile_cache_id,
+                @zoom_level,
+                @tile_column,
+                @tile_row,
+                @content_type,
+                @content,
+                @source_url)
+            ON CONFLICT (tile_cache_id, zoom_level, tile_column, tile_row) DO NOTHING;
+            """;
+        cmd.Parameters.AddWithValue("tile_cache_id", record.TileCacheId);
+        cmd.Parameters.AddWithValue("zoom_level", record.Z);
+        cmd.Parameters.AddWithValue("tile_column", record.X);
+        cmd.Parameters.AddWithValue("tile_row", record.Y);
+        cmd.Parameters.AddWithValue("content_type", record.ContentType);
+        cmd.Parameters.Add("content", NpgsqlDbType.Bytea).Value = record.Content;
+        cmd.Parameters.AddWithValue("source_url", record.SourceUrl);
+
+        var inserted = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        if (inserted == 1)
+        {
+            return OgcTileCacheWriteStatus.Inserted;
+        }
+
+        return OgcTileCacheWriteStatus.AlreadyPresent;
+    }
+
+    /// <summary>
+    /// Build a deterministic tile-cache identifier from the descriptor. The
+    /// identifier collapses long URLs and identifiers to a short fingerprint
+    /// so the row count in <c>honua.tile_caches</c> stays bounded by the
+    /// number of distinct (layer, tile-matrix-set, style, format, source URL)
+    /// tuples.
+    /// </summary>
+    internal static string BuildTileCacheId(OgcTileCacheDescriptor descriptor)
+    {
+        var key = string.Create(CultureInfo.InvariantCulture,
+            $"{descriptor.LayerIdentifier}|{descriptor.TileMatrixSetIdentifier}|{descriptor.StyleIdentifier}|{descriptor.TileFormat}|{descriptor.SourceServiceUrl}");
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(key));
+        var fingerprint = Convert.ToHexString(hash, 0, 8).ToLowerInvariant();
+        return $"tilecache:{SanitizeSlug(descriptor.LayerIdentifier)}:{SanitizeSlug(descriptor.TileMatrixSetIdentifier)}:{fingerprint}";
+    }
+
+    private static string SanitizeSlug(string value)
+    {
+        var sb = new StringBuilder(value.Length);
+        foreach (var ch in value.AsSpan())
+        {
+            sb.Append(char.IsLetterOrDigit(ch) ? char.ToLowerInvariant(ch) : '-');
+        }
+
+        var slug = sb.ToString().Trim('-');
+        return slug.Length == 0 ? "_" : slug;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(7960, LogLevel.Information,
+            "Tile cache {TileCacheId} ensured for layer {Layer} tile-matrix-set {TileMatrixSet}")]
+        public static partial void CacheEnsured(ILogger logger, string tileCacheId, string layer, string tileMatrixSet);
+    }
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -391,6 +391,30 @@ internal static class ServiceCollectionExtensions
                 serviceProvider.GetService<PostgresSchemaConfiguration>());
         });
 
+        // Register OGC WMTS tile-cache export service (#1016 slice 4). Reuses the OGC service
+        // migration scanner for inventory/manifest resolution; the dedicated HTTP client is
+        // tuned for short-lived tile fetches; the sink is the Postgres-backed tile catalog.
+        services.AddResilientHttpClient(
+            OgcTileCacheExportService.HttpClientName,
+            "ogc-tile-cache-export",
+            HttpResiliencePolicies.SlowServiceDefaults,
+            configureClient: client =>
+            {
+                client.DefaultRequestHeaders.Add("User-Agent", "HonuaServer/1.0");
+                client.Timeout = TimeSpan.FromMinutes(2);
+            },
+            configureHandler: static () => OgcServiceMigrationScanner.CreatePinnedDnsHttpMessageHandler());
+        services.AddScoped<IOgcTileCacheSink, PostgresOgcTileCacheSink>();
+        services.AddScoped<IOgcTileCacheExportService>(serviceProvider =>
+        {
+            var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+            return new OgcTileCacheExportService(
+                serviceProvider.GetRequiredService<IOgcServiceMigrationScanner>(),
+                serviceProvider.GetRequiredService<IOgcTileCacheSink>(),
+                httpClientFactory.CreateClient(OgcTileCacheExportService.HttpClientName),
+                serviceProvider.GetRequiredService<ILogger<OgcTileCacheExportService>>());
+        });
+
         // Register secure connection management services
         services.AddSecureConnectionServices(configuration);
         services.UseSecureConnectionProvider(configuration);

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -277,6 +277,9 @@ public static class EndpointRegistry
         // v1 admin import endpoints (OGC WFS)
         new("POST", "/api/v1/admin/import/ogc-wfs/start"),
 
+        // v1 admin import endpoints (OGC WMTS tile cache export #1016 slice 4)
+        new("POST", "/api/v1/admin/import/ogc-tiles/export"),
+
         // v1 admin operational monitoring endpoints (#512)
         new("GET", "/api/v1/admin/operations/cache/health"),
         new("GET", "/api/v1/admin/operations/cache/statistics"),

--- a/src/Honua.Server/Features/Import/OgcTileCacheExportEndpoints.cs
+++ b/src/Honua.Server/Features/Import/OgcTileCacheExportEndpoints.cs
@@ -1,0 +1,237 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Helpers;
+
+namespace Honua.Server.Features.Import;
+
+/// <summary>
+/// Admin endpoints for OGC WMTS tile-cache export (#1016 slice 4).
+/// </summary>
+internal static class OgcTileCacheExportEndpoints
+{
+    /// <summary>
+    /// Maps tile-cache export endpoints.
+    /// </summary>
+    public static void MapOgcTileCacheExportEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/v{version:apiVersion}/admin/import/ogc-tiles")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("OgcTileCacheExport")
+            .RequireAdminAuthorization();
+
+        _ = group.MapPost("/export", HandleExport)
+            .WithName("ExportOgcTileCache")
+            .WithSummary("Export XYZ/TMS tile caches from an automated WMTS migration plan into Honua's tile catalog");
+    }
+
+    private static async Task HandleExport(HttpContext context)
+    {
+        var cancellationToken = context.RequestAborted;
+
+        OgcTileCacheExportApiRequest? request;
+        try
+        {
+            request = await context.Request.ReadFromJsonAsync(
+                OgcTileCacheExportJsonContext.Default.OgcTileCacheExportApiRequest,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Invalid request body", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (request == null)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "Request body is required", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ServiceUrl))
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "serviceUrl is required.", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var isDryRun = request.DryRun ?? false;
+        var isApplyMode = request.ApplyMode ?? false;
+        if (!isDryRun && !isApplyMode)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                "Non-dry-run tile-cache exports require applyMode=true to acknowledge that the reviewed migration plan will write tiles into the Honua tile catalog.",
+                StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var minZoom = request.MinZoom ?? OgcTileCacheExportSafetyLimits.DefaultMinZoom;
+        var maxZoom = request.MaxZoom ?? OgcTileCacheExportSafetyLimits.DefaultMaxZoom;
+        if (minZoom < 0 || maxZoom < 0 || maxZoom < minZoom)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                "minZoom and maxZoom must be non-negative and minZoom must not exceed maxZoom.",
+                StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var timeoutSeconds = request.RequestTimeoutSeconds ?? 30;
+        if (timeoutSeconds <= 0)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, "requestTimeoutSeconds must be greater than zero.", StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        var allowUnsafeLocalUrls = GeoServerImportExecutionSettings.ShouldAllowUnsafeLocalUrls(context.RequestServices);
+        var validation = await OgcServiceUrlValidation.ValidateAsync(
+            request.ServiceUrl,
+            allowUnsafeLocalUrls,
+            cancellationToken).ConfigureAwait(false);
+        if (!validation.IsValid)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, validation.ErrorMessage!, StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        OgcTileCacheTileWindow? window = null;
+        if (request.Window != null)
+        {
+            window = new OgcTileCacheTileWindow
+            {
+                MinColumn = request.Window.MinColumn,
+                MaxColumn = request.Window.MaxColumn,
+                MinRow = request.Window.MinRow,
+                MaxRow = request.Window.MaxRow
+            };
+        }
+
+        var exportService = context.RequestServices.GetRequiredService<IOgcTileCacheExportService>();
+
+        OgcTileCacheExportResult result;
+        try
+        {
+            result = await exportService.ExportAsync(
+                new OgcTileCacheExportRequest
+                {
+                    ServiceUrl = request.ServiceUrl,
+                    Version = request.Version,
+                    LayerIdentifiers = request.LayerIdentifiers,
+                    TileMatrixSetIdentifiers = request.TileMatrixSetIdentifiers,
+                    TileFormat = request.TileFormat,
+                    StyleIdentifier = request.StyleIdentifier,
+                    MinZoom = minZoom,
+                    MaxZoom = maxZoom,
+                    Window = window,
+                    DryRun = isDryRun,
+                    ApplyMode = isApplyMode,
+                    RequestTimeoutSeconds = timeoutSeconds,
+                    AllowUnsafeLocalUrls = allowUnsafeLocalUrls
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            await AdminResponseWriter.WriteErrorAsync(
+                context,
+                "Tile-cache export was canceled by the operator.",
+                StatusCodes.Status499ClientClosedRequest);
+            return;
+        }
+        catch (ArgumentException ex)
+        {
+            await AdminResponseWriter.WriteErrorAsync(context, ex.Message, StatusCodes.Status400BadRequest);
+            return;
+        }
+
+        if (!result.Success)
+        {
+            await Results.Json(result, OgcTileCacheExportJsonContext.Default.OgcTileCacheExportResult,
+                    statusCode: StatusCodes.Status502BadGateway)
+                .ExecuteAsync(context).ConfigureAwait(false);
+            return;
+        }
+
+        await Results.Json(result, OgcTileCacheExportJsonContext.Default.OgcTileCacheExportResult).ExecuteAsync(context).ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// API request model for the WMTS tile-cache export endpoint.
+/// </summary>
+internal sealed record OgcTileCacheExportApiRequest
+{
+    /// <summary>WMTS service URL (root or GetCapabilities URL).</summary>
+    public string? ServiceUrl { get; init; }
+
+    /// <summary>Optional WMTS version.</summary>
+    public string? Version { get; init; }
+
+    /// <summary>Specific WMTS layer identifiers to export (omit to export every automated tile-set).</summary>
+    public string[]? LayerIdentifiers { get; init; }
+
+    /// <summary>Specific WMTS tile-matrix-set identifiers to export.</summary>
+    public string[]? TileMatrixSetIdentifiers { get; init; }
+
+    /// <summary>Output tile format (defaults to image/png).</summary>
+    public string? TileFormat { get; init; }
+
+    /// <summary>WMTS style identifier (defaults to "default").</summary>
+    public string? StyleIdentifier { get; init; }
+
+    /// <summary>Minimum zoom level (inclusive).</summary>
+    public int? MinZoom { get; init; }
+
+    /// <summary>Maximum zoom level (inclusive).</summary>
+    public int? MaxZoom { get; init; }
+
+    /// <summary>Optional per-zoom tile window.</summary>
+    public OgcTileCacheExportWindowApiModel? Window { get; init; }
+
+    /// <summary>Preview mode: resolve plan + URLs without fetching tile bytes.</summary>
+    public bool? DryRun { get; init; }
+
+    /// <summary>Operator opt-in safety gate for non-dry-run exports.</summary>
+    public bool? ApplyMode { get; init; }
+
+    /// <summary>Per-tile HTTP timeout in seconds.</summary>
+    public int? RequestTimeoutSeconds { get; init; }
+}
+
+/// <summary>
+/// API tile-window model.
+/// </summary>
+internal sealed record OgcTileCacheExportWindowApiModel
+{
+    /// <summary>Inclusive minimum tile column.</summary>
+    public required int MinColumn { get; init; }
+
+    /// <summary>Inclusive maximum tile column.</summary>
+    public required int MaxColumn { get; init; }
+
+    /// <summary>Inclusive minimum tile row.</summary>
+    public required int MinRow { get; init; }
+
+    /// <summary>Inclusive maximum tile row.</summary>
+    public required int MaxRow { get; init; }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(OgcTileCacheExportApiRequest))]
+[JsonSerializable(typeof(OgcTileCacheExportWindowApiModel))]
+[JsonSerializable(typeof(OgcTileCacheExportResult))]
+[JsonSerializable(typeof(OgcTileCacheExportedTileSet))]
+[JsonSerializable(typeof(OgcTileCacheExportedTileSet[]))]
+[JsonSerializable(typeof(IReadOnlyList<OgcTileCacheExportedTileSet>))]
+[JsonSerializable(typeof(IReadOnlyList<string>))]
+[JsonSerializable(typeof(string[]))]
+internal sealed partial class OgcTileCacheExportJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Migrations/029_CreateTileCacheCatalog.sql
+++ b/src/Honua.Server/Migrations/029_CreateTileCacheCatalog.sql
@@ -1,0 +1,45 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Tile cache catalog tables for the XYZ/TMS tile-cache export emitted by the
+-- WMTS migration planner (slice 4 of issue #1016). The catalog stores one row
+-- per (source layer, tile-matrix-set, style, format) tile cache and one row
+-- per (z, x, y) tile. Repeated exports are idempotent because tile rows are
+-- keyed on (cache_id, zoom_level, tile_column, tile_row).
+
+CREATE TABLE IF NOT EXISTS honua.tile_caches (
+    tile_cache_id      TEXT PRIMARY KEY,
+    layer_identifier   TEXT NOT NULL,
+    tile_matrix_set    TEXT NOT NULL,
+    source_service_url TEXT NOT NULL,
+    tile_format        TEXT NOT NULL DEFAULT 'image/png',
+    style_identifier   TEXT NOT NULL DEFAULT 'default',
+    min_zoom           INTEGER NOT NULL,
+    max_zoom           INTEGER NOT NULL,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (layer_identifier, tile_matrix_set, style_identifier, tile_format, source_service_url)
+);
+
+COMMENT ON TABLE honua.tile_caches IS 'Tile-cache catalog populated by the WMTS migration tile-cache exporter (#1016 slice 4).';
+COMMENT ON COLUMN honua.tile_caches.tile_cache_id IS 'Stable identifier derived from layer + tile-matrix-set + style + format + source URL.';
+
+CREATE TABLE IF NOT EXISTS honua.tile_cache_entries (
+    tile_cache_id  TEXT NOT NULL REFERENCES honua.tile_caches (tile_cache_id) ON DELETE CASCADE,
+    zoom_level     INTEGER NOT NULL,
+    tile_column    INTEGER NOT NULL,
+    tile_row       INTEGER NOT NULL,
+    content_type   TEXT NOT NULL,
+    content        BYTEA NOT NULL,
+    source_url     TEXT NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tile_cache_id, zoom_level, tile_column, tile_row),
+    CHECK (zoom_level >= 0),
+    CHECK (tile_column >= 0),
+    CHECK (tile_row >= 0)
+);
+
+COMMENT ON TABLE honua.tile_cache_entries IS 'Per-tile rows for a tile-cache populated by the WMTS migration tile-cache exporter (#1016 slice 4).';
+
+CREATE INDEX IF NOT EXISTS tile_cache_entries_cache_zoom_idx
+    ON honua.tile_cache_entries (tile_cache_id, zoom_level);

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -820,6 +820,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Import.RasterImportJsonContext.Default,
         Honua.Server.Features.Import.GeoservicesImportApiJsonContext.Default,
         Honua.Server.Features.Import.OgcWfsImportJsonContext.Default,
+        Honua.Server.Features.Import.OgcTileCacheExportJsonContext.Default,
         Honua.Server.Features.Admin.OperationsProgressJsonContext.Default,
         Honua.Server.Features.Admin.FeatureEventReplayJsonContext.Default,
         Honua.Server.Features.Mobile.Auth.MobileAuthJsonContext.Default,
@@ -1227,6 +1228,9 @@ app.MapGeoServerImportEndpoints();
 
 // Configure OGC WFS data import endpoints (#1016 slice 2)
 app.MapOgcWfsImportEndpoints();
+
+// Configure OGC WMTS tile-cache export endpoints (#1016 slice 4)
+app.MapOgcTileCacheExportEndpoints();
 
 if (isTestEnvironment)
 {

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcTileCacheExportServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcTileCacheExportServiceTests.cs
@@ -1,0 +1,447 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text;
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Core.Tests.Features.Import;
+
+/// <summary>
+/// Tests for the slice-4 XYZ/TMS tile-cache exporter
+/// (<see cref="OgcTileCacheExportService"/>).
+/// </summary>
+public sealed class OgcTileCacheExportServiceTests
+{
+    private const string ServiceUrl = "https://wmts.example.test/wmts";
+    private const string LayerId = "basemap";
+    private const string TileMatrixSetId = "WebMercatorQuad";
+
+    [Fact]
+    public async Task ExportAsync_AutomatedTileSet_DeterministicallyFetchesAndPersistsTiles()
+    {
+        var inventory = BuildWmtsInventory(trivial: true);
+        var handler = new CountingTileHandler();
+        using var httpClient = new HttpClient(handler);
+        var sink = new InMemoryTileCacheSink();
+        var service = new OgcTileCacheExportService(
+            new InMemoryScanner(inventory),
+            sink,
+            httpClient,
+            NullLogger<OgcTileCacheExportService>.Instance);
+
+        var result = await service.ExportAsync(new OgcTileCacheExportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            ApplyMode = true,
+            AllowUnsafeLocalUrls = true,
+            MinZoom = 0,
+            MaxZoom = 1
+        });
+
+        result.Success.Should().BeTrue();
+        result.WasDryRun.Should().BeFalse();
+        result.TileSetsPlanned.Should().Be(1);
+        result.TileSetsExported.Should().Be(1);
+        result.TileSetsSkipped.Should().Be(0);
+        // Zoom 0: 1 tile, Zoom 1: 4 tiles, total 5 tiles.
+        result.TilesPersisted.Should().Be(5);
+        result.TilesAlreadyPresent.Should().Be(0);
+        result.TilesFailed.Should().Be(0);
+
+        var tileSet = result.TileSets.Should().ContainSingle().Subject;
+        tileSet.LayerIdentifier.Should().Be(LayerId);
+        tileSet.TileMatrixSetIdentifier.Should().Be(TileMatrixSetId);
+        tileSet.Classification.Should().Be(MigrationFidelityAutomationStatuses.Automated);
+        tileSet.Code.Should().Be(ImportCompatibilityCodes.OgcWmtsTileCacheExported);
+        tileSet.TargetTileCacheId.Should().NotBeNullOrWhiteSpace();
+
+        handler.RequestUris.Should().HaveCount(5);
+        sink.Records.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task ExportAsync_DryRun_DoesNotFetchTilesOrWriteSink()
+    {
+        var inventory = BuildWmtsInventory(trivial: true);
+        var handler = new CountingTileHandler();
+        using var httpClient = new HttpClient(handler);
+        var sink = new InMemoryTileCacheSink();
+        var service = new OgcTileCacheExportService(
+            new InMemoryScanner(inventory),
+            sink,
+            httpClient,
+            NullLogger<OgcTileCacheExportService>.Instance);
+
+        var result = await service.ExportAsync(new OgcTileCacheExportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            DryRun = true,
+            AllowUnsafeLocalUrls = true,
+            MinZoom = 0,
+            MaxZoom = 1
+        });
+
+        result.Success.Should().BeTrue();
+        result.WasDryRun.Should().BeTrue();
+        result.TilesPersisted.Should().Be(0);
+        result.TilesFailed.Should().Be(0);
+        handler.RequestUris.Should().BeEmpty();
+        sink.Records.Should().BeEmpty();
+        sink.EnsureCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExportAsync_RerunWithSameSink_IsIdempotent()
+    {
+        var inventory = BuildWmtsInventory(trivial: true);
+        var sink = new InMemoryTileCacheSink();
+
+        var firstHandler = new CountingTileHandler();
+        using (var firstClient = new HttpClient(firstHandler))
+        {
+            var first = new OgcTileCacheExportService(
+                new InMemoryScanner(inventory),
+                sink,
+                firstClient,
+                NullLogger<OgcTileCacheExportService>.Instance);
+            var firstResult = await first.ExportAsync(new OgcTileCacheExportRequest
+            {
+                ServiceUrl = ServiceUrl,
+                ApplyMode = true,
+                AllowUnsafeLocalUrls = true,
+                MinZoom = 0,
+                MaxZoom = 0
+            });
+            firstResult.TilesPersisted.Should().Be(1);
+            firstResult.TilesAlreadyPresent.Should().Be(0);
+        }
+
+        var secondHandler = new CountingTileHandler();
+        using var secondClient = new HttpClient(secondHandler);
+        var second = new OgcTileCacheExportService(
+            new InMemoryScanner(inventory),
+            sink,
+            secondClient,
+            NullLogger<OgcTileCacheExportService>.Instance);
+
+        var secondResult = await second.ExportAsync(new OgcTileCacheExportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            ApplyMode = true,
+            AllowUnsafeLocalUrls = true,
+            MinZoom = 0,
+            MaxZoom = 0
+        });
+
+        secondResult.Success.Should().BeTrue();
+        secondResult.TilesPersisted.Should().Be(0, "the sink already holds the tile");
+        secondResult.TilesAlreadyPresent.Should().Be(1);
+        secondHandler.RequestUris.Should().HaveCount(1, "rerun still fetches the tile body, but the sink rejects the duplicate write");
+        sink.Records.Should().HaveCount(1, "no duplicate row should be created on rerun");
+    }
+
+    [Fact]
+    public async Task ExportAsync_RequestedZoomBeyondSafetyThreshold_ReclassifiesAsManualReview()
+    {
+        var inventory = BuildWmtsInventory(trivial: true);
+        var handler = new CountingTileHandler();
+        using var httpClient = new HttpClient(handler);
+        var sink = new InMemoryTileCacheSink();
+        var service = new OgcTileCacheExportService(
+            new InMemoryScanner(inventory),
+            sink,
+            httpClient,
+            NullLogger<OgcTileCacheExportService>.Instance);
+
+        var result = await service.ExportAsync(new OgcTileCacheExportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            ApplyMode = true,
+            AllowUnsafeLocalUrls = true,
+            MinZoom = 0,
+            MaxZoom = OgcTileCacheExportSafetyLimits.MaxAutomatedZoomLevel + 1
+        });
+
+        result.Success.Should().BeTrue();
+        result.TileSetsPlanned.Should().Be(1);
+        result.TileSetsExported.Should().Be(0);
+        result.TileSetsSkipped.Should().Be(1);
+        result.TilesPersisted.Should().Be(0);
+        handler.RequestUris.Should().BeEmpty();
+
+        var tileSet = result.TileSets.Should().ContainSingle().Subject;
+        tileSet.Classification.Should().Be(MigrationFidelityAutomationStatuses.ManualReview);
+        tileSet.Code.Should().Be(ImportCompatibilityCodes.OgcWmtsTileCacheZoomThresholdExceeded);
+    }
+
+    [Fact]
+    public async Task ExportAsync_NonTrivialTileMatrixSet_IsSkippedAsManualReview()
+    {
+        var inventory = BuildWmtsInventory(trivial: false);
+        var handler = new CountingTileHandler();
+        using var httpClient = new HttpClient(handler);
+        var sink = new InMemoryTileCacheSink();
+        var service = new OgcTileCacheExportService(
+            new InMemoryScanner(inventory),
+            sink,
+            httpClient,
+            NullLogger<OgcTileCacheExportService>.Instance);
+
+        var result = await service.ExportAsync(new OgcTileCacheExportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            ApplyMode = true,
+            AllowUnsafeLocalUrls = true,
+            MinZoom = 0,
+            MaxZoom = 1
+        });
+
+        result.Success.Should().BeTrue();
+        result.TileSetsPlanned.Should().Be(1);
+        result.TileSetsSkipped.Should().Be(1);
+        result.TilesPersisted.Should().Be(0);
+        var tileSet = result.TileSets.Should().ContainSingle().Subject;
+        tileSet.Classification.Should().Be(MigrationFidelityAutomationStatuses.ManualReview);
+        tileSet.Code.Should().Be(ImportCompatibilityCodes.OgcWmtsTileCacheSkippedManualReview);
+    }
+
+    [Fact]
+    public async Task ExportAsync_TileFetchFailure_PropagatesAsTileSetWarning()
+    {
+        var inventory = BuildWmtsInventory(trivial: true);
+        var handler = new FailingTileHandler();
+        using var httpClient = new HttpClient(handler);
+        var sink = new InMemoryTileCacheSink();
+        var service = new OgcTileCacheExportService(
+            new InMemoryScanner(inventory),
+            sink,
+            httpClient,
+            NullLogger<OgcTileCacheExportService>.Instance);
+
+        var result = await service.ExportAsync(new OgcTileCacheExportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            ApplyMode = true,
+            AllowUnsafeLocalUrls = true,
+            MinZoom = 0,
+            MaxZoom = 0
+        });
+
+        result.Success.Should().BeTrue();
+        result.TilesPersisted.Should().Be(0);
+        result.TilesFailed.Should().Be(1);
+        var tileSet = result.TileSets.Should().ContainSingle().Subject;
+        tileSet.Classification.Should().Be(MigrationFidelityAutomationStatuses.ManualReview);
+        tileSet.Code.Should().Be(ImportCompatibilityCodes.OgcWmtsTileCacheFetchFailed);
+        tileSet.Warnings.Should().NotBeEmpty();
+        sink.Records.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExportAsync_ScannerFailure_ReturnsFailureResult()
+    {
+        var handler = new CountingTileHandler();
+        using var httpClient = new HttpClient(handler);
+        var sink = new InMemoryTileCacheSink();
+        var service = new OgcTileCacheExportService(
+            new ThrowingScanner(),
+            sink,
+            httpClient,
+            NullLogger<OgcTileCacheExportService>.Instance);
+
+        var result = await service.ExportAsync(new OgcTileCacheExportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            ApplyMode = true,
+            AllowUnsafeLocalUrls = true
+        });
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("scan WMTS source");
+        handler.RequestUris.Should().BeEmpty();
+        sink.Records.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExportAsync_NonWmtsInventory_ReturnsFailureResult()
+    {
+        var inventory = BuildWmtsInventory(trivial: true) with { SourceKind = "ogc-wfs" };
+        var handler = new CountingTileHandler();
+        using var httpClient = new HttpClient(handler);
+        var sink = new InMemoryTileCacheSink();
+        var service = new OgcTileCacheExportService(
+            new InMemoryScanner(inventory),
+            sink,
+            httpClient,
+            NullLogger<OgcTileCacheExportService>.Instance);
+
+        var result = await service.ExportAsync(new OgcTileCacheExportRequest
+        {
+            ServiceUrl = ServiceUrl,
+            ApplyMode = true,
+            AllowUnsafeLocalUrls = true
+        });
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("WMTS endpoint");
+    }
+
+    private static MigrationSourceInventoryArtifact BuildWmtsInventory(bool trivial)
+    {
+        const string containerId = "service:wmts";
+        var tileMatrixName = trivial ? TileMatrixSetId : "CustomGrid";
+        var tileMatrixIdValue = trivial ? "tile-matrix-set:webmercatorquad" : "tile-matrix-set:custom-grid";
+
+        var resources = new[]
+        {
+            new MigrationInventoryResource
+            {
+                Id = $"wmts-layer:{LayerId}",
+                ContainerId = containerId,
+                Kind = "tile-layer",
+                Name = LayerId,
+                Title = "Basemap",
+                Capabilities = ["wmts:GetCapabilities", "wmts:GetTile"],
+                ExternalDependencyIds = [tileMatrixIdValue],
+                Compatibility = new MigrationCompatibilityAssessment
+                {
+                    Level = "incompatible",
+                    Code = ImportCompatibilityCodes.OgcWmtsTileOnlySource,
+                    Reason = "WMTS exposes pre-rendered tiles."
+                }
+            }
+        };
+
+        var dependencies = new[]
+        {
+            new MigrationExternalDependency
+            {
+                Id = tileMatrixIdValue,
+                ContainerId = containerId,
+                Kind = "tile-matrix-set",
+                Name = tileMatrixName,
+                DependencyType = "WMTS TileMatrixSet",
+                Compatibility = Partial("Tile matrix set captured.", ImportCompatibilityCodes.OgcWmtsTileOnlySource)
+            }
+        };
+
+        var containers = new[]
+        {
+            new MigrationInventoryContainer
+            {
+                Id = containerId,
+                Kind = "ogc-service",
+                Name = "WMTS",
+                Title = "Reference WMTS",
+                IsDefault = true,
+                Compatibility = Partial("Container captured.", ImportCompatibilityCodes.ManualReview)
+            }
+        };
+
+        return new MigrationSourceInventoryArtifact
+        {
+            SourceKind = "ogc-wmts",
+            Source = new MigrationSourceIdentity
+            {
+                DisplayName = "Reference WMTS",
+                BaseUrl = ServiceUrl,
+                Product = "OGC WMTS",
+                Version = "1.0.0",
+                ServiceType = "WMTS"
+            },
+            AuthPosture = new MigrationInventoryAuthPosture { Mode = "anonymous" },
+            ScanCompleteness = new MigrationInventoryCompleteness { Status = "complete" },
+            Summary = new MigrationInventorySummary
+            {
+                ContainerCount = containers.Length,
+                ResourceCount = resources.Length,
+                ExternalDependencyCount = dependencies.Length
+            },
+            OverallCompatibility = Partial("Render-only source captured.", ImportCompatibilityCodes.ManualReview),
+            Containers = containers,
+            Resources = resources,
+            ExternalDependencies = dependencies
+        };
+    }
+
+    private static MigrationCompatibilityAssessment Partial(string reason, string code) => new()
+    {
+        Level = "partial",
+        Code = code,
+        Reason = reason
+    };
+
+    private sealed class InMemoryScanner(MigrationSourceInventoryArtifact inventory) : IOgcServiceMigrationScanner
+    {
+        public Task<MigrationSourceInventoryArtifact> ScanSourceAsync(
+            OgcServiceScanRequest request,
+            CancellationToken cancellationToken = default) => Task.FromResult(inventory);
+    }
+
+    private sealed class ThrowingScanner : IOgcServiceMigrationScanner
+    {
+        public Task<MigrationSourceInventoryArtifact> ScanSourceAsync(
+            OgcServiceScanRequest request,
+            CancellationToken cancellationToken = default)
+            => throw new HttpRequestException("simulated WMTS capabilities outage");
+    }
+
+    private sealed class CountingTileHandler : HttpMessageHandler
+    {
+        public List<Uri> RequestUris { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestUris.Add(request.RequestUri!);
+            var payload = Encoding.UTF8.GetBytes($"tile:{request.RequestUri}");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(payload)
+                {
+                    Headers = { ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/png") }
+                }
+            });
+        }
+    }
+
+    private sealed class FailingTileHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("upstream error", Encoding.UTF8, "text/plain")
+            });
+    }
+
+    private sealed class InMemoryTileCacheSink : IOgcTileCacheSink
+    {
+        private readonly ConcurrentDictionary<string, byte> _present = new(StringComparer.Ordinal);
+
+        public List<OgcTileCacheRecord> Records { get; } = [];
+
+        public int EnsureCalls { get; private set; }
+
+        public Task<string> EnsureTileCacheAsync(OgcTileCacheDescriptor descriptor, CancellationToken cancellationToken = default)
+        {
+            EnsureCalls++;
+            return Task.FromResult($"tilecache:{descriptor.LayerIdentifier}:{descriptor.TileMatrixSetIdentifier}");
+        }
+
+        public Task<OgcTileCacheWriteStatus> WriteTileAsync(OgcTileCacheRecord record, CancellationToken cancellationToken = default)
+        {
+            var key = $"{record.TileCacheId}|{record.Z}|{record.X}|{record.Y}";
+            if (_present.TryAdd(key, 0))
+            {
+                Records.Add(record);
+                return Task.FromResult(OgcTileCacheWriteStatus.Inserted);
+            }
+
+            return Task.FromResult(OgcTileCacheWriteStatus.AlreadyPresent);
+        }
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/PostgresOgcTileCacheSinkTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/PostgresOgcTileCacheSinkTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using System.Text;
+using Honua.Core.Features.Import.Abstractions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Import;
+using Honua.TestKit;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+/// <summary>
+/// Integration tests for <see cref="PostgresOgcTileCacheSink"/> backed by a
+/// real Postgres + PostGIS container.
+/// </summary>
+[Collection("Database")]
+public sealed class PostgresOgcTileCacheSinkTests(PostgresFixture fixture)
+{
+    private const string SourceServiceUrl = "https://wmts.example.test/wmts";
+
+    [Fact]
+    public async Task WriteTileAsync_Inserts_Then_RepeatedWrite_IsAlreadyPresent()
+    {
+        var sink = new PostgresOgcTileCacheSink(
+            new FixtureConnectionProvider(fixture),
+            NullLogger<PostgresOgcTileCacheSink>.Instance);
+
+        var descriptor = new OgcTileCacheDescriptor
+        {
+            LayerIdentifier = "basemap",
+            TileMatrixSetIdentifier = "WebMercatorQuad",
+            SourceServiceUrl = SourceServiceUrl,
+            TileFormat = "image/png",
+            StyleIdentifier = "default",
+            MinZoom = 0,
+            MaxZoom = 1
+        };
+        var cacheId = await sink.EnsureTileCacheAsync(descriptor);
+        cacheId.Should().StartWith("tilecache:basemap:webmercatorquad:");
+
+        var bytes = Encoding.UTF8.GetBytes("tile-content-z0-x0-y0");
+        var record = new OgcTileCacheRecord
+        {
+            TileCacheId = cacheId,
+            Z = 0,
+            X = 0,
+            Y = 0,
+            ContentType = "image/png",
+            Content = bytes,
+            SourceUrl = SourceServiceUrl
+        };
+
+        var firstStatus = await sink.WriteTileAsync(record);
+        firstStatus.Should().Be(OgcTileCacheWriteStatus.Inserted);
+
+        var secondStatus = await sink.WriteTileAsync(record);
+        secondStatus.Should().Be(OgcTileCacheWriteStatus.AlreadyPresent);
+
+        var (rowCount, persistedContent) = await ReadTileAsync(cacheId, 0, 0, 0);
+        rowCount.Should().Be(1, "repeated writes must not duplicate the row");
+        persistedContent.Should().BeEquivalentTo(bytes);
+    }
+
+    [Fact]
+    public async Task EnsureTileCacheAsync_IsIdempotent_AndExpandsZoomRange()
+    {
+        var sink = new PostgresOgcTileCacheSink(
+            new FixtureConnectionProvider(fixture),
+            NullLogger<PostgresOgcTileCacheSink>.Instance);
+
+        var descriptor = new OgcTileCacheDescriptor
+        {
+            LayerIdentifier = "topo",
+            TileMatrixSetIdentifier = "WebMercatorQuad",
+            SourceServiceUrl = SourceServiceUrl,
+            TileFormat = "image/png",
+            StyleIdentifier = "default",
+            MinZoom = 1,
+            MaxZoom = 2
+        };
+        var firstId = await sink.EnsureTileCacheAsync(descriptor);
+        var expanded = descriptor with { MinZoom = 0, MaxZoom = 3 };
+        var secondId = await sink.EnsureTileCacheAsync(expanded);
+        secondId.Should().Be(firstId, "the descriptor fingerprint must be deterministic");
+
+        var (min, max) = await ReadCacheZoomRangeAsync(firstId);
+        min.Should().Be(0);
+        max.Should().Be(3);
+    }
+
+    private async Task<(int RowCount, byte[] Content)> ReadTileAsync(string cacheId, int z, int x, int y)
+    {
+        await using var connection = await fixture.GetConnectionAsync();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT content FROM honua.tile_cache_entries
+            WHERE tile_cache_id = @cache AND zoom_level = @z AND tile_column = @x AND tile_row = @y;
+            """;
+        cmd.Parameters.AddWithValue("cache", cacheId);
+        cmd.Parameters.AddWithValue("z", z);
+        cmd.Parameters.AddWithValue("x", x);
+        cmd.Parameters.AddWithValue("y", y);
+
+        var bytes = Array.Empty<byte>();
+        var count = 0;
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            count++;
+            bytes = (byte[])reader.GetValue(0);
+        }
+
+        return (count, bytes);
+    }
+
+    private async Task<(int Min, int Max)> ReadCacheZoomRangeAsync(string cacheId)
+    {
+        await using var connection = await fixture.GetConnectionAsync();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT min_zoom, max_zoom FROM honua.tile_caches WHERE tile_cache_id = @cache;";
+        cmd.Parameters.AddWithValue("cache", cacheId);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        (await reader.ReadAsync()).Should().BeTrue();
+        return (reader.GetInt32(0), reader.GetInt32(1));
+    }
+
+    private sealed class FixtureConnectionProvider(PostgresFixture postgresFixture) : IDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => postgresFixture.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+            => await postgresFixture.DataSource.OpenConnectionAsync(cancellationToken);
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var connection = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var transaction = await connection.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (connection, transaction);
+            }
+            catch
+            {
+                await connection.DisposeAsync();
+                throw;
+            }
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken = default)
+            => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(Func<Task> operation, CancellationToken cancellationToken = default)
+            => operation();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Import/OgcTileCacheExportEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/OgcTileCacheExportEndpointTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Import;
+
+/// <summary>
+/// Integration tests for the OGC WMTS tile-cache export endpoint (#1016 slice 4).
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Import)]
+public sealed class OgcTileCacheExportEndpointTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/ogc-tiles/export")]
+    public async Task Export_WithMissingServiceUrl_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/import/ogc-tiles/export", new
+        {
+            DryRun = true
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("serviceUrl is required.");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/ogc-tiles/export")]
+    public async Task Export_NonDryRunWithoutApplyMode_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/import/ogc-tiles/export", new
+        {
+            ServiceUrl = "https://wmts.example.test/wmts",
+            DryRun = false,
+            ApplyMode = false
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("applyMode=true");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/ogc-tiles/export")]
+    public async Task Export_WithInvalidZoomRange_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/import/ogc-tiles/export", new
+        {
+            ServiceUrl = "https://wmts.example.test/wmts",
+            DryRun = true,
+            MinZoom = 5,
+            MaxZoom = 1
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("minZoom");
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1016 (slice 4 of N)

## Summary
Slice 3 classified WMTS tile-sets as `automated` when their tile-matrix-set
mapped to a trivial XYZ/TMS-compatible grid (WebMercatorQuad and friends)
and as `manual-review` otherwise. Slice 4 actually executes the export for
the trivial case while leaving heavy custom grids deferred:

- A new `IOgcTileCacheExportService` reuses the existing OGC migration
  scanner to resolve a manifest, walks each WMTS service plan, and for
  every `tile-set` plan entry classified `automated` fetches the
  configured zoom-level window from the source and hands tile bytes to
  an idempotent sink. Manual-review tile-sets, requests that exceed the
  safety threshold, and tile fetch failures are surfaced as `manual-review`
  outcomes with stable codes so downstream automation can branch on them.
- `PostgresOgcTileCacheSink` writes into a new
  `honua.tile_caches` + `honua.tile_cache_entries` catalog (migration
  `029_CreateTileCacheCatalog.sql`). Cache identifiers are derived from
  a deterministic fingerprint over `(layer, tile-matrix-set, style,
  format, source URL)` so repeated exports converge on the same rows
  and `ON CONFLICT DO NOTHING` keeps re-runs idempotent.
- New `POST /api/v1/admin/import/ogc-tiles/export` endpoint, registered
  in `EndpointRegistry`, wired through DI and the JSON source generator,
  and backed by an `IntegrationTest` suite using the existing
  `WebAppFixture`.

## Changes Made
- Add deterministic XYZ/TMS tile-cache exporter (`OgcTileCacheExportService`)
  plus `IOgcTileCacheSink` abstraction in `Honua.Core.Features.Import`.
- Add `PostgresOgcTileCacheSink` + migration `029_CreateTileCacheCatalog.sql`.
- Add `POST /api/v1/admin/import/ogc-tiles/export` endpoint, JSON
  context, DI registration, and EndpointRegistry entry.
- Add tests: end-to-end export of a fixture WMTS tile-set, dry-run, idempotent
  re-export, zoom-threshold reclassification, non-trivial tile-matrix-set
  skip, tile-fetch error propagation, scanner failure, non-WMTS rejection,
  Postgres sink round-trip + idempotency, and three endpoint
  `IntegrationTest`+`Endpoint` checks (missing service URL, missing
  apply-mode, invalid zoom range).

### Safety thresholds chosen
- Default zoom window `0..2` (caps export at 21 tiles per tile-set out of the box).
- Per-request hard ceiling: max zoom `6` (4 096 tiles at z=6) and projected
  tile count `1 024`. Beyond either, the tile-set is reclassified as
  `manual-review` instead of being exported.
- Per-tile HTTP timeout default of 30s, max tile body 4 MiB.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [x] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Stacked on #1120 (`codex/issue-1016-wms-wmts-planning`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)