### PR TITLE
feat: OGC coverage migration evidence pack (#1030 slice 5/5)

### DIFF
--- a/src/Honua.Core/Features/Import/Domain/OgcCoverageMigrationEvidencePackArtifact.cs
+++ b/src/Honua.Core/Features/Import/Domain/OgcCoverageMigrationEvidencePackArtifact.cs
@@ -1,0 +1,293 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Import.Domain;
+
+/// <summary>
+/// Slice 5 (capstone) of issue #1030. Single deterministic evidence bundle
+/// emitted from a successful OGC coverage migration run. Aggregates the
+/// slice-1 coverage inventory, slice-2 OGC API Coverages import records,
+/// slice-3 legacy WCS import records, and slice-4 coverage-style migration
+/// diagnostics into a single artifact so reviewers (and nightly fixture
+/// runs) have one pack to audit raster data + style migration outcomes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pack carries a SHA-256 fingerprint computed over the canonical JSON
+/// of its bundle so identical inputs always produce the same fingerprint.
+/// The fingerprint deliberately excludes the wall-clock timestamp, run id,
+/// and generator label so re-runs across machines stay byte-identical.
+/// </para>
+/// <para>
+/// Privacy posture: <see cref="OgcCoverageMigrationEvidencePackBundle.Source"/>
+/// and the embedded inventory snapshot reuse the redaction behavior of the
+/// upstream inventory artifact. The builder additionally strips credentials
+/// (userinfo, query, fragment) from the source URL before any field is
+/// embedded in the pack. Raw raster payloads and style documents are never
+/// included — only counts, classifications, and diagnostic messages derived
+/// from slices 1-4.
+/// </para>
+/// <para>
+/// AOT note: this record uses POCO-only properties (no polymorphic
+/// converters, no <c>JsonExtensionData</c>) so the source-generated
+/// <see cref="OgcCoverageMigrationEvidencePackJsonContext"/> remains
+/// trim/AOT safe.
+/// </para>
+/// </remarks>
+public sealed record OgcCoverageMigrationEvidencePackArtifact
+{
+    /// <summary>
+    /// Stable artifact kind identifier.
+    /// </summary>
+    public string ArtifactKind { get; init; } = "honua.migration.ogc-coverage-evidence-pack";
+
+    /// <summary>
+    /// Artifact schema version.
+    /// </summary>
+    public string ArtifactVersion { get; init; } = "1.0";
+
+    /// <summary>
+    /// Stable run identifier supplied by the harness or nightly workflow.
+    /// Excluded from <see cref="BundleFingerprint"/>.
+    /// </summary>
+    public required string RunId { get; init; }
+
+    /// <summary>
+    /// Free-form generator label, e.g. <c>ogc-coverage-evidence-builder/1.0</c>.
+    /// Excluded from <see cref="BundleFingerprint"/> so re-runs across CI
+    /// images stay byte-identical.
+    /// </summary>
+    public required string Generator { get; init; }
+
+    /// <summary>
+    /// UTC instant the pack was generated. Excluded from
+    /// <see cref="BundleFingerprint"/> so re-runs stay byte-identical.
+    /// </summary>
+    public required DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>
+    /// SHA-256 fingerprint computed over the canonical JSON of
+    /// <see cref="Bundle"/>. Identical inputs always produce the same value.
+    /// </summary>
+    public required string BundleFingerprint { get; init; }
+
+    /// <summary>
+    /// Deterministic evidence bundle that aggregates slice 1-4 artifacts.
+    /// </summary>
+    public required OgcCoverageMigrationEvidencePackBundle Bundle { get; init; }
+}
+
+/// <summary>
+/// Deterministic content bundle covered by
+/// <see cref="OgcCoverageMigrationEvidencePackArtifact.BundleFingerprint"/>.
+/// </summary>
+public sealed record OgcCoverageMigrationEvidencePackBundle
+{
+    /// <summary>
+    /// Source kind identifier such as <c>ogc-api-coverages</c> or
+    /// <c>ogc-wcs</c>. Mirrors the inventory artifact source kind.
+    /// </summary>
+    public required string SourceKind { get; init; }
+
+    /// <summary>
+    /// Secret-safe source identity (credentials and URL secrets stripped).
+    /// </summary>
+    public required MigrationSourceIdentity Source { get; init; }
+
+    /// <summary>
+    /// Operator-requested coverage scope. Empty when the run imported every
+    /// inventoried coverage. Captured here as coverage-scoping evidence so
+    /// reviewers can audit that coverages outside the requested scope were
+    /// not migrated.
+    /// </summary>
+    public required OgcCoverageMigrationEvidencePackScope CoverageScope { get; init; }
+
+    /// <summary>
+    /// Aggregate counts across the OGC API Coverages and WCS protocol
+    /// channels, plus a style roll-up surfaced from slice-4 diagnostics.
+    /// </summary>
+    public required OgcCoverageMigrationEvidencePackSummary Summary { get; init; }
+
+    /// <summary>
+    /// Per-protocol channels covering OGC API Coverages and WCS uniformly.
+    /// Channels are emitted in canonical order
+    /// (<see cref="OgcCoverageMigrationEvidencePackChannelIds.OgcApiCoverages"/>,
+    /// <see cref="OgcCoverageMigrationEvidencePackChannelIds.Wcs"/>) so the
+    /// fingerprint stays deterministic regardless of caller order.
+    /// </summary>
+    public OgcCoverageMigrationEvidencePackChannel[] Channels { get; init; } = [];
+
+    /// <summary>
+    /// Aggregated coverage-style migration diagnostics (slice 4 of #1030).
+    /// Combined across all channels so a reviewer can audit every
+    /// non-trivial style hint from one place.
+    /// </summary>
+    public MigrationCoverageStyleDiagnostic[] StyleDiagnostics { get; init; } = [];
+
+    /// <summary>
+    /// Coverage inventory snapshot copied from the slice-1 scan input. Source
+    /// URLs are redacted.
+    /// </summary>
+    public required MigrationSourceInventoryArtifact Inventory { get; init; }
+}
+
+/// <summary>
+/// Operator-requested coverage scope captured in the evidence pack.
+/// </summary>
+public sealed record OgcCoverageMigrationEvidencePackScope
+{
+    /// <summary>
+    /// Whether the operator restricted the run to specific source coverage
+    /// identifiers. When <c>false</c>, all inventoried coverages were
+    /// eligible.
+    /// </summary>
+    public required bool Restricted { get; init; }
+
+    /// <summary>
+    /// Deterministically ordered list of requested source coverage ids.
+    /// Empty when <see cref="Restricted"/> is <c>false</c>.
+    /// </summary>
+    public string[] CoverageIds { get; init; } = [];
+}
+
+/// <summary>
+/// Aggregate evidence summary spanning every protocol channel and the
+/// slice-4 style diagnostic roll-up.
+/// </summary>
+public sealed record OgcCoverageMigrationEvidencePackSummary
+{
+    /// <summary>
+    /// Total number of per-coverage import records across all channels.
+    /// </summary>
+    public int TotalCoverageCount { get; init; }
+
+    /// <summary>
+    /// Number of records whose action is <c>imported</c>.
+    /// </summary>
+    public int ImportedCount { get; init; }
+
+    /// <summary>
+    /// Number of records whose action is <c>planned</c> (dry-run preview).
+    /// </summary>
+    public int PlannedCount { get; init; }
+
+    /// <summary>
+    /// Number of records whose action is <c>skipped</c>.
+    /// </summary>
+    public int SkippedCount { get; init; }
+
+    /// <summary>
+    /// Number of records whose action is <c>manual-review</c>.
+    /// </summary>
+    public int ManualReviewCount { get; init; }
+
+    /// <summary>
+    /// Number of records whose action is <c>failed</c>.
+    /// </summary>
+    public int FailedCount { get; init; }
+
+    /// <summary>
+    /// Total style diagnostic count across all channels.
+    /// </summary>
+    public int StyleDiagnosticCount { get; init; }
+
+    /// <summary>
+    /// Number of slice-4 style diagnostics classified as
+    /// <c>manual-review</c>. Per issue #1030 AC, these block any
+    /// visual-parity claim.
+    /// </summary>
+    public int StyleManualReviewCount { get; init; }
+}
+
+/// <summary>
+/// Per-channel view of the coverage migration. The pack carries one channel
+/// per supported protocol so OGC API Coverages and legacy WCS imports are
+/// rolled up uniformly.
+/// </summary>
+public sealed record OgcCoverageMigrationEvidencePackChannel
+{
+    /// <summary>
+    /// Canonical channel id:
+    /// <see cref="OgcCoverageMigrationEvidencePackChannelIds.OgcApiCoverages"/>
+    /// or <see cref="OgcCoverageMigrationEvidencePackChannelIds.Wcs"/>.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Whether the channel ran in apply mode. Slice-2/3 results carry this
+    /// flag; it is mirrored here for audit.
+    /// </summary>
+    public bool ApplyMode { get; init; }
+
+    /// <summary>
+    /// Whether the channel ran in dry-run mode.
+    /// </summary>
+    public bool DryRun { get; init; }
+
+    /// <summary>
+    /// Per-channel WCS protocol version (e.g. <c>2.0.1</c>) when the channel
+    /// is the legacy WCS path. Null for OGC API Coverages.
+    /// </summary>
+    public string? ResolvedVersion { get; init; }
+
+    /// <summary>
+    /// Per-channel WCS requested output format (e.g. <c>image/tiff</c>) when
+    /// the channel is the legacy WCS path. Null for OGC API Coverages.
+    /// </summary>
+    public string? RequestedOutputFormat { get; init; }
+
+    /// <summary>
+    /// Number of per-coverage records in the channel.
+    /// </summary>
+    public int CoverageCount { get; init; }
+
+    /// <summary>
+    /// Number of records with action <c>imported</c>.
+    /// </summary>
+    public int ImportedCount { get; init; }
+
+    /// <summary>
+    /// Number of records with action <c>planned</c>.
+    /// </summary>
+    public int PlannedCount { get; init; }
+
+    /// <summary>
+    /// Number of records with action <c>skipped</c>.
+    /// </summary>
+    public int SkippedCount { get; init; }
+
+    /// <summary>
+    /// Number of records with action <c>manual-review</c>.
+    /// </summary>
+    public int ManualReviewCount { get; init; }
+
+    /// <summary>
+    /// Number of records with action <c>failed</c>.
+    /// </summary>
+    public int FailedCount { get; init; }
+
+    /// <summary>
+    /// Per-coverage records ordered by
+    /// <see cref="OgcCoverageImportRecord.SourceCoverageId"/>.
+    /// </summary>
+    public OgcCoverageImportRecord[] Records { get; init; } = [];
+
+    /// <summary>
+    /// Per-coverage migration manifest emitted by the channel. Source URLs
+    /// are redacted in the embedded artifact.
+    /// </summary>
+    public required MigrationManifestArtifact Manifest { get; init; }
+}
+
+/// <summary>
+/// Canonical channel identifiers used by the OGC coverage migration
+/// evidence pack.
+/// </summary>
+public static class OgcCoverageMigrationEvidencePackChannelIds
+{
+    /// <summary>Modern OGC API Coverages import channel (slice 2).</summary>
+    public const string OgcApiCoverages = "ogc-api-coverages";
+
+    /// <summary>Legacy OGC WCS coverage import channel (slice 3).</summary>
+    public const string Wcs = "ogc-wcs";
+}

--- a/src/Honua.Core/Features/Import/Services/OgcCoverageMigrationEvidencePackBuilder.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcCoverageMigrationEvidencePackBuilder.cs
@@ -1,0 +1,441 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Cryptography;
+using System.Text.Json;
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// Slice 5 (capstone) of issue #1030. Aggregates the slice 1-4 artifacts
+/// emitted by a successful OGC coverage migration run — coverage scanner
+/// inventory, OGC API Coverages import (slice 2), legacy WCS import
+/// (slice 3), and coverage-style migration diagnostics (slice 4) — into a
+/// single deterministic
+/// <see cref="OgcCoverageMigrationEvidencePackArtifact"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The builder is intentionally pure and side-effect free so the same
+/// inputs always produce the same output (and the same
+/// <see cref="OgcCoverageMigrationEvidencePackArtifact.BundleFingerprint"/>).
+/// It performs no I/O, no logging, and no clock reads except for the
+/// caller-supplied
+/// <see cref="OgcCoverageMigrationEvidencePackBuilderOptions.GeneratedAt"/>
+/// stamp, which is excluded from the fingerprint.
+/// </para>
+/// <para>
+/// Credential redaction: the source identity is sanitized by stripping
+/// userinfo, query, and fragment components from <c>BaseUrl</c> before the
+/// inventory snapshot and per-channel manifests are included in the bundle.
+/// The builder never copies raw raster payloads or style documents — only
+/// counts, classifications, and slice-4 diagnostic messages.
+/// </para>
+/// <para>
+/// Channels are emitted in canonical order
+/// (<see cref="OgcCoverageMigrationEvidencePackChannelIds.OgcApiCoverages"/>
+/// then <see cref="OgcCoverageMigrationEvidencePackChannelIds.Wcs"/>) and
+/// only when the corresponding slice-2 or slice-3 result was supplied, so
+/// the same set of inputs always produces the same channel order regardless
+/// of caller order.
+/// </para>
+/// </remarks>
+public static class OgcCoverageMigrationEvidencePackBuilder
+{
+    private const string BuilderGenerator = "honua.migration.ogc-coverage-evidence-pack-builder/1.0";
+
+    /// <summary>
+    /// Build an evidence pack from the slice 1-4 inputs.
+    /// </summary>
+    /// <param name="inputs">Inventory and per-channel import inputs.</param>
+    /// <param name="options">Optional run id / generator / clock overrides.</param>
+    public static OgcCoverageMigrationEvidencePackArtifact Build(
+        OgcCoverageMigrationEvidencePackInputs inputs,
+        OgcCoverageMigrationEvidencePackBuilderOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+        ArgumentNullException.ThrowIfNull(inputs.Inventory);
+
+        if (inputs.OgcApiCoveragesImport is null && inputs.WcsImport is null)
+        {
+            throw new ArgumentException(
+                "At least one of OgcApiCoveragesImport or WcsImport must be supplied.",
+                nameof(inputs));
+        }
+
+        var resolvedOptions = options ?? new OgcCoverageMigrationEvidencePackBuilderOptions();
+
+        var redactedInventory = inputs.Inventory with { Source = RedactSource(inputs.Inventory.Source) };
+
+        var channels = BuildChannels(inputs);
+        var styleDiagnostics = BuildAggregateStyleDiagnostics(inputs);
+        var summary = BuildSummary(channels, styleDiagnostics);
+        var coverageScope = BuildCoverageScope(inputs.RequestedCoverageIds);
+
+        var bundle = new OgcCoverageMigrationEvidencePackBundle
+        {
+            SourceKind = inputs.Inventory.SourceKind,
+            Source = RedactSource(inputs.Inventory.Source),
+            CoverageScope = coverageScope,
+            Summary = summary,
+            Channels = channels,
+            StyleDiagnostics = styleDiagnostics,
+            Inventory = redactedInventory
+        };
+
+        var fingerprint = ComputeBundleFingerprint(bundle);
+
+        return new OgcCoverageMigrationEvidencePackArtifact
+        {
+            RunId = string.IsNullOrWhiteSpace(resolvedOptions.RunId)
+                ? "ogc-coverage-migration-evidence-run"
+                : resolvedOptions.RunId,
+            Generator = string.IsNullOrWhiteSpace(resolvedOptions.Generator)
+                ? BuilderGenerator
+                : resolvedOptions.Generator,
+            GeneratedAt = resolvedOptions.GeneratedAt ?? DateTimeOffset.UnixEpoch,
+            BundleFingerprint = fingerprint,
+            Bundle = bundle
+        };
+    }
+
+    /// <summary>
+    /// Compute the deterministic SHA-256 fingerprint that is also embedded
+    /// in the pack via
+    /// <see cref="OgcCoverageMigrationEvidencePackArtifact.BundleFingerprint"/>.
+    /// Exposed for tests and downstream verifiers.
+    /// </summary>
+    public static string ComputeBundleFingerprint(OgcCoverageMigrationEvidencePackBundle bundle)
+    {
+        ArgumentNullException.ThrowIfNull(bundle);
+        var payload = JsonSerializer.SerializeToUtf8Bytes(
+            bundle,
+            OgcCoverageMigrationEvidencePackJsonContext.Default.OgcCoverageMigrationEvidencePackBundle);
+        var hash = SHA256.HashData(payload);
+        return $"sha256:{Convert.ToHexString(hash).ToLowerInvariant()}";
+    }
+
+    private static OgcCoverageMigrationEvidencePackChannel[] BuildChannels(
+        OgcCoverageMigrationEvidencePackInputs inputs)
+    {
+        var channels = new List<OgcCoverageMigrationEvidencePackChannel>(capacity: 2);
+
+        if (inputs.OgcApiCoveragesImport is { } coverages)
+        {
+            channels.Add(BuildOgcApiCoveragesChannel(coverages));
+        }
+
+        if (inputs.WcsImport is { } wcs)
+        {
+            channels.Add(BuildWcsChannel(wcs));
+        }
+
+        return channels.ToArray();
+    }
+
+    private static OgcCoverageMigrationEvidencePackChannel BuildOgcApiCoveragesChannel(
+        OgcCoverageImportResult result)
+    {
+        var orderedRecords = OrderRecords(result.Records);
+        return new OgcCoverageMigrationEvidencePackChannel
+        {
+            Id = OgcCoverageMigrationEvidencePackChannelIds.OgcApiCoverages,
+            ApplyMode = result.ApplyMode,
+            DryRun = result.DryRun,
+            ResolvedVersion = null,
+            RequestedOutputFormat = null,
+            CoverageCount = orderedRecords.Length,
+            ImportedCount = CountByAction(orderedRecords, "imported"),
+            PlannedCount = CountByAction(orderedRecords, "planned"),
+            SkippedCount = CountByAction(orderedRecords, "skipped"),
+            ManualReviewCount = CountByAction(orderedRecords, "manual-review"),
+            FailedCount = CountByAction(orderedRecords, "failed"),
+            Records = orderedRecords,
+            Manifest = RedactManifest(result.Manifest)
+        };
+    }
+
+    private static OgcCoverageMigrationEvidencePackChannel BuildWcsChannel(OgcWcsImportResult result)
+    {
+        var orderedRecords = OrderRecords(result.Records);
+        return new OgcCoverageMigrationEvidencePackChannel
+        {
+            Id = OgcCoverageMigrationEvidencePackChannelIds.Wcs,
+            ApplyMode = result.ApplyMode,
+            DryRun = result.DryRun,
+            ResolvedVersion = result.ResolvedVersion,
+            RequestedOutputFormat = result.RequestedOutputFormat,
+            CoverageCount = orderedRecords.Length,
+            ImportedCount = CountByAction(orderedRecords, "imported"),
+            PlannedCount = CountByAction(orderedRecords, "planned"),
+            SkippedCount = CountByAction(orderedRecords, "skipped"),
+            ManualReviewCount = CountByAction(orderedRecords, "manual-review"),
+            FailedCount = CountByAction(orderedRecords, "failed"),
+            Records = orderedRecords,
+            Manifest = RedactManifest(result.Manifest)
+        };
+    }
+
+    private static OgcCoverageImportRecord[] OrderRecords(OgcCoverageImportRecord[]? records)
+    {
+        if (records is null || records.Length == 0)
+        {
+            return [];
+        }
+
+        return records
+            .OrderBy(static r => r.SourceCoverageId, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static int CountByAction(IReadOnlyList<OgcCoverageImportRecord> records, string action)
+    {
+        var count = 0;
+        for (var i = 0; i < records.Count; i++)
+        {
+            if (string.Equals(records[i].Action, action, StringComparison.Ordinal))
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static MigrationCoverageStyleDiagnostic[] BuildAggregateStyleDiagnostics(
+        OgcCoverageMigrationEvidencePackInputs inputs)
+    {
+        var diagnostics = new List<MigrationCoverageStyleDiagnostic>();
+        if (inputs.OgcApiCoveragesImport?.StyleDiagnostics is { Length: > 0 } a)
+        {
+            diagnostics.AddRange(a);
+        }
+        if (inputs.WcsImport?.StyleDiagnostics is { Length: > 0 } w)
+        {
+            diagnostics.AddRange(w);
+        }
+
+        if (diagnostics.Count == 0)
+        {
+            return [];
+        }
+
+        // Deduplicate identical diagnostics that appear in both channels
+        // (slice 4 emits per-source-coverage rows, so identical hint+kind+
+        // source-coverage pairs across channels collapse to one row in the
+        // pack), then order deterministically by (sourceCoverageId, kind,
+        // sourceStyleId, reason).
+        return diagnostics
+            .Distinct(MigrationCoverageStyleDiagnosticEqualityComparer.Instance)
+            .OrderBy(static d => d.SourceCoverageId, StringComparer.Ordinal)
+            .ThenBy(static d => d.Kind, StringComparer.Ordinal)
+            .ThenBy(static d => d.SourceStyleId ?? string.Empty, StringComparer.Ordinal)
+            .ThenBy(static d => d.Reason, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static OgcCoverageMigrationEvidencePackSummary BuildSummary(
+        IReadOnlyList<OgcCoverageMigrationEvidencePackChannel> channels,
+        IReadOnlyList<MigrationCoverageStyleDiagnostic> styleDiagnostics)
+    {
+        var total = 0;
+        var imported = 0;
+        var planned = 0;
+        var skipped = 0;
+        var manualReview = 0;
+        var failed = 0;
+
+        for (var i = 0; i < channels.Count; i++)
+        {
+            var channel = channels[i];
+            total += channel.CoverageCount;
+            imported += channel.ImportedCount;
+            planned += channel.PlannedCount;
+            skipped += channel.SkippedCount;
+            manualReview += channel.ManualReviewCount;
+            failed += channel.FailedCount;
+        }
+
+        var styleManualReview = 0;
+        for (var i = 0; i < styleDiagnostics.Count; i++)
+        {
+            if (string.Equals(styleDiagnostics[i].Classification, "manual-review", StringComparison.Ordinal))
+            {
+                styleManualReview++;
+            }
+        }
+
+        return new OgcCoverageMigrationEvidencePackSummary
+        {
+            TotalCoverageCount = total,
+            ImportedCount = imported,
+            PlannedCount = planned,
+            SkippedCount = skipped,
+            ManualReviewCount = manualReview,
+            FailedCount = failed,
+            StyleDiagnosticCount = styleDiagnostics.Count,
+            StyleManualReviewCount = styleManualReview
+        };
+    }
+
+    private static OgcCoverageMigrationEvidencePackScope BuildCoverageScope(
+        IReadOnlyCollection<string>? requestedCoverageIds)
+    {
+        if (requestedCoverageIds is null || requestedCoverageIds.Count == 0)
+        {
+            return new OgcCoverageMigrationEvidencePackScope
+            {
+                Restricted = false,
+                CoverageIds = []
+            };
+        }
+
+        var ordered = requestedCoverageIds
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static value => value, StringComparer.Ordinal)
+            .ToArray();
+
+        return new OgcCoverageMigrationEvidencePackScope
+        {
+            Restricted = ordered.Length > 0,
+            CoverageIds = ordered
+        };
+    }
+
+    private static MigrationManifestArtifact RedactManifest(MigrationManifestArtifact manifest)
+    {
+        return manifest with { Source = RedactSource(manifest.Source) };
+    }
+
+    private static MigrationSourceIdentity RedactSource(MigrationSourceIdentity source)
+    {
+        return new MigrationSourceIdentity
+        {
+            DisplayName = source.DisplayName,
+            BaseUrl = RedactUrl(source.BaseUrl),
+            Product = source.Product,
+            Version = source.Version,
+            Build = source.Build,
+            ServiceType = source.ServiceType
+        };
+    }
+
+    private static string RedactUrl(string baseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return baseUrl;
+        }
+
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri))
+        {
+            return baseUrl;
+        }
+
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+
+        return builder.Uri.AbsoluteUri;
+    }
+
+    private sealed class MigrationCoverageStyleDiagnosticEqualityComparer
+        : IEqualityComparer<MigrationCoverageStyleDiagnostic>
+    {
+        public static readonly MigrationCoverageStyleDiagnosticEqualityComparer Instance = new();
+
+        public bool Equals(MigrationCoverageStyleDiagnostic? x, MigrationCoverageStyleDiagnostic? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+            if (x is null || y is null)
+            {
+                return false;
+            }
+            return string.Equals(x.Kind, y.Kind, StringComparison.Ordinal)
+                && string.Equals(x.Classification, y.Classification, StringComparison.Ordinal)
+                && string.Equals(x.SourceCoverageId, y.SourceCoverageId, StringComparison.Ordinal)
+                && string.Equals(x.SourceStyleId, y.SourceStyleId, StringComparison.Ordinal)
+                && string.Equals(x.Reason, y.Reason, StringComparison.Ordinal)
+                && string.Equals(x.SuggestedTargetStyleId, y.SuggestedTargetStyleId, StringComparison.Ordinal)
+                && string.Equals(x.VendorName, y.VendorName, StringComparison.Ordinal)
+                && x.ManualSteps.SequenceEqual(y.ManualSteps, StringComparer.Ordinal);
+        }
+
+        public int GetHashCode(MigrationCoverageStyleDiagnostic obj)
+        {
+            return HashCode.Combine(
+                obj.Kind,
+                obj.Classification,
+                obj.SourceCoverageId,
+                obj.SourceStyleId,
+                obj.Reason,
+                obj.SuggestedTargetStyleId,
+                obj.VendorName);
+        }
+    }
+}
+
+/// <summary>
+/// Aggregated inputs consumed by
+/// <see cref="OgcCoverageMigrationEvidencePackBuilder.Build"/>.
+/// </summary>
+public sealed record OgcCoverageMigrationEvidencePackInputs
+{
+    /// <summary>
+    /// Slice-1 coverage inventory artifact captured from the source scan.
+    /// </summary>
+    public required MigrationSourceInventoryArtifact Inventory { get; init; }
+
+    /// <summary>
+    /// Slice-2 OGC API Coverages import result. Null when the run did not
+    /// drive the modern OGC API Coverages channel.
+    /// </summary>
+    public OgcCoverageImportResult? OgcApiCoveragesImport { get; init; }
+
+    /// <summary>
+    /// Slice-3 legacy WCS import result. Null when the run did not drive
+    /// the WCS channel.
+    /// </summary>
+    public OgcWcsImportResult? WcsImport { get; init; }
+
+    /// <summary>
+    /// Operator-requested coverage scope (source coverage identifiers), or
+    /// <c>null</c>/empty when every inventoried coverage was eligible.
+    /// </summary>
+    public IReadOnlyCollection<string>? RequestedCoverageIds { get; init; }
+}
+
+/// <summary>
+/// Override hooks for tests and the nightly workflow.
+/// </summary>
+public sealed record OgcCoverageMigrationEvidencePackBuilderOptions
+{
+    /// <summary>
+    /// Run identifier embedded in the artifact. Excluded from the bundle
+    /// fingerprint so the same inputs produce the same fingerprint across
+    /// nightly runs.
+    /// </summary>
+    public string? RunId { get; init; }
+
+    /// <summary>
+    /// Generator label embedded in the artifact. Excluded from the bundle
+    /// fingerprint.
+    /// </summary>
+    public string? Generator { get; init; }
+
+    /// <summary>
+    /// Generation timestamp. Excluded from the bundle fingerprint. Defaults
+    /// to <see cref="DateTimeOffset.UnixEpoch"/> when omitted so
+    /// deterministic tests do not have to set it.
+    /// </summary>
+    public DateTimeOffset? GeneratedAt { get; init; }
+}

--- a/src/Honua.Core/Features/Import/Services/OgcCoverageMigrationEvidencePackJsonContext.cs
+++ b/src/Honua.Core/Features/Import/Services/OgcCoverageMigrationEvidencePackJsonContext.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Import.Domain;
+
+namespace Honua.Core.Features.Import.Services;
+
+/// <summary>
+/// AOT-safe JSON serialization context for the slice-5 OGC coverage
+/// migration evidence pack (issue #1030). Source-generated metadata avoids
+/// reflection-based serialization so the pack can be emitted under
+/// <c>PublishAot</c> builds without trimming warnings.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    WriteIndented = false)]
+[JsonSerializable(typeof(OgcCoverageMigrationEvidencePackArtifact))]
+[JsonSerializable(typeof(OgcCoverageMigrationEvidencePackBundle))]
+[JsonSerializable(typeof(OgcCoverageMigrationEvidencePackScope))]
+[JsonSerializable(typeof(OgcCoverageMigrationEvidencePackSummary))]
+[JsonSerializable(typeof(OgcCoverageMigrationEvidencePackChannel))]
+[JsonSerializable(typeof(OgcCoverageMigrationEvidencePackChannel[]))]
+[JsonSerializable(typeof(OgcCoverageImportRecord))]
+[JsonSerializable(typeof(OgcCoverageImportRecord[]))]
+[JsonSerializable(typeof(MigrationCoverageStyleDiagnostic))]
+[JsonSerializable(typeof(MigrationCoverageStyleDiagnostic[]))]
+[JsonSerializable(typeof(MigrationSourceInventoryArtifact))]
+[JsonSerializable(typeof(MigrationManifestArtifact))]
+[JsonSerializable(typeof(MigrationSourceIdentity))]
+[JsonSerializable(typeof(MigrationCompatibilityAssessment))]
+public sealed partial class OgcCoverageMigrationEvidencePackJsonContext : JsonSerializerContext
+{
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/OgcCoverageMigrationEvidencePackBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/OgcCoverageMigrationEvidencePackBuilderTests.cs
@@ -1,0 +1,517 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Import.Services;
+
+namespace Honua.Core.Tests.Features.Import;
+
+/// <summary>
+/// Slice 5 (capstone) of issue #1030: deterministic OGC coverage migration
+/// evidence-pack generation tests. Covers fingerprint determinism, schema
+/// stability, credential redaction, combined OGC API Coverages + WCS
+/// roll-up, scoping evidence, and aggregated style-diagnostic surfacing.
+/// </summary>
+public sealed class OgcCoverageMigrationEvidencePackBuilderTests
+{
+    [Fact]
+    public void Build_ProducesDeterministicFingerprint_ForIdenticalInputs()
+    {
+        var inputs = BuildCombinedInputs();
+
+        var first = OgcCoverageMigrationEvidencePackBuilder.Build(inputs, new OgcCoverageMigrationEvidencePackBuilderOptions
+        {
+            RunId = "nightly-20260519",
+            Generator = "test/1.0",
+            GeneratedAt = DateTimeOffset.Parse("2026-05-19T00:00:00Z")
+        });
+
+        var second = OgcCoverageMigrationEvidencePackBuilder.Build(inputs, new OgcCoverageMigrationEvidencePackBuilderOptions
+        {
+            // Different run-time metadata; fingerprint must be unaffected.
+            RunId = "nightly-20260601",
+            Generator = "test/2.0",
+            GeneratedAt = DateTimeOffset.Parse("2026-06-01T12:34:56Z")
+        });
+
+        first.BundleFingerprint.Should().StartWith("sha256:");
+        first.BundleFingerprint.Should().Be(second.BundleFingerprint,
+            "fingerprint must cover the bundle only — wall-clock, run id, and generator labels are excluded so nightly re-runs stay byte-identical.");
+
+        first.RunId.Should().Be("nightly-20260519");
+        second.RunId.Should().Be("nightly-20260601");
+    }
+
+    [Fact]
+    public void Build_FingerprintChanges_WhenACoverageRecordChanges()
+    {
+        var inputs = BuildCombinedInputs();
+        var mutated = inputs with
+        {
+            OgcApiCoveragesImport = inputs.OgcApiCoveragesImport! with
+            {
+                Records = inputs.OgcApiCoveragesImport!.Records
+                    .Select(r => r.SourceCoverageId == "coverages/dem"
+                        ? r with { Action = "manual-review", ErrorMessage = "Operator review required." }
+                        : r)
+                    .ToArray()
+            }
+        };
+
+        var baseline = OgcCoverageMigrationEvidencePackBuilder.Build(inputs);
+        var changed = OgcCoverageMigrationEvidencePackBuilder.Build(mutated);
+
+        baseline.BundleFingerprint.Should().NotBe(changed.BundleFingerprint,
+            "any change to the bundle inputs must propagate to the fingerprint.");
+    }
+
+    [Fact]
+    public void Build_FingerprintChanges_WhenAStyleDiagnosticChanges()
+    {
+        var inputs = BuildCombinedInputs();
+        var mutated = inputs with
+        {
+            OgcApiCoveragesImport = inputs.OgcApiCoveragesImport! with
+            {
+                StyleDiagnostics =
+                [
+                    new MigrationCoverageStyleDiagnostic
+                    {
+                        Kind = "renderingHint",
+                        Classification = "manual-review",
+                        SourceCoverageId = "coverages/dem",
+                        Reason = "Different reason than baseline."
+                    }
+                ]
+            }
+        };
+
+        var baseline = OgcCoverageMigrationEvidencePackBuilder.Build(inputs);
+        var changed = OgcCoverageMigrationEvidencePackBuilder.Build(mutated);
+
+        baseline.BundleFingerprint.Should().NotBe(changed.BundleFingerprint,
+            "style-diagnostic changes must propagate to the fingerprint.");
+    }
+
+    [Fact]
+    public void Build_GroupsChannelsInCanonicalOrder_RegardlessOfCallerOrder()
+    {
+        var inputs = BuildCombinedInputs();
+
+        var pack = OgcCoverageMigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.Channels.Should().HaveCount(2);
+        pack.Bundle.Channels.Select(c => c.Id).Should().Equal(
+            OgcCoverageMigrationEvidencePackChannelIds.OgcApiCoverages,
+            OgcCoverageMigrationEvidencePackChannelIds.Wcs);
+    }
+
+    [Fact]
+    public void Build_EmitsOnlyOgcApiCoveragesChannel_WhenWcsResultMissing()
+    {
+        var inputs = BuildCombinedInputs() with { WcsImport = null };
+
+        var pack = OgcCoverageMigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.Channels.Should().HaveCount(1);
+        pack.Bundle.Channels[0].Id.Should().Be(OgcCoverageMigrationEvidencePackChannelIds.OgcApiCoverages);
+    }
+
+    [Fact]
+    public void Build_EmitsOnlyWcsChannel_WhenOgcApiCoveragesResultMissing()
+    {
+        var inputs = BuildCombinedInputs() with { OgcApiCoveragesImport = null };
+
+        var pack = OgcCoverageMigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.Channels.Should().HaveCount(1);
+        pack.Bundle.Channels[0].Id.Should().Be(OgcCoverageMigrationEvidencePackChannelIds.Wcs);
+        pack.Bundle.Channels[0].ResolvedVersion.Should().Be("2.0.1");
+        pack.Bundle.Channels[0].RequestedOutputFormat.Should().Be("image/tiff");
+    }
+
+    [Fact]
+    public void Build_Throws_WhenBothImportResultsMissing()
+    {
+        var inputs = BuildCombinedInputs() with
+        {
+            OgcApiCoveragesImport = null,
+            WcsImport = null
+        };
+
+        var act = () => OgcCoverageMigrationEvidencePackBuilder.Build(inputs);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*OgcApiCoveragesImport*WcsImport*");
+    }
+
+    [Fact]
+    public void Build_RollsUpSummary_AcrossBothChannels()
+    {
+        var inputs = BuildCombinedInputs();
+
+        var pack = OgcCoverageMigrationEvidencePackBuilder.Build(inputs);
+
+        // OGC API: 1 imported (dem) + 1 manual-review (orthomosaic) = 2 records.
+        // WCS: 1 imported (climate-baseline) + 1 failed (legacy-radar) = 2 records.
+        pack.Bundle.Summary.TotalCoverageCount.Should().Be(4);
+        pack.Bundle.Summary.ImportedCount.Should().Be(2);
+        pack.Bundle.Summary.ManualReviewCount.Should().Be(1);
+        pack.Bundle.Summary.FailedCount.Should().Be(1);
+        pack.Bundle.Summary.PlannedCount.Should().Be(0);
+        pack.Bundle.Summary.SkippedCount.Should().Be(0);
+
+        pack.Bundle.Summary.StyleDiagnosticCount.Should().BeGreaterThan(0);
+        pack.Bundle.Summary.StyleManualReviewCount.Should().Be(
+            pack.Bundle.StyleDiagnostics.Count(d => d.Classification == "manual-review"));
+    }
+
+    [Fact]
+    public void Build_AggregatesStyleDiagnostics_AndDeduplicatesAcrossChannels()
+    {
+        var sharedDiagnostic = new MigrationCoverageStyleDiagnostic
+        {
+            Kind = "colorMap",
+            Classification = "assisted",
+            SourceCoverageId = "coverages/dem",
+            Reason = "Indexed color table preserved verbatim.",
+            SuggestedTargetStyleId = "indexed-color-table"
+        };
+        var ogcOnlyDiagnostic = new MigrationCoverageStyleDiagnostic
+        {
+            Kind = "renderingHint",
+            Classification = "manual-review",
+            SourceCoverageId = "coverages/orthomosaic",
+            Reason = "Vendor-specific renderer requires manual review.",
+            VendorName = "Esri"
+        };
+
+        var inputs = BuildCombinedInputs() with
+        {
+            OgcApiCoveragesImport = BuildCombinedInputs().OgcApiCoveragesImport! with
+            {
+                StyleDiagnostics = [sharedDiagnostic, ogcOnlyDiagnostic]
+            },
+            WcsImport = BuildCombinedInputs().WcsImport! with
+            {
+                // Same diagnostic surfaced through WCS channel; must dedupe.
+                StyleDiagnostics = [sharedDiagnostic]
+            }
+        };
+
+        var pack = OgcCoverageMigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.StyleDiagnostics.Should().HaveCount(2,
+            "duplicate diagnostics across channels collapse to a single row in the pack.");
+        pack.Bundle.StyleDiagnostics.Select(d => d.SourceCoverageId)
+            .Should().BeInAscendingOrder(StringComparer.Ordinal);
+        pack.Bundle.Summary.StyleDiagnosticCount.Should().Be(2);
+        pack.Bundle.Summary.StyleManualReviewCount.Should().Be(1,
+            "slice-4 manual-review style diagnostics must be surfaced so the pack does not claim visual parity for them.");
+    }
+
+    [Fact]
+    public void Build_RedactsCredentials_FromSourceUrls()
+    {
+        var inputs = BuildCombinedInputs();
+        const string SecretUrl = "https://admin:hunter2@coverage.example.com:8443/ogcapi?token=topsecret";
+
+        var withSecretUrl = inputs with
+        {
+            Inventory = inputs.Inventory with
+            {
+                Source = inputs.Inventory.Source with { BaseUrl = SecretUrl }
+            },
+            OgcApiCoveragesImport = inputs.OgcApiCoveragesImport! with
+            {
+                Manifest = inputs.OgcApiCoveragesImport!.Manifest with
+                {
+                    Source = inputs.OgcApiCoveragesImport!.Manifest.Source with { BaseUrl = SecretUrl }
+                }
+            },
+            WcsImport = inputs.WcsImport! with
+            {
+                Manifest = inputs.WcsImport!.Manifest with
+                {
+                    Source = inputs.WcsImport!.Manifest.Source with { BaseUrl = SecretUrl }
+                }
+            }
+        };
+
+        var pack = OgcCoverageMigrationEvidencePackBuilder.Build(withSecretUrl);
+
+        pack.Bundle.Source.BaseUrl.Should().NotContain("hunter2");
+        pack.Bundle.Source.BaseUrl.Should().NotContain("topsecret");
+        pack.Bundle.Source.BaseUrl.Should().Be("https://coverage.example.com:8443/ogcapi");
+
+        pack.Bundle.Inventory.Source.BaseUrl.Should().NotContain("hunter2");
+        pack.Bundle.Inventory.Source.BaseUrl.Should().NotContain("topsecret");
+
+        foreach (var channel in pack.Bundle.Channels)
+        {
+            channel.Manifest.Source.BaseUrl.Should().NotContain("hunter2");
+            channel.Manifest.Source.BaseUrl.Should().NotContain("topsecret");
+        }
+
+        // Serialize the entire pack and assert no credential leaked anywhere.
+        var json = JsonSerializer.Serialize(
+            pack,
+            OgcCoverageMigrationEvidencePackJsonContext.Default.OgcCoverageMigrationEvidencePackArtifact);
+        json.Should().NotContain("hunter2");
+        json.Should().NotContain("topsecret");
+        json.Should().NotContain("admin:hunter2");
+    }
+
+    [Fact]
+    public void Build_CapturesCoverageScope_WhenOperatorRestrictsRun()
+    {
+        var inputs = BuildCombinedInputs() with
+        {
+            RequestedCoverageIds = new[] { "coverages/dem", "coverages/dem", "coverages/orthomosaic" }
+        };
+
+        var pack = OgcCoverageMigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.CoverageScope.Restricted.Should().BeTrue();
+        pack.Bundle.CoverageScope.CoverageIds.Should().Equal("coverages/dem", "coverages/orthomosaic");
+    }
+
+    [Fact]
+    public void Build_CapturesCoverageScope_AsUnrestricted_WhenNoIdsProvided()
+    {
+        var inputs = BuildCombinedInputs();
+
+        var pack = OgcCoverageMigrationEvidencePackBuilder.Build(inputs);
+
+        pack.Bundle.CoverageScope.Restricted.Should().BeFalse();
+        pack.Bundle.CoverageScope.CoverageIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Build_OrdersRecordsBySourceCoverageId_WithinEachChannel()
+    {
+        var inputs = BuildCombinedInputs() with
+        {
+            OgcApiCoveragesImport = BuildCombinedInputs().OgcApiCoveragesImport! with
+            {
+                // Pass records in reverse order; builder must canonicalize.
+                Records = BuildCombinedInputs().OgcApiCoveragesImport!.Records.Reverse().ToArray()
+            }
+        };
+
+        var pack = OgcCoverageMigrationEvidencePackBuilder.Build(inputs);
+
+        var ogcChannel = pack.Bundle.Channels
+            .Single(c => c.Id == OgcCoverageMigrationEvidencePackChannelIds.OgcApiCoverages);
+        ogcChannel.Records.Select(r => r.SourceCoverageId)
+            .Should().BeInAscendingOrder(StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Artifact_Shape_HasStableTopLevelFields()
+    {
+        // Schema-stability guard: surface any accidental addition/rename of
+        // the evidence-pack contract so reviewers update downstream
+        // consumers (admin UI, SDK orchestration) intentionally.
+        var pack = OgcCoverageMigrationEvidencePackBuilder.Build(BuildCombinedInputs());
+        var json = JsonSerializer.Serialize(
+            pack,
+            OgcCoverageMigrationEvidencePackJsonContext.Default.OgcCoverageMigrationEvidencePackArtifact);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        // Top-level artifact contract.
+        root.GetProperty("artifactKind").GetString().Should().Be("honua.migration.ogc-coverage-evidence-pack");
+        root.GetProperty("artifactVersion").GetString().Should().Be("1.0");
+        root.GetProperty("runId").ValueKind.Should().Be(JsonValueKind.String);
+        root.GetProperty("generator").ValueKind.Should().Be(JsonValueKind.String);
+        root.GetProperty("generatedAt").ValueKind.Should().Be(JsonValueKind.String);
+        root.GetProperty("bundleFingerprint").GetString().Should().StartWith("sha256:");
+
+        // Bundle contract.
+        var bundle = root.GetProperty("bundle");
+        bundle.GetProperty("sourceKind").ValueKind.Should().Be(JsonValueKind.String);
+        bundle.GetProperty("source").ValueKind.Should().Be(JsonValueKind.Object);
+        bundle.GetProperty("coverageScope").ValueKind.Should().Be(JsonValueKind.Object);
+        bundle.GetProperty("summary").ValueKind.Should().Be(JsonValueKind.Object);
+        bundle.GetProperty("channels").ValueKind.Should().Be(JsonValueKind.Array);
+        bundle.GetProperty("styleDiagnostics").ValueKind.Should().Be(JsonValueKind.Array);
+        bundle.GetProperty("inventory").ValueKind.Should().Be(JsonValueKind.Object);
+
+        var summary = bundle.GetProperty("summary");
+        summary.GetProperty("totalCoverageCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("importedCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("plannedCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("skippedCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("manualReviewCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("failedCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("styleDiagnosticCount").ValueKind.Should().Be(JsonValueKind.Number);
+        summary.GetProperty("styleManualReviewCount").ValueKind.Should().Be(JsonValueKind.Number);
+
+        var channels = bundle.GetProperty("channels");
+        channels.GetArrayLength().Should().Be(2);
+        foreach (var channel in channels.EnumerateArray())
+        {
+            channel.GetProperty("id").ValueKind.Should().Be(JsonValueKind.String);
+            channel.GetProperty("applyMode").ValueKind.Should().BeOneOf(JsonValueKind.True, JsonValueKind.False);
+            channel.GetProperty("dryRun").ValueKind.Should().BeOneOf(JsonValueKind.True, JsonValueKind.False);
+            channel.GetProperty("coverageCount").ValueKind.Should().Be(JsonValueKind.Number);
+            channel.GetProperty("records").ValueKind.Should().Be(JsonValueKind.Array);
+            channel.GetProperty("manifest").ValueKind.Should().Be(JsonValueKind.Object);
+        }
+    }
+
+    private static OgcCoverageMigrationEvidencePackInputs BuildCombinedInputs()
+    {
+        var source = new MigrationSourceIdentity
+        {
+            DisplayName = "Coverage Sample",
+            BaseUrl = "https://coverage.example.com/ogcapi",
+            Product = "OGC API Coverages",
+            Version = "1.0",
+            ServiceType = "REST"
+        };
+
+        var inventory = new MigrationSourceInventoryArtifact
+        {
+            SourceKind = "ogc-api-coverages",
+            Source = source,
+            AuthPosture = new MigrationInventoryAuthPosture
+            {
+                Mode = "anonymous",
+                CredentialsSupplied = false,
+                AccessConfirmed = true
+            },
+            ScanCompleteness = new MigrationInventoryCompleteness { Status = "complete" },
+            Summary = new MigrationInventorySummary
+            {
+                ContainerCount = 1,
+                ResourceCount = 2,
+                StyleCount = 0
+            },
+            OverallCompatibility = new MigrationCompatibilityAssessment
+            {
+                Level = "compatible",
+                Reason = "Coverage inventory is compatible with Honua migration."
+            }
+        };
+
+        var manifest = new MigrationManifestArtifact
+        {
+            SourceKind = "ogc-api-coverages",
+            Source = source,
+            Summary = new MigrationManifestSummary
+            {
+                SourceResourceCount = 2,
+                TargetResourceCount = 2,
+                StyleActionCount = 0
+            }
+        };
+
+        var ogcCoveragesResult = new OgcCoverageImportResult
+        {
+            Manifest = manifest,
+            ApplyMode = true,
+            DryRun = false,
+            Records =
+            [
+                new OgcCoverageImportRecord
+                {
+                    SourceCoverageId = "coverages/orthomosaic",
+                    TargetCoverageName = "ortho-2026",
+                    OutputFormat = "CloudOptimizedGeoTIFF",
+                    Classification = "manual-review",
+                    Action = "manual-review",
+                    DeclaredCrs = ["EPSG:3857"],
+                    DeclaredBands = ["red", "green", "blue"]
+                },
+                new OgcCoverageImportRecord
+                {
+                    SourceCoverageId = "coverages/dem",
+                    TargetCoverageName = "dem-2026",
+                    OutputFormat = "GeoTIFF",
+                    Classification = "automated",
+                    Action = "imported",
+                    DeclaredCrs = ["EPSG:4326"],
+                    DeclaredBands = ["elevation"],
+                    ByteCount = 1024 * 1024,
+                    RasterId = 42L
+                }
+            ],
+            StyleDiagnostics =
+            [
+                new MigrationCoverageStyleDiagnostic
+                {
+                    Kind = "colorMap",
+                    Classification = "assisted",
+                    SourceCoverageId = "coverages/dem",
+                    Reason = "Indexed color table preserved verbatim.",
+                    SuggestedTargetStyleId = "indexed-color-table"
+                },
+                new MigrationCoverageStyleDiagnostic
+                {
+                    Kind = "renderingHint",
+                    Classification = "manual-review",
+                    SourceCoverageId = "coverages/orthomosaic",
+                    Reason = "Vendor-specific renderer requires manual review.",
+                    VendorName = "Esri"
+                }
+            ]
+        };
+
+        var wcsResult = new OgcWcsImportResult
+        {
+            Manifest = manifest with { SourceKind = "ogc-wcs" },
+            ApplyMode = true,
+            DryRun = false,
+            RequestedOutputFormat = "image/tiff",
+            ResolvedVersion = "2.0.1",
+            Records =
+            [
+                new OgcCoverageImportRecord
+                {
+                    SourceCoverageId = "wcs:legacy-radar",
+                    TargetCoverageName = "legacy-radar-2026",
+                    OutputFormat = "GeoTIFF",
+                    Classification = "manual-review",
+                    Action = "failed",
+                    DeclaredCrs = ["EPSG:4326"],
+                    DeclaredBands = ["dbz"],
+                    ErrorMessage = "Source service returned a malformed envelope."
+                },
+                new OgcCoverageImportRecord
+                {
+                    SourceCoverageId = "wcs:climate-baseline",
+                    TargetCoverageName = "climate-baseline-2026",
+                    OutputFormat = "GeoTIFF",
+                    Classification = "automated",
+                    Action = "imported",
+                    DeclaredCrs = ["EPSG:4326"],
+                    DeclaredBands = ["temperature"],
+                    ByteCount = 2L * 1024 * 1024,
+                    RasterId = 43L
+                }
+            ],
+            StyleDiagnostics =
+            [
+                new MigrationCoverageStyleDiagnostic
+                {
+                    Kind = "noDataValue",
+                    Classification = "automated",
+                    SourceCoverageId = "wcs:legacy-radar",
+                    Reason = "NoData value preserved by raw pixel copy."
+                }
+            ]
+        };
+
+        return new OgcCoverageMigrationEvidencePackInputs
+        {
+            Inventory = inventory,
+            OgcApiCoveragesImport = ogcCoveragesResult,
+            WcsImport = wcsResult
+        };
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1030

## Summary
Slice 5 (capstone) of issue #1030 aggregates the slice 1-4 OGC coverage migration artifacts — coverage scanner inventory + modern OGC API Coverages import results + legacy WCS import results + coverage style diagnostics — into a single deterministic evidence pack so reviewers, the admin UI, and the nightly fixture run can audit raster data + style migration outcomes from one artifact. Mirrors the GeoServer evidence pack pattern from #1015 slice 4 / PR #1117, but rolls up the modern and legacy protocol surfaces uniformly under one canonical channel collection.

## Changes Made
- `OgcCoverageMigrationEvidencePackArtifact` + bundle records in `Honua.Core.Features.Import.Domain` carrying a SHA-256 fingerprint over the bundle payload (run id, generator label, and wall-clock timestamps are excluded so nightly re-runs stay byte-identical). Coverage-scoping evidence and per-channel WCS protocol metadata are surfaced alongside per-coverage records.
- `OgcCoverageMigrationEvidencePackBuilder` in `Honua.Core.Features.Import.Services` composes the inventory + per-channel import results into the bundle. OGC API Coverages and WCS results fold into one canonical channel collection (always emitted in `ogc-api-coverages` then `ogc-wcs` order). Style diagnostics are aggregated across channels and deduplicated. Source URLs are redacted (userinfo + query + fragment stripped) before the inventory and per-channel manifests are embedded.
- `OgcCoverageMigrationEvidencePackJsonContext` provides an AOT-safe source-generated serialization context so the pack can be emitted under `PublishAot` builds.
- `OgcCoverageMigrationEvidencePackBuilderTests` covering deterministic output, fingerprint sensitivity (per-record + per-style-diagnostic), canonical channel ordering, single-channel emission, combined OGC + WCS roll-up summary, style-diagnostic aggregation + cross-channel deduplication, credential redaction, coverage scope capture, deterministic per-record ordering, and a schema-stability guard.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

> Stacked on `codex/issue-1030-coverage-style` (PR #1124). Rebase / merge after the base PR lands.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>