### PR TITLE
feat: Metadata GitOps semantic release package and environment bindings (#1163)

### DIFF
--- a/src/Honua.Core/Features/Metadata/Abstractions/IMetadataReleasePackageStore.cs
+++ b/src/Honua.Core/Features/Metadata/Abstractions/IMetadataReleasePackageStore.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Core.Features.Metadata.Abstractions;
+
+/// <summary>
+/// Persistence contract for metadata release packages.
+/// </summary>
+public interface IMetadataReleasePackageStore
+{
+    /// <summary>
+    /// Persists a metadata release package.
+    /// </summary>
+    Task<MetadataReleasePackage> CreateAsync(
+        MetadataReleasePackage package,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns a metadata release package by identifier, or null when not found.
+    /// </summary>
+    Task<MetadataReleasePackage?> GetAsync(
+        Guid packageId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Metadata/Abstractions/IMetadataReleaseService.cs
+++ b/src/Honua.Core/Features/Metadata/Abstractions/IMetadataReleaseService.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Core.Features.Metadata.Abstractions;
+
+/// <summary>
+/// Service layer for semantic metadata inventories, environment bindings, and release packages.
+/// </summary>
+public interface IMetadataReleaseService
+{
+    /// <summary>
+    /// Returns semantic inventory for an environment, or null when the environment has no active snapshot.
+    /// </summary>
+    Task<MetadataSemanticInventoryResponse?> GetSemanticInventoryAsync(
+        string environment,
+        MetadataSemanticInventoryFilter filter,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns binding summaries for semantic artifacts across environments.
+    /// </summary>
+    Task<MetadataEnvironmentBindingsResponse> GetEnvironmentBindingsAsync(
+        MetadataEnvironmentBindingsRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates and persists a metadata release package.
+    /// </summary>
+    Task<MetadataReleasePackage> CreateReleasePackageAsync(
+        CreateMetadataReleasePackageRequest request,
+        string createdBy,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns a persisted metadata release package.
+    /// </summary>
+    Task<MetadataReleasePackage?> GetReleasePackageAsync(
+        Guid packageId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Exports a persisted metadata release package as a GitOps-safe manifest.
+    /// </summary>
+    Task<GitOpsMetadataReleaseManifest?> GetGitOpsManifestAsync(
+        Guid packageId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Metadata/Abstractions/IMetadataV2EnvironmentSnapshotReader.cs
+++ b/src/Honua.Core/Features/Metadata/Abstractions/IMetadataV2EnvironmentSnapshotReader.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Core.Features.Metadata.Abstractions;
+
+/// <summary>
+/// Environment-aware read access to Metadata v2 graph snapshots for admin and release workflows.
+/// </summary>
+public interface IMetadataV2EnvironmentSnapshotReader
+{
+    /// <summary>
+    /// Returns the current Metadata v2 graph snapshot for an environment, or null when unavailable.
+    /// </summary>
+    ValueTask<MetadataV2GraphSnapshot?> GetCurrentAsync(
+        string environment,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns a specific Metadata v2 graph revision for an environment, or null when unavailable.
+    /// </summary>
+    ValueTask<MetadataV2GraphSnapshot?> GetByRevisionAsync(
+        string environment,
+        long revision,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists current revision metadata for requested environments.
+    /// </summary>
+    IAsyncEnumerable<MetadataV2EnvironmentRevision> ListCurrentRevisionsAsync(
+        IReadOnlyList<string> environments,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataReleaseEnums.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataReleaseEnums.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Semantic artifact groups exposed by metadata inventory and release packages.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataSemanticArtifactKind>))]
+public enum MetadataSemanticArtifactKind
+{
+    /// <summary>A canonical Metadata v2 resource.</summary>
+    [JsonStringEnumMemberName("resource")]
+    Resource,
+
+    /// <summary>A service that publishes resources.</summary>
+    [JsonStringEnumMemberName("service")]
+    Service,
+
+    /// <summary>A publication that binds a resource to a service.</summary>
+    [JsonStringEnumMemberName("publication")]
+    Publication,
+
+    /// <summary>A field owned by a resource schema.</summary>
+    [JsonStringEnumMemberName("field")]
+    Field,
+
+    /// <summary>A catalog target.</summary>
+    [JsonStringEnumMemberName("catalog")]
+    Catalog,
+
+    /// <summary>A Metadata v2 policy.</summary>
+    [JsonStringEnumMemberName("policy")]
+    Policy,
+
+    /// <summary>A Metadata v2 role.</summary>
+    [JsonStringEnumMemberName("role")]
+    Role,
+}
+
+/// <summary>
+/// Binding state for a semantic artifact in a requested environment.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataEnvironmentBindingState>))]
+public enum MetadataEnvironmentBindingState
+{
+    /// <summary>The environment contains a binding for the semantic artifact.</summary>
+    [JsonStringEnumMemberName("bound")]
+    Bound,
+
+    /// <summary>The environment is available but the semantic artifact is absent.</summary>
+    [JsonStringEnumMemberName("missing")]
+    Missing,
+
+    /// <summary>The requested environment has no active Metadata v2 snapshot.</summary>
+    [JsonStringEnumMemberName("environment-unavailable")]
+    EnvironmentUnavailable,
+}
+
+/// <summary>
+/// Coarse class of change represented by a release entry.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataReleaseChangeClass>))]
+public enum MetadataReleaseChangeClass
+{
+    /// <summary>Metadata-only change.</summary>
+    [JsonStringEnumMemberName("metadata")]
+    Metadata,
+
+    /// <summary>Content-version change.</summary>
+    [JsonStringEnumMemberName("content")]
+    Content,
+
+    /// <summary>Environment binding or physical target change.</summary>
+    [JsonStringEnumMemberName("binding")]
+    Binding,
+
+    /// <summary>RBAC policy or role change.</summary>
+    [JsonStringEnumMemberName("policy")]
+    Policy,
+
+    /// <summary>Deletion or retirement of the artifact.</summary>
+    [JsonStringEnumMemberName("delete")]
+    Delete,
+}
+
+/// <summary>
+/// Lifecycle state for a metadata release package.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataReleasePackageStatus>))]
+public enum MetadataReleasePackageStatus
+{
+    /// <summary>Draft package that has not been staged.</summary>
+    [JsonStringEnumMemberName("draft")]
+    Draft,
+
+    /// <summary>Package is ready for downstream GitOps processing.</summary>
+    [JsonStringEnumMemberName("ready")]
+    Ready,
+
+    /// <summary>Package has been staged by downstream automation.</summary>
+    [JsonStringEnumMemberName("staged")]
+    Staged,
+
+    /// <summary>Package was superseded by a newer package.</summary>
+    [JsonStringEnumMemberName("superseded")]
+    Superseded,
+
+    /// <summary>Package was cancelled before promotion.</summary>
+    [JsonStringEnumMemberName("cancelled")]
+    Cancelled,
+}
+
+/// <summary>
+/// Per-entry release state.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataReleaseEntryStatus>))]
+public enum MetadataReleaseEntryStatus
+{
+    /// <summary>Entry is included in a draft release package.</summary>
+    [JsonStringEnumMemberName("draft")]
+    Draft,
+
+    /// <summary>Entry is ready for downstream processing.</summary>
+    [JsonStringEnumMemberName("ready")]
+    Ready,
+}

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataReleaseJsonContext.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataReleaseJsonContext.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Console.Domain;
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// JSON serialization context for Metadata v2 release package contracts.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(MetadataSemanticInventoryResponse))]
+[JsonSerializable(typeof(MetadataSemanticInventoryEntry))]
+[JsonSerializable(typeof(MetadataEnvironmentBindingsRequest))]
+[JsonSerializable(typeof(MetadataEnvironmentBindingsResponse))]
+[JsonSerializable(typeof(MetadataEnvironmentBindingSummary))]
+[JsonSerializable(typeof(MetadataBoundResourceSummary))]
+[JsonSerializable(typeof(MetadataBoundFieldSummary))]
+[JsonSerializable(typeof(MetadataBoundServiceSummary))]
+[JsonSerializable(typeof(MetadataBoundPublicationSummary))]
+[JsonSerializable(typeof(MetadataBoundStorageSummary))]
+[JsonSerializable(typeof(MetadataBoundConnectionSummary))]
+[JsonSerializable(typeof(CreateMetadataReleasePackageRequest))]
+[JsonSerializable(typeof(MetadataReleasePackage))]
+[JsonSerializable(typeof(MetadataReleaseEntry))]
+[JsonSerializable(typeof(MetadataReleaseTargetState))]
+[JsonSerializable(typeof(GitOpsMetadataReleaseManifest))]
+[JsonSerializable(typeof(GitOpsMetadataReleaseSpec))]
+[JsonSerializable(typeof(GitOpsMetadataReleaseSource))]
+[JsonSerializable(typeof(GitOpsMetadataReleaseTarget))]
+[JsonSerializable(typeof(GitOpsMetadataReleaseEntry))]
+[JsonSerializable(typeof(MetadataV2EnvironmentRevision))]
+[JsonSerializable(typeof(MetadataV2ObjectMetadata))]
+[JsonSerializable(typeof(MetadataV2Status))]
+[JsonSerializable(typeof(MetadataV2Condition))]
+[JsonSerializable(typeof(ConsoleProvenanceRef))]
+[JsonSerializable(typeof(MetadataReleaseEntry[]))]
+[JsonSerializable(typeof(GitOpsMetadataReleaseEntry[]))]
+[JsonSerializable(typeof(MetadataReleaseTargetState[]))]
+[JsonSerializable(typeof(string[]))]
+[JsonSerializable(typeof(IReadOnlyDictionary<string, string>), TypeInfoPropertyName = "ReadOnlyDictionaryStringString")]
+[JsonSerializable(typeof(IReadOnlyDictionary<string, JsonElement>), TypeInfoPropertyName = "ReadOnlyDictionaryStringJsonElement")]
+public sealed partial class MetadataReleaseJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataReleaseModels.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataReleaseModels.cs
@@ -518,6 +518,10 @@ public sealed record MetadataReleaseEntry
     [JsonPropertyName("resourceType")]
     public MetadataV2ResourceType? ResourceType { get; init; }
 
+    /// <summary>Source field identity when this entry promotes a resource field.</summary>
+    [JsonPropertyName("sourceField")]
+    public MetadataBoundFieldSummary? SourceField { get; init; }
+
     /// <summary>Desired Metadata v2 revision.</summary>
     [JsonPropertyName("desiredMetadataRevision")]
     public required long DesiredMetadataRevision { get; init; }
@@ -663,6 +667,10 @@ public sealed record GitOpsMetadataReleaseEntry
     /// <summary>Resource type when applicable.</summary>
     [JsonPropertyName("resourceType")]
     public MetadataV2ResourceType? ResourceType { get; init; }
+
+    /// <summary>Source field identity when this entry promotes a resource field.</summary>
+    [JsonPropertyName("sourceField")]
+    public MetadataBoundFieldSummary? SourceField { get; init; }
 
     /// <summary>Desired Metadata v2 revision.</summary>
     [JsonPropertyName("desiredMetadataRevision")]

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataReleaseModels.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataReleaseModels.cs
@@ -1,0 +1,691 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Console.Domain;
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Current Metadata v2 revision metadata for one environment.
+/// </summary>
+public sealed record MetadataV2EnvironmentRevision
+{
+    /// <summary>Environment identifier.</summary>
+    [JsonPropertyName("environment")]
+    public required string Environment { get; init; }
+
+    /// <summary>Active Metadata v2 revision.</summary>
+    [JsonPropertyName("revision")]
+    public required long Revision { get; init; }
+
+    /// <summary>Active Metadata v2 entity tag.</summary>
+    [JsonPropertyName("etag")]
+    public required string ETag { get; init; }
+
+    /// <summary>Timestamp when the revision was activated or observed.</summary>
+    [JsonPropertyName("activatedAt")]
+    public DateTimeOffset? ActivatedAt { get; init; }
+}
+
+/// <summary>
+/// Filter used when projecting semantic inventory from an environment snapshot.
+/// </summary>
+public sealed record MetadataSemanticInventoryFilter
+{
+    /// <summary>Optional artifact kind filter.</summary>
+    public MetadataSemanticArtifactKind? ArtifactKind { get; init; }
+
+    /// <summary>Optional Metadata v2 resource type filter.</summary>
+    public MetadataV2ResourceType? ResourceType { get; init; }
+}
+
+/// <summary>
+/// Semantic resource inventory for an environment.
+/// </summary>
+public sealed record MetadataSemanticInventoryResponse
+{
+    /// <summary>Environment represented by the inventory.</summary>
+    [JsonPropertyName("environment")]
+    public required string Environment { get; init; }
+
+    /// <summary>Active Metadata v2 revision used to project the inventory.</summary>
+    [JsonPropertyName("revision")]
+    public required long Revision { get; init; }
+
+    /// <summary>Active Metadata v2 entity tag used to project the inventory.</summary>
+    [JsonPropertyName("etag")]
+    public required string ETag { get; init; }
+
+    /// <summary>Timestamp when the inventory was generated.</summary>
+    [JsonPropertyName("generatedAt")]
+    public required DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>Inventory entries.</summary>
+    [JsonPropertyName("entries")]
+    public IReadOnlyList<MetadataSemanticInventoryEntry> Entries { get; init; } =
+        Array.Empty<MetadataSemanticInventoryEntry>();
+}
+
+/// <summary>
+/// One semantic artifact in an environment inventory.
+/// </summary>
+public sealed record MetadataSemanticInventoryEntry
+{
+    /// <summary>Stable semantic identifier.</summary>
+    [JsonPropertyName("semanticId")]
+    public required string SemanticId { get; init; }
+
+    /// <summary>Artifact kind.</summary>
+    [JsonPropertyName("artifactKind")]
+    public required MetadataSemanticArtifactKind ArtifactKind { get; init; }
+
+    /// <summary>Resource type when the artifact is a resource or resource child.</summary>
+    [JsonPropertyName("resourceType")]
+    public MetadataV2ResourceType? ResourceType { get; init; }
+
+    /// <summary>Service type when the artifact is a service.</summary>
+    [JsonPropertyName("serviceType")]
+    public MetadataV2ServiceType? ServiceType { get; init; }
+
+    /// <summary>Publication type when the artifact is a publication.</summary>
+    [JsonPropertyName("publicationType")]
+    public MetadataV2PublicationType? PublicationType { get; init; }
+
+    /// <summary>Parent semantic identifier for fields and publications.</summary>
+    [JsonPropertyName("parentSemanticId")]
+    public string? ParentSemanticId { get; init; }
+
+    /// <summary>Machine-friendly name.</summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>Optional namespace.</summary>
+    [JsonPropertyName("namespace")]
+    public string? Namespace { get; init; }
+
+    /// <summary>Human-readable title.</summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>Metadata generation for optimistic comparisons.</summary>
+    [JsonPropertyName("metadataGeneration")]
+    public long? MetadataGeneration { get; init; }
+
+    /// <summary>Lifecycle and operational status reused from Metadata v2.</summary>
+    [JsonPropertyName("status")]
+    public MetadataV2Status? Status { get; init; }
+
+    /// <summary>Desired or observed content-version reference.</summary>
+    [JsonPropertyName("contentVersionId")]
+    public string? ContentVersionId { get; init; }
+
+    /// <summary>Provenance references reused from Console content metadata.</summary>
+    [JsonPropertyName("provenance")]
+    public IReadOnlyList<ConsoleProvenanceRef> Provenance { get; init; } = Array.Empty<ConsoleProvenanceRef>();
+
+    /// <summary>Metadata v2 policy identifiers associated with the artifact.</summary>
+    [JsonPropertyName("policyIds")]
+    public IReadOnlyList<string> PolicyIds { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Request for environment binding summaries.
+/// </summary>
+public sealed record MetadataEnvironmentBindingsRequest
+{
+    /// <summary>Environments to inspect.</summary>
+    [JsonPropertyName("environments")]
+    public IReadOnlyList<string> Environments { get; init; } = Array.Empty<string>();
+
+    /// <summary>Semantic identifiers to resolve in each environment.</summary>
+    [JsonPropertyName("semanticIds")]
+    public IReadOnlyList<string> SemanticIds { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Binding summaries for requested semantic artifacts across environments.
+/// </summary>
+public sealed record MetadataEnvironmentBindingsResponse
+{
+    /// <summary>Timestamp when bindings were requested.</summary>
+    [JsonPropertyName("requestedAt")]
+    public required DateTimeOffset RequestedAt { get; init; }
+
+    /// <summary>Environment identifiers requested by the caller.</summary>
+    [JsonPropertyName("environments")]
+    public IReadOnlyList<string> Environments { get; init; } = Array.Empty<string>();
+
+    /// <summary>Binding summaries in environment and semantic-id order.</summary>
+    [JsonPropertyName("bindings")]
+    public IReadOnlyList<MetadataEnvironmentBindingSummary> Bindings { get; init; } =
+        Array.Empty<MetadataEnvironmentBindingSummary>();
+}
+
+/// <summary>
+/// Secret-safe binding summary for one semantic artifact in one environment.
+/// </summary>
+public sealed record MetadataEnvironmentBindingSummary
+{
+    /// <summary>Semantic identifier requested by the caller.</summary>
+    [JsonPropertyName("semanticId")]
+    public required string SemanticId { get; init; }
+
+    /// <summary>Environment inspected.</summary>
+    [JsonPropertyName("environment")]
+    public required string Environment { get; init; }
+
+    /// <summary>Binding state.</summary>
+    [JsonPropertyName("state")]
+    public required MetadataEnvironmentBindingState State { get; init; }
+
+    /// <summary>Metadata v2 revision observed in the environment.</summary>
+    [JsonPropertyName("revision")]
+    public long? Revision { get; init; }
+
+    /// <summary>Metadata v2 entity tag observed in the environment.</summary>
+    [JsonPropertyName("etag")]
+    public string? ETag { get; init; }
+
+    /// <summary>Artifact kind when resolved.</summary>
+    [JsonPropertyName("artifactKind")]
+    public MetadataSemanticArtifactKind? ArtifactKind { get; init; }
+
+    /// <summary>Resource summary when applicable.</summary>
+    [JsonPropertyName("resource")]
+    public MetadataBoundResourceSummary? Resource { get; init; }
+
+    /// <summary>Field summary when applicable.</summary>
+    [JsonPropertyName("field")]
+    public MetadataBoundFieldSummary? Field { get; init; }
+
+    /// <summary>Service summary when applicable.</summary>
+    [JsonPropertyName("service")]
+    public MetadataBoundServiceSummary? Service { get; init; }
+
+    /// <summary>Publication summary when applicable.</summary>
+    [JsonPropertyName("publication")]
+    public MetadataBoundPublicationSummary? Publication { get; init; }
+
+    /// <summary>Storage binding summary when applicable.</summary>
+    [JsonPropertyName("storage")]
+    public MetadataBoundStorageSummary? Storage { get; init; }
+
+    /// <summary>Connection reference summary when applicable.</summary>
+    [JsonPropertyName("connection")]
+    public MetadataBoundConnectionSummary? Connection { get; init; }
+
+    /// <summary>Content-version reference observed for the artifact.</summary>
+    [JsonPropertyName("contentVersionId")]
+    public string? ContentVersionId { get; init; }
+
+    /// <summary>Timestamp when the binding snapshot was observed.</summary>
+    [JsonPropertyName("lastObservedAt")]
+    public DateTimeOffset? LastObservedAt { get; init; }
+}
+
+/// <summary>
+/// Secret-safe resource binding summary.
+/// </summary>
+public sealed record MetadataBoundResourceSummary
+{
+    /// <summary>Resource semantic identifier.</summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>Resource name.</summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>Optional namespace.</summary>
+    [JsonPropertyName("namespace")]
+    public string? Namespace { get; init; }
+
+    /// <summary>Resource title.</summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>Resource type.</summary>
+    [JsonPropertyName("resourceType")]
+    public required MetadataV2ResourceType ResourceType { get; init; }
+
+    /// <summary>Primary storage binding identifier.</summary>
+    [JsonPropertyName("primaryStorageBindingId")]
+    public string? PrimaryStorageBindingId { get; init; }
+}
+
+/// <summary>
+/// Secret-safe field binding summary.
+/// </summary>
+public sealed record MetadataBoundFieldSummary
+{
+    /// <summary>Field semantic identifier.</summary>
+    [JsonPropertyName("semanticId")]
+    public required string SemanticId { get; init; }
+
+    /// <summary>Parent resource semantic identifier.</summary>
+    [JsonPropertyName("parentResourceId")]
+    public required string ParentResourceId { get; init; }
+
+    /// <summary>Field name.</summary>
+    [JsonPropertyName("fieldName")]
+    public required string FieldName { get; init; }
+
+    /// <summary>Field type.</summary>
+    [JsonPropertyName("fieldType")]
+    public string? FieldType { get; init; }
+}
+
+/// <summary>
+/// Secret-safe service binding summary.
+/// </summary>
+public sealed record MetadataBoundServiceSummary
+{
+    /// <summary>Service semantic identifier.</summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>Service name.</summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>Optional namespace.</summary>
+    [JsonPropertyName("namespace")]
+    public string? Namespace { get; init; }
+
+    /// <summary>Service title.</summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>Service type.</summary>
+    [JsonPropertyName("serviceType")]
+    public required MetadataV2ServiceType ServiceType { get; init; }
+
+    /// <summary>Service route or base path.</summary>
+    [JsonPropertyName("route")]
+    public string? Route { get; init; }
+}
+
+/// <summary>
+/// Secret-safe publication binding summary.
+/// </summary>
+public sealed record MetadataBoundPublicationSummary
+{
+    /// <summary>Publication semantic identifier.</summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>Resource semantic identifier.</summary>
+    [JsonPropertyName("resourceId")]
+    public required string ResourceId { get; init; }
+
+    /// <summary>Service semantic identifier.</summary>
+    [JsonPropertyName("serviceId")]
+    public required string ServiceId { get; init; }
+
+    /// <summary>Publication type.</summary>
+    [JsonPropertyName("publicationType")]
+    public required MetadataV2PublicationType PublicationType { get; init; }
+
+    /// <summary>Service-local path.</summary>
+    [JsonPropertyName("path")]
+    public string? Path { get; init; }
+
+    /// <summary>Service-local layer index.</summary>
+    [JsonPropertyName("layerIndex")]
+    public int? LayerIndex { get; init; }
+
+    /// <summary>Service-local identifier.</summary>
+    [JsonPropertyName("serviceLocalId")]
+    public string? ServiceLocalId { get; init; }
+}
+
+/// <summary>
+/// Secret-safe storage binding summary.
+/// </summary>
+public sealed record MetadataBoundStorageSummary
+{
+    /// <summary>Storage binding semantic identifier.</summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>Resource semantic identifier.</summary>
+    [JsonPropertyName("resourceId")]
+    public required string ResourceId { get; init; }
+
+    /// <summary>Storage type.</summary>
+    [JsonPropertyName("storageType")]
+    public required MetadataV2StorageType StorageType { get; init; }
+
+    /// <summary>Physical locator such as schema/table, object key, or route.</summary>
+    [JsonPropertyName("locator")]
+    public required string Locator { get; init; }
+
+    /// <summary>Connection identifier.</summary>
+    [JsonPropertyName("connectionId")]
+    public string? ConnectionId { get; init; }
+}
+
+/// <summary>
+/// Secret-safe connection reference summary.
+/// </summary>
+public sealed record MetadataBoundConnectionSummary
+{
+    /// <summary>Connection semantic identifier.</summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>Connection name.</summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>Connection type.</summary>
+    [JsonPropertyName("connectionType")]
+    public required MetadataV2ConnectionType ConnectionType { get; init; }
+
+    /// <summary>Provider name.</summary>
+    [JsonPropertyName("provider")]
+    public string? Provider { get; init; }
+
+    /// <summary>Safe endpoint when the Metadata v2 graph already declares one.</summary>
+    [JsonPropertyName("endpoint")]
+    public Uri? Endpoint { get; init; }
+
+    /// <summary>External secret reference name; never a resolved credential value.</summary>
+    [JsonPropertyName("secretRef")]
+    public string? SecretRef { get; init; }
+}
+
+/// <summary>
+/// Request to create a metadata release package.
+/// </summary>
+public sealed record CreateMetadataReleasePackageRequest
+{
+    /// <summary>Optional package key. Generated when absent.</summary>
+    [JsonPropertyName("packageKey")]
+    public string? PackageKey { get; init; }
+
+    /// <summary>Optional package namespace.</summary>
+    [JsonPropertyName("namespace")]
+    public string? Namespace { get; init; }
+
+    /// <summary>Display title.</summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>Package summary.</summary>
+    [JsonPropertyName("summary")]
+    public string? Summary { get; init; }
+
+    /// <summary>Source environment.</summary>
+    [JsonPropertyName("sourceEnvironment")]
+    public required string SourceEnvironment { get; init; }
+
+    /// <summary>Target environments.</summary>
+    [JsonPropertyName("targetEnvironments")]
+    public IReadOnlyList<string> TargetEnvironments { get; init; } = Array.Empty<string>();
+
+    /// <summary>Changed semantic identifiers.</summary>
+    [JsonPropertyName("semanticIds")]
+    public IReadOnlyList<string> SemanticIds { get; init; } = Array.Empty<string>();
+
+    /// <summary>Desired Metadata v2 revision. Defaults to the source active revision.</summary>
+    [JsonPropertyName("desiredRevision")]
+    public long? DesiredRevision { get; init; }
+
+    /// <summary>Optional content-version reference applied to entries without per-artifact content references.</summary>
+    [JsonPropertyName("desiredContentVersionId")]
+    public string? DesiredContentVersionId { get; init; }
+
+    /// <summary>Optional per-semantic-id change class overrides.</summary>
+    [JsonPropertyName("changeClasses")]
+    public IReadOnlyDictionary<string, MetadataReleaseChangeClass>? ChangeClasses { get; init; }
+
+    /// <summary>Package-level provenance references reused from Console content metadata.</summary>
+    [JsonPropertyName("provenance")]
+    public IReadOnlyList<ConsoleProvenanceRef> Provenance { get; init; } = Array.Empty<ConsoleProvenanceRef>();
+}
+
+/// <summary>
+/// Persisted metadata release package.
+/// </summary>
+public sealed record MetadataReleasePackage
+{
+    /// <summary>Package identifier.</summary>
+    [JsonPropertyName("packageId")]
+    public required Guid PackageId { get; init; }
+
+    /// <summary>Package Metadata v2 object metadata.</summary>
+    [JsonPropertyName("metadata")]
+    public required MetadataV2ObjectMetadata Metadata { get; init; }
+
+    /// <summary>Source environment.</summary>
+    [JsonPropertyName("sourceEnvironment")]
+    public required string SourceEnvironment { get; init; }
+
+    /// <summary>Source Metadata v2 revision.</summary>
+    [JsonPropertyName("sourceRevision")]
+    public required long SourceRevision { get; init; }
+
+    /// <summary>Source Metadata v2 entity tag.</summary>
+    [JsonPropertyName("sourceEtag")]
+    public required string SourceEtag { get; init; }
+
+    /// <summary>Target environments.</summary>
+    [JsonPropertyName("targetEnvironments")]
+    public IReadOnlyList<string> TargetEnvironments { get; init; } = Array.Empty<string>();
+
+    /// <summary>Release entries.</summary>
+    [JsonPropertyName("entries")]
+    public IReadOnlyList<MetadataReleaseEntry> Entries { get; init; } = Array.Empty<MetadataReleaseEntry>();
+
+    /// <summary>Package status.</summary>
+    [JsonPropertyName("status")]
+    public MetadataReleasePackageStatus Status { get; init; } = MetadataReleasePackageStatus.Draft;
+
+    /// <summary>Actor that created the package.</summary>
+    [JsonPropertyName("createdBy")]
+    public required string CreatedBy { get; init; }
+
+    /// <summary>Creation timestamp.</summary>
+    [JsonPropertyName("createdAt")]
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>Last update timestamp.</summary>
+    [JsonPropertyName("updatedAt")]
+    public required DateTimeOffset UpdatedAt { get; init; }
+
+    /// <summary>Extension data for alpha consumers.</summary>
+    [JsonPropertyName("extensions")]
+    public IReadOnlyDictionary<string, JsonElement> Extensions { get; init; } = new Dictionary<string, JsonElement>();
+}
+
+/// <summary>
+/// One semantic artifact entry in a release package.
+/// </summary>
+public sealed record MetadataReleaseEntry
+{
+    /// <summary>Semantic identifier.</summary>
+    [JsonPropertyName("semanticId")]
+    public required string SemanticId { get; init; }
+
+    /// <summary>Artifact kind.</summary>
+    [JsonPropertyName("artifactKind")]
+    public required MetadataSemanticArtifactKind ArtifactKind { get; init; }
+
+    /// <summary>Resource type when applicable.</summary>
+    [JsonPropertyName("resourceType")]
+    public MetadataV2ResourceType? ResourceType { get; init; }
+
+    /// <summary>Desired Metadata v2 revision.</summary>
+    [JsonPropertyName("desiredMetadataRevision")]
+    public required long DesiredMetadataRevision { get; init; }
+
+    /// <summary>Desired content-version reference.</summary>
+    [JsonPropertyName("desiredContentVersionId")]
+    public string? DesiredContentVersionId { get; init; }
+
+    /// <summary>Desired provenance references.</summary>
+    [JsonPropertyName("desiredProvenance")]
+    public IReadOnlyList<ConsoleProvenanceRef> DesiredProvenance { get; init; } = Array.Empty<ConsoleProvenanceRef>();
+
+    /// <summary>Change class.</summary>
+    [JsonPropertyName("changeClass")]
+    public MetadataReleaseChangeClass ChangeClass { get; init; } = MetadataReleaseChangeClass.Metadata;
+
+    /// <summary>Last-observed target states.</summary>
+    [JsonPropertyName("targetStates")]
+    public IReadOnlyList<MetadataReleaseTargetState> TargetStates { get; init; } = Array.Empty<MetadataReleaseTargetState>();
+
+    /// <summary>Dependent semantic identifiers.</summary>
+    [JsonPropertyName("dependentSemanticIds")]
+    public IReadOnlyList<string> DependentSemanticIds { get; init; } = Array.Empty<string>();
+
+    /// <summary>Entry status.</summary>
+    [JsonPropertyName("status")]
+    public MetadataReleaseEntryStatus Status { get; init; } = MetadataReleaseEntryStatus.Draft;
+}
+
+/// <summary>
+/// Last-observed target environment state captured for a release entry.
+/// </summary>
+public sealed record MetadataReleaseTargetState
+{
+    /// <summary>Target environment.</summary>
+    [JsonPropertyName("environment")]
+    public required string Environment { get; init; }
+
+    /// <summary>Current Metadata v2 revision in the target environment.</summary>
+    [JsonPropertyName("currentMetadataRevision")]
+    public long? CurrentMetadataRevision { get; init; }
+
+    /// <summary>Current content-version reference in the target environment.</summary>
+    [JsonPropertyName("currentContentVersionId")]
+    public string? CurrentContentVersionId { get; init; }
+
+    /// <summary>Binding state in the target environment.</summary>
+    [JsonPropertyName("bindingState")]
+    public required MetadataEnvironmentBindingState BindingState { get; init; }
+
+    /// <summary>Secret-safe binding summary.</summary>
+    [JsonPropertyName("bindingSummary")]
+    public MetadataEnvironmentBindingSummary? BindingSummary { get; init; }
+}
+
+/// <summary>
+/// GitOps-safe metadata release manifest.
+/// </summary>
+public sealed record GitOpsMetadataReleaseManifest
+{
+    /// <summary>Manifest API version.</summary>
+    [JsonPropertyName("apiVersion")]
+    public string ApiVersion { get; init; } = MetadataV2Constants.ApiVersion;
+
+    /// <summary>Manifest kind.</summary>
+    [JsonPropertyName("kind")]
+    public string Kind { get; init; } = "MetadataReleasePackage";
+
+    /// <summary>Manifest metadata.</summary>
+    [JsonPropertyName("metadata")]
+    public required MetadataV2ObjectMetadata Metadata { get; init; }
+
+    /// <summary>Manifest specification.</summary>
+    [JsonPropertyName("spec")]
+    public required GitOpsMetadataReleaseSpec Spec { get; init; }
+}
+
+/// <summary>
+/// GitOps manifest spec for a metadata release package.
+/// </summary>
+public sealed record GitOpsMetadataReleaseSpec
+{
+    /// <summary>Package identifier.</summary>
+    [JsonPropertyName("packageId")]
+    public required Guid PackageId { get; init; }
+
+    /// <summary>Source environment revision.</summary>
+    [JsonPropertyName("source")]
+    public required GitOpsMetadataReleaseSource Source { get; init; }
+
+    /// <summary>Target environments.</summary>
+    [JsonPropertyName("targets")]
+    public IReadOnlyList<GitOpsMetadataReleaseTarget> Targets { get; init; } =
+        Array.Empty<GitOpsMetadataReleaseTarget>();
+
+    /// <summary>Release entries.</summary>
+    [JsonPropertyName("entries")]
+    public IReadOnlyList<GitOpsMetadataReleaseEntry> Entries { get; init; } =
+        Array.Empty<GitOpsMetadataReleaseEntry>();
+}
+
+/// <summary>
+/// GitOps manifest source environment state.
+/// </summary>
+public sealed record GitOpsMetadataReleaseSource
+{
+    /// <summary>Source environment.</summary>
+    [JsonPropertyName("environment")]
+    public required string Environment { get; init; }
+
+    /// <summary>Source Metadata v2 revision.</summary>
+    [JsonPropertyName("revision")]
+    public required long Revision { get; init; }
+
+    /// <summary>Source Metadata v2 entity tag.</summary>
+    [JsonPropertyName("etag")]
+    public required string ETag { get; init; }
+}
+
+/// <summary>
+/// GitOps manifest target environment.
+/// </summary>
+public sealed record GitOpsMetadataReleaseTarget
+{
+    /// <summary>Target environment.</summary>
+    [JsonPropertyName("environment")]
+    public required string Environment { get; init; }
+}
+
+/// <summary>
+/// GitOps-safe release entry.
+/// </summary>
+public sealed record GitOpsMetadataReleaseEntry
+{
+    /// <summary>Semantic identifier.</summary>
+    [JsonPropertyName("semanticId")]
+    public required string SemanticId { get; init; }
+
+    /// <summary>Artifact kind.</summary>
+    [JsonPropertyName("artifactKind")]
+    public required MetadataSemanticArtifactKind ArtifactKind { get; init; }
+
+    /// <summary>Resource type when applicable.</summary>
+    [JsonPropertyName("resourceType")]
+    public MetadataV2ResourceType? ResourceType { get; init; }
+
+    /// <summary>Desired Metadata v2 revision.</summary>
+    [JsonPropertyName("desiredMetadataRevision")]
+    public required long DesiredMetadataRevision { get; init; }
+
+    /// <summary>Desired content-version reference.</summary>
+    [JsonPropertyName("desiredContentVersionId")]
+    public string? DesiredContentVersionId { get; init; }
+
+    /// <summary>Desired provenance references.</summary>
+    [JsonPropertyName("desiredProvenance")]
+    public IReadOnlyList<ConsoleProvenanceRef> DesiredProvenance { get; init; } = Array.Empty<ConsoleProvenanceRef>();
+
+    /// <summary>Change class.</summary>
+    [JsonPropertyName("changeClass")]
+    public required MetadataReleaseChangeClass ChangeClass { get; init; }
+
+    /// <summary>Last-observed target states with secret-safe bindings.</summary>
+    [JsonPropertyName("targetStates")]
+    public IReadOnlyList<MetadataReleaseTargetState> TargetStates { get; init; } =
+        Array.Empty<MetadataReleaseTargetState>();
+
+    /// <summary>Dependent semantic identifiers.</summary>
+    [JsonPropertyName("dependentSemanticIds")]
+    public IReadOnlyList<string> DependentSemanticIds { get; init; } = Array.Empty<string>();
+}

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2Common.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2Common.cs
@@ -196,6 +196,12 @@ public sealed record MetadataV2ExtensionPoint
 public sealed record MetadataV2Field
 {
     /// <summary>
+    /// Stable semantic identifier for field-level promotion across environments.
+    /// </summary>
+    [JsonPropertyName("semanticId")]
+    public string? SemanticId { get; init; }
+
+    /// <summary>
     /// Stable source field name.
     /// </summary>
     [JsonPropertyName("name")]

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2Enums.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataV2Enums.cs
@@ -57,7 +57,49 @@ public enum MetadataV2ResourceType
     /// An external resource represented in the metadata graph.
     /// </summary>
     [JsonStringEnumMemberName("external-resource")]
-    ExternalResource
+    ExternalResource,
+
+    /// <summary>
+    /// A saved map composition or map document.
+    /// </summary>
+    [JsonStringEnumMemberName("map")]
+    Map,
+
+    /// <summary>
+    /// A dashboard composed from one or more data sources.
+    /// </summary>
+    [JsonStringEnumMemberName("dashboard")]
+    Dashboard,
+
+    /// <summary>
+    /// A field-collection or data-entry form.
+    /// </summary>
+    [JsonStringEnumMemberName("form")]
+    Form,
+
+    /// <summary>
+    /// A generated or configured application surface.
+    /// </summary>
+    [JsonStringEnumMemberName("app")]
+    App,
+
+    /// <summary>
+    /// A workflow definition.
+    /// </summary>
+    [JsonStringEnumMemberName("workflow")]
+    Workflow,
+
+    /// <summary>
+    /// A geoprocessing service definition.
+    /// </summary>
+    [JsonStringEnumMemberName("geoprocessing-service")]
+    GeoprocessingService,
+
+    /// <summary>
+    /// An ETL pipeline definition.
+    /// </summary>
+    [JsonStringEnumMemberName("etl-pipeline")]
+    EtlPipeline
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Metadata/MetadataServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Metadata/MetadataServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Honua.Core.Features.Metadata;
 
@@ -12,6 +13,21 @@ namespace Honua.Core.Features.Metadata;
 /// </summary>
 public static class MetadataServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers Metadata v2 release package services.
+    /// </summary>
+    /// <param name="services">The service collection to add services to.</param>
+    public static IServiceCollection AddMetadataReleaseServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(TimeProvider.System);
+        services.TryAddScoped<IMetadataV2EnvironmentSnapshotReader, MetadataV2GraphProviderEnvironmentSnapshotReader>();
+        services.TryAddSingleton<IMetadataReleasePackageStore, InMemoryMetadataReleasePackageStore>();
+        services.TryAddScoped<IMetadataReleaseService, MetadataReleaseService>();
+        return services;
+    }
+
     /// <summary>
     /// Registers the file-backed Metadata v2 graph provider. Loads a single JSON document
     /// at the given path. Intended for tests, fixtures, and dev scenarios where Postgres

--- a/src/Honua.Core/Features/Metadata/Services/InMemoryMetadataReleasePackageStore.cs
+++ b/src/Honua.Core/Features/Metadata/Services/InMemoryMetadataReleasePackageStore.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Core.Features.Metadata.Services;
+
+internal sealed class InMemoryMetadataReleasePackageStore : IMetadataReleasePackageStore
+{
+    private readonly ConcurrentDictionary<Guid, MetadataReleasePackage> _packages = new();
+
+    public Task<MetadataReleasePackage> CreateAsync(
+        MetadataReleasePackage package,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_packages.TryAdd(package.PackageId, package))
+        {
+            throw new InvalidOperationException($"Metadata release package '{package.PackageId}' already exists.");
+        }
+
+        return Task.FromResult(package);
+    }
+
+    public Task<MetadataReleasePackage?> GetAsync(
+        Guid packageId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _packages.TryGetValue(packageId, out var package);
+        return Task.FromResult(package);
+    }
+}

--- a/src/Honua.Core/Features/Metadata/Services/InMemoryMetadataReleasePackageStore.cs
+++ b/src/Honua.Core/Features/Metadata/Services/InMemoryMetadataReleasePackageStore.cs
@@ -10,6 +10,7 @@ namespace Honua.Core.Features.Metadata.Services;
 internal sealed class InMemoryMetadataReleasePackageStore : IMetadataReleasePackageStore
 {
     private readonly ConcurrentDictionary<Guid, MetadataReleasePackage> _packages = new();
+    private readonly ConcurrentDictionary<PackageIdentity, Guid> _packageKeys = new();
 
     public Task<MetadataReleasePackage> CreateAsync(
         MetadataReleasePackage package,
@@ -18,8 +19,16 @@ internal sealed class InMemoryMetadataReleasePackageStore : IMetadataReleasePack
         ArgumentNullException.ThrowIfNull(package);
         cancellationToken.ThrowIfCancellationRequested();
 
+        var identity = PackageIdentity.From(package.Metadata);
+        if (!_packageKeys.TryAdd(identity, package.PackageId))
+        {
+            throw new InvalidOperationException(
+                $"Metadata release package key '{identity.PackageKey}' already exists in namespace '{identity.Namespace}'.");
+        }
+
         if (!_packages.TryAdd(package.PackageId, package))
         {
+            _packageKeys.TryRemove(identity, out _);
             throw new InvalidOperationException($"Metadata release package '{package.PackageId}' already exists.");
         }
 
@@ -33,5 +42,20 @@ internal sealed class InMemoryMetadataReleasePackageStore : IMetadataReleasePack
         cancellationToken.ThrowIfCancellationRequested();
         _packages.TryGetValue(packageId, out var package);
         return Task.FromResult(package);
+    }
+
+    private readonly record struct PackageIdentity(string Namespace, string PackageKey)
+    {
+        public static PackageIdentity From(MetadataV2ObjectMetadata metadata)
+        {
+            var packageKey = string.IsNullOrWhiteSpace(metadata.Name)
+                ? throw new ArgumentException("Package metadata name is required.", nameof(metadata))
+                : metadata.Name.Trim();
+            var packageNamespace = string.IsNullOrWhiteSpace(metadata.Namespace)
+                ? string.Empty
+                : metadata.Namespace.Trim();
+
+            return new PackageIdentity(packageNamespace, packageKey);
+        }
     }
 }

--- a/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
+++ b/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
@@ -27,7 +27,7 @@ public sealed class MetadataReleaseService(
     private const string ContentVersionAnnotation = "honua.io/content-version-id";
     private const string ContentVersionCamelAnnotation = "contentVersionId";
     private const string ProvenanceAnnotation = "honua.io/provenance-ref";
-    private static readonly ActivitySource ActivitySource = new("Honua.Metadata.Release");
+    private static readonly ActivitySource ActivitySource = new("Honua.Core.Metadata");
 
     private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
 
@@ -163,9 +163,12 @@ public sealed class MetadataReleaseService(
                 });
             }
 
-            var desiredContentVersionId = string.IsNullOrWhiteSpace(request.DesiredContentVersionId)
-                ? artifact.ContentVersionId
+            var requestedContentVersionId = string.IsNullOrWhiteSpace(request.DesiredContentVersionId)
+                ? null
                 : request.DesiredContentVersionId!.Trim();
+            var desiredContentVersionId = string.IsNullOrWhiteSpace(artifact.ContentVersionId)
+                ? requestedContentVersionId
+                : artifact.ContentVersionId;
             var desiredProvenance = request.Provenance.Count > 0 ? request.Provenance : artifact.Provenance;
 
             entries.Add(new MetadataReleaseEntry

--- a/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
+++ b/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
@@ -1,0 +1,921 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.Console.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.Metadata.Services;
+
+/// <summary>
+/// Default implementation of semantic metadata inventory, binding, and release package workflows.
+/// </summary>
+public sealed class MetadataReleaseService(
+    IMetadataV2EnvironmentSnapshotReader snapshotReader,
+    IMetadataReleasePackageStore packageStore,
+    TimeProvider? timeProvider,
+    ILogger<MetadataReleaseService> logger) : IMetadataReleaseService
+{
+    private const int MaxBindingEnvironments = 10;
+    private const int MaxBindingSemanticIds = 500;
+    private const int MaxPackageEntries = 1000;
+    private const string ContentVersionAnnotation = "honua.io/content-version-id";
+    private const string ContentVersionCamelAnnotation = "contentVersionId";
+    private const string ProvenanceAnnotation = "honua.io/provenance-ref";
+    private static readonly ActivitySource ActivitySource = new("Honua.Metadata.Release");
+
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+
+    /// <inheritdoc />
+    public async Task<MetadataSemanticInventoryResponse?> GetSemanticInventoryAsync(
+        string environment,
+        MetadataSemanticInventoryFilter filter,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateEnvironment(environment);
+        using var activity = ActivitySource.StartActivity("honua.metadata.release.inventory", ActivityKind.Internal);
+        activity?.SetTag("metadata.environment", environment);
+
+        var snapshot = await snapshotReader.GetCurrentAsync(environment, cancellationToken).ConfigureAwait(false);
+        if (snapshot is null)
+        {
+            return null;
+        }
+
+        var entries = ProjectInventory(snapshot, filter);
+        activity?.SetTag("metadata.revision", snapshot.Revision);
+        activity?.SetTag("metadata.inventory.count", entries.Count);
+        MetadataReleaseServiceLog.InventoryProjected(logger, environment, snapshot.Revision, entries.Count);
+
+        return new MetadataSemanticInventoryResponse
+        {
+            Environment = snapshot.Graph.Environment,
+            Revision = snapshot.Revision,
+            ETag = snapshot.Etag,
+            GeneratedAt = _timeProvider.GetUtcNow(),
+            Entries = entries,
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<MetadataEnvironmentBindingsResponse> GetEnvironmentBindingsAsync(
+        MetadataEnvironmentBindingsRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var environments = NormalizeRequiredList(request.Environments, nameof(request.Environments), MaxBindingEnvironments);
+        var semanticIds = NormalizeRequiredList(request.SemanticIds, nameof(request.SemanticIds), MaxBindingSemanticIds);
+
+        using var activity = ActivitySource.StartActivity("honua.metadata.release.bindings", ActivityKind.Internal);
+        activity?.SetTag("metadata.environment.count", environments.Count);
+        activity?.SetTag("metadata.semantic_id.count", semanticIds.Count);
+
+        var bindings = new List<MetadataEnvironmentBindingSummary>(environments.Count * semanticIds.Count);
+        foreach (var environment in environments)
+        {
+            var snapshot = await snapshotReader.GetCurrentAsync(environment, cancellationToken).ConfigureAwait(false);
+            if (snapshot is null)
+            {
+                foreach (var semanticId in semanticIds)
+                {
+                    bindings.Add(new MetadataEnvironmentBindingSummary
+                    {
+                        SemanticId = semanticId,
+                        Environment = environment,
+                        State = MetadataEnvironmentBindingState.EnvironmentUnavailable,
+                    });
+                }
+                continue;
+            }
+
+            foreach (var semanticId in semanticIds)
+            {
+                bindings.Add(ProjectBinding(snapshot, semanticId));
+            }
+        }
+
+        MetadataReleaseServiceLog.BindingsResolved(logger, environments.Count, semanticIds.Count, bindings.Count);
+        return new MetadataEnvironmentBindingsResponse
+        {
+            RequestedAt = _timeProvider.GetUtcNow(),
+            Environments = environments,
+            Bindings = bindings,
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<MetadataReleasePackage> CreateReleasePackageAsync(
+        CreateMetadataReleasePackageRequest request,
+        string createdBy,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ValidateEnvironment(request.SourceEnvironment);
+
+        var targetEnvironments = NormalizeRequiredList(
+            request.TargetEnvironments,
+            nameof(request.TargetEnvironments),
+            MaxBindingEnvironments);
+        var semanticIds = NormalizeRequiredList(request.SemanticIds, nameof(request.SemanticIds), MaxPackageEntries);
+
+        using var activity = ActivitySource.StartActivity("honua.metadata.release.package.create", ActivityKind.Internal);
+        activity?.SetTag("metadata.source_environment", request.SourceEnvironment);
+        activity?.SetTag("metadata.target_environment.count", targetEnvironments.Count);
+        activity?.SetTag("metadata.semantic_id.count", semanticIds.Count);
+
+        var sourceSnapshot = await snapshotReader.GetCurrentAsync(request.SourceEnvironment, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new KeyNotFoundException(
+                $"Metadata v2 environment '{request.SourceEnvironment}' does not have an active revision.");
+
+        var targetSnapshots = new Dictionary<string, MetadataV2GraphSnapshot>(StringComparer.OrdinalIgnoreCase);
+        foreach (var targetEnvironment in targetEnvironments)
+        {
+            var snapshot = await snapshotReader.GetCurrentAsync(targetEnvironment, cancellationToken).ConfigureAwait(false)
+                ?? throw new KeyNotFoundException(
+                    $"Metadata v2 environment '{targetEnvironment}' does not have an active revision.");
+            targetSnapshots[targetEnvironment] = snapshot;
+        }
+
+        var entries = new List<MetadataReleaseEntry>(semanticIds.Count);
+        foreach (var semanticId in semanticIds)
+        {
+            var artifact = ResolveArtifact(sourceSnapshot, semanticId)
+                ?? throw new KeyNotFoundException(
+                    $"Semantic artifact '{semanticId}' was not found in source environment '{sourceSnapshot.Graph.Environment}'.");
+
+            var targetStates = new List<MetadataReleaseTargetState>(targetEnvironments.Count);
+            foreach (var targetEnvironment in targetEnvironments)
+            {
+                var binding = ProjectBinding(targetSnapshots[targetEnvironment], semanticId);
+                targetStates.Add(new MetadataReleaseTargetState
+                {
+                    Environment = targetEnvironment,
+                    CurrentMetadataRevision = binding.Revision,
+                    CurrentContentVersionId = binding.ContentVersionId,
+                    BindingState = binding.State,
+                    BindingSummary = binding,
+                });
+            }
+
+            var desiredContentVersionId = string.IsNullOrWhiteSpace(request.DesiredContentVersionId)
+                ? artifact.ContentVersionId
+                : request.DesiredContentVersionId!.Trim();
+            var desiredProvenance = request.Provenance.Count > 0 ? request.Provenance : artifact.Provenance;
+
+            entries.Add(new MetadataReleaseEntry
+            {
+                SemanticId = semanticId,
+                ArtifactKind = artifact.Kind,
+                ResourceType = artifact.Resource?.Type ?? artifact.ParentResource?.Type,
+                DesiredMetadataRevision = request.DesiredRevision ?? sourceSnapshot.Revision,
+                DesiredContentVersionId = desiredContentVersionId,
+                DesiredProvenance = desiredProvenance,
+                ChangeClass = ResolveChangeClass(request, semanticId),
+                TargetStates = targetStates,
+                DependentSemanticIds = ResolveDependencies(artifact),
+                Status = MetadataReleaseEntryStatus.Draft,
+            });
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        var packageId = Guid.NewGuid();
+        var packageKey = string.IsNullOrWhiteSpace(request.PackageKey)
+            ? BuildPackageKey(request, now)
+            : request.PackageKey!.Trim();
+        var metadata = new MetadataV2ObjectMetadata
+        {
+            Id = packageId.ToString("D"),
+            Name = packageKey,
+            Namespace = string.IsNullOrWhiteSpace(request.Namespace) ? null : request.Namespace.Trim(),
+            Title = string.IsNullOrWhiteSpace(request.Title) ? packageKey : request.Title.Trim(),
+            Description = string.IsNullOrWhiteSpace(request.Summary) ? null : request.Summary.Trim(),
+            CreatedAt = now,
+            UpdatedAt = now,
+            Generation = 1,
+            Labels = new Dictionary<string, string>
+            {
+                ["sourceEnvironment"] = sourceSnapshot.Graph.Environment,
+                ["sourceRevision"] = sourceSnapshot.Revision.ToString(CultureInfo.InvariantCulture),
+            },
+            Annotations = new Dictionary<string, string>
+            {
+                ["metadata.honua.io/sourceEtag"] = sourceSnapshot.Etag,
+            },
+        };
+
+        var package = new MetadataReleasePackage
+        {
+            PackageId = packageId,
+            Metadata = metadata,
+            SourceEnvironment = sourceSnapshot.Graph.Environment,
+            SourceRevision = sourceSnapshot.Revision,
+            SourceEtag = sourceSnapshot.Etag,
+            TargetEnvironments = targetEnvironments,
+            Entries = entries,
+            Status = MetadataReleasePackageStatus.Draft,
+            CreatedBy = string.IsNullOrWhiteSpace(createdBy) ? "system" : createdBy.Trim(),
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        var stored = await packageStore.CreateAsync(package, cancellationToken).ConfigureAwait(false);
+        activity?.SetTag("metadata.package_id", stored.PackageId);
+        activity?.SetTag("metadata.source_revision", stored.SourceRevision);
+        MetadataReleaseServiceLog.PackageCreated(
+            logger,
+            stored.PackageId,
+            stored.SourceEnvironment,
+            stored.SourceRevision,
+            stored.TargetEnvironments.Count,
+            stored.Entries.Count);
+        return stored;
+    }
+
+    /// <inheritdoc />
+    public Task<MetadataReleasePackage?> GetReleasePackageAsync(
+        Guid packageId,
+        CancellationToken cancellationToken = default)
+    {
+        if (packageId == Guid.Empty)
+        {
+            throw new ArgumentException("Package id is required.", nameof(packageId));
+        }
+
+        return packageStore.GetAsync(packageId, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<GitOpsMetadataReleaseManifest?> GetGitOpsManifestAsync(
+        Guid packageId,
+        CancellationToken cancellationToken = default)
+    {
+        using var activity = ActivitySource.StartActivity("honua.metadata.release.manifest.export", ActivityKind.Internal);
+        activity?.SetTag("metadata.package_id", packageId);
+
+        var package = await GetReleasePackageAsync(packageId, cancellationToken).ConfigureAwait(false);
+        if (package is null)
+        {
+            return null;
+        }
+
+        var manifest = new GitOpsMetadataReleaseManifest
+        {
+            Metadata = package.Metadata,
+            Spec = new GitOpsMetadataReleaseSpec
+            {
+                PackageId = package.PackageId,
+                Source = new GitOpsMetadataReleaseSource
+                {
+                    Environment = package.SourceEnvironment,
+                    Revision = package.SourceRevision,
+                    ETag = package.SourceEtag,
+                },
+                Targets = package.TargetEnvironments
+                    .Select(static environment => new GitOpsMetadataReleaseTarget { Environment = environment })
+                    .ToArray(),
+                Entries = package.Entries.Select(static entry => new GitOpsMetadataReleaseEntry
+                {
+                    SemanticId = entry.SemanticId,
+                    ArtifactKind = entry.ArtifactKind,
+                    ResourceType = entry.ResourceType,
+                    DesiredMetadataRevision = entry.DesiredMetadataRevision,
+                    DesiredContentVersionId = entry.DesiredContentVersionId,
+                    DesiredProvenance = entry.DesiredProvenance,
+                    ChangeClass = entry.ChangeClass,
+                    TargetStates = entry.TargetStates,
+                    DependentSemanticIds = entry.DependentSemanticIds,
+                }).ToArray(),
+            },
+        };
+
+        MetadataReleaseServiceLog.ManifestExported(logger, package.PackageId, package.Entries.Count);
+        return manifest;
+    }
+
+    private static List<MetadataSemanticInventoryEntry> ProjectInventory(
+        MetadataV2GraphSnapshot snapshot,
+        MetadataSemanticInventoryFilter filter)
+    {
+        var entries = new List<MetadataSemanticInventoryEntry>(
+            snapshot.Graph.Resources.Count
+            + snapshot.Graph.Services.Count
+            + snapshot.Graph.Publications.Count
+            + snapshot.Graph.Catalogs.Count
+            + snapshot.Graph.Policies.Count
+            + snapshot.Graph.Roles.Count);
+
+        foreach (var resource in snapshot.Graph.Resources)
+        {
+            AddIfMatches(entries, ToInventoryEntry(resource), filter);
+            foreach (var field in resource.SchemaFields)
+            {
+                AddIfMatches(entries, ToInventoryEntry(resource, field), filter);
+            }
+        }
+
+        foreach (var service in snapshot.Graph.Services)
+        {
+            AddIfMatches(entries, ToInventoryEntry(service), filter);
+        }
+
+        foreach (var publication in snapshot.Graph.Publications)
+        {
+            snapshot.Index.ResourcesById.TryGetValue(publication.ResourceId, out var resource);
+            AddIfMatches(entries, ToInventoryEntry(publication, resource), filter);
+        }
+
+        foreach (var catalog in snapshot.Graph.Catalogs)
+        {
+            AddIfMatches(entries, ToInventoryEntry(catalog), filter);
+        }
+
+        foreach (var policy in snapshot.Graph.Policies)
+        {
+            AddIfMatches(entries, ToInventoryEntry(policy), filter);
+        }
+
+        foreach (var role in snapshot.Graph.Roles)
+        {
+            AddIfMatches(entries, ToInventoryEntry(role), filter);
+        }
+
+        return entries;
+    }
+
+    private static void AddIfMatches(
+        List<MetadataSemanticInventoryEntry> entries,
+        MetadataSemanticInventoryEntry entry,
+        MetadataSemanticInventoryFilter filter)
+    {
+        if (filter.ArtifactKind is { } artifactKind && entry.ArtifactKind != artifactKind)
+        {
+            return;
+        }
+
+        if (filter.ResourceType is { } resourceType && entry.ResourceType != resourceType)
+        {
+            return;
+        }
+
+        entries.Add(entry);
+    }
+
+    private static MetadataEnvironmentBindingSummary ProjectBinding(
+        MetadataV2GraphSnapshot snapshot,
+        string semanticId)
+    {
+        var artifact = ResolveArtifact(snapshot, semanticId);
+        if (artifact is null)
+        {
+            return new MetadataEnvironmentBindingSummary
+            {
+                SemanticId = semanticId,
+                Environment = snapshot.Graph.Environment,
+                State = MetadataEnvironmentBindingState.Missing,
+                Revision = snapshot.Revision,
+                ETag = snapshot.Etag,
+                LastObservedAt = snapshot.LoadedAt,
+            };
+        }
+
+        var storage = ResolveStorage(snapshot, artifact);
+        var connection = ResolveConnection(snapshot, storage);
+        return new MetadataEnvironmentBindingSummary
+        {
+            SemanticId = semanticId,
+            Environment = snapshot.Graph.Environment,
+            State = MetadataEnvironmentBindingState.Bound,
+            Revision = snapshot.Revision,
+            ETag = snapshot.Etag,
+            ArtifactKind = artifact.Kind,
+            Resource = artifact.Resource is not null ? ToResourceSummary(artifact.Resource) :
+                artifact.ParentResource is not null ? ToResourceSummary(artifact.ParentResource) : null,
+            Field = artifact.Field is not null && artifact.ParentResource is not null
+                ? ToFieldSummary(artifact.ParentResource, artifact.Field)
+                : null,
+            Service = artifact.Service is not null ? ToServiceSummary(artifact.Service) : null,
+            Publication = artifact.Publication is not null ? ToPublicationSummary(artifact.Publication) : null,
+            Storage = storage is not null ? ToStorageSummary(storage) : null,
+            Connection = connection is not null ? ToConnectionSummary(connection) : null,
+            ContentVersionId = artifact.ContentVersionId,
+            LastObservedAt = snapshot.LoadedAt,
+        };
+    }
+
+    private static ResolvedSemanticArtifact? ResolveArtifact(MetadataV2GraphSnapshot snapshot, string semanticId)
+    {
+        if (snapshot.Index.ResourcesById.TryGetValue(semanticId, out var resource))
+        {
+            return new ResolvedSemanticArtifact(
+                semanticId,
+                MetadataSemanticArtifactKind.Resource,
+                Resource: resource,
+                ContentVersionId: ExtractContentVersion(resource.Metadata),
+                ProvenanceRefs: ExtractProvenance(resource.Metadata));
+        }
+
+        if (snapshot.Index.ServicesById.TryGetValue(semanticId, out var service))
+        {
+            return new ResolvedSemanticArtifact(
+                semanticId,
+                MetadataSemanticArtifactKind.Service,
+                Service: service,
+                ContentVersionId: ExtractContentVersion(service.Metadata),
+                ProvenanceRefs: ExtractProvenance(service.Metadata));
+        }
+
+        if (snapshot.Index.PublicationsById.TryGetValue(semanticId, out var publication))
+        {
+            snapshot.Index.ResourcesById.TryGetValue(publication.ResourceId, out var publicationResource);
+            snapshot.Index.ServicesById.TryGetValue(publication.ServiceId, out var publicationService);
+            return new ResolvedSemanticArtifact(
+                semanticId,
+                MetadataSemanticArtifactKind.Publication,
+                ParentResource: publicationResource,
+                Service: publicationService,
+                Publication: publication,
+                ContentVersionId: ExtractContentVersion(publication.Metadata),
+                ProvenanceRefs: ExtractProvenance(publication.Metadata));
+        }
+
+        if (snapshot.Index.CatalogsById.TryGetValue(semanticId, out var catalog))
+        {
+            return new ResolvedSemanticArtifact(
+                semanticId,
+                MetadataSemanticArtifactKind.Catalog,
+                Catalog: catalog,
+                ContentVersionId: ExtractContentVersion(catalog.Metadata),
+                ProvenanceRefs: ExtractProvenance(catalog.Metadata));
+        }
+
+        if (snapshot.Index.PoliciesById.TryGetValue(semanticId, out var policy))
+        {
+            return new ResolvedSemanticArtifact(
+                semanticId,
+                MetadataSemanticArtifactKind.Policy,
+                Policy: policy,
+                ContentVersionId: ExtractContentVersion(policy.Metadata),
+                ProvenanceRefs: ExtractProvenance(policy.Metadata));
+        }
+
+        if (snapshot.Index.RolesById.TryGetValue(semanticId, out var role))
+        {
+            return new ResolvedSemanticArtifact(
+                semanticId,
+                MetadataSemanticArtifactKind.Role,
+                Role: role,
+                ContentVersionId: ExtractContentVersion(role.Metadata),
+                ProvenanceRefs: ExtractProvenance(role.Metadata));
+        }
+
+        foreach (var candidateResource in snapshot.Graph.Resources)
+        {
+            foreach (var field in candidateResource.SchemaFields)
+            {
+                var fieldSemanticId = GetFieldSemanticId(candidateResource, field);
+                if (!string.Equals(fieldSemanticId, semanticId, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                return new ResolvedSemanticArtifact(
+                    semanticId,
+                    MetadataSemanticArtifactKind.Field,
+                    ParentResource: candidateResource,
+                    Field: field,
+                    ContentVersionId: ExtractContentVersion(candidateResource.Metadata),
+                    ProvenanceRefs: ExtractProvenance(candidateResource.Metadata));
+            }
+        }
+
+        return null;
+    }
+
+    private static MetadataV2StorageBinding? ResolveStorage(
+        MetadataV2GraphSnapshot snapshot,
+        ResolvedSemanticArtifact artifact)
+    {
+        var resource = artifact.Resource ?? artifact.ParentResource;
+        if (artifact.Publication?.StorageBindingId is { Length: > 0 } publicationStorageBindingId &&
+            snapshot.Index.StorageBindingsById.TryGetValue(publicationStorageBindingId, out var publicationStorage))
+        {
+            return publicationStorage;
+        }
+
+        if (resource?.PrimaryStorageBindingId is { Length: > 0 } primaryStorageBindingId &&
+            snapshot.Index.StorageBindingsById.TryGetValue(primaryStorageBindingId, out var primaryStorage))
+        {
+            return primaryStorage;
+        }
+
+        if (resource is null)
+        {
+            return null;
+        }
+
+        return snapshot.Index.StorageBindingsByResource[resource.Metadata.Id].FirstOrDefault();
+    }
+
+    private static MetadataV2Connection? ResolveConnection(
+        MetadataV2GraphSnapshot snapshot,
+        MetadataV2StorageBinding? storage)
+    {
+        if (storage?.ConnectionId is not { Length: > 0 } connectionId)
+        {
+            return null;
+        }
+
+        return snapshot.Index.ConnectionsById.TryGetValue(connectionId, out var connection) ? connection : null;
+    }
+
+    private static MetadataReleaseChangeClass ResolveChangeClass(
+        CreateMetadataReleasePackageRequest request,
+        string semanticId)
+    {
+        if (request.ChangeClasses is not null &&
+            request.ChangeClasses.TryGetValue(semanticId, out var changeClass))
+        {
+            return changeClass;
+        }
+
+        return MetadataReleaseChangeClass.Metadata;
+    }
+
+    private static string[] ResolveDependencies(ResolvedSemanticArtifact artifact)
+    {
+        var dependencies = new List<string>(3);
+        if (artifact.ParentResource is not null)
+        {
+            dependencies.Add(artifact.ParentResource.Metadata.Id);
+        }
+
+        if (artifact.Publication is not null)
+        {
+            dependencies.Add(artifact.Publication.ResourceId);
+            dependencies.Add(artifact.Publication.ServiceId);
+            if (!string.IsNullOrWhiteSpace(artifact.Publication.StorageBindingId))
+            {
+                dependencies.Add(artifact.Publication.StorageBindingId);
+            }
+        }
+
+        return dependencies.Distinct(StringComparer.Ordinal).ToArray();
+    }
+
+    private static MetadataSemanticInventoryEntry ToInventoryEntry(MetadataV2Resource resource)
+        => new()
+        {
+            SemanticId = resource.Metadata.Id,
+            ArtifactKind = MetadataSemanticArtifactKind.Resource,
+            ResourceType = resource.Type,
+            Name = resource.Metadata.Name,
+            Namespace = resource.Metadata.Namespace,
+            Title = resource.Metadata.Title,
+            MetadataGeneration = resource.Metadata.Generation,
+            Status = resource.Status,
+            ContentVersionId = ExtractContentVersion(resource.Metadata),
+            Provenance = ExtractProvenance(resource.Metadata),
+            PolicyIds = resource.PolicyIds,
+        };
+
+    private static MetadataSemanticInventoryEntry ToInventoryEntry(MetadataV2Resource resource, MetadataV2Field field)
+        => new()
+        {
+            SemanticId = GetFieldSemanticId(resource, field),
+            ArtifactKind = MetadataSemanticArtifactKind.Field,
+            ResourceType = resource.Type,
+            ParentSemanticId = resource.Metadata.Id,
+            Name = field.Name,
+            Namespace = resource.Metadata.Namespace,
+            Title = field.Title,
+            MetadataGeneration = resource.Metadata.Generation,
+            ContentVersionId = ExtractContentVersion(resource.Metadata),
+            Provenance = ExtractProvenance(resource.Metadata),
+            PolicyIds = resource.PolicyIds,
+        };
+
+    private static MetadataSemanticInventoryEntry ToInventoryEntry(MetadataV2Service service)
+        => new()
+        {
+            SemanticId = service.Metadata.Id,
+            ArtifactKind = MetadataSemanticArtifactKind.Service,
+            ServiceType = service.ServiceType,
+            Name = service.Metadata.Name,
+            Namespace = service.Metadata.Namespace,
+            Title = service.Metadata.Title,
+            MetadataGeneration = service.Metadata.Generation,
+            Status = service.Status,
+            ContentVersionId = ExtractContentVersion(service.Metadata),
+            Provenance = ExtractProvenance(service.Metadata),
+        };
+
+    private static MetadataSemanticInventoryEntry ToInventoryEntry(
+        MetadataV2Publication publication,
+        MetadataV2Resource? resource)
+        => new()
+        {
+            SemanticId = publication.Metadata.Id,
+            ArtifactKind = MetadataSemanticArtifactKind.Publication,
+            ResourceType = resource?.Type,
+            PublicationType = publication.PublicationType,
+            ParentSemanticId = publication.ResourceId,
+            Name = publication.Metadata.Name,
+            Namespace = publication.Metadata.Namespace,
+            Title = publication.TitleOverride ?? publication.Metadata.Title,
+            MetadataGeneration = publication.Metadata.Generation,
+            Status = publication.Status,
+            ContentVersionId = ExtractContentVersion(publication.Metadata),
+            Provenance = ExtractProvenance(publication.Metadata),
+        };
+
+    private static MetadataSemanticInventoryEntry ToInventoryEntry(MetadataV2Catalog catalog)
+        => new()
+        {
+            SemanticId = catalog.Metadata.Id,
+            ArtifactKind = MetadataSemanticArtifactKind.Catalog,
+            Name = catalog.Metadata.Name,
+            Namespace = catalog.Metadata.Namespace,
+            Title = catalog.Metadata.Title,
+            MetadataGeneration = catalog.Metadata.Generation,
+            Status = catalog.Status,
+            ContentVersionId = ExtractContentVersion(catalog.Metadata),
+            Provenance = ExtractProvenance(catalog.Metadata),
+        };
+
+    private static MetadataSemanticInventoryEntry ToInventoryEntry(MetadataV2Policy policy)
+        => new()
+        {
+            SemanticId = policy.Metadata.Id,
+            ArtifactKind = MetadataSemanticArtifactKind.Policy,
+            Name = policy.Metadata.Name,
+            Namespace = policy.Metadata.Namespace,
+            Title = policy.Metadata.Title,
+            MetadataGeneration = policy.Metadata.Generation,
+            Status = policy.Status,
+            ContentVersionId = ExtractContentVersion(policy.Metadata),
+            Provenance = ExtractProvenance(policy.Metadata),
+        };
+
+    private static MetadataSemanticInventoryEntry ToInventoryEntry(MetadataV2Role role)
+        => new()
+        {
+            SemanticId = role.Metadata.Id,
+            ArtifactKind = MetadataSemanticArtifactKind.Role,
+            Name = role.Metadata.Name,
+            Namespace = role.Metadata.Namespace,
+            Title = role.Metadata.Title,
+            MetadataGeneration = role.Metadata.Generation,
+            Status = role.Status,
+            ContentVersionId = ExtractContentVersion(role.Metadata),
+            Provenance = ExtractProvenance(role.Metadata),
+            PolicyIds = role.PolicyIds,
+        };
+
+    private static MetadataBoundResourceSummary ToResourceSummary(MetadataV2Resource resource)
+        => new()
+        {
+            Id = resource.Metadata.Id,
+            Name = resource.Metadata.Name,
+            Namespace = resource.Metadata.Namespace,
+            Title = resource.Metadata.Title,
+            ResourceType = resource.Type,
+            PrimaryStorageBindingId = resource.PrimaryStorageBindingId,
+        };
+
+    private static MetadataBoundFieldSummary ToFieldSummary(MetadataV2Resource resource, MetadataV2Field field)
+        => new()
+        {
+            SemanticId = GetFieldSemanticId(resource, field),
+            ParentResourceId = resource.Metadata.Id,
+            FieldName = field.Name,
+            FieldType = field.Type,
+        };
+
+    private static MetadataBoundServiceSummary ToServiceSummary(MetadataV2Service service)
+        => new()
+        {
+            Id = service.Metadata.Id,
+            Name = service.Metadata.Name,
+            Namespace = service.Metadata.Namespace,
+            Title = service.Metadata.Title,
+            ServiceType = service.ServiceType,
+            Route = service.Route,
+        };
+
+    private static MetadataBoundPublicationSummary ToPublicationSummary(MetadataV2Publication publication)
+        => new()
+        {
+            Id = publication.Metadata.Id,
+            ResourceId = publication.ResourceId,
+            ServiceId = publication.ServiceId,
+            PublicationType = publication.PublicationType,
+            Path = publication.Path,
+            LayerIndex = publication.LayerIndex,
+            ServiceLocalId = publication.ServiceLocalId,
+        };
+
+    private static MetadataBoundStorageSummary ToStorageSummary(MetadataV2StorageBinding storage)
+        => new()
+        {
+            Id = storage.Metadata.Id,
+            ResourceId = storage.ResourceId,
+            StorageType = storage.StorageType,
+            Locator = storage.Locator,
+            ConnectionId = storage.ConnectionId,
+        };
+
+    private static MetadataBoundConnectionSummary ToConnectionSummary(MetadataV2Connection connection)
+        => new()
+        {
+            Id = connection.Metadata.Id,
+            Name = connection.Metadata.Name,
+            ConnectionType = connection.Type,
+            Provider = connection.Provider,
+            Endpoint = connection.Endpoint,
+            SecretRef = connection.SecretRef,
+        };
+
+    private static string? ExtractContentVersion(MetadataV2ObjectMetadata metadata)
+    {
+        if (TryGetString(metadata.Annotations, ContentVersionAnnotation, out var annotationValue) ||
+            TryGetString(metadata.Annotations, ContentVersionCamelAnnotation, out annotationValue) ||
+            TryGetString(metadata.Labels, ContentVersionAnnotation, out annotationValue) ||
+            TryGetString(metadata.Labels, ContentVersionCamelAnnotation, out annotationValue))
+        {
+            return annotationValue;
+        }
+
+        return null;
+    }
+
+    private static ConsoleProvenanceRef[] ExtractProvenance(MetadataV2ObjectMetadata metadata)
+    {
+        if (!TryGetString(metadata.Annotations, ProvenanceAnnotation, out var value))
+        {
+            return Array.Empty<ConsoleProvenanceRef>();
+        }
+
+        return
+        [
+            new ConsoleProvenanceRef
+            {
+                Kind = "metadata-v2",
+                ItemId = value,
+                Rel = "derived-from",
+                Namespace = metadata.Namespace,
+            },
+        ];
+    }
+
+    private static bool TryGetString(
+        IReadOnlyDictionary<string, string> values,
+        string key,
+        out string value)
+    {
+        if (values.TryGetValue(key, out var candidate) && !string.IsNullOrWhiteSpace(candidate))
+        {
+            value = candidate.Trim();
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    private static string GetFieldSemanticId(MetadataV2Resource resource, MetadataV2Field field)
+        => string.IsNullOrWhiteSpace(field.SemanticId)
+            ? $"field.{resource.Metadata.Id}.{field.Name}"
+            : field.SemanticId.Trim();
+
+    private static List<string> NormalizeRequiredList(
+        IReadOnlyList<string> values,
+        string parameterName,
+        int maxCount)
+    {
+        if (values.Count == 0)
+        {
+            throw new ArgumentException($"{parameterName} must contain at least one value.", parameterName);
+        }
+
+        if (values.Count > maxCount)
+        {
+            throw new ArgumentException($"{parameterName} cannot contain more than {maxCount} values.", parameterName);
+        }
+
+        var normalized = new List<string>(values.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException($"{parameterName} cannot contain blank values.", parameterName);
+            }
+
+            var trimmed = value.Trim();
+            if (seen.Add(trimmed))
+            {
+                normalized.Add(trimmed);
+            }
+        }
+
+        return normalized;
+    }
+
+    private static void ValidateEnvironment(string environment)
+    {
+        if (string.IsNullOrWhiteSpace(environment))
+        {
+            throw new ArgumentException("Environment is required.", nameof(environment));
+        }
+    }
+
+    private static string BuildPackageKey(CreateMetadataReleasePackageRequest request, DateTimeOffset now)
+    {
+        var basis = string.IsNullOrWhiteSpace(request.Title)
+            ? $"metadata-release-{request.SourceEnvironment}-{now:yyyyMMddHHmmss}"
+            : request.Title!;
+        var builder = new StringBuilder(basis.Length);
+        foreach (var ch in basis.Trim().ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                builder.Append(ch);
+            }
+            else if (builder.Length > 0 && builder[^1] != '-')
+            {
+                builder.Append('-');
+            }
+        }
+
+        var result = builder.ToString().Trim('-');
+        return string.IsNullOrEmpty(result) ? $"metadata-release-{now:yyyyMMddHHmmss}" : result;
+    }
+
+    private sealed record ResolvedSemanticArtifact(
+        string SemanticId,
+        MetadataSemanticArtifactKind Kind,
+        MetadataV2Resource? Resource = null,
+        MetadataV2Resource? ParentResource = null,
+        MetadataV2Field? Field = null,
+        MetadataV2Service? Service = null,
+        MetadataV2Publication? Publication = null,
+        MetadataV2Catalog? Catalog = null,
+        MetadataV2Policy? Policy = null,
+        MetadataV2Role? Role = null,
+        string? ContentVersionId = null,
+        IReadOnlyList<ConsoleProvenanceRef>? ProvenanceRefs = null)
+    {
+        public IReadOnlyList<ConsoleProvenanceRef> Provenance { get; } =
+            ProvenanceRefs ?? Array.Empty<ConsoleProvenanceRef>();
+    }
+}
+
+internal static partial class MetadataReleaseServiceLog
+{
+    [LoggerMessage(
+        EventId = 116300,
+        Level = LogLevel.Information,
+        Message = "Metadata release inventory projected for environment {Environment} revision {Revision} with {EntryCount} entries.")]
+    public static partial void InventoryProjected(
+        ILogger logger,
+        string environment,
+        long revision,
+        int entryCount);
+
+    [LoggerMessage(
+        EventId = 116301,
+        Level = LogLevel.Information,
+        Message = "Metadata release bindings resolved for {EnvironmentCount} environments and {SemanticIdCount} semantic ids with {BindingCount} bindings.")]
+    public static partial void BindingsResolved(
+        ILogger logger,
+        int environmentCount,
+        int semanticIdCount,
+        int bindingCount);
+
+    [LoggerMessage(
+        EventId = 116302,
+        Level = LogLevel.Information,
+        Message = "Metadata release package {PackageId} created from {SourceEnvironment} revision {SourceRevision} for {TargetEnvironmentCount} targets and {EntryCount} entries.")]
+    public static partial void PackageCreated(
+        ILogger logger,
+        Guid packageId,
+        string sourceEnvironment,
+        long sourceRevision,
+        int targetEnvironmentCount,
+        int entryCount);
+
+    [LoggerMessage(
+        EventId = 116303,
+        Level = LogLevel.Information,
+        Message = "Metadata release package {PackageId} exported as GitOps manifest with {EntryCount} entries.")]
+    public static partial void ManifestExported(
+        ILogger logger,
+        Guid packageId,
+        int entryCount);
+}

--- a/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
+++ b/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
@@ -182,6 +182,7 @@ public sealed class MetadataReleaseService(
                 SemanticId = semanticId,
                 ArtifactKind = artifact.Kind,
                 ResourceType = artifact.Resource?.Type ?? artifact.ParentResource?.Type,
+                SourceField = ToSourceFieldSummary(artifact),
                 DesiredMetadataRevision = request.DesiredRevision ?? sourceSnapshot.Revision,
                 DesiredContentVersionId = desiredContentVersionId,
                 DesiredProvenance = desiredProvenance,
@@ -293,6 +294,7 @@ public sealed class MetadataReleaseService(
                     SemanticId = entry.SemanticId,
                     ArtifactKind = entry.ArtifactKind,
                     ResourceType = entry.ResourceType,
+                    SourceField = entry.SourceField,
                     DesiredMetadataRevision = entry.DesiredMetadataRevision,
                     DesiredContentVersionId = entry.DesiredContentVersionId,
                     DesiredProvenance = entry.DesiredProvenance,
@@ -705,6 +707,11 @@ public sealed class MetadataReleaseService(
             FieldName = field.Name,
             FieldType = field.Type,
         };
+
+    private static MetadataBoundFieldSummary? ToSourceFieldSummary(ResolvedSemanticArtifact artifact)
+        => artifact.Field is not null && artifact.ParentResource is not null
+            ? ToFieldSummary(artifact.ParentResource, artifact.Field)
+            : null;
 
     private static MetadataBoundServiceSummary ToServiceSummary(MetadataV2Service service)
         => new()

--- a/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
+++ b/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
@@ -122,6 +122,7 @@ public sealed class MetadataReleaseService(
             nameof(request.TargetEnvironments),
             MaxBindingEnvironments);
         var semanticIds = NormalizeRequiredList(request.SemanticIds, nameof(request.SemanticIds), MaxPackageEntries);
+        var provenance = NormalizeOptionalList(request.Provenance, nameof(request.Provenance));
 
         using var activity = ActivitySource.StartActivity("honua.metadata.release.package.create", ActivityKind.Internal);
         activity?.SetTag("metadata.source_environment", request.SourceEnvironment);
@@ -169,7 +170,7 @@ public sealed class MetadataReleaseService(
             var desiredContentVersionId = string.IsNullOrWhiteSpace(artifact.ContentVersionId)
                 ? requestedContentVersionId
                 : artifact.ContentVersionId;
-            var desiredProvenance = request.Provenance.Count > 0 ? request.Provenance : artifact.Provenance;
+            var desiredProvenance = provenance.Count > 0 ? provenance : artifact.Provenance;
 
             entries.Add(new MetadataReleaseEntry
             {
@@ -797,10 +798,15 @@ public sealed class MetadataReleaseService(
             : field.SemanticId.Trim();
 
     private static List<string> NormalizeRequiredList(
-        IReadOnlyList<string> values,
+        IReadOnlyList<string>? values,
         string parameterName,
         int maxCount)
     {
+        if (values is null)
+        {
+            throw new ArgumentException($"{parameterName} must be an array.", parameterName);
+        }
+
         if (values.Count == 0)
         {
             throw new ArgumentException($"{parameterName} must contain at least one value.", parameterName);
@@ -828,6 +834,18 @@ public sealed class MetadataReleaseService(
         }
 
         return normalized;
+    }
+
+    private static IReadOnlyList<T> NormalizeOptionalList<T>(
+        IReadOnlyList<T>? values,
+        string parameterName)
+    {
+        if (values is null)
+        {
+            throw new ArgumentException($"{parameterName} must be an array.", parameterName);
+        }
+
+        return values;
     }
 
     private static void ValidateEnvironment(string environment)

--- a/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
+++ b/src/Honua.Core/Features/Metadata/Services/MetadataReleaseService.cs
@@ -129,10 +129,15 @@ public sealed class MetadataReleaseService(
         activity?.SetTag("metadata.target_environment.count", targetEnvironments.Count);
         activity?.SetTag("metadata.semantic_id.count", semanticIds.Count);
 
-        var sourceSnapshot = await snapshotReader.GetCurrentAsync(request.SourceEnvironment, cancellationToken)
-            .ConfigureAwait(false)
-            ?? throw new KeyNotFoundException(
-                $"Metadata v2 environment '{request.SourceEnvironment}' does not have an active revision.");
+        var sourceSnapshot = request.DesiredRevision is long desiredRevision
+            ? await snapshotReader.GetByRevisionAsync(request.SourceEnvironment, desiredRevision, cancellationToken)
+                .ConfigureAwait(false)
+                ?? throw new KeyNotFoundException(
+                    $"Metadata v2 environment '{request.SourceEnvironment}' does not have revision '{desiredRevision.ToString(CultureInfo.InvariantCulture)}'.")
+            : await snapshotReader.GetCurrentAsync(request.SourceEnvironment, cancellationToken)
+                .ConfigureAwait(false)
+                ?? throw new KeyNotFoundException(
+                    $"Metadata v2 environment '{request.SourceEnvironment}' does not have an active revision.");
 
         var targetSnapshots = new Dictionary<string, MetadataV2GraphSnapshot>(StringComparer.OrdinalIgnoreCase);
         foreach (var targetEnvironment in targetEnvironments)
@@ -190,7 +195,7 @@ public sealed class MetadataReleaseService(
         var now = _timeProvider.GetUtcNow();
         var packageId = Guid.NewGuid();
         var packageKey = string.IsNullOrWhiteSpace(request.PackageKey)
-            ? BuildPackageKey(request, now)
+            ? BuildPackageKey(request, now, packageId)
             : request.PackageKey!.Trim();
         var metadata = new MetadataV2ObjectMetadata
         {
@@ -856,12 +861,12 @@ public sealed class MetadataReleaseService(
         }
     }
 
-    private static string BuildPackageKey(CreateMetadataReleasePackageRequest request, DateTimeOffset now)
+    private static string BuildPackageKey(CreateMetadataReleasePackageRequest request, DateTimeOffset now, Guid packageId)
     {
         var basis = string.IsNullOrWhiteSpace(request.Title)
-            ? $"metadata-release-{request.SourceEnvironment}-{now:yyyyMMddHHmmss}"
+            ? $"metadata-release-{request.SourceEnvironment}"
             : request.Title!;
-        var builder = new StringBuilder(basis.Length);
+        var builder = new StringBuilder(basis.Length + 26);
         foreach (var ch in basis.Trim().ToLowerInvariant())
         {
             if (char.IsLetterOrDigit(ch))
@@ -875,7 +880,14 @@ public sealed class MetadataReleaseService(
         }
 
         var result = builder.ToString().Trim('-');
-        return string.IsNullOrEmpty(result) ? $"metadata-release-{now:yyyyMMddHHmmss}" : result;
+        if (string.IsNullOrEmpty(result))
+        {
+            result = "metadata-release";
+        }
+
+        var timestamp = now.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
+        var nonce = packageId.ToString("N")[..8];
+        return string.Concat(result, "-", timestamp, "-", nonce);
     }
 
     private sealed record ResolvedSemanticArtifact(

--- a/src/Honua.Core/Features/Metadata/Services/MetadataV2GraphProviderEnvironmentSnapshotReader.cs
+++ b/src/Honua.Core/Features/Metadata/Services/MetadataV2GraphProviderEnvironmentSnapshotReader.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Core.Features.Metadata.Services;
+
+internal sealed class MetadataV2GraphProviderEnvironmentSnapshotReader(
+    IMetadataV2GraphProvider graphProvider) : IMetadataV2EnvironmentSnapshotReader
+{
+    public async ValueTask<MetadataV2GraphSnapshot?> GetCurrentAsync(
+        string environment,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(environment))
+        {
+            return null;
+        }
+
+        var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        return MatchesEnvironment(snapshot, environment) ? snapshot : null;
+    }
+
+    public async ValueTask<MetadataV2GraphSnapshot?> GetByRevisionAsync(
+        string environment,
+        long revision,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(environment))
+        {
+            return null;
+        }
+
+        var snapshot = await graphProvider.GetByRevisionAsync(revision, cancellationToken).ConfigureAwait(false);
+        return snapshot is not null && MatchesEnvironment(snapshot, environment) ? snapshot : null;
+    }
+
+    public async IAsyncEnumerable<MetadataV2EnvironmentRevision> ListCurrentRevisionsAsync(
+        IReadOnlyList<string> environments,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (environments.Count == 0)
+        {
+            yield break;
+        }
+
+        var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var environment in environments)
+        {
+            if (MatchesEnvironment(snapshot, environment))
+            {
+                yield return new MetadataV2EnvironmentRevision
+                {
+                    Environment = snapshot.Graph.Environment,
+                    Revision = snapshot.Revision,
+                    ETag = snapshot.Etag,
+                    ActivatedAt = snapshot.LoadedAt,
+                };
+            }
+        }
+    }
+
+    private static bool MatchesEnvironment(MetadataV2GraphSnapshot snapshot, string environment)
+        => string.Equals(snapshot.Graph.Environment, environment.Trim(), StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Honua.Postgres/Features/Metadata/PostgresMetadataReleasePackageStore.cs
+++ b/src/Honua.Postgres/Features/Metadata/PostgresMetadataReleasePackageStore.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.Metadata;
+
+internal sealed class PostgresMetadataReleasePackageStore : IMetadataReleasePackageStore
+{
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly string _packagesTable;
+
+    public PostgresMetadataReleasePackageStore(
+        IDatabaseConnectionProvider connectionProvider,
+        string? schemaName = null)
+    {
+        ArgumentNullException.ThrowIfNull(connectionProvider);
+        _connectionProvider = connectionProvider;
+        _packagesTable = Infrastructure.SchemaSearchPath.QualifyTable("metadata_v2_release_packages", schemaName);
+    }
+
+    public async Task<MetadataReleasePackage> CreateAsync(
+        MetadataReleasePackage package,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+
+        var targetEnvironmentsJson = JsonSerializer.Serialize(
+            package.TargetEnvironments.ToArray(),
+            MetadataReleaseJsonContext.Default.StringArray);
+        var entriesJson = JsonSerializer.Serialize(
+            package.Entries.ToArray(),
+            MetadataReleaseJsonContext.Default.MetadataReleaseEntryArray);
+        var metadataJson = JsonSerializer.Serialize(
+            package.Metadata,
+            MetadataReleaseJsonContext.Default.MetadataV2ObjectMetadata);
+
+        var sql = $"""
+            INSERT INTO {_packagesTable}
+                (package_id, package_key, package_namespace, status, source_environment, source_revision,
+                 source_etag, target_environments, entries, package_metadata, created_by, created_at, updated_at)
+            VALUES
+                (@package_id, @package_key, @package_namespace, @status, @source_environment, @source_revision,
+                 @source_etag, @target_environments, @entries, @package_metadata, @created_by, @created_at, @updated_at)
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@package_id", package.PackageId);
+        command.Parameters.AddWithValue("@package_key", package.Metadata.Name);
+        command.Parameters.AddWithValue("@package_namespace", (object?)package.Metadata.Namespace ?? DBNull.Value);
+        command.Parameters.AddWithValue("@status", ToDbStatus(package.Status));
+        command.Parameters.AddWithValue("@source_environment", package.SourceEnvironment);
+        command.Parameters.AddWithValue("@source_revision", package.SourceRevision);
+        command.Parameters.AddWithValue("@source_etag", package.SourceEtag);
+        command.Parameters.Add(new NpgsqlParameter("@target_environments", NpgsqlDbType.Jsonb) { Value = targetEnvironmentsJson });
+        command.Parameters.Add(new NpgsqlParameter("@entries", NpgsqlDbType.Jsonb) { Value = entriesJson });
+        command.Parameters.Add(new NpgsqlParameter("@package_metadata", NpgsqlDbType.Jsonb) { Value = metadataJson });
+        command.Parameters.AddWithValue("@created_by", package.CreatedBy);
+        command.Parameters.AddWithValue("@created_at", package.CreatedAt);
+        command.Parameters.AddWithValue("@updated_at", package.UpdatedAt);
+
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return package;
+    }
+
+    public async Task<MetadataReleasePackage?> GetAsync(
+        Guid packageId,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SELECT package_id, status, source_environment, source_revision, source_etag,
+                   target_environments, entries, package_metadata, created_by, created_at, updated_at
+            FROM {_packagesTable}
+            WHERE package_id = @package_id
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@package_id", packageId);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        var targetEnvironments = JsonSerializer.Deserialize(
+                reader.GetString(5),
+                MetadataReleaseJsonContext.Default.StringArray)
+            ?? Array.Empty<string>();
+        var entries = JsonSerializer.Deserialize(
+                reader.GetString(6),
+                MetadataReleaseJsonContext.Default.MetadataReleaseEntryArray)
+            ?? Array.Empty<MetadataReleaseEntry>();
+        var metadata = JsonSerializer.Deserialize(
+                reader.GetString(7),
+                MetadataReleaseJsonContext.Default.MetadataV2ObjectMetadata)
+            ?? throw new InvalidDataException("Metadata release package metadata was empty.");
+
+        return new MetadataReleasePackage
+        {
+            PackageId = reader.GetGuid(0),
+            Metadata = metadata,
+            SourceEnvironment = reader.GetString(2),
+            SourceRevision = reader.GetInt64(3),
+            SourceEtag = reader.GetString(4),
+            TargetEnvironments = targetEnvironments,
+            Entries = entries,
+            Status = FromDbStatus(reader.GetString(1)),
+            CreatedBy = reader.GetString(8),
+            CreatedAt = reader.GetFieldValue<DateTimeOffset>(9),
+            UpdatedAt = reader.GetFieldValue<DateTimeOffset>(10),
+        };
+    }
+
+    private static string ToDbStatus(MetadataReleasePackageStatus status)
+        => status switch
+        {
+            MetadataReleasePackageStatus.Draft => "draft",
+            MetadataReleasePackageStatus.Ready => "ready",
+            MetadataReleasePackageStatus.Staged => "staged",
+            MetadataReleasePackageStatus.Superseded => "superseded",
+            MetadataReleasePackageStatus.Cancelled => "cancelled",
+            _ => "draft",
+        };
+
+    private static MetadataReleasePackageStatus FromDbStatus(string status)
+        => status switch
+        {
+            "draft" => MetadataReleasePackageStatus.Draft,
+            "ready" => MetadataReleasePackageStatus.Ready,
+            "staged" => MetadataReleasePackageStatus.Staged,
+            "superseded" => MetadataReleasePackageStatus.Superseded,
+            "cancelled" => MetadataReleasePackageStatus.Cancelled,
+            _ => MetadataReleasePackageStatus.Draft,
+        };
+}

--- a/src/Honua.Postgres/Features/Metadata/PostgresMetadataReleasePackageStore.cs
+++ b/src/Honua.Postgres/Features/Metadata/PostgresMetadataReleasePackageStore.cs
@@ -65,7 +65,16 @@ internal sealed class PostgresMetadataReleasePackageStore : IMetadataReleasePack
         command.Parameters.AddWithValue("@created_at", package.CreatedAt);
         command.Parameters.AddWithValue("@updated_at", package.UpdatedAt);
 
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
+        {
+            throw new InvalidOperationException(
+                "Metadata release package conflicts with an existing package.", ex);
+        }
+
         return package;
     }
 

--- a/src/Honua.Postgres/Features/Metadata/PostgresMetadataV2EnvironmentSnapshotReader.cs
+++ b/src/Honua.Postgres/Features/Metadata/PostgresMetadataV2EnvironmentSnapshotReader.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Npgsql;
+
+namespace Honua.Postgres.Features.Metadata;
+
+internal sealed class PostgresMetadataV2EnvironmentSnapshotReader : IMetadataV2EnvironmentSnapshotReader
+{
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly string _snapshotsTable;
+    private readonly string _currentTable;
+
+    public PostgresMetadataV2EnvironmentSnapshotReader(
+        IDatabaseConnectionProvider connectionProvider,
+        string? schemaName = null)
+    {
+        ArgumentNullException.ThrowIfNull(connectionProvider);
+        _connectionProvider = connectionProvider;
+        _snapshotsTable = Infrastructure.SchemaSearchPath.QualifyTable("metadata_v2_snapshots", schemaName);
+        _currentTable = Infrastructure.SchemaSearchPath.QualifyTable("metadata_v2_current", schemaName);
+    }
+
+    public async ValueTask<MetadataV2GraphSnapshot?> GetCurrentAsync(
+        string environment,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(environment))
+        {
+            return null;
+        }
+
+        var sql = $"""
+            SELECT s.document, s.etag
+            FROM {_currentTable} c
+            JOIN {_snapshotsTable} s ON s.environment = c.environment AND s.revision = c.revision
+            WHERE c.environment = @environment
+            """;
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@environment", environment.Trim());
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return MaterializeSnapshot(reader.GetString(0), reader.GetString(1));
+    }
+
+    public async ValueTask<MetadataV2GraphSnapshot?> GetByRevisionAsync(
+        string environment,
+        long revision,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(environment))
+        {
+            return null;
+        }
+
+        var sql = $"""
+            SELECT document, etag
+            FROM {_snapshotsTable}
+            WHERE environment = @environment AND revision = @revision
+            """;
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@environment", environment.Trim());
+        command.Parameters.AddWithValue("@revision", revision);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return MaterializeSnapshot(reader.GetString(0), reader.GetString(1));
+    }
+
+    public async IAsyncEnumerable<MetadataV2EnvironmentRevision> ListCurrentRevisionsAsync(
+        IReadOnlyList<string> environments,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (environments.Count == 0)
+        {
+            yield break;
+        }
+
+        var normalized = environments
+            .Where(static environment => !string.IsNullOrWhiteSpace(environment))
+            .Select(static environment => environment.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (normalized.Length == 0)
+        {
+            yield break;
+        }
+
+        var sql = $"""
+            SELECT environment, revision, etag, activated_at
+            FROM {_currentTable}
+            WHERE environment = ANY(@environments)
+            ORDER BY environment
+            """;
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@environments", normalized);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            yield return new MetadataV2EnvironmentRevision
+            {
+                Environment = reader.GetString(0),
+                Revision = reader.GetInt64(1),
+                ETag = reader.GetString(2),
+                ActivatedAt = reader.GetFieldValue<DateTimeOffset>(3),
+            };
+        }
+    }
+
+    private static MetadataV2GraphSnapshot MaterializeSnapshot(string json, string etag)
+    {
+        var graph = JsonSerializer.Deserialize(json, MetadataV2JsonContext.Default.MetadataV2Graph)
+            ?? throw new InvalidDataException("Metadata v2 graph document was empty.");
+        return new MetadataV2GraphSnapshot(graph, etag, DateTimeOffset.UtcNow);
+    }
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -155,6 +155,14 @@ internal static class ServiceCollectionExtensions
                 configuration["Metadata:Environment"] ?? configuration["Environment"] ?? "default",
                 configuration["Database:Schema"]));
         services.AddScoped<IMetadataV2GraphProvider>(sp => sp.GetRequiredService<IMetadataV2GraphStore>());
+        services.AddScoped<IMetadataV2EnvironmentSnapshotReader>(serviceProvider =>
+            new Features.Metadata.PostgresMetadataV2EnvironmentSnapshotReader(
+                serviceProvider.GetRequiredService<IDatabaseConnectionProvider>(),
+                configuration["Database:Schema"]));
+        services.AddScoped<IMetadataReleasePackageStore>(serviceProvider =>
+            new Features.Metadata.PostgresMetadataReleasePackageStore(
+                serviceProvider.GetRequiredService<IDatabaseConnectionProvider>(),
+                configuration["Database:Schema"]));
 
         // Register layer style catalog for MapLibre/GeoServices styling
         services.AddScoped<ILayerStyleCatalog>(serviceProvider =>

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -96,6 +96,11 @@ public static class EndpointRegistry
         new("GET", "/api/v1/admin/version"),
         new("GET", "/api/v1/admin/capabilities"),
         // v1 manifest endpoints removed in #1035 cutover (V2 admin UX is tracked under epic #1046).
+        new("GET", "/api/v1/admin/metadata/environments/{environment}/inventory"),
+        new("POST", "/api/v1/admin/metadata/environment-bindings/query"),
+        new("POST", "/api/v1/admin/metadata/release-packages"),
+        new("GET", "/api/v1/admin/metadata/release-packages/{packageId}"),
+        new("GET", "/api/v1/admin/metadata/release-packages/{packageId}/gitops-manifest"),
         new("GET", "/api/v1/admin/deploy/preflight"),
         new("POST", "/api/v1/admin/deploy/plan"),
         new("POST", "/api/v1/admin/deploy/operations"),

--- a/src/Honua.Server/Features/Admin/MetadataReleaseEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/MetadataReleaseEndpoints.cs
@@ -1,0 +1,266 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Server.Features.Console;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Admin endpoints for Metadata v2 semantic inventory, environment bindings, and release packages.
+/// </summary>
+internal static class MetadataReleaseEndpoints
+{
+    /// <summary>
+    /// Maps Metadata v2 release package endpoints.
+    /// </summary>
+    public static void MapMetadataReleaseEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/metadata")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Metadata", "Releases")
+            .RequireAdminAuthorization();
+
+        group.MapGet("/environments/{environment}/inventory", HandleGetInventory)
+            .WithDisplayName("Get Metadata Semantic Inventory")
+            .WithSummary("Returns the active Metadata v2 revision-stamped semantic inventory for an environment.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<MetadataSemanticInventoryResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        group.MapPost("/environment-bindings/query", HandleQueryEnvironmentBindings)
+            .WithDisplayName("Query Metadata Environment Bindings")
+            .WithSummary("Returns secret-safe binding summaries for semantic ids across environments.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
+            .Produces<MetadataEnvironmentBindingsResponse>();
+
+        group.MapPost("/release-packages", HandleCreateReleasePackage)
+            .WithDisplayName("Create Metadata Release Package")
+            .WithSummary("Persists a Metadata v2 release package for semantic cross-environment promotion.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
+            .Produces<MetadataReleasePackage>(StatusCodes.Status201Created);
+
+        group.MapGet("/release-packages/{packageId:guid}", HandleGetReleasePackage)
+            .WithDisplayName("Get Metadata Release Package")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<MetadataReleasePackage>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        group.MapGet("/release-packages/{packageId:guid}/gitops-manifest", HandleGetGitOpsManifest)
+            .WithDisplayName("Get Metadata Release GitOps Manifest")
+            .WithSummary("Exports a persisted release package as a GitOps-safe JSON manifest.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<GitOpsMetadataReleaseManifest>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+    }
+
+    private static async Task<IResult> HandleGetInventory(
+        string environment,
+        [FromServices] IMetadataReleaseService releaseService,
+        HttpContext context,
+        [FromQuery] string? artifactKind = null,
+        [FromQuery] string? resourceType = null)
+    {
+        var artifactKindValid = TryParseArtifactKind(artifactKind, out var artifactKindFilter, out var artifactKindError);
+        var resourceTypeValid = TryParseResourceType(resourceType, out var resourceTypeFilter, out var resourceTypeError);
+        if (!artifactKindValid || !resourceTypeValid)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status400BadRequest,
+                artifactKindError ?? resourceTypeError ?? "Invalid inventory filter.");
+        }
+
+        try
+        {
+            var response = await releaseService.GetSemanticInventoryAsync(
+                environment,
+                new MetadataSemanticInventoryFilter
+                {
+                    ArtifactKind = artifactKindFilter,
+                    ResourceType = resourceTypeFilter,
+                },
+                context.RequestAborted).ConfigureAwait(false);
+
+            return response is null
+                ? ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status404NotFound,
+                    $"Metadata v2 environment '{environment}' does not have an active revision.")
+                : Results.Json(response, MetadataReleaseJsonContext.Default.MetadataSemanticInventoryResponse);
+        }
+        catch (ArgumentException ex)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, ex.Message);
+        }
+    }
+
+    private static async Task<IResult> HandleQueryEnvironmentBindings(
+        [FromBody] MetadataEnvironmentBindingsRequest request,
+        [FromServices] IMetadataReleaseService releaseService,
+        HttpContext context)
+    {
+        try
+        {
+            var response = await releaseService.GetEnvironmentBindingsAsync(request, context.RequestAborted)
+                .ConfigureAwait(false);
+            return Results.Json(response, MetadataReleaseJsonContext.Default.MetadataEnvironmentBindingsResponse);
+        }
+        catch (ArgumentException ex)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, ex.Message);
+        }
+    }
+
+    private static async Task<IResult> HandleCreateReleasePackage(
+        [FromBody] CreateMetadataReleasePackageRequest request,
+        [FromServices] IMetadataReleaseService releaseService,
+        HttpContext context)
+    {
+        try
+        {
+            var actor = ConsolePrincipal.ResolveActorId(context.User) ?? "system";
+            var package = await releaseService.CreateReleasePackageAsync(request, actor, context.RequestAborted)
+                .ConfigureAwait(false);
+            return Results.Json(
+                package,
+                MetadataReleaseJsonContext.Default.MetadataReleasePackage,
+                statusCode: StatusCodes.Status201Created);
+        }
+        catch (ArgumentException ex)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, ex.Message);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status404NotFound, ex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status409Conflict,
+                "Metadata release package conflicts with an existing package.");
+        }
+        catch (Exception)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status500InternalServerError,
+                "Metadata release package could not be created.");
+        }
+    }
+
+    private static async Task<IResult> HandleGetReleasePackage(
+        Guid packageId,
+        [FromServices] IMetadataReleaseService releaseService,
+        HttpContext context)
+    {
+        try
+        {
+            var package = await releaseService.GetReleasePackageAsync(packageId, context.RequestAborted)
+                .ConfigureAwait(false);
+            return package is null
+                ? ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status404NotFound,
+                    $"Metadata release package '{packageId}' was not found.")
+                : Results.Json(package, MetadataReleaseJsonContext.Default.MetadataReleasePackage);
+        }
+        catch (ArgumentException ex)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, ex.Message);
+        }
+    }
+
+    private static async Task<IResult> HandleGetGitOpsManifest(
+        Guid packageId,
+        [FromServices] IMetadataReleaseService releaseService,
+        HttpContext context)
+    {
+        try
+        {
+            var manifest = await releaseService.GetGitOpsManifestAsync(packageId, context.RequestAborted)
+                .ConfigureAwait(false);
+            return manifest is null
+                ? ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status404NotFound,
+                    $"Metadata release package '{packageId}' was not found.")
+                : Results.Json(manifest, MetadataReleaseJsonContext.Default.GitOpsMetadataReleaseManifest);
+        }
+        catch (ArgumentException ex)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, ex.Message);
+        }
+    }
+
+    private static bool TryParseArtifactKind(
+        string? raw,
+        out MetadataSemanticArtifactKind? value,
+        out string? error)
+    {
+        value = null;
+        error = null;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return true;
+        }
+
+        value = raw.Trim().ToLowerInvariant() switch
+        {
+            "resource" => MetadataSemanticArtifactKind.Resource,
+            "service" => MetadataSemanticArtifactKind.Service,
+            "publication" => MetadataSemanticArtifactKind.Publication,
+            "field" => MetadataSemanticArtifactKind.Field,
+            "catalog" => MetadataSemanticArtifactKind.Catalog,
+            "policy" => MetadataSemanticArtifactKind.Policy,
+            "role" => MetadataSemanticArtifactKind.Role,
+            _ => null,
+        };
+
+        error = value is null ? $"Unsupported artifactKind filter '{raw}'." : null;
+        return value is not null;
+    }
+
+    private static bool TryParseResourceType(
+        string? raw,
+        out MetadataV2ResourceType? value,
+        out string? error)
+    {
+        value = null;
+        error = null;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return true;
+        }
+
+        value = raw.Trim().ToLowerInvariant() switch
+        {
+            "feature-dataset" or "featuredataset" => MetadataV2ResourceType.FeatureDataset,
+            "raster-dataset" or "rasterdataset" => MetadataV2ResourceType.RasterDataset,
+            "table" => MetadataV2ResourceType.Table,
+            "tile-dataset" or "tiledataset" => MetadataV2ResourceType.TileDataset,
+            "process" => MetadataV2ResourceType.Process,
+            "style" => MetadataV2ResourceType.Style,
+            "document" => MetadataV2ResourceType.Document,
+            "external-resource" or "externalresource" => MetadataV2ResourceType.ExternalResource,
+            "map" => MetadataV2ResourceType.Map,
+            "dashboard" => MetadataV2ResourceType.Dashboard,
+            "form" => MetadataV2ResourceType.Form,
+            "app" => MetadataV2ResourceType.App,
+            "workflow" => MetadataV2ResourceType.Workflow,
+            "geoprocessing-service" or "geoprocessingservice" => MetadataV2ResourceType.GeoprocessingService,
+            "etl-pipeline" or "etlpipeline" => MetadataV2ResourceType.EtlPipeline,
+            _ => null,
+        };
+
+        error = value is null ? $"Unsupported resourceType filter '{raw}'." : null;
+        return value is not null;
+    }
+}

--- a/src/Honua.Server/Features/Admin/MetadataReleaseEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/MetadataReleaseEndpoints.cs
@@ -147,7 +147,7 @@ internal static class MetadataReleaseEndpoints
                 StatusCodes.Status409Conflict,
                 "Metadata release package conflicts with an existing package.");
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             return ProblemDetailsHelpers.CreateAdminProblem(
                 context,

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.Compliance;
+using Honua.Core.Features.Metadata;
 using Honua.Postgres.Features.Scene;
 using Honua.Server.Features.Admin;
 using Honua.Server.Features.Infrastructure.Scene;
@@ -98,6 +99,7 @@ internal static class FeatureRegistrationExtensions
         services.AddSpatialAnalytics();
         services.AddSpec(configuration);
         services.AddEnhancedAdminServices();
+        services.AddMetadataReleaseServices();
         services.AddCompliance(configuration);
         services.AddOrchestration();
         services.AddPMTilesProxy();

--- a/src/Honua.Server/Migrations/034_CreateMetadataV2ReleasePackages.sql
+++ b/src/Honua.Server/Migrations/034_CreateMetadataV2ReleasePackages.sql
@@ -1,0 +1,36 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Metadata v2 release packages for GitOps-safe semantic promotion (#1163).
+-- Packages reference Metadata v2 revisions and serialize changed semantic entries as JSONB while
+-- the release contract is alpha. Secret material is never stored here; bindings carry references only.
+
+CREATE TABLE IF NOT EXISTS honua.metadata_v2_release_packages (
+    package_id          UUID        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    package_key         TEXT        NOT NULL,
+    package_namespace   TEXT        NULL,
+    status              TEXT        NOT NULL DEFAULT 'draft',
+    source_environment  TEXT        NOT NULL,
+    source_revision     BIGINT      NOT NULL,
+    source_etag         TEXT        NOT NULL,
+    target_environments JSONB       NOT NULL,
+    entries             JSONB       NOT NULL,
+    package_metadata    JSONB       NOT NULL,
+    created_by          TEXT        NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT metadata_v2_release_packages_status
+        CHECK (status IN ('draft','ready','staged','superseded','cancelled'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_metadata_v2_release_packages_key
+    ON honua.metadata_v2_release_packages (package_namespace, package_key);
+
+CREATE INDEX IF NOT EXISTS idx_metadata_v2_release_packages_created
+    ON honua.metadata_v2_release_packages (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_metadata_v2_release_packages_status
+    ON honua.metadata_v2_release_packages (status);
+
+COMMENT ON TABLE honua.metadata_v2_release_packages IS
+    'GitOps-safe Metadata v2 release packages for semantic cross-environment promotion (#1163).';

--- a/src/Honua.Server/Migrations/034_CreateMetadataV2ReleasePackages.sql
+++ b/src/Honua.Server/Migrations/034_CreateMetadataV2ReleasePackages.sql
@@ -24,7 +24,10 @@ CREATE TABLE IF NOT EXISTS honua.metadata_v2_release_packages (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_metadata_v2_release_packages_key
-    ON honua.metadata_v2_release_packages (package_namespace, package_key);
+    ON honua.metadata_v2_release_packages (
+        (COALESCE(NULLIF(BTRIM(package_namespace), ''), '')),
+        package_key
+    );
 
 CREATE INDEX IF NOT EXISTS idx_metadata_v2_release_packages_created
     ON honua.metadata_v2_release_packages (created_at DESC);

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -534,6 +534,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Admin.Models.SecureConnectionJsonContext.Default,
         Honua.Server.Features.Admin.Models.LayerPublishingJsonContext.Default,
         Honua.Server.Features.Admin.Models.ServiceSettingsJsonContext.Default,
+        Honua.Core.Features.Metadata.Domain.V2.MetadataReleaseJsonContext.Default,
         Honua.Server.Features.Admin.Models.DeployControlJsonContext.Default,
         Honua.Server.Features.Infrastructure.Monitoring.MetricsJsonContext.Default,
         Honua.Server.Features.Import.ImportJsonContext.Default,
@@ -940,6 +941,7 @@ app.MapServiceSettingsEndpoints();
 
 // Configure admin metadata version/manifest endpoints
 // v1 admin endpoint mappings removed in #1035 cutover; V2 admin UX (#1046) lives elsewhere.
+app.MapMetadataReleaseEndpoints();
 app.MapDeployControlEndpoints();
 
 // Configure admin layer style endpoints

--- a/src/Honua.Server/Startup/JsonContextRegistration.cs
+++ b/src/Honua.Server/Startup/JsonContextRegistration.cs
@@ -28,6 +28,7 @@ internal static class JsonContextRegistration
                 Honua.Server.Features.Admin.Models.SecureConnectionJsonContext.Default,
                 Honua.Server.Features.Admin.Models.LayerPublishingJsonContext.Default,
                 Honua.Server.Features.Admin.Models.ServiceSettingsJsonContext.Default,
+                Honua.Core.Features.Metadata.Domain.V2.MetadataReleaseJsonContext.Default,
                 Honua.Server.Features.Admin.Models.DeployControlJsonContext.Default,
                 Honua.Server.Features.Infrastructure.Monitoring.MetricsJsonContext.Default,
                 Honua.Server.Features.Import.ImportJsonContext.Default,

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataV2ModelTests.cs
@@ -330,7 +330,14 @@ public sealed class MetadataV2ModelTests
             nameof(MetadataV2ResourceType.Process),
             nameof(MetadataV2ResourceType.Style),
             nameof(MetadataV2ResourceType.Document),
-            nameof(MetadataV2ResourceType.ExternalResource));
+            nameof(MetadataV2ResourceType.ExternalResource),
+            nameof(MetadataV2ResourceType.Map),
+            nameof(MetadataV2ResourceType.Dashboard),
+            nameof(MetadataV2ResourceType.Form),
+            nameof(MetadataV2ResourceType.App),
+            nameof(MetadataV2ResourceType.Workflow),
+            nameof(MetadataV2ResourceType.GeoprocessingService),
+            nameof(MetadataV2ResourceType.EtlPipeline));
 
         Enum.GetNames<MetadataV2PublicationType>().Should().Contain(
             [

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataReleaseServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataReleaseServiceTests.cs
@@ -193,6 +193,51 @@ public sealed class MetadataReleaseServiceTests
     }
 
     [UnitTest]
+    public async Task CreateReleasePackageAsync_WithFieldAndMissingTarget_PersistsSourceFieldIdentity()
+    {
+        var service = CreateService(
+            BuildGraph("dev", 41, MetadataV2ResourceType.FeatureDataset),
+            BuildGraph("staging", 7, MetadataV2ResourceType.FeatureDataset, includeSchemaField: false));
+
+        var package = await service.CreateReleasePackageAsync(
+            new CreateMetadataReleasePackageRequest
+            {
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["field.parcels.apn"],
+            },
+            "user-1");
+
+        var entry = package.Entries.Should().ContainSingle().Subject;
+        entry.SemanticId.Should().Be("field.parcels.apn");
+        entry.ArtifactKind.Should().Be(MetadataSemanticArtifactKind.Field);
+        entry.SourceField.Should().NotBeNull();
+        entry.SourceField!.SemanticId.Should().Be("field.parcels.apn");
+        entry.SourceField.ParentResourceId.Should().Be("res.parcels");
+        entry.SourceField.FieldName.Should().Be("apn");
+        entry.SourceField.FieldType.Should().Be("string");
+        var targetState = entry.TargetStates.Should().ContainSingle().Subject;
+        targetState.Environment.Should().Be("staging");
+        targetState.CurrentMetadataRevision.Should().Be(7);
+        targetState.BindingState.Should().Be(MetadataEnvironmentBindingState.Missing);
+        targetState.BindingSummary.Should().NotBeNull();
+        targetState.BindingSummary!.Field.Should().BeNull();
+
+        var manifest = await service.GetGitOpsManifestAsync(package.PackageId);
+        var manifestEntry = manifest!.Spec.Entries.Should().ContainSingle().Subject;
+        manifestEntry.SourceField.Should().NotBeNull();
+        manifestEntry.SourceField!.ParentResourceId.Should().Be("res.parcels");
+        manifestEntry.SourceField.FieldName.Should().Be("apn");
+
+        var json = JsonSerializer.Serialize(
+            manifest,
+            MetadataReleaseJsonContext.Default.GitOpsMetadataReleaseManifest);
+        json.Should().Contain("\"sourceField\"");
+        json.Should().Contain("\"parentResourceId\":\"res.parcels\"");
+        json.Should().Contain("\"fieldName\":\"apn\"");
+    }
+
+    [UnitTest]
     public async Task CreateReleasePackageAsync_WithGeneratedTitleKey_CreatesUniquePackageNames()
     {
         var service = CreateService(
@@ -356,7 +401,8 @@ public sealed class MetadataReleaseServiceTests
         string environment,
         long revision,
         MetadataV2ResourceType resourceType,
-        string contentVersionId = "content-v1")
+        string contentVersionId = "content-v1",
+        bool includeSchemaField = true)
     {
         var passwordOption = JsonSerializer.Deserialize<JsonElement>("\"super-secret-password\"");
         return new MetadataV2Graph
@@ -382,15 +428,7 @@ public sealed class MetadataReleaseServiceTests
                     Type = resourceType,
                     StorageBindingIds = ["storage.parcels"],
                     PrimaryStorageBindingId = "storage.parcels",
-                    SchemaFields =
-                    [
-                        new MetadataV2Field
-                        {
-                            SemanticId = "field.parcels.apn",
-                            Name = "apn",
-                            Type = "string",
-                        },
-                    ],
+                    SchemaFields = BuildSchemaFields(includeSchemaField),
                     PolicyIds = ["policy.read-parcels"],
                 },
             ],
@@ -462,6 +500,24 @@ public sealed class MetadataReleaseServiceTests
                 },
             ],
         };
+    }
+
+    private static MetadataV2Field[] BuildSchemaFields(bool includeSchemaField)
+    {
+        if (!includeSchemaField)
+        {
+            return Array.Empty<MetadataV2Field>();
+        }
+
+        return
+        [
+            new MetadataV2Field
+            {
+                SemanticId = "field.parcels.apn",
+                Name = "apn",
+                Type = "string",
+            },
+        ];
     }
 
     private sealed class StaticEnvironmentReader : IMetadataV2EnvironmentSnapshotReader

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataReleaseServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataReleaseServiceTests.cs
@@ -169,6 +169,61 @@ public sealed class MetadataReleaseServiceTests
     }
 
     [UnitTest]
+    public async Task CreateReleasePackageAsync_WithDesiredRevision_ResolvesArtifactsFromRequestedSourceSnapshot()
+    {
+        var service = CreateService(
+            BuildGraph("dev", 40, MetadataV2ResourceType.FeatureDataset, "content-v40"),
+            BuildGraph("dev", 41, MetadataV2ResourceType.FeatureDataset, "content-v41"),
+            BuildGraph("staging", 7, MetadataV2ResourceType.FeatureDataset));
+
+        var package = await service.CreateReleasePackageAsync(
+            new CreateMetadataReleasePackageRequest
+            {
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["res.parcels"],
+                DesiredRevision = 40,
+            },
+            "user-1");
+
+        package.SourceRevision.Should().Be(40);
+        package.SourceEtag.Should().Be("etag-dev-40");
+        package.Entries.Should().ContainSingle()
+            .Subject.DesiredContentVersionId.Should().Be("content-v40");
+    }
+
+    [UnitTest]
+    public async Task CreateReleasePackageAsync_WithGeneratedTitleKey_CreatesUniquePackageNames()
+    {
+        var service = CreateService(
+            BuildGraph("dev", 41, MetadataV2ResourceType.FeatureDataset),
+            BuildGraph("staging", 7, MetadataV2ResourceType.FeatureDataset));
+
+        var first = await service.CreateReleasePackageAsync(
+            new CreateMetadataReleasePackageRequest
+            {
+                Title = "Promote parcels",
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["res.parcels"],
+            },
+            "user-1");
+        var second = await service.CreateReleasePackageAsync(
+            new CreateMetadataReleasePackageRequest
+            {
+                Title = "Promote parcels",
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["res.parcels"],
+            },
+            "user-1");
+
+        first.Metadata.Name.Should().StartWith("promote-parcels-");
+        second.Metadata.Name.Should().StartWith("promote-parcels-");
+        second.Metadata.Name.Should().NotBe(first.Metadata.Name);
+    }
+
+    [UnitTest]
     public async Task CreateReleasePackageAsync_WithRequestContentVersion_KeepsArtifactContentVersionWhenPresent()
     {
         var service = CreateService(
@@ -256,7 +311,7 @@ public sealed class MetadataReleaseServiceTests
     public async Task GetGitOpsManifestAsync_ForPersistedPackage_UsesSourceGeneratedSecretSafeShape()
     {
         var service = CreateService(
-            BuildGraph("dev", 41, MetadataV2ResourceType.FeatureDataset),
+            BuildGraph("dev", 42, MetadataV2ResourceType.FeatureDataset),
             BuildGraph("staging", 7, MetadataV2ResourceType.FeatureDataset));
         var package = await service.CreateReleasePackageAsync(
             new CreateMetadataReleasePackageRequest
@@ -274,7 +329,7 @@ public sealed class MetadataReleaseServiceTests
         manifest.Should().NotBeNull();
         manifest!.ApiVersion.Should().Be(MetadataV2Constants.ApiVersion);
         manifest.Kind.Should().Be("MetadataReleasePackage");
-        manifest.Spec.Source.Revision.Should().Be(41);
+        manifest.Spec.Source.Revision.Should().Be(42);
         manifest.Spec.Entries.Should().ContainSingle(entry =>
             entry.SemanticId == "pub.parcels" &&
             entry.DesiredMetadataRevision == 42 &&
@@ -300,7 +355,8 @@ public sealed class MetadataReleaseServiceTests
     private static MetadataV2Graph BuildGraph(
         string environment,
         long revision,
-        MetadataV2ResourceType resourceType)
+        MetadataV2ResourceType resourceType,
+        string contentVersionId = "content-v1")
     {
         var passwordOption = JsonSerializer.Deserialize<JsonElement>("\"super-secret-password\"");
         return new MetadataV2Graph
@@ -320,7 +376,7 @@ public sealed class MetadataReleaseServiceTests
                         Generation = revision,
                         Annotations = new Dictionary<string, string>
                         {
-                            ["honua.io/content-version-id"] = "content-v1",
+                            ["honua.io/content-version-id"] = contentVersionId,
                         },
                     },
                     Type = resourceType,
@@ -410,32 +466,49 @@ public sealed class MetadataReleaseServiceTests
 
     private sealed class StaticEnvironmentReader : IMetadataV2EnvironmentSnapshotReader
     {
-        private readonly Dictionary<string, MetadataV2GraphSnapshot> _snapshots;
+        private readonly Dictionary<string, MetadataV2GraphSnapshot> _currentSnapshots;
+        private readonly Dictionary<string, Dictionary<long, MetadataV2GraphSnapshot>> _snapshotsByRevision;
 
         public StaticEnvironmentReader(IEnumerable<MetadataV2Graph> graphs)
         {
-            _snapshots = graphs.ToDictionary(
-                static graph => graph.Environment,
-                static graph => new MetadataV2GraphSnapshot(
+            _snapshotsByRevision = new Dictionary<string, Dictionary<long, MetadataV2GraphSnapshot>>(
+                StringComparer.OrdinalIgnoreCase);
+            _currentSnapshots = new Dictionary<string, MetadataV2GraphSnapshot>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var graph in graphs)
+            {
+                var snapshot = new MetadataV2GraphSnapshot(
                     graph,
                     $"etag-{graph.Environment}-{graph.Revision}",
-                    DateTimeOffset.UtcNow),
-                StringComparer.OrdinalIgnoreCase);
+                    DateTimeOffset.UtcNow);
+                if (!_snapshotsByRevision.TryGetValue(graph.Environment, out var revisions))
+                {
+                    revisions = new Dictionary<long, MetadataV2GraphSnapshot>();
+                    _snapshotsByRevision[graph.Environment] = revisions;
+                }
+
+                revisions[graph.Revision] = snapshot;
+                if (!_currentSnapshots.TryGetValue(graph.Environment, out var current) || graph.Revision > current.Revision)
+                {
+                    _currentSnapshots[graph.Environment] = snapshot;
+                }
+            }
         }
 
         public ValueTask<MetadataV2GraphSnapshot?> GetCurrentAsync(
             string environment,
             CancellationToken cancellationToken = default)
             => ValueTask.FromResult(
-                _snapshots.TryGetValue(environment, out var snapshot) ? snapshot : null);
+                _currentSnapshots.TryGetValue(environment, out var snapshot) ? snapshot : null);
 
         public ValueTask<MetadataV2GraphSnapshot?> GetByRevisionAsync(
             string environment,
             long revision,
             CancellationToken cancellationToken = default)
         {
-            var snapshot = _snapshots.TryGetValue(environment, out var current) && current.Revision == revision
-                ? current
+            var snapshot = _snapshotsByRevision.TryGetValue(environment, out var revisions) &&
+                revisions.TryGetValue(revision, out var requested)
+                ? requested
                 : null;
             return ValueTask.FromResult(snapshot);
         }
@@ -447,7 +520,7 @@ public sealed class MetadataReleaseServiceTests
             await Task.Yield();
             foreach (var environment in environments)
             {
-                if (_snapshots.TryGetValue(environment, out var snapshot))
+                if (_currentSnapshots.TryGetValue(environment, out var snapshot))
                 {
                     yield return new MetadataV2EnvironmentRevision
                     {

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataReleaseServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataReleaseServiceTests.cs
@@ -1,0 +1,330 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Console.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Metadata.Services;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Core.Tests.Features.Metadata.Services;
+
+[Protocol(Protocols.TestQuality)]
+[Operation(Operations.Metadata)]
+public sealed class MetadataReleaseServiceTests
+{
+    [UnitTest]
+    public async Task GetSemanticInventoryAsync_WithKindAndResourceTypeFilters_ReturnsRevisionStampedEntries()
+    {
+        var service = CreateService(
+            BuildGraph("dev", 41, MetadataV2ResourceType.Map),
+            BuildGraph("staging", 7, MetadataV2ResourceType.Map));
+
+        var response = await service.GetSemanticInventoryAsync(
+            "dev",
+            new MetadataSemanticInventoryFilter
+            {
+                ArtifactKind = MetadataSemanticArtifactKind.Resource,
+                ResourceType = MetadataV2ResourceType.Map,
+            });
+
+        response.Should().NotBeNull();
+        response!.Environment.Should().Be("dev");
+        response.Revision.Should().Be(41);
+        response.ETag.Should().Be("etag-dev-41");
+        response.Entries.Should().ContainSingle(entry =>
+            entry.SemanticId == "res.parcels" &&
+            entry.ArtifactKind == MetadataSemanticArtifactKind.Resource &&
+            entry.ResourceType == MetadataV2ResourceType.Map &&
+            entry.ContentVersionId == "content-v1");
+    }
+
+    [UnitTest]
+    public async Task GetEnvironmentBindingsAsync_WithMissingAndUnavailableStates_ScrubsConnectionOptions()
+    {
+        var service = CreateService(
+            BuildGraph("dev", 41, MetadataV2ResourceType.FeatureDataset),
+            BuildGraph("staging", 7, MetadataV2ResourceType.FeatureDataset));
+
+        var response = await service.GetEnvironmentBindingsAsync(new MetadataEnvironmentBindingsRequest
+        {
+            Environments = ["dev", "prod"],
+            SemanticIds = ["res.parcels", "res.missing"],
+        });
+
+        response.Bindings.Should().Contain(binding =>
+            binding.Environment == "dev" &&
+            binding.SemanticId == "res.parcels" &&
+            binding.State == MetadataEnvironmentBindingState.Bound &&
+            binding.Revision == 41 &&
+            binding.Connection!.SecretRef == "aws-sm://honua/dev/parcels");
+        response.Bindings.Should().Contain(binding =>
+            binding.Environment == "dev" &&
+            binding.SemanticId == "res.missing" &&
+            binding.State == MetadataEnvironmentBindingState.Missing);
+        response.Bindings.Should().Contain(binding =>
+            binding.Environment == "prod" &&
+            binding.State == MetadataEnvironmentBindingState.EnvironmentUnavailable);
+
+        var json = JsonSerializer.Serialize(
+            response,
+            MetadataReleaseJsonContext.Default.MetadataEnvironmentBindingsResponse);
+        json.Should().Contain("aws-sm://honua/dev/parcels");
+        json.Should().NotContain("super-secret-password");
+        json.Should().NotContain("connectionString");
+    }
+
+    [UnitTest]
+    public async Task CreateReleasePackageAsync_WithSourceAndTarget_CapturesDesiredAndCurrentRevisions()
+    {
+        var service = CreateService(
+            BuildGraph("dev", 41, MetadataV2ResourceType.FeatureDataset),
+            BuildGraph("staging", 7, MetadataV2ResourceType.FeatureDataset));
+
+        var package = await service.CreateReleasePackageAsync(
+            new CreateMetadataReleasePackageRequest
+            {
+                Title = "Promote parcels",
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["res.parcels"],
+                Provenance =
+                [
+                    new ConsoleProvenanceRef
+                    {
+                        Kind = "console-content",
+                        ItemId = "content.parcels",
+                        Rel = "derived-from",
+                    },
+                ],
+            },
+            "user-1");
+
+        package.SourceEnvironment.Should().Be("dev");
+        package.SourceRevision.Should().Be(41);
+        package.SourceEtag.Should().Be("etag-dev-41");
+        package.TargetEnvironments.Should().Equal("staging");
+        package.CreatedBy.Should().Be("user-1");
+        var entry = package.Entries.Should().ContainSingle().Subject;
+        entry.SemanticId.Should().Be("res.parcels");
+        entry.DesiredMetadataRevision.Should().Be(41);
+        entry.DesiredContentVersionId.Should().Be("content-v1");
+        entry.DesiredProvenance.Should().ContainSingle(p => p.ItemId == "content.parcels");
+        entry.TargetStates.Should().ContainSingle(state =>
+            state.Environment == "staging" &&
+            state.CurrentMetadataRevision == 7 &&
+            state.BindingState == MetadataEnvironmentBindingState.Bound);
+    }
+
+    [UnitTest]
+    public async Task GetGitOpsManifestAsync_ForPersistedPackage_UsesSourceGeneratedSecretSafeShape()
+    {
+        var service = CreateService(
+            BuildGraph("dev", 41, MetadataV2ResourceType.FeatureDataset),
+            BuildGraph("staging", 7, MetadataV2ResourceType.FeatureDataset));
+        var package = await service.CreateReleasePackageAsync(
+            new CreateMetadataReleasePackageRequest
+            {
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["pub.parcels"],
+                DesiredRevision = 42,
+                DesiredContentVersionId = "content-v2",
+            },
+            "user-1");
+
+        var manifest = await service.GetGitOpsManifestAsync(package.PackageId);
+
+        manifest.Should().NotBeNull();
+        manifest!.ApiVersion.Should().Be(MetadataV2Constants.ApiVersion);
+        manifest.Kind.Should().Be("MetadataReleasePackage");
+        manifest.Spec.Source.Revision.Should().Be(41);
+        manifest.Spec.Entries.Should().ContainSingle(entry =>
+            entry.SemanticId == "pub.parcels" &&
+            entry.DesiredMetadataRevision == 42 &&
+            entry.DesiredContentVersionId == "content-v2");
+
+        var json = JsonSerializer.Serialize(
+            manifest,
+            MetadataReleaseJsonContext.Default.GitOpsMetadataReleaseManifest);
+        json.Should().Contain("MetadataReleasePackage");
+        json.Should().NotContain("super-secret-password");
+    }
+
+    private static MetadataReleaseService CreateService(params MetadataV2Graph[] graphs)
+    {
+        var reader = new StaticEnvironmentReader(graphs);
+        return new MetadataReleaseService(
+            reader,
+            new InMemoryMetadataReleasePackageStore(),
+            TimeProvider.System,
+            NullLogger<MetadataReleaseService>.Instance);
+    }
+
+    private static MetadataV2Graph BuildGraph(
+        string environment,
+        long revision,
+        MetadataV2ResourceType resourceType)
+    {
+        var passwordOption = JsonSerializer.Deserialize<JsonElement>("\"super-secret-password\"");
+        return new MetadataV2Graph
+        {
+            Environment = environment,
+            Revision = revision,
+            GeneratedAt = DateTimeOffset.UtcNow,
+            Resources =
+            [
+                new MetadataV2Resource
+                {
+                    Metadata = new MetadataV2ObjectMetadata
+                    {
+                        Id = "res.parcels",
+                        Name = "parcels",
+                        Title = "Parcels",
+                        Generation = revision,
+                        Annotations = new Dictionary<string, string>
+                        {
+                            ["honua.io/content-version-id"] = "content-v1",
+                        },
+                    },
+                    Type = resourceType,
+                    StorageBindingIds = ["storage.parcels"],
+                    PrimaryStorageBindingId = "storage.parcels",
+                    SchemaFields =
+                    [
+                        new MetadataV2Field
+                        {
+                            SemanticId = "field.parcels.apn",
+                            Name = "apn",
+                            Type = "string",
+                        },
+                    ],
+                    PolicyIds = ["policy.read-parcels"],
+                },
+            ],
+            Connections =
+            [
+                new MetadataV2Connection
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "conn.parcels", Name = "parcels-db" },
+                    Type = MetadataV2ConnectionType.Database,
+                    Provider = "postgres",
+                    Endpoint = new Uri("https://metadata.example.test/connections/parcels"),
+                    SecretRef = "aws-sm://honua/dev/parcels",
+                    Options = new Dictionary<string, JsonElement>
+                    {
+                        ["connectionString"] = passwordOption,
+                    },
+                },
+            ],
+            StorageBindings =
+            [
+                new MetadataV2StorageBinding
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "storage.parcels", Name = "storage.parcels" },
+                    ResourceId = "res.parcels",
+                    ConnectionId = "conn.parcels",
+                    StorageType = MetadataV2StorageType.RelationalTable,
+                    Locator = $"{environment}_schema.parcels",
+                },
+            ],
+            Services =
+            [
+                new MetadataV2Service
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "svc.features", Name = "features" },
+                    ServiceType = MetadataV2ServiceType.OgcApiFeatures,
+                    Route = $"/{environment}/ogc/features",
+                    PublicationIds = ["pub.parcels"],
+                },
+            ],
+            Publications =
+            [
+                new MetadataV2Publication
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "pub.parcels", Name = "parcels" },
+                    ResourceId = "res.parcels",
+                    ServiceId = "svc.features",
+                    StorageBindingId = "storage.parcels",
+                    PublicationType = MetadataV2PublicationType.OgcCollection,
+                    Path = "parcels",
+                    ServiceLocalId = "parcels",
+                },
+            ],
+            Policies =
+            [
+                new MetadataV2Policy
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "policy.read-parcels", Name = "read-parcels" },
+                    Engine = "rbac",
+                    Effect = "allow",
+                },
+            ],
+            Roles =
+            [
+                new MetadataV2Role
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "role.publisher", Name = "publisher" },
+                    Permissions = ["metadata.read", "metadata.write"],
+                    PolicyIds = ["policy.read-parcels"],
+                },
+            ],
+        };
+    }
+
+    private sealed class StaticEnvironmentReader : IMetadataV2EnvironmentSnapshotReader
+    {
+        private readonly Dictionary<string, MetadataV2GraphSnapshot> _snapshots;
+
+        public StaticEnvironmentReader(IEnumerable<MetadataV2Graph> graphs)
+        {
+            _snapshots = graphs.ToDictionary(
+                static graph => graph.Environment,
+                static graph => new MetadataV2GraphSnapshot(
+                    graph,
+                    $"etag-{graph.Environment}-{graph.Revision}",
+                    DateTimeOffset.UtcNow),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        public ValueTask<MetadataV2GraphSnapshot?> GetCurrentAsync(
+            string environment,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(
+                _snapshots.TryGetValue(environment, out var snapshot) ? snapshot : null);
+
+        public ValueTask<MetadataV2GraphSnapshot?> GetByRevisionAsync(
+            string environment,
+            long revision,
+            CancellationToken cancellationToken = default)
+        {
+            var snapshot = _snapshots.TryGetValue(environment, out var current) && current.Revision == revision
+                ? current
+                : null;
+            return ValueTask.FromResult(snapshot);
+        }
+
+        public async IAsyncEnumerable<MetadataV2EnvironmentRevision> ListCurrentRevisionsAsync(
+            IReadOnlyList<string> environments,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            foreach (var environment in environments)
+            {
+                if (_snapshots.TryGetValue(environment, out var snapshot))
+                {
+                    yield return new MetadataV2EnvironmentRevision
+                    {
+                        Environment = snapshot.Graph.Environment,
+                        Revision = snapshot.Revision,
+                        ETag = snapshot.Etag,
+                        ActivatedAt = snapshot.LoadedAt,
+                    };
+                }
+            }
+        }
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataReleaseServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataReleaseServiceTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Diagnostics;
 using System.Text.Json;
 using Honua.Core.Features.Console.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
@@ -16,6 +17,32 @@ namespace Honua.Core.Tests.Features.Metadata.Services;
 [Operation(Operations.Metadata)]
 public sealed class MetadataReleaseServiceTests
 {
+    [UnitTest]
+    public async Task GetSemanticInventoryAsync_WhenObserved_EmitsRegisteredMetadataActivity()
+    {
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == "Honua.Core.Metadata",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activity => activities.Add(activity),
+        };
+        ActivitySource.AddActivityListener(listener);
+        var service = CreateService(BuildGraph("dev", 41, MetadataV2ResourceType.Map));
+
+        await service.GetSemanticInventoryAsync(
+            "dev",
+            new MetadataSemanticInventoryFilter
+            {
+                ArtifactKind = MetadataSemanticArtifactKind.Resource,
+            });
+
+        activities.Should().Contain(activity =>
+            activity.Source.Name == "Honua.Core.Metadata" &&
+            activity.OperationName == "honua.metadata.release.inventory" &&
+            activity.TagObjects.Any(tag => tag.Key == "metadata.inventory.count" && Equals(tag.Value, 1)));
+    }
+
     [UnitTest]
     public async Task GetSemanticInventoryAsync_WithKindAndResourceTypeFilters_ReturnsRevisionStampedEntries()
     {
@@ -117,6 +144,48 @@ public sealed class MetadataReleaseServiceTests
             state.Environment == "staging" &&
             state.CurrentMetadataRevision == 7 &&
             state.BindingState == MetadataEnvironmentBindingState.Bound);
+    }
+
+    [UnitTest]
+    public async Task CreateReleasePackageAsync_WithRequestContentVersion_KeepsArtifactContentVersionWhenPresent()
+    {
+        var service = CreateService(
+            BuildGraph("dev", 41, MetadataV2ResourceType.FeatureDataset),
+            BuildGraph("staging", 7, MetadataV2ResourceType.FeatureDataset));
+
+        var package = await service.CreateReleasePackageAsync(
+            new CreateMetadataReleasePackageRequest
+            {
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["res.parcels"],
+                DesiredContentVersionId = "request-content-v2",
+            },
+            "user-1");
+
+        package.Entries.Should().ContainSingle()
+            .Subject.DesiredContentVersionId.Should().Be("content-v1");
+    }
+
+    [UnitTest]
+    public async Task CreateReleasePackageAsync_WithRequestContentVersion_UsesRequestFallbackWhenArtifactHasNone()
+    {
+        var service = CreateService(
+            BuildGraph("dev", 41, MetadataV2ResourceType.FeatureDataset),
+            BuildGraph("staging", 7, MetadataV2ResourceType.FeatureDataset));
+
+        var package = await service.CreateReleasePackageAsync(
+            new CreateMetadataReleasePackageRequest
+            {
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["pub.parcels"],
+                DesiredContentVersionId = "request-content-v2",
+            },
+            "user-1");
+
+        package.Entries.Should().ContainSingle()
+            .Subject.DesiredContentVersionId.Should().Be("request-content-v2");
     }
 
     [UnitTest]

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataReleaseServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataReleaseServiceTests.cs
@@ -105,6 +105,28 @@ public sealed class MetadataReleaseServiceTests
     }
 
     [UnitTest]
+    public async Task GetEnvironmentBindingsAsync_WithNullRequiredArrays_ThrowsValidationError()
+    {
+        var service = CreateService();
+
+        var nullEnvironments = await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.GetEnvironmentBindingsAsync(new MetadataEnvironmentBindingsRequest
+            {
+                Environments = null!,
+                SemanticIds = ["res.parcels"],
+            }));
+        nullEnvironments.Message.Should().Contain("Environments must be an array.");
+
+        var nullSemanticIds = await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.GetEnvironmentBindingsAsync(new MetadataEnvironmentBindingsRequest
+            {
+                Environments = ["dev"],
+                SemanticIds = null!,
+            }));
+        nullSemanticIds.Message.Should().Contain("SemanticIds must be an array.");
+    }
+
+    [UnitTest]
     public async Task CreateReleasePackageAsync_WithSourceAndTarget_CapturesDesiredAndCurrentRevisions()
     {
         var service = CreateService(
@@ -186,6 +208,48 @@ public sealed class MetadataReleaseServiceTests
 
         package.Entries.Should().ContainSingle()
             .Subject.DesiredContentVersionId.Should().Be("request-content-v2");
+    }
+
+    [UnitTest]
+    public async Task CreateReleasePackageAsync_WithNullRequestArrays_ThrowsValidationError()
+    {
+        var service = CreateService(
+            BuildGraph("dev", 41, MetadataV2ResourceType.FeatureDataset),
+            BuildGraph("staging", 7, MetadataV2ResourceType.FeatureDataset));
+
+        var nullTargets = await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.CreateReleasePackageAsync(
+                new CreateMetadataReleasePackageRequest
+                {
+                    SourceEnvironment = "dev",
+                    TargetEnvironments = null!,
+                    SemanticIds = ["res.parcels"],
+                },
+                "user-1"));
+        nullTargets.Message.Should().Contain("TargetEnvironments must be an array.");
+
+        var nullSemanticIds = await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.CreateReleasePackageAsync(
+                new CreateMetadataReleasePackageRequest
+                {
+                    SourceEnvironment = "dev",
+                    TargetEnvironments = ["staging"],
+                    SemanticIds = null!,
+                },
+                "user-1"));
+        nullSemanticIds.Message.Should().Contain("SemanticIds must be an array.");
+
+        var nullProvenance = await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.CreateReleasePackageAsync(
+                new CreateMetadataReleasePackageRequest
+                {
+                    SourceEnvironment = "dev",
+                    TargetEnvironments = ["staging"],
+                    SemanticIds = ["res.parcels"],
+                    Provenance = null!,
+                },
+                "user-1"));
+        nullProvenance.Message.Should().Contain("Provenance must be an array.");
     }
 
     [UnitTest]

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataReleaseStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataReleaseStoreTests.cs
@@ -99,6 +99,30 @@ public sealed class PostgresMetadataReleaseStoreTests(PostgresFixture fixture)
         }
     }
 
+    [IntegrationTest]
+    public async Task ReleasePackageStore_CreateAsync_WithDuplicateDefaultNamespaceKey_ThrowsConflict()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresMetadataReleaseStoreTests));
+        try
+        {
+            await EnsureTablesAsync(schema);
+            var provider = new TestConnectionProvider(fixture.DataSource, schema);
+            var store = new PostgresMetadataReleasePackageStore(provider, schema);
+            var first = BuildPackage(Guid.NewGuid(), "promote-parcels", null);
+            var duplicate = BuildPackage(Guid.NewGuid(), "promote-parcels", null);
+
+            await store.CreateAsync(first);
+            var act = () => store.CreateAsync(duplicate);
+
+            await act.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("Metadata release package conflicts with an existing package.");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
     private async Task EnsureTablesAsync(string schema)
     {
         await using var connection = await fixtureConnection(schema).ConfigureAwait(false);
@@ -143,6 +167,12 @@ public sealed class PostgresMetadataReleaseStoreTests(PostgresFixture fixture)
                 CONSTRAINT metadata_v2_release_packages_status
                     CHECK (status IN ('draft','ready','staged','superseded','cancelled'))
             );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_metadata_v2_release_packages_key
+                ON "{schema}".metadata_v2_release_packages (
+                    (COALESCE(NULLIF(BTRIM(package_namespace), ''), '')),
+                    package_key
+                );
             """;
         await command.ExecuteNonQueryAsync();
 
@@ -196,6 +226,49 @@ public sealed class PostgresMetadataReleaseStoreTests(PostgresFixture fixture)
                 },
             ],
         };
+
+    private static MetadataReleasePackage BuildPackage(Guid packageId, string packageKey, string? packageNamespace)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new MetadataReleasePackage
+        {
+            PackageId = packageId,
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = packageId.ToString("D"),
+                Name = packageKey,
+                Namespace = packageNamespace,
+                Title = "Promote parcels",
+            },
+            SourceEnvironment = "dev",
+            SourceRevision = 41,
+            SourceEtag = "etag-dev-41",
+            TargetEnvironments = ["staging"],
+            Entries =
+            [
+                new MetadataReleaseEntry
+                {
+                    SemanticId = "res.parcels",
+                    ArtifactKind = MetadataSemanticArtifactKind.Resource,
+                    ResourceType = MetadataV2ResourceType.FeatureDataset,
+                    DesiredMetadataRevision = 41,
+                    DesiredContentVersionId = "content-v1",
+                    TargetStates =
+                    [
+                        new MetadataReleaseTargetState
+                        {
+                            Environment = "staging",
+                            CurrentMetadataRevision = 7,
+                            BindingState = MetadataEnvironmentBindingState.Bound,
+                        },
+                    ],
+                },
+            ],
+            CreatedBy = "user-1",
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
 
     private sealed class TestConnectionProvider(NpgsqlDataSource dataSource, string schemaName) : IDatabaseConnectionProvider
     {

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataReleaseStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataReleaseStoreTests.cs
@@ -72,6 +72,29 @@ public sealed class PostgresMetadataReleaseStoreTests(PostgresFixture fixture)
                             },
                         ],
                     },
+                    new MetadataReleaseEntry
+                    {
+                        SemanticId = "field.parcels.apn",
+                        ArtifactKind = MetadataSemanticArtifactKind.Field,
+                        ResourceType = MetadataV2ResourceType.FeatureDataset,
+                        SourceField = new MetadataBoundFieldSummary
+                        {
+                            SemanticId = "field.parcels.apn",
+                            ParentResourceId = "res.parcels",
+                            FieldName = "apn",
+                            FieldType = "string",
+                        },
+                        DesiredMetadataRevision = 41,
+                        TargetStates =
+                        [
+                            new MetadataReleaseTargetState
+                            {
+                                Environment = "staging",
+                                CurrentMetadataRevision = 7,
+                                BindingState = MetadataEnvironmentBindingState.Missing,
+                            },
+                        ],
+                    },
                 ],
                 CreatedBy = "user-1",
                 CreatedAt = now,
@@ -88,10 +111,14 @@ public sealed class PostgresMetadataReleaseStoreTests(PostgresFixture fixture)
             loaded.SourceRevision.Should().Be(41);
             loaded.SourceEtag.Should().Be("etag-dev-41");
             loaded.TargetEnvironments.Should().Equal("staging");
-            loaded.Entries.Should().ContainSingle(entry =>
+            loaded.Entries.Should().Contain(entry =>
                 entry.SemanticId == "res.parcels" &&
                 entry.DesiredContentVersionId == "content-v1" &&
                 entry.TargetStates.Single().CurrentMetadataRevision == 7);
+            loaded.Entries.Should().ContainSingle(entry =>
+                entry.SemanticId == "field.parcels.apn" &&
+                entry.SourceField!.ParentResourceId == "res.parcels" &&
+                entry.SourceField.FieldName == "apn");
         }
         finally
         {

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataReleaseStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataReleaseStoreTests.cs
@@ -1,0 +1,240 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Postgres.Features.Metadata;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Tests.Features.Metadata;
+
+[Collection("Database")]
+public sealed class PostgresMetadataReleaseStoreTests(PostgresFixture fixture)
+{
+    [IntegrationTest]
+    public async Task EnvironmentReader_AndReleasePackageStore_RoundTripMetadataReleasePackage()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresMetadataReleaseStoreTests));
+        try
+        {
+            await EnsureTablesAsync(schema);
+            await InsertSnapshotAsync(schema, BuildGraph("dev", 41), "etag-dev-41");
+
+            var provider = new TestConnectionProvider(fixture.DataSource, schema);
+            var reader = new PostgresMetadataV2EnvironmentSnapshotReader(provider, schema);
+            var snapshot = await reader.GetCurrentAsync("dev");
+
+            snapshot.Should().NotBeNull();
+            snapshot!.Revision.Should().Be(41);
+            snapshot.Etag.Should().Be("etag-dev-41");
+            snapshot.Graph.Resources.Should().ContainSingle(resource => resource.Metadata.Id == "res.parcels");
+
+            var store = new PostgresMetadataReleasePackageStore(provider, schema);
+            var packageId = Guid.NewGuid();
+            var now = DateTimeOffset.UtcNow;
+            var package = new MetadataReleasePackage
+            {
+                PackageId = packageId,
+                Metadata = new MetadataV2ObjectMetadata
+                {
+                    Id = packageId.ToString("D"),
+                    Name = "promote-parcels",
+                    Namespace = "ops",
+                    Title = "Promote parcels",
+                },
+                SourceEnvironment = "dev",
+                SourceRevision = 41,
+                SourceEtag = "etag-dev-41",
+                TargetEnvironments = ["staging"],
+                Entries =
+                [
+                    new MetadataReleaseEntry
+                    {
+                        SemanticId = "res.parcels",
+                        ArtifactKind = MetadataSemanticArtifactKind.Resource,
+                        ResourceType = MetadataV2ResourceType.FeatureDataset,
+                        DesiredMetadataRevision = 41,
+                        DesiredContentVersionId = "content-v1",
+                        TargetStates =
+                        [
+                            new MetadataReleaseTargetState
+                            {
+                                Environment = "staging",
+                                CurrentMetadataRevision = 7,
+                                BindingState = MetadataEnvironmentBindingState.Bound,
+                            },
+                        ],
+                    },
+                ],
+                CreatedBy = "user-1",
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+
+            await store.CreateAsync(package);
+            var loaded = await store.GetAsync(packageId);
+
+            loaded.Should().NotBeNull();
+            loaded!.Metadata.Name.Should().Be("promote-parcels");
+            loaded.Metadata.Namespace.Should().Be("ops");
+            loaded.SourceEnvironment.Should().Be("dev");
+            loaded.SourceRevision.Should().Be(41);
+            loaded.SourceEtag.Should().Be("etag-dev-41");
+            loaded.TargetEnvironments.Should().Equal("staging");
+            loaded.Entries.Should().ContainSingle(entry =>
+                entry.SemanticId == "res.parcels" &&
+                entry.DesiredContentVersionId == "content-v1" &&
+                entry.TargetStates.Single().CurrentMetadataRevision == 7);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    private async Task EnsureTablesAsync(string schema)
+    {
+        await using var connection = await fixtureConnection(schema).ConfigureAwait(false);
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            CREATE TABLE IF NOT EXISTS "{schema}".metadata_v2_snapshots (
+                environment       TEXT          NOT NULL,
+                revision          BIGINT        NOT NULL,
+                schema_version    TEXT          NOT NULL,
+                api_version       TEXT          NOT NULL,
+                document          JSONB         NOT NULL,
+                etag              TEXT          NOT NULL,
+                generated_at      TIMESTAMPTZ   NOT NULL,
+                created_at        TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+                PRIMARY KEY (environment, revision)
+            );
+
+            CREATE TABLE IF NOT EXISTS "{schema}".metadata_v2_current (
+                environment       TEXT          NOT NULL PRIMARY KEY,
+                revision          BIGINT        NOT NULL,
+                etag              TEXT          NOT NULL,
+                activated_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+                FOREIGN KEY (environment, revision)
+                    REFERENCES "{schema}".metadata_v2_snapshots(environment, revision)
+                    ON DELETE RESTRICT
+            );
+
+            CREATE TABLE IF NOT EXISTS "{schema}".metadata_v2_release_packages (
+                package_id          UUID        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+                package_key         TEXT        NOT NULL,
+                package_namespace   TEXT        NULL,
+                status              TEXT        NOT NULL DEFAULT 'draft',
+                source_environment  TEXT        NOT NULL,
+                source_revision     BIGINT      NOT NULL,
+                source_etag         TEXT        NOT NULL,
+                target_environments JSONB       NOT NULL,
+                entries             JSONB       NOT NULL,
+                package_metadata    JSONB       NOT NULL,
+                created_by          TEXT        NOT NULL,
+                created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT metadata_v2_release_packages_status
+                    CHECK (status IN ('draft','ready','staged','superseded','cancelled'))
+            );
+            """;
+        await command.ExecuteNonQueryAsync();
+
+        async Task<NpgsqlConnection> fixtureConnection(string schemaName)
+        {
+            var dataSource = fixture.DataSource;
+            var conn = await dataSource.OpenConnectionAsync();
+            await using var searchPath = conn.CreateCommand();
+            searchPath.CommandText = $"SET search_path TO \"{schemaName}\", public;";
+            await searchPath.ExecuteNonQueryAsync();
+            return conn;
+        }
+    }
+
+    private async Task InsertSnapshotAsync(string schema, MetadataV2Graph graph, string etag)
+    {
+        var json = JsonSerializer.Serialize(graph, MetadataV2JsonContext.Default.MetadataV2Graph);
+        await using var connection = await fixture.DataSource.OpenConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            INSERT INTO "{schema}".metadata_v2_snapshots
+                (environment, revision, schema_version, api_version, document, etag, generated_at)
+            VALUES
+                (@environment, @revision, @schema_version, @api_version, @document, @etag, @generated_at);
+
+            INSERT INTO "{schema}".metadata_v2_current (environment, revision, etag)
+            VALUES (@environment, @revision, @etag);
+            """;
+        command.Parameters.AddWithValue("@environment", graph.Environment);
+        command.Parameters.AddWithValue("@revision", graph.Revision);
+        command.Parameters.AddWithValue("@schema_version", graph.SchemaVersion);
+        command.Parameters.AddWithValue("@api_version", graph.ApiVersion);
+        command.Parameters.Add(new NpgsqlParameter("@document", NpgsqlDbType.Jsonb) { Value = json });
+        command.Parameters.AddWithValue("@etag", etag);
+        command.Parameters.AddWithValue("@generated_at", graph.GeneratedAt);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static MetadataV2Graph BuildGraph(string environment, long revision)
+        => new()
+        {
+            Environment = environment,
+            Revision = revision,
+            GeneratedAt = DateTimeOffset.UtcNow,
+            Resources =
+            [
+                new MetadataV2Resource
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "res.parcels", Name = "parcels" },
+                    Type = MetadataV2ResourceType.FeatureDataset,
+                },
+            ],
+        };
+
+    private sealed class TestConnectionProvider(NpgsqlDataSource dataSource, string schemaName) : IDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => dataSource.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            var conn = await dataSource.OpenConnectionAsync(cancellationToken);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SET search_path TO \"{schemaName}\", public;";
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+            return conn;
+        }
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var conn = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var tx = await conn.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (conn, tx);
+            }
+            catch
+            {
+                await conn.DisposeAsync();
+                throw;
+            }
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(
+            Func<Task<T>> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(
+            Func<Task> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
@@ -112,6 +112,47 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/metadata/environment-bindings/query")]
+    [Endpoint("POST /api/v1/admin/metadata/release-packages")]
+    public async Task ReleaseRequestEndpoints_WithExplicitNullArrays_ReturnBadRequest()
+    {
+        (string Path, string Body, string ExpectedMessage)[] cases =
+        [
+            (
+                "/api/v1/admin/metadata/environment-bindings/query",
+                "{\"environments\":null,\"semanticIds\":[\"res.parcels\"]}",
+                "Environments must be an array."),
+            (
+                "/api/v1/admin/metadata/environment-bindings/query",
+                "{\"environments\":[\"dev\"],\"semanticIds\":null}",
+                "SemanticIds must be an array."),
+            (
+                "/api/v1/admin/metadata/release-packages",
+                "{\"sourceEnvironment\":\"dev\",\"targetEnvironments\":null,\"semanticIds\":[\"res.parcels\"]}",
+                "TargetEnvironments must be an array."),
+            (
+                "/api/v1/admin/metadata/release-packages",
+                "{\"sourceEnvironment\":\"dev\",\"targetEnvironments\":[\"staging\"],\"semanticIds\":null}",
+                "SemanticIds must be an array."),
+            (
+                "/api/v1/admin/metadata/release-packages",
+                "{\"sourceEnvironment\":\"dev\",\"targetEnvironments\":[\"staging\"],\"semanticIds\":[\"res.parcels\"],\"provenance\":null}",
+                "Provenance must be an array."),
+        ];
+
+        foreach (var (path, body, expectedMessage) in cases)
+        {
+            var response = await _client.PostAsync(
+                path,
+                new StringContent(body, Encoding.UTF8, "application/json"));
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            var payload = await response.Content.ReadAsStringAsync();
+            payload.Should().Contain(expectedMessage);
+        }
+    }
+
+    [IntegrationTest]
     [Endpoint("POST /api/v1/admin/metadata/release-packages")]
     [Endpoint("GET /api/v1/admin/metadata/release-packages/{packageId}")]
     [Endpoint("GET /api/v1/admin/metadata/release-packages/{packageId}/gitops-manifest")]

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
@@ -42,7 +42,7 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
                     new StaticEnvironmentReader(
                         BuildGraph("dev", 41),
                         BuildGraph("staging", 7)));
-                services.AddSingleton<IMetadataReleasePackageStore, InMemoryMetadataReleasePackageStore>();
+                services.AddSingleton<IMetadataReleasePackageStore, CancellationAwareReleasePackageStore>();
             });
     }
 
@@ -232,6 +232,29 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
         payload.Should().Contain("Metadata release package conflicts with an existing package.");
     }
 
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/metadata/release-packages")]
+    public async Task CreateReleasePackage_WhenStoreCancellationOccurs_DoesNotMapToPackageCreateFailure()
+    {
+        var body = JsonSerializer.Serialize(
+            new CreateMetadataReleasePackageRequest
+            {
+                PackageKey = "cancelled-package",
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["res.parcels"],
+            },
+            MetadataReleaseJsonContext.Default.CreateMetadataReleasePackageRequest);
+
+        var response = await _client.PostAsync(
+            "/api/v1/admin/metadata/release-packages",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.RequestTimeout);
+        var payload = await response.Content.ReadAsStringAsync();
+        payload.Should().NotContain("Metadata release package could not be created.");
+    }
+
     private static MetadataV2Graph BuildGraph(string environment, long revision)
     {
         var passwordOption = JsonSerializer.Deserialize<JsonElement>("\"super-secret-password\"");
@@ -361,5 +384,27 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
                 }
             }
         }
+    }
+
+    private sealed class CancellationAwareReleasePackageStore : IMetadataReleasePackageStore
+    {
+        private readonly InMemoryMetadataReleasePackageStore _inner = new();
+
+        public Task<MetadataReleasePackage> CreateAsync(
+            MetadataReleasePackage package,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.Equals(package.Metadata.Name, "cancelled-package", StringComparison.Ordinal))
+            {
+                throw new OperationCanceledException("Simulated package store cancellation.");
+            }
+
+            return _inner.CreateAsync(package, cancellationToken);
+        }
+
+        public Task<MetadataReleasePackage?> GetAsync(
+            Guid packageId,
+            CancellationToken cancellationToken = default)
+            => _inner.GetAsync(packageId, cancellationToken);
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
@@ -41,7 +41,7 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
                 services.AddSingleton<IMetadataV2EnvironmentSnapshotReader>(
                     new StaticEnvironmentReader(
                         BuildGraph("dev", 41),
-                        BuildGraph("staging", 7)));
+                        BuildGraph("staging", 7, includeSchemaField: false)));
                 services.AddSingleton<IMetadataReleasePackageStore, CancellationAwareReleasePackageStore>();
             });
     }
@@ -205,6 +205,48 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/metadata/release-packages")]
+    [Endpoint("GET /api/v1/admin/metadata/release-packages/{packageId}/gitops-manifest")]
+    public async Task ReleasePackageEndpoints_WithFieldAndMissingTarget_ExportsSourceFieldIdentity()
+    {
+        var body = JsonSerializer.Serialize(
+            new CreateMetadataReleasePackageRequest
+            {
+                Title = "Promote parcel APN",
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["field.parcels.apn"],
+            },
+            MetadataReleaseJsonContext.Default.CreateMetadataReleasePackageRequest);
+
+        var createResponse = await _client.PostAsync(
+            "/api/v1/admin/metadata/release-packages",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var createPayload = await createResponse.Content.ReadAsStringAsync();
+        var created = JsonSerializer.Deserialize(
+            createPayload,
+            MetadataReleaseJsonContext.Default.MetadataReleasePackage);
+        created.Should().NotBeNull();
+        var entry = created!.Entries.Should().ContainSingle().Subject;
+        entry.SourceField.Should().NotBeNull();
+        entry.SourceField!.ParentResourceId.Should().Be("res.parcels");
+        entry.SourceField.FieldName.Should().Be("apn");
+        var targetState = entry.TargetStates.Should().ContainSingle().Subject;
+        targetState.Environment.Should().Be("staging");
+        targetState.BindingState.Should().Be(MetadataEnvironmentBindingState.Missing);
+
+        var manifestResponse = await _client.GetAsync(
+            $"/api/v1/admin/metadata/release-packages/{created.PackageId:D}/gitops-manifest");
+        manifestResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var manifestPayload = await manifestResponse.Content.ReadAsStringAsync();
+        manifestPayload.Should().Contain("\"sourceField\"");
+        manifestPayload.Should().Contain("\"parentResourceId\":\"res.parcels\"");
+        manifestPayload.Should().Contain("\"fieldName\":\"apn\"");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/metadata/release-packages")]
     public async Task CreateReleasePackage_WithRepeatedGeneratedTitleKeys_ReturnsCreatedPackages()
     {
         var body = JsonSerializer.Serialize(
@@ -295,7 +337,7 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
         payload.Should().NotContain("Metadata release package could not be created.");
     }
 
-    private static MetadataV2Graph BuildGraph(string environment, long revision)
+    private static MetadataV2Graph BuildGraph(string environment, long revision, bool includeSchemaField = true)
     {
         var passwordOption = JsonSerializer.Deserialize<JsonElement>("\"super-secret-password\"");
         return new MetadataV2Graph
@@ -320,6 +362,7 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
                     Type = MetadataV2ResourceType.Map,
                     StorageBindingIds = ["storage.parcels"],
                     PrimaryStorageBindingId = "storage.parcels",
+                    SchemaFields = BuildSchemaFields(includeSchemaField),
                 },
             ],
             Connections =
@@ -371,6 +414,24 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
                 },
             ],
         };
+    }
+
+    private static MetadataV2Field[] BuildSchemaFields(bool includeSchemaField)
+    {
+        if (!includeSchemaField)
+        {
+            return Array.Empty<MetadataV2Field>();
+        }
+
+        return
+        [
+            new MetadataV2Field
+            {
+                SemanticId = "field.parcels.apn",
+                Name = "apn",
+                Type = "string",
+            },
+        ];
     }
 
     private sealed class StaticEnvironmentReader : IMetadataV2EnvironmentSnapshotReader

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
@@ -1,0 +1,295 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Metadata.Services;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Metadata)]
+public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public MetadataReleaseEndpointsTests()
+    {
+        _fixture = new WebAppFixture()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", WebAppFixture.SharedAdminPassword);
+            })
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IMetadataV2EnvironmentSnapshotReader>();
+                services.RemoveAll<IMetadataReleasePackageStore>();
+                services.AddSingleton<IMetadataV2EnvironmentSnapshotReader>(
+                    new StaticEnvironmentReader(
+                        BuildGraph("dev", 41),
+                        BuildGraph("staging", 7)));
+                services.AddSingleton<IMetadataReleasePackageStore, InMemoryMetadataReleasePackageStore>();
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateAdminClient();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/metadata/environments/{environment}/inventory")]
+    public async Task GetInventory_WithFilters_ReturnsRevisionStampedSemanticInventory()
+    {
+        var response = await _client.GetAsync(
+            "/api/v1/admin/metadata/environments/dev/inventory?artifactKind=resource&resourceType=map");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadAsStringAsync();
+        var inventory = JsonSerializer.Deserialize(
+            payload,
+            MetadataReleaseJsonContext.Default.MetadataSemanticInventoryResponse);
+
+        inventory.Should().NotBeNull();
+        inventory!.Environment.Should().Be("dev");
+        inventory.Revision.Should().Be(41);
+        inventory.ETag.Should().Be("etag-dev-41");
+        inventory.Entries.Should().ContainSingle(entry =>
+            entry.SemanticId == "res.parcels" &&
+            entry.ArtifactKind == MetadataSemanticArtifactKind.Resource &&
+            entry.ResourceType == MetadataV2ResourceType.Map);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/metadata/environment-bindings/query")]
+    public async Task QueryEnvironmentBindings_WithUnavailableEnvironment_ReturnsSecretSafeStates()
+    {
+        var body = JsonSerializer.Serialize(
+            new MetadataEnvironmentBindingsRequest
+            {
+                Environments = ["dev", "prod"],
+                SemanticIds = ["res.parcels"],
+            },
+            MetadataReleaseJsonContext.Default.MetadataEnvironmentBindingsRequest);
+
+        var response = await _client.PostAsync(
+            "/api/v1/admin/metadata/environment-bindings/query",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadAsStringAsync();
+        payload.Should().Contain("aws-sm://honua/dev/parcels");
+        payload.Should().NotContain("super-secret-password");
+
+        var bindings = JsonSerializer.Deserialize(
+            payload,
+            MetadataReleaseJsonContext.Default.MetadataEnvironmentBindingsResponse);
+        bindings.Should().NotBeNull();
+        bindings!.Bindings.Should().Contain(binding =>
+            binding.Environment == "dev" &&
+            binding.State == MetadataEnvironmentBindingState.Bound &&
+            binding.Connection!.SecretRef == "aws-sm://honua/dev/parcels");
+        bindings.Bindings.Should().Contain(binding =>
+            binding.Environment == "prod" &&
+            binding.State == MetadataEnvironmentBindingState.EnvironmentUnavailable);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/metadata/release-packages")]
+    [Endpoint("GET /api/v1/admin/metadata/release-packages/{packageId}")]
+    [Endpoint("GET /api/v1/admin/metadata/release-packages/{packageId}/gitops-manifest")]
+    public async Task ReleasePackageEndpoints_CreateReadAndExportGitOpsSafeManifest()
+    {
+        var body = JsonSerializer.Serialize(
+            new CreateMetadataReleasePackageRequest
+            {
+                Title = "Promote parcels",
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["res.parcels"],
+            },
+            MetadataReleaseJsonContext.Default.CreateMetadataReleasePackageRequest);
+
+        var createResponse = await _client.PostAsync(
+            "/api/v1/admin/metadata/release-packages",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var createPayload = await createResponse.Content.ReadAsStringAsync();
+        var created = JsonSerializer.Deserialize(
+            createPayload,
+            MetadataReleaseJsonContext.Default.MetadataReleasePackage);
+        created.Should().NotBeNull();
+        created!.SourceRevision.Should().Be(41);
+        created.Entries.Should().ContainSingle(entry =>
+            entry.SemanticId == "res.parcels" &&
+            entry.TargetStates.Single().CurrentMetadataRevision == 7);
+
+        var getResponse = await _client.GetAsync(
+            $"/api/v1/admin/metadata/release-packages/{created.PackageId:D}");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var manifestResponse = await _client.GetAsync(
+            $"/api/v1/admin/metadata/release-packages/{created.PackageId:D}/gitops-manifest");
+        manifestResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var manifestPayload = await manifestResponse.Content.ReadAsStringAsync();
+        manifestPayload.Should().Contain("MetadataReleasePackage");
+        manifestPayload.Should().Contain("content-v1");
+        manifestPayload.Should().NotContain("super-secret-password");
+
+        var manifest = JsonSerializer.Deserialize(
+            manifestPayload,
+            MetadataReleaseJsonContext.Default.GitOpsMetadataReleaseManifest);
+        manifest.Should().NotBeNull();
+        manifest!.Spec.Source.Revision.Should().Be(41);
+        manifest.Spec.Targets.Should().ContainSingle(target => target.Environment == "staging");
+    }
+
+    private static MetadataV2Graph BuildGraph(string environment, long revision)
+    {
+        var passwordOption = JsonSerializer.Deserialize<JsonElement>("\"super-secret-password\"");
+        return new MetadataV2Graph
+        {
+            Environment = environment,
+            Revision = revision,
+            GeneratedAt = DateTimeOffset.UtcNow,
+            Resources =
+            [
+                new MetadataV2Resource
+                {
+                    Metadata = new MetadataV2ObjectMetadata
+                    {
+                        Id = "res.parcels",
+                        Name = "parcels",
+                        Title = "Parcels",
+                        Annotations = new Dictionary<string, string>
+                        {
+                            ["honua.io/content-version-id"] = "content-v1",
+                        },
+                    },
+                    Type = MetadataV2ResourceType.Map,
+                    StorageBindingIds = ["storage.parcels"],
+                    PrimaryStorageBindingId = "storage.parcels",
+                },
+            ],
+            Connections =
+            [
+                new MetadataV2Connection
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "conn.parcels", Name = "parcels-db" },
+                    Type = MetadataV2ConnectionType.Database,
+                    Provider = "postgres",
+                    SecretRef = "aws-sm://honua/dev/parcels",
+                    Options = new Dictionary<string, JsonElement>
+                    {
+                        ["password"] = passwordOption,
+                    },
+                },
+            ],
+            StorageBindings =
+            [
+                new MetadataV2StorageBinding
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "storage.parcels", Name = "storage.parcels" },
+                    ResourceId = "res.parcels",
+                    ConnectionId = "conn.parcels",
+                    StorageType = MetadataV2StorageType.RelationalTable,
+                    Locator = $"{environment}_schema.parcels",
+                },
+            ],
+            Services =
+            [
+                new MetadataV2Service
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "svc.features", Name = "features" },
+                    ServiceType = MetadataV2ServiceType.OgcApiFeatures,
+                    Route = $"/{environment}/ogc/features",
+                    PublicationIds = ["pub.parcels"],
+                },
+            ],
+            Publications =
+            [
+                new MetadataV2Publication
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "pub.parcels", Name = "parcels" },
+                    ResourceId = "res.parcels",
+                    ServiceId = "svc.features",
+                    StorageBindingId = "storage.parcels",
+                    PublicationType = MetadataV2PublicationType.OgcCollection,
+                    Path = "parcels",
+                    ServiceLocalId = "parcels",
+                },
+            ],
+        };
+    }
+
+    private sealed class StaticEnvironmentReader : IMetadataV2EnvironmentSnapshotReader
+    {
+        private readonly Dictionary<string, MetadataV2GraphSnapshot> _snapshots;
+
+        public StaticEnvironmentReader(params MetadataV2Graph[] graphs)
+        {
+            _snapshots = graphs.ToDictionary(
+                static graph => graph.Environment,
+                static graph => new MetadataV2GraphSnapshot(
+                    graph,
+                    $"etag-{graph.Environment}-{graph.Revision}",
+                    DateTimeOffset.UtcNow),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        public ValueTask<MetadataV2GraphSnapshot?> GetCurrentAsync(
+            string environment,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(
+                _snapshots.TryGetValue(environment, out var snapshot) ? snapshot : null);
+
+        public ValueTask<MetadataV2GraphSnapshot?> GetByRevisionAsync(
+            string environment,
+            long revision,
+            CancellationToken cancellationToken = default)
+        {
+            var snapshot = _snapshots.TryGetValue(environment, out var current) && current.Revision == revision
+                ? current
+                : null;
+            return ValueTask.FromResult(snapshot);
+        }
+
+        public async IAsyncEnumerable<MetadataV2EnvironmentRevision> ListCurrentRevisionsAsync(
+            IReadOnlyList<string> environments,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            foreach (var environment in environments)
+            {
+                if (_snapshots.TryGetValue(environment, out var snapshot))
+                {
+                    yield return new MetadataV2EnvironmentRevision
+                    {
+                        Environment = snapshot.Graph.Environment,
+                        Revision = snapshot.Revision,
+                        ETag = snapshot.Etag,
+                        ActivatedAt = snapshot.LoadedAt,
+                    };
+                }
+            }
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
@@ -162,6 +162,35 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
         manifest.Spec.Targets.Should().ContainSingle(target => target.Environment == "staging");
     }
 
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/metadata/release-packages")]
+    public async Task CreateReleasePackage_WithDuplicateDefaultNamespacePackageKey_ReturnsConflict()
+    {
+        var body = JsonSerializer.Serialize(
+            new CreateMetadataReleasePackageRequest
+            {
+                PackageKey = "duplicate-package-key",
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["res.parcels"],
+            },
+            MetadataReleaseJsonContext.Default.CreateMetadataReleasePackageRequest);
+        var content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        var firstResponse = await _client.PostAsync(
+            "/api/v1/admin/metadata/release-packages",
+            content);
+
+        firstResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var secondResponse = await _client.PostAsync(
+            "/api/v1/admin/metadata/release-packages",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var payload = await secondResponse.Content.ReadAsStringAsync();
+        payload.Should().Contain("Metadata release package conflicts with an existing package.");
+    }
+
     private static MetadataV2Graph BuildGraph(string environment, long revision)
     {
         var passwordOption = JsonSerializer.Deserialize<JsonElement>("\"super-secret-password\"");

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
@@ -205,6 +205,46 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/metadata/release-packages")]
+    public async Task CreateReleasePackage_WithRepeatedGeneratedTitleKeys_ReturnsCreatedPackages()
+    {
+        var body = JsonSerializer.Serialize(
+            new CreateMetadataReleasePackageRequest
+            {
+                Title = "Promote parcels",
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["res.parcels"],
+            },
+            MetadataReleaseJsonContext.Default.CreateMetadataReleasePackageRequest);
+
+        var firstResponse = await _client.PostAsync(
+            "/api/v1/admin/metadata/release-packages",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+        var secondResponse = await _client.PostAsync(
+            "/api/v1/admin/metadata/release-packages",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        firstResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var firstPayload = await firstResponse.Content.ReadAsStringAsync();
+        var secondPayload = await secondResponse.Content.ReadAsStringAsync();
+        var first = JsonSerializer.Deserialize(
+            firstPayload,
+            MetadataReleaseJsonContext.Default.MetadataReleasePackage);
+        var second = JsonSerializer.Deserialize(
+            secondPayload,
+            MetadataReleaseJsonContext.Default.MetadataReleasePackage);
+
+        first.Should().NotBeNull();
+        second.Should().NotBeNull();
+        first!.Metadata.Name.Should().StartWith("promote-parcels-");
+        second!.Metadata.Name.Should().StartWith("promote-parcels-");
+        second.Metadata.Name.Should().NotBe(first.Metadata.Name);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/metadata/release-packages")]
     public async Task CreateReleasePackage_WithDuplicateDefaultNamespacePackageKey_ReturnsConflict()
     {
         var body = JsonSerializer.Serialize(


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #1163
## Summary

Metadata GitOps semantic release package and environment bindings
## Changes Made

- Metadata GitOps semantic release package and environment bindings
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/ci/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
