### PR TITLE
fix(grpc): normalize wildcard out fields

### DIFF
--- a/src/Honua.Server/Features/Protocols/Grpc/GrpcConversionHelpers.cs
+++ b/src/Honua.Server/Features/Protocols/Grpc/GrpcConversionHelpers.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using Google.Protobuf;
+using Google.Protobuf.Collections;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
@@ -45,9 +46,7 @@ internal static class GrpcConversionHelpers
             ObjectIds = request.ObjectIds.Count > 0
                 ? request.ObjectIds.ToImmutableArray()
                 : null,
-            OutFields = request.OutFields.Count > 0
-                ? request.OutFields.ToImmutableArray()
-                : null,
+            OutFields = NormalizeOutFields(request.OutFields),
             Offset = request.ResultOffset > 0 ? request.ResultOffset : null,
             Limit = request.ResultRecordCount > 0 ? request.ResultRecordCount : null,
             OutputSrid = TryResolveOutputSrid(request.OutSr),
@@ -78,6 +77,26 @@ internal static class GrpcConversionHelpers
         }
 
         return query;
+    }
+
+    private static ImmutableArray<string>? NormalizeOutFields(RepeatedField<string> outFields)
+    {
+        if (outFields.Count == 0)
+        {
+            return null;
+        }
+
+        var fields = outFields
+            .SelectMany(static field => field.Split(
+                ',',
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Where(static field => field.Length > 0)
+            .ToImmutableArray();
+
+        return fields.IsDefaultOrEmpty ||
+            fields.Any(static field => string.Equals(field, "*", StringComparison.Ordinal))
+                ? null
+                : fields;
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcConversionHelpersTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcConversionHelpersTests.cs
@@ -97,6 +97,37 @@ public sealed class GrpcConversionHelpersTests
     }
 
     [UnitTest]
+    public void ToFeatureQuery_WithOutFieldsWildcard_TreatsAsAllFields()
+    {
+        var request = new Proto.QueryFeaturesRequest
+        {
+            ServiceId = "test",
+            LayerId = 0,
+        };
+        request.OutFields.Add("*");
+
+        var query = GrpcConversionHelpers.ToFeatureQuery(request);
+
+        query.OutFields.Should().BeNull();
+    }
+
+    [UnitTest]
+    public void ToFeatureQuery_WithCommaSeparatedOutFields_SetsOutFields()
+    {
+        var request = new Proto.QueryFeaturesRequest
+        {
+            ServiceId = "test",
+            LayerId = 0,
+        };
+        request.OutFields.Add("name, population");
+
+        var query = GrpcConversionHelpers.ToFeatureQuery(request);
+
+        query.OutFields.Should().NotBeNull();
+        query.OutFields!.Value.Should().Equal("name", "population");
+    }
+
+    [UnitTest]
     public void ToFeatureQuery_WithOutSr_SetsOutputSrid()
     {
         var request = new Proto.QueryFeaturesRequest

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcFeatureServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcFeatureServiceTests.cs
@@ -841,6 +841,42 @@ public sealed class GrpcFeatureServiceTests
     }
 
     [UnitTest]
+    [Endpoint("POST /grpc/geospatial.v1.FeatureService/QueryFeaturesStream")]
+    public async Task QueryFeaturesStream_WithGeoServicesParityOptions_NormalizesWildcardOutFields()
+    {
+        var features = new[]
+        {
+            Feature.Create(1, null, ImmutableDictionary<string, object?>.Empty.Add("name", "pump"))
+        }.ToAsyncEnumerable();
+
+        _streamingStore.StreamFeaturesAsync(0, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(features);
+
+        var request = new Proto.QueryFeaturesRequest
+        {
+            ServiceId = "test",
+            LayerId = 0,
+            Where = "1=1",
+            ReturnGeometry = true,
+            ResultRecordCount = 1
+        };
+        request.OutFields.Add("*");
+
+        var writer = new TestServerStreamWriter<Proto.FeaturePage>();
+        await _sut.QueryFeaturesStream(request, writer, CreateCallContext());
+
+        writer.Pages.Should().ContainSingle();
+        writer.Pages[0].Features.Should().ContainSingle();
+        _streamingStore.Received(1).StreamFeaturesAsync(
+            0,
+            Arg.Is<FeatureQuery>(query =>
+                query.Where == "1=1" &&
+                query.OutFields == null &&
+                query.Limit == 1),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
     [Endpoint("POST /grpc/geospatial.v1.FeatureService/QueryFeatures")]
     public async Task QueryFeatures_WithUnsupportedSpatialFilterWkid_ThrowsInvalidArgument()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcIntegrationTests.cs
@@ -85,8 +85,11 @@ public sealed class GrpcIntegrationTests : IAsyncLifetime
         {
             ServiceId = WebAppFixture.TestServiceId,
             LayerId = WebAppFixture.TestLayerId,
-            Where = "1=1"
+            Where = "1=1",
+            ReturnGeometry = true,
+            ResultRecordCount = 1
         };
+        request.OutFields.Add("*");
 
         var call = _client!.QueryFeaturesStream(request, _headers);
         var pages = new List<Proto.FeaturePage>();


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1161

## Summary
Normalizes gRPC `out_fields` wildcard handling so `QueryFeaturesStream` accepts the same mobile FeatureServer-style request shape as REST/unary clients.

## Changes Made
- Treats gRPC `out_fields=["*"]` as all fields instead of a literal projection field.
- Splits comma-separated gRPC out-field values defensively before domain projection.
- Adds converter, service-level streaming, and database-backed gRPC streaming tests for the mobile request shape.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact
- [x] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` validation locally; default shard timeout was too low, rerun with `HONUA_PRE_PR_SERVER_TEST_TIMEOUT_MINUTES=45` passed restore/build/format/Core/Admin/Cloud/Import/Performance/Comprehensive/FeatureServer shards before the intentionally stopped full sweep.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

## Validation
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~GrpcConversionHelpersTests.ToFeatureQuery_WithOutFieldsWildcard_TreatsAsAllFields|FullyQualifiedName~GrpcConversionHelpersTests.ToFeatureQuery_WithCommaSeparatedOutFields_SetsOutFields|FullyQualifiedName~GrpcFeatureServiceTests.QueryFeaturesStream_WithGeoServicesParityOptions_NormalizesWildcardOutFields"`
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --no-build --no-restore --filter "FullyQualifiedName~GrpcIntegrationTests.QueryFeaturesStream_ReturnsPages"`
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --no-build --no-restore --filter "FullyQualifiedName~Features.Protocols.Grpc"`
- `HONUA_PRE_PR_SERVER_TEST_TIMEOUT_MINUTES=45 HONUA_PRE_PR_HEARTBEAT_SECONDS=120 scripts/ci/pre-pr-check.sh` progressed through restore, build, format, Core, Admin/Infrastructure, Cloud/Contract, Import, Performance, Comprehensive, FeatureServer Endpoints, Services, and Replication before the local full sweep was stopped to avoid continuing unrelated long-running shards.

Unblocks honua-io/honua-mobile#202.
