### PR TITLE
feat: Metadata GitOps compatibility prevalidation with data script coverage (#1164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ See **[docs/README.md](docs/README.md)** for the full table of contents. Common 
 | See protocol coverage | [Protocols Overview](docs/gis/STANDARDS_APIS.md) |
 | Use the admin API | [Control Plane API](docs/operator/CONTROL_PLANE_API.md) |
 | Check compatibility | [MVP Compatibility Contract](docs/gis/MVP_COMPATIBILITY_CONTRACT.md) |
+| Prevalidate Metadata v2 release packages | [Metadata Prevalidation Admin API](docs/admin-api/metadata-prevalidation.md) |
 | Run the STAC ops sample | [STAC Ops Demo](samples/Honua.StacOpsDemo/README.md) |
 | Contribute code | [Contributing](docs/contributor/development/contributing.md) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -158,6 +158,7 @@ How to build against Honua's APIs, SDKs, and protocols.
 
 - [Console Content and RBAC (Baseline)](admin-api/console-content-and-rbac.md) — Metadata v2 content item, session bootstrap, action-check, and provenance endpoints under `/api/v1/console/**` (#1162).
 - [Console Job Observability](admin-api/console-job-observability.md) — Durable execution job list, detail, logs, artifacts, action, cancel, retry, and Operate event correlation endpoints under `/api/v1/admin/jobs/**` (#1170).
+- [Metadata Prevalidation Admin API](admin-api/metadata-prevalidation.md) — Metadata v2 release-package compatibility reports for Console pre-PR and CI checks (#1164).
 - [Scene Dataset Registry](admin-api/scene-dataset-registry.md)
 
 ## Contributor Guides

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -73,6 +73,7 @@
 - [NVIDIA Construction Demo Fixture](demo/nvidia-construction.md)
 - [Console Content and RBAC (Admin API)](admin-api/console-content-and-rbac.md)
 - [Console Job Observability (Admin API)](admin-api/console-job-observability.md)
+- [Metadata Prevalidation Admin API](admin-api/metadata-prevalidation.md)
 - [Scene Dataset Registry (Admin API)](admin-api/scene-dataset-registry.md)
 - [SDK Compatibility](developer/SDK_COMPATIBILITY_MATRIX.md)
 - [SDK Migration Automation Evidence Manifest](developer/sdk-migration-evidence-manifest.md)

--- a/docs/admin-api/metadata-prevalidation.md
+++ b/docs/admin-api/metadata-prevalidation.md
@@ -24,7 +24,7 @@ Provide exactly one package source:
 Required fields:
 
 - `targetEnvironment`: target environment name.
-- `dataScripts`: optional declared script contracts. Send an array when present; `null` is rejected.
+- `dataScripts`: optional declared script contracts. Omit for no scripts; when present it must be an array. Explicit `null` is rejected.
 
 Request validation:
 
@@ -32,7 +32,7 @@ Request validation:
 - Exactly one of `releasePackageId` or `releasePackage` is required.
 - `targetEnvironment` is trimmed and must not be blank.
 - Up to 100 data scripts may be supplied.
-- Each script needs a non-blank `scriptId`, `declaredOperations` as an array, and optional `beforeContract` / `afterContract` objects whose `resources` and `fields` members are arrays.
+- Each script needs a non-blank `scriptId`. `declaredOperations`, contract `resources`, and contract `fields` may be omitted and are treated as empty arrays; when present, they must be arrays and explicit `null` is rejected.
 - A single script may declare up to 1000 contract fields.
 
 ## Response
@@ -81,7 +81,12 @@ Stable finding codes use the `metadata.compat.*` namespace. Current codes cover 
 
 Data scripts may cover findings only when the `beforeContract` matches the current target state and `afterContract` satisfies the missing requirement. If a script's before-contract does not match the target state, the original finding remains uncovered and the report includes `metadata.compat.script.before_contract_mismatch`.
 
-For missing artifacts, `exists: true` alone is not sufficient coverage. The `afterContract` must also declare the expected discriminator and details: `resourceType` for resources, `serviceType` and `route` for services, `publicationType` plus `resourceId`, `serviceId`, path/local id details for publications, and `storage.storageBindingId`, `storage.storageType`, and required storage capabilities for storage bindings.
+For missing artifacts, `exists: true` alone is not sufficient coverage. The `afterContract` must also declare the expected discriminator and details:
+
+- Resources: `resourceType`.
+- Services: `serviceType`, `route`, and any required `capabilities` matching expected enabled protocols.
+- Publications: `publicationType`, `resourceId`, `serviceId`, `path`, `serviceLocalId`, `layerIndex`, and required `supportedFormats` / `capabilities`.
+- Storage bindings: `storage.storageBindingId`, `storage.storageType`, and required storage `storage.capabilities`.
 
 ## Rollback Readiness
 

--- a/docs/admin-api/metadata-prevalidation.md
+++ b/docs/admin-api/metadata-prevalidation.md
@@ -32,7 +32,7 @@ Request validation:
 - Exactly one of `releasePackageId` or `releasePackage` is required.
 - `targetEnvironment` is trimmed and must not be blank.
 - Up to 100 data scripts may be supplied.
-- Each script needs a non-blank `scriptId`. `declaredOperations`, contract `resources`, and contract `fields` may be omitted and are treated as empty arrays; when present, they must be arrays and explicit `null` is rejected.
+- Each script needs a non-blank `scriptId`. Script contract collections may be omitted and are treated as empty arrays; when present, they must be arrays and explicit `null` arrays or entries are rejected. This includes `declaredOperations`, `resources`, `fields`, `requiredIdentifiers`, `domains`, `indexes`, `capabilities`, `supportedFormats`, `semanticRoles`, and storage `capabilities`.
 - A single script may declare up to 1000 contract fields.
 
 ## Response

--- a/docs/admin-api/metadata-prevalidation.md
+++ b/docs/admin-api/metadata-prevalidation.md
@@ -21,7 +21,7 @@ Provide exactly one package source:
 - `releasePackageId`: persisted `MetadataReleasePackage` identifier.
 - `releasePackage`: inline `MetadataReleasePackage` payload for pre-PR drafts.
 
-Required fields:
+Request fields:
 
 - `targetEnvironment`: target environment name.
 - `dataScripts`: optional declared script contracts. Omit for no scripts; when present it must be an array. Explicit `null` is rejected.
@@ -32,12 +32,28 @@ Request validation:
 - Exactly one of `releasePackageId` or `releasePackage` is required.
 - `targetEnvironment` is trimmed and must not be blank.
 - Up to 100 data scripts may be supplied.
-- Each script needs a non-blank `scriptId`. Script contract collections may be omitted and are treated as empty arrays; when present, they must be arrays and explicit `null` arrays or entries are rejected. This includes `declaredOperations`, `resources`, `fields`, `requiredIdentifiers`, `domains`, `indexes`, `capabilities`, `supportedFormats`, `semanticRoles`, and storage `capabilities`.
+- Each script needs a non-blank `scriptId`. A script-level
+  `targetEnvironment` is optional; omitted or blank applies to every target, and
+  a populated value is trimmed and matched case-insensitively against the
+  requested target environment.
+- `beforeContract` and `afterContract` may be omitted when not known. Script
+  contract collections may be omitted and are treated as empty arrays; when
+  present, they must be arrays and explicit `null` arrays or entries are
+  rejected. This includes `declaredOperations`, `resources`, `fields`,
+  `requiredIdentifiers`, `domains`, `indexes`, `capabilities`,
+  `supportedFormats`, `semanticRoles`, and storage `capabilities`.
 - A single script may declare up to 1000 contract fields.
 
 ## Response
 
 The response is `ApiResponse<MetadataCompatibilityReport>`.
+
+Malformed JSON or validation failures return `400` as
+`application/problem+json` with a safe detail message. Missing persisted
+packages, unavailable source revisions, and unavailable target snapshots are not
+`404` responses from this endpoint; they return a successful admin envelope with
+`status: "unknown"` and a `metadata.compat.state.unavailable` finding so
+automation can gate on one report shape.
 
 Top-level report fields:
 

--- a/docs/admin-api/metadata-prevalidation.md
+++ b/docs/admin-api/metadata-prevalidation.md
@@ -1,0 +1,42 @@
+# Metadata Prevalidation Admin API
+
+`POST /api/v1/admin/metadata/prevalidate` generates a server-owned compatibility report for a Metadata v2 release package against a named target environment. Console can call it before opening a Git PR, and CI can call the same endpoint after a release package is committed.
+
+The endpoint is admin-authorized and does not execute data scripts. It compares the proposed package state with the target environment's current Metadata v2 graph snapshot.
+
+## Request
+
+Provide exactly one package source:
+
+- `releasePackageId`: persisted `MetadataReleasePackage` identifier.
+- `releasePackage`: inline `MetadataReleasePackage` payload for pre-PR drafts.
+
+Required fields:
+
+- `targetEnvironment`: target environment name.
+- `dataScripts`: optional declared script contracts. Scripts may cover findings only when `beforeContract` matches current target state and `afterContract` satisfies the missing requirement.
+
+## Response
+
+The response is `ApiResponse<MetadataCompatibilityReport>`.
+
+Report status values:
+
+- `ready`: no findings block or warn.
+- `warning`: no uncovered errors, but warnings or script-covered errors remain.
+- `blocked`: at least one error finding is not covered by a declared script.
+- `unknown`: source package state, target graph state, or comparable declared metadata is unavailable.
+
+`canCreatePullRequest` and `canPromote` are `false` for `blocked` and `unknown` reports.
+
+## Findings
+
+Each finding includes a stable `code`, `severity`, `kind`, affected semantic id/kind, safe `expected` and `actual` details, `requiredAction`, and data-script coverage state.
+
+Rollback readiness is classified as:
+
+- `metadata-only`
+- `service-revision`
+- `script-reversible`
+- `snapshot-required`
+- `manual`

--- a/docs/admin-api/metadata-prevalidation.md
+++ b/docs/admin-api/metadata-prevalidation.md
@@ -2,7 +2,17 @@
 
 `POST /api/v1/admin/metadata/prevalidate` generates a server-owned compatibility report for a Metadata v2 release package against a named target environment. Console can call it before opening a Git PR, and CI can call the same endpoint after a release package is committed.
 
-The endpoint is admin-authorized and does not execute data scripts. It compares the proposed package state with the target environment's current Metadata v2 graph snapshot.
+The endpoint is admin-authorized and does not execute data scripts. It compares the proposed package state with the target environment's current Metadata v2 graph snapshot, using the package source graph revision as the desired-state side of the comparison.
+
+Related Metadata v2 release endpoints:
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/v1/admin/metadata/environments/{environment}/inventory` | Returns revision-stamped semantic inventory for a target environment. |
+| `POST /api/v1/admin/metadata/environment-bindings/query` | Returns secret-safe binding summaries for semantic ids across environments. |
+| `POST /api/v1/admin/metadata/release-packages` | Creates a persisted `MetadataReleasePackage` from source and target environments. |
+| `GET /api/v1/admin/metadata/release-packages/{packageId}` | Reads a persisted release package. |
+| `GET /api/v1/admin/metadata/release-packages/{packageId}/gitops-manifest` | Exports a GitOps-safe JSON manifest for the package. |
 
 ## Request
 
@@ -14,11 +24,36 @@ Provide exactly one package source:
 Required fields:
 
 - `targetEnvironment`: target environment name.
-- `dataScripts`: optional declared script contracts. Scripts may cover findings only when `beforeContract` matches current target state and `afterContract` satisfies the missing requirement.
+- `dataScripts`: optional declared script contracts. Send an array when present; `null` is rejected.
+
+Request validation:
+
+- `releasePackageId` must not be an empty GUID.
+- Exactly one of `releasePackageId` or `releasePackage` is required.
+- `targetEnvironment` is trimmed and must not be blank.
+- Up to 100 data scripts may be supplied.
+- Each script needs a non-blank `scriptId`, `declaredOperations` as an array, and optional `beforeContract` / `afterContract` objects whose `resources` and `fields` members are arrays.
+- A single script may declare up to 1000 contract fields.
 
 ## Response
 
 The response is `ApiResponse<MetadataCompatibilityReport>`.
+
+Top-level report fields:
+
+| Field | Notes |
+|---|---|
+| `targetEnvironment` | Environment analyzed after normalization. |
+| `releasePackageId`, `packageKey` | Package identity when known. |
+| `sourceEnvironment`, `sourceRevision`, `sourceEtag` | Desired-state source package graph. |
+| `targetRevision`, `targetEtag` | Current target graph snapshot used for comparison. |
+| `generatedAt` | Server UTC generation timestamp. |
+| `status` | `ready`, `warning`, `blocked`, or `unknown`. |
+| `canCreatePullRequest`, `canPromote` | `false` for `blocked` and `unknown`; `true` for `ready` and `warning`. |
+| `uncoveredErrorCount`, `coveredErrorCount`, `warningCount`, `scriptCount` | Rollup counters for automation gates. |
+| `findings` | Deterministically ordered finding list. |
+| `affectedDependents` | Blast-radius inventory for Console visualization. |
+| `rollbackReadiness` | Rollback classification and required operator posture. |
 
 Report status values:
 
@@ -27,16 +62,124 @@ Report status values:
 - `blocked`: at least one error finding is not covered by a declared script.
 - `unknown`: source package state, target graph state, or comparable declared metadata is unavailable.
 
-`canCreatePullRequest` and `canPromote` are `false` for `blocked` and `unknown` reports.
+`canCreatePullRequest` and `canPromote` are both status-derived. Script-covered error findings allow those gates to pass, but the report remains `warning` so callers can show the required script step.
 
 ## Findings
 
 Each finding includes a stable `code`, `severity`, `kind`, affected semantic id/kind, safe `expected` and `actual` details, `requiredAction`, and data-script coverage state.
 
+Finding kinds are `state`, `resource`, `field`, `identifier`, `spatial`, `temporal`, `storage`, `service`, `publication`, `projection`, `policy`, and `script`. Severities are `info`, `warning`, and `error`.
+
+Coverage states:
+
+- `not-applicable`: no data-script coverage is needed.
+- `uncovered`: an error finding still blocks the gate.
+- `covered-by-script`: a declared script can cover the finding.
+- `unknown`: state is unavailable or the declared metadata is insufficient.
+
+Stable finding codes use the `metadata.compat.*` namespace. Current codes cover unavailable state, missing or mismatched resources, fields, identifiers, spatial metadata, temporal metadata, storage bindings, services, publications, projection semantics, policy references, and script before-contract mismatches.
+
+Data scripts may cover findings only when the `beforeContract` matches the current target state and `afterContract` satisfies the missing requirement. If a script's before-contract does not match the target state, the original finding remains uncovered and the report includes `metadata.compat.script.before_contract_mismatch`.
+
+For missing artifacts, `exists: true` alone is not sufficient coverage. The `afterContract` must also declare the expected discriminator and details: `resourceType` for resources, `serviceType` and `route` for services, `publicationType` plus `resourceId`, `serviceId`, path/local id details for publications, and `storage.storageBindingId`, `storage.storageType`, and required storage capabilities for storage bindings.
+
+## Rollback Readiness
+
 Rollback readiness is classified as:
 
-- `metadata-only`
-- `service-revision`
-- `script-reversible`
-- `snapshot-required`
-- `manual`
+- `metadata-only`: only Metadata v2 graph/package state needs rollback.
+- `service-revision`: service or publication identity changed and rollback should use a service revision.
+- `script-reversible`: covered data-impacting changes use scripts declared as reversible.
+- `snapshot-required`: at least one covering script is not declared reversible.
+- `manual`: state/script applicability is unknown, or uncovered data-impacting errors need operator planning.
+
+## Example
+
+```http
+POST /api/v1/admin/metadata/prevalidate
+Content-Type: application/json
+X-API-Key: <admin-api-key>
+
+{
+  "releasePackageId": "33333333-3333-3333-3333-333333333333",
+  "targetEnvironment": "staging",
+  "dataScripts": [
+    {
+      "scriptId": "script.add-apn",
+      "kind": "sql",
+      "reversible": true,
+      "declaredOperations": ["add-field"],
+      "beforeContract": {
+        "resources": [
+          {
+            "semanticId": "res.parcels",
+            "semanticKind": "resource",
+            "exists": true,
+            "fields": [
+              { "semanticId": "field.parcels.apn", "name": "apn", "exists": false }
+            ]
+          }
+        ]
+      },
+      "afterContract": {
+        "resources": [
+          {
+            "semanticId": "res.parcels",
+            "semanticKind": "resource",
+            "exists": true,
+            "fields": [
+              { "semanticId": "field.parcels.apn", "name": "apn", "exists": true, "type": "string", "nullable": false }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Successful responses use the normal admin envelope:
+
+```json
+{
+  "success": true,
+  "data": {
+    "targetEnvironment": "staging",
+    "releasePackageId": "33333333-3333-3333-3333-333333333333",
+    "status": "warning",
+    "canCreatePullRequest": true,
+    "canPromote": true,
+    "uncoveredErrorCount": 0,
+    "coveredErrorCount": 1,
+    "warningCount": 0,
+    "scriptCount": 1,
+    "findings": [
+      {
+        "code": "metadata.compat.field.missing",
+        "severity": "error",
+        "kind": "field",
+        "affectedSemanticId": "field.parcels.apn",
+        "affectedSemanticKind": "field",
+        "affectedParentSemanticId": "res.parcels",
+        "message": "Required field is missing in the target environment.",
+        "expected": { "label": "field", "value": "apn", "details": { "type": "string" } },
+        "actual": { "label": "field", "value": "missing" },
+        "requiredAction": "run-data-script",
+        "coverageState": "covered-by-script",
+        "coveringScriptId": "script.add-apn"
+      }
+    ],
+    "affectedDependents": [],
+    "rollbackReadiness": {
+      "classification": "script-reversible",
+      "requiresSnapshot": false,
+      "requiresManualAction": false,
+      "scriptIds": ["script.add-apn"]
+    }
+  }
+}
+```
+
+## Observability
+
+The core service emits the `honua.metadata.compatibility.prevalidate` activity with target environment, package id, source revision, script count, finding count, uncovered/covered error counts, dependent count, status, and target revision tags. Structured logs use event ids `116400` through `116402`.

--- a/docs/contributor/architecture/metadata-v2-release-readiness.md
+++ b/docs/contributor/architecture/metadata-v2-release-readiness.md
@@ -174,9 +174,11 @@ Release evidence:
   while preserving the automation gates.
 - Declared data scripts are never executed by prevalidation. They cover findings
   only when their before-contract matches target state and their after-contract
-  satisfies the missing requirement.
+  satisfies the missing requirement; `exists: true` alone does not cover missing
+  resources, services, publications, or storage bindings.
 - Core analysis and the admin endpoint have tests for ready, blocked, warning,
-  unavailable-state, script-covered, before-contract-mismatch, and rollback
+  unavailable-state, script-covered, exists-only non-coverage,
+  before-contract-mismatch, explicit `dataScripts: null` rejection, and rollback
   readiness outcomes.
 
 ## Review Output

--- a/docs/contributor/architecture/metadata-v2-release-readiness.md
+++ b/docs/contributor/architecture/metadata-v2-release-readiness.md
@@ -175,11 +175,13 @@ Release evidence:
 - Declared data scripts are never executed by prevalidation. They cover findings
   only when their before-contract matches target state and their after-contract
   satisfies the missing requirement; `exists: true` alone does not cover missing
-  resources, services, publications, or storage bindings.
+  resources, services, publications, or storage bindings. Script-level
+  `targetEnvironment` narrows coverage to the matching target environment.
 - Core analysis and the admin endpoint have tests for ready, blocked, warning,
   unavailable-state, script-covered, exists-only non-coverage,
-  before-contract-mismatch, explicit `dataScripts: null` rejection, and rollback
-  readiness outcomes.
+  before-contract-mismatch, explicit `dataScripts: null` and nested null
+  collection rejection, omitted collection normalization, and rollback readiness
+  outcomes.
 
 ## Review Output
 

--- a/docs/contributor/architecture/metadata-v2-release-readiness.md
+++ b/docs/contributor/architecture/metadata-v2-release-readiness.md
@@ -151,6 +151,34 @@ Release evidence:
   persistent backing is tracked under #1163 and is not required to gate this
   baseline.
 
+## GitOps Release Prevalidation (#1164)
+
+Derived from:
+
+- [#1163](https://github.com/honua-io/honua-server/issues/1163)
+- [#1164](https://github.com/honua-io/honua-server/issues/1164)
+
+Release evidence:
+
+- `/api/v1/admin/metadata/prevalidate` is documented in
+  [Metadata Prevalidation Admin API](../../admin-api/metadata-prevalidation.md)
+  and listed in `EndpointRegistry.All`.
+- The endpoint accepts either a persisted `releasePackageId` or an inline
+  `MetadataReleasePackage`, plus a target environment and optional declared
+  data-script contracts.
+- Reports include deterministic `metadata.compat.*` finding codes, secret-safe
+  expected/actual values, affected semantic ids, required actions, coverage
+  state, affected dependents, and rollback readiness.
+- `canCreatePullRequest` and `canPromote` are false for `blocked` and
+  `unknown`; script-covered errors downgrade the overall status to `warning`
+  while preserving the automation gates.
+- Declared data scripts are never executed by prevalidation. They cover findings
+  only when their before-contract matches target state and their after-contract
+  satisfies the missing requirement.
+- Core analysis and the admin endpoint have tests for ready, blocked, warning,
+  unavailable-state, script-covered, before-contract-mismatch, and rollback
+  readiness outcomes.
+
 ## Review Output
 
 For a Metadata v2 release candidate, capture:

--- a/docs/developer/api-specs/README.md
+++ b/docs/developer/api-specs/README.md
@@ -97,6 +97,7 @@ See the [OGC API Coverages Coverage](../../gis/specifications/ogc-api-coverages-
 - Publish and configure layers from database tables
 - Control layer enabling/disabling and protocol settings
 - Manage map styles and layer styling
+- Create Metadata v2 release packages and prevalidate release compatibility against target environments before GitOps promotion
 - Scan GeoServer REST and ArcGIS GeoServices REST FeatureServer/MapServer service roots into deterministic migration inventory artifacts with compatibility rollups
 - Monitor system health and observability
 - Inspect durable background jobs, structured logs, artifacts, control actions, and Operate event correlations

--- a/docs/developer/api-specs/admin-api.json
+++ b/docs/developer/api-specs/admin-api.json
@@ -3017,6 +3017,216 @@
         }
       }
     },
+    "/metadata/environments/{environment}/inventory": {
+      "get": {
+        "tags": ["Metadata"],
+        "summary": "Get Metadata Semantic Inventory",
+        "description": "Return the active Metadata v2 revision-stamped semantic inventory for an environment.",
+        "operationId": "getMetadataSemanticInventory",
+        "parameters": [
+          {
+            "name": "environment",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "artifactKind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["resource", "service", "publication", "field", "catalog", "policy", "role"]
+            }
+          },
+          {
+            "name": "resourceType",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["feature-dataset", "raster-dataset", "table", "tile-dataset", "process", "style", "document", "external-resource", "map", "dashboard", "form", "app", "workflow", "geoprocessing-service", "etl-pipeline"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Revision-stamped semantic inventory",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MetadataSemanticInventoryResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/metadata/environment-bindings/query": {
+      "post": {
+        "tags": ["Metadata"],
+        "summary": "Query Metadata Environment Bindings",
+        "description": "Return secret-safe binding summaries for semantic ids across target environments.",
+        "operationId": "queryMetadataEnvironmentBindings",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MetadataEnvironmentBindingsRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Secret-safe binding summaries",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MetadataEnvironmentBindingsResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/metadata/release-packages": {
+      "post": {
+        "tags": ["Metadata"],
+        "summary": "Create Metadata Release Package",
+        "description": "Persist a Metadata v2 release package for semantic cross-environment promotion.",
+        "operationId": "createMetadataReleasePackage",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateMetadataReleasePackageRequest" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Metadata release package created",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MetadataReleasePackage" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "409": { "$ref": "#/components/responses/Conflict" }
+        }
+      }
+    },
+    "/metadata/release-packages/{packageId}": {
+      "get": {
+        "tags": ["Metadata"],
+        "summary": "Get Metadata Release Package",
+        "operationId": "getMetadataReleasePackage",
+        "parameters": [
+          {
+            "name": "packageId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Metadata release package",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MetadataReleasePackage" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/metadata/release-packages/{packageId}/gitops-manifest": {
+      "get": {
+        "tags": ["Metadata"],
+        "summary": "Get Metadata Release GitOps Manifest",
+        "description": "Export a persisted release package as a GitOps-safe JSON manifest.",
+        "operationId": "getMetadataReleaseGitOpsManifest",
+        "parameters": [
+          {
+            "name": "packageId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GitOps-safe metadata release manifest",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/GitOpsMetadataReleaseManifest" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/metadata/prevalidate": {
+      "post": {
+        "tags": ["Metadata"],
+        "summary": "Prevalidate Metadata Release Package Compatibility",
+        "description": "Generate an environment-scoped Metadata v2 compatibility report for a release package. The endpoint compares the package source graph revision with the current target environment snapshot, evaluates optional declared data-script before/after contracts, and does not execute scripts.",
+        "operationId": "prevalidateMetadataReleasePackageCompatibility",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataPrevalidateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Metadata compatibility report",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponseMetadataCompatibilityReport"
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": {
+            "description": "Prevalidation could not be completed",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/metadata/resources": {
       "get": {
         "tags": ["Metadata Resources"],
@@ -8368,6 +8578,649 @@
           "data": { "$ref": "#/components/schemas/ManifestApplyResult" },
           "message": { "type": "string" },
           "timestamp": { "type": "string", "format": "date-time" }
+        }
+      },
+      "MetadataSemanticInventoryResponse": {
+        "type": "object",
+        "required": ["environment", "revision", "etag", "generatedAt", "entries"],
+        "properties": {
+          "environment": { "type": "string" },
+          "revision": { "type": "integer", "format": "int64" },
+          "etag": { "type": "string" },
+          "generatedAt": { "type": "string", "format": "date-time" },
+          "entries": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/MetadataSemanticInventoryEntry" }
+          }
+        }
+      },
+      "MetadataSemanticInventoryEntry": {
+        "type": "object",
+        "required": ["semanticId", "artifactKind", "name"],
+        "properties": {
+          "semanticId": { "type": "string" },
+          "artifactKind": {
+            "type": "string",
+            "enum": ["resource", "service", "publication", "field", "catalog", "policy", "role"]
+          },
+          "resourceType": {
+            "type": "string",
+            "enum": ["feature-dataset", "raster-dataset", "table", "tile-dataset", "process", "style", "document", "external-resource", "map", "dashboard", "form", "app", "workflow", "geoprocessing-service", "etl-pipeline"]
+          },
+          "serviceType": {
+            "type": "string",
+            "enum": ["ogc-api-features", "wfs", "wms", "wmts", "esri-feature-service", "esri-map-service", "esri-image-service", "stac-api", "dcat-catalog", "ogc-records", "odata", "custom"]
+          },
+          "publicationType": {
+            "type": "string",
+            "enum": ["ogc-collection", "wfs-feature-type", "wms-layer", "wmts-layer", "esri-feature-layer", "esri-map-layer", "esri-image-layer", "stac-collection", "dcat-distribution", "ogc-record", "odata-entity-set", "custom"]
+          },
+          "parentSemanticId": { "type": "string" },
+          "name": { "type": "string" },
+          "namespace": { "type": "string" },
+          "title": { "type": "string" },
+          "metadataGeneration": { "type": "integer", "format": "int64" },
+          "status": { "type": "string", "enum": ["draft", "active", "deprecated", "retired", "archived"] },
+          "contentVersionId": { "type": "string" },
+          "provenance": {
+            "type": "array",
+            "items": { "type": "object", "additionalProperties": true }
+          },
+          "policyIds": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "MetadataEnvironmentBindingsRequest": {
+        "type": "object",
+        "properties": {
+          "environments": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "semanticIds": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "MetadataEnvironmentBindingsResponse": {
+        "type": "object",
+        "required": ["requestedAt", "environments", "bindings"],
+        "properties": {
+          "requestedAt": { "type": "string", "format": "date-time" },
+          "environments": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "bindings": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/MetadataEnvironmentBindingSummary" }
+          }
+        }
+      },
+      "MetadataEnvironmentBindingSummary": {
+        "type": "object",
+        "required": ["semanticId", "environment", "state"],
+        "properties": {
+          "semanticId": { "type": "string" },
+          "environment": { "type": "string" },
+          "state": { "type": "string", "enum": ["bound", "missing", "environment-unavailable"] },
+          "revision": { "type": "integer", "format": "int64" },
+          "etag": { "type": "string" },
+          "artifactKind": {
+            "type": "string",
+            "enum": ["resource", "service", "publication", "field", "catalog", "policy", "role"]
+          },
+          "resource": { "type": "object", "additionalProperties": true },
+          "field": { "$ref": "#/components/schemas/MetadataBoundFieldSummary" },
+          "service": { "type": "object", "additionalProperties": true },
+          "publication": { "type": "object", "additionalProperties": true },
+          "storage": { "type": "object", "additionalProperties": true },
+          "connection": { "type": "object", "additionalProperties": true },
+          "contentVersionId": { "type": "string" },
+          "lastObservedAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "CreateMetadataReleasePackageRequest": {
+        "type": "object",
+        "required": ["sourceEnvironment"],
+        "properties": {
+          "packageKey": { "type": "string" },
+          "namespace": { "type": "string" },
+          "title": { "type": "string" },
+          "summary": { "type": "string" },
+          "sourceEnvironment": { "type": "string" },
+          "targetEnvironments": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "semanticIds": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "desiredRevision": { "type": "integer", "format": "int64" },
+          "desiredContentVersionId": { "type": "string" },
+          "changeClasses": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "enum": ["metadata", "content", "binding", "policy", "delete"]
+            }
+          },
+          "provenance": {
+            "type": "array",
+            "items": { "type": "object", "additionalProperties": true }
+          }
+        }
+      },
+      "MetadataPrevalidateRequest": {
+        "type": "object",
+        "required": ["targetEnvironment"],
+        "description": "Request body for Metadata v2 release-package compatibility prevalidation. Exactly one of releasePackageId or releasePackage is required.",
+        "properties": {
+          "releasePackageId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Persisted MetadataReleasePackage identifier. Must not be an empty GUID."
+          },
+          "releasePackage": {
+            "$ref": "#/components/schemas/MetadataReleasePackage"
+          },
+          "targetEnvironment": {
+            "type": "string",
+            "description": "Target environment whose current Metadata v2 graph snapshot is compared."
+          },
+          "dataScripts": {
+            "type": "array",
+            "description": "Optional declared data script contracts. Prevalidation analyzes these declarations but never executes scripts.",
+            "items": { "$ref": "#/components/schemas/MetadataDataScriptEntry" }
+          }
+        }
+      },
+      "ApiResponseMetadataCompatibilityReport": {
+        "type": "object",
+        "properties": {
+          "success": { "type": "boolean" },
+          "data": { "$ref": "#/components/schemas/MetadataCompatibilityReport" },
+          "message": { "type": "string" },
+          "timestamp": { "type": "string", "format": "date-time" }
+        }
+      },
+      "MetadataCompatibilityReport": {
+        "type": "object",
+        "required": [
+          "targetEnvironment",
+          "generatedAt",
+          "status",
+          "canCreatePullRequest",
+          "canPromote",
+          "uncoveredErrorCount",
+          "coveredErrorCount",
+          "warningCount",
+          "scriptCount",
+          "findings",
+          "affectedDependents",
+          "rollbackReadiness"
+        ],
+        "properties": {
+          "targetEnvironment": { "type": "string" },
+          "releasePackageId": { "type": "string", "format": "uuid" },
+          "packageKey": { "type": "string" },
+          "sourceEnvironment": { "type": "string" },
+          "sourceRevision": { "type": "integer", "format": "int64" },
+          "sourceEtag": { "type": "string" },
+          "targetRevision": { "type": "integer", "format": "int64" },
+          "targetEtag": { "type": "string" },
+          "generatedAt": { "type": "string", "format": "date-time" },
+          "status": {
+            "type": "string",
+            "enum": ["ready", "warning", "blocked", "unknown"]
+          },
+          "canCreatePullRequest": {
+            "type": "boolean",
+            "description": "False for blocked and unknown reports; true for ready and warning reports."
+          },
+          "canPromote": {
+            "type": "boolean",
+            "description": "False for blocked and unknown reports; true for ready and warning reports."
+          },
+          "uncoveredErrorCount": { "type": "integer", "format": "int32" },
+          "coveredErrorCount": { "type": "integer", "format": "int32" },
+          "warningCount": { "type": "integer", "format": "int32" },
+          "scriptCount": { "type": "integer", "format": "int32" },
+          "findings": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/MetadataCompatibilityFinding" }
+          },
+          "affectedDependents": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/MetadataAffectedDependent" }
+          },
+          "rollbackReadiness": { "$ref": "#/components/schemas/MetadataRollbackReadiness" }
+        }
+      },
+      "MetadataCompatibilityFinding": {
+        "type": "object",
+        "required": [
+          "code",
+          "severity",
+          "kind",
+          "affectedSemanticId",
+          "affectedSemanticKind",
+          "message",
+          "expected",
+          "actual",
+          "requiredAction"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Stable metadata.compat.* finding code."
+          },
+          "severity": { "type": "string", "enum": ["info", "warning", "error"] },
+          "kind": {
+            "type": "string",
+            "enum": ["state", "resource", "field", "identifier", "spatial", "temporal", "storage", "service", "publication", "projection", "policy", "script"]
+          },
+          "affectedSemanticId": { "type": "string" },
+          "affectedSemanticKind": {
+            "type": "string",
+            "enum": ["resource", "service", "publication", "field", "catalog", "policy", "role"]
+          },
+          "affectedParentSemanticId": { "type": "string" },
+          "displayName": { "type": "string" },
+          "message": { "type": "string" },
+          "expected": { "$ref": "#/components/schemas/MetadataCompatibilityValue" },
+          "actual": { "$ref": "#/components/schemas/MetadataCompatibilityValue" },
+          "requiredAction": {
+            "type": "string",
+            "enum": [
+              "none",
+              "resolve-state",
+              "add-resource",
+              "update-resource",
+              "add-field",
+              "update-field",
+              "update-identifier",
+              "update-spatial",
+              "update-temporal",
+              "update-storage",
+              "add-service",
+              "update-service",
+              "add-publication",
+              "update-publication",
+              "run-data-script",
+              "manual-review"
+            ]
+          },
+          "coverageState": {
+            "type": "string",
+            "enum": ["not-applicable", "uncovered", "covered-by-script", "unknown"]
+          },
+          "coveringScriptId": { "type": "string" },
+          "coverageNotes": { "type": "string" }
+        }
+      },
+      "MetadataCompatibilityValue": {
+        "type": "object",
+        "required": ["label"],
+        "properties": {
+          "label": { "type": "string" },
+          "value": { "type": "string" },
+          "details": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          }
+        }
+      },
+      "MetadataAffectedDependent": {
+        "type": "object",
+        "required": ["semanticId", "semanticKind", "impactSeverity", "reason"],
+        "properties": {
+          "semanticId": { "type": "string" },
+          "semanticKind": {
+            "type": "string",
+            "enum": ["resource", "service", "publication", "field", "catalog", "policy", "role"]
+          },
+          "displayName": { "type": "string" },
+          "impactSeverity": { "type": "string", "enum": ["info", "warning", "error"] },
+          "reason": { "type": "string" },
+          "viaSemanticId": { "type": "string" },
+          "relationshipKind": { "type": "string" }
+        }
+      },
+      "MetadataRollbackReadiness": {
+        "type": "object",
+        "required": ["classification", "reason", "requiresSnapshot", "requiresManualAction", "scriptIds"],
+        "properties": {
+          "classification": {
+            "type": "string",
+            "enum": ["metadata-only", "service-revision", "script-reversible", "snapshot-required", "manual"]
+          },
+          "reason": { "type": "string" },
+          "requiresSnapshot": { "type": "boolean" },
+          "requiresManualAction": { "type": "boolean" },
+          "scriptIds": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "MetadataDataScriptEntry": {
+        "type": "object",
+        "required": ["scriptId"],
+        "properties": {
+          "scriptId": { "type": "string" },
+          "title": { "type": "string" },
+          "kind": { "type": "string" },
+          "targetEnvironment": { "type": "string" },
+          "reversible": { "type": "boolean" },
+          "beforeContract": { "$ref": "#/components/schemas/MetadataDataScriptContract" },
+          "afterContract": { "$ref": "#/components/schemas/MetadataDataScriptContract" },
+          "declaredOperations": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "notes": { "type": "string" }
+        }
+      },
+      "MetadataDataScriptContract": {
+        "type": "object",
+        "properties": {
+          "resources": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/MetadataScriptResourceContract" }
+          }
+        }
+      },
+      "MetadataScriptResourceContract": {
+        "type": "object",
+        "required": ["semanticId"],
+        "properties": {
+          "semanticId": { "type": "string" },
+          "semanticKind": {
+            "type": "string",
+            "enum": ["resource", "service", "publication", "field", "catalog", "policy", "role"]
+          },
+          "resourceId": { "type": "string" },
+          "serviceId": { "type": "string" },
+          "exists": { "type": "boolean" },
+          "resourceType": {
+            "type": "string",
+            "enum": ["feature-dataset", "raster-dataset", "table", "tile-dataset", "process", "style", "document", "external-resource", "map", "dashboard", "form", "app", "workflow", "geoprocessing-service", "etl-pipeline"]
+          },
+          "serviceType": {
+            "type": "string",
+            "enum": ["ogc-api-features", "wfs", "wms", "wmts", "esri-feature-service", "esri-map-service", "esri-image-service", "stac-api", "dcat-catalog", "ogc-records", "odata", "custom"]
+          },
+          "publicationType": {
+            "type": "string",
+            "enum": ["ogc-collection", "wfs-feature-type", "wms-layer", "wmts-layer", "esri-feature-layer", "esri-map-layer", "esri-image-layer", "stac-collection", "dcat-distribution", "ogc-record", "odata-entity-set", "custom"]
+          },
+          "route": { "type": "string" },
+          "path": { "type": "string" },
+          "serviceLocalId": { "type": "string" },
+          "layerIndex": { "type": "integer", "format": "int32" },
+          "fields": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/MetadataScriptFieldContract" }
+          },
+          "requiredIdentifiers": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "domains": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "indexes": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "spatial": { "$ref": "#/components/schemas/MetadataScriptSpatialContract" },
+          "temporal": { "$ref": "#/components/schemas/MetadataScriptTemporalContract" },
+          "storage": { "$ref": "#/components/schemas/MetadataScriptStorageContract" },
+          "capabilities": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "supportedFormats": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "MetadataScriptFieldContract": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "semanticId": { "type": "string" },
+          "name": { "type": "string" },
+          "exists": { "type": "boolean" },
+          "type": { "type": "string" },
+          "nullable": { "type": "boolean" },
+          "semanticRoles": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "domains": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "indexes": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "MetadataScriptSpatialContract": {
+        "type": "object",
+        "properties": {
+          "geometryType": { "type": "string" },
+          "srid": { "type": "integer", "format": "int32" }
+        }
+      },
+      "MetadataScriptTemporalContract": {
+        "type": "object",
+        "properties": {
+          "startTimeField": { "type": "string" },
+          "endTimeField": { "type": "string" },
+          "trackIdField": { "type": "string" }
+        }
+      },
+      "MetadataScriptStorageContract": {
+        "type": "object",
+        "properties": {
+          "storageBindingId": { "type": "string" },
+          "storageType": {
+            "type": "string",
+            "enum": ["relational-table", "sql-view", "sql-query", "geopackage-table", "geojson", "geoparquet", "arrow", "cloud-optimized-geotiff", "zarr", "netcdf", "mbtiles", "pmtiles", "tile-cache", "object-prefix", "external-api", "stac-asset"]
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["query", "filter", "sort", "aggregate", "edit", "transactions", "render", "tile", "download", "search"]
+            }
+          }
+        }
+      },
+      "MetadataReleasePackage": {
+        "type": "object",
+        "required": ["packageId", "metadata", "sourceEnvironment", "sourceRevision", "sourceEtag", "createdBy", "createdAt", "updatedAt"],
+        "properties": {
+          "packageId": { "type": "string", "format": "uuid" },
+          "metadata": { "$ref": "#/components/schemas/MetadataV2ObjectMetadata" },
+          "sourceEnvironment": { "type": "string" },
+          "sourceRevision": { "type": "integer", "format": "int64" },
+          "sourceEtag": { "type": "string" },
+          "targetEnvironments": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "entries": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/MetadataReleaseEntry" }
+          },
+          "status": { "type": "string", "enum": ["draft", "ready", "staged", "superseded", "cancelled"] },
+          "createdBy": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" },
+          "extensions": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "MetadataReleaseEntry": {
+        "type": "object",
+        "required": ["semanticId", "artifactKind", "desiredMetadataRevision"],
+        "properties": {
+          "semanticId": { "type": "string" },
+          "artifactKind": {
+            "type": "string",
+            "enum": ["resource", "service", "publication", "field", "catalog", "policy", "role"]
+          },
+          "resourceType": {
+            "type": "string",
+            "enum": ["feature-dataset", "raster-dataset", "table", "tile-dataset", "process", "style", "document", "external-resource", "map", "dashboard", "form", "app", "workflow", "geoprocessing-service", "etl-pipeline"]
+          },
+          "sourceField": { "$ref": "#/components/schemas/MetadataBoundFieldSummary" },
+          "desiredMetadataRevision": { "type": "integer", "format": "int64" },
+          "desiredContentVersionId": { "type": "string" },
+          "desiredProvenance": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "changeClass": { "type": "string", "enum": ["metadata", "content", "binding", "policy", "delete"] },
+          "targetStates": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/MetadataReleaseTargetState" }
+          },
+          "dependentSemanticIds": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "status": { "type": "string", "enum": ["draft", "ready"] }
+        }
+      },
+      "MetadataReleaseTargetState": {
+        "type": "object",
+        "required": ["environment", "bindingState"],
+        "properties": {
+          "environment": { "type": "string" },
+          "currentMetadataRevision": { "type": "integer", "format": "int64" },
+          "currentContentVersionId": { "type": "string" },
+          "bindingState": { "type": "string", "enum": ["bound", "missing", "environment-unavailable"] },
+          "bindingSummary": {
+            "type": "object",
+            "description": "Secret-safe environment binding summary.",
+            "additionalProperties": true
+          }
+        }
+      },
+      "GitOpsMetadataReleaseManifest": {
+        "type": "object",
+        "required": ["metadata", "spec"],
+        "properties": {
+          "apiVersion": { "type": "string", "description": "Metadata v2 API version." },
+          "kind": { "type": "string", "enum": ["MetadataReleasePackage"] },
+          "metadata": { "$ref": "#/components/schemas/MetadataV2ObjectMetadata" },
+          "spec": { "$ref": "#/components/schemas/GitOpsMetadataReleaseSpec" }
+        }
+      },
+      "GitOpsMetadataReleaseSpec": {
+        "type": "object",
+        "required": ["packageId", "source", "targets", "entries"],
+        "properties": {
+          "packageId": { "type": "string", "format": "uuid" },
+          "source": { "$ref": "#/components/schemas/GitOpsMetadataReleaseSource" },
+          "targets": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/GitOpsMetadataReleaseTarget" }
+          },
+          "entries": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/GitOpsMetadataReleaseEntry" }
+          }
+        }
+      },
+      "GitOpsMetadataReleaseSource": {
+        "type": "object",
+        "required": ["environment", "revision", "etag"],
+        "properties": {
+          "environment": { "type": "string" },
+          "revision": { "type": "integer", "format": "int64" },
+          "etag": { "type": "string" }
+        }
+      },
+      "GitOpsMetadataReleaseTarget": {
+        "type": "object",
+        "required": ["environment"],
+        "properties": {
+          "environment": { "type": "string" }
+        }
+      },
+      "GitOpsMetadataReleaseEntry": {
+        "type": "object",
+        "required": ["semanticId", "artifactKind", "desiredMetadataRevision"],
+        "properties": {
+          "semanticId": { "type": "string" },
+          "artifactKind": {
+            "type": "string",
+            "enum": ["resource", "service", "publication", "field", "catalog", "policy", "role"]
+          },
+          "resourceType": {
+            "type": "string",
+            "enum": ["feature-dataset", "raster-dataset", "table", "tile-dataset", "process", "style", "document", "external-resource", "map", "dashboard", "form", "app", "workflow", "geoprocessing-service", "etl-pipeline"]
+          },
+          "sourceField": { "$ref": "#/components/schemas/MetadataBoundFieldSummary" },
+          "desiredMetadataRevision": { "type": "integer", "format": "int64" },
+          "desiredContentVersionId": { "type": "string" },
+          "desiredProvenance": {
+            "type": "array",
+            "items": { "type": "object", "additionalProperties": true }
+          },
+          "changeClass": { "type": "string", "enum": ["metadata", "content", "binding", "policy", "delete"] },
+          "targetStates": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/MetadataReleaseTargetState" }
+          },
+          "dependentSemanticIds": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "MetadataV2ObjectMetadata": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "namespace": { "type": "string" },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "metadataGeneration": { "type": "integer", "format": "int64" },
+          "annotations": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          }
+        }
+      },
+      "MetadataBoundFieldSummary": {
+        "type": "object",
+        "required": ["semanticId", "parentResourceId", "fieldName"],
+        "properties": {
+          "semanticId": { "type": "string" },
+          "parentResourceId": { "type": "string" },
+          "fieldName": { "type": "string" },
+          "fieldType": { "type": "string" }
         }
       },
       "MetadataResource": {

--- a/docs/developer/api-specs/admin-api.json
+++ b/docs/developer/api-specs/admin-api.json
@@ -8734,7 +8734,7 @@
           },
           "dataScripts": {
             "type": "array",
-            "description": "Optional declared data script contracts. Prevalidation analyzes these declarations but never executes scripts.",
+            "description": "Optional declared data script contracts. Omit for no scripts; explicit null is rejected. Prevalidation analyzes these declarations but never executes scripts.",
             "items": { "$ref": "#/components/schemas/MetadataDataScriptEntry" }
           }
         }
@@ -8918,9 +8918,13 @@
           "targetEnvironment": { "type": "string" },
           "reversible": { "type": "boolean" },
           "beforeContract": { "$ref": "#/components/schemas/MetadataDataScriptContract" },
-          "afterContract": { "$ref": "#/components/schemas/MetadataDataScriptContract" },
+          "afterContract": {
+            "description": "Declared post-script state. Missing-artifact coverage requires expected discriminator/detail fields, not only exists=true.",
+            "allOf": [{ "$ref": "#/components/schemas/MetadataDataScriptContract" }]
+          },
           "declaredOperations": {
             "type": "array",
+            "description": "Optional operation labels. Omit for no labels; explicit null is rejected.",
             "items": { "type": "string" }
           },
           "notes": { "type": "string" }
@@ -8931,12 +8935,14 @@
         "properties": {
           "resources": {
             "type": "array",
+            "description": "Semantic artifact contracts. Omit for an empty contract; explicit null is rejected.",
             "items": { "$ref": "#/components/schemas/MetadataScriptResourceContract" }
           }
         }
       },
       "MetadataScriptResourceContract": {
         "type": "object",
+        "description": "Semantic artifact contract used by data-script before/after coverage. For missing artifacts, exists=true alone is not sufficient; include expected resourceType, serviceType/route/protocols, publication identity/details, or storage binding details as applicable.",
         "required": ["semanticId"],
         "properties": {
           "semanticId": { "type": "string" },

--- a/docs/developer/api-specs/admin-api.json
+++ b/docs/developer/api-specs/admin-api.json
@@ -8730,11 +8730,11 @@
           },
           "targetEnvironment": {
             "type": "string",
-            "description": "Target environment whose current Metadata v2 graph snapshot is compared."
+            "description": "Target environment whose current Metadata v2 graph snapshot is compared. The value is trimmed and must not be blank."
           },
           "dataScripts": {
             "type": "array",
-            "description": "Optional declared data script contracts. Omit for no scripts; explicit null is rejected. Prevalidation analyzes these declarations but never executes scripts.",
+            "description": "Optional declared data script contracts. Omit for no scripts; explicit null arrays or entries are rejected. Prevalidation analyzes these declarations but never executes scripts.",
             "items": { "$ref": "#/components/schemas/MetadataDataScriptEntry" }
           }
         }
@@ -8915,11 +8915,17 @@
           "scriptId": { "type": "string" },
           "title": { "type": "string" },
           "kind": { "type": "string" },
-          "targetEnvironment": { "type": "string" },
+          "targetEnvironment": {
+            "type": "string",
+            "description": "Optional target environment for this script. Omitted or blank applies to every target; populated values are trimmed and matched case-insensitively."
+          },
           "reversible": { "type": "boolean" },
-          "beforeContract": { "$ref": "#/components/schemas/MetadataDataScriptContract" },
+          "beforeContract": {
+            "description": "Declared pre-script state. Omit when not known; child collection arrays may be omitted but explicit null arrays or entries are rejected.",
+            "allOf": [{ "$ref": "#/components/schemas/MetadataDataScriptContract" }]
+          },
           "afterContract": {
-            "description": "Declared post-script state. Missing-artifact coverage requires expected discriminator/detail fields, not only exists=true.",
+            "description": "Declared post-script state. Omit when no script coverage is claimed. Missing-artifact coverage requires expected discriminator/detail fields, not only exists=true.",
             "allOf": [{ "$ref": "#/components/schemas/MetadataDataScriptContract" }]
           },
           "declaredOperations": {
@@ -9055,7 +9061,7 @@
           },
           "capabilities": {
             "type": "array",
-            "description": "Storage binding capabilities. Omit for none; explicit null arrays are rejected.",
+            "description": "Storage binding capabilities. Omit for none; explicit null arrays or entries are rejected.",
             "items": {
               "type": "string",
               "enum": ["query", "filter", "sort", "aggregate", "edit", "transactions", "render", "tile", "download", "search"]

--- a/docs/developer/api-specs/admin-api.json
+++ b/docs/developer/api-specs/admin-api.json
@@ -8924,7 +8924,7 @@
           },
           "declaredOperations": {
             "type": "array",
-            "description": "Optional operation labels. Omit for no labels; explicit null is rejected.",
+            "description": "Optional operation labels. Omit for no labels; explicit null arrays or entries are rejected.",
             "items": { "type": "string" }
           },
           "notes": { "type": "string" }
@@ -8935,7 +8935,7 @@
         "properties": {
           "resources": {
             "type": "array",
-            "description": "Semantic artifact contracts. Omit for an empty contract; explicit null is rejected.",
+            "description": "Semantic artifact contracts. Omit for an empty contract; explicit null arrays or entries are rejected.",
             "items": { "$ref": "#/components/schemas/MetadataScriptResourceContract" }
           }
         }
@@ -8971,18 +8971,22 @@
           "layerIndex": { "type": "integer", "format": "int32" },
           "fields": {
             "type": "array",
+            "description": "Fields expected before or after the script. Omit for no fields; explicit null arrays or entries are rejected.",
             "items": { "$ref": "#/components/schemas/MetadataScriptFieldContract" }
           },
           "requiredIdentifiers": {
             "type": "array",
+            "description": "Required field identifiers expected before or after the script. Omit for none; explicit null arrays or entries are rejected.",
             "items": { "type": "string" }
           },
           "domains": {
             "type": "array",
+            "description": "Canonical domain identifiers expected before or after the script. Omit for none; explicit null arrays or entries are rejected.",
             "items": { "type": "string" }
           },
           "indexes": {
             "type": "array",
+            "description": "Canonical index identifiers expected before or after the script. Omit for none; explicit null arrays or entries are rejected.",
             "items": { "type": "string" }
           },
           "spatial": { "$ref": "#/components/schemas/MetadataScriptSpatialContract" },
@@ -8990,10 +8994,12 @@
           "storage": { "$ref": "#/components/schemas/MetadataScriptStorageContract" },
           "capabilities": {
             "type": "array",
+            "description": "Service or publication capabilities expected before or after the script. Omit for none; explicit null arrays or entries are rejected.",
             "items": { "type": "string" }
           },
           "supportedFormats": {
             "type": "array",
+            "description": "Publication formats expected before or after the script. Omit for none; explicit null arrays or entries are rejected.",
             "items": { "type": "string" }
           }
         }
@@ -9009,14 +9015,17 @@
           "nullable": { "type": "boolean" },
           "semanticRoles": {
             "type": "array",
+            "description": "Semantic roles expected on the field. Omit for none; explicit null arrays or entries are rejected.",
             "items": { "type": "string" }
           },
           "domains": {
             "type": "array",
+            "description": "Canonical domain identifiers expected on the field. Omit for none; explicit null arrays or entries are rejected.",
             "items": { "type": "string" }
           },
           "indexes": {
             "type": "array",
+            "description": "Canonical index identifiers expected on the field. Omit for none; explicit null arrays or entries are rejected.",
             "items": { "type": "string" }
           }
         }
@@ -9046,6 +9055,7 @@
           },
           "capabilities": {
             "type": "array",
+            "description": "Storage binding capabilities. Omit for none; explicit null arrays are rejected.",
             "items": {
               "type": "string",
               "enum": ["query", "filter", "sort", "aggregate", "edit", "transactions", "render", "tile", "download", "search"]

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -12,7 +12,7 @@ This map summarizes source-backed runtime capabilities in `honua-server`.
 
 ## Control Plane
 
-- Admin APIs for auth, capabilities, version, connections, service settings, layer publishing, metadata resources, styles, SLD import/export, style suggestions, imports, manifests, GitOps watch/drift/approval, deployment control, observability, geofence zones and alert rules, cache, rate limits, license, identity/OIDC, users, roles, geocoding, tile operations, and scene datasets.
+- Admin APIs for auth, capabilities, version, connections, service settings, layer publishing, Metadata v2 environment inventory, release packages, compatibility prevalidation, styles, SLD import/export, style suggestions, imports, deployment control, observability, geofence zones and alert rules, cache, rate limits, license, identity/OIDC, users, roles, geocoding, tile operations, and scene datasets.
 - Spec workspace endpoints for validate, plan, apply, cancel, artifacts, and grounding helpers.
 - Runtime licensing loads offline Ed25519-signed JSON envelopes, publishes active edition/entitlement status through admin and health surfaces, and gates paid features by entitlement key with HTTP 402 or gRPC `FAILED_PRECONDITION`.
 - Configuration discovery, production monitoring, performance metrics, query-cache stats, health endpoints, OpenTelemetry, structured logs, Redis/in-memory caching, and output caching.

--- a/docs/operator/CONTROL_PLANE_API.md
+++ b/docs/operator/CONTROL_PLANE_API.md
@@ -532,9 +532,10 @@ The public `GET /api/styles/{layerId}.json` endpoint accepts an optional `?theme
 
 Metadata v2 release prevalidation accepts either `releasePackageId` or an inline
 `releasePackage`, plus a `targetEnvironment` and optional declared
-`dataScripts`. It does not execute scripts. It reports `ready`, `warning`,
-`blocked`, or `unknown`, carries `canCreatePullRequest` / `canPromote` gates,
-lists affected dependents, and classifies rollback readiness. See
+`dataScripts`. Omit `dataScripts` for no scripts; explicit `null` is rejected.
+It does not execute scripts. It reports `ready`, `warning`, `blocked`, or
+`unknown`, carries `canCreatePullRequest` / `canPromote` gates, lists affected
+dependents, and classifies rollback readiness. See
 [Metadata Prevalidation Admin API](../admin-api/metadata-prevalidation.md) for
 the full contract.
 

--- a/docs/operator/CONTROL_PLANE_API.md
+++ b/docs/operator/CONTROL_PLANE_API.md
@@ -46,7 +46,7 @@ The Honua Admin UI is intended to operate as a UI on top of this control-plane A
 |-- version, capabilities, manifest
 |-- connections/              # Secure connections + table/layer publishing
 |-- services/                 # Service-level protocol and MapServer settings
-|-- metadata/resources/       # Metadata resources
+|-- metadata/                 # Metadata v2 inventory, release packages, prevalidation, and styles
 |-- metadata/layers/{id}/style
 |-- deploy/                   # Deploy preflight, plan, operations, submit, rollback
 |-- import/                   # Import workflows
@@ -511,6 +511,12 @@ The public `GET /api/styles/{layerId}.json` endpoint accepts an optional `?theme
 |----------|--------|---------|
 | `/api/v1/admin/version` | GET | Get current control-plane and metadata schema version info |
 | `/api/v1/admin/capabilities` | GET | Get admin metadata capabilities and the SDK compatibility contract |
+| `/api/v1/admin/metadata/environments/{environment}/inventory` | GET | Get revision-stamped Metadata v2 semantic inventory for an environment |
+| `/api/v1/admin/metadata/environment-bindings/query` | POST | Query secret-safe semantic binding summaries across environments |
+| `/api/v1/admin/metadata/release-packages` | POST | Create a persisted Metadata v2 release package for cross-environment promotion |
+| `/api/v1/admin/metadata/release-packages/{packageId}` | GET | Get a persisted Metadata v2 release package |
+| `/api/v1/admin/metadata/release-packages/{packageId}/gitops-manifest` | GET | Export a release package as a GitOps-safe manifest |
+| `/api/v1/admin/metadata/prevalidate` | POST | Generate an environment-scoped Metadata v2 compatibility report for a release package |
 | `/api/v1/admin/manifest` | GET | Export metadata manifest |
 | `/api/v1/admin/manifest/apply` | POST | Apply metadata manifest (supports dry-run/prune controls) |
 | `/api/v1/admin/metadata/resources` | GET | List metadata resources |
@@ -523,6 +529,14 @@ The public `GET /api/styles/{layerId}.json` endpoint accepts an optional `?theme
 | `/api/v1/admin/metadata/layers/{layerId}/style/import-sld` | POST | Convert an SLD/SE 1.0 or 1.1 XML document to MapLibre style JSON and store it (admin only, Community edition; 1 MiB body cap). See [SLD Migration Reference](sld-migration.md). |
 | `/api/v1/admin/metadata/layers/{layerId}/style/export-sld` | GET | Export the stored MapLibre style as an `application/xml` SLD 1.0 document. Diagnostic count surfaces in the `X-Sld-Diagnostic-Count` response header. |
 | `/api/styles/{layerId}.json` | GET | Public MapLibre style fetch with optional `?theme=default\|dark\|colorblind-safe\|print` deterministic transform; output cache varies per theme. |
+
+Metadata v2 release prevalidation accepts either `releasePackageId` or an inline
+`releasePackage`, plus a `targetEnvironment` and optional declared
+`dataScripts`. It does not execute scripts. It reports `ready`, `warning`,
+`blocked`, or `unknown`, carries `canCreatePullRequest` / `canPromote` gates,
+lists affected dependents, and classifies rollback readiness. See
+[Metadata Prevalidation Admin API](../admin-api/metadata-prevalidation.md) for
+the full contract.
 
 `Group` and `SourceDescriptor` are stable `honua.io/v1alpha1` metadata resource kinds on the generic CRUD surface. SDKs can list them with `GET /api/v1/admin/metadata/resources?kind=Group` and `GET /api/v1/admin/metadata/resources?kind=SourceDescriptor` instead of probing undocumented catalog endpoints.
 

--- a/docs/operator/CONTROL_PLANE_API.md
+++ b/docs/operator/CONTROL_PLANE_API.md
@@ -533,9 +533,10 @@ The public `GET /api/styles/{layerId}.json` endpoint accepts an optional `?theme
 Metadata v2 release prevalidation accepts either `releasePackageId` or an inline
 `releasePackage`, plus a `targetEnvironment` and optional declared
 `dataScripts`. Omit `dataScripts` for no scripts; explicit `null` is rejected.
-It does not execute scripts. It reports `ready`, `warning`, `blocked`, or
-`unknown`, carries `canCreatePullRequest` / `canPromote` gates, lists affected
-dependents, and classifies rollback readiness. See
+Script-level `targetEnvironment` narrows a declaration to a matching target. It
+does not execute scripts. It reports `ready`, `warning`, `blocked`, or `unknown`,
+carries `canCreatePullRequest` / `canPromote` gates, lists affected dependents,
+and classifies rollback readiness. See
 [Metadata Prevalidation Admin API](../admin-api/metadata-prevalidation.md) for
 the full contract.
 

--- a/src/Honua.Core/Features/Metadata/Abstractions/IMetadataCompatibilityPrevalidationService.cs
+++ b/src/Honua.Core/Features/Metadata/Abstractions/IMetadataCompatibilityPrevalidationService.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Core.Features.Metadata.Abstractions;
+
+/// <summary>
+/// Generates Metadata v2 release-package compatibility reports for target environments.
+/// </summary>
+public interface IMetadataCompatibilityPrevalidationService
+{
+    /// <summary>
+    /// Generates an environment-scoped compatibility report for a persisted or inline release package.
+    /// </summary>
+    /// <param name="request">Prevalidation request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Compatibility report.</returns>
+    Task<MetadataCompatibilityReport> PrevalidateAsync(
+        MetadataCompatibilityPrevalidationRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzer.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzer.cs
@@ -1043,7 +1043,7 @@ public static class MetadataCompatibilityAnalyzer
             MetadataCompatibilityCode.TemporalFieldMismatch =>
                 TemporalContractMatchesActual(FindArtifactContract(contract, finding), finding),
             MetadataCompatibilityCode.StorageBindingMissing =>
-                FindArtifactContract(contract, finding)?.Storage is null,
+                StorageBindingBeforeContractMatches(FindArtifactContract(contract, finding)),
             MetadataCompatibilityCode.StorageTypeMismatch =>
                 FindArtifactContract(contract, finding)?.Storage?.StorageType?.ToString() == finding.Actual.Value,
             MetadataCompatibilityCode.StorageCapabilityMissing =>
@@ -1069,6 +1069,9 @@ public static class MetadataCompatibilityAnalyzer
             contract?.Storage is not null &&
             !contract.Storage.Capabilities.Any(capability =>
                 string.Equals(capability.ToString(), finding.Expected.Value, StringComparison.Ordinal));
+
+    private static bool StorageBindingBeforeContractMatches(MetadataScriptResourceContract? contract)
+        => contract is not null && contract.Storage is null;
 
     private static bool TargetArtifactExists(MetadataV2GraphSnapshot targetSnapshot, MetadataCompatibilityFinding finding)
         => finding.AffectedSemanticKind switch

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzer.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzer.cs
@@ -902,7 +902,6 @@ public static class MetadataCompatibilityAnalyzer
 
         var updated = new List<MetadataCompatibilityFinding>(findings.Count);
         var scriptMismatchFindings = new List<MetadataCompatibilityFinding>();
-        var mismatchKeys = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var finding in findings)
         {
@@ -913,6 +912,8 @@ public static class MetadataCompatibilityAnalyzer
             }
 
             var covered = false;
+            var candidateMismatchFindings = new List<MetadataCompatibilityFinding>();
+            var candidateMismatchKeys = new HashSet<string>(StringComparer.Ordinal);
             foreach (var script in dataScripts)
             {
                 if (!AppliesToTarget(script, targetEnvironment) ||
@@ -935,9 +936,9 @@ public static class MetadataCompatibilityAnalyzer
                 }
 
                 var key = string.Concat(script.ScriptId, "|", finding.Code, "|", finding.AffectedSemanticId);
-                if (mismatchKeys.Add(key))
+                if (candidateMismatchKeys.Add(key))
                 {
-                    scriptMismatchFindings.Add(Finding(
+                    candidateMismatchFindings.Add(Finding(
                         MetadataCompatibilityCode.ScriptBeforeContractMismatch,
                         MetadataCompatibilityFindingSeverity.Error,
                         MetadataCompatibilityFindingKind.Script,
@@ -956,6 +957,7 @@ public static class MetadataCompatibilityAnalyzer
             if (!covered)
             {
                 updated.Add(finding);
+                scriptMismatchFindings.AddRange(candidateMismatchFindings);
             }
         }
 
@@ -1045,7 +1047,7 @@ public static class MetadataCompatibilityAnalyzer
             MetadataCompatibilityCode.StorageTypeMismatch =>
                 FindArtifactContract(contract, finding)?.Storage?.StorageType?.ToString() == finding.Actual.Value,
             MetadataCompatibilityCode.StorageCapabilityMissing =>
-                FindArtifactContract(contract, finding)?.Storage is not null,
+                StorageContractMatchesMissingCapability(FindArtifactContract(contract, finding), finding),
             MetadataCompatibilityCode.ServiceTypeMismatch =>
                 FindArtifactContract(contract, finding)?.ServiceType?.ToString() == finding.Actual.Value,
             MetadataCompatibilityCode.ServiceProtocolMissing =>
@@ -1059,6 +1061,14 @@ public static class MetadataCompatibilityAnalyzer
             _ => false,
         };
     }
+
+    private static bool StorageContractMatchesMissingCapability(
+        MetadataScriptResourceContract? contract,
+        MetadataCompatibilityFinding finding)
+        => !string.IsNullOrWhiteSpace(finding.Expected.Value) &&
+            contract?.Storage is not null &&
+            !contract.Storage.Capabilities.Any(capability =>
+                string.Equals(capability.ToString(), finding.Expected.Value, StringComparison.Ordinal));
 
     private static bool TargetArtifactExists(MetadataV2GraphSnapshot targetSnapshot, MetadataCompatibilityFinding finding)
         => finding.AffectedSemanticKind switch

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzer.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzer.cs
@@ -1,0 +1,1805 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Pure in-memory compatibility analyzer for Metadata v2 release packages.
+/// </summary>
+public static class MetadataCompatibilityAnalyzer
+{
+    private const string DomainIdKey = "domainId";
+    private const string DomainKey = "domain";
+    private const string DomainsKey = "domains";
+    private const string IndexNameKey = "indexName";
+    private const string IndexKey = "index";
+    private const string IndexesKey = "indexes";
+    private const string IndexedKey = "indexed";
+
+    /// <summary>
+    /// Creates an unknown-state report for package or graph resolution failures.
+    /// </summary>
+    public static MetadataCompatibilityReport CreateUnavailableReport(
+        MetadataReleasePackage? package,
+        string targetEnvironment,
+        DateTimeOffset generatedAt,
+        string affectedSemanticId,
+        string expected,
+        string actual,
+        string message,
+        int scriptCount)
+    {
+        ArgumentNullException.ThrowIfNull(targetEnvironment);
+        ArgumentNullException.ThrowIfNull(affectedSemanticId);
+        ArgumentNullException.ThrowIfNull(expected);
+        ArgumentNullException.ThrowIfNull(actual);
+        ArgumentNullException.ThrowIfNull(message);
+
+        var finding = new MetadataCompatibilityFinding
+        {
+            Code = MetadataCompatibilityCode.StateUnavailable,
+            Severity = MetadataCompatibilityFindingSeverity.Error,
+            Kind = MetadataCompatibilityFindingKind.State,
+            AffectedSemanticId = affectedSemanticId,
+            AffectedSemanticKind = MetadataSemanticArtifactKind.Resource,
+            Message = message,
+            Expected = Value("state", expected),
+            Actual = Value("state", actual),
+            RequiredAction = MetadataCompatibilityRequiredAction.ResolveState,
+            CoverageState = MetadataCompatibilityCoverageState.Unknown,
+        };
+
+        return BuildReport(
+            package,
+            targetEnvironment.Trim(),
+            targetRevision: null,
+            targetEtag: null,
+            generatedAt,
+            [finding],
+            Array.Empty<MetadataAffectedDependent>(),
+            Array.Empty<MetadataDataScriptEntry>(),
+            scriptCount);
+    }
+
+    /// <summary>
+    /// Analyzes the release package against source and target graph snapshots.
+    /// </summary>
+    public static MetadataCompatibilityReport Analyze(
+        MetadataReleasePackage package,
+        MetadataV2GraphSnapshot sourceSnapshot,
+        MetadataV2GraphSnapshot targetSnapshot,
+        IReadOnlyList<MetadataDataScriptEntry> dataScripts,
+        DateTimeOffset generatedAt)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+        ArgumentNullException.ThrowIfNull(sourceSnapshot);
+        ArgumentNullException.ThrowIfNull(targetSnapshot);
+        dataScripts ??= Array.Empty<MetadataDataScriptEntry>();
+
+        var findings = new List<MetadataCompatibilityFinding>();
+        var changedSemanticIds = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var entry in package.Entries)
+        {
+            var sourceArtifact = ResolveArtifact(sourceSnapshot, entry);
+            if (sourceArtifact is null)
+            {
+                findings.Add(Finding(
+                    MetadataCompatibilityCode.StateUnavailable,
+                    MetadataCompatibilityFindingSeverity.Error,
+                    MetadataCompatibilityFindingKind.State,
+                    entry.SemanticId,
+                    entry.ArtifactKind,
+                    null,
+                    null,
+                    "The release package entry cannot be resolved in the source graph snapshot.",
+                    Value("source", entry.SemanticId),
+                    Value("source", "missing"),
+                    MetadataCompatibilityRequiredAction.ResolveState,
+                    MetadataCompatibilityCoverageState.Unknown));
+                continue;
+            }
+
+            changedSemanticIds.Add(entry.SemanticId);
+            if (sourceArtifact.ParentResource is not null)
+            {
+                changedSemanticIds.Add(sourceArtifact.ParentResource.Metadata.Id);
+            }
+
+            switch (sourceArtifact.Kind)
+            {
+                case MetadataSemanticArtifactKind.Resource:
+                    CompareResource(sourceArtifact.Resource!, sourceSnapshot, targetSnapshot, findings);
+                    break;
+                case MetadataSemanticArtifactKind.Field:
+                    CompareFieldEntry(sourceArtifact.ParentResource!, sourceArtifact.Field!, targetSnapshot, findings);
+                    break;
+                case MetadataSemanticArtifactKind.Service:
+                    CompareService(sourceArtifact.Service!, targetSnapshot, findings);
+                    break;
+                case MetadataSemanticArtifactKind.Publication:
+                    ComparePublication(sourceArtifact.Publication!, targetSnapshot, findings);
+                    break;
+                case MetadataSemanticArtifactKind.Catalog:
+                    CompareCatalog(sourceArtifact.Catalog!, targetSnapshot, findings);
+                    break;
+                case MetadataSemanticArtifactKind.Policy:
+                    ComparePolicy(sourceArtifact.Policy!, targetSnapshot, findings);
+                    break;
+                case MetadataSemanticArtifactKind.Role:
+                    CompareRole(sourceArtifact.Role!, targetSnapshot, findings);
+                    break;
+            }
+        }
+
+        findings = ApplyDataScriptCoverage(findings, targetSnapshot, dataScripts, package.TargetEnvironments, targetSnapshot.Graph.Environment);
+        var dependents = BuildAffectedDependents(package, targetSnapshot, changedSemanticIds, findings);
+        return BuildReport(
+            package,
+            targetSnapshot.Graph.Environment,
+            targetSnapshot.Revision,
+            targetSnapshot.Etag,
+            generatedAt,
+            findings,
+            dependents,
+            dataScripts,
+            dataScripts.Count);
+    }
+
+    private static void CompareResource(
+        MetadataV2Resource source,
+        MetadataV2GraphSnapshot sourceSnapshot,
+        MetadataV2GraphSnapshot targetSnapshot,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        if (!targetSnapshot.Index.ResourcesById.TryGetValue(source.Metadata.Id, out var target))
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.ResourceMissing,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Resource,
+                source.Metadata.Id,
+                MetadataSemanticArtifactKind.Resource,
+                null,
+                source.Metadata.Title ?? source.Metadata.Name,
+                "The target environment is missing a required resource.",
+                Value("resourceType", source.Type.ToString()),
+                Value("resource", "missing"),
+                MetadataCompatibilityRequiredAction.AddResource,
+                MetadataCompatibilityCoverageState.Uncovered));
+            return;
+        }
+
+        if (source.Type != target.Type)
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.ResourceTypeMismatch,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Resource,
+                source.Metadata.Id,
+                MetadataSemanticArtifactKind.Resource,
+                null,
+                source.Metadata.Title ?? source.Metadata.Name,
+                "The target resource type does not match the proposed resource type.",
+                Value("resourceType", source.Type.ToString()),
+                Value("resourceType", target.Type.ToString()),
+                MetadataCompatibilityRequiredAction.UpdateResource,
+                MetadataCompatibilityCoverageState.Uncovered));
+        }
+
+        CompareResourceFields(source, target, findings);
+        CompareIdentifiers(source, target, findings);
+        CompareSpatial(source, target, findings);
+        CompareTemporal(source, target, findings);
+        CompareStorage(source, target, sourceSnapshot, targetSnapshot, findings);
+        ComparePolicyReferences(source.Metadata.Id, MetadataSemanticArtifactKind.Resource, source.PolicyIds, target.PolicyIds, targetSnapshot, findings);
+    }
+
+    private static void CompareResourceFields(
+        MetadataV2Resource source,
+        MetadataV2Resource target,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        foreach (var sourceField in source.SchemaFields)
+        {
+            CompareField(source, sourceField, target, findings);
+        }
+    }
+
+    private static void CompareFieldEntry(
+        MetadataV2Resource sourceParent,
+        MetadataV2Field sourceField,
+        MetadataV2GraphSnapshot targetSnapshot,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        if (!targetSnapshot.Index.ResourcesById.TryGetValue(sourceParent.Metadata.Id, out var targetParent))
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.ResourceMissing,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Resource,
+                sourceParent.Metadata.Id,
+                MetadataSemanticArtifactKind.Resource,
+                null,
+                sourceParent.Metadata.Title ?? sourceParent.Metadata.Name,
+                "The target environment is missing the parent resource for a required field.",
+                Value("resource", sourceParent.Metadata.Id),
+                Value("resource", "missing"),
+                MetadataCompatibilityRequiredAction.AddResource,
+                MetadataCompatibilityCoverageState.Uncovered));
+            return;
+        }
+
+        CompareField(sourceParent, sourceField, targetParent, findings);
+    }
+
+    private static void CompareField(
+        MetadataV2Resource sourceResource,
+        MetadataV2Field sourceField,
+        MetadataV2Resource targetResource,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        var fieldSemanticId = GetFieldSemanticId(sourceResource, sourceField);
+        var targetField = FindMatchingField(targetResource, sourceField);
+        var expectedDetails = FieldDetails(sourceResource, sourceField);
+
+        if (targetField is null)
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.FieldMissing,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Field,
+                fieldSemanticId,
+                MetadataSemanticArtifactKind.Field,
+                sourceResource.Metadata.Id,
+                sourceField.Title ?? sourceField.Name,
+                "The target resource is missing a required field.",
+                Value("field", sourceField.Name, expectedDetails),
+                Value("field", "missing"),
+                MetadataCompatibilityRequiredAction.AddField,
+                MetadataCompatibilityCoverageState.Uncovered));
+            return;
+        }
+
+        if (!string.Equals(sourceField.Type, targetField.Type, StringComparison.OrdinalIgnoreCase))
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.FieldTypeMismatch,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Field,
+                fieldSemanticId,
+                MetadataSemanticArtifactKind.Field,
+                sourceResource.Metadata.Id,
+                sourceField.Title ?? sourceField.Name,
+                "The target field type does not match the proposed field type.",
+                Value("fieldType", sourceField.Type, expectedDetails),
+                Value("fieldType", targetField.Type, FieldDetails(targetResource, targetField)),
+                MetadataCompatibilityRequiredAction.UpdateField,
+                MetadataCompatibilityCoverageState.Uncovered));
+        }
+
+        if (sourceField.Nullable != targetField.Nullable)
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.FieldNullabilityMismatch,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Field,
+                fieldSemanticId,
+                MetadataSemanticArtifactKind.Field,
+                sourceResource.Metadata.Id,
+                sourceField.Title ?? sourceField.Name,
+                "The target field nullability does not match the proposed field nullability.",
+                Value("nullable", sourceField.Nullable.ToString(CultureInfo.InvariantCulture), expectedDetails),
+                Value("nullable", targetField.Nullable.ToString(CultureInfo.InvariantCulture), FieldDetails(targetResource, targetField)),
+                MetadataCompatibilityRequiredAction.UpdateField,
+                MetadataCompatibilityCoverageState.Uncovered));
+        }
+
+        CompareCanonicalFieldTokens(
+            sourceResource,
+            sourceField,
+            targetResource,
+            targetField,
+            ExtractTokens(sourceField.Extensions, DomainIdKey, DomainKey, DomainsKey),
+            ExtractTokens(targetField.Extensions, DomainIdKey, DomainKey, DomainsKey),
+            MetadataCompatibilityCode.FieldDomainMismatch,
+            "domain",
+            findings);
+
+        CompareCanonicalFieldTokens(
+            sourceResource,
+            sourceField,
+            targetResource,
+            targetField,
+            ExtractTokens(sourceField.Extensions, IndexNameKey, IndexKey, IndexesKey, IndexedKey),
+            ExtractTokens(targetField.Extensions, IndexNameKey, IndexKey, IndexesKey, IndexedKey),
+            MetadataCompatibilityCode.FieldIndexMissing,
+            "index",
+            findings);
+    }
+
+    private static void CompareCanonicalFieldTokens(
+        MetadataV2Resource sourceResource,
+        MetadataV2Field sourceField,
+        MetadataV2Resource targetResource,
+        MetadataV2Field targetField,
+        string[] expectedTokens,
+        string[] actualTokens,
+        string code,
+        string label,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        if (expectedTokens.Length == 0)
+        {
+            return;
+        }
+
+        var missing = expectedTokens
+            .Where(token => !actualTokens.Contains(token, StringComparer.OrdinalIgnoreCase))
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (missing.Length == 0)
+        {
+            return;
+        }
+
+        findings.Add(Finding(
+            code,
+            MetadataCompatibilityFindingSeverity.Warning,
+            MetadataCompatibilityFindingKind.Field,
+            GetFieldSemanticId(sourceResource, sourceField),
+            MetadataSemanticArtifactKind.Field,
+            sourceResource.Metadata.Id,
+            sourceField.Title ?? sourceField.Name,
+            $"The target field is missing required canonical {label} metadata.",
+            Value(label, string.Join(",", expectedTokens), FieldDetails(sourceResource, sourceField)),
+            Value(label, actualTokens.Length == 0 ? "unavailable" : string.Join(",", actualTokens), FieldDetails(targetResource, targetField)),
+            MetadataCompatibilityRequiredAction.UpdateField,
+            actualTokens.Length == 0 ? MetadataCompatibilityCoverageState.Unknown : MetadataCompatibilityCoverageState.NotApplicable));
+    }
+
+    private static void CompareIdentifiers(
+        MetadataV2Resource source,
+        MetadataV2Resource target,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        var sourceIdentifier = FindPrimaryIdentifierField(source);
+        if (sourceIdentifier is null)
+        {
+            return;
+        }
+
+        var targetIdentifier = FindPrimaryIdentifierField(target);
+        if (targetIdentifier is not null &&
+            (string.Equals(sourceIdentifier.Name, targetIdentifier.Name, StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(GetFieldSemanticId(source, sourceIdentifier), GetFieldSemanticId(target, targetIdentifier), StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        findings.Add(Finding(
+            MetadataCompatibilityCode.IdentifierMissing,
+            MetadataCompatibilityFindingSeverity.Error,
+            MetadataCompatibilityFindingKind.Identifier,
+            GetFieldSemanticId(source, sourceIdentifier),
+            MetadataSemanticArtifactKind.Field,
+            source.Metadata.Id,
+            sourceIdentifier.Title ?? sourceIdentifier.Name,
+            "The target resource is missing the required primary identifier field.",
+            Value("identifier", sourceIdentifier.Name, FieldDetails(source, sourceIdentifier)),
+            Value("identifier", targetIdentifier?.Name ?? "missing"),
+            MetadataCompatibilityRequiredAction.UpdateIdentifier,
+            MetadataCompatibilityCoverageState.Uncovered));
+    }
+
+    private static void CompareSpatial(
+        MetadataV2Resource source,
+        MetadataV2Resource target,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        var expectedGeometryType = source.ReadGeometryType();
+        if (!string.IsNullOrWhiteSpace(expectedGeometryType))
+        {
+            var actualGeometryType = target.ReadGeometryType();
+            if (string.IsNullOrWhiteSpace(actualGeometryType))
+            {
+                findings.Add(Finding(
+                    MetadataCompatibilityCode.SpatialGeometryTypeMismatch,
+                    MetadataCompatibilityFindingSeverity.Warning,
+                    MetadataCompatibilityFindingKind.Spatial,
+                    source.Metadata.Id,
+                    MetadataSemanticArtifactKind.Resource,
+                    null,
+                    source.Metadata.Title ?? source.Metadata.Name,
+                    "The target resource does not declare comparable geometry type metadata.",
+                    Value("geometryType", expectedGeometryType),
+                    Value("geometryType", "unavailable"),
+                    MetadataCompatibilityRequiredAction.UpdateSpatial,
+                    MetadataCompatibilityCoverageState.Unknown));
+            }
+            else if (!string.Equals(expectedGeometryType, actualGeometryType, StringComparison.OrdinalIgnoreCase))
+            {
+                findings.Add(Finding(
+                    MetadataCompatibilityCode.SpatialGeometryTypeMismatch,
+                    MetadataCompatibilityFindingSeverity.Error,
+                    MetadataCompatibilityFindingKind.Spatial,
+                    source.Metadata.Id,
+                    MetadataSemanticArtifactKind.Resource,
+                    null,
+                    source.Metadata.Title ?? source.Metadata.Name,
+                    "The target resource geometry type does not match the proposed geometry type.",
+                    Value("geometryType", expectedGeometryType),
+                    Value("geometryType", actualGeometryType),
+                    MetadataCompatibilityRequiredAction.UpdateSpatial,
+                    MetadataCompatibilityCoverageState.Uncovered));
+            }
+        }
+
+        var expectedSrid = source.ReadSrid();
+        if (expectedSrid is not null)
+        {
+            var actualSrid = target.ReadSrid();
+            if (actualSrid is null)
+            {
+                findings.Add(Finding(
+                    MetadataCompatibilityCode.SpatialCrsMismatch,
+                    MetadataCompatibilityFindingSeverity.Warning,
+                    MetadataCompatibilityFindingKind.Spatial,
+                    source.Metadata.Id,
+                    MetadataSemanticArtifactKind.Resource,
+                    null,
+                    source.Metadata.Title ?? source.Metadata.Name,
+                    "The target resource does not declare comparable CRS metadata.",
+                    Value("srid", expectedSrid.Value.ToString(CultureInfo.InvariantCulture)),
+                    Value("srid", "unavailable"),
+                    MetadataCompatibilityRequiredAction.UpdateSpatial,
+                    MetadataCompatibilityCoverageState.Unknown));
+            }
+            else if (expectedSrid.Value != actualSrid.Value)
+            {
+                findings.Add(Finding(
+                    MetadataCompatibilityCode.SpatialCrsMismatch,
+                    MetadataCompatibilityFindingSeverity.Error,
+                    MetadataCompatibilityFindingKind.Spatial,
+                    source.Metadata.Id,
+                    MetadataSemanticArtifactKind.Resource,
+                    null,
+                    source.Metadata.Title ?? source.Metadata.Name,
+                    "The target resource CRS/SRID does not match the proposed CRS/SRID.",
+                    Value("srid", expectedSrid.Value.ToString(CultureInfo.InvariantCulture)),
+                    Value("srid", actualSrid.Value.ToString(CultureInfo.InvariantCulture)),
+                    MetadataCompatibilityRequiredAction.UpdateSpatial,
+                    MetadataCompatibilityCoverageState.Uncovered));
+            }
+        }
+    }
+
+    private static void CompareTemporal(
+        MetadataV2Resource source,
+        MetadataV2Resource target,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        var expected = source.ReadTemporalFields();
+        if (expected.StartTimeField is null && expected.EndTimeField is null && expected.TrackIdField is null)
+        {
+            return;
+        }
+
+        var actual = target.ReadTemporalFields();
+        if (!string.Equals(expected.StartTimeField, actual.StartTimeField, StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(expected.EndTimeField, actual.EndTimeField, StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(expected.TrackIdField, actual.TrackIdField, StringComparison.OrdinalIgnoreCase))
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.TemporalFieldMismatch,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Temporal,
+                source.Metadata.Id,
+                MetadataSemanticArtifactKind.Resource,
+                null,
+                source.Metadata.Title ?? source.Metadata.Name,
+                "The target resource temporal field metadata does not match the proposed temporal field metadata.",
+                Value("temporal", FormatTemporal(expected), TemporalDetails(expected)),
+                Value("temporal", FormatTemporal(actual), TemporalDetails(actual)),
+                MetadataCompatibilityRequiredAction.UpdateTemporal,
+                MetadataCompatibilityCoverageState.Uncovered));
+        }
+    }
+
+    private static void CompareStorage(
+        MetadataV2Resource source,
+        MetadataV2Resource target,
+        MetadataV2GraphSnapshot sourceSnapshot,
+        MetadataV2GraphSnapshot targetSnapshot,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        var sourceBinding = ResolvePrimaryStorage(source, sourceSnapshot);
+        if (sourceBinding is null)
+        {
+            return;
+        }
+
+        var targetBinding = ResolvePrimaryStorage(target, targetSnapshot);
+        if (targetBinding is null)
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.StorageBindingMissing,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Storage,
+                source.Metadata.Id,
+                MetadataSemanticArtifactKind.Resource,
+                null,
+                source.Metadata.Title ?? source.Metadata.Name,
+                "The target resource is missing a required primary storage binding.",
+                Value("storageBinding", source.PrimaryStorageBindingId ?? sourceBinding.Metadata.Id),
+                Value("storageBinding", "missing"),
+                MetadataCompatibilityRequiredAction.UpdateStorage,
+                MetadataCompatibilityCoverageState.Uncovered));
+            return;
+        }
+
+        if (sourceBinding.StorageType != targetBinding.StorageType)
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.StorageTypeMismatch,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Storage,
+                source.Metadata.Id,
+                MetadataSemanticArtifactKind.Resource,
+                null,
+                source.Metadata.Title ?? source.Metadata.Name,
+                "The target storage type does not match the proposed storage type.",
+                Value("storageType", sourceBinding.StorageType.ToString()),
+                Value("storageType", targetBinding.StorageType.ToString()),
+                MetadataCompatibilityRequiredAction.UpdateStorage,
+                MetadataCompatibilityCoverageState.Uncovered));
+        }
+
+        foreach (var capability in sourceBinding.Capabilities)
+        {
+            if (!targetBinding.Capabilities.Contains(capability))
+            {
+                findings.Add(Finding(
+                    MetadataCompatibilityCode.StorageCapabilityMissing,
+                    MetadataCompatibilityFindingSeverity.Error,
+                    MetadataCompatibilityFindingKind.Storage,
+                    source.Metadata.Id,
+                    MetadataSemanticArtifactKind.Resource,
+                    null,
+                    source.Metadata.Title ?? source.Metadata.Name,
+                    "The target storage binding is missing a required capability.",
+                    Value("capability", capability.ToString()),
+                    Value("capability", "missing"),
+                    MetadataCompatibilityRequiredAction.UpdateStorage,
+                    MetadataCompatibilityCoverageState.Uncovered));
+            }
+        }
+
+        if (!string.Equals(sourceBinding.Locator, targetBinding.Locator, StringComparison.Ordinal))
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.StorageLocatorChanged,
+                MetadataCompatibilityFindingSeverity.Warning,
+                MetadataCompatibilityFindingKind.Storage,
+                source.Metadata.Id,
+                MetadataSemanticArtifactKind.Resource,
+                null,
+                source.Metadata.Title ?? source.Metadata.Name,
+                "The target storage locator differs from the proposed storage locator.",
+                Value("locator", SafeLocator(sourceBinding.Locator)),
+                Value("locator", SafeLocator(targetBinding.Locator)),
+                MetadataCompatibilityRequiredAction.ManualReview,
+                MetadataCompatibilityCoverageState.NotApplicable));
+        }
+    }
+
+    private static void CompareService(
+        MetadataV2Service source,
+        MetadataV2GraphSnapshot targetSnapshot,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        if (!targetSnapshot.Index.ServicesById.TryGetValue(source.Metadata.Id, out var target))
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.ServiceMissing,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Service,
+                source.Metadata.Id,
+                MetadataSemanticArtifactKind.Service,
+                null,
+                source.Metadata.Title ?? source.Metadata.Name,
+                "The target environment is missing a required service.",
+                Value("serviceType", source.ServiceType.ToString()),
+                Value("service", "missing"),
+                MetadataCompatibilityRequiredAction.AddService,
+                MetadataCompatibilityCoverageState.Uncovered));
+            return;
+        }
+
+        if (source.ServiceType != target.ServiceType)
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.ServiceTypeMismatch,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Service,
+                source.Metadata.Id,
+                MetadataSemanticArtifactKind.Service,
+                null,
+                source.Metadata.Title ?? source.Metadata.Name,
+                "The target service type does not match the proposed service type.",
+                Value("serviceType", source.ServiceType.ToString()),
+                Value("serviceType", target.ServiceType.ToString()),
+                MetadataCompatibilityRequiredAction.UpdateService,
+                MetadataCompatibilityCoverageState.Uncovered));
+        }
+
+        if (!string.Equals(source.Route, target.Route, StringComparison.Ordinal))
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.ServiceRouteChanged,
+                MetadataCompatibilityFindingSeverity.Warning,
+                MetadataCompatibilityFindingKind.Service,
+                source.Metadata.Id,
+                MetadataSemanticArtifactKind.Service,
+                null,
+                source.Metadata.Title ?? source.Metadata.Name,
+                "The target service route differs from the proposed service route.",
+                Value("route", source.Route),
+                Value("route", target.Route),
+                MetadataCompatibilityRequiredAction.UpdateService,
+                MetadataCompatibilityCoverageState.NotApplicable));
+        }
+
+        foreach (var protocol in source.EnabledProtocols ?? Array.Empty<string>())
+        {
+            if (target.EnabledProtocols is null ||
+                !target.EnabledProtocols.Contains(protocol, StringComparer.OrdinalIgnoreCase))
+            {
+                findings.Add(Finding(
+                    MetadataCompatibilityCode.ServiceProtocolMissing,
+                    MetadataCompatibilityFindingSeverity.Error,
+                    MetadataCompatibilityFindingKind.Service,
+                    source.Metadata.Id,
+                    MetadataSemanticArtifactKind.Service,
+                    null,
+                    source.Metadata.Title ?? source.Metadata.Name,
+                    "The target service is missing a required enabled protocol.",
+                    Value("protocol", protocol),
+                    Value("protocol", "missing"),
+                    MetadataCompatibilityRequiredAction.UpdateService,
+                    MetadataCompatibilityCoverageState.Uncovered));
+            }
+        }
+    }
+
+    private static void ComparePublication(
+        MetadataV2Publication source,
+        MetadataV2GraphSnapshot targetSnapshot,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        if (!targetSnapshot.Index.PublicationsById.TryGetValue(source.Metadata.Id, out var target))
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.PublicationMissing,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Publication,
+                source.Metadata.Id,
+                MetadataSemanticArtifactKind.Publication,
+                source.ResourceId,
+                source.TitleOverride ?? source.Metadata.Title ?? source.Metadata.Name,
+                "The target environment is missing a required publication.",
+                Value("publicationType", source.PublicationType.ToString(), PublicationDetails(source)),
+                Value("publication", "missing"),
+                MetadataCompatibilityRequiredAction.AddPublication,
+                MetadataCompatibilityCoverageState.Uncovered));
+            return;
+        }
+
+        if (source.PublicationType != target.PublicationType)
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.PublicationTypeMismatch,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Publication,
+                source.Metadata.Id,
+                MetadataSemanticArtifactKind.Publication,
+                source.ResourceId,
+                source.TitleOverride ?? source.Metadata.Title ?? source.Metadata.Name,
+                "The target publication type does not match the proposed publication type.",
+                Value("publicationType", source.PublicationType.ToString(), PublicationDetails(source)),
+                Value("publicationType", target.PublicationType.ToString(), PublicationDetails(target)),
+                MetadataCompatibilityRequiredAction.UpdatePublication,
+                MetadataCompatibilityCoverageState.Uncovered));
+        }
+
+        if (!string.Equals(source.Path, target.Path, StringComparison.Ordinal) ||
+            !string.Equals(source.ServiceLocalId, target.ServiceLocalId, StringComparison.Ordinal) ||
+            source.LayerIndex != target.LayerIndex)
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.PublicationRouteChanged,
+                MetadataCompatibilityFindingSeverity.Warning,
+                MetadataCompatibilityFindingKind.Publication,
+                source.Metadata.Id,
+                MetadataSemanticArtifactKind.Publication,
+                source.ResourceId,
+                source.TitleOverride ?? source.Metadata.Title ?? source.Metadata.Name,
+                "The target publication route, path, layer index, or local id differs from the proposed publication.",
+                Value("publicationRoute", FormatPublicationRoute(source), PublicationDetails(source)),
+                Value("publicationRoute", FormatPublicationRoute(target), PublicationDetails(target)),
+                MetadataCompatibilityRequiredAction.UpdatePublication,
+                MetadataCompatibilityCoverageState.NotApplicable));
+        }
+
+        foreach (var format in source.SupportedFormats)
+        {
+            if (!target.SupportedFormats.Contains(format, StringComparer.OrdinalIgnoreCase))
+            {
+                findings.Add(Finding(
+                    MetadataCompatibilityCode.PublicationFormatMissing,
+                    MetadataCompatibilityFindingSeverity.Error,
+                    MetadataCompatibilityFindingKind.Publication,
+                    source.Metadata.Id,
+                    MetadataSemanticArtifactKind.Publication,
+                    source.ResourceId,
+                    source.TitleOverride ?? source.Metadata.Title ?? source.Metadata.Name,
+                    "The target publication is missing a required supported format.",
+                    Value("format", format),
+                    Value("format", "missing"),
+                    MetadataCompatibilityRequiredAction.UpdatePublication,
+                    MetadataCompatibilityCoverageState.Uncovered));
+            }
+        }
+
+        foreach (var capability in source.Capabilities)
+        {
+            if (!target.Capabilities.Contains(capability, StringComparer.OrdinalIgnoreCase))
+            {
+                findings.Add(Finding(
+                    MetadataCompatibilityCode.PublicationCapabilityMissing,
+                    MetadataCompatibilityFindingSeverity.Error,
+                    MetadataCompatibilityFindingKind.Publication,
+                    source.Metadata.Id,
+                    MetadataSemanticArtifactKind.Publication,
+                    source.ResourceId,
+                    source.TitleOverride ?? source.Metadata.Title ?? source.Metadata.Name,
+                    "The target publication is missing a required capability.",
+                    Value("capability", capability),
+                    Value("capability", "missing"),
+                    MetadataCompatibilityRequiredAction.UpdatePublication,
+                    MetadataCompatibilityCoverageState.Uncovered));
+            }
+        }
+    }
+
+    private static void CompareCatalog(
+        MetadataV2Catalog source,
+        MetadataV2GraphSnapshot targetSnapshot,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        if (targetSnapshot.Index.CatalogsById.ContainsKey(source.Metadata.Id))
+        {
+            return;
+        }
+
+        findings.Add(Finding(
+            MetadataCompatibilityCode.ResourceMissing,
+            MetadataCompatibilityFindingSeverity.Error,
+            MetadataCompatibilityFindingKind.Resource,
+            source.Metadata.Id,
+            MetadataSemanticArtifactKind.Catalog,
+            null,
+            source.Metadata.Title ?? source.Metadata.Name,
+            "The target environment is missing a required catalog.",
+            Value("catalog", source.Target),
+            Value("catalog", "missing"),
+            MetadataCompatibilityRequiredAction.AddResource,
+            MetadataCompatibilityCoverageState.Uncovered));
+    }
+
+    private static void ComparePolicy(
+        MetadataV2Policy source,
+        MetadataV2GraphSnapshot targetSnapshot,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        if (targetSnapshot.Index.PoliciesById.ContainsKey(source.Metadata.Id))
+        {
+            return;
+        }
+
+        findings.Add(Finding(
+            MetadataCompatibilityCode.PolicyReferenceMissing,
+            MetadataCompatibilityFindingSeverity.Error,
+            MetadataCompatibilityFindingKind.Policy,
+            source.Metadata.Id,
+            MetadataSemanticArtifactKind.Policy,
+            null,
+            source.Metadata.Title ?? source.Metadata.Name,
+            "The target environment is missing a required policy.",
+            Value("policy", source.Metadata.Id),
+            Value("policy", "missing"),
+            MetadataCompatibilityRequiredAction.ManualReview,
+            MetadataCompatibilityCoverageState.Uncovered));
+    }
+
+    private static void CompareRole(
+        MetadataV2Role source,
+        MetadataV2GraphSnapshot targetSnapshot,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        if (!targetSnapshot.Index.RolesById.TryGetValue(source.Metadata.Id, out var target))
+        {
+            findings.Add(Finding(
+                MetadataCompatibilityCode.PolicyReferenceMissing,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Policy,
+                source.Metadata.Id,
+                MetadataSemanticArtifactKind.Role,
+                null,
+                source.Metadata.Title ?? source.Metadata.Name,
+                "The target environment is missing a required role.",
+                Value("role", source.Metadata.Id),
+                Value("role", "missing"),
+                MetadataCompatibilityRequiredAction.ManualReview,
+                MetadataCompatibilityCoverageState.Uncovered));
+            return;
+        }
+
+        ComparePolicyReferences(source.Metadata.Id, MetadataSemanticArtifactKind.Role, source.PolicyIds, target.PolicyIds, targetSnapshot, findings);
+    }
+
+    private static void ComparePolicyReferences(
+        string semanticId,
+        MetadataSemanticArtifactKind semanticKind,
+        IReadOnlyList<string> expectedPolicyIds,
+        IReadOnlyList<string> actualPolicyIds,
+        MetadataV2GraphSnapshot targetSnapshot,
+        List<MetadataCompatibilityFinding> findings)
+    {
+        foreach (var policyId in expectedPolicyIds)
+        {
+            if (actualPolicyIds.Contains(policyId, StringComparer.Ordinal) &&
+                targetSnapshot.Index.PoliciesById.ContainsKey(policyId))
+            {
+                continue;
+            }
+
+            findings.Add(Finding(
+                MetadataCompatibilityCode.PolicyReferenceMissing,
+                MetadataCompatibilityFindingSeverity.Error,
+                MetadataCompatibilityFindingKind.Policy,
+                semanticId,
+                semanticKind,
+                null,
+                semanticId,
+                "The target environment is missing a required policy reference.",
+                Value("policy", policyId),
+                Value("policy", "missing"),
+                MetadataCompatibilityRequiredAction.ManualReview,
+                MetadataCompatibilityCoverageState.Uncovered));
+        }
+    }
+
+    private static List<MetadataCompatibilityFinding> ApplyDataScriptCoverage(
+        List<MetadataCompatibilityFinding> findings,
+        MetadataV2GraphSnapshot targetSnapshot,
+        IReadOnlyList<MetadataDataScriptEntry> dataScripts,
+        IReadOnlyList<string> packageTargets,
+        string targetEnvironment)
+    {
+        if (dataScripts.Count == 0)
+        {
+            return findings;
+        }
+
+        var updated = new List<MetadataCompatibilityFinding>(findings.Count);
+        var scriptMismatchFindings = new List<MetadataCompatibilityFinding>();
+        var mismatchKeys = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var finding in findings)
+        {
+            if (!IsCoverable(finding))
+            {
+                updated.Add(finding);
+                continue;
+            }
+
+            var covered = false;
+            foreach (var script in dataScripts)
+            {
+                if (!AppliesToTarget(script, targetEnvironment) ||
+                    !AfterContractCovers(script.AfterContract, finding))
+                {
+                    continue;
+                }
+
+                if (BeforeContractMatches(script.BeforeContract, finding, targetSnapshot))
+                {
+                    updated.Add(finding with
+                    {
+                        CoverageState = MetadataCompatibilityCoverageState.CoveredByScript,
+                        CoveringScriptId = script.ScriptId,
+                        CoverageNotes = "Declared after-contract satisfies the requirement and before-contract matches target state.",
+                        RequiredAction = MetadataCompatibilityRequiredAction.RunDataScript,
+                    });
+                    covered = true;
+                    break;
+                }
+
+                var key = string.Concat(script.ScriptId, "|", finding.Code, "|", finding.AffectedSemanticId);
+                if (mismatchKeys.Add(key))
+                {
+                    scriptMismatchFindings.Add(Finding(
+                        MetadataCompatibilityCode.ScriptBeforeContractMismatch,
+                        MetadataCompatibilityFindingSeverity.Error,
+                        MetadataCompatibilityFindingKind.Script,
+                        finding.AffectedSemanticId,
+                        finding.AffectedSemanticKind,
+                        finding.AffectedParentSemanticId,
+                        finding.DisplayName,
+                        "A data script declares an after-contract that could cover this finding, but its before-contract does not match the target state.",
+                        Value("scriptId", script.ScriptId),
+                        Value("beforeContract", "mismatch"),
+                        MetadataCompatibilityRequiredAction.ManualReview,
+                        MetadataCompatibilityCoverageState.Uncovered));
+                }
+            }
+
+            if (!covered)
+            {
+                updated.Add(finding);
+            }
+        }
+
+        updated.AddRange(scriptMismatchFindings);
+        return updated
+            .OrderBy(static finding => finding.Code, StringComparer.Ordinal)
+            .ThenBy(static finding => finding.AffectedSemanticId, StringComparer.Ordinal)
+            .ThenBy(static finding => finding.AffectedParentSemanticId, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static bool IsCoverable(MetadataCompatibilityFinding finding)
+        => finding.Severity == MetadataCompatibilityFindingSeverity.Error &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.Uncovered;
+
+    private static bool AppliesToTarget(MetadataDataScriptEntry script, string targetEnvironment)
+        => string.IsNullOrWhiteSpace(script.TargetEnvironment) ||
+            string.Equals(script.TargetEnvironment.Trim(), targetEnvironment, StringComparison.OrdinalIgnoreCase);
+
+    private static bool AfterContractCovers(MetadataDataScriptContract? contract, MetadataCompatibilityFinding finding)
+    {
+        if (contract is null)
+        {
+            return false;
+        }
+
+        return finding.Code switch
+        {
+            MetadataCompatibilityCode.ResourceMissing => FindArtifactContract(contract, finding)?.Exists == true,
+            MetadataCompatibilityCode.ResourceTypeMismatch => FindArtifactContract(contract, finding)?.ResourceType?.ToString() == finding.Expected.Value,
+            MetadataCompatibilityCode.FieldMissing or
+            MetadataCompatibilityCode.FieldTypeMismatch or
+            MetadataCompatibilityCode.FieldNullabilityMismatch or
+            MetadataCompatibilityCode.IdentifierMissing => FieldContractSatisfies(FindResourceContract(contract, finding), finding),
+            MetadataCompatibilityCode.SpatialGeometryTypeMismatch or
+            MetadataCompatibilityCode.SpatialCrsMismatch => SpatialContractSatisfies(FindArtifactContract(contract, finding), finding),
+            MetadataCompatibilityCode.TemporalFieldMismatch => TemporalContractSatisfies(FindArtifactContract(contract, finding), finding),
+            MetadataCompatibilityCode.StorageBindingMissing or
+            MetadataCompatibilityCode.StorageTypeMismatch or
+            MetadataCompatibilityCode.StorageCapabilityMissing => StorageContractSatisfies(FindArtifactContract(contract, finding), finding),
+            MetadataCompatibilityCode.ServiceMissing => FindArtifactContract(contract, finding)?.Exists == true,
+            MetadataCompatibilityCode.ServiceTypeMismatch => FindArtifactContract(contract, finding)?.ServiceType?.ToString() == finding.Expected.Value,
+            MetadataCompatibilityCode.ServiceProtocolMissing => FindArtifactContract(contract, finding)?.Capabilities.Contains(finding.Expected.Value ?? string.Empty, StringComparer.OrdinalIgnoreCase) == true,
+            MetadataCompatibilityCode.PublicationMissing => FindArtifactContract(contract, finding)?.Exists == true,
+            MetadataCompatibilityCode.PublicationTypeMismatch => FindArtifactContract(contract, finding)?.PublicationType?.ToString() == finding.Expected.Value,
+            MetadataCompatibilityCode.PublicationFormatMissing => FindArtifactContract(contract, finding)?.SupportedFormats.Contains(finding.Expected.Value ?? string.Empty, StringComparer.OrdinalIgnoreCase) == true,
+            MetadataCompatibilityCode.PublicationCapabilityMissing => FindArtifactContract(contract, finding)?.Capabilities.Contains(finding.Expected.Value ?? string.Empty, StringComparer.OrdinalIgnoreCase) == true,
+            MetadataCompatibilityCode.PolicyReferenceMissing => FindArtifactContract(contract, finding)?.Exists == true,
+            _ => false,
+        };
+    }
+
+    private static bool BeforeContractMatches(
+        MetadataDataScriptContract? contract,
+        MetadataCompatibilityFinding finding,
+        MetadataV2GraphSnapshot targetSnapshot)
+    {
+        if (contract is null)
+        {
+            return false;
+        }
+
+        return finding.Code switch
+        {
+            MetadataCompatibilityCode.ResourceMissing or
+            MetadataCompatibilityCode.ServiceMissing or
+            MetadataCompatibilityCode.PublicationMissing or
+            MetadataCompatibilityCode.PolicyReferenceMissing =>
+                FindArtifactContract(contract, finding)?.Exists == false && !TargetArtifactExists(targetSnapshot, finding),
+            MetadataCompatibilityCode.ResourceTypeMismatch =>
+                FindArtifactContract(contract, finding)?.ResourceType?.ToString() == finding.Actual.Value,
+            MetadataCompatibilityCode.FieldMissing =>
+                FindFieldContract(FindResourceContract(contract, finding), finding)?.Exists == false,
+            MetadataCompatibilityCode.FieldTypeMismatch =>
+                string.Equals(FindFieldContract(FindResourceContract(contract, finding), finding)?.Type, finding.Actual.Value, StringComparison.OrdinalIgnoreCase),
+            MetadataCompatibilityCode.FieldNullabilityMismatch =>
+                BoolToString(FindFieldContract(FindResourceContract(contract, finding), finding)?.Nullable) == finding.Actual.Value,
+            MetadataCompatibilityCode.IdentifierMissing =>
+                FindFieldContract(FindResourceContract(contract, finding), finding)?.Exists == false,
+            MetadataCompatibilityCode.SpatialGeometryTypeMismatch or
+            MetadataCompatibilityCode.SpatialCrsMismatch =>
+                SpatialContractMatchesActual(FindArtifactContract(contract, finding), finding),
+            MetadataCompatibilityCode.TemporalFieldMismatch =>
+                TemporalContractMatchesActual(FindArtifactContract(contract, finding), finding),
+            MetadataCompatibilityCode.StorageBindingMissing =>
+                FindArtifactContract(contract, finding)?.Storage is null,
+            MetadataCompatibilityCode.StorageTypeMismatch =>
+                FindArtifactContract(contract, finding)?.Storage?.StorageType?.ToString() == finding.Actual.Value,
+            MetadataCompatibilityCode.StorageCapabilityMissing =>
+                FindArtifactContract(contract, finding)?.Storage is not null,
+            MetadataCompatibilityCode.ServiceTypeMismatch =>
+                FindArtifactContract(contract, finding)?.ServiceType?.ToString() == finding.Actual.Value,
+            MetadataCompatibilityCode.ServiceProtocolMissing =>
+                FindArtifactContract(contract, finding)?.Capabilities.Contains(finding.Expected.Value ?? string.Empty, StringComparer.OrdinalIgnoreCase) == false,
+            MetadataCompatibilityCode.PublicationTypeMismatch =>
+                FindArtifactContract(contract, finding)?.PublicationType?.ToString() == finding.Actual.Value,
+            MetadataCompatibilityCode.PublicationFormatMissing =>
+                FindArtifactContract(contract, finding)?.SupportedFormats.Contains(finding.Expected.Value ?? string.Empty, StringComparer.OrdinalIgnoreCase) == false,
+            MetadataCompatibilityCode.PublicationCapabilityMissing =>
+                FindArtifactContract(contract, finding)?.Capabilities.Contains(finding.Expected.Value ?? string.Empty, StringComparer.OrdinalIgnoreCase) == false,
+            _ => false,
+        };
+    }
+
+    private static bool TargetArtifactExists(MetadataV2GraphSnapshot targetSnapshot, MetadataCompatibilityFinding finding)
+        => finding.AffectedSemanticKind switch
+        {
+            MetadataSemanticArtifactKind.Resource => targetSnapshot.Index.ResourcesById.ContainsKey(finding.AffectedSemanticId),
+            MetadataSemanticArtifactKind.Service => targetSnapshot.Index.ServicesById.ContainsKey(finding.AffectedSemanticId),
+            MetadataSemanticArtifactKind.Publication => targetSnapshot.Index.PublicationsById.ContainsKey(finding.AffectedSemanticId),
+            MetadataSemanticArtifactKind.Catalog => targetSnapshot.Index.CatalogsById.ContainsKey(finding.AffectedSemanticId),
+            MetadataSemanticArtifactKind.Policy => targetSnapshot.Index.PoliciesById.ContainsKey(finding.AffectedSemanticId),
+            MetadataSemanticArtifactKind.Role => targetSnapshot.Index.RolesById.ContainsKey(finding.AffectedSemanticId),
+            MetadataSemanticArtifactKind.Field => finding.AffectedParentSemanticId is { Length: > 0 } parentId &&
+                targetSnapshot.Index.ResourcesById.TryGetValue(parentId, out var resource) &&
+                resource.SchemaFields.Any(field => string.Equals(GetFieldSemanticId(resource, field), finding.AffectedSemanticId, StringComparison.Ordinal)),
+            _ => false,
+        };
+
+    private static MetadataScriptResourceContract? FindArtifactContract(
+        MetadataDataScriptContract contract,
+        MetadataCompatibilityFinding finding)
+        => contract.Resources.FirstOrDefault(resource =>
+            string.Equals(resource.SemanticId, finding.AffectedSemanticId, StringComparison.Ordinal) &&
+            resource.SemanticKind == finding.AffectedSemanticKind);
+
+    private static MetadataScriptResourceContract? FindResourceContract(
+        MetadataDataScriptContract contract,
+        MetadataCompatibilityFinding finding)
+    {
+        var resourceId = finding.AffectedParentSemanticId ?? finding.AffectedSemanticId;
+        return contract.Resources.FirstOrDefault(resource =>
+            string.Equals(resource.SemanticId, resourceId, StringComparison.Ordinal) &&
+            resource.SemanticKind == MetadataSemanticArtifactKind.Resource);
+    }
+
+    private static bool FieldContractSatisfies(
+        MetadataScriptResourceContract? resourceContract,
+        MetadataCompatibilityFinding finding)
+    {
+        var field = FindFieldContract(resourceContract, finding);
+        if (field is null || field.Exists == false)
+        {
+            return false;
+        }
+
+        if (finding.Expected.Details.TryGetValue("type", out var type) &&
+            !string.Equals(field.Type, type, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (finding.Expected.Details.TryGetValue("nullable", out var nullable) &&
+            BoolToString(field.Nullable) != nullable)
+        {
+            return false;
+        }
+
+        if (finding.Code == MetadataCompatibilityCode.IdentifierMissing)
+        {
+            return field.SemanticRoles.Contains("id.primary", StringComparer.OrdinalIgnoreCase) ||
+                field.SemanticRoles.Contains("identifier.primary", StringComparer.OrdinalIgnoreCase);
+        }
+
+        return true;
+    }
+
+    private static MetadataScriptFieldContract? FindFieldContract(
+        MetadataScriptResourceContract? resourceContract,
+        MetadataCompatibilityFinding finding)
+    {
+        if (resourceContract is null)
+        {
+            return null;
+        }
+
+        finding.Expected.Details.TryGetValue("fieldName", out var fieldName);
+        finding.Expected.Details.TryGetValue("semanticId", out var semanticId);
+        return resourceContract.Fields.FirstOrDefault(field =>
+            (!string.IsNullOrWhiteSpace(semanticId) &&
+             string.Equals(field.SemanticId, semanticId, StringComparison.Ordinal)) ||
+            (!string.IsNullOrWhiteSpace(fieldName) &&
+             string.Equals(field.Name, fieldName, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    private static bool SpatialContractSatisfies(
+        MetadataScriptResourceContract? contract,
+        MetadataCompatibilityFinding finding)
+    {
+        if (contract?.Spatial is null)
+        {
+            return false;
+        }
+
+        return finding.Code switch
+        {
+            MetadataCompatibilityCode.SpatialGeometryTypeMismatch =>
+                string.Equals(contract.Spatial.GeometryType, finding.Expected.Value, StringComparison.OrdinalIgnoreCase),
+            MetadataCompatibilityCode.SpatialCrsMismatch =>
+                contract.Spatial.Srid?.ToString(CultureInfo.InvariantCulture) == finding.Expected.Value,
+            _ => false,
+        };
+    }
+
+    private static bool SpatialContractMatchesActual(
+        MetadataScriptResourceContract? contract,
+        MetadataCompatibilityFinding finding)
+    {
+        if (contract?.Spatial is null)
+        {
+            return false;
+        }
+
+        return finding.Code switch
+        {
+            MetadataCompatibilityCode.SpatialGeometryTypeMismatch =>
+                string.Equals(contract.Spatial.GeometryType, finding.Actual.Value, StringComparison.OrdinalIgnoreCase),
+            MetadataCompatibilityCode.SpatialCrsMismatch =>
+                contract.Spatial.Srid?.ToString(CultureInfo.InvariantCulture) == finding.Actual.Value,
+            _ => false,
+        };
+    }
+
+    private static bool TemporalContractSatisfies(
+        MetadataScriptResourceContract? contract,
+        MetadataCompatibilityFinding finding)
+        => contract?.Temporal is not null &&
+            finding.Expected.Details.TryGetValue("startTimeField", out var start) &&
+            finding.Expected.Details.TryGetValue("endTimeField", out var end) &&
+            finding.Expected.Details.TryGetValue("trackIdField", out var track) &&
+            string.Equals(contract.Temporal.StartTimeField ?? string.Empty, start, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(contract.Temporal.EndTimeField ?? string.Empty, end, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(contract.Temporal.TrackIdField ?? string.Empty, track, StringComparison.OrdinalIgnoreCase);
+
+    private static bool TemporalContractMatchesActual(
+        MetadataScriptResourceContract? contract,
+        MetadataCompatibilityFinding finding)
+        => contract?.Temporal is not null &&
+            finding.Actual.Details.TryGetValue("startTimeField", out var start) &&
+            finding.Actual.Details.TryGetValue("endTimeField", out var end) &&
+            finding.Actual.Details.TryGetValue("trackIdField", out var track) &&
+            string.Equals(contract.Temporal.StartTimeField ?? string.Empty, start, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(contract.Temporal.EndTimeField ?? string.Empty, end, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(contract.Temporal.TrackIdField ?? string.Empty, track, StringComparison.OrdinalIgnoreCase);
+
+    private static bool StorageContractSatisfies(
+        MetadataScriptResourceContract? contract,
+        MetadataCompatibilityFinding finding)
+    {
+        if (contract?.Storage is null)
+        {
+            return false;
+        }
+
+        return finding.Code switch
+        {
+            MetadataCompatibilityCode.StorageBindingMissing => true,
+            MetadataCompatibilityCode.StorageTypeMismatch => contract.Storage.StorageType?.ToString() == finding.Expected.Value,
+            MetadataCompatibilityCode.StorageCapabilityMissing => contract.Storage.Capabilities.Any(capability => capability.ToString() == finding.Expected.Value),
+            _ => false,
+        };
+    }
+
+    private static MetadataAffectedDependent[] BuildAffectedDependents(
+        MetadataReleasePackage package,
+        MetadataV2GraphSnapshot targetSnapshot,
+        HashSet<string> changedSemanticIds,
+        IReadOnlyList<MetadataCompatibilityFinding> findings)
+    {
+        var states = new Dictionary<string, DependentState>(StringComparer.Ordinal);
+
+        foreach (var entry in package.Entries)
+        {
+            foreach (var dependentId in entry.DependentSemanticIds)
+            {
+                AddDependent(states, targetSnapshot, dependentId, entry.SemanticId, "release-package-dependent", "Declared release package dependent.", SeverityFor(entry.SemanticId, findings));
+            }
+        }
+
+        foreach (var resourceId in changedSemanticIds)
+        {
+            foreach (var publication in targetSnapshot.Index.PublicationsByResource[resourceId])
+            {
+                AddDependent(states, targetSnapshot, publication.Metadata.Id, resourceId, "publication-by-resource", "Publication exposes a changed resource.", SeverityFor(resourceId, findings));
+                AddDependent(states, targetSnapshot, publication.ServiceId, publication.Metadata.Id, "service-by-publication", "Service exposes an affected publication.", SeverityFor(resourceId, findings));
+            }
+
+            foreach (var publication in targetSnapshot.Index.PublicationsByService[resourceId])
+            {
+                AddDependent(states, targetSnapshot, publication.Metadata.Id, resourceId, "publication-by-service", "Publication belongs to a changed service.", SeverityFor(resourceId, findings));
+            }
+        }
+
+        foreach (var resource in targetSnapshot.Graph.Resources)
+        {
+            foreach (var relationship in resource.Relationships)
+            {
+                if (changedSemanticIds.Contains(relationship.RelatedResourceId))
+                {
+                    AddDependent(states, targetSnapshot, resource.Metadata.Id, relationship.RelatedResourceId, "resource-relationship", "Resource declares a relationship to a changed resource.", SeverityFor(relationship.RelatedResourceId, findings));
+                }
+            }
+
+            foreach (var styleResourceId in resource.StyleResourceIds)
+            {
+                if (changedSemanticIds.Contains(styleResourceId))
+                {
+                    AddDependent(states, targetSnapshot, resource.Metadata.Id, styleResourceId, "style-resource", "Resource references a changed style resource.", SeverityFor(styleResourceId, findings));
+                }
+            }
+        }
+
+        foreach (var profile in targetSnapshot.Graph.ProjectionProfiles)
+        {
+            foreach (var required in profile.RequiredSemantics)
+            {
+                if (changedSemanticIds.Contains(required))
+                {
+                    AddDependent(states, targetSnapshot, profile.Metadata.Id, required, "projection-required-semantics", "Projection profile requires a changed semantic.", SeverityFor(required, findings));
+                }
+            }
+        }
+
+        foreach (var role in targetSnapshot.Graph.Roles)
+        {
+            foreach (var policyId in role.PolicyIds)
+            {
+                if (changedSemanticIds.Contains(policyId))
+                {
+                    AddDependent(states, targetSnapshot, role.Metadata.Id, policyId, "role-policy", "Role references a changed policy.", SeverityFor(policyId, findings));
+                }
+            }
+        }
+
+        return states.Values
+            .OrderBy(static state => state.SemanticId, StringComparer.Ordinal)
+            .ThenBy(static state => state.Reason, StringComparer.Ordinal)
+            .Select(static state => state.ToDependent())
+            .ToArray();
+    }
+
+    private static void AddDependent(
+        Dictionary<string, DependentState> states,
+        MetadataV2GraphSnapshot snapshot,
+        string semanticId,
+        string viaSemanticId,
+        string relationshipKind,
+        string reason,
+        MetadataCompatibilityFindingSeverity severity)
+    {
+        if (string.IsNullOrWhiteSpace(semanticId))
+        {
+            return;
+        }
+
+        var key = string.Concat(semanticId, "|", reason);
+        if (states.TryGetValue(key, out var existing))
+        {
+            if (SeverityRank(severity) > SeverityRank(existing.ImpactSeverity))
+            {
+                states[key] = existing with { ImpactSeverity = severity };
+            }
+            return;
+        }
+
+        var artifact = ResolveArtifact(snapshot, semanticId);
+        states[key] = new DependentState(
+            semanticId,
+            artifact?.Kind ?? MetadataSemanticArtifactKind.Resource,
+            artifact?.DisplayName,
+            severity,
+            reason,
+            viaSemanticId,
+            relationshipKind);
+    }
+
+    private static MetadataCompatibilityFindingSeverity SeverityFor(
+        string semanticId,
+        IReadOnlyList<MetadataCompatibilityFinding> findings)
+    {
+        var severity = MetadataCompatibilityFindingSeverity.Info;
+        foreach (var finding in findings)
+        {
+            if ((string.Equals(finding.AffectedSemanticId, semanticId, StringComparison.Ordinal) ||
+                 string.Equals(finding.AffectedParentSemanticId, semanticId, StringComparison.Ordinal)) &&
+                SeverityRank(finding.Severity) > SeverityRank(severity))
+            {
+                severity = finding.Severity;
+            }
+        }
+
+        return severity;
+    }
+
+    private static MetadataCompatibilityReport BuildReport(
+        MetadataReleasePackage? package,
+        string targetEnvironment,
+        long? targetRevision,
+        string? targetEtag,
+        DateTimeOffset generatedAt,
+        IReadOnlyList<MetadataCompatibilityFinding> findings,
+        IReadOnlyList<MetadataAffectedDependent> dependents,
+        IReadOnlyList<MetadataDataScriptEntry> dataScripts,
+        int scriptCount)
+    {
+        var uncoveredErrorCount = findings.Count(static finding =>
+            finding.Severity == MetadataCompatibilityFindingSeverity.Error &&
+            finding.CoverageState != MetadataCompatibilityCoverageState.CoveredByScript);
+        var coveredErrorCount = findings.Count(static finding =>
+            finding.Severity == MetadataCompatibilityFindingSeverity.Error &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.CoveredByScript);
+        var warningCount = findings.Count(static finding => finding.Severity == MetadataCompatibilityFindingSeverity.Warning);
+        var hasUnknown = findings.Any(static finding =>
+            finding.Code == MetadataCompatibilityCode.StateUnavailable ||
+            finding.CoverageState == MetadataCompatibilityCoverageState.Unknown);
+
+        var status = hasUnknown
+            ? MetadataCompatibilityStatus.Unknown
+            : uncoveredErrorCount > 0
+                ? MetadataCompatibilityStatus.Blocked
+                : warningCount > 0 || coveredErrorCount > 0
+                    ? MetadataCompatibilityStatus.Warning
+                    : MetadataCompatibilityStatus.Ready;
+
+        return new MetadataCompatibilityReport
+        {
+            TargetEnvironment = targetEnvironment,
+            ReleasePackageId = package?.PackageId,
+            PackageKey = package?.Metadata.Name,
+            SourceEnvironment = package?.SourceEnvironment,
+            SourceRevision = package?.SourceRevision,
+            SourceEtag = package?.SourceEtag,
+            TargetRevision = targetRevision,
+            TargetEtag = targetEtag,
+            GeneratedAt = generatedAt,
+            Status = status,
+            CanCreatePullRequest = status is not MetadataCompatibilityStatus.Blocked and not MetadataCompatibilityStatus.Unknown,
+            CanPromote = status is not MetadataCompatibilityStatus.Blocked and not MetadataCompatibilityStatus.Unknown,
+            UncoveredErrorCount = uncoveredErrorCount,
+            CoveredErrorCount = coveredErrorCount,
+            WarningCount = warningCount,
+            ScriptCount = scriptCount,
+            Findings = findings
+                .OrderBy(static finding => finding.Code, StringComparer.Ordinal)
+                .ThenBy(static finding => finding.AffectedParentSemanticId, StringComparer.Ordinal)
+                .ThenBy(static finding => finding.AffectedSemanticId, StringComparer.Ordinal)
+                .ToArray(),
+            AffectedDependents = dependents,
+            RollbackReadiness = ClassifyRollback(findings, dataScripts),
+        };
+    }
+
+    private static MetadataRollbackReadiness ClassifyRollback(
+        IReadOnlyList<MetadataCompatibilityFinding> findings,
+        IReadOnlyList<MetadataDataScriptEntry> dataScripts)
+    {
+        if (findings.Any(static finding =>
+            finding.Code == MetadataCompatibilityCode.StateUnavailable ||
+            finding.Code == MetadataCompatibilityCode.ScriptBeforeContractMismatch))
+        {
+            return Rollback(
+                MetadataRollbackReadinessClassification.Manual,
+                "Rollback readiness cannot be determined while state or script applicability is unknown.",
+                requiresManualAction: true);
+        }
+
+        var uncoveredErrors = findings.Where(static finding =>
+            finding.Severity == MetadataCompatibilityFindingSeverity.Error &&
+            finding.CoverageState != MetadataCompatibilityCoverageState.CoveredByScript).ToArray();
+        if (uncoveredErrors.Length > 0 && uncoveredErrors.Any(static finding => IsDataImpacting(finding.Code)))
+        {
+            return Rollback(
+                MetadataRollbackReadinessClassification.Manual,
+                "Uncovered data-impacting errors require manual rollback planning.",
+                requiresManualAction: true);
+        }
+
+        var coveredScripts = findings
+            .Where(static finding => finding.CoverageState == MetadataCompatibilityCoverageState.CoveredByScript)
+            .Select(static finding => finding.CoveringScriptId)
+            .Where(static scriptId => !string.IsNullOrWhiteSpace(scriptId))
+            .Distinct(StringComparer.Ordinal)
+            .Cast<string>()
+            .ToArray();
+        if (coveredScripts.Length > 0)
+        {
+            var reversibleScriptIds = dataScripts
+                .Where(script => script.Reversible)
+                .Select(script => script.ScriptId)
+                .ToHashSet(StringComparer.Ordinal);
+            if (coveredScripts.Any(scriptId => !reversibleScriptIds.Contains(scriptId)))
+            {
+                return Rollback(
+                    MetadataRollbackReadinessClassification.SnapshotRequired,
+                    "At least one covering data script is not declared reversible.",
+                    requiresSnapshot: true,
+                    scriptIds: coveredScripts);
+            }
+
+            return Rollback(
+                MetadataRollbackReadinessClassification.ScriptReversible,
+                "Data-impacting findings are covered by declared scripts and require script rollback review.",
+                scriptIds: coveredScripts);
+        }
+
+        if (findings.Any(static finding =>
+            finding.Code is MetadataCompatibilityCode.ServiceRouteChanged or
+                MetadataCompatibilityCode.ServiceTypeMismatch or
+                MetadataCompatibilityCode.PublicationRouteChanged or
+                MetadataCompatibilityCode.PublicationTypeMismatch))
+        {
+            return Rollback(
+                MetadataRollbackReadinessClassification.ServiceRevision,
+                "Service or publication identity changed and should be rolled back through a service revision.");
+        }
+
+        return Rollback(
+            MetadataRollbackReadinessClassification.MetadataOnly,
+            "Only Metadata v2 graph/package state is required for rollback.");
+    }
+
+    private static MetadataRollbackReadiness Rollback(
+        MetadataRollbackReadinessClassification classification,
+        string reason,
+        bool requiresSnapshot = false,
+        bool requiresManualAction = false,
+        IReadOnlyList<string>? scriptIds = null)
+        => new()
+        {
+            Classification = classification,
+            Reason = reason,
+            RequiresSnapshot = requiresSnapshot,
+            RequiresManualAction = requiresManualAction,
+            ScriptIds = scriptIds ?? Array.Empty<string>(),
+        };
+
+    private static bool IsDataImpacting(string code)
+        => code is MetadataCompatibilityCode.ResourceMissing or
+            MetadataCompatibilityCode.ResourceTypeMismatch or
+            MetadataCompatibilityCode.FieldMissing or
+            MetadataCompatibilityCode.FieldTypeMismatch or
+            MetadataCompatibilityCode.FieldNullabilityMismatch or
+            MetadataCompatibilityCode.IdentifierMissing or
+            MetadataCompatibilityCode.SpatialGeometryTypeMismatch or
+            MetadataCompatibilityCode.SpatialCrsMismatch or
+            MetadataCompatibilityCode.TemporalFieldMismatch or
+            MetadataCompatibilityCode.StorageBindingMissing or
+            MetadataCompatibilityCode.StorageTypeMismatch or
+            MetadataCompatibilityCode.StorageCapabilityMissing;
+
+    private static MetadataV2StorageBinding? ResolvePrimaryStorage(
+        MetadataV2Resource resource,
+        MetadataV2GraphSnapshot snapshot)
+    {
+        if (!string.IsNullOrWhiteSpace(resource.PrimaryStorageBindingId) &&
+            snapshot.Index.StorageBindingsById.TryGetValue(resource.PrimaryStorageBindingId, out var primary))
+        {
+            return primary;
+        }
+
+        return snapshot.Index.StorageBindingsByResource[resource.Metadata.Id].FirstOrDefault();
+    }
+
+    private static ResolvedArtifact? ResolveArtifact(MetadataV2GraphSnapshot snapshot, MetadataReleaseEntry entry)
+    {
+        if (entry.ArtifactKind == MetadataSemanticArtifactKind.Field && entry.SourceField is not null)
+        {
+            if (!snapshot.Index.ResourcesById.TryGetValue(entry.SourceField.ParentResourceId, out var parent))
+            {
+                return null;
+            }
+
+            var field = parent.SchemaFields.FirstOrDefault(field =>
+                string.Equals(GetFieldSemanticId(parent, field), entry.SemanticId, StringComparison.Ordinal) ||
+                string.Equals(field.Name, entry.SourceField.FieldName, StringComparison.OrdinalIgnoreCase));
+            return field is null ? null : ResolvedArtifact.ForField(entry.SemanticId, parent, field);
+        }
+
+        return ResolveArtifact(snapshot, entry.SemanticId);
+    }
+
+    private static ResolvedArtifact? ResolveArtifact(MetadataV2GraphSnapshot snapshot, string semanticId)
+    {
+        if (snapshot.Index.ResourcesById.TryGetValue(semanticId, out var resource))
+        {
+            return new ResolvedArtifact(semanticId, MetadataSemanticArtifactKind.Resource, resource.Metadata.Title ?? resource.Metadata.Name, Resource: resource);
+        }
+
+        if (snapshot.Index.ServicesById.TryGetValue(semanticId, out var service))
+        {
+            return new ResolvedArtifact(semanticId, MetadataSemanticArtifactKind.Service, service.Metadata.Title ?? service.Metadata.Name, Service: service);
+        }
+
+        if (snapshot.Index.PublicationsById.TryGetValue(semanticId, out var publication))
+        {
+            return new ResolvedArtifact(semanticId, MetadataSemanticArtifactKind.Publication, publication.TitleOverride ?? publication.Metadata.Title ?? publication.Metadata.Name, Publication: publication);
+        }
+
+        if (snapshot.Index.CatalogsById.TryGetValue(semanticId, out var catalog))
+        {
+            return new ResolvedArtifact(semanticId, MetadataSemanticArtifactKind.Catalog, catalog.Metadata.Title ?? catalog.Metadata.Name, Catalog: catalog);
+        }
+
+        if (snapshot.Index.PoliciesById.TryGetValue(semanticId, out var policy))
+        {
+            return new ResolvedArtifact(semanticId, MetadataSemanticArtifactKind.Policy, policy.Metadata.Title ?? policy.Metadata.Name, Policy: policy);
+        }
+
+        if (snapshot.Index.RolesById.TryGetValue(semanticId, out var role))
+        {
+            return new ResolvedArtifact(semanticId, MetadataSemanticArtifactKind.Role, role.Metadata.Title ?? role.Metadata.Name, Role: role);
+        }
+
+        foreach (var candidateResource in snapshot.Graph.Resources)
+        {
+            foreach (var field in candidateResource.SchemaFields)
+            {
+                var fieldSemanticId = GetFieldSemanticId(candidateResource, field);
+                if (string.Equals(fieldSemanticId, semanticId, StringComparison.Ordinal))
+                {
+                    return ResolvedArtifact.ForField(semanticId, candidateResource, field);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static MetadataV2Field? FindMatchingField(MetadataV2Resource resource, MetadataV2Field sourceField)
+    {
+        var sourceSemanticId = GetFieldSemanticId(resource, sourceField);
+        return resource.SchemaFields.FirstOrDefault(field =>
+            string.Equals(GetFieldSemanticId(resource, field), sourceSemanticId, StringComparison.Ordinal) ||
+            string.Equals(field.Name, sourceField.Name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static MetadataV2Field? FindPrimaryIdentifierField(MetadataV2Resource resource)
+        => resource.SchemaFields.FirstOrDefault(static field =>
+                field.SemanticRoles.Contains("id.primary", StringComparer.OrdinalIgnoreCase) ||
+                field.SemanticRoles.Contains("identifier.primary", StringComparer.OrdinalIgnoreCase))
+            ?? resource.FindPrimaryIdField();
+
+    private static string GetFieldSemanticId(MetadataV2Resource resource, MetadataV2Field field)
+        => string.IsNullOrWhiteSpace(field.SemanticId)
+            ? $"field.{resource.Metadata.Id}.{field.Name}"
+            : field.SemanticId.Trim();
+
+    private static Dictionary<string, string> FieldDetails(MetadataV2Resource resource, MetadataV2Field field)
+        => new(StringComparer.Ordinal)
+        {
+            ["semanticId"] = GetFieldSemanticId(resource, field),
+            ["fieldName"] = field.Name,
+            ["type"] = field.Type,
+            ["nullable"] = field.Nullable.ToString(CultureInfo.InvariantCulture),
+            ["resourceId"] = resource.Metadata.Id,
+        };
+
+    private static Dictionary<string, string> TemporalDetails(MetadataV2TemporalFields fields)
+        => new(StringComparer.Ordinal)
+        {
+            ["startTimeField"] = fields.StartTimeField ?? string.Empty,
+            ["endTimeField"] = fields.EndTimeField ?? string.Empty,
+            ["trackIdField"] = fields.TrackIdField ?? string.Empty,
+        };
+
+    private static Dictionary<string, string> PublicationDetails(MetadataV2Publication publication)
+        => new(StringComparer.Ordinal)
+        {
+            ["resourceId"] = publication.ResourceId,
+            ["serviceId"] = publication.ServiceId,
+            ["path"] = publication.Path ?? string.Empty,
+            ["serviceLocalId"] = publication.ServiceLocalId ?? string.Empty,
+            ["layerIndex"] = publication.LayerIndex?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+        };
+
+    private static string[] ExtractTokens(
+        IReadOnlyDictionary<string, JsonElement> values,
+        params string[] keys)
+    {
+        var tokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var key in keys)
+        {
+            if (!values.TryGetValue(key, out var element))
+            {
+                continue;
+            }
+
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.String:
+                    AddToken(tokens, element.GetString());
+                    break;
+                case JsonValueKind.True:
+                    tokens.Add(key == IndexedKey ? "indexed" : key);
+                    break;
+                case JsonValueKind.Array:
+                    foreach (var item in element.EnumerateArray())
+                    {
+                        if (item.ValueKind == JsonValueKind.String)
+                        {
+                            AddToken(tokens, item.GetString());
+                        }
+                    }
+                    break;
+            }
+        }
+
+        return tokens.Order(StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    private static void AddToken(HashSet<string> tokens, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            tokens.Add(value.Trim());
+        }
+    }
+
+    private static MetadataCompatibilityFinding Finding(
+        string code,
+        MetadataCompatibilityFindingSeverity severity,
+        MetadataCompatibilityFindingKind kind,
+        string semanticId,
+        MetadataSemanticArtifactKind semanticKind,
+        string? parentSemanticId,
+        string? displayName,
+        string message,
+        MetadataCompatibilityValue expected,
+        MetadataCompatibilityValue actual,
+        MetadataCompatibilityRequiredAction requiredAction,
+        MetadataCompatibilityCoverageState coverageState)
+        => new()
+        {
+            Code = code,
+            Severity = severity,
+            Kind = kind,
+            AffectedSemanticId = semanticId,
+            AffectedSemanticKind = semanticKind,
+            AffectedParentSemanticId = parentSemanticId,
+            DisplayName = displayName,
+            Message = message,
+            Expected = expected,
+            Actual = actual,
+            RequiredAction = requiredAction,
+            CoverageState = coverageState,
+        };
+
+    private static MetadataCompatibilityValue Value(
+        string label,
+        string? value,
+        IReadOnlyDictionary<string, string>? details = null)
+        => new()
+        {
+            Label = label,
+            Value = value,
+            Details = details ?? new Dictionary<string, string>(),
+        };
+
+    private static string FormatTemporal(MetadataV2TemporalFields fields)
+        => string.Join(
+            ",",
+            new[]
+            {
+                fields.StartTimeField,
+                fields.EndTimeField,
+                fields.TrackIdField,
+            }.Where(static value => !string.IsNullOrWhiteSpace(value)));
+
+    private static string FormatPublicationRoute(MetadataV2Publication publication)
+        => string.Concat(
+            publication.Path ?? string.Empty,
+            "|",
+            publication.ServiceLocalId ?? string.Empty,
+            "|",
+            publication.LayerIndex?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+
+    private static string SafeLocator(string? locator)
+    {
+        if (string.IsNullOrWhiteSpace(locator))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = locator.Trim();
+        if (trimmed.Contains("://", StringComparison.Ordinal) ||
+            trimmed.StartsWith('/') ||
+            trimmed.Contains('\\') ||
+            trimmed.Contains("password", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.Contains("secret", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.Contains("connectionstring", StringComparison.OrdinalIgnoreCase))
+        {
+            return "[redacted]";
+        }
+
+        return trimmed.Length <= 96 ? trimmed : string.Concat(trimmed.AsSpan(0, 93), "...");
+    }
+
+    private static string? BoolToString(bool? value)
+        => value?.ToString(CultureInfo.InvariantCulture);
+
+    private static int SeverityRank(MetadataCompatibilityFindingSeverity severity)
+        => severity switch
+        {
+            MetadataCompatibilityFindingSeverity.Error => 3,
+            MetadataCompatibilityFindingSeverity.Warning => 2,
+            _ => 1,
+        };
+
+    private sealed record ResolvedArtifact(
+        string SemanticId,
+        MetadataSemanticArtifactKind Kind,
+        string? DisplayName,
+        MetadataV2Resource? Resource = null,
+        MetadataV2Resource? ParentResource = null,
+        MetadataV2Field? Field = null,
+        MetadataV2Service? Service = null,
+        MetadataV2Publication? Publication = null,
+        MetadataV2Catalog? Catalog = null,
+        MetadataV2Policy? Policy = null,
+        MetadataV2Role? Role = null)
+    {
+        public static ResolvedArtifact ForField(string semanticId, MetadataV2Resource parent, MetadataV2Field field)
+            => new(
+                semanticId,
+                MetadataSemanticArtifactKind.Field,
+                field.Title ?? field.Name,
+                ParentResource: parent,
+                Field: field);
+    }
+
+    private sealed record DependentState(
+        string SemanticId,
+        MetadataSemanticArtifactKind SemanticKind,
+        string? DisplayName,
+        MetadataCompatibilityFindingSeverity ImpactSeverity,
+        string Reason,
+        string ViaSemanticId,
+        string RelationshipKind)
+    {
+        public MetadataAffectedDependent ToDependent()
+            => new()
+            {
+                SemanticId = SemanticId,
+                SemanticKind = SemanticKind,
+                DisplayName = DisplayName,
+                ImpactSeverity = ImpactSeverity,
+                Reason = Reason,
+                ViaSemanticId = ViaSemanticId,
+                RelationshipKind = RelationshipKind,
+            };
+    }
+}

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzer.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzer.cs
@@ -226,7 +226,7 @@ public static class MetadataCompatibilityAnalyzer
                 null,
                 sourceParent.Metadata.Title ?? sourceParent.Metadata.Name,
                 "The target environment is missing the parent resource for a required field.",
-                Value("resource", sourceParent.Metadata.Id),
+                Value("resourceType", sourceParent.Type.ToString()),
                 Value("resource", "missing"),
                 MetadataCompatibilityRequiredAction.AddResource,
                 MetadataCompatibilityCoverageState.Uncovered));
@@ -534,7 +534,10 @@ public static class MetadataCompatibilityAnalyzer
                 null,
                 source.Metadata.Title ?? source.Metadata.Name,
                 "The target resource is missing a required primary storage binding.",
-                Value("storageBinding", source.PrimaryStorageBindingId ?? sourceBinding.Metadata.Id),
+                Value(
+                    "storageBinding",
+                    source.PrimaryStorageBindingId ?? sourceBinding.Metadata.Id,
+                    StorageDetails(sourceBinding)),
                 Value("storageBinding", "missing"),
                 MetadataCompatibilityRequiredAction.UpdateStorage,
                 MetadataCompatibilityCoverageState.Uncovered));
@@ -612,7 +615,7 @@ public static class MetadataCompatibilityAnalyzer
                 null,
                 source.Metadata.Title ?? source.Metadata.Name,
                 "The target environment is missing a required service.",
-                Value("serviceType", source.ServiceType.ToString()),
+                Value("serviceType", source.ServiceType.ToString(), ServiceDetails(source)),
                 Value("service", "missing"),
                 MetadataCompatibilityRequiredAction.AddService,
                 MetadataCompatibilityCoverageState.Uncovered));
@@ -979,7 +982,7 @@ public static class MetadataCompatibilityAnalyzer
 
         return finding.Code switch
         {
-            MetadataCompatibilityCode.ResourceMissing => FindArtifactContract(contract, finding)?.Exists == true,
+            MetadataCompatibilityCode.ResourceMissing => ResourceContractSatisfies(FindArtifactContract(contract, finding), finding),
             MetadataCompatibilityCode.ResourceTypeMismatch => FindArtifactContract(contract, finding)?.ResourceType?.ToString() == finding.Expected.Value,
             MetadataCompatibilityCode.FieldMissing or
             MetadataCompatibilityCode.FieldTypeMismatch or
@@ -991,10 +994,10 @@ public static class MetadataCompatibilityAnalyzer
             MetadataCompatibilityCode.StorageBindingMissing or
             MetadataCompatibilityCode.StorageTypeMismatch or
             MetadataCompatibilityCode.StorageCapabilityMissing => StorageContractSatisfies(FindArtifactContract(contract, finding), finding),
-            MetadataCompatibilityCode.ServiceMissing => FindArtifactContract(contract, finding)?.Exists == true,
+            MetadataCompatibilityCode.ServiceMissing => ServiceContractSatisfies(FindArtifactContract(contract, finding), finding),
             MetadataCompatibilityCode.ServiceTypeMismatch => FindArtifactContract(contract, finding)?.ServiceType?.ToString() == finding.Expected.Value,
             MetadataCompatibilityCode.ServiceProtocolMissing => FindArtifactContract(contract, finding)?.Capabilities.Contains(finding.Expected.Value ?? string.Empty, StringComparer.OrdinalIgnoreCase) == true,
-            MetadataCompatibilityCode.PublicationMissing => FindArtifactContract(contract, finding)?.Exists == true,
+            MetadataCompatibilityCode.PublicationMissing => PublicationContractSatisfies(FindArtifactContract(contract, finding), finding),
             MetadataCompatibilityCode.PublicationTypeMismatch => FindArtifactContract(contract, finding)?.PublicationType?.ToString() == finding.Expected.Value,
             MetadataCompatibilityCode.PublicationFormatMissing => FindArtifactContract(contract, finding)?.SupportedFormats.Contains(finding.Expected.Value ?? string.Empty, StringComparer.OrdinalIgnoreCase) == true,
             MetadataCompatibilityCode.PublicationCapabilityMissing => FindArtifactContract(contract, finding)?.Capabilities.Contains(finding.Expected.Value ?? string.Empty, StringComparer.OrdinalIgnoreCase) == true,
@@ -1085,6 +1088,52 @@ public static class MetadataCompatibilityAnalyzer
         return contract.Resources.FirstOrDefault(resource =>
             string.Equals(resource.SemanticId, resourceId, StringComparison.Ordinal) &&
             resource.SemanticKind == MetadataSemanticArtifactKind.Resource);
+    }
+
+    private static bool ResourceContractSatisfies(
+        MetadataScriptResourceContract? contract,
+        MetadataCompatibilityFinding finding)
+        => contract?.Exists == true &&
+            contract.ResourceType?.ToString() == finding.Expected.Value;
+
+    private static bool ServiceContractSatisfies(
+        MetadataScriptResourceContract? contract,
+        MetadataCompatibilityFinding finding)
+    {
+        if (contract?.Exists != true ||
+            contract.ServiceType?.ToString() != finding.Expected.Value)
+        {
+            return false;
+        }
+
+        if (!ContractDetailMatches(contract.Route, finding.Expected.Details, "route"))
+        {
+            return false;
+        }
+
+        return ContractContainsAll(
+            contract.Capabilities,
+            finding.Expected.Details,
+            "enabledProtocols");
+    }
+
+    private static bool PublicationContractSatisfies(
+        MetadataScriptResourceContract? contract,
+        MetadataCompatibilityFinding finding)
+    {
+        if (contract?.Exists != true ||
+            contract.PublicationType?.ToString() != finding.Expected.Value)
+        {
+            return false;
+        }
+
+        return ContractDetailMatches(contract.ResourceId, finding.Expected.Details, "resourceId") &&
+            ContractDetailMatches(contract.ServiceId, finding.Expected.Details, "serviceId") &&
+            ContractDetailMatches(contract.Path, finding.Expected.Details, "path") &&
+            ContractDetailMatches(contract.ServiceLocalId, finding.Expected.Details, "serviceLocalId") &&
+            ContractDetailMatches(contract.LayerIndex?.ToString(CultureInfo.InvariantCulture), finding.Expected.Details, "layerIndex") &&
+            ContractContainsAll(contract.SupportedFormats, finding.Expected.Details, "supportedFormats") &&
+            ContractContainsAll(contract.Capabilities, finding.Expected.Details, "capabilities");
     }
 
     private static bool FieldContractSatisfies(
@@ -1207,11 +1256,53 @@ public static class MetadataCompatibilityAnalyzer
 
         return finding.Code switch
         {
-            MetadataCompatibilityCode.StorageBindingMissing => true,
+            MetadataCompatibilityCode.StorageBindingMissing =>
+                ContractDetailMatches(contract.Storage.StorageBindingId, finding.Expected.Value) &&
+                ContractDetailMatches(contract.Storage.StorageType?.ToString(), finding.Expected.Details, "storageType") &&
+                ContractContainsAll(contract.Storage.Capabilities.Select(static capability => capability.ToString()), finding.Expected.Details, "capabilities"),
             MetadataCompatibilityCode.StorageTypeMismatch => contract.Storage.StorageType?.ToString() == finding.Expected.Value,
             MetadataCompatibilityCode.StorageCapabilityMissing => contract.Storage.Capabilities.Any(capability => capability.ToString() == finding.Expected.Value),
             _ => false,
         };
+    }
+
+    private static bool ContractDetailMatches(
+        string? actual,
+        IReadOnlyDictionary<string, string> expectedDetails,
+        string key)
+    {
+        if (!expectedDetails.TryGetValue(key, out var expected))
+        {
+            return true;
+        }
+
+        return ContractDetailMatches(actual, expected);
+    }
+
+    private static bool ContractDetailMatches(string? actual, string? expected)
+        => string.Equals(actual ?? string.Empty, expected ?? string.Empty, StringComparison.Ordinal);
+
+    private static bool ContractContainsAll(
+        IEnumerable<string> actualValues,
+        IReadOnlyDictionary<string, string> expectedDetails,
+        string key)
+    {
+        if (!expectedDetails.TryGetValue(key, out var expected) ||
+            string.IsNullOrWhiteSpace(expected))
+        {
+            return true;
+        }
+
+        var actual = new HashSet<string>(actualValues, StringComparer.OrdinalIgnoreCase);
+        foreach (var expectedValue in expected.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (!actual.Contains(expectedValue))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static MetadataAffectedDependent[] BuildAffectedDependents(
@@ -1616,6 +1707,21 @@ public static class MetadataCompatibilityAnalyzer
             ["trackIdField"] = fields.TrackIdField ?? string.Empty,
         };
 
+    private static Dictionary<string, string> StorageDetails(MetadataV2StorageBinding binding)
+        => new(StringComparer.Ordinal)
+        {
+            ["storageBindingId"] = binding.Metadata.Id,
+            ["storageType"] = binding.StorageType.ToString(),
+            ["capabilities"] = JoinTokens(binding.Capabilities.Select(static capability => capability.ToString())),
+        };
+
+    private static Dictionary<string, string> ServiceDetails(MetadataV2Service service)
+        => new(StringComparer.Ordinal)
+        {
+            ["route"] = service.Route ?? string.Empty,
+            ["enabledProtocols"] = JoinTokens(service.EnabledProtocols ?? Array.Empty<string>()),
+        };
+
     private static Dictionary<string, string> PublicationDetails(MetadataV2Publication publication)
         => new(StringComparer.Ordinal)
         {
@@ -1624,7 +1730,16 @@ public static class MetadataCompatibilityAnalyzer
             ["path"] = publication.Path ?? string.Empty,
             ["serviceLocalId"] = publication.ServiceLocalId ?? string.Empty,
             ["layerIndex"] = publication.LayerIndex?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+            ["supportedFormats"] = JoinTokens(publication.SupportedFormats),
+            ["capabilities"] = JoinTokens(publication.Capabilities),
         };
+
+    private static string JoinTokens(IEnumerable<string> values)
+        => string.Join(
+            ",",
+            values
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Order(StringComparer.OrdinalIgnoreCase));
 
     private static string[] ExtractTokens(
         IReadOnlyDictionary<string, JsonElement> values,

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzer.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzer.cs
@@ -718,7 +718,9 @@ public static class MetadataCompatibilityAnalyzer
                 MetadataCompatibilityCoverageState.Uncovered));
         }
 
-        if (!string.Equals(source.Path, target.Path, StringComparison.Ordinal) ||
+        if (!string.Equals(source.ResourceId, target.ResourceId, StringComparison.Ordinal) ||
+            !string.Equals(source.ServiceId, target.ServiceId, StringComparison.Ordinal) ||
+            !string.Equals(source.Path, target.Path, StringComparison.Ordinal) ||
             !string.Equals(source.ServiceLocalId, target.ServiceLocalId, StringComparison.Ordinal) ||
             source.LayerIndex != target.LayerIndex)
         {
@@ -730,7 +732,7 @@ public static class MetadataCompatibilityAnalyzer
                 MetadataSemanticArtifactKind.Publication,
                 source.ResourceId,
                 source.TitleOverride ?? source.Metadata.Title ?? source.Metadata.Name,
-                "The target publication route, path, layer index, or local id differs from the proposed publication.",
+                "The target publication resource, service, route, path, layer index, or local id differs from the proposed publication.",
                 Value("publicationRoute", FormatPublicationRoute(source), PublicationDetails(source)),
                 Value("publicationRoute", FormatPublicationRoute(target), PublicationDetails(target)),
                 MetadataCompatibilityRequiredAction.UpdatePublication,
@@ -1500,11 +1502,12 @@ public static class MetadataCompatibilityAnalyzer
     {
         if (findings.Any(static finding =>
             finding.Code == MetadataCompatibilityCode.StateUnavailable ||
-            finding.Code == MetadataCompatibilityCode.ScriptBeforeContractMismatch))
+            finding.Code == MetadataCompatibilityCode.ScriptBeforeContractMismatch ||
+            finding.CoverageState == MetadataCompatibilityCoverageState.Unknown))
         {
             return Rollback(
                 MetadataRollbackReadinessClassification.Manual,
-                "Rollback readiness cannot be determined while state or script applicability is unknown.",
+                "Rollback readiness cannot be determined while state, metadata coverage, or script applicability is unknown.",
                 requiresManualAction: true);
         }
 
@@ -1836,6 +1839,10 @@ public static class MetadataCompatibilityAnalyzer
 
     private static string FormatPublicationRoute(MetadataV2Publication publication)
         => string.Concat(
+            publication.ResourceId,
+            "|",
+            publication.ServiceId,
+            "|",
             publication.Path ?? string.Empty,
             "|",
             publication.ServiceLocalId ?? string.Empty,

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityCode.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityCode.cs
@@ -74,7 +74,7 @@ public static class MetadataCompatibilityCode
     /// <summary>Publication type differs between source and target.</summary>
     public const string PublicationTypeMismatch = "metadata.compat.publication.type_mismatch";
 
-    /// <summary>Publication route, path, layer index, or local id changed.</summary>
+    /// <summary>Publication resource, service, route, path, layer index, or local id changed.</summary>
     public const string PublicationRouteChanged = "metadata.compat.publication.route_changed";
 
     /// <summary>Required publication format is absent from target.</summary>

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityCode.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityCode.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Stable Metadata v2 compatibility finding codes.
+/// </summary>
+public static class MetadataCompatibilityCode
+{
+    /// <summary>Required source, package, or target state is unavailable.</summary>
+    public const string StateUnavailable = "metadata.compat.state.unavailable";
+
+    /// <summary>Required semantic artifact is missing.</summary>
+    public const string ResourceMissing = "metadata.compat.resource.missing";
+
+    /// <summary>Semantic artifact kind differs between source and target.</summary>
+    public const string ResourceTypeMismatch = "metadata.compat.resource.type_mismatch";
+
+    /// <summary>Required field is missing.</summary>
+    public const string FieldMissing = "metadata.compat.field.missing";
+
+    /// <summary>Field type differs between source and target.</summary>
+    public const string FieldTypeMismatch = "metadata.compat.field.type_mismatch";
+
+    /// <summary>Field nullability differs between source and target.</summary>
+    public const string FieldNullabilityMismatch = "metadata.compat.field.nullability_mismatch";
+
+    /// <summary>Required canonical field domain is missing or incompatible.</summary>
+    public const string FieldDomainMismatch = "metadata.compat.field.domain_mismatch";
+
+    /// <summary>Required canonical field index is missing or incompatible.</summary>
+    public const string FieldIndexMissing = "metadata.compat.field.index_missing";
+
+    /// <summary>Required identifier field is missing.</summary>
+    public const string IdentifierMissing = "metadata.compat.identifier.missing";
+
+    /// <summary>Geometry type differs between source and target.</summary>
+    public const string SpatialGeometryTypeMismatch = "metadata.compat.spatial.geometry_type_mismatch";
+
+    /// <summary>CRS/SRID differs or is unavailable for comparison.</summary>
+    public const string SpatialCrsMismatch = "metadata.compat.spatial.crs_mismatch";
+
+    /// <summary>Temporal field metadata differs between source and target.</summary>
+    public const string TemporalFieldMismatch = "metadata.compat.temporal.field_mismatch";
+
+    /// <summary>Required primary storage binding is missing.</summary>
+    public const string StorageBindingMissing = "metadata.compat.storage.binding_missing";
+
+    /// <summary>Storage type differs between source and target.</summary>
+    public const string StorageTypeMismatch = "metadata.compat.storage.type_mismatch";
+
+    /// <summary>Required storage capability is missing.</summary>
+    public const string StorageCapabilityMissing = "metadata.compat.storage.capability_missing";
+
+    /// <summary>Storage locator changed and needs review.</summary>
+    public const string StorageLocatorChanged = "metadata.compat.storage.locator_changed";
+
+    /// <summary>Required service is missing.</summary>
+    public const string ServiceMissing = "metadata.compat.service.missing";
+
+    /// <summary>Service type differs between source and target.</summary>
+    public const string ServiceTypeMismatch = "metadata.compat.service.type_mismatch";
+
+    /// <summary>Service route changed and clients may need a service revision.</summary>
+    public const string ServiceRouteChanged = "metadata.compat.service.route_changed";
+
+    /// <summary>Required service protocol is absent from target.</summary>
+    public const string ServiceProtocolMissing = "metadata.compat.service.protocol_missing";
+
+    /// <summary>Required publication is missing.</summary>
+    public const string PublicationMissing = "metadata.compat.publication.missing";
+
+    /// <summary>Publication type differs between source and target.</summary>
+    public const string PublicationTypeMismatch = "metadata.compat.publication.type_mismatch";
+
+    /// <summary>Publication route, path, layer index, or local id changed.</summary>
+    public const string PublicationRouteChanged = "metadata.compat.publication.route_changed";
+
+    /// <summary>Required publication format is absent from target.</summary>
+    public const string PublicationFormatMissing = "metadata.compat.publication.format_missing";
+
+    /// <summary>Required publication capability is absent from target.</summary>
+    public const string PublicationCapabilityMissing = "metadata.compat.publication.capability_missing";
+
+    /// <summary>Required projection semantic is absent from target.</summary>
+    public const string ProjectionRequiredSemanticRemoved = "metadata.compat.projection.required_semantic_removed";
+
+    /// <summary>Required policy or role reference is absent from target.</summary>
+    public const string PolicyReferenceMissing = "metadata.compat.policy.reference_missing";
+
+    /// <summary>A declared data script before-contract does not match target state.</summary>
+    public const string ScriptBeforeContractMismatch = "metadata.compat.script.before_contract_mismatch";
+}

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityJsonContext.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityJsonContext.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// JSON serialization context for Metadata v2 compatibility prevalidation contracts.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(MetadataCompatibilityPrevalidationRequest))]
+[JsonSerializable(typeof(MetadataCompatibilityReport))]
+[JsonSerializable(typeof(MetadataCompatibilityFinding))]
+[JsonSerializable(typeof(MetadataCompatibilityValue))]
+[JsonSerializable(typeof(MetadataAffectedDependent))]
+[JsonSerializable(typeof(MetadataRollbackReadiness))]
+[JsonSerializable(typeof(MetadataDataScriptEntry))]
+[JsonSerializable(typeof(MetadataDataScriptContract))]
+[JsonSerializable(typeof(MetadataScriptResourceContract))]
+[JsonSerializable(typeof(MetadataScriptFieldContract))]
+[JsonSerializable(typeof(MetadataScriptSpatialContract))]
+[JsonSerializable(typeof(MetadataScriptTemporalContract))]
+[JsonSerializable(typeof(MetadataScriptStorageContract))]
+[JsonSerializable(typeof(MetadataCompatibilityFinding[]))]
+[JsonSerializable(typeof(MetadataAffectedDependent[]))]
+[JsonSerializable(typeof(MetadataDataScriptEntry[]))]
+[JsonSerializable(typeof(MetadataScriptResourceContract[]))]
+[JsonSerializable(typeof(MetadataScriptFieldContract[]))]
+[JsonSerializable(typeof(string[]))]
+[JsonSerializable(typeof(IReadOnlyDictionary<string, string>), TypeInfoPropertyName = "ReadOnlyDictionaryStringString")]
+public sealed partial class MetadataCompatibilityJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityModels.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityModels.cs
@@ -1,0 +1,696 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Metadata.Domain.V2;
+
+/// <summary>
+/// Request for Metadata v2 release-package compatibility prevalidation.
+/// </summary>
+public sealed record MetadataCompatibilityPrevalidationRequest
+{
+    /// <summary>Persisted release package identifier to resolve before analysis.</summary>
+    [JsonPropertyName("releasePackageId")]
+    public Guid? ReleasePackageId { get; init; }
+
+    /// <summary>Inline release package payload for pre-PR compatibility checks.</summary>
+    [JsonPropertyName("releasePackage")]
+    public MetadataReleasePackage? ReleasePackage { get; init; }
+
+    /// <summary>Target environment whose current graph snapshot is compared.</summary>
+    [JsonPropertyName("targetEnvironment")]
+    public required string TargetEnvironment { get; init; }
+
+    /// <summary>Optional declared data scripts that may cover compatibility gaps.</summary>
+    [JsonPropertyName("dataScripts")]
+    public IReadOnlyList<MetadataDataScriptEntry> DataScripts { get; init; } = Array.Empty<MetadataDataScriptEntry>();
+}
+
+/// <summary>
+/// Environment-scoped compatibility report for a release package.
+/// </summary>
+public sealed record MetadataCompatibilityReport
+{
+    /// <summary>Target environment analyzed.</summary>
+    [JsonPropertyName("targetEnvironment")]
+    public required string TargetEnvironment { get; init; }
+
+    /// <summary>Release package identifier, when known.</summary>
+    [JsonPropertyName("releasePackageId")]
+    public Guid? ReleasePackageId { get; init; }
+
+    /// <summary>Release package key, when known.</summary>
+    [JsonPropertyName("packageKey")]
+    public string? PackageKey { get; init; }
+
+    /// <summary>Source environment declared by the release package.</summary>
+    [JsonPropertyName("sourceEnvironment")]
+    public string? SourceEnvironment { get; init; }
+
+    /// <summary>Source Metadata v2 revision used for desired state.</summary>
+    [JsonPropertyName("sourceRevision")]
+    public long? SourceRevision { get; init; }
+
+    /// <summary>Source graph entity tag used for desired state.</summary>
+    [JsonPropertyName("sourceEtag")]
+    public string? SourceEtag { get; init; }
+
+    /// <summary>Target Metadata v2 revision observed for comparison.</summary>
+    [JsonPropertyName("targetRevision")]
+    public long? TargetRevision { get; init; }
+
+    /// <summary>Target graph entity tag observed for comparison.</summary>
+    [JsonPropertyName("targetEtag")]
+    public string? TargetEtag { get; init; }
+
+    /// <summary>Timestamp when the report was generated.</summary>
+    [JsonPropertyName("generatedAt")]
+    public required DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>Overall compatibility status.</summary>
+    [JsonPropertyName("status")]
+    public required MetadataCompatibilityStatus Status { get; init; }
+
+    /// <summary>True when the report has no uncovered blockers and is not unknown.</summary>
+    [JsonPropertyName("canCreatePullRequest")]
+    public bool CanCreatePullRequest { get; init; }
+
+    /// <summary>True when the report has no uncovered blockers and is not unknown.</summary>
+    [JsonPropertyName("canPromote")]
+    public bool CanPromote { get; init; }
+
+    /// <summary>Number of error findings that are not covered by a declared data script.</summary>
+    [JsonPropertyName("uncoveredErrorCount")]
+    public int UncoveredErrorCount { get; init; }
+
+    /// <summary>Number of error findings covered by a declared data script.</summary>
+    [JsonPropertyName("coveredErrorCount")]
+    public int CoveredErrorCount { get; init; }
+
+    /// <summary>Number of warning findings.</summary>
+    [JsonPropertyName("warningCount")]
+    public int WarningCount { get; init; }
+
+    /// <summary>Number of data scripts supplied with the request.</summary>
+    [JsonPropertyName("scriptCount")]
+    public int ScriptCount { get; init; }
+
+    /// <summary>Compatibility findings in deterministic order.</summary>
+    [JsonPropertyName("findings")]
+    public IReadOnlyList<MetadataCompatibilityFinding> Findings { get; init; } =
+        Array.Empty<MetadataCompatibilityFinding>();
+
+    /// <summary>Affected dependent artifacts for Console blast-radius visualization.</summary>
+    [JsonPropertyName("affectedDependents")]
+    public IReadOnlyList<MetadataAffectedDependent> AffectedDependents { get; init; } =
+        Array.Empty<MetadataAffectedDependent>();
+
+    /// <summary>Rollback readiness classification for the proposed package.</summary>
+    [JsonPropertyName("rollbackReadiness")]
+    public required MetadataRollbackReadiness RollbackReadiness { get; init; }
+}
+
+/// <summary>
+/// One compatibility finding in a prevalidation report.
+/// </summary>
+public sealed record MetadataCompatibilityFinding
+{
+    /// <summary>Stable machine-readable compatibility code.</summary>
+    [JsonPropertyName("code")]
+    public required string Code { get; init; }
+
+    /// <summary>Finding severity.</summary>
+    [JsonPropertyName("severity")]
+    public required MetadataCompatibilityFindingSeverity Severity { get; init; }
+
+    /// <summary>Finding category.</summary>
+    [JsonPropertyName("kind")]
+    public required MetadataCompatibilityFindingKind Kind { get; init; }
+
+    /// <summary>Affected semantic artifact identifier.</summary>
+    [JsonPropertyName("affectedSemanticId")]
+    public required string AffectedSemanticId { get; init; }
+
+    /// <summary>Affected semantic artifact kind.</summary>
+    [JsonPropertyName("affectedSemanticKind")]
+    public required MetadataSemanticArtifactKind AffectedSemanticKind { get; init; }
+
+    /// <summary>Parent semantic identifier for field or publication findings.</summary>
+    [JsonPropertyName("affectedParentSemanticId")]
+    public string? AffectedParentSemanticId { get; init; }
+
+    /// <summary>Optional human-readable affected artifact name.</summary>
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; init; }
+
+    /// <summary>Short safe message describing the compatibility issue.</summary>
+    [JsonPropertyName("message")]
+    public required string Message { get; init; }
+
+    /// <summary>Expected secret-safe value or details.</summary>
+    [JsonPropertyName("expected")]
+    public required MetadataCompatibilityValue Expected { get; init; }
+
+    /// <summary>Actual secret-safe value or details.</summary>
+    [JsonPropertyName("actual")]
+    public required MetadataCompatibilityValue Actual { get; init; }
+
+    /// <summary>Required action for a human or automation workflow.</summary>
+    [JsonPropertyName("requiredAction")]
+    public required MetadataCompatibilityRequiredAction RequiredAction { get; init; }
+
+    /// <summary>Coverage state after declared data scripts are evaluated.</summary>
+    [JsonPropertyName("coverageState")]
+    public MetadataCompatibilityCoverageState CoverageState { get; init; } =
+        MetadataCompatibilityCoverageState.NotApplicable;
+
+    /// <summary>Identifier of the data script that covers this finding, when any.</summary>
+    [JsonPropertyName("coveringScriptId")]
+    public string? CoveringScriptId { get; init; }
+
+    /// <summary>Optional notes about script coverage or applicability.</summary>
+    [JsonPropertyName("coverageNotes")]
+    public string? CoverageNotes { get; init; }
+}
+
+/// <summary>
+/// Secret-safe expected or actual value carried by a compatibility finding.
+/// </summary>
+public sealed record MetadataCompatibilityValue
+{
+    /// <summary>Value label, such as field, type, or CRS.</summary>
+    [JsonPropertyName("label")]
+    public required string Label { get; init; }
+
+    /// <summary>Primary value rendered as a safe string.</summary>
+    [JsonPropertyName("value")]
+    public string? Value { get; init; }
+
+    /// <summary>Additional safe key/value details.</summary>
+    [JsonPropertyName("details")]
+    public IReadOnlyDictionary<string, string> Details { get; init; } = new Dictionary<string, string>();
+}
+
+/// <summary>
+/// Dependent artifact affected by one or more compatibility findings.
+/// </summary>
+public sealed record MetadataAffectedDependent
+{
+    /// <summary>Dependent semantic identifier.</summary>
+    [JsonPropertyName("semanticId")]
+    public required string SemanticId { get; init; }
+
+    /// <summary>Dependent semantic kind.</summary>
+    [JsonPropertyName("semanticKind")]
+    public required MetadataSemanticArtifactKind SemanticKind { get; init; }
+
+    /// <summary>Optional display name.</summary>
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; init; }
+
+    /// <summary>Impact severity for Console visualization.</summary>
+    [JsonPropertyName("impactSeverity")]
+    public required MetadataCompatibilityFindingSeverity ImpactSeverity { get; init; }
+
+    /// <summary>Safe reason for the dependent impact.</summary>
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
+
+    /// <summary>Semantic identifier through which the dependency is reached.</summary>
+    [JsonPropertyName("viaSemanticId")]
+    public string? ViaSemanticId { get; init; }
+
+    /// <summary>Relationship kind or path label.</summary>
+    [JsonPropertyName("relationshipKind")]
+    public string? RelationshipKind { get; init; }
+}
+
+/// <summary>
+/// Rollback readiness for a compatibility report.
+/// </summary>
+public sealed record MetadataRollbackReadiness
+{
+    /// <summary>Rollback classification.</summary>
+    [JsonPropertyName("classification")]
+    public required MetadataRollbackReadinessClassification Classification { get; init; }
+
+    /// <summary>Safe reason for the classification.</summary>
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
+
+    /// <summary>True when rollback requires an external data snapshot.</summary>
+    [JsonPropertyName("requiresSnapshot")]
+    public bool RequiresSnapshot { get; init; }
+
+    /// <summary>True when rollback requires manual operator intervention.</summary>
+    [JsonPropertyName("requiresManualAction")]
+    public bool RequiresManualAction { get; init; }
+
+    /// <summary>Data scripts involved in the rollback classification.</summary>
+    [JsonPropertyName("scriptIds")]
+    public IReadOnlyList<string> ScriptIds { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Data script declaration used only for compatibility coverage analysis.
+/// </summary>
+public sealed record MetadataDataScriptEntry
+{
+    /// <summary>Stable script identifier.</summary>
+    [JsonPropertyName("scriptId")]
+    public required string ScriptId { get; init; }
+
+    /// <summary>Optional display title.</summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>Script kind or implementation family.</summary>
+    [JsonPropertyName("kind")]
+    public string? Kind { get; init; }
+
+    /// <summary>Optional target environment. Empty means the script is environment-agnostic.</summary>
+    [JsonPropertyName("targetEnvironment")]
+    public string? TargetEnvironment { get; init; }
+
+    /// <summary>True when the script declares a reversible data operation.</summary>
+    [JsonPropertyName("reversible")]
+    public bool Reversible { get; init; }
+
+    /// <summary>Declared state that must match the target before the script applies.</summary>
+    [JsonPropertyName("beforeContract")]
+    public MetadataDataScriptContract? BeforeContract { get; init; }
+
+    /// <summary>Declared state expected after the script applies.</summary>
+    [JsonPropertyName("afterContract")]
+    public MetadataDataScriptContract? AfterContract { get; init; }
+
+    /// <summary>Declared operation labels, such as add-field or alter-type.</summary>
+    [JsonPropertyName("declaredOperations")]
+    public IReadOnlyList<string> DeclaredOperations { get; init; } = Array.Empty<string>();
+
+    /// <summary>Optional script notes.</summary>
+    [JsonPropertyName("notes")]
+    public string? Notes { get; init; }
+}
+
+/// <summary>
+/// Declared semantic state before or after a data script.
+/// </summary>
+public sealed record MetadataDataScriptContract
+{
+    /// <summary>Semantic artifact contracts included in the data script declaration.</summary>
+    [JsonPropertyName("resources")]
+    public IReadOnlyList<MetadataScriptResourceContract> Resources { get; init; } =
+        Array.Empty<MetadataScriptResourceContract>();
+}
+
+/// <summary>
+/// Declared script contract for a Metadata v2 semantic artifact.
+/// </summary>
+public sealed record MetadataScriptResourceContract
+{
+    /// <summary>Semantic artifact identifier represented by this contract.</summary>
+    [JsonPropertyName("semanticId")]
+    public required string SemanticId { get; init; }
+
+    /// <summary>Semantic artifact kind.</summary>
+    [JsonPropertyName("semanticKind")]
+    public MetadataSemanticArtifactKind SemanticKind { get; init; } = MetadataSemanticArtifactKind.Resource;
+
+    /// <summary>Parent resource identifier for field or publication contracts.</summary>
+    [JsonPropertyName("resourceId")]
+    public string? ResourceId { get; init; }
+
+    /// <summary>Whether the artifact is expected to exist.</summary>
+    [JsonPropertyName("exists")]
+    public bool? Exists { get; init; }
+
+    /// <summary>Resource type expected after the script.</summary>
+    [JsonPropertyName("resourceType")]
+    public MetadataV2ResourceType? ResourceType { get; init; }
+
+    /// <summary>Service type expected after the script.</summary>
+    [JsonPropertyName("serviceType")]
+    public MetadataV2ServiceType? ServiceType { get; init; }
+
+    /// <summary>Publication type expected after the script.</summary>
+    [JsonPropertyName("publicationType")]
+    public MetadataV2PublicationType? PublicationType { get; init; }
+
+    /// <summary>Service route expected after the script.</summary>
+    [JsonPropertyName("route")]
+    public string? Route { get; init; }
+
+    /// <summary>Publication path expected after the script.</summary>
+    [JsonPropertyName("path")]
+    public string? Path { get; init; }
+
+    /// <summary>Publication service-local identifier expected after the script.</summary>
+    [JsonPropertyName("serviceLocalId")]
+    public string? ServiceLocalId { get; init; }
+
+    /// <summary>Publication layer index expected after the script.</summary>
+    [JsonPropertyName("layerIndex")]
+    public int? LayerIndex { get; init; }
+
+    /// <summary>Fields expected before or after the script.</summary>
+    [JsonPropertyName("fields")]
+    public IReadOnlyList<MetadataScriptFieldContract> Fields { get; init; } =
+        Array.Empty<MetadataScriptFieldContract>();
+
+    /// <summary>Required field identifiers expected before or after the script.</summary>
+    [JsonPropertyName("requiredIdentifiers")]
+    public IReadOnlyList<string> RequiredIdentifiers { get; init; } = Array.Empty<string>();
+
+    /// <summary>Canonical domain identifiers expected before or after the script.</summary>
+    [JsonPropertyName("domains")]
+    public IReadOnlyList<string> Domains { get; init; } = Array.Empty<string>();
+
+    /// <summary>Canonical index identifiers expected before or after the script.</summary>
+    [JsonPropertyName("indexes")]
+    public IReadOnlyList<string> Indexes { get; init; } = Array.Empty<string>();
+
+    /// <summary>Spatial metadata expected before or after the script.</summary>
+    [JsonPropertyName("spatial")]
+    public MetadataScriptSpatialContract? Spatial { get; init; }
+
+    /// <summary>Temporal metadata expected before or after the script.</summary>
+    [JsonPropertyName("temporal")]
+    public MetadataScriptTemporalContract? Temporal { get; init; }
+
+    /// <summary>Storage metadata expected before or after the script.</summary>
+    [JsonPropertyName("storage")]
+    public MetadataScriptStorageContract? Storage { get; init; }
+
+    /// <summary>Publication capabilities expected before or after the script.</summary>
+    [JsonPropertyName("capabilities")]
+    public IReadOnlyList<string> Capabilities { get; init; } = Array.Empty<string>();
+
+    /// <summary>Publication formats expected before or after the script.</summary>
+    [JsonPropertyName("supportedFormats")]
+    public IReadOnlyList<string> SupportedFormats { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Field-level before or after contract for a data script.
+/// </summary>
+public sealed record MetadataScriptFieldContract
+{
+    /// <summary>Field semantic identifier, when available.</summary>
+    [JsonPropertyName("semanticId")]
+    public string? SemanticId { get; init; }
+
+    /// <summary>Field name.</summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>Whether the field is expected to exist.</summary>
+    [JsonPropertyName("exists")]
+    public bool? Exists { get; init; }
+
+    /// <summary>Field type.</summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    /// <summary>Field nullability.</summary>
+    [JsonPropertyName("nullable")]
+    public bool? Nullable { get; init; }
+
+    /// <summary>Semantic roles expected on the field.</summary>
+    [JsonPropertyName("semanticRoles")]
+    public IReadOnlyList<string> SemanticRoles { get; init; } = Array.Empty<string>();
+
+    /// <summary>Canonical domain identifiers expected on the field.</summary>
+    [JsonPropertyName("domains")]
+    public IReadOnlyList<string> Domains { get; init; } = Array.Empty<string>();
+
+    /// <summary>Canonical index identifiers expected on the field.</summary>
+    [JsonPropertyName("indexes")]
+    public IReadOnlyList<string> Indexes { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Spatial before or after contract for a data script.
+/// </summary>
+public sealed record MetadataScriptSpatialContract
+{
+    /// <summary>Geometry type.</summary>
+    [JsonPropertyName("geometryType")]
+    public string? GeometryType { get; init; }
+
+    /// <summary>Spatial reference identifier.</summary>
+    [JsonPropertyName("srid")]
+    public int? Srid { get; init; }
+}
+
+/// <summary>
+/// Temporal before or after contract for a data script.
+/// </summary>
+public sealed record MetadataScriptTemporalContract
+{
+    /// <summary>Start-time field.</summary>
+    [JsonPropertyName("startTimeField")]
+    public string? StartTimeField { get; init; }
+
+    /// <summary>End-time field.</summary>
+    [JsonPropertyName("endTimeField")]
+    public string? EndTimeField { get; init; }
+
+    /// <summary>Track identifier field.</summary>
+    [JsonPropertyName("trackIdField")]
+    public string? TrackIdField { get; init; }
+}
+
+/// <summary>
+/// Storage before or after contract for a data script.
+/// </summary>
+public sealed record MetadataScriptStorageContract
+{
+    /// <summary>Storage type.</summary>
+    [JsonPropertyName("storageType")]
+    public MetadataV2StorageType? StorageType { get; init; }
+
+    /// <summary>Storage binding capabilities.</summary>
+    [JsonPropertyName("capabilities")]
+    public IReadOnlyList<MetadataV2StorageBindingCapability> Capabilities { get; init; } =
+        Array.Empty<MetadataV2StorageBindingCapability>();
+}
+
+/// <summary>
+/// Overall compatibility status.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataCompatibilityStatus>))]
+public enum MetadataCompatibilityStatus
+{
+    /// <summary>All declared requirements are satisfied.</summary>
+    [JsonStringEnumMemberName("ready")]
+    Ready,
+
+    /// <summary>No uncovered blockers exist, but warnings or script-covered blockers remain.</summary>
+    [JsonStringEnumMemberName("warning")]
+    Warning,
+
+    /// <summary>At least one error finding is not covered by a declared data script.</summary>
+    [JsonStringEnumMemberName("blocked")]
+    Blocked,
+
+    /// <summary>Required source, target, or comparison metadata is unavailable.</summary>
+    [JsonStringEnumMemberName("unknown")]
+    Unknown,
+}
+
+/// <summary>
+/// Finding severity.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataCompatibilityFindingSeverity>))]
+public enum MetadataCompatibilityFindingSeverity
+{
+    /// <summary>Informational finding.</summary>
+    [JsonStringEnumMemberName("info")]
+    Info,
+
+    /// <summary>Warning finding.</summary>
+    [JsonStringEnumMemberName("warning")]
+    Warning,
+
+    /// <summary>Error finding.</summary>
+    [JsonStringEnumMemberName("error")]
+    Error,
+}
+
+/// <summary>
+/// Finding kind.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataCompatibilityFindingKind>))]
+public enum MetadataCompatibilityFindingKind
+{
+    /// <summary>Source or target state availability.</summary>
+    [JsonStringEnumMemberName("state")]
+    State,
+
+    /// <summary>Resource compatibility.</summary>
+    [JsonStringEnumMemberName("resource")]
+    Resource,
+
+    /// <summary>Field compatibility.</summary>
+    [JsonStringEnumMemberName("field")]
+    Field,
+
+    /// <summary>Identifier compatibility.</summary>
+    [JsonStringEnumMemberName("identifier")]
+    Identifier,
+
+    /// <summary>Spatial metadata compatibility.</summary>
+    [JsonStringEnumMemberName("spatial")]
+    Spatial,
+
+    /// <summary>Temporal metadata compatibility.</summary>
+    [JsonStringEnumMemberName("temporal")]
+    Temporal,
+
+    /// <summary>Storage binding compatibility.</summary>
+    [JsonStringEnumMemberName("storage")]
+    Storage,
+
+    /// <summary>Service compatibility.</summary>
+    [JsonStringEnumMemberName("service")]
+    Service,
+
+    /// <summary>Publication compatibility.</summary>
+    [JsonStringEnumMemberName("publication")]
+    Publication,
+
+    /// <summary>Projection profile compatibility.</summary>
+    [JsonStringEnumMemberName("projection")]
+    Projection,
+
+    /// <summary>Policy or role reference compatibility.</summary>
+    [JsonStringEnumMemberName("policy")]
+    Policy,
+
+    /// <summary>Data script applicability or coverage.</summary>
+    [JsonStringEnumMemberName("script")]
+    Script,
+}
+
+/// <summary>
+/// Data script coverage state for a finding.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataCompatibilityCoverageState>))]
+public enum MetadataCompatibilityCoverageState
+{
+    /// <summary>The finding does not need data-script coverage.</summary>
+    [JsonStringEnumMemberName("not-applicable")]
+    NotApplicable,
+
+    /// <summary>The finding is not covered by any applicable script.</summary>
+    [JsonStringEnumMemberName("uncovered")]
+    Uncovered,
+
+    /// <summary>The finding is covered by a declared script.</summary>
+    [JsonStringEnumMemberName("covered-by-script")]
+    CoveredByScript,
+
+    /// <summary>Coverage could not be established from declared metadata.</summary>
+    [JsonStringEnumMemberName("unknown")]
+    Unknown,
+}
+
+/// <summary>
+/// Required action for a compatibility finding.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataCompatibilityRequiredAction>))]
+public enum MetadataCompatibilityRequiredAction
+{
+    /// <summary>No action is required.</summary>
+    [JsonStringEnumMemberName("none")]
+    None,
+
+    /// <summary>Resolve source or target Metadata v2 state.</summary>
+    [JsonStringEnumMemberName("resolve-state")]
+    ResolveState,
+
+    /// <summary>Add or restore a Metadata v2 resource.</summary>
+    [JsonStringEnumMemberName("add-resource")]
+    AddResource,
+
+    /// <summary>Update a Metadata v2 resource.</summary>
+    [JsonStringEnumMemberName("update-resource")]
+    UpdateResource,
+
+    /// <summary>Add a missing field.</summary>
+    [JsonStringEnumMemberName("add-field")]
+    AddField,
+
+    /// <summary>Update field metadata.</summary>
+    [JsonStringEnumMemberName("update-field")]
+    UpdateField,
+
+    /// <summary>Update identifier metadata.</summary>
+    [JsonStringEnumMemberName("update-identifier")]
+    UpdateIdentifier,
+
+    /// <summary>Update spatial metadata.</summary>
+    [JsonStringEnumMemberName("update-spatial")]
+    UpdateSpatial,
+
+    /// <summary>Update temporal metadata.</summary>
+    [JsonStringEnumMemberName("update-temporal")]
+    UpdateTemporal,
+
+    /// <summary>Update storage binding metadata.</summary>
+    [JsonStringEnumMemberName("update-storage")]
+    UpdateStorage,
+
+    /// <summary>Add or restore a service.</summary>
+    [JsonStringEnumMemberName("add-service")]
+    AddService,
+
+    /// <summary>Update service metadata.</summary>
+    [JsonStringEnumMemberName("update-service")]
+    UpdateService,
+
+    /// <summary>Add or restore a publication.</summary>
+    [JsonStringEnumMemberName("add-publication")]
+    AddPublication,
+
+    /// <summary>Update publication metadata.</summary>
+    [JsonStringEnumMemberName("update-publication")]
+    UpdatePublication,
+
+    /// <summary>Run and review the covering data script.</summary>
+    [JsonStringEnumMemberName("run-data-script")]
+    RunDataScript,
+
+    /// <summary>Review metadata manually.</summary>
+    [JsonStringEnumMemberName("manual-review")]
+    ManualReview,
+}
+
+/// <summary>
+/// Rollback readiness classification.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<MetadataRollbackReadinessClassification>))]
+public enum MetadataRollbackReadinessClassification
+{
+    /// <summary>Only Metadata v2 graph/package state needs rollback.</summary>
+    [JsonStringEnumMemberName("metadata-only")]
+    MetadataOnly,
+
+    /// <summary>Service or publication revisions are needed for rollback.</summary>
+    [JsonStringEnumMemberName("service-revision")]
+    ServiceRevision,
+
+    /// <summary>All data-impacting changes are covered by reversible scripts.</summary>
+    [JsonStringEnumMemberName("script-reversible")]
+    ScriptReversible,
+
+    /// <summary>Rollback requires an external data snapshot.</summary>
+    [JsonStringEnumMemberName("snapshot-required")]
+    SnapshotRequired,
+
+    /// <summary>Rollback readiness cannot be automated from declared metadata.</summary>
+    [JsonStringEnumMemberName("manual")]
+    Manual,
+}

--- a/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityModels.cs
+++ b/src/Honua.Core/Features/Metadata/Domain/V2/MetadataCompatibilityModels.cs
@@ -322,6 +322,10 @@ public sealed record MetadataScriptResourceContract
     [JsonPropertyName("resourceId")]
     public string? ResourceId { get; init; }
 
+    /// <summary>Parent service identifier for publication contracts.</summary>
+    [JsonPropertyName("serviceId")]
+    public string? ServiceId { get; init; }
+
     /// <summary>Whether the artifact is expected to exist.</summary>
     [JsonPropertyName("exists")]
     public bool? Exists { get; init; }
@@ -467,6 +471,10 @@ public sealed record MetadataScriptTemporalContract
 /// </summary>
 public sealed record MetadataScriptStorageContract
 {
+    /// <summary>Storage binding semantic identifier expected before or after the script.</summary>
+    [JsonPropertyName("storageBindingId")]
+    public string? StorageBindingId { get; init; }
+
     /// <summary>Storage type.</summary>
     [JsonPropertyName("storageType")]
     public MetadataV2StorageType? StorageType { get; init; }

--- a/src/Honua.Core/Features/Metadata/MetadataServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Metadata/MetadataServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class MetadataServiceCollectionExtensions
         services.TryAddScoped<IMetadataV2EnvironmentSnapshotReader, MetadataV2GraphProviderEnvironmentSnapshotReader>();
         services.TryAddSingleton<IMetadataReleasePackageStore, InMemoryMetadataReleasePackageStore>();
         services.TryAddScoped<IMetadataReleaseService, MetadataReleaseService>();
+        services.TryAddScoped<IMetadataCompatibilityPrevalidationService, MetadataCompatibilityPrevalidationService>();
         return services;
     }
 

--- a/src/Honua.Core/Features/Metadata/Services/MetadataCompatibilityPrevalidationService.cs
+++ b/src/Honua.Core/Features/Metadata/Services/MetadataCompatibilityPrevalidationService.cs
@@ -204,10 +204,7 @@ public sealed class MetadataCompatibilityPrevalidationService(
                 throw new ArgumentException("DataScripts cannot contain a script with a blank scriptId.", nameof(dataScripts));
             }
 
-            if (script.DeclaredOperations is null)
-            {
-                throw new ArgumentException("Data script declaredOperations must be an array.", nameof(dataScripts));
-            }
+            ValidateCollection(script.DeclaredOperations, script.ScriptId, "declaredOperations", nameof(dataScripts));
 
             ValidateContract(script.BeforeContract, script.ScriptId, "beforeContract");
             ValidateContract(script.AfterContract, script.ScriptId, "afterContract");
@@ -226,39 +223,33 @@ public sealed class MetadataCompatibilityPrevalidationService(
             return;
         }
 
-        if (contract.Resources is null)
-        {
-            throw new ArgumentException($"Data script '{scriptId}' {propertyName}.resources must be an array.", propertyName);
-        }
+        ValidateCollection(contract.Resources, scriptId, $"{propertyName}.resources", propertyName);
 
         var fieldCount = 0;
         foreach (var resource in contract.Resources)
         {
-            if (resource is null)
-            {
-                throw new ArgumentException(
-                    $"Data script '{scriptId}' {propertyName}.resources cannot contain null entries.",
-                    propertyName);
-            }
-
             if (string.IsNullOrWhiteSpace(resource.SemanticId))
             {
                 throw new ArgumentException($"Data script '{scriptId}' contains a contract resource with a blank semanticId.", propertyName);
             }
 
-            if (resource.Fields is null)
-            {
-                throw new ArgumentException($"Data script '{scriptId}' contract fields must be an array.", propertyName);
-            }
+            ValidateCollection(resource.Fields, scriptId, $"{propertyName}.resources.fields", propertyName);
+            ValidateCollection(resource.RequiredIdentifiers, scriptId, $"{propertyName}.resources.requiredIdentifiers", propertyName);
+            ValidateCollection(resource.Domains, scriptId, $"{propertyName}.resources.domains", propertyName);
+            ValidateCollection(resource.Indexes, scriptId, $"{propertyName}.resources.indexes", propertyName);
+            ValidateCollection(resource.Capabilities, scriptId, $"{propertyName}.resources.capabilities", propertyName);
+            ValidateCollection(resource.SupportedFormats, scriptId, $"{propertyName}.resources.supportedFormats", propertyName);
 
             foreach (var field in resource.Fields)
             {
-                if (field is null)
-                {
-                    throw new ArgumentException(
-                        $"Data script '{scriptId}' contract fields cannot contain null entries.",
-                        propertyName);
-                }
+                ValidateCollection(field.SemanticRoles, scriptId, $"{propertyName}.resources.fields.semanticRoles", propertyName);
+                ValidateCollection(field.Domains, scriptId, $"{propertyName}.resources.fields.domains", propertyName);
+                ValidateCollection(field.Indexes, scriptId, $"{propertyName}.resources.fields.indexes", propertyName);
+            }
+
+            if (resource.Storage is not null)
+            {
+                ValidateCollection(resource.Storage.Capabilities, scriptId, $"{propertyName}.resources.storage.capabilities", propertyName);
             }
 
             fieldCount += resource.Fields.Count;
@@ -266,6 +257,28 @@ public sealed class MetadataCompatibilityPrevalidationService(
             {
                 throw new ArgumentException(
                     $"Data script '{scriptId}' cannot declare more than {MaxScriptFields} contract fields.",
+                    propertyName);
+            }
+        }
+    }
+
+    private static void ValidateCollection<T>(
+        IReadOnlyList<T>? values,
+        string scriptId,
+        string collectionPath,
+        string propertyName)
+    {
+        if (values is null)
+        {
+            throw new ArgumentException($"Data script '{scriptId}' {collectionPath} must be an array.", propertyName);
+        }
+
+        foreach (var value in values)
+        {
+            if (value is null)
+            {
+                throw new ArgumentException(
+                    $"Data script '{scriptId}' {collectionPath} cannot contain null entries.",
                     propertyName);
             }
         }

--- a/src/Honua.Core/Features/Metadata/Services/MetadataCompatibilityPrevalidationService.cs
+++ b/src/Honua.Core/Features/Metadata/Services/MetadataCompatibilityPrevalidationService.cs
@@ -194,6 +194,11 @@ public sealed class MetadataCompatibilityPrevalidationService(
 
         foreach (var script in dataScripts)
         {
+            if (script is null)
+            {
+                throw new ArgumentException("DataScripts cannot contain null entries.", nameof(dataScripts));
+            }
+
             if (string.IsNullOrWhiteSpace(script.ScriptId))
             {
                 throw new ArgumentException("DataScripts cannot contain a script with a blank scriptId.", nameof(dataScripts));
@@ -229,6 +234,13 @@ public sealed class MetadataCompatibilityPrevalidationService(
         var fieldCount = 0;
         foreach (var resource in contract.Resources)
         {
+            if (resource is null)
+            {
+                throw new ArgumentException(
+                    $"Data script '{scriptId}' {propertyName}.resources cannot contain null entries.",
+                    propertyName);
+            }
+
             if (string.IsNullOrWhiteSpace(resource.SemanticId))
             {
                 throw new ArgumentException($"Data script '{scriptId}' contains a contract resource with a blank semanticId.", propertyName);
@@ -237,6 +249,16 @@ public sealed class MetadataCompatibilityPrevalidationService(
             if (resource.Fields is null)
             {
                 throw new ArgumentException($"Data script '{scriptId}' contract fields must be an array.", propertyName);
+            }
+
+            foreach (var field in resource.Fields)
+            {
+                if (field is null)
+                {
+                    throw new ArgumentException(
+                        $"Data script '{scriptId}' contract fields cannot contain null entries.",
+                        propertyName);
+                }
             }
 
             fieldCount += resource.Fields.Count;

--- a/src/Honua.Core/Features/Metadata/Services/MetadataCompatibilityPrevalidationService.cs
+++ b/src/Honua.Core/Features/Metadata/Services/MetadataCompatibilityPrevalidationService.cs
@@ -1,0 +1,305 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.Metadata.Services;
+
+/// <summary>
+/// Default service for Metadata v2 compatibility prevalidation.
+/// </summary>
+public sealed class MetadataCompatibilityPrevalidationService(
+    IMetadataV2EnvironmentSnapshotReader snapshotReader,
+    IMetadataReleasePackageStore packageStore,
+    TimeProvider? timeProvider,
+    ILogger<MetadataCompatibilityPrevalidationService> logger) : IMetadataCompatibilityPrevalidationService
+{
+    private const int MaxDataScripts = 100;
+    private const int MaxScriptFields = 1000;
+    private static readonly ActivitySource ActivitySource = new("Honua.Core.Metadata");
+
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+
+    /// <inheritdoc />
+    public async Task<MetadataCompatibilityReport> PrevalidateAsync(
+        MetadataCompatibilityPrevalidationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var targetEnvironment = NormalizeTargetEnvironment(request.TargetEnvironment);
+        var dataScripts = ValidateDataScripts(request.DataScripts);
+
+        using var activity = ActivitySource.StartActivity(
+            "honua.metadata.compatibility.prevalidate",
+            ActivityKind.Internal);
+        activity?.SetTag("metadata.target_environment", targetEnvironment);
+        activity?.SetTag("metadata.script.count", dataScripts.Count);
+
+        MetadataCompatibilityPrevalidationLog.Started(logger, targetEnvironment, dataScripts.Count);
+
+        var package = await ResolvePackageAsync(request, targetEnvironment, dataScripts.Count, cancellationToken)
+            .ConfigureAwait(false);
+        if (package.Report is not null)
+        {
+            TagReport(activity, package.Report);
+            return package.Report;
+        }
+
+        var resolvedPackage = package.Package!;
+        activity?.SetTag("metadata.package_id", resolvedPackage.PackageId);
+        activity?.SetTag("metadata.source_revision", resolvedPackage.SourceRevision);
+
+        var sourceSnapshot = await snapshotReader.GetByRevisionAsync(
+                resolvedPackage.SourceEnvironment,
+                resolvedPackage.SourceRevision,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (sourceSnapshot is null)
+        {
+            MetadataCompatibilityPrevalidationLog.StateUnavailable(
+                logger,
+                resolvedPackage.PackageId,
+                resolvedPackage.SourceEnvironment,
+                targetEnvironment,
+                "source-revision");
+            var report = MetadataCompatibilityAnalyzer.CreateUnavailableReport(
+                resolvedPackage,
+                targetEnvironment,
+                _timeProvider.GetUtcNow(),
+                resolvedPackage.SourceEnvironment,
+                $"source revision {resolvedPackage.SourceRevision}",
+                "unavailable",
+                "The release package source graph revision is unavailable.",
+                dataScripts.Count);
+            TagReport(activity, report);
+            return report;
+        }
+
+        var targetSnapshot = await snapshotReader.GetCurrentAsync(targetEnvironment, cancellationToken)
+            .ConfigureAwait(false);
+        if (targetSnapshot is null)
+        {
+            MetadataCompatibilityPrevalidationLog.StateUnavailable(
+                logger,
+                resolvedPackage.PackageId,
+                resolvedPackage.SourceEnvironment,
+                targetEnvironment,
+                "target-current");
+            var report = MetadataCompatibilityAnalyzer.CreateUnavailableReport(
+                resolvedPackage,
+                targetEnvironment,
+                _timeProvider.GetUtcNow(),
+                targetEnvironment,
+                "target current Metadata v2 graph",
+                "unavailable",
+                "The target environment graph snapshot is unavailable.",
+                dataScripts.Count);
+            TagReport(activity, report);
+            return report;
+        }
+
+        var compatibilityReport = MetadataCompatibilityAnalyzer.Analyze(
+            resolvedPackage,
+            sourceSnapshot,
+            targetSnapshot,
+            dataScripts,
+            _timeProvider.GetUtcNow());
+        TagReport(activity, compatibilityReport);
+
+        MetadataCompatibilityPrevalidationLog.Completed(
+            logger,
+            resolvedPackage.PackageId,
+            targetEnvironment,
+            compatibilityReport.Status,
+            compatibilityReport.Findings.Count,
+            compatibilityReport.UncoveredErrorCount,
+            compatibilityReport.CoveredErrorCount,
+            compatibilityReport.AffectedDependents.Count);
+
+        return compatibilityReport;
+    }
+
+    private async Task<PackageResolution> ResolvePackageAsync(
+        MetadataCompatibilityPrevalidationRequest request,
+        string targetEnvironment,
+        int scriptCount,
+        CancellationToken cancellationToken)
+    {
+        var hasId = request.ReleasePackageId is { } packageId && packageId != Guid.Empty;
+        if (request.ReleasePackageId == Guid.Empty)
+        {
+            throw new ArgumentException("ReleasePackageId must not be empty.", nameof(request));
+        }
+
+        var hasInline = request.ReleasePackage is not null;
+        if (hasId == hasInline)
+        {
+            throw new ArgumentException("Exactly one of ReleasePackageId or ReleasePackage is required.", nameof(request));
+        }
+
+        if (hasInline)
+        {
+            return new PackageResolution(request.ReleasePackage, null);
+        }
+
+        var persisted = await packageStore.GetAsync(request.ReleasePackageId!.Value, cancellationToken).ConfigureAwait(false);
+        if (persisted is not null)
+        {
+            return new PackageResolution(persisted, null);
+        }
+
+        MetadataCompatibilityPrevalidationLog.StateUnavailable(
+            logger,
+            request.ReleasePackageId.Value,
+            "unknown",
+            targetEnvironment,
+            "package");
+        var report = MetadataCompatibilityAnalyzer.CreateUnavailableReport(
+            null,
+            targetEnvironment,
+            _timeProvider.GetUtcNow(),
+            request.ReleasePackageId.Value.ToString("D"),
+            "persisted release package",
+            "not found",
+            "The requested metadata release package was not found.",
+            scriptCount);
+        return new PackageResolution(null, report);
+    }
+
+    private static string NormalizeTargetEnvironment(string targetEnvironment)
+    {
+        if (string.IsNullOrWhiteSpace(targetEnvironment))
+        {
+            throw new ArgumentException("TargetEnvironment is required.", nameof(targetEnvironment));
+        }
+
+        return targetEnvironment.Trim();
+    }
+
+    private static IReadOnlyList<MetadataDataScriptEntry> ValidateDataScripts(
+        IReadOnlyList<MetadataDataScriptEntry>? dataScripts)
+    {
+        if (dataScripts is null)
+        {
+            throw new ArgumentException("DataScripts must be an array.", nameof(dataScripts));
+        }
+
+        if (dataScripts.Count > MaxDataScripts)
+        {
+            throw new ArgumentException($"DataScripts cannot contain more than {MaxDataScripts} entries.", nameof(dataScripts));
+        }
+
+        foreach (var script in dataScripts)
+        {
+            if (string.IsNullOrWhiteSpace(script.ScriptId))
+            {
+                throw new ArgumentException("DataScripts cannot contain a script with a blank scriptId.", nameof(dataScripts));
+            }
+
+            if (script.DeclaredOperations is null)
+            {
+                throw new ArgumentException("Data script declaredOperations must be an array.", nameof(dataScripts));
+            }
+
+            ValidateContract(script.BeforeContract, script.ScriptId, "beforeContract");
+            ValidateContract(script.AfterContract, script.ScriptId, "afterContract");
+        }
+
+        return dataScripts;
+    }
+
+    private static void ValidateContract(
+        MetadataDataScriptContract? contract,
+        string scriptId,
+        string propertyName)
+    {
+        if (contract is null)
+        {
+            return;
+        }
+
+        if (contract.Resources is null)
+        {
+            throw new ArgumentException($"Data script '{scriptId}' {propertyName}.resources must be an array.", propertyName);
+        }
+
+        var fieldCount = 0;
+        foreach (var resource in contract.Resources)
+        {
+            if (string.IsNullOrWhiteSpace(resource.SemanticId))
+            {
+                throw new ArgumentException($"Data script '{scriptId}' contains a contract resource with a blank semanticId.", propertyName);
+            }
+
+            if (resource.Fields is null)
+            {
+                throw new ArgumentException($"Data script '{scriptId}' contract fields must be an array.", propertyName);
+            }
+
+            fieldCount += resource.Fields.Count;
+            if (fieldCount > MaxScriptFields)
+            {
+                throw new ArgumentException(
+                    $"Data script '{scriptId}' cannot declare more than {MaxScriptFields} contract fields.",
+                    propertyName);
+            }
+        }
+    }
+
+    private static void TagReport(Activity? activity, MetadataCompatibilityReport report)
+    {
+        activity?.SetTag("metadata.status", report.Status.ToString());
+        activity?.SetTag("metadata.finding.count", report.Findings.Count);
+        activity?.SetTag("metadata.uncovered_error.count", report.UncoveredErrorCount);
+        activity?.SetTag("metadata.covered_error.count", report.CoveredErrorCount);
+        activity?.SetTag("metadata.dependent.count", report.AffectedDependents.Count);
+        if (report.TargetRevision is { } targetRevision)
+        {
+            activity?.SetTag("metadata.target_revision", targetRevision);
+        }
+    }
+
+    private sealed record PackageResolution(
+        MetadataReleasePackage? Package,
+        MetadataCompatibilityReport? Report);
+}
+
+internal static partial class MetadataCompatibilityPrevalidationLog
+{
+    [LoggerMessage(
+        EventId = 116400,
+        Level = LogLevel.Information,
+        Message = "Metadata compatibility prevalidation started for target environment {TargetEnvironment} with {ScriptCount} scripts.")]
+    public static partial void Started(
+        ILogger logger,
+        string targetEnvironment,
+        int scriptCount);
+
+    [LoggerMessage(
+        EventId = 116401,
+        Level = LogLevel.Warning,
+        Message = "Metadata compatibility prevalidation state unavailable for package {PackageId} source {SourceEnvironment} target {TargetEnvironment}: {StateKind}.")]
+    public static partial void StateUnavailable(
+        ILogger logger,
+        Guid packageId,
+        string sourceEnvironment,
+        string targetEnvironment,
+        string stateKind);
+
+    [LoggerMessage(
+        EventId = 116402,
+        Level = LogLevel.Information,
+        Message = "Metadata compatibility prevalidation completed for package {PackageId} target {TargetEnvironment}: {Status}, findings={FindingCount}, uncoveredErrors={UncoveredErrorCount}, coveredErrors={CoveredErrorCount}, dependents={DependentCount}.")]
+    public static partial void Completed(
+        ILogger logger,
+        Guid packageId,
+        string targetEnvironment,
+        MetadataCompatibilityStatus status,
+        int findingCount,
+        int uncoveredErrorCount,
+        int coveredErrorCount,
+        int dependentCount);
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -101,6 +101,7 @@ public static class EndpointRegistry
         new("POST", "/api/v1/admin/metadata/release-packages"),
         new("GET", "/api/v1/admin/metadata/release-packages/{packageId}"),
         new("GET", "/api/v1/admin/metadata/release-packages/{packageId}/gitops-manifest"),
+        new("POST", "/api/v1/admin/metadata/prevalidate"),
         new("GET", "/api/v1/admin/deploy/preflight"),
         new("POST", "/api/v1/admin/deploy/plan"),
         new("POST", "/api/v1/admin/deploy/operations"),

--- a/src/Honua.Server/Features/Admin/MetadataPrevalidationEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/MetadataPrevalidationEndpoints.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Text.Json;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Server.Features.Admin.Models;
@@ -30,17 +31,18 @@ internal static class MetadataPrevalidationEndpoints
             .WithDisplayName("Prevalidate Metadata Release Package Compatibility")
             .WithSummary("Returns an environment-scoped Metadata v2 compatibility report for a release package.")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
+            .Accepts<MetadataPrevalidateRequest>("application/json")
             .Produces<ApiResponse<MetadataCompatibilityReport>>()
             .ProducesProblem(StatusCodes.Status400BadRequest);
     }
 
     private static async Task<IResult> HandlePrevalidate(
-        [FromBody] MetadataPrevalidateRequest request,
         [FromServices] IMetadataCompatibilityPrevalidationService prevalidationService,
         HttpContext context)
     {
         try
         {
+            var request = await ReadRequestAsync(context).ConfigureAwait(false);
             var report = await prevalidationService.PrevalidateAsync(
                     request.ToCoreRequest(),
                     context.RequestAborted)
@@ -53,6 +55,13 @@ internal static class MetadataPrevalidationEndpoints
         {
             return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, ex.Message);
         }
+        catch (JsonException)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status400BadRequest,
+                "Request body must be valid JSON.");
+        }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             return ProblemDetailsHelpers.CreateAdminProblem(
@@ -60,5 +69,27 @@ internal static class MetadataPrevalidationEndpoints
                 StatusCodes.Status500InternalServerError,
                 "Metadata compatibility prevalidation could not be completed.");
         }
+    }
+
+    private static async ValueTask<MetadataPrevalidateRequest> ReadRequestAsync(HttpContext context)
+    {
+        using var document = await JsonDocument.ParseAsync(
+                context.Request.Body,
+                cancellationToken: context.RequestAborted)
+            .ConfigureAwait(false);
+
+        if (document.RootElement.ValueKind != JsonValueKind.Object)
+        {
+            throw new ArgumentException("Request body must be a JSON object.");
+        }
+
+        if (document.RootElement.TryGetProperty("dataScripts", out var dataScripts) &&
+            dataScripts.ValueKind == JsonValueKind.Null)
+        {
+            throw new ArgumentException("DataScripts must be an array.");
+        }
+
+        return document.RootElement.Deserialize(MetadataPrevalidationJsonContext.Default.MetadataPrevalidateRequest)
+            ?? throw new ArgumentException("Request body is required.");
     }
 }

--- a/src/Honua.Server/Features/Admin/MetadataPrevalidationEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/MetadataPrevalidationEndpoints.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Admin endpoint for Metadata v2 release-package compatibility prevalidation.
+/// </summary>
+internal static class MetadataPrevalidationEndpoints
+{
+    /// <summary>
+    /// Maps Metadata v2 compatibility prevalidation endpoints.
+    /// </summary>
+    public static void MapMetadataPrevalidationEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/metadata")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Metadata", "Validation")
+            .RequireAdminAuthorization();
+
+        group.MapPost("/prevalidate", HandlePrevalidate)
+            .WithDisplayName("Prevalidate Metadata Release Package Compatibility")
+            .WithSummary("Returns an environment-scoped Metadata v2 compatibility report for a release package.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
+            .Produces<ApiResponse<MetadataCompatibilityReport>>()
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+    }
+
+    private static async Task<IResult> HandlePrevalidate(
+        [FromBody] MetadataPrevalidateRequest request,
+        [FromServices] IMetadataCompatibilityPrevalidationService prevalidationService,
+        HttpContext context)
+    {
+        try
+        {
+            var report = await prevalidationService.PrevalidateAsync(
+                    request.ToCoreRequest(),
+                    context.RequestAborted)
+                .ConfigureAwait(false);
+            return Results.Json(
+                ApiResponse<MetadataCompatibilityReport>.CreateSuccess(report),
+                MetadataPrevalidationJsonContext.Default.ApiResponseMetadataCompatibilityReport);
+        }
+        catch (ArgumentException ex)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status400BadRequest, ex.Message);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status500InternalServerError,
+                "Metadata compatibility prevalidation could not be completed.");
+        }
+    }
+}

--- a/src/Honua.Server/Features/Admin/MetadataPrevalidationEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/MetadataPrevalidationEndpoints.cs
@@ -83,13 +83,154 @@ internal static class MetadataPrevalidationEndpoints
             throw new ArgumentException("Request body must be a JSON object.");
         }
 
-        if (document.RootElement.TryGetProperty("dataScripts", out var dataScripts) &&
-            dataScripts.ValueKind == JsonValueKind.Null)
+        ValidateDataScriptCollections(document.RootElement);
+
+        return document.RootElement.Deserialize(MetadataPrevalidationJsonContext.Default.MetadataPrevalidateRequest)
+            ?? throw new ArgumentException("Request body is required.");
+    }
+
+    private static void ValidateDataScriptCollections(JsonElement root)
+    {
+        if (!root.TryGetProperty("dataScripts", out var dataScripts))
+        {
+            return;
+        }
+
+        if (dataScripts.ValueKind != JsonValueKind.Array)
         {
             throw new ArgumentException("DataScripts must be an array.");
         }
 
-        return document.RootElement.Deserialize(MetadataPrevalidationJsonContext.Default.MetadataPrevalidateRequest)
-            ?? throw new ArgumentException("Request body is required.");
+        foreach (var script in dataScripts.EnumerateArray())
+        {
+            if (script.ValueKind == JsonValueKind.Null)
+            {
+                throw new ArgumentException("DataScripts cannot contain null entries.");
+            }
+
+            if (script.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var scriptId = ReadScriptId(script);
+            ValidateOptionalArray(script, "declaredOperations", scriptId, "declaredOperations");
+            ValidateContractCollections(script, "beforeContract", scriptId);
+            ValidateContractCollections(script, "afterContract", scriptId);
+        }
+    }
+
+    private static void ValidateContractCollections(JsonElement script, string propertyName, string scriptId)
+    {
+        if (!script.TryGetProperty(propertyName, out var contract) ||
+            contract.ValueKind == JsonValueKind.Null ||
+            contract.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        if (!ValidateOptionalArray(contract, "resources", scriptId, $"{propertyName}.resources", out var resources))
+        {
+            return;
+        }
+
+        foreach (var resource in resources.EnumerateArray())
+        {
+            if (resource.ValueKind == JsonValueKind.Null)
+            {
+                throw new ArgumentException($"Data script '{scriptId}' {propertyName}.resources cannot contain null entries.");
+            }
+
+            if (resource.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            ValidateOptionalArray(resource, "requiredIdentifiers", scriptId, $"{propertyName}.resources.requiredIdentifiers");
+            ValidateOptionalArray(resource, "domains", scriptId, $"{propertyName}.resources.domains");
+            ValidateOptionalArray(resource, "indexes", scriptId, $"{propertyName}.resources.indexes");
+            ValidateOptionalArray(resource, "capabilities", scriptId, $"{propertyName}.resources.capabilities");
+            ValidateOptionalArray(resource, "supportedFormats", scriptId, $"{propertyName}.resources.supportedFormats");
+
+            if (ValidateOptionalArray(resource, "fields", scriptId, $"{propertyName}.resources.fields", out var fields))
+            {
+                ValidateFieldCollections(fields, scriptId, propertyName);
+            }
+
+            if (resource.TryGetProperty("storage", out var storage) &&
+                storage.ValueKind == JsonValueKind.Object)
+            {
+                ValidateOptionalArray(storage, "capabilities", scriptId, $"{propertyName}.resources.storage.capabilities");
+            }
+        }
+    }
+
+    private static void ValidateFieldCollections(JsonElement fields, string scriptId, string propertyName)
+    {
+        foreach (var field in fields.EnumerateArray())
+        {
+            if (field.ValueKind == JsonValueKind.Null)
+            {
+                throw new ArgumentException($"Data script '{scriptId}' {propertyName}.resources.fields cannot contain null entries.");
+            }
+
+            if (field.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            ValidateOptionalArray(field, "semanticRoles", scriptId, $"{propertyName}.resources.fields.semanticRoles");
+            ValidateOptionalArray(field, "domains", scriptId, $"{propertyName}.resources.fields.domains");
+            ValidateOptionalArray(field, "indexes", scriptId, $"{propertyName}.resources.fields.indexes");
+        }
+    }
+
+    private static bool ValidateOptionalArray(
+        JsonElement owner,
+        string propertyName,
+        string scriptId,
+        string collectionPath)
+        => ValidateOptionalArray(owner, propertyName, scriptId, collectionPath, out _);
+
+    private static bool ValidateOptionalArray(
+        JsonElement owner,
+        string propertyName,
+        string scriptId,
+        string collectionPath,
+        out JsonElement array)
+    {
+        array = default;
+        if (!owner.TryGetProperty(propertyName, out var value))
+        {
+            return false;
+        }
+
+        if (value.ValueKind != JsonValueKind.Array)
+        {
+            throw new ArgumentException($"Data script '{scriptId}' {collectionPath} must be an array.");
+        }
+
+        foreach (var item in value.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.Null)
+            {
+                throw new ArgumentException($"Data script '{scriptId}' {collectionPath} cannot contain null entries.");
+            }
+        }
+
+        array = value;
+        return true;
+    }
+
+    private static string ReadScriptId(JsonElement script)
+    {
+        if (script.TryGetProperty("scriptId", out var scriptId) &&
+            scriptId.ValueKind == JsonValueKind.String &&
+            !string.IsNullOrWhiteSpace(scriptId.GetString()))
+        {
+            return scriptId.GetString()!;
+        }
+
+        return "<unknown>";
     }
 }

--- a/src/Honua.Server/Features/Admin/Models/MetadataPrevalidationModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/MetadataPrevalidationModels.cs
@@ -38,8 +38,103 @@ internal sealed record MetadataPrevalidateRequest
             ReleasePackageId = ReleasePackageId,
             ReleasePackage = ReleasePackage,
             TargetEnvironment = TargetEnvironment,
-            DataScripts = DataScripts ?? Array.Empty<MetadataDataScriptEntry>(),
+            DataScripts = NormalizeDataScripts(DataScripts),
         };
+
+    private static MetadataDataScriptEntry[] NormalizeDataScripts(
+        IReadOnlyList<MetadataDataScriptEntry>? dataScripts)
+    {
+        if (dataScripts is null || dataScripts.Count == 0)
+        {
+            return Array.Empty<MetadataDataScriptEntry>();
+        }
+
+        var normalized = new MetadataDataScriptEntry[dataScripts.Count];
+        for (var index = 0; index < dataScripts.Count; index++)
+        {
+            var script = dataScripts[index];
+            normalized[index] = script is null
+                ? null!
+                : script with
+                {
+                    DeclaredOperations = script.DeclaredOperations ?? Array.Empty<string>(),
+                    BeforeContract = NormalizeContract(script.BeforeContract),
+                    AfterContract = NormalizeContract(script.AfterContract),
+                };
+        }
+
+        return normalized;
+    }
+
+    private static MetadataDataScriptContract? NormalizeContract(MetadataDataScriptContract? contract)
+        => contract is null
+            ? null
+            : contract with
+            {
+                Resources = NormalizeResources(contract.Resources),
+            };
+
+    private static MetadataScriptResourceContract[] NormalizeResources(
+        IReadOnlyList<MetadataScriptResourceContract>? resources)
+    {
+        if (resources is null || resources.Count == 0)
+        {
+            return Array.Empty<MetadataScriptResourceContract>();
+        }
+
+        var normalized = new MetadataScriptResourceContract[resources.Count];
+        for (var index = 0; index < resources.Count; index++)
+        {
+            var resource = resources[index];
+            normalized[index] = resource is null
+                ? null!
+                : resource with
+                {
+                    Fields = NormalizeFields(resource.Fields),
+                    RequiredIdentifiers = resource.RequiredIdentifiers ?? Array.Empty<string>(),
+                    Domains = resource.Domains ?? Array.Empty<string>(),
+                    Indexes = resource.Indexes ?? Array.Empty<string>(),
+                    Storage = NormalizeStorage(resource.Storage),
+                    Capabilities = resource.Capabilities ?? Array.Empty<string>(),
+                    SupportedFormats = resource.SupportedFormats ?? Array.Empty<string>(),
+                };
+        }
+
+        return normalized;
+    }
+
+    private static MetadataScriptFieldContract[] NormalizeFields(
+        IReadOnlyList<MetadataScriptFieldContract>? fields)
+    {
+        if (fields is null || fields.Count == 0)
+        {
+            return Array.Empty<MetadataScriptFieldContract>();
+        }
+
+        var normalized = new MetadataScriptFieldContract[fields.Count];
+        for (var index = 0; index < fields.Count; index++)
+        {
+            var field = fields[index];
+            normalized[index] = field is null
+                ? null!
+                : field with
+                {
+                    SemanticRoles = field.SemanticRoles ?? Array.Empty<string>(),
+                    Domains = field.Domains ?? Array.Empty<string>(),
+                    Indexes = field.Indexes ?? Array.Empty<string>(),
+                };
+        }
+
+        return normalized;
+    }
+
+    private static MetadataScriptStorageContract? NormalizeStorage(MetadataScriptStorageContract? storage)
+        => storage is null
+            ? null
+            : storage with
+            {
+                Capabilities = storage.Capabilities ?? Array.Empty<MetadataV2StorageBindingCapability>(),
+            };
 }
 
 /// <summary>

--- a/src/Honua.Server/Features/Admin/Models/MetadataPrevalidationModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/MetadataPrevalidationModels.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Server.Features.Infrastructure.Models;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Request body for Metadata v2 compatibility prevalidation.
+/// </summary>
+internal sealed record MetadataPrevalidateRequest
+{
+    /// <summary>Persisted release package identifier.</summary>
+    [JsonPropertyName("releasePackageId")]
+    public Guid? ReleasePackageId { get; init; }
+
+    /// <summary>Inline release package payload.</summary>
+    [JsonPropertyName("releasePackage")]
+    public MetadataReleasePackage? ReleasePackage { get; init; }
+
+    /// <summary>Target environment to compare against.</summary>
+    [JsonPropertyName("targetEnvironment")]
+    public required string TargetEnvironment { get; init; }
+
+    /// <summary>Optional declared data script contracts.</summary>
+    [JsonPropertyName("dataScripts")]
+    public IReadOnlyList<MetadataDataScriptEntry>? DataScripts { get; init; } =
+        Array.Empty<MetadataDataScriptEntry>();
+
+    /// <summary>
+    /// Converts the server request DTO into the Core service request.
+    /// </summary>
+    public MetadataCompatibilityPrevalidationRequest ToCoreRequest()
+        => new()
+        {
+            ReleasePackageId = ReleasePackageId,
+            ReleasePackage = ReleasePackage,
+            TargetEnvironment = TargetEnvironment,
+            DataScripts = DataScripts ?? Array.Empty<MetadataDataScriptEntry>(),
+        };
+}
+
+/// <summary>
+/// JSON source generation context for Metadata v2 compatibility prevalidation APIs.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(MetadataPrevalidateRequest))]
+[JsonSerializable(typeof(ApiResponse<MetadataCompatibilityReport>))]
+[JsonSerializable(typeof(MetadataCompatibilityReport))]
+[JsonSerializable(typeof(MetadataCompatibilityFinding))]
+[JsonSerializable(typeof(MetadataCompatibilityValue))]
+[JsonSerializable(typeof(MetadataAffectedDependent))]
+[JsonSerializable(typeof(MetadataRollbackReadiness))]
+[JsonSerializable(typeof(MetadataDataScriptEntry))]
+[JsonSerializable(typeof(MetadataDataScriptContract))]
+[JsonSerializable(typeof(MetadataScriptResourceContract))]
+[JsonSerializable(typeof(MetadataScriptFieldContract))]
+[JsonSerializable(typeof(MetadataScriptSpatialContract))]
+[JsonSerializable(typeof(MetadataScriptTemporalContract))]
+[JsonSerializable(typeof(MetadataScriptStorageContract))]
+[JsonSerializable(typeof(MetadataReleasePackage))]
+[JsonSerializable(typeof(MetadataReleaseEntry))]
+[JsonSerializable(typeof(MetadataReleaseTargetState))]
+[JsonSerializable(typeof(MetadataV2ObjectMetadata))]
+[JsonSerializable(typeof(MetadataBoundFieldSummary))]
+[JsonSerializable(typeof(MetadataCompatibilityFinding[]))]
+[JsonSerializable(typeof(MetadataAffectedDependent[]))]
+[JsonSerializable(typeof(MetadataDataScriptEntry[]))]
+[JsonSerializable(typeof(MetadataScriptResourceContract[]))]
+[JsonSerializable(typeof(MetadataScriptFieldContract[]))]
+[JsonSerializable(typeof(string[]))]
+[JsonSerializable(typeof(IReadOnlyDictionary<string, string>), TypeInfoPropertyName = "ReadOnlyDictionaryStringString")]
+internal sealed partial class MetadataPrevalidationJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -538,6 +538,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Admin.Models.LayerPublishingJsonContext.Default,
         Honua.Server.Features.Admin.Models.ServiceSettingsJsonContext.Default,
         Honua.Core.Features.Metadata.Domain.V2.MetadataReleaseJsonContext.Default,
+        Honua.Server.Features.Admin.Models.MetadataPrevalidationJsonContext.Default,
         Honua.Server.Features.Admin.Models.DeployControlJsonContext.Default,
         Honua.Server.Features.Infrastructure.Monitoring.MetricsJsonContext.Default,
         Honua.Server.Features.Import.ImportJsonContext.Default,
@@ -946,6 +947,7 @@ app.MapServiceSettingsEndpoints();
 // Configure admin metadata version/manifest endpoints
 // v1 admin endpoint mappings removed in #1035 cutover; V2 admin UX (#1046) lives elsewhere.
 app.MapMetadataReleaseEndpoints();
+app.MapMetadataPrevalidationEndpoints();
 app.MapDeployControlEndpoints();
 
 // Configure admin layer style endpoints

--- a/src/Honua.Server/Startup/JsonContextRegistration.cs
+++ b/src/Honua.Server/Startup/JsonContextRegistration.cs
@@ -29,6 +29,7 @@ internal static class JsonContextRegistration
                 Honua.Server.Features.Admin.Models.LayerPublishingJsonContext.Default,
                 Honua.Server.Features.Admin.Models.ServiceSettingsJsonContext.Default,
                 Honua.Core.Features.Metadata.Domain.V2.MetadataReleaseJsonContext.Default,
+                Honua.Server.Features.Admin.Models.MetadataPrevalidationJsonContext.Default,
                 Honua.Server.Features.Admin.Models.DeployControlJsonContext.Default,
                 Honua.Server.Features.Infrastructure.Monitoring.MetricsJsonContext.Default,
                 Honua.Server.Features.Import.ImportJsonContext.Default,

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzerTests.cs
@@ -293,6 +293,29 @@ public sealed class MetadataCompatibilityAnalyzerTests
     }
 
     [UnitTest]
+    public void Analyze_StorageContractWithoutBeforeResource_LeavesMissingBindingBlocked()
+    {
+        var source = Snapshot(BuildGraph("dev", 41));
+        var target = Snapshot(BuildGraph("staging", 7, includeStorage: false));
+        var package = Package(Entry("res.parcels", MetadataSemanticArtifactKind.Resource));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            [MissingStorageBindingScript(includeRequiredDetails: true, includeBeforeResourceContract: false)],
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Blocked);
+        report.CoveredErrorCount.Should().Be(0);
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.StorageBindingMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.Uncovered);
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.ScriptBeforeContractMismatch);
+    }
+
+    [UnitTest]
     public void Analyze_StorageCapabilityBeforeContractAlreadyHasMissingCapability_LeavesFindingBlocked()
     {
         var source = Snapshot(BuildGraph(
@@ -610,7 +633,9 @@ public sealed class MetadataCompatibilityAnalyzerTests
             },
         };
 
-    private static MetadataDataScriptEntry MissingStorageBindingScript(bool includeRequiredDetails)
+    private static MetadataDataScriptEntry MissingStorageBindingScript(
+        bool includeRequiredDetails,
+        bool includeBeforeResourceContract = true)
         => new()
         {
             ScriptId = "script.bind-storage",
@@ -619,15 +644,17 @@ public sealed class MetadataCompatibilityAnalyzerTests
             DeclaredOperations = ["bind-storage"],
             BeforeContract = new MetadataDataScriptContract
             {
-                Resources =
-                [
-                    new MetadataScriptResourceContract
-                    {
-                        SemanticId = "res.parcels",
-                        SemanticKind = MetadataSemanticArtifactKind.Resource,
-                        Exists = true,
-                    },
-                ],
+                Resources = includeBeforeResourceContract
+                    ?
+                    [
+                        new MetadataScriptResourceContract
+                        {
+                            SemanticId = "res.parcels",
+                            SemanticKind = MetadataSemanticArtifactKind.Resource,
+                            Exists = true,
+                        },
+                    ]
+                    : Array.Empty<MetadataScriptResourceContract>(),
             },
             AfterContract = new MetadataDataScriptContract
             {

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzerTests.cs
@@ -1,0 +1,415 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Core.Tests.Features.Metadata.Domain.V2;
+
+[Protocol(Protocols.TestQuality)]
+[Operation(Operations.Validation)]
+public sealed class MetadataCompatibilityAnalyzerTests
+{
+    private static readonly DateTimeOffset GeneratedAt = new(2026, 5, 24, 12, 0, 0, TimeSpan.Zero);
+
+    [UnitTest]
+    public void Analyze_MatchingSourceAndTarget_ReturnsReadyMetadataOnlyReport()
+    {
+        var source = Snapshot(BuildGraph("dev", 41));
+        var target = Snapshot(BuildGraph("staging", 7));
+        var package = Package(Entry("res.parcels", MetadataSemanticArtifactKind.Resource));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            Array.Empty<MetadataDataScriptEntry>(),
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Ready);
+        report.CanCreatePullRequest.Should().BeTrue();
+        report.CanPromote.Should().BeTrue();
+        report.Findings.Should().BeEmpty();
+        report.RollbackReadiness.Classification.Should().Be(MetadataRollbackReadinessClassification.MetadataOnly);
+    }
+
+    [UnitTest]
+    public void Analyze_MissingSchemaServicePublicationAndCrs_ReturnsBlockedFindings()
+    {
+        var source = Snapshot(BuildGraph("dev", 41, identifierRole: true, srid: 4326));
+        var target = Snapshot(BuildGraph(
+            "staging",
+            7,
+            includeField: false,
+            srid: 3857,
+            includeService: false,
+            includePublication: false));
+        var package = Package(
+            Entry("res.parcels", MetadataSemanticArtifactKind.Resource),
+            Entry("svc.features", MetadataSemanticArtifactKind.Service),
+            Entry("pub.parcels", MetadataSemanticArtifactKind.Publication));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            Array.Empty<MetadataDataScriptEntry>(),
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Blocked);
+        report.CanCreatePullRequest.Should().BeFalse();
+        report.Findings.Should().Contain(finding => finding.Code == MetadataCompatibilityCode.FieldMissing);
+        report.Findings.Should().Contain(finding => finding.Code == MetadataCompatibilityCode.IdentifierMissing);
+        report.Findings.Should().Contain(finding => finding.Code == MetadataCompatibilityCode.SpatialCrsMismatch);
+        report.Findings.Should().Contain(finding => finding.Code == MetadataCompatibilityCode.ServiceMissing);
+        report.Findings.Should().Contain(finding => finding.Code == MetadataCompatibilityCode.PublicationMissing);
+        report.Findings.Should().OnlyContain(finding =>
+            finding.Expected.Value == null || !finding.Expected.Value.Contains("password", StringComparison.OrdinalIgnoreCase));
+        report.RollbackReadiness.Classification.Should().Be(MetadataRollbackReadinessClassification.Manual);
+    }
+
+    [UnitTest]
+    public void Analyze_ReversibleDataScriptCoversMissingField_ReturnsWarningAndScriptReversibleRollback()
+    {
+        var source = Snapshot(BuildGraph("dev", 41));
+        var target = Snapshot(BuildGraph("staging", 7, includeField: false));
+        var package = Package(Entry("res.parcels", MetadataSemanticArtifactKind.Resource));
+        var scripts = new[]
+        {
+            MissingFieldScript(reversible: true, beforeFieldExists: false),
+        };
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            scripts,
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Warning);
+        report.UncoveredErrorCount.Should().Be(0);
+        report.CoveredErrorCount.Should().Be(1);
+        report.CanCreatePullRequest.Should().BeTrue();
+        report.Findings.Should().ContainSingle(finding =>
+            finding.Code == MetadataCompatibilityCode.FieldMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.CoveredByScript &&
+            finding.CoveringScriptId == "script.add-apn");
+        report.RollbackReadiness.Classification.Should().Be(MetadataRollbackReadinessClassification.ScriptReversible);
+    }
+
+    [UnitTest]
+    public void Analyze_NonReversibleDataScriptCoversMissingField_ReturnsSnapshotRequiredRollback()
+    {
+        var source = Snapshot(BuildGraph("dev", 41));
+        var target = Snapshot(BuildGraph("staging", 7, includeField: false));
+        var package = Package(Entry("res.parcels", MetadataSemanticArtifactKind.Resource));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            [MissingFieldScript(reversible: false, beforeFieldExists: false)],
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Warning);
+        report.RollbackReadiness.Classification.Should().Be(MetadataRollbackReadinessClassification.SnapshotRequired);
+        report.RollbackReadiness.RequiresSnapshot.Should().BeTrue();
+        report.RollbackReadiness.ScriptIds.Should().ContainSingle("script.add-apn");
+    }
+
+    [UnitTest]
+    public void Analyze_ScriptBeforeContractMismatch_LeavesFindingBlocked()
+    {
+        var source = Snapshot(BuildGraph("dev", 41));
+        var target = Snapshot(BuildGraph("staging", 7, includeField: false));
+        var package = Package(Entry("res.parcels", MetadataSemanticArtifactKind.Resource));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            [MissingFieldScript(reversible: true, beforeFieldExists: true)],
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Blocked);
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.FieldMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.Uncovered);
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.ScriptBeforeContractMismatch);
+        report.RollbackReadiness.Classification.Should().Be(MetadataRollbackReadinessClassification.Manual);
+    }
+
+    [UnitTest]
+    public void Analyze_ServiceRouteChange_ListsDependentsAndRequiresServiceRevisionRollback()
+    {
+        var source = Snapshot(BuildGraph("dev", 41, serviceRoute: "/shared/ogc/features"));
+        var target = Snapshot(BuildGraph(
+            "staging",
+            7,
+            serviceRoute: "/old/ogc/features",
+            includeRelationshipDependent: true,
+            includeProjectionProfile: true));
+        var package = Package(
+            Entry("res.parcels", MetadataSemanticArtifactKind.Resource, dependentIds: ["res.parcel-dashboard"]),
+            Entry("svc.features", MetadataSemanticArtifactKind.Service));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            Array.Empty<MetadataDataScriptEntry>(),
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Warning);
+        report.Findings.Should().ContainSingle(finding => finding.Code == MetadataCompatibilityCode.ServiceRouteChanged);
+        report.AffectedDependents.Should().Contain(dependent =>
+            dependent.SemanticId == "pub.parcels" &&
+            dependent.RelationshipKind == "publication-by-resource");
+        report.AffectedDependents.Should().Contain(dependent =>
+            dependent.SemanticId == "res.parcel-dashboard" &&
+            dependent.RelationshipKind == "release-package-dependent");
+        report.AffectedDependents.Should().Contain(dependent =>
+            dependent.SemanticId == "profile.ogc" &&
+            dependent.RelationshipKind == "projection-required-semantics");
+        report.RollbackReadiness.Classification.Should().Be(MetadataRollbackReadinessClassification.ServiceRevision);
+    }
+
+    [UnitTest]
+    public void CreateUnavailableReport_ReturnsUnknownManualReport()
+    {
+        var report = MetadataCompatibilityAnalyzer.CreateUnavailableReport(
+            null,
+            "prod",
+            GeneratedAt,
+            "package.missing",
+            "persisted release package",
+            "not found",
+            "The requested metadata release package was not found.",
+            scriptCount: 0);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Unknown);
+        report.CanCreatePullRequest.Should().BeFalse();
+        report.Findings.Should().ContainSingle(finding =>
+            finding.Code == MetadataCompatibilityCode.StateUnavailable &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.Unknown);
+        report.RollbackReadiness.Classification.Should().Be(MetadataRollbackReadinessClassification.Manual);
+    }
+
+    private static MetadataReleasePackage Package(params MetadataReleaseEntry[] entries)
+        => new()
+        {
+            PackageId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "pkg.parcels",
+                Name = "promote-parcels",
+                Title = "Promote parcels",
+            },
+            SourceEnvironment = "dev",
+            SourceRevision = 41,
+            SourceEtag = "etag-dev-41",
+            TargetEnvironments = ["staging"],
+            Entries = entries,
+            CreatedBy = "tester",
+            CreatedAt = GeneratedAt,
+            UpdatedAt = GeneratedAt,
+        };
+
+    private static MetadataReleaseEntry Entry(
+        string semanticId,
+        MetadataSemanticArtifactKind kind,
+        IReadOnlyList<string>? dependentIds = null)
+        => new()
+        {
+            SemanticId = semanticId,
+            ArtifactKind = kind,
+            DesiredMetadataRevision = 41,
+            DependentSemanticIds = dependentIds ?? Array.Empty<string>(),
+        };
+
+    private static MetadataDataScriptEntry MissingFieldScript(bool reversible, bool beforeFieldExists)
+        => new()
+        {
+            ScriptId = "script.add-apn",
+            Kind = "sql",
+            Reversible = reversible,
+            DeclaredOperations = ["add-field"],
+            BeforeContract = new MetadataDataScriptContract
+            {
+                Resources =
+                [
+                    new MetadataScriptResourceContract
+                    {
+                        SemanticId = "res.parcels",
+                        SemanticKind = MetadataSemanticArtifactKind.Resource,
+                        Exists = true,
+                        Fields =
+                        [
+                            new MetadataScriptFieldContract
+                            {
+                                SemanticId = "field.parcels.apn",
+                                Name = "apn",
+                                Exists = beforeFieldExists,
+                                Type = "string",
+                                Nullable = false,
+                            },
+                        ],
+                    },
+                ],
+            },
+            AfterContract = new MetadataDataScriptContract
+            {
+                Resources =
+                [
+                    new MetadataScriptResourceContract
+                    {
+                        SemanticId = "res.parcels",
+                        SemanticKind = MetadataSemanticArtifactKind.Resource,
+                        Exists = true,
+                        Fields =
+                        [
+                            new MetadataScriptFieldContract
+                            {
+                                SemanticId = "field.parcels.apn",
+                                Name = "apn",
+                                Exists = true,
+                                Type = "string",
+                                Nullable = false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+
+    private static MetadataV2GraphSnapshot Snapshot(MetadataV2Graph graph)
+        => new(graph, $"etag-{graph.Environment}-{graph.Revision}", GeneratedAt);
+
+    private static MetadataV2Graph BuildGraph(
+        string environment,
+        long revision,
+        bool includeField = true,
+        bool identifierRole = false,
+        int srid = 4326,
+        bool includeService = true,
+        bool includePublication = true,
+        string serviceRoute = "/shared/ogc/features",
+        bool includeRelationshipDependent = false,
+        bool includeProjectionProfile = false)
+    {
+        var spatial = JsonSerializer.Deserialize<JsonElement>(
+            $$"""{"srid":{{srid}},"geometryType":"Point"}""");
+
+        var resources = new List<MetadataV2Resource>
+        {
+            new()
+            {
+                Metadata = new MetadataV2ObjectMetadata
+                {
+                    Id = "res.parcels",
+                    Name = "parcels",
+                    Title = "Parcels",
+                },
+                Type = MetadataV2ResourceType.FeatureDataset,
+                StorageBindingIds = ["storage.parcels"],
+                PrimaryStorageBindingId = "storage.parcels",
+                SchemaFields = includeField ? [BuildField(identifierRole)] : Array.Empty<MetadataV2Field>(),
+                Spatial = spatial,
+            },
+        };
+
+        if (includeRelationshipDependent)
+        {
+            resources.Add(new MetadataV2Resource
+            {
+                Metadata = new MetadataV2ObjectMetadata
+                {
+                    Id = "res.parcel-dashboard",
+                    Name = "parcel-dashboard",
+                    Title = "Parcel Dashboard",
+                },
+                Type = MetadataV2ResourceType.Dashboard,
+                Relationships =
+                [
+                    new MetadataV2Relationship
+                    {
+                        Id = "rel.dashboard.parcels",
+                        Name = "Dashboard parcels",
+                        RelatedResourceId = "res.parcels",
+                    },
+                ],
+            });
+        }
+
+        return new MetadataV2Graph
+        {
+            Environment = environment,
+            Revision = revision,
+            GeneratedAt = GeneratedAt,
+            Resources = resources,
+            StorageBindings =
+            [
+                new MetadataV2StorageBinding
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "storage.parcels", Name = "storage.parcels" },
+                    ResourceId = "res.parcels",
+                    StorageType = MetadataV2StorageType.RelationalTable,
+                    Locator = "shared.parcels",
+                    Capabilities = [MetadataV2StorageBindingCapability.Query],
+                },
+            ],
+            Services = includeService
+                ?
+                [
+                    new MetadataV2Service
+                    {
+                        Metadata = new MetadataV2ObjectMetadata { Id = "svc.features", Name = "features" },
+                        ServiceType = MetadataV2ServiceType.OgcApiFeatures,
+                        Route = serviceRoute,
+                        PublicationIds = includePublication ? ["pub.parcels"] : Array.Empty<string>(),
+                    },
+                ]
+                : Array.Empty<MetadataV2Service>(),
+            Publications = includePublication
+                ?
+                [
+                    new MetadataV2Publication
+                    {
+                        Metadata = new MetadataV2ObjectMetadata { Id = "pub.parcels", Name = "parcels" },
+                        ResourceId = "res.parcels",
+                        ServiceId = "svc.features",
+                        StorageBindingId = "storage.parcels",
+                        PublicationType = MetadataV2PublicationType.OgcCollection,
+                        Path = "parcels",
+                        ServiceLocalId = "parcels",
+                    },
+                ]
+                : Array.Empty<MetadataV2Publication>(),
+            ProjectionProfiles = includeProjectionProfile
+                ?
+                [
+                    new MetadataV2ProjectionProfile
+                    {
+                        Metadata = new MetadataV2ObjectMetadata { Id = "profile.ogc", Name = "ogc" },
+                        Target = "ogc-api-features",
+                        RequiredSemantics = ["res.parcels"],
+                    },
+                ]
+                : Array.Empty<MetadataV2ProjectionProfile>(),
+        };
+    }
+
+    private static MetadataV2Field BuildField(bool identifierRole)
+        => new()
+        {
+            SemanticId = "field.parcels.apn",
+            Name = "apn",
+            Type = "string",
+            Nullable = false,
+            SemanticRoles = identifierRole ? ["identifier.primary"] : Array.Empty<string>(),
+        };
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzerTests.cs
@@ -144,6 +144,122 @@ public sealed class MetadataCompatibilityAnalyzerTests
     }
 
     [UnitTest]
+    public void Analyze_ExistsOnlyScriptForMissingArtifacts_LeavesFindingsBlocked()
+    {
+        var source = Snapshot(BuildGraph("dev", 41));
+        var target = Snapshot(BuildGraph(
+            "staging",
+            7,
+            includeResource: false,
+            includeStorage: false,
+            includeService: false,
+            includePublication: false));
+        var package = Package(
+            Entry("res.parcels", MetadataSemanticArtifactKind.Resource),
+            Entry("svc.features", MetadataSemanticArtifactKind.Service),
+            Entry("pub.parcels", MetadataSemanticArtifactKind.Publication));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            [MissingArtifactsScript(includeRequiredDetails: false)],
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Blocked);
+        report.CoveredErrorCount.Should().Be(0);
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.ResourceMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.Uncovered);
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.ServiceMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.Uncovered);
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.PublicationMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.Uncovered);
+    }
+
+    [UnitTest]
+    public void Analyze_FullScriptContractsForMissingArtifacts_CoverFindings()
+    {
+        var source = Snapshot(BuildGraph("dev", 41));
+        var target = Snapshot(BuildGraph(
+            "staging",
+            7,
+            includeResource: false,
+            includeStorage: false,
+            includeService: false,
+            includePublication: false));
+        var package = Package(
+            Entry("res.parcels", MetadataSemanticArtifactKind.Resource),
+            Entry("svc.features", MetadataSemanticArtifactKind.Service),
+            Entry("pub.parcels", MetadataSemanticArtifactKind.Publication));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            [MissingArtifactsScript(includeRequiredDetails: true)],
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Warning);
+        report.UncoveredErrorCount.Should().Be(0);
+        report.CoveredErrorCount.Should().Be(3);
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.ResourceMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.CoveredByScript);
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.ServiceMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.CoveredByScript);
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.PublicationMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.CoveredByScript);
+    }
+
+    [UnitTest]
+    public void Analyze_StorageContractWithoutBindingDetails_LeavesMissingBindingBlocked()
+    {
+        var source = Snapshot(BuildGraph("dev", 41));
+        var target = Snapshot(BuildGraph("staging", 7, includeStorage: false));
+        var package = Package(Entry("res.parcels", MetadataSemanticArtifactKind.Resource));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            [MissingStorageBindingScript(includeRequiredDetails: false)],
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Blocked);
+        report.CoveredErrorCount.Should().Be(0);
+        report.Findings.Should().ContainSingle(finding =>
+            finding.Code == MetadataCompatibilityCode.StorageBindingMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.Uncovered);
+    }
+
+    [UnitTest]
+    public void Analyze_FullStorageContract_CoversMissingBinding()
+    {
+        var source = Snapshot(BuildGraph("dev", 41));
+        var target = Snapshot(BuildGraph("staging", 7, includeStorage: false));
+        var package = Package(Entry("res.parcels", MetadataSemanticArtifactKind.Resource));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            [MissingStorageBindingScript(includeRequiredDetails: true)],
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Warning);
+        report.UncoveredErrorCount.Should().Be(0);
+        report.CoveredErrorCount.Should().Be(1);
+        report.Findings.Should().ContainSingle(finding =>
+            finding.Code == MetadataCompatibilityCode.StorageBindingMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.CoveredByScript);
+    }
+
+    [UnitTest]
     public void Analyze_ServiceRouteChange_ListsDependentsAndRequiresServiceRevisionRollback()
     {
         var source = Snapshot(BuildGraph("dev", 41, serviceRoute: "/shared/ogc/features"));
@@ -286,6 +402,112 @@ public sealed class MetadataCompatibilityAnalyzerTests
             },
         };
 
+    private static MetadataDataScriptEntry MissingArtifactsScript(bool includeRequiredDetails)
+        => new()
+        {
+            ScriptId = "script.create-artifacts",
+            Kind = "sql",
+            Reversible = true,
+            DeclaredOperations = ["create-artifacts"],
+            BeforeContract = new MetadataDataScriptContract
+            {
+                Resources =
+                [
+                    new MetadataScriptResourceContract
+                    {
+                        SemanticId = "res.parcels",
+                        SemanticKind = MetadataSemanticArtifactKind.Resource,
+                        Exists = false,
+                    },
+                    new MetadataScriptResourceContract
+                    {
+                        SemanticId = "svc.features",
+                        SemanticKind = MetadataSemanticArtifactKind.Service,
+                        Exists = false,
+                    },
+                    new MetadataScriptResourceContract
+                    {
+                        SemanticId = "pub.parcels",
+                        SemanticKind = MetadataSemanticArtifactKind.Publication,
+                        Exists = false,
+                    },
+                ],
+            },
+            AfterContract = new MetadataDataScriptContract
+            {
+                Resources =
+                [
+                    new MetadataScriptResourceContract
+                    {
+                        SemanticId = "res.parcels",
+                        SemanticKind = MetadataSemanticArtifactKind.Resource,
+                        Exists = true,
+                        ResourceType = includeRequiredDetails ? MetadataV2ResourceType.FeatureDataset : null,
+                    },
+                    new MetadataScriptResourceContract
+                    {
+                        SemanticId = "svc.features",
+                        SemanticKind = MetadataSemanticArtifactKind.Service,
+                        Exists = true,
+                        ServiceType = includeRequiredDetails ? MetadataV2ServiceType.OgcApiFeatures : null,
+                        Route = includeRequiredDetails ? "/shared/ogc/features" : null,
+                    },
+                    new MetadataScriptResourceContract
+                    {
+                        SemanticId = "pub.parcels",
+                        SemanticKind = MetadataSemanticArtifactKind.Publication,
+                        Exists = true,
+                        ResourceId = includeRequiredDetails ? "res.parcels" : null,
+                        ServiceId = includeRequiredDetails ? "svc.features" : null,
+                        PublicationType = includeRequiredDetails ? MetadataV2PublicationType.OgcCollection : null,
+                        Path = includeRequiredDetails ? "parcels" : null,
+                        ServiceLocalId = includeRequiredDetails ? "parcels" : null,
+                    },
+                ],
+            },
+        };
+
+    private static MetadataDataScriptEntry MissingStorageBindingScript(bool includeRequiredDetails)
+        => new()
+        {
+            ScriptId = "script.bind-storage",
+            Kind = "sql",
+            Reversible = true,
+            DeclaredOperations = ["bind-storage"],
+            BeforeContract = new MetadataDataScriptContract
+            {
+                Resources =
+                [
+                    new MetadataScriptResourceContract
+                    {
+                        SemanticId = "res.parcels",
+                        SemanticKind = MetadataSemanticArtifactKind.Resource,
+                        Exists = true,
+                    },
+                ],
+            },
+            AfterContract = new MetadataDataScriptContract
+            {
+                Resources =
+                [
+                    new MetadataScriptResourceContract
+                    {
+                        SemanticId = "res.parcels",
+                        SemanticKind = MetadataSemanticArtifactKind.Resource,
+                        Exists = true,
+                        Storage = new MetadataScriptStorageContract
+                        {
+                            StorageBindingId = includeRequiredDetails ? "storage.parcels" : null,
+                            StorageType = includeRequiredDetails ? MetadataV2StorageType.RelationalTable : null,
+                            Capabilities = includeRequiredDetails
+                                ? [MetadataV2StorageBindingCapability.Query]
+                                : Array.Empty<MetadataV2StorageBindingCapability>(),
+                        },
+                    },
+                ],
+            },
+        };
+
     private static MetadataV2GraphSnapshot Snapshot(MetadataV2Graph graph)
         => new(graph, $"etag-{graph.Environment}-{graph.Revision}", GeneratedAt);
 
@@ -299,14 +521,17 @@ public sealed class MetadataCompatibilityAnalyzerTests
         bool includePublication = true,
         string serviceRoute = "/shared/ogc/features",
         bool includeRelationshipDependent = false,
-        bool includeProjectionProfile = false)
+        bool includeProjectionProfile = false,
+        bool includeResource = true,
+        bool includeStorage = true)
     {
         var spatial = JsonSerializer.Deserialize<JsonElement>(
             $$"""{"srid":{{srid}},"geometryType":"Point"}""");
 
-        var resources = new List<MetadataV2Resource>
+        var resources = new List<MetadataV2Resource>();
+        if (includeResource)
         {
-            new()
+            resources.Add(new MetadataV2Resource
             {
                 Metadata = new MetadataV2ObjectMetadata
                 {
@@ -319,8 +544,8 @@ public sealed class MetadataCompatibilityAnalyzerTests
                 PrimaryStorageBindingId = "storage.parcels",
                 SchemaFields = includeField ? [BuildField(identifierRole)] : Array.Empty<MetadataV2Field>(),
                 Spatial = spatial,
-            },
-        };
+            });
+        }
 
         if (includeRelationshipDependent)
         {
@@ -351,17 +576,19 @@ public sealed class MetadataCompatibilityAnalyzerTests
             Revision = revision,
             GeneratedAt = GeneratedAt,
             Resources = resources,
-            StorageBindings =
-            [
-                new MetadataV2StorageBinding
-                {
-                    Metadata = new MetadataV2ObjectMetadata { Id = "storage.parcels", Name = "storage.parcels" },
-                    ResourceId = "res.parcels",
-                    StorageType = MetadataV2StorageType.RelationalTable,
-                    Locator = "shared.parcels",
-                    Capabilities = [MetadataV2StorageBindingCapability.Query],
-                },
-            ],
+            StorageBindings = includeStorage
+                ?
+                [
+                    new MetadataV2StorageBinding
+                    {
+                        Metadata = new MetadataV2ObjectMetadata { Id = "storage.parcels", Name = "storage.parcels" },
+                        ResourceId = "res.parcels",
+                        StorageType = MetadataV2StorageType.RelationalTable,
+                        Locator = "shared.parcels",
+                        Capabilities = [MetadataV2StorageBindingCapability.Query],
+                    },
+                ]
+                : Array.Empty<MetadataV2StorageBinding>(),
             Services = includeService
                 ?
                 [

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzerTests.cs
@@ -295,6 +295,57 @@ public sealed class MetadataCompatibilityAnalyzerTests
     }
 
     [UnitTest]
+    public void Analyze_PublicationIdentityChange_ReturnsWarningAndServiceRevisionRollback()
+    {
+        var source = Snapshot(BuildGraph("dev", 41));
+        var target = Snapshot(BuildGraph(
+            "staging",
+            7,
+            publicationResourceId: "res.archive",
+            publicationServiceId: "svc.archive"));
+        var package = Package(Entry("pub.parcels", MetadataSemanticArtifactKind.Publication));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            Array.Empty<MetadataDataScriptEntry>(),
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Warning);
+        report.Findings.Should().ContainSingle(finding =>
+            finding.Code == MetadataCompatibilityCode.PublicationRouteChanged &&
+            finding.Expected.Details["resourceId"] == "res.parcels" &&
+            finding.Expected.Details["serviceId"] == "svc.features" &&
+            finding.Actual.Details["resourceId"] == "res.archive" &&
+            finding.Actual.Details["serviceId"] == "svc.archive");
+        report.RollbackReadiness.Classification.Should().Be(MetadataRollbackReadinessClassification.ServiceRevision);
+    }
+
+    [UnitTest]
+    public void Analyze_TargetSpatialMetadataUnavailable_ReturnsUnknownManualRollback()
+    {
+        var source = Snapshot(BuildGraph("dev", 41));
+        var target = Snapshot(BuildGraph("staging", 7, includeSpatial: false));
+        var package = Package(Entry("res.parcels", MetadataSemanticArtifactKind.Resource));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            Array.Empty<MetadataDataScriptEntry>(),
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Unknown);
+        report.CanCreatePullRequest.Should().BeFalse();
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.SpatialCrsMismatch &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.Unknown);
+        report.RollbackReadiness.Classification.Should().Be(MetadataRollbackReadinessClassification.Manual);
+        report.RollbackReadiness.RequiresManualAction.Should().BeTrue();
+    }
+
+    [UnitTest]
     public void CreateUnavailableReport_ReturnsUnknownManualReport()
     {
         var report = MetadataCompatibilityAnalyzer.CreateUnavailableReport(
@@ -523,7 +574,10 @@ public sealed class MetadataCompatibilityAnalyzerTests
         bool includeRelationshipDependent = false,
         bool includeProjectionProfile = false,
         bool includeResource = true,
-        bool includeStorage = true)
+        bool includeStorage = true,
+        bool includeSpatial = true,
+        string publicationResourceId = "res.parcels",
+        string publicationServiceId = "svc.features")
     {
         var spatial = JsonSerializer.Deserialize<JsonElement>(
             $$"""{"srid":{{srid}},"geometryType":"Point"}""");
@@ -543,7 +597,7 @@ public sealed class MetadataCompatibilityAnalyzerTests
                 StorageBindingIds = ["storage.parcels"],
                 PrimaryStorageBindingId = "storage.parcels",
                 SchemaFields = includeField ? [BuildField(identifierRole)] : Array.Empty<MetadataV2Field>(),
-                Spatial = spatial,
+                Spatial = includeSpatial ? spatial : null,
             });
         }
 
@@ -607,8 +661,8 @@ public sealed class MetadataCompatibilityAnalyzerTests
                     new MetadataV2Publication
                     {
                         Metadata = new MetadataV2ObjectMetadata { Id = "pub.parcels", Name = "parcels" },
-                        ResourceId = "res.parcels",
-                        ServiceId = "svc.features",
+                        ResourceId = publicationResourceId,
+                        ServiceId = publicationServiceId,
                         StorageBindingId = "storage.parcels",
                         PublicationType = MetadataV2PublicationType.OgcCollection,
                         Path = "parcels",

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzerTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Domain/V2/MetadataCompatibilityAnalyzerTests.cs
@@ -144,6 +144,39 @@ public sealed class MetadataCompatibilityAnalyzerTests
     }
 
     [UnitTest]
+    public void Analyze_LaterScriptCoversFinding_DoesNotKeepEarlierBeforeContractMismatch()
+    {
+        var source = Snapshot(BuildGraph("dev", 41));
+        var target = Snapshot(BuildGraph("staging", 7, includeField: false));
+        var package = Package(Entry("res.parcels", MetadataSemanticArtifactKind.Resource));
+        var mismatchedScript = MissingFieldScript(reversible: true, beforeFieldExists: true) with
+        {
+            ScriptId = "script.wrong-before",
+        };
+        var coveringScript = MissingFieldScript(reversible: true, beforeFieldExists: false) with
+        {
+            ScriptId = "script.add-apn-later",
+        };
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            [mismatchedScript, coveringScript],
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Warning);
+        report.UncoveredErrorCount.Should().Be(0);
+        report.CoveredErrorCount.Should().Be(1);
+        report.Findings.Should().ContainSingle(finding =>
+            finding.Code == MetadataCompatibilityCode.FieldMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.CoveredByScript &&
+            finding.CoveringScriptId == "script.add-apn-later");
+        report.Findings.Should().NotContain(finding =>
+            finding.Code == MetadataCompatibilityCode.ScriptBeforeContractMismatch);
+    }
+
+    [UnitTest]
     public void Analyze_ExistsOnlyScriptForMissingArtifacts_LeavesFindingsBlocked()
     {
         var source = Snapshot(BuildGraph("dev", 41));
@@ -256,6 +289,65 @@ public sealed class MetadataCompatibilityAnalyzerTests
         report.CoveredErrorCount.Should().Be(1);
         report.Findings.Should().ContainSingle(finding =>
             finding.Code == MetadataCompatibilityCode.StorageBindingMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.CoveredByScript);
+    }
+
+    [UnitTest]
+    public void Analyze_StorageCapabilityBeforeContractAlreadyHasMissingCapability_LeavesFindingBlocked()
+    {
+        var source = Snapshot(BuildGraph(
+            "dev",
+            41,
+            storageCapabilities:
+            [
+                MetadataV2StorageBindingCapability.Query,
+                MetadataV2StorageBindingCapability.Edit,
+            ]));
+        var target = Snapshot(BuildGraph("staging", 7));
+        var package = Package(Entry("res.parcels", MetadataSemanticArtifactKind.Resource));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            [StorageCapabilityScript(beforeIncludesMissingCapability: true)],
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Blocked);
+        report.CoveredErrorCount.Should().Be(0);
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.StorageCapabilityMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.Uncovered);
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.ScriptBeforeContractMismatch);
+    }
+
+    [UnitTest]
+    public void Analyze_StorageCapabilityBeforeContractOmitsMissingCapability_CoversFinding()
+    {
+        var source = Snapshot(BuildGraph(
+            "dev",
+            41,
+            storageCapabilities:
+            [
+                MetadataV2StorageBindingCapability.Query,
+                MetadataV2StorageBindingCapability.Edit,
+            ]));
+        var target = Snapshot(BuildGraph("staging", 7));
+        var package = Package(Entry("res.parcels", MetadataSemanticArtifactKind.Resource));
+
+        var report = MetadataCompatibilityAnalyzer.Analyze(
+            package,
+            source,
+            target,
+            [StorageCapabilityScript(beforeIncludesMissingCapability: false)],
+            GeneratedAt);
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Warning);
+        report.UncoveredErrorCount.Should().Be(0);
+        report.CoveredErrorCount.Should().Be(1);
+        report.Findings.Should().ContainSingle(finding =>
+            finding.Code == MetadataCompatibilityCode.StorageCapabilityMissing &&
             finding.CoverageState == MetadataCompatibilityCoverageState.CoveredByScript);
     }
 
@@ -559,6 +651,61 @@ public sealed class MetadataCompatibilityAnalyzerTests
             },
         };
 
+    private static MetadataDataScriptEntry StorageCapabilityScript(bool beforeIncludesMissingCapability)
+        => new()
+        {
+            ScriptId = "script.add-storage-capability",
+            Kind = "sql",
+            Reversible = true,
+            DeclaredOperations = ["add-storage-capability"],
+            BeforeContract = new MetadataDataScriptContract
+            {
+                Resources =
+                [
+                    new MetadataScriptResourceContract
+                    {
+                        SemanticId = "res.parcels",
+                        SemanticKind = MetadataSemanticArtifactKind.Resource,
+                        Exists = true,
+                        Storage = new MetadataScriptStorageContract
+                        {
+                            StorageBindingId = "storage.parcels",
+                            StorageType = MetadataV2StorageType.RelationalTable,
+                            Capabilities = beforeIncludesMissingCapability
+                                ?
+                                [
+                                    MetadataV2StorageBindingCapability.Query,
+                                    MetadataV2StorageBindingCapability.Edit,
+                                ]
+                                : [MetadataV2StorageBindingCapability.Query],
+                        },
+                    },
+                ],
+            },
+            AfterContract = new MetadataDataScriptContract
+            {
+                Resources =
+                [
+                    new MetadataScriptResourceContract
+                    {
+                        SemanticId = "res.parcels",
+                        SemanticKind = MetadataSemanticArtifactKind.Resource,
+                        Exists = true,
+                        Storage = new MetadataScriptStorageContract
+                        {
+                            StorageBindingId = "storage.parcels",
+                            StorageType = MetadataV2StorageType.RelationalTable,
+                            Capabilities =
+                            [
+                                MetadataV2StorageBindingCapability.Query,
+                                MetadataV2StorageBindingCapability.Edit,
+                            ],
+                        },
+                    },
+                ],
+            },
+        };
+
     private static MetadataV2GraphSnapshot Snapshot(MetadataV2Graph graph)
         => new(graph, $"etag-{graph.Environment}-{graph.Revision}", GeneratedAt);
 
@@ -577,7 +724,8 @@ public sealed class MetadataCompatibilityAnalyzerTests
         bool includeStorage = true,
         bool includeSpatial = true,
         string publicationResourceId = "res.parcels",
-        string publicationServiceId = "svc.features")
+        string publicationServiceId = "svc.features",
+        IReadOnlyList<MetadataV2StorageBindingCapability>? storageCapabilities = null)
     {
         var spatial = JsonSerializer.Deserialize<JsonElement>(
             $$"""{"srid":{{srid}},"geometryType":"Point"}""");
@@ -639,7 +787,7 @@ public sealed class MetadataCompatibilityAnalyzerTests
                         ResourceId = "res.parcels",
                         StorageType = MetadataV2StorageType.RelationalTable,
                         Locator = "shared.parcels",
-                        Capabilities = [MetadataV2StorageBindingCapability.Query],
+                        Capabilities = storageCapabilities ?? [MetadataV2StorageBindingCapability.Query],
                     },
                 ]
                 : Array.Empty<MetadataV2StorageBinding>(),

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataCompatibilityPrevalidationServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Services/MetadataCompatibilityPrevalidationServiceTests.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Metadata.Services;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Core.Tests.Features.Metadata.Services;
+
+[Protocol(Protocols.TestQuality)]
+[Operation(Operations.Validation)]
+public sealed class MetadataCompatibilityPrevalidationServiceTests
+{
+    private static readonly DateTimeOffset GeneratedAt = new(2026, 5, 24, 12, 0, 0, TimeSpan.Zero);
+
+    [UnitTest]
+    public async Task PrevalidateAsync_WithPersistedPackageId_LoadsSnapshotsAndEmitsActivity()
+    {
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == "Honua.Core.Metadata",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activity => activities.Add(activity),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var store = new InMemoryMetadataReleasePackageStore();
+        var package = BuildPackage();
+        await store.CreateAsync(package);
+        var service = CreateService(
+            store,
+            BuildGraph("dev", 41, includeField: true),
+            BuildGraph("staging", 7, includeField: false));
+
+        var report = await service.PrevalidateAsync(new MetadataCompatibilityPrevalidationRequest
+        {
+            ReleasePackageId = package.PackageId,
+            TargetEnvironment = "staging",
+        });
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Blocked);
+        report.ReleasePackageId.Should().Be(package.PackageId);
+        report.Findings.Should().Contain(finding => finding.Code == MetadataCompatibilityCode.FieldMissing);
+        activities.Should().Contain(activity =>
+            activity.OperationName == "honua.metadata.compatibility.prevalidate" &&
+            activity.TagObjects.Any(tag => tag.Key == "metadata.finding.count"));
+    }
+
+    [UnitTest]
+    public async Task PrevalidateAsync_WithUnavailableTarget_ReturnsUnknownReport()
+    {
+        var service = CreateService(new InMemoryMetadataReleasePackageStore(), BuildGraph("dev", 41, includeField: true));
+
+        var report = await service.PrevalidateAsync(new MetadataCompatibilityPrevalidationRequest
+        {
+            ReleasePackage = BuildPackage(),
+            TargetEnvironment = "prod",
+        });
+
+        report.Status.Should().Be(MetadataCompatibilityStatus.Unknown);
+        report.CanPromote.Should().BeFalse();
+        report.Findings.Should().ContainSingle(finding => finding.Code == MetadataCompatibilityCode.StateUnavailable);
+    }
+
+    [UnitTest]
+    public async Task PrevalidateAsync_WithBothPackageInputs_ThrowsValidationError()
+    {
+        var service = CreateService(new InMemoryMetadataReleasePackageStore(), BuildGraph("dev", 41, includeField: true));
+
+        var act = () => service.PrevalidateAsync(new MetadataCompatibilityPrevalidationRequest
+        {
+            ReleasePackageId = Guid.NewGuid(),
+            ReleasePackage = BuildPackage(),
+            TargetEnvironment = "staging",
+        });
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(act);
+        exception.Message.Should().Contain("Exactly one of ReleasePackageId or ReleasePackage is required.");
+    }
+
+    private static MetadataCompatibilityPrevalidationService CreateService(
+        IMetadataReleasePackageStore store,
+        params MetadataV2Graph[] graphs)
+        => new(
+            new StaticEnvironmentReader(graphs),
+            store,
+            new FakeTimeProvider(GeneratedAt),
+            NullLogger<MetadataCompatibilityPrevalidationService>.Instance);
+
+    private static MetadataReleasePackage BuildPackage()
+        => new()
+        {
+            PackageId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "pkg.parcels",
+                Name = "promote-parcels",
+            },
+            SourceEnvironment = "dev",
+            SourceRevision = 41,
+            SourceEtag = "etag-dev-41",
+            TargetEnvironments = ["staging"],
+            Entries =
+            [
+                new MetadataReleaseEntry
+                {
+                    SemanticId = "res.parcels",
+                    ArtifactKind = MetadataSemanticArtifactKind.Resource,
+                    DesiredMetadataRevision = 41,
+                },
+            ],
+            CreatedBy = "tester",
+            CreatedAt = GeneratedAt,
+            UpdatedAt = GeneratedAt,
+        };
+
+    private static MetadataV2Graph BuildGraph(string environment, long revision, bool includeField)
+        => new()
+        {
+            Environment = environment,
+            Revision = revision,
+            GeneratedAt = GeneratedAt,
+            Resources =
+            [
+                new MetadataV2Resource
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "res.parcels", Name = "parcels" },
+                    Type = MetadataV2ResourceType.FeatureDataset,
+                    StorageBindingIds = ["storage.parcels"],
+                    PrimaryStorageBindingId = "storage.parcels",
+                    SchemaFields = includeField
+                        ?
+                        [
+                            new MetadataV2Field
+                            {
+                                SemanticId = "field.parcels.apn",
+                                Name = "apn",
+                                Type = "string",
+                            },
+                        ]
+                        : Array.Empty<MetadataV2Field>(),
+                },
+            ],
+            StorageBindings =
+            [
+                new MetadataV2StorageBinding
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "storage.parcels", Name = "storage.parcels" },
+                    ResourceId = "res.parcels",
+                    StorageType = MetadataV2StorageType.RelationalTable,
+                    Locator = "shared.parcels",
+                },
+            ],
+        };
+
+    private sealed class StaticEnvironmentReader(IEnumerable<MetadataV2Graph> graphs) : IMetadataV2EnvironmentSnapshotReader
+    {
+        private readonly Dictionary<string, MetadataV2GraphSnapshot> _snapshots = graphs.ToDictionary(
+            static graph => graph.Environment,
+            static graph => new MetadataV2GraphSnapshot(
+                graph,
+                $"etag-{graph.Environment}-{graph.Revision}",
+                GeneratedAt),
+            StringComparer.OrdinalIgnoreCase);
+
+        public ValueTask<MetadataV2GraphSnapshot?> GetCurrentAsync(
+            string environment,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(
+                _snapshots.TryGetValue(environment, out var snapshot) ? snapshot : null);
+
+        public ValueTask<MetadataV2GraphSnapshot?> GetByRevisionAsync(
+            string environment,
+            long revision,
+            CancellationToken cancellationToken = default)
+        {
+            var snapshot = _snapshots.TryGetValue(environment, out var current) && current.Revision == revision
+                ? current
+                : null;
+            return ValueTask.FromResult(snapshot);
+        }
+
+        public async IAsyncEnumerable<MetadataV2EnvironmentRevision> ListCurrentRevisionsAsync(
+            IReadOnlyList<string> environments,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            foreach (var environment in environments)
+            {
+                if (_snapshots.TryGetValue(environment, out var snapshot))
+                {
+                    yield return new MetadataV2EnvironmentRevision
+                    {
+                        Environment = snapshot.Graph.Environment,
+                        Revision = snapshot.Revision,
+                        ETag = snapshot.Etag,
+                        ActivatedAt = snapshot.LoadedAt,
+                    };
+                }
+            }
+        }
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
@@ -8,6 +8,8 @@ using FluentAssertions;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Metadata.Services;
+using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Infrastructure.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -246,6 +248,171 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Operation(Operations.Validation)]
+    [Endpoint("POST /api/v1/admin/metadata/prevalidate")]
+    public async Task Prevalidate_WithInlinePackage_ReturnsBlockedCompatibilityReport()
+    {
+        var body = JsonSerializer.Serialize(
+            new MetadataPrevalidateRequest
+            {
+                ReleasePackage = BuildInlinePackage(),
+                TargetEnvironment = "staging",
+            },
+            MetadataPrevalidationJsonContext.Default.MetadataPrevalidateRequest);
+
+        var response = await _client.PostAsync(
+            "/api/v1/admin/metadata/prevalidate",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var report = await ReadPrevalidationReportAsync(response);
+        report.Status.Should().Be(MetadataCompatibilityStatus.Blocked);
+        report.CanCreatePullRequest.Should().BeFalse();
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.FieldMissing &&
+            finding.AffectedSemanticId == "field.parcels.apn");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Validation)]
+    [Endpoint("POST /api/v1/admin/metadata/prevalidate")]
+    public async Task Prevalidate_WithPersistedPackageId_ReturnsCompatibilityReport()
+    {
+        var createBody = JsonSerializer.Serialize(
+            new CreateMetadataReleasePackageRequest
+            {
+                SourceEnvironment = "dev",
+                TargetEnvironments = ["staging"],
+                SemanticIds = ["res.parcels"],
+            },
+            MetadataReleaseJsonContext.Default.CreateMetadataReleasePackageRequest);
+        var createResponse = await _client.PostAsync(
+            "/api/v1/admin/metadata/release-packages",
+            new StringContent(createBody, Encoding.UTF8, "application/json"));
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = JsonSerializer.Deserialize(
+            await createResponse.Content.ReadAsStringAsync(),
+            MetadataReleaseJsonContext.Default.MetadataReleasePackage);
+
+        var body = JsonSerializer.Serialize(
+            new MetadataPrevalidateRequest
+            {
+                ReleasePackageId = created!.PackageId,
+                TargetEnvironment = "staging",
+            },
+            MetadataPrevalidationJsonContext.Default.MetadataPrevalidateRequest);
+
+        var response = await _client.PostAsync(
+            "/api/v1/admin/metadata/prevalidate",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var report = await ReadPrevalidationReportAsync(response);
+        report.ReleasePackageId.Should().Be(created.PackageId);
+        report.TargetEnvironment.Should().Be("staging");
+        report.Status.Should().Be(MetadataCompatibilityStatus.Blocked);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Validation)]
+    [Endpoint("POST /api/v1/admin/metadata/prevalidate")]
+    public async Task Prevalidate_WithCoveringDataScript_ReturnsWarningReport()
+    {
+        var body = JsonSerializer.Serialize(
+            new MetadataPrevalidateRequest
+            {
+                ReleasePackage = BuildInlinePackage(),
+                TargetEnvironment = "staging",
+                DataScripts =
+                [
+                    new MetadataDataScriptEntry
+                    {
+                        ScriptId = "script.add-apn",
+                        Kind = "sql",
+                        Reversible = true,
+                        DeclaredOperations = ["add-field"],
+                        BeforeContract = MissingFieldContract(exists: false),
+                        AfterContract = MissingFieldContract(exists: true),
+                    },
+                ],
+            },
+            MetadataPrevalidationJsonContext.Default.MetadataPrevalidateRequest);
+
+        var response = await _client.PostAsync(
+            "/api/v1/admin/metadata/prevalidate",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var report = await ReadPrevalidationReportAsync(response);
+        report.Status.Should().Be(MetadataCompatibilityStatus.Warning);
+        report.UncoveredErrorCount.Should().Be(0);
+        report.Findings.Should().Contain(finding =>
+            finding.Code == MetadataCompatibilityCode.FieldMissing &&
+            finding.CoverageState == MetadataCompatibilityCoverageState.CoveredByScript &&
+            finding.CoveringScriptId == "script.add-apn");
+        report.RollbackReadiness.Classification.Should().Be(MetadataRollbackReadinessClassification.ScriptReversible);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Validation)]
+    [Endpoint("POST /api/v1/admin/metadata/prevalidate")]
+    public async Task Prevalidate_WithInvalidRequestShape_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsync(
+            "/api/v1/admin/metadata/prevalidate",
+            new StringContent("{\"targetEnvironment\":\"staging\"}", Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var payload = await response.Content.ReadAsStringAsync();
+        payload.Should().Contain("Exactly one of ReleasePackageId or ReleasePackage is required.");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Validation)]
+    [Endpoint("POST /api/v1/admin/metadata/prevalidate")]
+    public async Task Prevalidate_WithUnavailableTarget_ReturnsUnknownReport()
+    {
+        var body = JsonSerializer.Serialize(
+            new MetadataPrevalidateRequest
+            {
+                ReleasePackage = BuildInlinePackage(),
+                TargetEnvironment = "prod",
+            },
+            MetadataPrevalidationJsonContext.Default.MetadataPrevalidateRequest);
+
+        var response = await _client.PostAsync(
+            "/api/v1/admin/metadata/prevalidate",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var report = await ReadPrevalidationReportAsync(response);
+        report.Status.Should().Be(MetadataCompatibilityStatus.Unknown);
+        report.CanPromote.Should().BeFalse();
+        report.Findings.Should().ContainSingle(finding => finding.Code == MetadataCompatibilityCode.StateUnavailable);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Validation)]
+    [Endpoint("POST /api/v1/admin/metadata/prevalidate")]
+    public async Task Prevalidate_WithoutAdminAuth_ReturnsUnauthorized()
+    {
+        using var unauthorizedClient = _fixture.CreateClient();
+        var body = JsonSerializer.Serialize(
+            new MetadataPrevalidateRequest
+            {
+                ReleasePackage = BuildInlinePackage(),
+                TargetEnvironment = "staging",
+            },
+            MetadataPrevalidationJsonContext.Default.MetadataPrevalidateRequest);
+
+        var response = await unauthorizedClient.PostAsync(
+            "/api/v1/admin/metadata/prevalidate",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [IntegrationTest]
     [Endpoint("POST /api/v1/admin/metadata/release-packages")]
     public async Task CreateReleasePackage_WithRepeatedGeneratedTitleKeys_ReturnsCreatedPackages()
     {
@@ -415,6 +582,72 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
             ],
         };
     }
+
+    private static async Task<MetadataCompatibilityReport> ReadPrevalidationReportAsync(HttpResponseMessage response)
+    {
+        var payload = await response.Content.ReadAsStringAsync();
+        var envelope = JsonSerializer.Deserialize(
+            payload,
+            MetadataPrevalidationJsonContext.Default.ApiResponseMetadataCompatibilityReport);
+        envelope.Should().NotBeNull();
+        envelope!.Success.Should().BeTrue();
+        envelope.Data.Should().NotBeNull();
+        return envelope.Data!;
+    }
+
+    private static MetadataReleasePackage BuildInlinePackage()
+        => new()
+        {
+            PackageId = Guid.Parse("33333333-3333-3333-3333-333333333333"),
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "pkg.parcels",
+                Name = "promote-parcels",
+                Title = "Promote parcels",
+            },
+            SourceEnvironment = "dev",
+            SourceRevision = 41,
+            SourceEtag = "etag-dev-41",
+            TargetEnvironments = ["staging"],
+            Entries =
+            [
+                new MetadataReleaseEntry
+                {
+                    SemanticId = "res.parcels",
+                    ArtifactKind = MetadataSemanticArtifactKind.Resource,
+                    ResourceType = MetadataV2ResourceType.Map,
+                    DesiredMetadataRevision = 41,
+                },
+            ],
+            CreatedBy = "tester",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+    private static MetadataDataScriptContract MissingFieldContract(bool exists)
+        => new()
+        {
+            Resources =
+            [
+                new MetadataScriptResourceContract
+                {
+                    SemanticId = "res.parcels",
+                    SemanticKind = MetadataSemanticArtifactKind.Resource,
+                    Exists = true,
+                    Fields =
+                    [
+                        new MetadataScriptFieldContract
+                        {
+                            SemanticId = "field.parcels.apn",
+                            Name = "apn",
+                            Exists = exists,
+                            Type = "string",
+                            Nullable = false,
+                        },
+                    ],
+                },
+            ],
+        };
 
     private static MetadataV2Field[] BuildSchemaFields(bool includeSchemaField)
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
@@ -387,6 +387,76 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Validation)]
     [Endpoint("POST /api/v1/admin/metadata/prevalidate")]
+    public async Task Prevalidate_WithNullDataScriptContractEntries_ReturnsBadRequest()
+    {
+        (string Body, string ExpectedMessage)[] cases =
+        [
+            (
+                """
+                {
+                  "releasePackageId": "33333333-3333-3333-3333-333333333333",
+                  "targetEnvironment": "staging",
+                  "dataScripts": [null]
+                }
+                """,
+                "DataScripts cannot contain null entries."),
+            (
+                """
+                {
+                  "releasePackageId": "33333333-3333-3333-3333-333333333333",
+                  "targetEnvironment": "staging",
+                  "dataScripts": [
+                    {
+                      "scriptId": "script.bad-resource",
+                      "declaredOperations": [],
+                      "afterContract": {
+                        "resources": [null]
+                      }
+                    }
+                  ]
+                }
+                """,
+                "Data script 'script.bad-resource' afterContract.resources cannot contain null entries."),
+            (
+                """
+                {
+                  "releasePackageId": "33333333-3333-3333-3333-333333333333",
+                  "targetEnvironment": "staging",
+                  "dataScripts": [
+                    {
+                      "scriptId": "script.bad-field",
+                      "declaredOperations": [],
+                      "afterContract": {
+                        "resources": [
+                          {
+                            "semanticId": "res.parcels",
+                            "fields": [null]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """,
+                "Data script 'script.bad-field' contract fields cannot contain null entries."),
+        ];
+
+        foreach (var (body, expectedMessage) in cases)
+        {
+            var response = await _client.PostAsync(
+                "/api/v1/admin/metadata/prevalidate",
+                new StringContent(body, Encoding.UTF8, "application/json"));
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            var payload = await response.Content.ReadAsStringAsync();
+            using var document = JsonDocument.Parse(payload);
+            document.RootElement.GetProperty("detail").GetString().Should().Contain(expectedMessage);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Validation)]
+    [Endpoint("POST /api/v1/admin/metadata/prevalidate")]
     public async Task Prevalidate_WithUnavailableTarget_ReturnsUnknownReport()
     {
         var body = JsonSerializer.Serialize(

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
@@ -438,7 +438,118 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
                   ]
                 }
                 """,
-                "Data script 'script.bad-field' contract fields cannot contain null entries."),
+                "Data script 'script.bad-field' afterContract.resources.fields cannot contain null entries."),
+            (
+                """
+                {
+                  "releasePackageId": "33333333-3333-3333-3333-333333333333",
+                  "targetEnvironment": "staging",
+                  "dataScripts": [
+                    {
+                      "scriptId": "script.bad-operations",
+                      "declaredOperations": null
+                    }
+                  ]
+                }
+                """,
+                "Data script 'script.bad-operations' declaredOperations must be an array."),
+            (
+                """
+                {
+                  "releasePackageId": "33333333-3333-3333-3333-333333333333",
+                  "targetEnvironment": "staging",
+                  "dataScripts": [
+                    {
+                      "scriptId": "script.bad-resource-capabilities",
+                      "declaredOperations": [],
+                      "afterContract": {
+                        "resources": [
+                          {
+                            "semanticId": "svc.features",
+                            "semanticKind": "service",
+                            "capabilities": null
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """,
+                "Data script 'script.bad-resource-capabilities' afterContract.resources.capabilities must be an array."),
+            (
+                """
+                {
+                  "releasePackageId": "33333333-3333-3333-3333-333333333333",
+                  "targetEnvironment": "staging",
+                  "dataScripts": [
+                    {
+                      "scriptId": "script.bad-publication-formats",
+                      "declaredOperations": [],
+                      "afterContract": {
+                        "resources": [
+                          {
+                            "semanticId": "pub.parcels",
+                            "semanticKind": "publication",
+                            "supportedFormats": null
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """,
+                "Data script 'script.bad-publication-formats' afterContract.resources.supportedFormats must be an array."),
+            (
+                """
+                {
+                  "releasePackageId": "33333333-3333-3333-3333-333333333333",
+                  "targetEnvironment": "staging",
+                  "dataScripts": [
+                    {
+                      "scriptId": "script.bad-field-roles",
+                      "declaredOperations": [],
+                      "afterContract": {
+                        "resources": [
+                          {
+                            "semanticId": "res.parcels",
+                            "fields": [
+                              {
+                                "name": "apn",
+                                "semanticRoles": null
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """,
+                "Data script 'script.bad-field-roles' afterContract.resources.fields.semanticRoles must be an array."),
+            (
+                """
+                {
+                  "releasePackageId": "33333333-3333-3333-3333-333333333333",
+                  "targetEnvironment": "staging",
+                  "dataScripts": [
+                    {
+                      "scriptId": "script.bad-storage-capabilities",
+                      "declaredOperations": [],
+                      "afterContract": {
+                        "resources": [
+                          {
+                            "semanticId": "res.parcels",
+                            "storage": {
+                              "capabilities": null
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """,
+                "Data script 'script.bad-storage-capabilities' afterContract.resources.storage.capabilities must be an array."),
         ];
 
         foreach (var (body, expectedMessage) in cases)
@@ -452,6 +563,40 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
             using var document = JsonDocument.Parse(payload);
             document.RootElement.GetProperty("detail").GetString().Should().Contain(expectedMessage);
         }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Validation)]
+    [Endpoint("POST /api/v1/admin/metadata/prevalidate")]
+    public async Task Prevalidate_WithOmittedDataScriptCollections_TreatsCollectionsAsEmpty()
+    {
+        const string body =
+            """
+            {
+              "releasePackageId": "33333333-3333-3333-3333-333333333333",
+              "targetEnvironment": "staging",
+              "dataScripts": [
+                {
+                  "scriptId": "script.omitted-collections",
+                  "afterContract": {
+                    "resources": [
+                      {
+                        "semanticId": "res.parcels"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+            """;
+
+        var response = await _client.PostAsync(
+            "/api/v1/admin/metadata/prevalidate",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var report = await ReadPrevalidationReportAsync(response);
+        report.Status.Should().Be(MetadataCompatibilityStatus.Unknown);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseEndpointsTests.cs
@@ -370,6 +370,23 @@ public sealed class MetadataReleaseEndpointsTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Validation)]
     [Endpoint("POST /api/v1/admin/metadata/prevalidate")]
+    public async Task Prevalidate_WithNullDataScripts_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsync(
+            "/api/v1/admin/metadata/prevalidate",
+            new StringContent(
+                "{\"releasePackageId\":\"33333333-3333-3333-3333-333333333333\",\"targetEnvironment\":\"staging\",\"dataScripts\":null}",
+                Encoding.UTF8,
+                "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var payload = await response.Content.ReadAsStringAsync();
+        payload.Should().Contain("DataScripts must be an array.");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Validation)]
+    [Endpoint("POST /api/v1/admin/metadata/prevalidate")]
     public async Task Prevalidate_WithUnavailableTarget_ReturnsUnknownReport()
     {
         var body = JsonSerializer.Serialize(

--- a/tests/dotnet/Honua.TestKit/Constants/Operations.cs
+++ b/tests/dotnet/Honua.TestKit/Constants/Operations.cs
@@ -51,6 +51,7 @@ public static class Operations
     // Admin Operations
     public const string TableDiscovery = "TableDiscovery";
     public const string Configuration = "Configuration";
+    public const string Validation = "Validation";
     public const string Cache = "Cache";
     public const string Infrastructure = "Infrastructure";
     public const string OperationsProgress = "OperationsProgress";


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #1164
## Summary

Metadata GitOps compatibility prevalidation with data script coverage
## Changes Made

- Metadata GitOps compatibility prevalidation with data script coverage
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/ci/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
