### PR TITLE
feat: Backend: Saved query and analysis content versions with job artifacts (#1182)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ The source-backed feature map is maintained in [docs/features/README.md](docs/fe
 
 **Async geoprocessing** — OGC API Processes landing/conformance, process discovery, async execution, job polling, dismiss, and job results over the canonical geoprocessing runtime. `/ogc/processes/jobs/{jobId}/results` returns `200 OK` with a document-mode JSON body on success (empty `{}` until the canonical process declares value-typed outputs and result storage is wired).
 
+**Durable analysis content** — Saved-query and analysis-package content items persist immutable versions, run/rerun provenance, preview artifacts, artifact binding metadata, and safe failed-job diagnostics under `/api/v1/analysis/**`.
+
 **AI operator workflows** — MCP JSON-RPC on `/mcp` exposes plan validation, dry runs, execution submission, cancellation, and job/result resource reads over the same canonical geoprocessing runtime used by gRPC and GPServer. Natural-language grounding and clarification (`honua_ground_candidates`, `honua_clarify_intent`) are functional over the built-in process and layer catalogs; remaining planning, workspace, and catalog contracts are discoverable as authenticated `not_implemented` placeholders so clients can bind before the upstream services land.
 
 **Workflow orchestration** — Declarative multi-step DAG workflows compose canonical analysis plans into chained, scheduled, and dependency-aware runs. Steps wire upstream artifacts to downstream inputs, support per-step retry policies and failure propagation, and execute over the durable job orchestration substrate. A cron scheduler fires time-triggered workflows with replica-safe deduplication. Requires Redis.

--- a/docs/README.md
+++ b/docs/README.md
@@ -160,6 +160,7 @@ How to build against Honua's APIs, SDKs, and protocols.
 - [Console Job Observability](admin-api/console-job-observability.md) — Durable execution job list, detail, logs, artifacts, action, cancel, retry, and Operate event correlation endpoints under `/api/v1/admin/jobs/**` (#1170).
 - [Metadata Prevalidation Admin API](admin-api/metadata-prevalidation.md) — Metadata v2 release-package compatibility reports for Console pre-PR and CI checks (#1164).
 - [Studio Package Lifecycle](admin-api/studio-package-lifecycle.md) — Server-owned draft, validation, preview, immutable version, publish, reopen, compare, and rollback endpoints under `/api/v1/studio/**` (#1180).
+- [Analysis Content](admin-api/analysis-content.md) — Durable saved-query and analysis-package content items, immutable versions, preview artifacts, run/rerun provenance, artifact binding lookup, and failed-job diagnostics under `/api/v1/analysis/**` (#1182).
 - [Scene Dataset Registry](admin-api/scene-dataset-registry.md)
 
 ## Contributor Guides

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -75,6 +75,7 @@
 - [Console Job Observability (Admin API)](admin-api/console-job-observability.md)
 - [Metadata Prevalidation Admin API](admin-api/metadata-prevalidation.md)
 - [Studio Package Lifecycle API](admin-api/studio-package-lifecycle.md)
+- [Analysis Content (Admin API)](admin-api/analysis-content.md)
 - [Scene Dataset Registry (Admin API)](admin-api/scene-dataset-registry.md)
 - [SDK Compatibility](developer/SDK_COMPATIBILITY_MATRIX.md)
 - [SDK Migration Automation Evidence Manifest](developer/sdk-migration-evidence-manifest.md)

--- a/docs/admin-api/analysis-content.md
+++ b/docs/admin-api/analysis-content.md
@@ -41,7 +41,7 @@ Status code conventions:
 | `400` | Invalid request payload, invalid limit, mismatched content kind, bad filter plan, or invalid canonical query. |
 | `401` / `403` | Admin authorization or geoprocessing authorization failed. |
 | `404` | Item, version, layer, job, or artifact was not found. |
-| `409` | The requested job has not failed, or a geoprocessing precondition failed. |
+| `409` | A concurrent version conflict could not be resolved, the requested job has not failed, or a geoprocessing precondition failed. |
 | `503` | The backing content, job, or log store is unavailable. |
 | `500` | Unexpected failures are returned as a generic problem without internal details. |
 
@@ -132,9 +132,9 @@ hash.
 { "limit": 10 }
 ```
 
-The preview limit defaults to the saved query's `previewLimit`, then to `25`.
-Values above `200` are clamped to `200`; values less than or equal to zero
-return `400`.
+The request `limit` is used first, then the saved query's `previewLimit`, then a
+default of `25`. Values above `200` are clamped to `200`; values less than or
+equal to zero return `400`.
 
 Preview execution uses the canonical query path: the saved `filterPlan` is
 compiled against the target layer, projected into `UnifiedQuery`, validated and
@@ -342,8 +342,10 @@ line-normalized, capped to 512 characters, and replaced with a generic failure
 message when they look like stack traces, provider internals, connection
 strings, or secret-bearing text (secret, token, credential, api key, or bearer
 values) — including secret-bearing values stored under otherwise innocuous
-metadata keys. Metadata keys containing password, secret, or connection are
-omitted; remaining metadata is capped to 20 entries.
+metadata keys. Metadata entries whose key name implies a secret (password, pwd,
+secret, connection, token, credential, api key, apikey, api_key, bearer, or
+private key) are dropped entirely, so an opaque value under a sensitive key name
+cannot leak; remaining metadata is capped to 20 entries.
 
 `GET /api/v1/analysis/jobs/{jobId}/failure` is only valid for failed or
 cancelled jobs. Failed jobs return a safe classification:

--- a/docs/admin-api/analysis-content.md
+++ b/docs/admin-api/analysis-content.md
@@ -244,10 +244,12 @@ before submitting the job.
 
 `POST /reruns` accepts `idempotencyKey`, `rerunOfJobId`,
 `rerunOfResultPackageId`, and `parameterOverrides`. When overrides are present,
-the server creates a new immutable version with the merged package parameters,
-links it to the source version, and submits that new version. Without
-overrides, the requested version is resubmitted. Rerun provenance is stamped
-onto job metadata with `analysis.content.rerun_of_job_id` and
+each override must match an existing executable plan step input. The server
+updates matching step inputs and merged package parameters in the new immutable
+version, links it to the source version, and submits that new version. Unknown
+override keys are rejected with `400`. Without overrides, the requested version
+is resubmitted. Rerun provenance is stamped onto job metadata with
+`analysis.content.rerun_of_job_id` and
 `analysis.content.rerun_of_result_package_id` when supplied.
 
 ## Artifacts And Bindings

--- a/docs/admin-api/analysis-content.md
+++ b/docs/admin-api/analysis-content.md
@@ -14,7 +14,9 @@ Tracked by issue **#1182**. The implementation lives in
 All routes live under `/api/v1/analysis/...` and require admin authorization.
 Responses are plain camelCase JSON DTOs, not the older `ApiResponse<T>`
 envelope. Null fields are omitted. Expected errors use the shared admin
-`application/problem+json` shape.
+`application/problem+json` shape. Admin authorization is enforced before the
+analysis-content handlers run; run, rerun, and failure requests can also return
+geoprocessing authorization problems from the canonical job service.
 
 | Method | Route | Purpose |
 | --- | --- | --- |
@@ -37,7 +39,7 @@ Status code conventions:
 | `201` | Content item or version was created. |
 | `200` | Read, preview, run, rerun, artifact, log, or failure request succeeded. |
 | `400` | Invalid request payload, invalid limit, mismatched content kind, bad filter plan, or invalid canonical query. |
-| `401` / `403` | Geoprocessing authorization failed. |
+| `401` / `403` | Admin authorization or geoprocessing authorization failed. |
 | `404` | Item, version, layer, job, or artifact was not found. |
 | `409` | The requested job has not failed, or a geoprocessing precondition failed. |
 | `503` | The backing content, job, or log store is unavailable. |
@@ -110,6 +112,12 @@ version:
 omitted, it defaults to the latest version id. `createdFromJobId` and
 `createdFromArtifactIds` are provenance fields for versions derived from prior
 results.
+
+The public slice reopens content by known `itemId` plus either `latest` or an
+explicit version number; it does not expose a list route yet. `contentHash` is
+computed from the saved `savedQuery` or `analysisPackage` payload only, so
+provenance-only fields such as `basedOnVersionId` do not change the payload
+hash.
 
 ## Saved Query Preview
 
@@ -229,6 +237,11 @@ the job id, current job status, and submitted version:
 }
 ```
 
+Runtime `parameters` are submitted as job provenance metadata and do not mutate
+the stored analysis package version. To make parameter changes durable, use
+`/reruns` with `parameterOverrides`, which creates a new immutable version
+before submitting the job.
+
 `POST /reruns` accepts `idempotencyKey`, `rerunOfJobId`,
 `rerunOfResultPackageId`, and `parameterOverrides`. When overrides are present,
 the server creates a new immutable version with the merged package parameters,
@@ -281,11 +294,14 @@ record and a binding clients can place into downstream packages:
 }
 ```
 
-Completed geoprocessing jobs that carry the same `analysis.content.*` metadata
-persist retained result-artifact records during terminal callback handling. The
-binding fields are intentionally stable so downstream maps, dashboards,
-reports, apps, and workflows can reference `artifactId` plus the source
-content version instead of duplicating preview or job state.
+Completed geoprocessing jobs that carry `analysis.content.item_id`,
+`analysis.content.version`, and `analysis.content.version_id` persist retained
+result-artifact records during terminal callback handling. These records store
+metadata, provenance, and the artifact URI produced by the job result package;
+they do not copy artifact bytes into the analysis-content tables. The binding
+fields are intentionally stable so downstream maps, dashboards, reports, apps,
+and workflows can reference `artifactId` plus the source content version
+instead of duplicating preview or job state.
 
 ## Job Diagnostics
 

--- a/docs/admin-api/analysis-content.md
+++ b/docs/admin-api/analysis-content.md
@@ -1,0 +1,356 @@
+# Analysis Content API
+
+The Analysis Content API makes natural-language saved queries and analysis
+packages durable, versioned content. It is the backend contract that lets maps,
+dashboards, reports, generated apps, workflows, and MCP clients bind to a saved
+query or analysis artifact without copying transient browser preview state.
+
+Tracked by issue **#1182**. The implementation lives in
+`Honua.Server.Features.AnalysisContent` and uses source-generated JSON through
+`AnalysisContentApiJsonContext` for trimming and Native AOT compatibility.
+
+## Surface
+
+All routes live under `/api/v1/analysis/...` and require admin authorization.
+Responses are plain camelCase JSON DTOs, not the older `ApiResponse<T>`
+envelope. Null fields are omitted. Expected errors use the shared admin
+`application/problem+json` shape.
+
+| Method | Route | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/v1/analysis/content/items` | Create a saved-query or analysis-package item plus version 1. |
+| `GET` | `/api/v1/analysis/content/items/{itemId}` | Open the item and its latest version. |
+| `GET` | `/api/v1/analysis/content/items/{itemId}/versions/latest` | Open the latest immutable version. |
+| `GET` | `/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}` | Open an explicit immutable version number. |
+| `POST` | `/api/v1/analysis/content/items/{itemId}/versions` | Add a new immutable version and advance the item pointer. |
+| `POST` | `/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/preview` | Preview a saved-query version through the canonical feature-query pipeline. |
+| `POST` | `/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/runs` | Submit an analysis-package version through the canonical geoprocessing runtime. |
+| `POST` | `/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/reruns` | Rerun an analysis package with provenance and optional parameter overrides. |
+| `GET` | `/api/v1/analysis/artifacts/{artifactId}` | Resolve stable artifact metadata and a downstream binding reference. |
+| `GET` | `/api/v1/analysis/jobs/{jobId}/logs` | Read bounded, safe structured logs for an analysis job. |
+| `GET` | `/api/v1/analysis/jobs/{jobId}/failure` | Read safe failure classification for a failed or cancelled analysis job. |
+
+Status code conventions:
+
+| Status | Meaning |
+| --- | --- |
+| `201` | Content item or version was created. |
+| `200` | Read, preview, run, rerun, artifact, log, or failure request succeeded. |
+| `400` | Invalid request payload, invalid limit, mismatched content kind, bad filter plan, or invalid canonical query. |
+| `401` / `403` | Geoprocessing authorization failed. |
+| `404` | Item, version, layer, job, or artifact was not found. |
+| `409` | The requested job has not failed, or a geoprocessing precondition failed. |
+| `503` | The backing content, job, or log store is unavailable. |
+| `500` | Unexpected failures are returned as a generic problem without internal details. |
+
+## Content Items And Versions
+
+Create requests must supply `kind`, `name`, and exactly one payload matching
+the kind:
+
+```json
+{
+  "kind": "savedQuery",
+  "name": "incidents-by-type",
+  "title": "Incidents by Type",
+  "savedQuery": {
+    "layerId": 42,
+    "serviceName": "public-safety",
+    "naturalLanguageQuery": "show recent incidents",
+    "previewLimit": 25,
+    "outputSrid": 4326,
+    "units": "meters"
+  }
+}
+```
+
+`kind` values are `savedQuery` and `analysisPackage`. Saved-query payloads
+require a non-negative `layerId`; analysis packages require a plan with at
+least one step. The server stamps `itemId`, `versionId`, `currentVersion`,
+`currentVersionId`, timestamps, owner/audit fields from the authenticated
+principal, `visibility = "organization"`, and `lifecycle = "active"`.
+
+Successful create and read responses return the item root and the selected
+version:
+
+```json
+{
+  "item": {
+    "itemId": "analysis-content-0f2...",
+    "kind": "savedQuery",
+    "name": "incidents-by-type",
+    "title": "Incidents by Type",
+    "visibility": "organization",
+    "currentVersion": 1,
+    "currentVersionId": "analysis-content-0f2...:v1",
+    "lifecycle": "active",
+    "createdAt": "2026-05-24T10:00:00Z",
+    "updatedAt": "2026-05-24T10:00:00Z"
+  },
+  "version": {
+    "versionId": "analysis-content-0f2...:v1",
+    "itemId": "analysis-content-0f2...",
+    "version": 1,
+    "kind": "savedQuery",
+    "savedQuery": {
+      "layerId": 42,
+      "serviceName": "public-safety",
+      "naturalLanguageQuery": "show recent incidents",
+      "previewLimit": 25,
+      "outputSrid": 4326,
+      "units": "meters"
+    },
+    "contentHash": "5bd...",
+    "createdAt": "2026-05-24T10:00:00Z"
+  }
+}
+```
+
+`POST /versions` stores a new immutable payload. If `basedOnVersionId` is
+omitted, it defaults to the latest version id. `createdFromJobId` and
+`createdFromArtifactIds` are provenance fields for versions derived from prior
+results.
+
+## Saved Query Preview
+
+`POST /preview` accepts an optional body:
+
+```json
+{ "limit": 10 }
+```
+
+The preview limit defaults to the saved query's `previewLimit`, then to `25`.
+Values above `200` are clamped to `200`; values less than or equal to zero
+return `400`.
+
+Preview execution uses the canonical query path: the saved `filterPlan` is
+compiled against the target layer, projected into `UnifiedQuery`, validated and
+optimized by `IQueryProcessor`, then executed by `IFeatureReader`. This keeps
+saved-query previews aligned with the normal feature-query behavior for
+filters, output fields, and output CRS.
+
+The response is a bounded feature preview plus a stable binding:
+
+```json
+{
+  "previewArtifactId": "analysis-preview-4ca...",
+  "itemId": "analysis-content-0f2...",
+  "version": 2,
+  "layerId": 42,
+  "features": [
+    {
+      "id": 1001,
+      "attributes": { "type": "inspection" },
+      "hasGeometry": true
+    }
+  ],
+  "totalCount": 17,
+  "exceededPreviewLimit": true,
+  "binding": {
+    "artifactId": "analysis-preview-4ca...",
+    "sourceItemId": "analysis-content-0f2...",
+    "sourceVersion": 2,
+    "sourceVersionId": "analysis-content-0f2...:v2",
+    "role": "preview",
+    "targetKind": "map",
+    "targetSlot": "source"
+  }
+}
+```
+
+Each preview also upserts a short-lived artifact record with
+`retentionState = "preview"`, `jobId = "preview"`, kind `FeatureLayer`, a
+`honua://analysis/artifacts/{artifactId}` URI, and a one-hour expiry. Preview
+requests are ad hoc feature queries and are not exact-response cached.
+
+## Analysis Package Runs And Reruns
+
+Analysis packages carry an executable `analysisPackage.plan`, default
+`parameters`, requested artifact kinds, optional binding hints, and spatial
+assumptions:
+
+```json
+{
+  "kind": "analysisPackage",
+  "name": "buffer-package",
+  "analysisPackage": {
+    "intent": {
+      "intentId": "intent-1",
+      "goal": "buffer incidents",
+      "requestedOutputs": ["FeatureLayer"]
+    },
+    "plan": {
+      "planId": "plan-1",
+      "intentId": "intent-1",
+      "steps": [
+        {
+          "stepId": "step-1",
+          "kind": "Geoprocess",
+          "processId": "geometry.buffer",
+          "inputs": { "distance": "10" }
+        }
+      ],
+      "outputs": ["FeatureLayer"]
+    },
+    "parameters": { "distance": "10" },
+    "requestedArtifacts": ["FeatureLayer"],
+    "spatialReferenceId": 4326,
+    "units": "meters"
+  }
+}
+```
+
+`POST /runs` submits the stored plan through `IGeoprocessingJobService`:
+
+```json
+{
+  "idempotencyKey": "run-1",
+  "parameters": { "format": "geojson" }
+}
+```
+
+The job receives source metadata using the `analysis.content.*` key namespace,
+including item id, version number, version id, content kind, source SRID,
+source units, package parameters, and runtime parameters. The response includes
+the job id, current job status, and submitted version:
+
+```json
+{
+  "jobId": "run-1",
+  "status": "Queued",
+  "version": {
+    "versionId": "analysis-content-0f2...:v1",
+    "itemId": "analysis-content-0f2...",
+    "version": 1,
+    "kind": "analysisPackage",
+    "contentHash": "a71...",
+    "createdAt": "2026-05-24T10:00:00Z"
+  }
+}
+```
+
+`POST /reruns` accepts `idempotencyKey`, `rerunOfJobId`,
+`rerunOfResultPackageId`, and `parameterOverrides`. When overrides are present,
+the server creates a new immutable version with the merged package parameters,
+links it to the source version, and submits that new version. Without
+overrides, the requested version is resubmitted. Rerun provenance is stamped
+onto job metadata with `analysis.content.rerun_of_job_id` and
+`analysis.content.rerun_of_result_package_id` when supplied.
+
+## Artifacts And Bindings
+
+`GET /api/v1/analysis/artifacts/{artifactId}` returns the durable artifact
+record and a binding clients can place into downstream packages:
+
+```json
+{
+  "artifact": {
+    "artifactId": "analysis-preview-4ca...",
+    "resultPackageId": "analysis-content-0f2...:v2:preview",
+    "jobId": "preview",
+    "sourceItemId": "analysis-content-0f2...",
+    "sourceVersion": 2,
+    "sourceVersionId": "analysis-content-0f2...:v2",
+    "kind": "FeatureLayer",
+    "label": "public-safety preview",
+    "uri": "honua://analysis/artifacts/analysis-preview-4ca...",
+    "contentType": "application/json",
+    "metadata": { "layerId": "42", "previewLimit": "10" },
+    "provenance": {
+      "analysis.content.item_id": "analysis-content-0f2...",
+      "analysis.content.version": "2",
+      "analysis.content.version_id": "analysis-content-0f2...:v2",
+      "analysis.content.kind": "SavedQuery",
+      "analysis.content.source_srid": "4326",
+      "analysis.content.source_units": "meters"
+    },
+    "retentionState": "preview",
+    "promotionState": "none",
+    "createdAt": "2026-05-24T10:05:00Z",
+    "expiresAt": "2026-05-24T11:05:00Z"
+  },
+  "binding": {
+    "artifactId": "analysis-preview-4ca...",
+    "sourceItemId": "analysis-content-0f2...",
+    "sourceVersion": 2,
+    "sourceVersionId": "analysis-content-0f2...:v2",
+    "role": "dataSource",
+    "targetKind": "content",
+    "targetSlot": "source"
+  }
+}
+```
+
+Completed geoprocessing jobs that carry the same `analysis.content.*` metadata
+persist retained result-artifact records during terminal callback handling. The
+binding fields are intentionally stable so downstream maps, dashboards,
+reports, apps, and workflows can reference `artifactId` plus the source
+content version instead of duplicating preview or job state.
+
+## Job Diagnostics
+
+`GET /api/v1/analysis/jobs/{jobId}/logs?limit=` returns the last bounded log
+entries. The default limit is `100`, the maximum is `200`, and values less than
+or equal to zero return `400`.
+
+```json
+{
+  "jobId": "failed-job",
+  "entries": [
+    {
+      "timestamp": "2026-05-24T10:00:00Z",
+      "level": "Error",
+      "message": "validation failed",
+      "phase": "validation",
+      "metadata": { "code": "invalid-distance" }
+    }
+  ],
+  "totalCount": 2,
+  "truncated": true
+}
+```
+
+If no execution log store is registered, the endpoint returns `200` with an
+empty entry list. Messages and phases are line-normalized, capped to 512
+characters, and replaced with a generic failure message when they look like
+stack traces, provider internals, connection strings, or secret-bearing text.
+Metadata keys containing password, secret, or connection are omitted; remaining
+metadata is capped to 20 entries.
+
+`GET /api/v1/analysis/jobs/{jobId}/failure` is only valid for failed or
+cancelled jobs. Failed jobs return a safe classification:
+
+```json
+{
+  "jobId": "failed-job",
+  "classification": "validationFailed",
+  "message": "validation failed: invalid buffer distance",
+  "isTerminal": true,
+  "failedAt": "2026-05-24T10:01:00Z"
+}
+```
+
+Classification values are `validationFailed`, `authorizationDenied`,
+`cancelled`, `timedOut`, `artifactOutputFailed`, `executionFailed`,
+`storeUnavailable`, and `unknown`. Non-failed, non-cancelled jobs return
+`409 Conflict`.
+
+## Storage Notes
+
+Postgres-backed deployments store this surface in migration
+`035_CreateAnalysisContent.sql`:
+
+- `honua.analysis_content_items`
+- `honua.analysis_content_versions`
+- `honua.analysis_result_artifacts`
+
+The server also registers an in-memory store as a fallback when no provider
+overrides `IAnalysisContentStore`. Postgres registration replaces it in normal
+PostGIS deployments.
+
+Related contracts:
+
+- [Console Job Observability](console-job-observability.md) documents the
+  broader `/api/v1/admin/jobs/**` operator job surface.
+- [Analysis Report Endpoints](../operator/CONTROL_PLANE_API.md#analysis-report-endpoints)
+  document report retrieval and rendering over completed analysis jobs.

--- a/docs/admin-api/analysis-content.md
+++ b/docs/admin-api/analysis-content.md
@@ -113,6 +113,11 @@ omitted, it defaults to the latest version id. `createdFromJobId` and
 `createdFromArtifactIds` are provenance fields for versions derived from prior
 results.
 
+Version creation re-reads the latest item state and retries bounded store
+conflicts before returning `409 Conflict`. Clients that receive `409` should
+reopen `versions/latest`, rebase their payload if needed, and submit a new
+version request.
+
 The public slice reopens content by known `itemId` plus either `latest` or an
 explicit version number; it does not expose a list route yet. `contentHash` is
 computed from the saved `savedQuery` or `analysisPackage` payload only, so
@@ -296,7 +301,7 @@ record and a binding clients can place into downstream packages:
 }
 ```
 
-Completed geoprocessing jobs that carry `analysis.content.item_id`,
+Terminal geoprocessing jobs that carry `analysis.content.item_id`,
 `analysis.content.version`, and `analysis.content.version_id` persist retained
 result-artifact records during terminal callback handling. These records store
 metadata, provenance, and the artifact URI produced by the job result package;
@@ -352,6 +357,19 @@ Classification values are `validationFailed`, `authorizationDenied`,
 `cancelled`, `timedOut`, `artifactOutputFailed`, `executionFailed`,
 `storeUnavailable`, and `unknown`. Non-failed, non-cancelled jobs return
 `409 Conflict`.
+
+## Runtime Notes
+
+Analysis content emits `honua.analysis_content.*` activities for create,
+version, preview, submit/rerun, artifact, log, and failure flows. The
+`honua.analysis_content.operations_total` counter is tagged by operation and
+`success` or `error`; bounded version-conflict retries are logged before a
+final `409` is returned.
+
+Saved-query previews are high-cardinality ad hoc feature queries, so the API
+does not add exact-response caching for preview responses. Persisted artifact
+records are metadata and binding handles only; artifact bytes remain in the
+backing artifact or job-result store.
 
 ## Storage Notes
 

--- a/docs/admin-api/analysis-content.md
+++ b/docs/admin-api/analysis-content.md
@@ -333,12 +333,17 @@ or equal to zero return `400`.
 }
 ```
 
-If no execution log store is registered, the endpoint returns `200` with an
-empty entry list. Messages and phases are line-normalized, capped to 512
-characters, and replaced with a generic failure message when they look like
-stack traces, provider internals, connection strings, or secret-bearing text.
-Metadata keys containing password, secret, or connection are omitted; remaining
-metadata is capped to 20 entries.
+The job is resolved through the job service before any log content is returned,
+so an unknown `jobId` returns `404` (not `200` with an empty list) and the same
+job-read authorization enforced by the failure endpoint is applied first. For a
+known job with no execution log store registered, the endpoint returns `200`
+with an empty entry list. Messages, phases, and metadata values are
+line-normalized, capped to 512 characters, and replaced with a generic failure
+message when they look like stack traces, provider internals, connection
+strings, or secret-bearing text (secret, token, credential, api key, or bearer
+values) — including secret-bearing values stored under otherwise innocuous
+metadata keys. Metadata keys containing password, secret, or connection are
+omitted; remaining metadata is capped to 20 entries.
 
 `GET /api/v1/analysis/jobs/{jobId}/failure` is only valid for failed or
 cancelled jobs. Failed jobs return a safe classification:

--- a/docs/developer/api-specs/README.md
+++ b/docs/developer/api-specs/README.md
@@ -85,6 +85,10 @@ See the [OGC API Coverages Coverage](../../gis/specifications/ogc-api-coverages-
 
 > **Note**: The runtime admin OpenAPI endpoint serves this bundled `admin-api.json` contract snapshot.
 > Use the [Server Management API guide](../../operator/CONTROL_PLANE_API.md) and `/api/v1/admin/config` for operational guidance.
+> The saved-query and analysis-package content surface lives beside the admin
+> API under `/api/v1/analysis/**`; its current markdown contract is
+> [Analysis Content](../../admin-api/analysis-content.md) until it is promoted
+> into the generated control-plane OpenAPI snapshot.
 >
 > **Migration scanner note**: `POST /api/v1/admin/import/scan` returns the inventory artifact itself, not the usual admin envelope, and a `200` response can still carry `scanCompleteness.status = "failed"`.
 > Request aliases normalize `sourceKind` to `geoserver-rest` or `arcgis-geoservices-rest`, and dependency addresses plus secret-like metadata are sanitized for planning-safe export.
@@ -112,6 +116,8 @@ See the [OGC API Coverages Coverage](../../gis/specifications/ogc-api-coverages-
 - Inspect deploy preflight and upgrade-readiness state per Honua instance
 - Manage geofence alert zones, realtime alert rules, draft validation, enable/disable state, and delivery health for Console Operate workflows
 - Inspect runtime license status, upload signed license files when enabled, and read the active feature/entitlement inventory
+- Save and reopen analysis content under `/api/v1/analysis/**` using the
+  markdown contract while the OpenAPI snapshot catches up
 
 {% swagger src="admin-api.json" %}
 {% endswagger %}
@@ -198,6 +204,7 @@ Control-plane SDK governance and contract diff checks:
 - [**Geospatial Data APIs**](../../gis/STANDARDS_APIS.md) - Protocol overview and selection guide
 - [**Server Management API**](../../operator/CONTROL_PLANE_API.md) - Admin API guide and key workflows
 - [**Console Job Observability**](../../admin-api/console-job-observability.md) - Durable job viewer contract for Console and admin integrations
+- [**Analysis Content**](../../admin-api/analysis-content.md) - Saved-query and analysis-package versions, preview artifacts, runs/reruns, artifact bindings, and safe failed-job diagnostics
 - [**Control Plane Versioning Policy**](../CONTROL_PLANE_VERSIONING_POLICY.md) - Breaking-change and deprecation lifecycle
 - [**Control Plane Migration Guide**](../CONTROL_PLANE_MIGRATION_GUIDE.md) - SDK quickstart and upgrade steps
 - [**API Examples**](../API_EXAMPLES.md) - Code examples for the major shipped protocols

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -8,12 +8,13 @@ This map summarizes source-backed runtime capabilities in `honua-server`.
 - OGC API Features, Tiles, Maps, Coverages, Processes, WFS 2.0, WMS 1.3, WMTS 1.0, WCS 2.0.1, OData v4, STAC catalog/search/items, COG registration, vector tiles, Terrain-RGB tiles, and elevation value/profile APIs.
 - Output formats and negotiation for JSON, GeoJSON, PBF, FlatGeobuf, GeoParquet, GeoArrow, and native GeoBuf when supported by the feature store.
 - File import for GeoJSON, Shapefile, GeoPackage, GPX, KML, WKT, FlatGeobuf, File Geodatabase zips, GeoParquet, and raster import; ArcGIS GeoServices REST layer import and migration inventory; GeoServer REST migration inventory, dry-run validation, and bounded PostGIS-backed catalog apply; and cross-server consume probes.
-- Streaming feature change/events endpoints and async geoprocessing over the canonical process runtime.
+- Streaming feature change/events endpoints, async geoprocessing over the canonical process runtime, and durable analysis content for saved-query/package versions plus reusable result artifacts.
 
 ## Control Plane
 
 - Admin APIs for auth, capabilities, version, connections, service settings, layer publishing, Metadata v2 environment inventory, release packages, compatibility prevalidation, metadata resources, styles, SLD import/export, style suggestions, imports, manifests, GitOps watch/drift/approval, deployment control, observability, geofence zones and alert rules, cache, rate limits, license, identity/OIDC, users, roles, geocoding, tile operations, and scene datasets.
 - Console/Studio APIs for server-owned content metadata, action checks, mutable Studio package drafts, immutable content versions, validation, preview plans, publication requests, reopen, comparison, and rollback for query, analysis, map, dashboard, report, form, app, workflow, GP, and ETL packages.
+- Analysis content APIs for saving query/package content versions, previewing saved queries, submitting/rerunning analysis packages, resolving artifact bindings, and exposing safe failed-job diagnostics.
 - Spec workspace endpoints for validate, plan, apply, cancel, artifacts, and grounding helpers.
 - Runtime licensing loads offline Ed25519-signed JSON envelopes, publishes active edition/entitlement status through admin and health surfaces, and gates paid features by entitlement key with HTTP 402 or gRPC `FAILED_PRECONDITION`.
 - Configuration discovery, production monitoring, performance metrics, query-cache stats, health endpoints, OpenTelemetry, structured logs, Redis/in-memory caching, and output caching.

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -2900,6 +2900,51 @@
       ]
     },
     {
+      "surfaceId": "analysis-content",
+      "displayName": "Analysis content and artifact HTTP surface",
+      "surfaceKind": "http-route-family",
+      "protocol": "Analysis Content",
+      "canonicalIdentifier": "/api/v1/analysis/content/* + /api/v1/analysis/artifacts/* + /api/v1/analysis/jobs/*",
+      "parentSurfaceId": null,
+      "endpointPrefixes": [
+        "/api/v1/analysis/content/",
+        "/api/v1/analysis/artifacts/",
+        "/api/v1/analysis/jobs/"
+      ],
+      "endpointExactMatches": [],
+      "endpointContains": [],
+      "operationKeys": [],
+      "proofs": [
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "EndpointRegistry coverage plus analysis content endpoint integration tests",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/EndpointRegistry.cs",
+            "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#1182",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "scenario-depth",
+          "proofMechanism": "Saved-query versioning and preview, analysis-package submit/rerun, artifact binding metadata, and safe failed-job diagnostics are covered by focused integration tests",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/GeoprocessingArtifactPersistenceTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#1182",
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
       "surfaceId": "analysis-reporting",
       "displayName": "Analysis report HTTP surface",
       "surfaceKind": "http-route-family",

--- a/docs/operator/CONTROL_PLANE_API.md
+++ b/docs/operator/CONTROL_PLANE_API.md
@@ -1107,7 +1107,9 @@ authorization. They persist saved-query and analysis-package content items as
 immutable versions, preview saved queries through the canonical feature-query
 pipeline, submit and rerun analysis packages through the canonical
 geoprocessing runtime, and expose stable artifact bindings for downstream maps,
-dashboards, reports, apps, and workflows.
+dashboards, reports, apps, and workflows. Responses are plain camelCase JSON
+DTOs with shared admin `application/problem+json` errors, not the older admin
+envelope shape.
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
@@ -1127,9 +1129,12 @@ Saved-query previews default to 25 features and clamp at 200. The preview path
 compiles any saved `filterPlan`, validates the canonical query against the
 target layer, and records a one-hour `preview` artifact. Analysis package run
 requests stamp the submitted job with `analysis.content.*` metadata for source
-item id, version, version id, source SRID, source units, parameters, and rerun
-links. Failed-job diagnostics redact stack traces, provider internals,
-connection strings, password/secret metadata, and long diagnostic values.
+item id, version, version id, source SRID, source units, package parameters,
+runtime parameters, and rerun links. Terminal geoprocessing jobs with analysis
+content source metadata persist retained artifact metadata and URIs; artifact
+bytes remain in the backing artifact store. Failed-job diagnostics redact stack
+traces, provider internals, connection strings, password/secret metadata, and
+long diagnostic values.
 
 Full request/response examples and storage notes are documented in
 [Analysis Content](../admin-api/analysis-content.md).

--- a/docs/operator/CONTROL_PLANE_API.md
+++ b/docs/operator/CONTROL_PLANE_API.md
@@ -1125,16 +1125,22 @@ envelope shape.
 | `/api/v1/analysis/jobs/{jobId}/logs` | GET | Read bounded, sanitized structured logs. |
 | `/api/v1/analysis/jobs/{jobId}/failure` | GET | Read safe failure classification for failed or cancelled jobs. |
 
-Saved-query previews default to 25 features and clamp at 200. The preview path
+Saved-query previews honor a request `limit` first, then the stored
+`previewLimit`, then the 25-feature default, and clamp at 200. The preview path
 compiles any saved `filterPlan`, validates the canonical query against the
-target layer, and records a one-hour `preview` artifact. Analysis package run
-requests stamp the submitted job with `analysis.content.*` metadata for source
-item id, version, version id, source SRID, source units, package parameters,
-runtime parameters, and rerun links. Terminal geoprocessing jobs with analysis
-content source metadata persist retained artifact metadata and URIs; artifact
-bytes remain in the backing artifact store. Failed-job diagnostics redact stack
-traces, provider internals, connection strings, password/secret metadata, and
-long diagnostic values.
+target layer, and records a one-hour `preview` artifact without exact-response
+caching. Version creation retries bounded store conflicts before returning
+`409`; callers should reopen `versions/latest` before rebasing after a
+conflict. Analysis package run requests stamp the submitted job with
+`analysis.content.*` metadata for source item id, version, version id, source
+SRID, source units, package parameters, runtime parameters, and rerun links.
+Terminal geoprocessing jobs with analysis content source metadata persist
+retained artifact metadata and URIs; artifact bytes remain in the backing
+artifact store. Failed-job diagnostics use bounded log tail reads and redact
+stack traces, provider internals, connection strings, password/secret metadata,
+and long diagnostic values. Analysis content emits `honua.analysis_content.*`
+activities and the `honua.analysis_content.operations_total` metric tagged by
+operation and success/error result.
 
 Full request/response examples and storage notes are documented in
 [Analysis Content](../admin-api/analysis-content.md).

--- a/docs/operator/CONTROL_PLANE_API.md
+++ b/docs/operator/CONTROL_PLANE_API.md
@@ -1100,6 +1100,40 @@ Notes:
   (`unauthenticated`, `permission_denied`, `not_found`, `failed_precondition`,
   `unavailable`).
 
+### **Analysis Content Endpoints**
+
+These routes also live at `/api/v1/analysis/...` and require admin
+authorization. They persist saved-query and analysis-package content items as
+immutable versions, preview saved queries through the canonical feature-query
+pipeline, submit and rerun analysis packages through the canonical
+geoprocessing runtime, and expose stable artifact bindings for downstream maps,
+dashboards, reports, apps, and workflows.
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/analysis/content/items` | POST | Create a saved-query or analysis-package item plus initial version. |
+| `/api/v1/analysis/content/items/{itemId}` | GET | Open the item and latest version. |
+| `/api/v1/analysis/content/items/{itemId}/versions/latest` | GET | Open the latest immutable version. |
+| `/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}` | GET | Open an explicit immutable version number. |
+| `/api/v1/analysis/content/items/{itemId}/versions` | POST | Create a new immutable version. |
+| `/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/preview` | POST | Preview a saved-query version and persist a short-lived preview artifact. |
+| `/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/runs` | POST | Submit an analysis-package version as a durable geoprocessing job. |
+| `/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/reruns` | POST | Rerun an analysis package with provenance and optional parameter overrides. |
+| `/api/v1/analysis/artifacts/{artifactId}` | GET | Resolve artifact metadata and a downstream binding reference. |
+| `/api/v1/analysis/jobs/{jobId}/logs` | GET | Read bounded, sanitized structured logs. |
+| `/api/v1/analysis/jobs/{jobId}/failure` | GET | Read safe failure classification for failed or cancelled jobs. |
+
+Saved-query previews default to 25 features and clamp at 200. The preview path
+compiles any saved `filterPlan`, validates the canonical query against the
+target layer, and records a one-hour `preview` artifact. Analysis package run
+requests stamp the submitted job with `analysis.content.*` metadata for source
+item id, version, version id, source SRID, source units, parameters, and rerun
+links. Failed-job diagnostics redact stack traces, provider internals,
+connection strings, password/secret metadata, and long diagnostic values.
+
+Full request/response examples and storage notes are documented in
+[Analysis Content](../admin-api/analysis-content.md).
+
 ---
 
 ## **Health Checks**

--- a/src/Honua.Core/Features/AnalysisContent/Abstractions/IAnalysisContentStore.cs
+++ b/src/Honua.Core/Features/AnalysisContent/Abstractions/IAnalysisContentStore.cs
@@ -6,6 +6,32 @@ using Honua.Core.Features.AnalysisContent.Domain;
 namespace Honua.Core.Features.AnalysisContent.Abstractions;
 
 /// <summary>
+/// Raised when a durable analysis content write conflicts with an existing item,
+/// version, or artifact record.
+/// </summary>
+public sealed class AnalysisContentStoreConflictException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AnalysisContentStoreConflictException"/> class.
+    /// </summary>
+    /// <param name="message">Safe conflict message.</param>
+    public AnalysisContentStoreConflictException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AnalysisContentStoreConflictException"/> class.
+    /// </summary>
+    /// <param name="message">Safe conflict message.</param>
+    /// <param name="innerException">Underlying provider exception.</param>
+    public AnalysisContentStoreConflictException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
 /// Durable store for saved-query and analysis-package content items, immutable versions,
 /// and job result artifact metadata.
 /// </summary>

--- a/src/Honua.Core/Features/AnalysisContent/Abstractions/IAnalysisContentStore.cs
+++ b/src/Honua.Core/Features/AnalysisContent/Abstractions/IAnalysisContentStore.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.AnalysisContent.Domain;
+
+namespace Honua.Core.Features.AnalysisContent.Abstractions;
+
+/// <summary>
+/// Durable store for saved-query and analysis-package content items, immutable versions,
+/// and job result artifact metadata.
+/// </summary>
+public interface IAnalysisContentStore
+{
+    /// <summary>
+    /// Creates a content item and its initial immutable version.
+    /// </summary>
+    /// <param name="item">Content item root.</param>
+    /// <param name="version">Initial immutable version.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The stored item root.</returns>
+    Task<AnalysisContentItem> CreateItemAsync(
+        AnalysisContentItem item,
+        AnalysisContentVersion version,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a content item root.
+    /// </summary>
+    /// <param name="itemId">Content item identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The item, or null when not found.</returns>
+    Task<AnalysisContentItem?> GetItemAsync(
+        string itemId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds an immutable version and advances the item current-version pointer.
+    /// </summary>
+    /// <param name="itemId">Content item identifier.</param>
+    /// <param name="version">Version to store.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The stored version.</returns>
+    Task<AnalysisContentVersion> AddVersionAsync(
+        string itemId,
+        AnalysisContentVersion version,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the latest or explicit version for a content item.
+    /// </summary>
+    /// <param name="itemId">Content item identifier.</param>
+    /// <param name="version">Explicit version, or null for the latest version.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The version, or null when not found.</returns>
+    Task<AnalysisContentVersion?> GetVersionAsync(
+        string itemId,
+        int? version = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all immutable versions for a content item in ascending version order.
+    /// </summary>
+    /// <param name="itemId">Content item identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Stored versions.</returns>
+    Task<IReadOnlyList<AnalysisContentVersion>> ListVersionsAsync(
+        string itemId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Inserts or updates durable result artifact metadata.
+    /// </summary>
+    /// <param name="artifact">Artifact metadata record.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The stored artifact record.</returns>
+    Task<ResultArtifactRecord> UpsertArtifactAsync(
+        ResultArtifactRecord artifact,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves durable result artifact metadata.
+    /// </summary>
+    /// <param name="artifactId">Artifact identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The artifact, or null when not found.</returns>
+    Task<ResultArtifactRecord?> GetArtifactAsync(
+        string artifactId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists artifacts created by a job.
+    /// </summary>
+    /// <param name="jobId">Job identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Artifact records in creation order.</returns>
+    Task<IReadOnlyList<ResultArtifactRecord>> ListArtifactsForJobAsync(
+        string jobId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/AnalysisContent/Abstractions/IAnalysisContentStore.cs
+++ b/src/Honua.Core/Features/AnalysisContent/Abstractions/IAnalysisContentStore.cs
@@ -32,6 +32,34 @@ public sealed class AnalysisContentStoreConflictException : Exception
 }
 
 /// <summary>
+/// Raised when the durable analysis content store cannot be reached or used because of an
+/// infrastructure outage (connection failure, timeout, resource exhaustion, or backend
+/// authorization failure) rather than a request-level problem. Callers map this to a
+/// retryable 503 so a transient store outage is not reported as a generic 500.
+/// </summary>
+public sealed class AnalysisContentStoreUnavailableException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AnalysisContentStoreUnavailableException"/> class.
+    /// </summary>
+    /// <param name="message">Safe, store-neutral unavailability message.</param>
+    public AnalysisContentStoreUnavailableException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AnalysisContentStoreUnavailableException"/> class.
+    /// </summary>
+    /// <param name="message">Safe, store-neutral unavailability message.</param>
+    /// <param name="innerException">Underlying provider exception.</param>
+    public AnalysisContentStoreUnavailableException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
 /// Durable store for saved-query and analysis-package content items, immutable versions,
 /// and job result artifact metadata.
 /// </summary>

--- a/src/Honua.Core/Features/AnalysisContent/AnalysisContentJsonContext.cs
+++ b/src/Honua.Core/Features/AnalysisContent/AnalysisContentJsonContext.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.NlQuery.Domain;
+
+namespace Honua.Core.Features.AnalysisContent;
+
+/// <summary>
+/// Source-generated JSON metadata for analysis content domain contracts.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true)]
+[JsonSerializable(typeof(AnalysisContentItem))]
+[JsonSerializable(typeof(AnalysisContentVersion))]
+[JsonSerializable(typeof(AnalysisContentVersion[]))]
+[JsonSerializable(typeof(SavedQueryContent))]
+[JsonSerializable(typeof(AnalysisPackageContent))]
+[JsonSerializable(typeof(ArtifactBindingRef))]
+[JsonSerializable(typeof(ArtifactBindingRef[]))]
+[JsonSerializable(typeof(ResultArtifactRecord))]
+[JsonSerializable(typeof(ResultArtifactRecord[]))]
+[JsonSerializable(typeof(SavedQueryPreviewResult))]
+[JsonSerializable(typeof(SavedQueryPreviewFeature))]
+[JsonSerializable(typeof(SavedQueryPreviewFeature[]))]
+[JsonSerializable(typeof(AnalysisJobFailure))]
+[JsonSerializable(typeof(AnalysisJobLogs))]
+[JsonSerializable(typeof(AnalysisJobLogEntry))]
+[JsonSerializable(typeof(AnalysisJobLogEntry[]))]
+[JsonSerializable(typeof(ExecutionLogEntry))]
+[JsonSerializable(typeof(FilterPlan))]
+[JsonSerializable(typeof(FilterPlanClause))]
+[JsonSerializable(typeof(FilterPlanClause[]))]
+[JsonSerializable(typeof(ComparisonClause))]
+[JsonSerializable(typeof(SpatialClause))]
+[JsonSerializable(typeof(TemporalClause))]
+[JsonSerializable(typeof(NestedClause))]
+[JsonSerializable(typeof(AnalysisIntent))]
+[JsonSerializable(typeof(IntentConstraints))]
+[JsonSerializable(typeof(AnalysisPlan))]
+[JsonSerializable(typeof(AnalysisPlanStep))]
+[JsonSerializable(typeof(AnalysisPlanStep[]))]
+[JsonSerializable(typeof(AnalysisResultPackage))]
+[JsonSerializable(typeof(ArtifactRef))]
+[JsonSerializable(typeof(ArtifactRef[]))]
+[JsonSerializable(typeof(WorkspaceRef))]
+[JsonSerializable(typeof(WorkspaceRef[]))]
+[JsonSerializable(typeof(ProvenanceRecord))]
+[JsonSerializable(typeof(ProvenanceSource))]
+[JsonSerializable(typeof(ProvenanceSource[]))]
+[JsonSerializable(typeof(ResultSummary))]
+[JsonSerializable(typeof(GeoprocessingError))]
+[JsonSerializable(typeof(GeoprocessingError[]))]
+[JsonSerializable(typeof(GeoprocessingValidationFailure))]
+[JsonSerializable(typeof(GeoprocessingValidationFailure[]))]
+[JsonSerializable(typeof(ImmutableDictionary<string, object?>))]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+[JsonSerializable(typeof(string[]))]
+public sealed partial class AnalysisContentJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Core/Features/AnalysisContent/AnalysisContentMetadataKeys.cs
+++ b/src/Honua.Core/Features/AnalysisContent/AnalysisContentMetadataKeys.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.AnalysisContent;
+
+/// <summary>
+/// Well-known metadata keys used to link geoprocessing jobs and result artifacts
+/// back to durable analysis content versions.
+/// </summary>
+public static class AnalysisContentMetadataKeys
+{
+    /// <summary>
+    /// Source content item identifier.
+    /// </summary>
+    public const string ItemId = "analysis.content.item_id";
+
+    /// <summary>
+    /// Source content item version number.
+    /// </summary>
+    public const string Version = "analysis.content.version";
+
+    /// <summary>
+    /// Source content version identifier.
+    /// </summary>
+    public const string VersionId = "analysis.content.version_id";
+
+    /// <summary>
+    /// Source content kind.
+    /// </summary>
+    public const string Kind = "analysis.content.kind";
+
+    /// <summary>
+    /// Source spatial reference assumption.
+    /// </summary>
+    public const string SourceSrid = "analysis.content.source_srid";
+
+    /// <summary>
+    /// Source unit assumption.
+    /// </summary>
+    public const string SourceUnits = "analysis.content.source_units";
+
+    /// <summary>
+    /// Job identifier that a rerun derives from.
+    /// </summary>
+    public const string RerunOfJobId = "analysis.content.rerun_of_job_id";
+
+    /// <summary>
+    /// Result package identifier that a rerun derives from.
+    /// </summary>
+    public const string RerunOfResultPackageId = "analysis.content.rerun_of_result_package_id";
+}

--- a/src/Honua.Core/Features/AnalysisContent/Domain/AnalysisContentContracts.cs
+++ b/src/Honua.Core/Features/AnalysisContent/Domain/AnalysisContentContracts.cs
@@ -1,0 +1,695 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.NlQuery.Domain;
+
+namespace Honua.Core.Features.AnalysisContent.Domain;
+
+/// <summary>
+/// Kind of durable analysis content item.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<AnalysisContentKind>))]
+public enum AnalysisContentKind
+{
+    /// <summary>
+    /// A reusable feature-query definition.
+    /// </summary>
+    [JsonStringEnumMemberName("savedQuery")]
+    SavedQuery,
+
+    /// <summary>
+    /// A reusable analysis plan package.
+    /// </summary>
+    [JsonStringEnumMemberName("analysisPackage")]
+    AnalysisPackage
+}
+
+/// <summary>
+/// Lifecycle state for analysis content records.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<AnalysisContentLifecycle>))]
+public enum AnalysisContentLifecycle
+{
+    /// <summary>
+    /// Content is available for normal use.
+    /// </summary>
+    [JsonStringEnumMemberName("active")]
+    Active,
+
+    /// <summary>
+    /// Content is retained but hidden from primary lists.
+    /// </summary>
+    [JsonStringEnumMemberName("archived")]
+    Archived,
+
+    /// <summary>
+    /// Content has been soft-deleted.
+    /// </summary>
+    [JsonStringEnumMemberName("deleted")]
+    Deleted
+}
+
+/// <summary>
+/// Retention state for result artifacts created by analysis jobs.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<ResultArtifactRetentionState>))]
+public enum ResultArtifactRetentionState
+{
+    /// <summary>
+    /// Artifact is a short-lived preview.
+    /// </summary>
+    [JsonStringEnumMemberName("preview")]
+    Preview,
+
+    /// <summary>
+    /// Artifact is retained under the job result package.
+    /// </summary>
+    [JsonStringEnumMemberName("retained")]
+    Retained,
+
+    /// <summary>
+    /// Artifact has been promoted for longer-lived downstream use.
+    /// </summary>
+    [JsonStringEnumMemberName("promoted")]
+    Promoted,
+
+    /// <summary>
+    /// Artifact retention has expired.
+    /// </summary>
+    [JsonStringEnumMemberName("expired")]
+    Expired
+}
+
+/// <summary>
+/// Promotion state for a result artifact.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<ResultArtifactPromotionState>))]
+public enum ResultArtifactPromotionState
+{
+    /// <summary>
+    /// Artifact has not been promoted.
+    /// </summary>
+    [JsonStringEnumMemberName("none")]
+    None,
+
+    /// <summary>
+    /// Artifact has been promoted.
+    /// </summary>
+    [JsonStringEnumMemberName("promoted")]
+    Promoted
+}
+
+/// <summary>
+/// Safe failure classes exposed to clients for failed analysis jobs.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<AnalysisJobFailureClassification>))]
+public enum AnalysisJobFailureClassification
+{
+    /// <summary>
+    /// Job failed during request or plan validation.
+    /// </summary>
+    [JsonStringEnumMemberName("validationFailed")]
+    ValidationFailed,
+
+    /// <summary>
+    /// Job failed because the caller was not authorized.
+    /// </summary>
+    [JsonStringEnumMemberName("authorizationDenied")]
+    AuthorizationDenied,
+
+    /// <summary>
+    /// Job was cancelled.
+    /// </summary>
+    [JsonStringEnumMemberName("cancelled")]
+    Cancelled,
+
+    /// <summary>
+    /// Job exceeded its allowed runtime.
+    /// </summary>
+    [JsonStringEnumMemberName("timedOut")]
+    TimedOut,
+
+    /// <summary>
+    /// Job failed while materializing output artifacts.
+    /// </summary>
+    [JsonStringEnumMemberName("artifactOutputFailed")]
+    ArtifactOutputFailed,
+
+    /// <summary>
+    /// Job failed during execution.
+    /// </summary>
+    [JsonStringEnumMemberName("executionFailed")]
+    ExecutionFailed,
+
+    /// <summary>
+    /// The backing job or log store was unavailable.
+    /// </summary>
+    [JsonStringEnumMemberName("storeUnavailable")]
+    StoreUnavailable,
+
+    /// <summary>
+    /// Failure type could not be classified more specifically.
+    /// </summary>
+    [JsonStringEnumMemberName("unknown")]
+    Unknown
+}
+
+/// <summary>
+/// Durable analysis content item root. Versions carry immutable payloads.
+/// </summary>
+public sealed record AnalysisContentItem
+{
+    /// <summary>
+    /// Stable item identifier used by downstream bindings.
+    /// </summary>
+    public required string ItemId { get; init; }
+
+    /// <summary>
+    /// Content item kind.
+    /// </summary>
+    public required AnalysisContentKind Kind { get; init; }
+
+    /// <summary>
+    /// Stable machine-readable name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Optional display title.
+    /// </summary>
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Optional owner identifier.
+    /// </summary>
+    public string? OwnerId { get; init; }
+
+    /// <summary>
+    /// Visibility scope such as personal, organization, or public.
+    /// </summary>
+    public string Visibility { get; init; } = "organization";
+
+    /// <summary>
+    /// Current version number.
+    /// </summary>
+    public required int CurrentVersion { get; init; }
+
+    /// <summary>
+    /// Current version identifier.
+    /// </summary>
+    public required string CurrentVersionId { get; init; }
+
+    /// <summary>
+    /// Item lifecycle state.
+    /// </summary>
+    public AnalysisContentLifecycle Lifecycle { get; init; } = AnalysisContentLifecycle.Active;
+
+    /// <summary>
+    /// UTC timestamp when the item was created.
+    /// </summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>
+    /// UTC timestamp when the item was last updated.
+    /// </summary>
+    public required DateTimeOffset UpdatedAt { get; init; }
+
+    /// <summary>
+    /// Principal that created the item, when known.
+    /// </summary>
+    public string? CreatedBy { get; init; }
+}
+
+/// <summary>
+/// Immutable analysis content version payload.
+/// </summary>
+public sealed record AnalysisContentVersion
+{
+    /// <summary>
+    /// Stable version identifier.
+    /// </summary>
+    public required string VersionId { get; init; }
+
+    /// <summary>
+    /// Parent content item identifier.
+    /// </summary>
+    public required string ItemId { get; init; }
+
+    /// <summary>
+    /// Monotonic item-scoped version number.
+    /// </summary>
+    public required int Version { get; init; }
+
+    /// <summary>
+    /// Version content kind.
+    /// </summary>
+    public required AnalysisContentKind Kind { get; init; }
+
+    /// <summary>
+    /// Saved-query content for <see cref="AnalysisContentKind.SavedQuery"/>.
+    /// </summary>
+    public SavedQueryContent? SavedQuery { get; init; }
+
+    /// <summary>
+    /// Analysis package content for <see cref="AnalysisContentKind.AnalysisPackage"/>.
+    /// </summary>
+    public AnalysisPackageContent? AnalysisPackage { get; init; }
+
+    /// <summary>
+    /// Stable SHA-256 content hash of the version payload.
+    /// </summary>
+    public required string ContentHash { get; init; }
+
+    /// <summary>
+    /// Optional parent version identifier when this version derives from another.
+    /// </summary>
+    public string? BasedOnVersionId { get; init; }
+
+    /// <summary>
+    /// Optional source job identifier when this version was created from a rerun or result.
+    /// </summary>
+    public string? CreatedFromJobId { get; init; }
+
+    /// <summary>
+    /// Source artifact identifiers when this version was created from job results.
+    /// </summary>
+    public IReadOnlyList<string> CreatedFromArtifactIds { get; init; } = [];
+
+    /// <summary>
+    /// UTC timestamp when this immutable version was created.
+    /// </summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>
+    /// Principal that created the version, when known.
+    /// </summary>
+    public string? CreatedBy { get; init; }
+}
+
+/// <summary>
+/// Durable saved-query payload compiled through the canonical query pipeline.
+/// </summary>
+public sealed record SavedQueryContent
+{
+    /// <summary>
+    /// Original natural-language query text, when available.
+    /// </summary>
+    public string? NaturalLanguageQuery { get; init; }
+
+    /// <summary>
+    /// Target layer identifier for preview and downstream query execution.
+    /// </summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>
+    /// Optional service name associated with the layer.
+    /// </summary>
+    public string? ServiceName { get; init; }
+
+    /// <summary>
+    /// Structured filter plan produced by natural-language query grounding.
+    /// </summary>
+    public FilterPlan? FilterPlan { get; init; }
+
+    /// <summary>
+    /// Attribute field projection. Empty means all fields.
+    /// </summary>
+    public IReadOnlyList<string> OutFields { get; init; } = [];
+
+    /// <summary>
+    /// Desired output spatial reference identifier.
+    /// </summary>
+    public int? OutputSrid { get; init; }
+
+    /// <summary>
+    /// Default preview limit for this saved query.
+    /// </summary>
+    public int? PreviewLimit { get; init; }
+
+    /// <summary>
+    /// Preferred output format for downstream consumers.
+    /// </summary>
+    public string? OutputFormat { get; init; }
+
+    /// <summary>
+    /// Unit assumptions attached to the query content.
+    /// </summary>
+    public string? Units { get; init; }
+
+    /// <summary>
+    /// Additional AOT-friendly metadata.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
+}
+
+/// <summary>
+/// Durable analysis package payload submitted through the canonical geoprocessing runtime.
+/// </summary>
+public sealed record AnalysisPackageContent
+{
+    /// <summary>
+    /// User intent that produced the plan, when captured.
+    /// </summary>
+    public AnalysisIntent? Intent { get; init; }
+
+    /// <summary>
+    /// Executable analysis plan.
+    /// </summary>
+    public required AnalysisPlan Plan { get; init; }
+
+    /// <summary>
+    /// Package parameters that can be overridden by reruns.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Parameters { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Requested output artifact kinds.
+    /// </summary>
+    public IReadOnlyList<ArtifactKind> RequestedArtifacts { get; init; } = [];
+
+    /// <summary>
+    /// Optional downstream binding hints for artifacts produced by this package.
+    /// </summary>
+    public IReadOnlyList<ArtifactBindingRef> BindingHints { get; init; } = [];
+
+    /// <summary>
+    /// Spatial reference assumption for the package.
+    /// </summary>
+    public int? SpatialReferenceId { get; init; }
+
+    /// <summary>
+    /// Unit assumption for the package.
+    /// </summary>
+    public string? Units { get; init; }
+
+    /// <summary>
+    /// Additional AOT-friendly metadata.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
+}
+
+/// <summary>
+/// Stable downstream binding reference for an analysis artifact.
+/// </summary>
+public sealed record ArtifactBindingRef
+{
+    /// <summary>
+    /// Stable artifact identifier.
+    /// </summary>
+    public required string ArtifactId { get; init; }
+
+    /// <summary>
+    /// Source content item identifier, when available.
+    /// </summary>
+    public string? SourceItemId { get; init; }
+
+    /// <summary>
+    /// Source item version number, when available.
+    /// </summary>
+    public int? SourceVersion { get; init; }
+
+    /// <summary>
+    /// Source content version identifier, when available.
+    /// </summary>
+    public string? SourceVersionId { get; init; }
+
+    /// <summary>
+    /// Binding role such as dataSource or preview.
+    /// </summary>
+    public string Role { get; init; } = "dataSource";
+
+    /// <summary>
+    /// Target content kind such as map, dashboard, report, app, or workflow.
+    /// </summary>
+    public string TargetKind { get; init; } = "content";
+
+    /// <summary>
+    /// Target slot name within the downstream content package.
+    /// </summary>
+    public string TargetSlot { get; init; } = "default";
+}
+
+/// <summary>
+/// Durable metadata for an artifact produced by a saved query preview or analysis job.
+/// </summary>
+public sealed record ResultArtifactRecord
+{
+    /// <summary>
+    /// Stable artifact identifier.
+    /// </summary>
+    public required string ArtifactId { get; init; }
+
+    /// <summary>
+    /// Result package identifier that contains this artifact.
+    /// </summary>
+    public required string ResultPackageId { get; init; }
+
+    /// <summary>
+    /// Source execution job identifier.
+    /// </summary>
+    public required string JobId { get; init; }
+
+    /// <summary>
+    /// Source content item identifier.
+    /// </summary>
+    public required string SourceItemId { get; init; }
+
+    /// <summary>
+    /// Source content item version number.
+    /// </summary>
+    public required int SourceVersion { get; init; }
+
+    /// <summary>
+    /// Source content version identifier.
+    /// </summary>
+    public required string SourceVersionId { get; init; }
+
+    /// <summary>
+    /// Artifact kind.
+    /// </summary>
+    public required ArtifactKind Kind { get; init; }
+
+    /// <summary>
+    /// Human-readable artifact label.
+    /// </summary>
+    public required string Label { get; init; }
+
+    /// <summary>
+    /// Optional artifact URI.
+    /// </summary>
+    public string? Uri { get; init; }
+
+    /// <summary>
+    /// Optional artifact media type.
+    /// </summary>
+    public string? ContentType { get; init; }
+
+    /// <summary>
+    /// Optional artifact size in bytes.
+    /// </summary>
+    public long? ByteSize { get; init; }
+
+    /// <summary>
+    /// AOT-friendly artifact metadata.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// AOT-friendly artifact provenance metadata.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Provenance { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Retention state.
+    /// </summary>
+    public ResultArtifactRetentionState RetentionState { get; init; } = ResultArtifactRetentionState.Retained;
+
+    /// <summary>
+    /// Promotion state.
+    /// </summary>
+    public ResultArtifactPromotionState PromotionState { get; init; } = ResultArtifactPromotionState.None;
+
+    /// <summary>
+    /// UTC timestamp when the artifact record was created.
+    /// </summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>
+    /// Optional UTC expiry timestamp.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+}
+
+/// <summary>
+/// Bounded feature preview returned for saved-query previews.
+/// </summary>
+public sealed record SavedQueryPreviewResult
+{
+    /// <summary>
+    /// Preview artifact identifier.
+    /// </summary>
+    public required string PreviewArtifactId { get; init; }
+
+    /// <summary>
+    /// Source content item identifier.
+    /// </summary>
+    public required string ItemId { get; init; }
+
+    /// <summary>
+    /// Source version number.
+    /// </summary>
+    public required int Version { get; init; }
+
+    /// <summary>
+    /// Target layer identifier.
+    /// </summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>
+    /// Preview feature items.
+    /// </summary>
+    public IReadOnlyList<SavedQueryPreviewFeature> Features { get; init; } = [];
+
+    /// <summary>
+    /// Result count reported by the feature store, when available.
+    /// </summary>
+    public long? TotalCount { get; init; }
+
+    /// <summary>
+    /// True when the result set may contain more rows than the preview limit.
+    /// </summary>
+    public bool ExceededPreviewLimit { get; init; }
+
+    /// <summary>
+    /// Stable binding metadata for downstream content packages.
+    /// </summary>
+    public required ArtifactBindingRef Binding { get; init; }
+}
+
+/// <summary>
+/// Compact feature shape used by saved-query previews.
+/// </summary>
+public sealed record SavedQueryPreviewFeature
+{
+    /// <summary>
+    /// Feature identifier.
+    /// </summary>
+    public required long Id { get; init; }
+
+    /// <summary>
+    /// Feature attributes.
+    /// </summary>
+    public IReadOnlyDictionary<string, object?> Attributes { get; init; } =
+        ImmutableDictionary<string, object?>.Empty;
+
+    /// <summary>
+    /// True when the feature has a geometry payload.
+    /// </summary>
+    public bool HasGeometry { get; init; }
+
+    /// <summary>
+    /// Creates a preview feature from a canonical feature.
+    /// </summary>
+    /// <param name="feature">Canonical feature.</param>
+    /// <returns>Preview feature.</returns>
+    public static SavedQueryPreviewFeature FromFeature(Feature feature)
+        => new()
+        {
+            Id = feature.Id,
+            Attributes = feature.Attributes,
+            HasGeometry = feature.Geometry is { Length: > 0 }
+        };
+}
+
+/// <summary>
+/// Safe failed-job diagnostic summary.
+/// </summary>
+public sealed record AnalysisJobFailure
+{
+    /// <summary>
+    /// Job identifier.
+    /// </summary>
+    public required string JobId { get; init; }
+
+    /// <summary>
+    /// Safe failure classification.
+    /// </summary>
+    public required AnalysisJobFailureClassification Classification { get; init; }
+
+    /// <summary>
+    /// Safe client-facing failure message.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// True when the job is terminal.
+    /// </summary>
+    public required bool IsTerminal { get; init; }
+
+    /// <summary>
+    /// Failure timestamp, when available.
+    /// </summary>
+    public DateTimeOffset? FailedAt { get; init; }
+}
+
+/// <summary>
+/// Bounded structured logs for an analysis job.
+/// </summary>
+public sealed record AnalysisJobLogs
+{
+    /// <summary>
+    /// Job identifier.
+    /// </summary>
+    public required string JobId { get; init; }
+
+    /// <summary>
+    /// Safe structured log entries.
+    /// </summary>
+    public IReadOnlyList<AnalysisJobLogEntry> Entries { get; init; } = [];
+
+    /// <summary>
+    /// Number of source entries before truncation.
+    /// </summary>
+    public required int TotalCount { get; init; }
+
+    /// <summary>
+    /// True when entries were truncated to the requested bound.
+    /// </summary>
+    public required bool Truncated { get; init; }
+}
+
+/// <summary>
+/// Safe structured log entry for an analysis job.
+/// </summary>
+public sealed record AnalysisJobLogEntry
+{
+    /// <summary>
+    /// UTC timestamp.
+    /// </summary>
+    public required DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>
+    /// Log level.
+    /// </summary>
+    public required ExecutionLogLevel Level { get; init; }
+
+    /// <summary>
+    /// Safe log message.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// Optional execution phase.
+    /// </summary>
+    public string? Phase { get; init; }
+
+    /// <summary>
+    /// Safe bounded metadata values.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Metadata { get; init; }
+}

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/IExecutionLogStore.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/IExecutionLogStore.cs
@@ -33,6 +33,18 @@ public interface IExecutionLogStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Retrieves the most recent structured log entries without reading the full log stream.
+    /// </summary>
+    /// <param name="operationId">Stable job identifier.</param>
+    /// <param name="limit">Maximum number of entries to return.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Tail entries in append order plus the total number of entries.</returns>
+    Task<ExecutionLogTail> TailAsync(
+        string operationId,
+        int limit,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Retrieves a page of structured log entries for the specified job in append order.
     /// </summary>
     /// <param name="operationId">Stable job identifier.</param>

--- a/src/Honua.Core/Features/ControlPlane/Domain/ExecutionQueries.cs
+++ b/src/Honua.Core/Features/ControlPlane/Domain/ExecutionQueries.cs
@@ -147,3 +147,19 @@ public sealed record ExecutionLogPage
     /// </summary>
     public string? NextCursor { get; init; }
 }
+
+/// <summary>
+/// Most recent structured execution log entries plus the total stream length.
+/// </summary>
+public sealed record ExecutionLogTail
+{
+    /// <summary>
+    /// Tail log entries returned in append order.
+    /// </summary>
+    public required IReadOnlyList<ExecutionLogEntry> Items { get; init; }
+
+    /// <summary>
+    /// Total number of entries in the backing log stream.
+    /// </summary>
+    public required int TotalCount { get; init; }
+}

--- a/src/Honua.Postgres/Features/AnalysisContent/PostgresAnalysisContentStore.cs
+++ b/src/Honua.Postgres/Features/AnalysisContent/PostgresAnalysisContentStore.cs
@@ -52,7 +52,9 @@ internal sealed class PostgresAnalysisContentStore : IAnalysisContentStore
         catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
         {
             await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException("Analysis content item conflicts with an existing record.", ex);
+            throw new AnalysisContentStoreConflictException(
+                "Analysis content item conflicts with an existing record.",
+                ex);
         }
     }
 
@@ -107,7 +109,9 @@ internal sealed class PostgresAnalysisContentStore : IAnalysisContentStore
         catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
         {
             await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException("Analysis content version conflicts with an existing record.", ex);
+            throw new AnalysisContentStoreConflictException(
+                "Analysis content version conflicts with an existing record.",
+                ex);
         }
     }
 

--- a/src/Honua.Postgres/Features/AnalysisContent/PostgresAnalysisContentStore.cs
+++ b/src/Honua.Postgres/Features/AnalysisContent/PostgresAnalysisContentStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Text.Json;
+using Honua.Core.Exceptions;
 using Honua.Core.Features.AnalysisContent;
 using Honua.Core.Features.AnalysisContent.Abstractions;
 using Honua.Core.Features.AnalysisContent.Domain;
@@ -299,6 +300,16 @@ internal sealed class PostgresAnalysisContentStore : IAnalysisContentStore
         try
         {
             return await operation().ConfigureAwait(false);
+        }
+        catch (ServiceUnavailableException ex)
+        {
+            // The shared connection provider classifies connect failures and broken circuits as
+            // ServiceUnavailableException before any raw NpgsqlException reaches this layer, so a
+            // real outage opens via OpenConnectionAsync and must be caught here too; otherwise it
+            // escapes as a generic 500 instead of the documented retryable 503.
+            throw new AnalysisContentStoreUnavailableException(
+                "The analysis content store is currently unavailable.",
+                ex);
         }
         catch (NpgsqlException ex) when (IsStoreUnavailable(ex))
         {

--- a/src/Honua.Postgres/Features/AnalysisContent/PostgresAnalysisContentStore.cs
+++ b/src/Honua.Postgres/Features/AnalysisContent/PostgresAnalysisContentStore.cs
@@ -30,254 +30,308 @@ internal sealed class PostgresAnalysisContentStore : IAnalysisContentStore
         _artifactsTable = SchemaSearchPath.QualifyTable("analysis_result_artifacts", schemaName);
     }
 
-    public async Task<AnalysisContentItem> CreateItemAsync(
+    public Task<AnalysisContentItem> CreateItemAsync(
         AnalysisContentItem item,
         AnalysisContentVersion version,
         CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(item);
-        ArgumentNullException.ThrowIfNull(version);
-
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-
-        try
+        => TranslateStoreFailuresAsync(async () =>
         {
-            await InsertItemAsync(connection, transaction, item, cancellationToken).ConfigureAwait(false);
-            await InsertVersionAsync(connection, transaction, version, cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            return item;
-        }
-        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
-        {
-            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            throw new AnalysisContentStoreConflictException(
-                "Analysis content item conflicts with an existing record.",
-                ex);
-        }
-    }
+            ArgumentNullException.ThrowIfNull(item);
+            ArgumentNullException.ThrowIfNull(version);
 
-    public async Task<AnalysisContentItem?> GetItemAsync(
+            await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+                .ConfigureAwait(false);
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                await InsertItemAsync(connection, transaction, item, cancellationToken).ConfigureAwait(false);
+                await InsertVersionAsync(connection, transaction, version, cancellationToken).ConfigureAwait(false);
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                return item;
+            }
+            catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                throw new AnalysisContentStoreConflictException(
+                    "Analysis content item conflicts with an existing record.",
+                    ex);
+            }
+        });
+
+    public Task<AnalysisContentItem?> GetItemAsync(
         string itemId,
         CancellationToken cancellationToken = default)
-    {
-        var sql = $"""
-            SELECT item_id, kind, name, title, owner_id, visibility, current_version,
-                   current_version_id, lifecycle, created_at, updated_at, created_by
-            FROM {_itemsTable}
-            WHERE item_id = @item_id
-            """;
+        => TranslateStoreFailuresAsync(async () =>
+        {
+            var sql = $"""
+                SELECT item_id, kind, name, title, owner_id, visibility, current_version,
+                       current_version_id, lifecycle, created_at, updated_at, created_by
+                FROM {_itemsTable}
+                WHERE item_id = @item_id
+                """;
 
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@item_id", itemId);
+            await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+                .ConfigureAwait(false);
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.Parameters.AddWithValue("@item_id", itemId);
 
-        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        return await reader.ReadAsync(cancellationToken).ConfigureAwait(false)
-            ? ReadItem(reader)
-            : null;
-    }
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            return await reader.ReadAsync(cancellationToken).ConfigureAwait(false)
+                ? ReadItem(reader)
+                : null;
+        });
 
-    public async Task<AnalysisContentVersion> AddVersionAsync(
+    public Task<AnalysisContentVersion> AddVersionAsync(
         string itemId,
         AnalysisContentVersion version,
         CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(version);
-
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-
-        var exists = await ItemExistsForUpdateAsync(connection, transaction, itemId, cancellationToken)
-            .ConfigureAwait(false);
-        if (!exists)
+        => TranslateStoreFailuresAsync(async () =>
         {
-            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            throw new KeyNotFoundException("Analysis content item was not found.");
-        }
+            ArgumentNullException.ThrowIfNull(version);
 
+            await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+                .ConfigureAwait(false);
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+            var exists = await ItemExistsForUpdateAsync(connection, transaction, itemId, cancellationToken)
+                .ConfigureAwait(false);
+            if (!exists)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                throw new KeyNotFoundException("Analysis content item was not found.");
+            }
+
+            try
+            {
+                await InsertVersionAsync(connection, transaction, version, cancellationToken).ConfigureAwait(false);
+                await UpdateCurrentVersionAsync(connection, transaction, version, cancellationToken).ConfigureAwait(false);
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                return version;
+            }
+            catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                throw new AnalysisContentStoreConflictException(
+                    "Analysis content version conflicts with an existing record.",
+                    ex);
+            }
+        });
+
+    public Task<AnalysisContentVersion?> GetVersionAsync(
+        string itemId,
+        int? version = null,
+        CancellationToken cancellationToken = default)
+        => TranslateStoreFailuresAsync(async () =>
+        {
+            var sql = version.HasValue
+                ? $"""
+                   SELECT version_body
+                   FROM {_versionsTable}
+                   WHERE item_id = @item_id AND version = @version
+                   """
+                : $"""
+                   SELECT version_body
+                   FROM {_versionsTable}
+                   WHERE item_id = @item_id
+                   ORDER BY version DESC
+                   LIMIT 1
+                   """;
+
+            await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+                .ConfigureAwait(false);
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.Parameters.AddWithValue("@item_id", itemId);
+            if (version.HasValue)
+            {
+                command.Parameters.AddWithValue("@version", version.Value);
+            }
+
+            var payload = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) as string;
+            return string.IsNullOrWhiteSpace(payload)
+                ? null
+                : JsonSerializer.Deserialize(payload, AnalysisContentJsonContext.Default.AnalysisContentVersion);
+        });
+
+    public Task<IReadOnlyList<AnalysisContentVersion>> ListVersionsAsync(
+        string itemId,
+        CancellationToken cancellationToken = default)
+        => TranslateStoreFailuresAsync<IReadOnlyList<AnalysisContentVersion>>(async () =>
+        {
+            var sql = $"""
+                SELECT version_body
+                FROM {_versionsTable}
+                WHERE item_id = @item_id
+                ORDER BY version ASC
+                """;
+
+            await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+                .ConfigureAwait(false);
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.Parameters.AddWithValue("@item_id", itemId);
+
+            var versions = new List<AnalysisContentVersion>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var version = JsonSerializer.Deserialize(
+                    reader.GetString(0),
+                    AnalysisContentJsonContext.Default.AnalysisContentVersion);
+                if (version is not null)
+                {
+                    versions.Add(version);
+                }
+            }
+
+            return versions;
+        });
+
+    public Task<ResultArtifactRecord> UpsertArtifactAsync(
+        ResultArtifactRecord artifact,
+        CancellationToken cancellationToken = default)
+        => TranslateStoreFailuresAsync(async () =>
+        {
+            ArgumentNullException.ThrowIfNull(artifact);
+
+            var recordJson = JsonSerializer.Serialize(artifact, AnalysisContentJsonContext.Default.ResultArtifactRecord);
+            var sql = $"""
+                INSERT INTO {_artifactsTable}
+                    (artifact_id, result_package_id, job_id, source_item_id, source_version,
+                     source_version_id, kind, retention_state, promotion_state, created_at, expires_at, artifact_body)
+                VALUES
+                    (@artifact_id, @result_package_id, @job_id, @source_item_id, @source_version,
+                     @source_version_id, @kind, @retention_state, @promotion_state, @created_at, @expires_at, @artifact_body)
+                ON CONFLICT (artifact_id) DO UPDATE SET
+                    result_package_id = EXCLUDED.result_package_id,
+                    job_id = EXCLUDED.job_id,
+                    source_item_id = EXCLUDED.source_item_id,
+                    source_version = EXCLUDED.source_version,
+                    source_version_id = EXCLUDED.source_version_id,
+                    kind = EXCLUDED.kind,
+                    retention_state = EXCLUDED.retention_state,
+                    promotion_state = EXCLUDED.promotion_state,
+                    expires_at = EXCLUDED.expires_at,
+                    artifact_body = EXCLUDED.artifact_body
+                """;
+
+            await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+                .ConfigureAwait(false);
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.Parameters.AddWithValue("@artifact_id", artifact.ArtifactId);
+            command.Parameters.AddWithValue("@result_package_id", artifact.ResultPackageId);
+            command.Parameters.AddWithValue("@job_id", artifact.JobId);
+            command.Parameters.AddWithValue("@source_item_id", artifact.SourceItemId);
+            command.Parameters.AddWithValue("@source_version", artifact.SourceVersion);
+            command.Parameters.AddWithValue("@source_version_id", artifact.SourceVersionId);
+            command.Parameters.AddWithValue("@kind", artifact.Kind.ToString());
+            command.Parameters.AddWithValue("@retention_state", artifact.RetentionState.ToString());
+            command.Parameters.AddWithValue("@promotion_state", artifact.PromotionState.ToString());
+            command.Parameters.AddWithValue("@created_at", artifact.CreatedAt);
+            command.Parameters.AddWithValue("@expires_at", (object?)artifact.ExpiresAt ?? DBNull.Value);
+            command.Parameters.Add(new NpgsqlParameter("@artifact_body", NpgsqlDbType.Jsonb) { Value = recordJson });
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            return artifact;
+        });
+
+    public Task<ResultArtifactRecord?> GetArtifactAsync(
+        string artifactId,
+        CancellationToken cancellationToken = default)
+        => TranslateStoreFailuresAsync(async () =>
+        {
+            var sql = $"""
+                SELECT artifact_body
+                FROM {_artifactsTable}
+                WHERE artifact_id = @artifact_id
+                """;
+
+            await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+                .ConfigureAwait(false);
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.Parameters.AddWithValue("@artifact_id", artifactId);
+
+            var payload = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) as string;
+            return string.IsNullOrWhiteSpace(payload)
+                ? null
+                : JsonSerializer.Deserialize(payload, AnalysisContentJsonContext.Default.ResultArtifactRecord);
+        });
+
+    public Task<IReadOnlyList<ResultArtifactRecord>> ListArtifactsForJobAsync(
+        string jobId,
+        CancellationToken cancellationToken = default)
+        => TranslateStoreFailuresAsync<IReadOnlyList<ResultArtifactRecord>>(async () =>
+        {
+            var sql = $"""
+                SELECT artifact_body
+                FROM {_artifactsTable}
+                WHERE job_id = @job_id
+                ORDER BY created_at ASC, artifact_id ASC
+                """;
+
+            await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+                .ConfigureAwait(false);
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.Parameters.AddWithValue("@job_id", jobId);
+
+            var artifacts = new List<ResultArtifactRecord>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var artifact = JsonSerializer.Deserialize(
+                    reader.GetString(0),
+                    AnalysisContentJsonContext.Default.ResultArtifactRecord);
+                if (artifact is not null)
+                {
+                    artifacts.Add(artifact);
+                }
+            }
+
+            return artifacts;
+        });
+
+    /// <summary>
+    /// Runs a store operation and maps provider connectivity / transient / operational failures
+    /// to <see cref="AnalysisContentStoreUnavailableException"/> so a store outage surfaces as a
+    /// retryable 503 instead of a generic 500. Request-level conflicts and not-found results are
+    /// raised by the operation itself and pass through unchanged.
+    /// </summary>
+    private static async Task<T> TranslateStoreFailuresAsync<T>(Func<Task<T>> operation)
+    {
         try
         {
-            await InsertVersionAsync(connection, transaction, version, cancellationToken).ConfigureAwait(false);
-            await UpdateCurrentVersionAsync(connection, transaction, version, cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            return version;
+            return await operation().ConfigureAwait(false);
         }
-        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
+        catch (NpgsqlException ex) when (IsStoreUnavailable(ex))
         {
-            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            throw new AnalysisContentStoreConflictException(
-                "Analysis content version conflicts with an existing record.",
+            throw new AnalysisContentStoreUnavailableException(
+                "The analysis content store is currently unavailable.",
                 ex);
         }
     }
 
-    public async Task<AnalysisContentVersion?> GetVersionAsync(
-        string itemId,
-        int? version = null,
-        CancellationToken cancellationToken = default)
+    private static bool IsStoreUnavailable(NpgsqlException exception)
     {
-        var sql = version.HasValue
-            ? $"""
-               SELECT version_body
-               FROM {_versionsTable}
-               WHERE item_id = @item_id AND version = @version
-               """
-            : $"""
-               SELECT version_body
-               FROM {_versionsTable}
-               WHERE item_id = @item_id
-               ORDER BY version DESC
-               LIMIT 1
-               """;
-
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@item_id", itemId);
-        if (version.HasValue)
+        // Socket / IO / connect-timeout failures surface as the NpgsqlException base type
+        // rather than a server-side PostgresException; treat them as store outages.
+        if (exception is not PostgresException postgres)
         {
-            command.Parameters.AddWithValue("@version", version.Value);
+            return true;
         }
 
-        var payload = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) as string;
-        return string.IsNullOrWhiteSpace(payload)
-            ? null
-            : JsonSerializer.Deserialize(payload, AnalysisContentJsonContext.Default.AnalysisContentVersion);
-    }
-
-    public async Task<IReadOnlyList<AnalysisContentVersion>> ListVersionsAsync(
-        string itemId,
-        CancellationToken cancellationToken = default)
-    {
-        var sql = $"""
-            SELECT version_body
-            FROM {_versionsTable}
-            WHERE item_id = @item_id
-            ORDER BY version ASC
-            """;
-
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@item_id", itemId);
-
-        var versions = new List<AnalysisContentVersion>();
-        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        // Unique violations are request-level conflicts that callers translate separately.
+        if (postgres.SqlState == PostgresErrorCodes.UniqueViolation)
         {
-            var version = JsonSerializer.Deserialize(
-                reader.GetString(0),
-                AnalysisContentJsonContext.Default.AnalysisContentVersion);
-            if (version is not null)
-            {
-                versions.Add(version);
-            }
+            return false;
         }
 
-        return versions;
-    }
-
-    public async Task<ResultArtifactRecord> UpsertArtifactAsync(
-        ResultArtifactRecord artifact,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(artifact);
-
-        var recordJson = JsonSerializer.Serialize(artifact, AnalysisContentJsonContext.Default.ResultArtifactRecord);
-        var sql = $"""
-            INSERT INTO {_artifactsTable}
-                (artifact_id, result_package_id, job_id, source_item_id, source_version,
-                 source_version_id, kind, retention_state, promotion_state, created_at, expires_at, artifact_body)
-            VALUES
-                (@artifact_id, @result_package_id, @job_id, @source_item_id, @source_version,
-                 @source_version_id, @kind, @retention_state, @promotion_state, @created_at, @expires_at, @artifact_body)
-            ON CONFLICT (artifact_id) DO UPDATE SET
-                result_package_id = EXCLUDED.result_package_id,
-                job_id = EXCLUDED.job_id,
-                source_item_id = EXCLUDED.source_item_id,
-                source_version = EXCLUDED.source_version,
-                source_version_id = EXCLUDED.source_version_id,
-                kind = EXCLUDED.kind,
-                retention_state = EXCLUDED.retention_state,
-                promotion_state = EXCLUDED.promotion_state,
-                expires_at = EXCLUDED.expires_at,
-                artifact_body = EXCLUDED.artifact_body
-            """;
-
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@artifact_id", artifact.ArtifactId);
-        command.Parameters.AddWithValue("@result_package_id", artifact.ResultPackageId);
-        command.Parameters.AddWithValue("@job_id", artifact.JobId);
-        command.Parameters.AddWithValue("@source_item_id", artifact.SourceItemId);
-        command.Parameters.AddWithValue("@source_version", artifact.SourceVersion);
-        command.Parameters.AddWithValue("@source_version_id", artifact.SourceVersionId);
-        command.Parameters.AddWithValue("@kind", artifact.Kind.ToString());
-        command.Parameters.AddWithValue("@retention_state", artifact.RetentionState.ToString());
-        command.Parameters.AddWithValue("@promotion_state", artifact.PromotionState.ToString());
-        command.Parameters.AddWithValue("@created_at", artifact.CreatedAt);
-        command.Parameters.AddWithValue("@expires_at", (object?)artifact.ExpiresAt ?? DBNull.Value);
-        command.Parameters.Add(new NpgsqlParameter("@artifact_body", NpgsqlDbType.Jsonb) { Value = recordJson });
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        return artifact;
-    }
-
-    public async Task<ResultArtifactRecord?> GetArtifactAsync(
-        string artifactId,
-        CancellationToken cancellationToken = default)
-    {
-        var sql = $"""
-            SELECT artifact_body
-            FROM {_artifactsTable}
-            WHERE artifact_id = @artifact_id
-            """;
-
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@artifact_id", artifactId);
-
-        var payload = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) as string;
-        return string.IsNullOrWhiteSpace(payload)
-            ? null
-            : JsonSerializer.Deserialize(payload, AnalysisContentJsonContext.Default.ResultArtifactRecord);
-    }
-
-    public async Task<IReadOnlyList<ResultArtifactRecord>> ListArtifactsForJobAsync(
-        string jobId,
-        CancellationToken cancellationToken = default)
-    {
-        var sql = $"""
-            SELECT artifact_body
-            FROM {_artifactsTable}
-            WHERE job_id = @job_id
-            ORDER BY created_at ASC, artifact_id ASC
-            """;
-
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddWithValue("@job_id", jobId);
-
-        var artifacts = new List<ResultArtifactRecord>();
-        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-        {
-            var artifact = JsonSerializer.Deserialize(
-                reader.GetString(0),
-                AnalysisContentJsonContext.Default.ResultArtifactRecord);
-            if (artifact is not null)
-            {
-                artifacts.Add(artifact);
-            }
-        }
-
-        return artifacts;
+        // Transient and operational SQL-state classes: connection_exception (08),
+        // insufficient_resources (53, e.g. too_many_connections), operator_intervention
+        // (57, e.g. admin shutdown / cannot_connect_now), and invalid_authorization (28,
+        // e.g. an auth-backend outage). These represent infrastructure unavailability.
+        return postgres.IsTransient
+            || postgres.SqlState.StartsWith("08", StringComparison.Ordinal)
+            || postgres.SqlState.StartsWith("53", StringComparison.Ordinal)
+            || postgres.SqlState.StartsWith("57", StringComparison.Ordinal)
+            || postgres.SqlState.StartsWith("28", StringComparison.Ordinal);
     }
 
     private async Task InsertItemAsync(

--- a/src/Honua.Postgres/Features/AnalysisContent/PostgresAnalysisContentStore.cs
+++ b/src/Honua.Postgres/Features/AnalysisContent/PostgresAnalysisContentStore.cs
@@ -1,0 +1,395 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.AnalysisContent;
+using Honua.Core.Features.AnalysisContent.Abstractions;
+using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Infrastructure;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.AnalysisContent;
+
+internal sealed class PostgresAnalysisContentStore : IAnalysisContentStore
+{
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly string _itemsTable;
+    private readonly string _versionsTable;
+    private readonly string _artifactsTable;
+
+    public PostgresAnalysisContentStore(
+        IDatabaseConnectionProvider connectionProvider,
+        string? schemaName = null)
+    {
+        ArgumentNullException.ThrowIfNull(connectionProvider);
+        _connectionProvider = connectionProvider;
+        _itemsTable = SchemaSearchPath.QualifyTable("analysis_content_items", schemaName);
+        _versionsTable = SchemaSearchPath.QualifyTable("analysis_content_versions", schemaName);
+        _artifactsTable = SchemaSearchPath.QualifyTable("analysis_result_artifacts", schemaName);
+    }
+
+    public async Task<AnalysisContentItem> CreateItemAsync(
+        AnalysisContentItem item,
+        AnalysisContentVersion version,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(version);
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+            .ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await InsertItemAsync(connection, transaction, item, cancellationToken).ConfigureAwait(false);
+            await InsertVersionAsync(connection, transaction, version, cancellationToken).ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return item;
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
+        {
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException("Analysis content item conflicts with an existing record.", ex);
+        }
+    }
+
+    public async Task<AnalysisContentItem?> GetItemAsync(
+        string itemId,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SELECT item_id, kind, name, title, owner_id, visibility, current_version,
+                   current_version_id, lifecycle, created_at, updated_at, created_by
+            FROM {_itemsTable}
+            WHERE item_id = @item_id
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+            .ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@item_id", itemId);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        return await reader.ReadAsync(cancellationToken).ConfigureAwait(false)
+            ? ReadItem(reader)
+            : null;
+    }
+
+    public async Task<AnalysisContentVersion> AddVersionAsync(
+        string itemId,
+        AnalysisContentVersion version,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(version);
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+            .ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        var exists = await ItemExistsForUpdateAsync(connection, transaction, itemId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!exists)
+        {
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            throw new KeyNotFoundException("Analysis content item was not found.");
+        }
+
+        try
+        {
+            await InsertVersionAsync(connection, transaction, version, cancellationToken).ConfigureAwait(false);
+            await UpdateCurrentVersionAsync(connection, transaction, version, cancellationToken).ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return version;
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
+        {
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException("Analysis content version conflicts with an existing record.", ex);
+        }
+    }
+
+    public async Task<AnalysisContentVersion?> GetVersionAsync(
+        string itemId,
+        int? version = null,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = version.HasValue
+            ? $"""
+               SELECT version_body
+               FROM {_versionsTable}
+               WHERE item_id = @item_id AND version = @version
+               """
+            : $"""
+               SELECT version_body
+               FROM {_versionsTable}
+               WHERE item_id = @item_id
+               ORDER BY version DESC
+               LIMIT 1
+               """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+            .ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@item_id", itemId);
+        if (version.HasValue)
+        {
+            command.Parameters.AddWithValue("@version", version.Value);
+        }
+
+        var payload = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) as string;
+        return string.IsNullOrWhiteSpace(payload)
+            ? null
+            : JsonSerializer.Deserialize(payload, AnalysisContentJsonContext.Default.AnalysisContentVersion);
+    }
+
+    public async Task<IReadOnlyList<AnalysisContentVersion>> ListVersionsAsync(
+        string itemId,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SELECT version_body
+            FROM {_versionsTable}
+            WHERE item_id = @item_id
+            ORDER BY version ASC
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+            .ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@item_id", itemId);
+
+        var versions = new List<AnalysisContentVersion>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var version = JsonSerializer.Deserialize(
+                reader.GetString(0),
+                AnalysisContentJsonContext.Default.AnalysisContentVersion);
+            if (version is not null)
+            {
+                versions.Add(version);
+            }
+        }
+
+        return versions;
+    }
+
+    public async Task<ResultArtifactRecord> UpsertArtifactAsync(
+        ResultArtifactRecord artifact,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var recordJson = JsonSerializer.Serialize(artifact, AnalysisContentJsonContext.Default.ResultArtifactRecord);
+        var sql = $"""
+            INSERT INTO {_artifactsTable}
+                (artifact_id, result_package_id, job_id, source_item_id, source_version,
+                 source_version_id, kind, retention_state, promotion_state, created_at, expires_at, artifact_body)
+            VALUES
+                (@artifact_id, @result_package_id, @job_id, @source_item_id, @source_version,
+                 @source_version_id, @kind, @retention_state, @promotion_state, @created_at, @expires_at, @artifact_body)
+            ON CONFLICT (artifact_id) DO UPDATE SET
+                result_package_id = EXCLUDED.result_package_id,
+                job_id = EXCLUDED.job_id,
+                source_item_id = EXCLUDED.source_item_id,
+                source_version = EXCLUDED.source_version,
+                source_version_id = EXCLUDED.source_version_id,
+                kind = EXCLUDED.kind,
+                retention_state = EXCLUDED.retention_state,
+                promotion_state = EXCLUDED.promotion_state,
+                expires_at = EXCLUDED.expires_at,
+                artifact_body = EXCLUDED.artifact_body
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+            .ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@artifact_id", artifact.ArtifactId);
+        command.Parameters.AddWithValue("@result_package_id", artifact.ResultPackageId);
+        command.Parameters.AddWithValue("@job_id", artifact.JobId);
+        command.Parameters.AddWithValue("@source_item_id", artifact.SourceItemId);
+        command.Parameters.AddWithValue("@source_version", artifact.SourceVersion);
+        command.Parameters.AddWithValue("@source_version_id", artifact.SourceVersionId);
+        command.Parameters.AddWithValue("@kind", artifact.Kind.ToString());
+        command.Parameters.AddWithValue("@retention_state", artifact.RetentionState.ToString());
+        command.Parameters.AddWithValue("@promotion_state", artifact.PromotionState.ToString());
+        command.Parameters.AddWithValue("@created_at", artifact.CreatedAt);
+        command.Parameters.AddWithValue("@expires_at", (object?)artifact.ExpiresAt ?? DBNull.Value);
+        command.Parameters.Add(new NpgsqlParameter("@artifact_body", NpgsqlDbType.Jsonb) { Value = recordJson });
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return artifact;
+    }
+
+    public async Task<ResultArtifactRecord?> GetArtifactAsync(
+        string artifactId,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SELECT artifact_body
+            FROM {_artifactsTable}
+            WHERE artifact_id = @artifact_id
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+            .ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@artifact_id", artifactId);
+
+        var payload = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) as string;
+        return string.IsNullOrWhiteSpace(payload)
+            ? null
+            : JsonSerializer.Deserialize(payload, AnalysisContentJsonContext.Default.ResultArtifactRecord);
+    }
+
+    public async Task<IReadOnlyList<ResultArtifactRecord>> ListArtifactsForJobAsync(
+        string jobId,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SELECT artifact_body
+            FROM {_artifactsTable}
+            WHERE job_id = @job_id
+            ORDER BY created_at ASC, artifact_id ASC
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+            .ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@job_id", jobId);
+
+        var artifacts = new List<ResultArtifactRecord>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var artifact = JsonSerializer.Deserialize(
+                reader.GetString(0),
+                AnalysisContentJsonContext.Default.ResultArtifactRecord);
+            if (artifact is not null)
+            {
+                artifacts.Add(artifact);
+            }
+        }
+
+        return artifacts;
+    }
+
+    private async Task InsertItemAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        AnalysisContentItem item,
+        CancellationToken cancellationToken)
+    {
+        var sql = $"""
+            INSERT INTO {_itemsTable}
+                (item_id, kind, name, title, owner_id, visibility, current_version,
+                 current_version_id, lifecycle, created_at, updated_at, created_by)
+            VALUES
+                (@item_id, @kind, @name, @title, @owner_id, @visibility, @current_version,
+                 @current_version_id, @lifecycle, @created_at, @updated_at, @created_by)
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("@item_id", item.ItemId);
+        command.Parameters.AddWithValue("@kind", item.Kind.ToString());
+        command.Parameters.AddWithValue("@name", item.Name);
+        command.Parameters.AddWithValue("@title", (object?)item.Title ?? DBNull.Value);
+        command.Parameters.AddWithValue("@owner_id", (object?)item.OwnerId ?? DBNull.Value);
+        command.Parameters.AddWithValue("@visibility", item.Visibility);
+        command.Parameters.AddWithValue("@current_version", item.CurrentVersion);
+        command.Parameters.AddWithValue("@current_version_id", item.CurrentVersionId);
+        command.Parameters.AddWithValue("@lifecycle", item.Lifecycle.ToString());
+        command.Parameters.AddWithValue("@created_at", item.CreatedAt);
+        command.Parameters.AddWithValue("@updated_at", item.UpdatedAt);
+        command.Parameters.AddWithValue("@created_by", (object?)item.CreatedBy ?? DBNull.Value);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task InsertVersionAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        AnalysisContentVersion version,
+        CancellationToken cancellationToken)
+    {
+        var versionJson = JsonSerializer.Serialize(
+            version,
+            AnalysisContentJsonContext.Default.AnalysisContentVersion);
+        var sql = $"""
+            INSERT INTO {_versionsTable}
+                (version_id, item_id, version, kind, content_hash, created_at, created_by, version_body)
+            VALUES
+                (@version_id, @item_id, @version, @kind, @content_hash, @created_at, @created_by, @version_body)
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("@version_id", version.VersionId);
+        command.Parameters.AddWithValue("@item_id", version.ItemId);
+        command.Parameters.AddWithValue("@version", version.Version);
+        command.Parameters.AddWithValue("@kind", version.Kind.ToString());
+        command.Parameters.AddWithValue("@content_hash", version.ContentHash);
+        command.Parameters.AddWithValue("@created_at", version.CreatedAt);
+        command.Parameters.AddWithValue("@created_by", (object?)version.CreatedBy ?? DBNull.Value);
+        command.Parameters.Add(new NpgsqlParameter("@version_body", NpgsqlDbType.Jsonb) { Value = versionJson });
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<bool> ItemExistsForUpdateAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string itemId,
+        CancellationToken cancellationToken)
+    {
+        var sql = $"""
+            SELECT 1
+            FROM {_itemsTable}
+            WHERE item_id = @item_id
+            FOR UPDATE
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("@item_id", itemId);
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return result is not null;
+    }
+
+    private async Task UpdateCurrentVersionAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        AnalysisContentVersion version,
+        CancellationToken cancellationToken)
+    {
+        var sql = $"""
+            UPDATE {_itemsTable}
+            SET current_version = @current_version,
+                current_version_id = @current_version_id,
+                updated_at = @updated_at
+            WHERE item_id = @item_id
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("@current_version", version.Version);
+        command.Parameters.AddWithValue("@current_version_id", version.VersionId);
+        command.Parameters.AddWithValue("@updated_at", version.CreatedAt);
+        command.Parameters.AddWithValue("@item_id", version.ItemId);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static AnalysisContentItem ReadItem(NpgsqlDataReader reader)
+        => new()
+        {
+            ItemId = reader.GetString(0),
+            Kind = Enum.Parse<AnalysisContentKind>(reader.GetString(1), ignoreCase: true),
+            Name = reader.GetString(2),
+            Title = reader.IsDBNull(3) ? null : reader.GetString(3),
+            OwnerId = reader.IsDBNull(4) ? null : reader.GetString(4),
+            Visibility = reader.GetString(5),
+            CurrentVersion = reader.GetInt32(6),
+            CurrentVersionId = reader.GetString(7),
+            Lifecycle = Enum.Parse<AnalysisContentLifecycle>(reader.GetString(8), ignoreCase: true),
+            CreatedAt = reader.GetFieldValue<DateTimeOffset>(9),
+            UpdatedAt = reader.GetFieldValue<DateTimeOffset>(10),
+            CreatedBy = reader.IsDBNull(11) ? null : reader.GetString(11)
+        };
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Net.Http;
 using Honua.Core.Features.Alerts.Abstractions;
+using Honua.Core.Features.AnalysisContent.Abstractions;
 using Honua.Core.Features.AuditLog.Abstractions;
 using Honua.Core.Features.Observability.Abstractions;
 using Honua.Core.Features.FeatureStore.Abstractions;
@@ -32,6 +33,7 @@ using Honua.Core.Features.Styling.Abstractions;
 using Honua.Core.Queries.Filters;
 using Honua.Postgres.Features.Admin;
 using Honua.Postgres.Features.Alerts;
+using Honua.Postgres.Features.AnalysisContent;
 using Honua.Postgres.Features.AuditLog;
 using Honua.Postgres.Features.Attachments;
 using Honua.Postgres.Features.Catalog;
@@ -167,6 +169,10 @@ internal static class ServiceCollectionExtensions
                 configuration["Database:Schema"]));
         services.AddScoped<IStudioPackageStore>(serviceProvider =>
             new PostgresStudioPackageStore(
+                serviceProvider.GetRequiredService<IDatabaseConnectionProvider>(),
+                configuration["Database:Schema"]));
+        services.AddScoped<IAnalysisContentStore>(serviceProvider =>
+            new PostgresAnalysisContentStore(
                 serviceProvider.GetRequiredService<IDatabaseConnectionProvider>(),
                 configuration["Database:Schema"]));
 

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -817,6 +817,19 @@ public static class EndpointRegistry
         new("POST", "/v1/spec/cancel"),
         new("GET", "/v1/spec/artifact/{hash}"),
 
+        // Analysis content HTTP surface (#1182).
+        new("POST", "/api/v1/analysis/content/items"),
+        new("GET", "/api/v1/analysis/content/items/{itemId}"),
+        new("GET", "/api/v1/analysis/content/items/{itemId}/versions/latest"),
+        new("GET", "/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}"),
+        new("POST", "/api/v1/analysis/content/items/{itemId}/versions"),
+        new("POST", "/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/preview"),
+        new("POST", "/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/runs"),
+        new("POST", "/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/reruns"),
+        new("GET", "/api/v1/analysis/artifacts/{artifactId}"),
+        new("GET", "/api/v1/analysis/jobs/{jobId}/logs"),
+        new("GET", "/api/v1/analysis/jobs/{jobId}/failure"),
+
         // Analysis report HTTP surface (#801).
         new("GET", "/api/v1/analysis/reports/{jobId}"),
         new("GET", "/api/v1/analysis/reports/{jobId}/render"),

--- a/src/Honua.Server/Features/AnalysisContent/AnalysisContentApiModels.cs
+++ b/src/Honua.Server/Features/AnalysisContent/AnalysisContentApiModels.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Server.Features.Infrastructure.Models;
+
+namespace Honua.Server.Features.AnalysisContent;
+
+internal sealed record CreateAnalysisContentItemRequest
+{
+    public AnalysisContentKind Kind { get; init; }
+
+    public string Name { get; init; } = string.Empty;
+
+    public string? Title { get; init; }
+
+    public SavedQueryContent? SavedQuery { get; init; }
+
+    public AnalysisPackageContent? AnalysisPackage { get; init; }
+}
+
+internal sealed record CreateAnalysisContentVersionRequest
+{
+    public SavedQueryContent? SavedQuery { get; init; }
+
+    public AnalysisPackageContent? AnalysisPackage { get; init; }
+
+    public string? BasedOnVersionId { get; init; }
+
+    public string? CreatedFromJobId { get; init; }
+
+    public IReadOnlyList<string>? CreatedFromArtifactIds { get; init; }
+}
+
+internal sealed record PreviewSavedQueryRequest
+{
+    public int? Limit { get; init; }
+}
+
+internal sealed record RunAnalysisContentVersionRequest
+{
+    public string? IdempotencyKey { get; init; }
+
+    public IReadOnlyDictionary<string, string>? Parameters { get; init; }
+}
+
+internal sealed record RerunAnalysisContentVersionRequest
+{
+    public string? IdempotencyKey { get; init; }
+
+    public string? RerunOfJobId { get; init; }
+
+    public string? RerunOfResultPackageId { get; init; }
+
+    public IReadOnlyDictionary<string, string>? ParameterOverrides { get; init; }
+}
+
+internal sealed record AnalysisContentItemResponse
+{
+    public required AnalysisContentItem Item { get; init; }
+
+    public required AnalysisContentVersion Version { get; init; }
+}
+
+internal sealed record AnalysisContentVersionResponse
+{
+    public required AnalysisContentItem Item { get; init; }
+
+    public required AnalysisContentVersion Version { get; init; }
+}
+
+internal sealed record AnalysisContentJobResponse
+{
+    public required string JobId { get; init; }
+
+    public required ExecutionJobStatus Status { get; init; }
+
+    public required AnalysisContentVersion Version { get; init; }
+}
+
+internal sealed record AnalysisArtifactResponse
+{
+    public required ResultArtifactRecord Artifact { get; init; }
+
+    public required ArtifactBindingRef Binding { get; init; }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true)]
+[JsonSerializable(typeof(CreateAnalysisContentItemRequest))]
+[JsonSerializable(typeof(CreateAnalysisContentVersionRequest))]
+[JsonSerializable(typeof(PreviewSavedQueryRequest))]
+[JsonSerializable(typeof(RunAnalysisContentVersionRequest))]
+[JsonSerializable(typeof(RerunAnalysisContentVersionRequest))]
+[JsonSerializable(typeof(AnalysisContentItemResponse))]
+[JsonSerializable(typeof(AnalysisContentVersionResponse))]
+[JsonSerializable(typeof(AnalysisContentJobResponse))]
+[JsonSerializable(typeof(AnalysisArtifactResponse))]
+[JsonSerializable(typeof(SavedQueryPreviewResult))]
+[JsonSerializable(typeof(AnalysisJobLogs))]
+[JsonSerializable(typeof(AnalysisJobFailure))]
+[JsonSerializable(typeof(ProblemDetailsResponse))]
+[JsonSerializable(typeof(AnalysisContentItem))]
+[JsonSerializable(typeof(AnalysisContentVersion))]
+[JsonSerializable(typeof(SavedQueryContent))]
+[JsonSerializable(typeof(AnalysisPackageContent))]
+[JsonSerializable(typeof(ResultArtifactRecord))]
+[JsonSerializable(typeof(ArtifactBindingRef))]
+[JsonSerializable(typeof(AnalysisPlan))]
+[JsonSerializable(typeof(AnalysisPlanStep))]
+[JsonSerializable(typeof(AnalysisIntent))]
+internal sealed partial class AnalysisContentApiJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/AnalysisContent/AnalysisContentEndpoints.cs
+++ b/src/Honua.Server/Features/AnalysisContent/AnalysisContentEndpoints.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.AnalysisContent.Abstractions;
 using Honua.Core.Features.AnalysisContent.Domain;
 using Honua.Server.Features.Geoprocessing;
 using Honua.Server.Features.Infrastructure.Authentication;
@@ -339,7 +340,7 @@ internal static partial class AnalysisContentEndpoints
     {
         try
         {
-            var logs = await service.GetJobLogsAsync(jobId, limit, context.RequestAborted).ConfigureAwait(false);
+            var logs = await service.GetJobLogsAsync(jobId, limit, context.User, context.RequestAborted).ConfigureAwait(false);
             return Results.Json(logs, AnalysisContentApiJsonContext.Default.AnalysisJobLogs);
         }
         catch (Exception ex) when (TryMapException(ex, context, out var problem))

--- a/src/Honua.Server/Features/AnalysisContent/AnalysisContentEndpoints.cs
+++ b/src/Honua.Server/Features/AnalysisContent/AnalysisContentEndpoints.cs
@@ -1,0 +1,497 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Server.Features.Geoprocessing;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.AnalysisContent;
+
+internal static partial class AnalysisContentEndpoints
+{
+    public static IEndpointRouteBuilder MapAnalysisContentEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var content = endpoints.MapGroup("/api/v{version:apiVersion}/analysis/content")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Analysis", "Content")
+            .WithDescription("Durable saved-query and analysis-package content versions.")
+            .RequireAdminAuthorization();
+
+        _ = content.MapPost("/items", HandleCreateItemAsync)
+            .WithName("CreateAnalysisContentItem")
+            .WithSummary("Create a saved-query or analysis-package content item.");
+
+        _ = content.MapGet("/items/{itemId}", HandleGetItemAsync)
+            .WithName("GetAnalysisContentItem")
+            .WithSummary("Open an analysis content item at its latest version.");
+
+        _ = content.MapGet("/items/{itemId}/versions/latest", HandleGetLatestVersionAsync)
+            .WithName("GetLatestAnalysisContentVersion")
+            .WithSummary("Open the latest immutable analysis content version.");
+
+        _ = content.MapGet("/items/{itemId}/versions/{contentVersion:int}", HandleGetVersionAsync)
+            .WithName("GetAnalysisContentVersion")
+            .WithSummary("Open an explicit immutable analysis content version.");
+
+        _ = content.MapPost("/items/{itemId}/versions", HandleCreateVersionAsync)
+            .WithName("CreateAnalysisContentVersion")
+            .WithSummary("Create a new immutable analysis content version.");
+
+        _ = content.MapPost("/items/{itemId}/versions/{contentVersion:int}/preview", HandlePreviewAsync)
+            .WithName("PreviewSavedQueryVersion")
+            .WithSummary("Preview a saved-query version through the canonical feature-query pipeline.");
+
+        _ = content.MapPost("/items/{itemId}/versions/{contentVersion:int}/runs", HandleRunAsync)
+            .WithName("RunAnalysisPackageVersion")
+            .WithSummary("Submit an analysis-package version to the canonical geoprocessing runtime.");
+
+        _ = content.MapPost("/items/{itemId}/versions/{contentVersion:int}/reruns", HandleRerunAsync)
+            .WithName("RerunAnalysisPackageVersion")
+            .WithSummary("Rerun an analysis-package version with provenance links.");
+
+        var artifacts = endpoints.MapGroup("/api/v{version:apiVersion}/analysis/artifacts")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Analysis", "Artifacts")
+            .RequireAdminAuthorization();
+
+        _ = artifacts.MapGet("/{artifactId}", HandleGetArtifactAsync)
+            .WithName("GetAnalysisArtifact")
+            .WithSummary("Resolve stable artifact metadata for downstream bindings.");
+
+        var jobs = endpoints.MapGroup("/api/v{version:apiVersion}/analysis/jobs")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Analysis", "Jobs")
+            .RequireAdminAuthorization();
+
+        _ = jobs.MapGet("/{jobId}/logs", HandleGetJobLogsAsync)
+            .WithName("GetAnalysisJobLogs")
+            .WithSummary("Read bounded safe structured logs for an analysis job.");
+
+        _ = jobs.MapGet("/{jobId}/failure", HandleGetJobFailureAsync)
+            .WithName("GetAnalysisJobFailure")
+            .WithSummary("Read safe failure classification for a failed analysis job.");
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleCreateItemAsync(
+        CreateAnalysisContentItemRequest request,
+        [FromServices] IAnalysisContentService service,
+        HttpContext context)
+    {
+        try
+        {
+            var result = await service.CreateItemAsync(
+                new CreateAnalysisContentItemCommand(
+                    request.Kind,
+                    request.Name,
+                    request.Title,
+                    request.SavedQuery,
+                    request.AnalysisPackage),
+                context.User,
+                context.RequestAborted).ConfigureAwait(false);
+
+            var response = ToItemResponse(result);
+            return Results.Json(
+                response,
+                AnalysisContentApiJsonContext.Default.AnalysisContentItemResponse,
+                statusCode: StatusCodes.Status201Created);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "analysis-content.create", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static async Task<IResult> HandleGetItemAsync(
+        string itemId,
+        [FromServices] IAnalysisContentService service,
+        HttpContext context)
+    {
+        try
+        {
+            var result = await service.GetItemAsync(itemId, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(ToItemResponse(result), AnalysisContentApiJsonContext.Default.AnalysisContentItemResponse);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "analysis-content.get", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static Task<IResult> HandleGetLatestVersionAsync(
+        string itemId,
+        [FromServices] IAnalysisContentService service,
+        HttpContext context)
+        => HandleGetVersionCoreAsync(itemId, null, service, context);
+
+    private static Task<IResult> HandleGetVersionAsync(
+        string itemId,
+        int contentVersion,
+        [FromServices] IAnalysisContentService service,
+        HttpContext context)
+        => HandleGetVersionCoreAsync(itemId, contentVersion, service, context);
+
+    private static async Task<IResult> HandleGetVersionCoreAsync(
+        string itemId,
+        int? contentVersion,
+        IAnalysisContentService service,
+        HttpContext context)
+    {
+        try
+        {
+            var result = await service.GetVersionAsync(
+                itemId,
+                contentVersion,
+                context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(
+                ToVersionResponse(result),
+                AnalysisContentApiJsonContext.Default.AnalysisContentVersionResponse);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "analysis-content.version.get", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static async Task<IResult> HandleCreateVersionAsync(
+        string itemId,
+        CreateAnalysisContentVersionRequest request,
+        [FromServices] IAnalysisContentService service,
+        HttpContext context)
+    {
+        try
+        {
+            var result = await service.AddVersionAsync(
+                itemId,
+                new CreateAnalysisContentVersionCommand(
+                    request.SavedQuery,
+                    request.AnalysisPackage,
+                    request.BasedOnVersionId,
+                    request.CreatedFromJobId,
+                    request.CreatedFromArtifactIds),
+                context.User,
+                context.RequestAborted).ConfigureAwait(false);
+
+            return Results.Json(
+                ToVersionResponse(result),
+                AnalysisContentApiJsonContext.Default.AnalysisContentVersionResponse,
+                statusCode: StatusCodes.Status201Created);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "analysis-content.version.create", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static async Task<IResult> HandlePreviewAsync(
+        string itemId,
+        int contentVersion,
+        PreviewSavedQueryRequest request,
+        [FromServices] IAnalysisContentService service,
+        HttpContext context)
+    {
+        try
+        {
+            var result = await service.PreviewSavedQueryAsync(
+                itemId,
+                contentVersion,
+                request.Limit,
+                context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(result, AnalysisContentApiJsonContext.Default.SavedQueryPreviewResult);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "analysis-content.preview", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static async Task<IResult> HandleRunAsync(
+        string itemId,
+        int contentVersion,
+        RunAnalysisContentVersionRequest request,
+        [FromServices] IAnalysisContentService service,
+        HttpContext context)
+    {
+        try
+        {
+            var result = await service.SubmitAnalysisPackageAsync(
+                itemId,
+                contentVersion,
+                new RunAnalysisContentVersionCommand(request.IdempotencyKey, request.Parameters),
+                context.User,
+                context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(ToJobResponse(result), AnalysisContentApiJsonContext.Default.AnalysisContentJobResponse);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "analysis-content.run", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static async Task<IResult> HandleRerunAsync(
+        string itemId,
+        int contentVersion,
+        RerunAnalysisContentVersionRequest request,
+        [FromServices] IAnalysisContentService service,
+        HttpContext context)
+    {
+        try
+        {
+            var result = await service.RerunAnalysisPackageAsync(
+                itemId,
+                contentVersion,
+                new RerunAnalysisContentVersionCommand(
+                    request.IdempotencyKey,
+                    request.RerunOfJobId,
+                    request.RerunOfResultPackageId,
+                    request.ParameterOverrides),
+                context.User,
+                context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(ToJobResponse(result), AnalysisContentApiJsonContext.Default.AnalysisContentJobResponse);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "analysis-content.rerun", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static async Task<IResult> HandleGetArtifactAsync(
+        string artifactId,
+        [FromServices] IAnalysisContentService service,
+        HttpContext context)
+    {
+        try
+        {
+            var artifact = await service.GetArtifactAsync(artifactId, context.RequestAborted).ConfigureAwait(false);
+            var binding = new ArtifactBindingRef
+            {
+                ArtifactId = artifact.ArtifactId,
+                SourceItemId = artifact.SourceItemId,
+                SourceVersion = artifact.SourceVersion,
+                SourceVersionId = artifact.SourceVersionId,
+                Role = "dataSource",
+                TargetKind = "content",
+                TargetSlot = "source"
+            };
+            return Results.Json(
+                new AnalysisArtifactResponse { Artifact = artifact, Binding = binding },
+                AnalysisContentApiJsonContext.Default.AnalysisArtifactResponse);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "analysis-content.artifact.get", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static async Task<IResult> HandleGetJobLogsAsync(
+        string jobId,
+        [FromQuery] int? limit,
+        [FromServices] IAnalysisContentService service,
+        HttpContext context)
+    {
+        try
+        {
+            var logs = await service.GetJobLogsAsync(jobId, limit, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(logs, AnalysisContentApiJsonContext.Default.AnalysisJobLogs);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "analysis-content.job.logs", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static async Task<IResult> HandleGetJobFailureAsync(
+        string jobId,
+        [FromServices] IAnalysisContentService service,
+        HttpContext context)
+    {
+        try
+        {
+            var failure = await service.GetJobFailureAsync(
+                jobId,
+                context.User,
+                context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(failure, AnalysisContentApiJsonContext.Default.AnalysisJobFailure);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "analysis-content.job.failure", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static AnalysisContentItemResponse ToItemResponse(AnalysisContentItemResult result)
+        => new() { Item = result.Item, Version = result.Version };
+
+    private static AnalysisContentVersionResponse ToVersionResponse(AnalysisContentVersionResult result)
+        => new() { Item = result.Item, Version = result.Version };
+
+    private static AnalysisContentJobResponse ToJobResponse(AnalysisContentJobResult result)
+        => new()
+        {
+            JobId = result.Job.OperationId,
+            Status = result.Job.Status,
+            Version = result.Version
+        };
+
+    private static bool TryMapException(Exception ex, HttpContext context, out IResult problem)
+    {
+        switch (ex)
+        {
+            case AnalysisContentValidationException validationEx:
+                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status400BadRequest,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+                    validationEx.Message);
+                return true;
+            case AnalysisContentNotFoundException notFoundEx:
+                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status404NotFound,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status404NotFound),
+                    notFoundEx.Message);
+                return true;
+            case AnalysisContentConflictException conflictEx:
+                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status409Conflict,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status409Conflict),
+                    conflictEx.Message);
+                return true;
+            case AnalysisContentStoreUnavailableException storeEx:
+                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status503ServiceUnavailable,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status503ServiceUnavailable),
+                    storeEx.Message);
+                return true;
+            case GeoprocessingAuthorizationException authEx when authEx.RequiresAuthentication:
+                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status401Unauthorized,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status401Unauthorized),
+                    authEx.Message);
+                return true;
+            case GeoprocessingAuthorizationException authEx:
+                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status403Forbidden,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status403Forbidden),
+                    authEx.Message);
+                return true;
+            case GeoprocessingNotFoundException notFoundEx:
+                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status404NotFound,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status404NotFound),
+                    notFoundEx.Message);
+                return true;
+            case GeoprocessingPreconditionFailedException preconditionEx:
+                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status409Conflict,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status409Conflict),
+                    preconditionEx.Message);
+                return true;
+            case GeoprocessingValidationException validationEx:
+                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status400BadRequest,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+                    validationEx.Message);
+                return true;
+            case GeoprocessingStoreUnavailableException storeEx:
+                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status503ServiceUnavailable,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status503ServiceUnavailable),
+                    storeEx.Message);
+                return true;
+            default:
+                problem = Results.Empty;
+                return false;
+        }
+    }
+
+    private static IResult CreateGenericProblem(HttpContext context)
+        => ProblemDetailsHelpers.CreateAdminProblem(
+            context,
+            StatusCodes.Status500InternalServerError,
+            ProblemDetailsHelpers.GetTitle(StatusCodes.Status500InternalServerError),
+            "An internal error occurred while processing the analysis content request.");
+
+    private static void LogEndpointFailed(HttpContext context, string operation, Exception exception)
+    {
+        var logger = context.RequestServices.GetRequiredService<ILogger<AnalysisContentEndpointsLog>>();
+        Log.EndpointFailed(logger, operation, exception);
+    }
+
+    internal sealed class AnalysisContentEndpointsLog;
+
+    private static partial class Log
+    {
+        [LoggerMessage(12020, LogLevel.Error, "Analysis content endpoint {Operation} failed")]
+        public static partial void EndpointFailed(
+            ILogger logger,
+            string operation,
+            Exception exception);
+    }
+}

--- a/src/Honua.Server/Features/AnalysisContent/AnalysisContentExceptions.cs
+++ b/src/Honua.Server/Features/AnalysisContent/AnalysisContentExceptions.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.AnalysisContent;
+
+internal sealed class AnalysisContentValidationException(string message) : Exception(message);
+
+internal sealed class AnalysisContentNotFoundException(string message) : Exception(message);
+
+internal sealed class AnalysisContentConflictException(string message) : Exception(message);
+
+internal sealed class AnalysisContentStoreUnavailableException(string message) : Exception(message);

--- a/src/Honua.Server/Features/AnalysisContent/AnalysisContentExceptions.cs
+++ b/src/Honua.Server/Features/AnalysisContent/AnalysisContentExceptions.cs
@@ -8,5 +8,3 @@ internal sealed class AnalysisContentValidationException(string message) : Excep
 internal sealed class AnalysisContentNotFoundException(string message) : Exception(message);
 
 internal sealed class AnalysisContentConflictException(string message) : Exception(message);
-
-internal sealed class AnalysisContentStoreUnavailableException(string message) : Exception(message);

--- a/src/Honua.Server/Features/AnalysisContent/AnalysisContentService.cs
+++ b/src/Honua.Server/Features/AnalysisContent/AnalysisContentService.cs
@@ -1,0 +1,703 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.AnalysisContent;
+using Honua.Core.Features.AnalysisContent.Abstractions;
+using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.NlQuery.Services;
+using Honua.Core.Features.Query;
+using Honua.Core.Queries.Filters;
+using Honua.Server.Features.Geoprocessing;
+
+namespace Honua.Server.Features.AnalysisContent;
+
+internal sealed partial class AnalysisContentService(
+    IAnalysisContentStore store,
+    ILayerCatalog layerCatalog,
+    IQueryProcessor queryProcessor,
+    IFeatureReader featureReader,
+    IGeoprocessingJobService geoprocessingJobService,
+    IEnumerable<IExecutionLogStore> logStores,
+    TimeProvider timeProvider,
+    ILogger<AnalysisContentService> logger) : IAnalysisContentService
+{
+    private const int DefaultPreviewLimit = 25;
+    private const int MaxPreviewLimit = 200;
+    private const int DefaultLogLimit = 100;
+    private const int MaxLogLimit = 200;
+    private const int MaxDiagnosticLength = 512;
+    private static readonly TimeSpan PreviewRetention = TimeSpan.FromHours(1);
+
+    private readonly IExecutionLogStore? _logStore = logStores.FirstOrDefault();
+
+    public async Task<AnalysisContentItemResult> CreateItemAsync(
+        CreateAnalysisContentItemCommand command,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken)
+    {
+        ValidateCreate(command);
+
+        var now = timeProvider.GetUtcNow();
+        var itemId = CreateItemId();
+        var version = CreateVersion(
+            itemId,
+            1,
+            command.Kind,
+            command.SavedQuery,
+            command.AnalysisPackage,
+            basedOnVersionId: null,
+            createdFromJobId: null,
+            createdFromArtifactIds: [],
+            createdBy: ResolveActor(principal),
+            now);
+
+        var item = new AnalysisContentItem
+        {
+            ItemId = itemId,
+            Kind = command.Kind,
+            Name = NormalizeName(command.Name),
+            Title = NormalizeOptional(command.Title),
+            OwnerId = ResolveActor(principal),
+            CurrentVersion = version.Version,
+            CurrentVersionId = version.VersionId,
+            CreatedAt = now,
+            UpdatedAt = now,
+            CreatedBy = ResolveActor(principal)
+        };
+
+        var stored = await store.CreateItemAsync(item, version, cancellationToken).ConfigureAwait(false);
+        Log.ContentItemCreated(logger, stored.ItemId, stored.Kind.ToString(), stored.CurrentVersion);
+        return new AnalysisContentItemResult(stored, version);
+    }
+
+    public async Task<AnalysisContentItemResult> GetItemAsync(
+        string itemId,
+        CancellationToken cancellationToken)
+    {
+        var item = await GetRequiredItemAsync(itemId, cancellationToken).ConfigureAwait(false);
+        var version = await GetRequiredVersionAsync(itemId, null, cancellationToken).ConfigureAwait(false);
+        return new AnalysisContentItemResult(item, version);
+    }
+
+    public async Task<AnalysisContentVersionResult> GetVersionAsync(
+        string itemId,
+        int? version,
+        CancellationToken cancellationToken)
+    {
+        var item = await GetRequiredItemAsync(itemId, cancellationToken).ConfigureAwait(false);
+        var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
+        return new AnalysisContentVersionResult(item, contentVersion);
+    }
+
+    public async Task<AnalysisContentVersionResult> AddVersionAsync(
+        string itemId,
+        CreateAnalysisContentVersionCommand command,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken)
+    {
+        var item = await GetRequiredItemAsync(itemId, cancellationToken).ConfigureAwait(false);
+        var latest = await GetRequiredVersionAsync(itemId, null, cancellationToken).ConfigureAwait(false);
+        var nextVersion = latest.Version + 1;
+        var now = timeProvider.GetUtcNow();
+
+        var version = CreateVersion(
+            itemId,
+            nextVersion,
+            item.Kind,
+            command.SavedQuery,
+            command.AnalysisPackage,
+            NormalizeOptional(command.BasedOnVersionId) ?? latest.VersionId,
+            NormalizeOptional(command.CreatedFromJobId),
+            command.CreatedFromArtifactIds ?? [],
+            ResolveActor(principal),
+            now);
+
+        ValidatePayload(item.Kind, version.SavedQuery, version.AnalysisPackage);
+
+        var stored = await store.AddVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
+        var updatedItem = await GetRequiredItemAsync(itemId, cancellationToken).ConfigureAwait(false);
+        Log.ContentVersionCreated(logger, itemId, stored.Version);
+        return new AnalysisContentVersionResult(updatedItem, stored);
+    }
+
+    public async Task<SavedQueryPreviewResult> PreviewSavedQueryAsync(
+        string itemId,
+        int version,
+        int? limit,
+        CancellationToken cancellationToken)
+    {
+        var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
+        var savedQuery = contentVersion.SavedQuery
+            ?? throw new AnalysisContentValidationException("The requested version is not a saved query.");
+
+        var layer = await layerCatalog.GetLayerAsync(savedQuery.LayerId, cancellationToken).ConfigureAwait(false)
+            ?? throw new AnalysisContentNotFoundException($"Layer '{savedQuery.LayerId}' was not found.");
+
+        var previewLimit = ResolveLimit(limit ?? savedQuery.PreviewLimit, DefaultPreviewLimit, MaxPreviewLimit);
+        QueryFilter? filter = null;
+        if (savedQuery.FilterPlan is { Clauses.Length: > 0 } filterPlan)
+        {
+            var compiled = FilterPlanCompiler.Compile(filterPlan, layer);
+            if (!compiled.IsSuccess || compiled.Expression is null)
+            {
+                throw new AnalysisContentValidationException(
+                    compiled.ErrorMessage ?? "Saved query filter plan could not be compiled.");
+            }
+
+            filter = QueryFilter.FromExpression(
+                compiled.Expression,
+                new FilterSource("saved-query", FilterLanguage.Cql2Json, "AnalysisContent"));
+        }
+
+        var query = new UnifiedQuery
+        {
+            Filter = filter,
+            Limit = previewLimit,
+            OutFields = savedQuery.OutFields.Count > 0
+                ? ImmutableArray.CreateRange(savedQuery.OutFields)
+                : null,
+            OutputCrs = savedQuery.OutputSrid.HasValue
+                ? QueryCrs.Create(savedQuery.OutputSrid.Value)
+                : null
+        };
+
+        var validation = queryProcessor.ValidateQuery(query, layer);
+        if (!validation.IsValid)
+        {
+            throw new AnalysisContentValidationException(
+                validation.ErrorMessage ?? "Saved query preview request is invalid.");
+        }
+
+        var optimized = queryProcessor.OptimizeQuery(query, layer);
+        var featureQuery = queryProcessor.ToFeatureQuery(optimized, layer);
+        var result = await featureReader.QueryAsync(layer.Id, featureQuery, cancellationToken).ConfigureAwait(false);
+
+        var artifactId = CreatePreviewArtifactId();
+        var binding = new ArtifactBindingRef
+        {
+            ArtifactId = artifactId,
+            SourceItemId = itemId,
+            SourceVersion = contentVersion.Version,
+            SourceVersionId = contentVersion.VersionId,
+            Role = "preview",
+            TargetKind = "map",
+            TargetSlot = "source"
+        };
+
+        var now = timeProvider.GetUtcNow();
+        await store.UpsertArtifactAsync(new ResultArtifactRecord
+        {
+            ArtifactId = artifactId,
+            ResultPackageId = $"{itemId}:v{contentVersion.Version}:preview",
+            JobId = "preview",
+            SourceItemId = itemId,
+            SourceVersion = contentVersion.Version,
+            SourceVersionId = contentVersion.VersionId,
+            Kind = ArtifactKind.FeatureLayer,
+            Label = $"{savedQuery.ServiceName ?? layer.Name} preview",
+            Uri = $"honua://analysis/artifacts/{artifactId}",
+            ContentType = "application/json",
+            Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["layerId"] = savedQuery.LayerId.ToString(CultureInfo.InvariantCulture),
+                ["previewLimit"] = previewLimit.ToString(CultureInfo.InvariantCulture)
+            },
+            Provenance = BuildSourceProvenance(contentVersion, savedQuery.OutputSrid, savedQuery.Units),
+            RetentionState = ResultArtifactRetentionState.Preview,
+            CreatedAt = now,
+            ExpiresAt = now.Add(PreviewRetention)
+        }, cancellationToken).ConfigureAwait(false);
+
+        Log.SavedQueryPreviewed(logger, itemId, contentVersion.Version, result.Items.Length);
+
+        return new SavedQueryPreviewResult
+        {
+            PreviewArtifactId = artifactId,
+            ItemId = itemId,
+            Version = contentVersion.Version,
+            LayerId = savedQuery.LayerId,
+            Features = result.Items.Select(SavedQueryPreviewFeature.FromFeature).ToArray(),
+            TotalCount = result.TotalCount,
+            ExceededPreviewLimit = result.HasMoreResults || result.TotalCount > previewLimit,
+            Binding = binding
+        };
+    }
+
+    public async Task<AnalysisContentJobResult> SubmitAnalysisPackageAsync(
+        string itemId,
+        int version,
+        RunAnalysisContentVersionCommand command,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken)
+    {
+        var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
+        var package = contentVersion.AnalysisPackage
+            ?? throw new AnalysisContentValidationException("The requested version is not an analysis package.");
+
+        var metadata = BuildJobMetadata(contentVersion, package, command.Parameters);
+        var job = await geoprocessingJobService.SubmitJobAsync(
+            package.Plan,
+            command.IdempotencyKey,
+            principal,
+            metadata,
+            cancellationToken).ConfigureAwait(false);
+
+        Log.AnalysisPackageSubmitted(logger, itemId, version, job.OperationId);
+        return new AnalysisContentJobResult(job, contentVersion);
+    }
+
+    public async Task<AnalysisContentJobResult> RerunAnalysisPackageAsync(
+        string itemId,
+        int version,
+        RerunAnalysisContentVersionCommand command,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken)
+    {
+        var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
+        var package = contentVersion.AnalysisPackage
+            ?? throw new AnalysisContentValidationException("The requested version is not an analysis package.");
+
+        var submittedVersion = contentVersion;
+        if (command.ParameterOverrides is { Count: > 0 })
+        {
+            var merged = new Dictionary<string, string>(package.Parameters, StringComparer.Ordinal);
+            foreach (var pair in command.ParameterOverrides)
+            {
+                if (!string.IsNullOrWhiteSpace(pair.Key))
+                {
+                    merged[pair.Key] = pair.Value;
+                }
+            }
+
+            var next = new CreateAnalysisContentVersionCommand(
+                SavedQuery: null,
+                AnalysisPackage: package with { Parameters = merged },
+                BasedOnVersionId: contentVersion.VersionId,
+                CreatedFromJobId: NormalizeOptional(command.RerunOfJobId),
+                CreatedFromArtifactIds: []);
+            var result = await AddVersionAsync(itemId, next, principal, cancellationToken).ConfigureAwait(false);
+            submittedVersion = result.Version;
+            package = submittedVersion.AnalysisPackage!;
+        }
+
+        var metadata = BuildJobMetadata(submittedVersion, package, runtimeParameters: null);
+        if (!string.IsNullOrWhiteSpace(command.RerunOfJobId))
+        {
+            metadata[AnalysisContentMetadataKeys.RerunOfJobId] = command.RerunOfJobId.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(command.RerunOfResultPackageId))
+        {
+            metadata[AnalysisContentMetadataKeys.RerunOfResultPackageId] = command.RerunOfResultPackageId.Trim();
+        }
+
+        var job = await geoprocessingJobService.SubmitJobAsync(
+            package.Plan,
+            command.IdempotencyKey,
+            principal,
+            metadata,
+            cancellationToken).ConfigureAwait(false);
+
+        Log.AnalysisPackageRerunSubmitted(logger, itemId, submittedVersion.Version, job.OperationId);
+        return new AnalysisContentJobResult(job, submittedVersion);
+    }
+
+    public async Task<ResultArtifactRecord> GetArtifactAsync(
+        string artifactId,
+        CancellationToken cancellationToken)
+    {
+        var artifact = await store.GetArtifactAsync(artifactId, cancellationToken).ConfigureAwait(false);
+        return artifact ?? throw new AnalysisContentNotFoundException($"Artifact '{artifactId}' was not found.");
+    }
+
+    public async Task<AnalysisJobLogs> GetJobLogsAsync(
+        string jobId,
+        int? limit,
+        CancellationToken cancellationToken)
+    {
+        var resolvedLimit = ResolveLimit(limit, DefaultLogLimit, MaxLogLimit);
+        if (_logStore is null)
+        {
+            return new AnalysisJobLogs
+            {
+                JobId = jobId,
+                Entries = [],
+                TotalCount = 0,
+                Truncated = false
+            };
+        }
+
+        var logs = await _logStore.GetLogsAsync(jobId, cancellationToken).ConfigureAwait(false);
+        var bounded = logs.TakeLast(resolvedLimit)
+            .Select(entry => new AnalysisJobLogEntry
+            {
+                Timestamp = entry.Timestamp,
+                Level = entry.Level,
+                Message = SanitizeDiagnostic(entry.Message),
+                Phase = SanitizePhase(entry.Phase),
+                Metadata = SanitizeMetadata(entry.Metadata)
+            })
+            .ToArray();
+
+        return new AnalysisJobLogs
+        {
+            JobId = jobId,
+            Entries = bounded,
+            TotalCount = logs.Count,
+            Truncated = logs.Count > bounded.Length
+        };
+    }
+
+    public async Task<AnalysisJobFailure> GetJobFailureAsync(
+        string jobId,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken)
+    {
+        var job = await geoprocessingJobService.GetJobAsync(jobId, principal, cancellationToken).ConfigureAwait(false);
+
+        return job.Status switch
+        {
+            ExecutionJobStatus.Failed => new AnalysisJobFailure
+            {
+                JobId = job.OperationId,
+                Classification = ClassifyFailure(job.ErrorMessage),
+                Message = SanitizeFailureMessage(job.ErrorMessage),
+                IsTerminal = true,
+                FailedAt = job.CompletedAt
+            },
+            ExecutionJobStatus.Cancelled => new AnalysisJobFailure
+            {
+                JobId = job.OperationId,
+                Classification = AnalysisJobFailureClassification.Cancelled,
+                Message = "The analysis job was cancelled.",
+                IsTerminal = true,
+                FailedAt = job.CompletedAt
+            },
+            _ => throw new AnalysisContentConflictException("The requested job has not failed.")
+        };
+    }
+
+    private async Task<AnalysisContentItem> GetRequiredItemAsync(
+        string itemId,
+        CancellationToken cancellationToken)
+    {
+        var item = await store.GetItemAsync(itemId, cancellationToken).ConfigureAwait(false);
+        return item ?? throw new AnalysisContentNotFoundException($"Analysis content item '{itemId}' was not found.");
+    }
+
+    private async Task<AnalysisContentVersion> GetRequiredVersionAsync(
+        string itemId,
+        int? version,
+        CancellationToken cancellationToken)
+    {
+        var contentVersion = await store.GetVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
+        return contentVersion ?? throw new AnalysisContentNotFoundException(
+            version.HasValue
+                ? $"Analysis content item '{itemId}' version '{version.Value}' was not found."
+                : $"Analysis content item '{itemId}' has no versions.");
+    }
+
+    private static void ValidateCreate(CreateAnalysisContentItemCommand command)
+    {
+        if (string.IsNullOrWhiteSpace(command.Name))
+        {
+            throw new AnalysisContentValidationException("Analysis content name is required.");
+        }
+
+        ValidatePayload(command.Kind, command.SavedQuery, command.AnalysisPackage);
+    }
+
+    private static void ValidatePayload(
+        AnalysisContentKind kind,
+        SavedQueryContent? savedQuery,
+        AnalysisPackageContent? analysisPackage)
+    {
+        switch (kind)
+        {
+            case AnalysisContentKind.SavedQuery:
+                if (savedQuery is null || analysisPackage is not null)
+                {
+                    throw new AnalysisContentValidationException("Saved-query content requires a savedQuery payload only.");
+                }
+
+                if (savedQuery.LayerId < 0)
+                {
+                    throw new AnalysisContentValidationException("Saved-query layerId must be non-negative.");
+                }
+
+                break;
+            case AnalysisContentKind.AnalysisPackage:
+                if (analysisPackage is null || savedQuery is not null)
+                {
+                    throw new AnalysisContentValidationException("Analysis-package content requires an analysisPackage payload only.");
+                }
+
+                if (analysisPackage.Plan.Steps.Count == 0)
+                {
+                    throw new AnalysisContentValidationException("Analysis package plan must contain at least one step.");
+                }
+
+                break;
+            default:
+                throw new AnalysisContentValidationException("Unsupported analysis content kind.");
+        }
+    }
+
+    private static AnalysisContentVersion CreateVersion(
+        string itemId,
+        int version,
+        AnalysisContentKind kind,
+        SavedQueryContent? savedQuery,
+        AnalysisPackageContent? analysisPackage,
+        string? basedOnVersionId,
+        string? createdFromJobId,
+        IReadOnlyList<string> createdFromArtifactIds,
+        string? createdBy,
+        DateTimeOffset now)
+    {
+        ValidatePayload(kind, savedQuery, analysisPackage);
+        return new AnalysisContentVersion
+        {
+            VersionId = $"{itemId}:v{version.ToString(CultureInfo.InvariantCulture)}",
+            ItemId = itemId,
+            Version = version,
+            Kind = kind,
+            SavedQuery = savedQuery,
+            AnalysisPackage = analysisPackage,
+            ContentHash = ComputeContentHash(kind, savedQuery, analysisPackage),
+            BasedOnVersionId = basedOnVersionId,
+            CreatedFromJobId = createdFromJobId,
+            CreatedFromArtifactIds = createdFromArtifactIds,
+            CreatedAt = now,
+            CreatedBy = createdBy
+        };
+    }
+
+    private static string ComputeContentHash(
+        AnalysisContentKind kind,
+        SavedQueryContent? savedQuery,
+        AnalysisPackageContent? analysisPackage)
+    {
+        byte[] payload = kind == AnalysisContentKind.SavedQuery
+            ? JsonSerializer.SerializeToUtf8Bytes(savedQuery, AnalysisContentJsonContext.Default.SavedQueryContent)
+            : JsonSerializer.SerializeToUtf8Bytes(analysisPackage, AnalysisContentJsonContext.Default.AnalysisPackageContent);
+
+        var hash = SHA256.HashData(payload);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static Dictionary<string, string> BuildJobMetadata(
+        AnalysisContentVersion version,
+        AnalysisPackageContent package,
+        IReadOnlyDictionary<string, string>? runtimeParameters)
+    {
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [AnalysisContentMetadataKeys.ItemId] = version.ItemId,
+            [AnalysisContentMetadataKeys.Version] = version.Version.ToString(CultureInfo.InvariantCulture),
+            [AnalysisContentMetadataKeys.VersionId] = version.VersionId,
+            [AnalysisContentMetadataKeys.Kind] = version.Kind.ToString(),
+        };
+
+        if (package.SpatialReferenceId.HasValue)
+        {
+            metadata[AnalysisContentMetadataKeys.SourceSrid] =
+                package.SpatialReferenceId.Value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (!string.IsNullOrWhiteSpace(package.Units))
+        {
+            metadata[AnalysisContentMetadataKeys.SourceUnits] = package.Units.Trim();
+        }
+
+        foreach (var pair in package.Parameters)
+        {
+            if (!string.IsNullOrWhiteSpace(pair.Key))
+            {
+                metadata[$"analysis.content.parameter.{pair.Key}"] = pair.Value;
+            }
+        }
+
+        if (runtimeParameters is not null)
+        {
+            foreach (var pair in runtimeParameters)
+            {
+                if (!string.IsNullOrWhiteSpace(pair.Key))
+                {
+                    metadata[$"analysis.content.runtime_parameter.{pair.Key}"] = pair.Value;
+                }
+            }
+        }
+
+        return metadata;
+    }
+
+    private static Dictionary<string, string> BuildSourceProvenance(
+        AnalysisContentVersion version,
+        int? srid,
+        string? units)
+    {
+        var provenance = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [AnalysisContentMetadataKeys.ItemId] = version.ItemId,
+            [AnalysisContentMetadataKeys.Version] = version.Version.ToString(CultureInfo.InvariantCulture),
+            [AnalysisContentMetadataKeys.VersionId] = version.VersionId,
+            [AnalysisContentMetadataKeys.Kind] = version.Kind.ToString()
+        };
+
+        if (srid.HasValue)
+        {
+            provenance[AnalysisContentMetadataKeys.SourceSrid] = srid.Value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (!string.IsNullOrWhiteSpace(units))
+        {
+            provenance[AnalysisContentMetadataKeys.SourceUnits] = units.Trim();
+        }
+
+        return provenance;
+    }
+
+    private static int ResolveLimit(int? limit, int defaultLimit, int maxLimit)
+    {
+        var resolved = limit.GetValueOrDefault(defaultLimit);
+        if (resolved <= 0)
+        {
+            throw new AnalysisContentValidationException("Limit must be greater than zero.");
+        }
+
+        return Math.Min(resolved, maxLimit);
+    }
+
+    private static AnalysisJobFailureClassification ClassifyFailure(string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return AnalysisJobFailureClassification.Unknown;
+        }
+
+        if (message.Contains("validation", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("invalid", StringComparison.OrdinalIgnoreCase))
+        {
+            return AnalysisJobFailureClassification.ValidationFailed;
+        }
+
+        if (message.Contains("unauthor", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("forbidden", StringComparison.OrdinalIgnoreCase))
+        {
+            return AnalysisJobFailureClassification.AuthorizationDenied;
+        }
+
+        if (message.Contains("timeout", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("timed out", StringComparison.OrdinalIgnoreCase))
+        {
+            return AnalysisJobFailureClassification.TimedOut;
+        }
+
+        if (message.Contains("artifact", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("output", StringComparison.OrdinalIgnoreCase))
+        {
+            return AnalysisJobFailureClassification.ArtifactOutputFailed;
+        }
+
+        return AnalysisJobFailureClassification.ExecutionFailed;
+    }
+
+    private static string SanitizeFailureMessage(string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return "The analysis job failed.";
+        }
+
+        var sanitized = SanitizeDiagnostic(message);
+        return string.IsNullOrWhiteSpace(sanitized)
+            ? "The analysis job failed."
+            : sanitized;
+    }
+
+    private static string SanitizeDiagnostic(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var sanitized = value.ReplaceLineEndings(" ").Trim();
+        if (sanitized.Contains(" at ", StringComparison.Ordinal) ||
+            sanitized.Contains("Npgsql", StringComparison.OrdinalIgnoreCase) ||
+            sanitized.Contains("connection string", StringComparison.OrdinalIgnoreCase) ||
+            sanitized.Contains("password", StringComparison.OrdinalIgnoreCase))
+        {
+            sanitized = "The analysis job failed. See server logs for details.";
+        }
+
+        return sanitized.Length <= MaxDiagnosticLength
+            ? sanitized
+            : sanitized[..MaxDiagnosticLength];
+    }
+
+    private static string? SanitizePhase(string? value)
+    {
+        var sanitized = SanitizeDiagnostic(value);
+        return string.IsNullOrWhiteSpace(sanitized) ? null : sanitized;
+    }
+
+    private static Dictionary<string, string>? SanitizeMetadata(IReadOnlyDictionary<string, string>? metadata)
+    {
+        if (metadata is null || metadata.Count == 0)
+        {
+            return null;
+        }
+
+        return metadata
+            .Where(pair => !pair.Key.Contains("password", StringComparison.OrdinalIgnoreCase)
+                           && !pair.Key.Contains("secret", StringComparison.OrdinalIgnoreCase)
+                           && !pair.Key.Contains("connection", StringComparison.OrdinalIgnoreCase))
+            .Take(20)
+            .ToDictionary(pair => pair.Key, pair => SanitizeDiagnostic(pair.Value), StringComparer.Ordinal);
+    }
+
+    private static string CreateItemId() => $"analysis-content-{Guid.NewGuid():N}";
+
+    private static string CreatePreviewArtifactId() => $"analysis-preview-{Guid.NewGuid():N}";
+
+    private static string NormalizeName(string value) => value.Trim();
+
+    private static string? NormalizeOptional(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? ResolveActor(ClaimsPrincipal principal)
+        => principal.Identity?.Name
+           ?? principal.FindFirstValue(ClaimTypes.NameIdentifier)
+           ?? principal.FindFirstValue("sub");
+
+    private static partial class Log
+    {
+        [LoggerMessage(12001, LogLevel.Information, "Created analysis content item {ItemId} kind {Kind} version {Version}")]
+        public static partial void ContentItemCreated(ILogger logger, string itemId, string kind, int version);
+
+        [LoggerMessage(12002, LogLevel.Information, "Created analysis content item {ItemId} version {Version}")]
+        public static partial void ContentVersionCreated(ILogger logger, string itemId, int version);
+
+        [LoggerMessage(12003, LogLevel.Information, "Previewed saved query {ItemId} version {Version} with {FeatureCount} features")]
+        public static partial void SavedQueryPreviewed(ILogger logger, string itemId, int version, int featureCount);
+
+        [LoggerMessage(12004, LogLevel.Information, "Submitted analysis package {ItemId} version {Version} as job {JobId}")]
+        public static partial void AnalysisPackageSubmitted(ILogger logger, string itemId, int version, string jobId);
+
+        [LoggerMessage(12005, LogLevel.Information, "Submitted analysis package rerun {ItemId} version {Version} as job {JobId}")]
+        public static partial void AnalysisPackageRerunSubmitted(ILogger logger, string itemId, int version, string jobId);
+    }
+}

--- a/src/Honua.Server/Features/AnalysisContent/AnalysisContentService.cs
+++ b/src/Honua.Server/Features/AnalysisContent/AnalysisContentService.cs
@@ -7,6 +7,7 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using Honua.Core.Exceptions;
 using Honua.Core.Features.AnalysisContent;
 using Honua.Core.Features.AnalysisContent.Abstractions;
 using Honua.Core.Features.AnalysisContent.Domain;
@@ -19,6 +20,7 @@ using Honua.Core.Features.NlQuery.Services;
 using Honua.Core.Features.Query;
 using Honua.Core.Queries.Filters;
 using Honua.Server.Features.Geoprocessing;
+using StackExchange.Redis;
 
 namespace Honua.Server.Features.AnalysisContent;
 
@@ -435,7 +437,8 @@ internal sealed partial class AnalysisContentService(
                 // Resolve the job through the job service first so unknown ids return not-found
                 // (instead of 200 with empty logs) and the same job-read authorization enforced by
                 // the failure endpoint is applied before any log content is returned.
-                _ = await geoprocessingJobService.GetJobAsync(jobId, principal, cancellationToken)
+                _ = await TranslateDiagnosticStoreFailuresAsync(
+                    () => geoprocessingJobService.GetJobAsync(jobId, principal, cancellationToken))
                     .ConfigureAwait(false);
 
                 if (_logStore is null)
@@ -449,7 +452,9 @@ internal sealed partial class AnalysisContentService(
                     };
                 }
 
-                var tail = await _logStore.TailAsync(jobId, resolvedLimit, cancellationToken).ConfigureAwait(false);
+                var tail = await TranslateDiagnosticStoreFailuresAsync(
+                    () => _logStore.TailAsync(jobId, resolvedLimit, cancellationToken))
+                    .ConfigureAwait(false);
                 var bounded = tail.Items
                     .Select(entry => new AnalysisJobLogEntry
                     {
@@ -479,7 +484,9 @@ internal sealed partial class AnalysisContentService(
             async activity =>
             {
                 activity?.SetTag(Honua.ServiceDefaults.HonuaTelemetry.Tags.JobId, jobId);
-                var job = await geoprocessingJobService.GetJobAsync(jobId, principal, cancellationToken).ConfigureAwait(false);
+                var job = await TranslateDiagnosticStoreFailuresAsync(
+                    () => geoprocessingJobService.GetJobAsync(jobId, principal, cancellationToken))
+                    .ConfigureAwait(false);
 
                 AnalysisJobFailure failure = job.Status switch
                 {
@@ -505,6 +512,33 @@ internal sealed partial class AnalysisContentService(
                 activity?.SetTag("honua.analysis_content.failure_classification", failure.Classification.ToString());
                 return failure;
             }).ConfigureAwait(false);
+
+    /// <summary>
+    /// Runs a job/log diagnostic read and maps backing job- or log-store outages to
+    /// <see cref="AnalysisContentStoreUnavailableException"/> so an unavailable Redis-backed store
+    /// surfaces as the documented retryable 503 instead of a generic 500. Job-read authorization
+    /// and not-found results are raised by the read itself and pass through unchanged, as does
+    /// cancellation.
+    /// </summary>
+    private static async Task<T> TranslateDiagnosticStoreFailuresAsync<T>(Func<Task<T>> read)
+    {
+        try
+        {
+            return await read().ConfigureAwait(false);
+        }
+        catch (ServiceUnavailableException ex)
+        {
+            throw new AnalysisContentStoreUnavailableException(
+                "The analysis job or log store is currently unavailable.",
+                ex);
+        }
+        catch (RedisException ex)
+        {
+            throw new AnalysisContentStoreUnavailableException(
+                "The analysis job or log store is currently unavailable.",
+                ex);
+        }
+    }
 
     private async Task<AnalysisContentItem> GetRequiredItemAsync(
         string itemId,
@@ -880,11 +914,41 @@ internal sealed partial class AnalysisContentService(
         }
 
         return metadata
-            .Where(pair => !pair.Key.Contains("password", StringComparison.OrdinalIgnoreCase)
-                           && !pair.Key.Contains("secret", StringComparison.OrdinalIgnoreCase)
-                           && !pair.Key.Contains("connection", StringComparison.OrdinalIgnoreCase))
+            .Where(pair => !IsSensitiveMetadataKey(pair.Key))
             .Take(20)
             .ToDictionary(pair => pair.Key, pair => SanitizeDiagnostic(pair.Value), StringComparer.Ordinal);
+    }
+
+    // Metadata key fragments that imply a secret value. Value-only inspection (SanitizeDiagnostic)
+    // cannot distinguish an opaque secret such as {"token":"abc123"} from ordinary data, so any
+    // entry whose key name matches is dropped wholesale. Mirrors the secret-key check used by the
+    // sibling console job viewer while preserving the original password/secret/connection coverage.
+    private static readonly string[] SensitiveMetadataKeyMarkers =
+    [
+        "password",
+        "pwd",
+        "secret",
+        "connection",
+        "token",
+        "credential",
+        "api key",
+        "apikey",
+        "api_key",
+        "bearer",
+        "private key"
+    ];
+
+    private static bool IsSensitiveMetadataKey(string key)
+    {
+        foreach (var marker in SensitiveMetadataKeyMarkers)
+        {
+            if (key.Contains(marker, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string CreateItemId() => $"analysis-content-{Guid.NewGuid():N}";

--- a/src/Honua.Server/Features/AnalysisContent/AnalysisContentService.cs
+++ b/src/Honua.Server/Features/AnalysisContent/AnalysisContentService.cs
@@ -37,6 +37,7 @@ internal sealed partial class AnalysisContentService(
     private const int DefaultLogLimit = 100;
     private const int MaxLogLimit = 200;
     private const int MaxDiagnosticLength = 512;
+    private const int MaxVersionCreateAttempts = 3;
     private static readonly TimeSpan PreviewRetention = TimeSpan.FromHours(1);
 
     private readonly IExecutionLogStore? _logStore = logStores.FirstOrDefault();
@@ -45,194 +46,261 @@ internal sealed partial class AnalysisContentService(
         CreateAnalysisContentItemCommand command,
         ClaimsPrincipal principal,
         CancellationToken cancellationToken)
-    {
-        ValidateCreate(command);
+        => await AnalysisContentTelemetry.TrackAsync(
+            AnalysisContentTelemetry.OperationsNames.CreateItem,
+            async activity =>
+            {
+                ValidateCreate(command);
 
-        var now = timeProvider.GetUtcNow();
-        var itemId = CreateItemId();
-        var version = CreateVersion(
-            itemId,
-            1,
-            command.Kind,
-            command.SavedQuery,
-            command.AnalysisPackage,
-            basedOnVersionId: null,
-            createdFromJobId: null,
-            createdFromArtifactIds: [],
-            createdBy: ResolveActor(principal),
-            now);
+                var now = timeProvider.GetUtcNow();
+                var itemId = CreateItemId();
+                var version = CreateVersion(
+                    itemId,
+                    1,
+                    command.Kind,
+                    command.SavedQuery,
+                    command.AnalysisPackage,
+                    basedOnVersionId: null,
+                    createdFromJobId: null,
+                    createdFromArtifactIds: [],
+                    createdBy: ResolveActor(principal),
+                    now);
 
-        var item = new AnalysisContentItem
-        {
-            ItemId = itemId,
-            Kind = command.Kind,
-            Name = NormalizeName(command.Name),
-            Title = NormalizeOptional(command.Title),
-            OwnerId = ResolveActor(principal),
-            CurrentVersion = version.Version,
-            CurrentVersionId = version.VersionId,
-            CreatedAt = now,
-            UpdatedAt = now,
-            CreatedBy = ResolveActor(principal)
-        };
+                var actor = ResolveActor(principal);
+                var item = new AnalysisContentItem
+                {
+                    ItemId = itemId,
+                    Kind = command.Kind,
+                    Name = NormalizeName(command.Name),
+                    Title = NormalizeOptional(command.Title),
+                    OwnerId = actor,
+                    CurrentVersion = version.Version,
+                    CurrentVersionId = version.VersionId,
+                    CreatedAt = now,
+                    UpdatedAt = now,
+                    CreatedBy = actor
+                };
 
-        var stored = await store.CreateItemAsync(item, version, cancellationToken).ConfigureAwait(false);
-        Log.ContentItemCreated(logger, stored.ItemId, stored.Kind.ToString(), stored.CurrentVersion);
-        return new AnalysisContentItemResult(stored, version);
-    }
+                AnalysisContentTelemetry.SetContentTags(activity, item.ItemId, item.Kind, version.Version, version.VersionId);
+                try
+                {
+                    var stored = await store.CreateItemAsync(item, version, cancellationToken).ConfigureAwait(false);
+                    Log.ContentItemCreated(logger, stored.ItemId, stored.Kind.ToString(), stored.CurrentVersion);
+                    return new AnalysisContentItemResult(stored, version);
+                }
+                catch (AnalysisContentStoreConflictException ex)
+                {
+                    throw new AnalysisContentConflictException(ex.Message);
+                }
+            }).ConfigureAwait(false);
 
     public async Task<AnalysisContentItemResult> GetItemAsync(
         string itemId,
         CancellationToken cancellationToken)
-    {
-        var item = await GetRequiredItemAsync(itemId, cancellationToken).ConfigureAwait(false);
-        var version = await GetRequiredVersionAsync(itemId, null, cancellationToken).ConfigureAwait(false);
-        return new AnalysisContentItemResult(item, version);
-    }
+        => await AnalysisContentTelemetry.TrackAsync(
+            AnalysisContentTelemetry.OperationsNames.GetItem,
+            async activity =>
+            {
+                var item = await GetRequiredItemAsync(itemId, cancellationToken).ConfigureAwait(false);
+                var version = await GetRequiredVersionAsync(itemId, null, cancellationToken).ConfigureAwait(false);
+                AnalysisContentTelemetry.SetContentTags(activity, item.ItemId, item.Kind, version.Version, version.VersionId);
+                return new AnalysisContentItemResult(item, version);
+            }).ConfigureAwait(false);
 
     public async Task<AnalysisContentVersionResult> GetVersionAsync(
         string itemId,
         int? version,
         CancellationToken cancellationToken)
-    {
-        var item = await GetRequiredItemAsync(itemId, cancellationToken).ConfigureAwait(false);
-        var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
-        return new AnalysisContentVersionResult(item, contentVersion);
-    }
+        => await AnalysisContentTelemetry.TrackAsync(
+            AnalysisContentTelemetry.OperationsNames.GetVersion,
+            async activity =>
+            {
+                var item = await GetRequiredItemAsync(itemId, cancellationToken).ConfigureAwait(false);
+                var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
+                AnalysisContentTelemetry.SetContentTags(
+                    activity,
+                    item.ItemId,
+                    item.Kind,
+                    contentVersion.Version,
+                    contentVersion.VersionId);
+                return new AnalysisContentVersionResult(item, contentVersion);
+            }).ConfigureAwait(false);
 
     public async Task<AnalysisContentVersionResult> AddVersionAsync(
         string itemId,
         CreateAnalysisContentVersionCommand command,
         ClaimsPrincipal principal,
         CancellationToken cancellationToken)
-    {
-        var item = await GetRequiredItemAsync(itemId, cancellationToken).ConfigureAwait(false);
-        var latest = await GetRequiredVersionAsync(itemId, null, cancellationToken).ConfigureAwait(false);
-        var nextVersion = latest.Version + 1;
-        var now = timeProvider.GetUtcNow();
+        => await AnalysisContentTelemetry.TrackAsync(
+            AnalysisContentTelemetry.OperationsNames.AddVersion,
+            async activity =>
+            {
+                var item = await GetRequiredItemAsync(itemId, cancellationToken).ConfigureAwait(false);
+                var actor = ResolveActor(principal);
+                var explicitBasedOnVersionId = NormalizeOptional(command.BasedOnVersionId);
+                var createdFromJobId = NormalizeOptional(command.CreatedFromJobId);
 
-        var version = CreateVersion(
-            itemId,
-            nextVersion,
-            item.Kind,
-            command.SavedQuery,
-            command.AnalysisPackage,
-            NormalizeOptional(command.BasedOnVersionId) ?? latest.VersionId,
-            NormalizeOptional(command.CreatedFromJobId),
-            command.CreatedFromArtifactIds ?? [],
-            ResolveActor(principal),
-            now);
+                for (var attempt = 1; attempt <= MaxVersionCreateAttempts; attempt++)
+                {
+                    var latest = await GetRequiredVersionAsync(itemId, null, cancellationToken).ConfigureAwait(false);
+                    var nextVersion = latest.Version + 1;
+                    var now = timeProvider.GetUtcNow();
 
-        ValidatePayload(item.Kind, version.SavedQuery, version.AnalysisPackage);
+                    var version = CreateVersion(
+                        itemId,
+                        nextVersion,
+                        item.Kind,
+                        command.SavedQuery,
+                        command.AnalysisPackage,
+                        explicitBasedOnVersionId ?? latest.VersionId,
+                        createdFromJobId,
+                        command.CreatedFromArtifactIds ?? [],
+                        actor,
+                        now);
 
-        var stored = await store.AddVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
-        var updatedItem = await GetRequiredItemAsync(itemId, cancellationToken).ConfigureAwait(false);
-        Log.ContentVersionCreated(logger, itemId, stored.Version);
-        return new AnalysisContentVersionResult(updatedItem, stored);
-    }
+                    ValidatePayload(item.Kind, version.SavedQuery, version.AnalysisPackage);
+                    AnalysisContentTelemetry.SetContentTags(
+                        activity,
+                        item.ItemId,
+                        item.Kind,
+                        version.Version,
+                        version.VersionId);
+
+                    try
+                    {
+                        var stored = await store.AddVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
+                        var updatedItem = await GetRequiredItemAsync(itemId, cancellationToken).ConfigureAwait(false);
+                        Log.ContentVersionCreated(logger, itemId, stored.Version);
+                        return new AnalysisContentVersionResult(updatedItem, stored);
+                    }
+                    catch (AnalysisContentStoreConflictException) when (attempt < MaxVersionCreateAttempts)
+                    {
+                        Log.ContentVersionConflictRetry(logger, itemId, attempt);
+                    }
+                    catch (AnalysisContentStoreConflictException ex)
+                    {
+                        throw new AnalysisContentConflictException(
+                            string.IsNullOrWhiteSpace(ex.Message)
+                                ? "Analysis content version changed while creating a new version; retry the request."
+                                : ex.Message);
+                    }
+                }
+
+                throw new AnalysisContentConflictException(
+                    "Analysis content version changed while creating a new version; retry the request.");
+            }).ConfigureAwait(false);
 
     public async Task<SavedQueryPreviewResult> PreviewSavedQueryAsync(
         string itemId,
         int version,
         int? limit,
         CancellationToken cancellationToken)
-    {
-        var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
-        var savedQuery = contentVersion.SavedQuery
-            ?? throw new AnalysisContentValidationException("The requested version is not a saved query.");
-
-        var layer = await layerCatalog.GetLayerAsync(savedQuery.LayerId, cancellationToken).ConfigureAwait(false)
-            ?? throw new AnalysisContentNotFoundException($"Layer '{savedQuery.LayerId}' was not found.");
-
-        var previewLimit = ResolveLimit(limit ?? savedQuery.PreviewLimit, DefaultPreviewLimit, MaxPreviewLimit);
-        QueryFilter? filter = null;
-        if (savedQuery.FilterPlan is { Clauses.Length: > 0 } filterPlan)
-        {
-            var compiled = FilterPlanCompiler.Compile(filterPlan, layer);
-            if (!compiled.IsSuccess || compiled.Expression is null)
+        => await AnalysisContentTelemetry.TrackAsync(
+            AnalysisContentTelemetry.OperationsNames.PreviewSavedQuery,
+            async activity =>
             {
-                throw new AnalysisContentValidationException(
-                    compiled.ErrorMessage ?? "Saved query filter plan could not be compiled.");
-            }
+                var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
+                var savedQuery = contentVersion.SavedQuery
+                    ?? throw new AnalysisContentValidationException("The requested version is not a saved query.");
+                AnalysisContentTelemetry.SetContentTags(
+                    activity,
+                    contentVersion.ItemId,
+                    contentVersion.Kind,
+                    contentVersion.Version,
+                    contentVersion.VersionId);
 
-            filter = QueryFilter.FromExpression(
-                compiled.Expression,
-                new FilterSource("saved-query", FilterLanguage.Cql2Json, "AnalysisContent"));
-        }
+                var layer = await layerCatalog.GetLayerAsync(savedQuery.LayerId, cancellationToken).ConfigureAwait(false)
+                    ?? throw new AnalysisContentNotFoundException($"Layer '{savedQuery.LayerId}' was not found.");
 
-        var query = new UnifiedQuery
-        {
-            Filter = filter,
-            Limit = previewLimit,
-            OutFields = savedQuery.OutFields.Count > 0
-                ? ImmutableArray.CreateRange(savedQuery.OutFields)
-                : null,
-            OutputCrs = savedQuery.OutputSrid.HasValue
-                ? QueryCrs.Create(savedQuery.OutputSrid.Value)
-                : null
-        };
+                var previewLimit = ResolveLimit(limit ?? savedQuery.PreviewLimit, DefaultPreviewLimit, MaxPreviewLimit);
+                QueryFilter? filter = null;
+                if (savedQuery.FilterPlan is { Clauses.Length: > 0 } filterPlan)
+                {
+                    var compiled = FilterPlanCompiler.Compile(filterPlan, layer);
+                    if (!compiled.IsSuccess || compiled.Expression is null)
+                    {
+                        throw new AnalysisContentValidationException(
+                            compiled.ErrorMessage ?? "Saved query filter plan could not be compiled.");
+                    }
 
-        var validation = queryProcessor.ValidateQuery(query, layer);
-        if (!validation.IsValid)
-        {
-            throw new AnalysisContentValidationException(
-                validation.ErrorMessage ?? "Saved query preview request is invalid.");
-        }
+                    filter = QueryFilter.FromExpression(
+                        compiled.Expression,
+                        new FilterSource("saved-query", FilterLanguage.Cql2Json, "AnalysisContent"));
+                }
 
-        var optimized = queryProcessor.OptimizeQuery(query, layer);
-        var featureQuery = queryProcessor.ToFeatureQuery(optimized, layer);
-        var result = await featureReader.QueryAsync(layer.Id, featureQuery, cancellationToken).ConfigureAwait(false);
+                var query = new UnifiedQuery
+                {
+                    Filter = filter,
+                    Limit = previewLimit,
+                    OutFields = savedQuery.OutFields.Count > 0
+                        ? ImmutableArray.CreateRange(savedQuery.OutFields)
+                        : null,
+                    OutputCrs = savedQuery.OutputSrid.HasValue
+                        ? QueryCrs.Create(savedQuery.OutputSrid.Value)
+                        : null
+                };
 
-        var artifactId = CreatePreviewArtifactId();
-        var binding = new ArtifactBindingRef
-        {
-            ArtifactId = artifactId,
-            SourceItemId = itemId,
-            SourceVersion = contentVersion.Version,
-            SourceVersionId = contentVersion.VersionId,
-            Role = "preview",
-            TargetKind = "map",
-            TargetSlot = "source"
-        };
+                var validation = queryProcessor.ValidateQuery(query, layer);
+                if (!validation.IsValid)
+                {
+                    throw new AnalysisContentValidationException(
+                        validation.ErrorMessage ?? "Saved query preview request is invalid.");
+                }
 
-        var now = timeProvider.GetUtcNow();
-        await store.UpsertArtifactAsync(new ResultArtifactRecord
-        {
-            ArtifactId = artifactId,
-            ResultPackageId = $"{itemId}:v{contentVersion.Version}:preview",
-            JobId = "preview",
-            SourceItemId = itemId,
-            SourceVersion = contentVersion.Version,
-            SourceVersionId = contentVersion.VersionId,
-            Kind = ArtifactKind.FeatureLayer,
-            Label = $"{savedQuery.ServiceName ?? layer.Name} preview",
-            Uri = $"honua://analysis/artifacts/{artifactId}",
-            ContentType = "application/json",
-            Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["layerId"] = savedQuery.LayerId.ToString(CultureInfo.InvariantCulture),
-                ["previewLimit"] = previewLimit.ToString(CultureInfo.InvariantCulture)
-            },
-            Provenance = BuildSourceProvenance(contentVersion, savedQuery.OutputSrid, savedQuery.Units),
-            RetentionState = ResultArtifactRetentionState.Preview,
-            CreatedAt = now,
-            ExpiresAt = now.Add(PreviewRetention)
-        }, cancellationToken).ConfigureAwait(false);
+                var optimized = queryProcessor.OptimizeQuery(query, layer);
+                var featureQuery = queryProcessor.ToFeatureQuery(optimized, layer);
+                var result = await featureReader.QueryAsync(layer.Id, featureQuery, cancellationToken).ConfigureAwait(false);
 
-        Log.SavedQueryPreviewed(logger, itemId, contentVersion.Version, result.Items.Length);
+                var artifactId = CreatePreviewArtifactId();
+                var binding = new ArtifactBindingRef
+                {
+                    ArtifactId = artifactId,
+                    SourceItemId = itemId,
+                    SourceVersion = contentVersion.Version,
+                    SourceVersionId = contentVersion.VersionId,
+                    Role = "preview",
+                    TargetKind = "map",
+                    TargetSlot = "source"
+                };
 
-        return new SavedQueryPreviewResult
-        {
-            PreviewArtifactId = artifactId,
-            ItemId = itemId,
-            Version = contentVersion.Version,
-            LayerId = savedQuery.LayerId,
-            Features = result.Items.Select(SavedQueryPreviewFeature.FromFeature).ToArray(),
-            TotalCount = result.TotalCount,
-            ExceededPreviewLimit = result.HasMoreResults || result.TotalCount > previewLimit,
-            Binding = binding
-        };
-    }
+                var now = timeProvider.GetUtcNow();
+                await store.UpsertArtifactAsync(new ResultArtifactRecord
+                {
+                    ArtifactId = artifactId,
+                    ResultPackageId = $"{itemId}:v{contentVersion.Version}:preview",
+                    JobId = "preview",
+                    SourceItemId = itemId,
+                    SourceVersion = contentVersion.Version,
+                    SourceVersionId = contentVersion.VersionId,
+                    Kind = ArtifactKind.FeatureLayer,
+                    Label = $"{savedQuery.ServiceName ?? layer.Name} preview",
+                    Uri = $"honua://analysis/artifacts/{artifactId}",
+                    ContentType = "application/json",
+                    Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["layerId"] = savedQuery.LayerId.ToString(CultureInfo.InvariantCulture),
+                        ["previewLimit"] = previewLimit.ToString(CultureInfo.InvariantCulture)
+                    },
+                    Provenance = BuildSourceProvenance(contentVersion, savedQuery.OutputSrid, savedQuery.Units),
+                    RetentionState = ResultArtifactRetentionState.Preview,
+                    CreatedAt = now,
+                    ExpiresAt = now.Add(PreviewRetention)
+                }, cancellationToken).ConfigureAwait(false);
+
+                Log.SavedQueryPreviewed(logger, itemId, contentVersion.Version, result.Items.Length);
+
+                return new SavedQueryPreviewResult
+                {
+                    PreviewArtifactId = artifactId,
+                    ItemId = itemId,
+                    Version = contentVersion.Version,
+                    LayerId = savedQuery.LayerId,
+                    Features = result.Items.Select(SavedQueryPreviewFeature.FromFeature).ToArray(),
+                    TotalCount = result.TotalCount,
+                    ExceededPreviewLimit = result.HasMoreResults || result.TotalCount > previewLimit,
+                    Binding = binding
+                };
+            }).ConfigureAwait(false);
 
     public async Task<AnalysisContentJobResult> SubmitAnalysisPackageAsync(
         string itemId,
@@ -240,22 +308,32 @@ internal sealed partial class AnalysisContentService(
         RunAnalysisContentVersionCommand command,
         ClaimsPrincipal principal,
         CancellationToken cancellationToken)
-    {
-        var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
-        var package = contentVersion.AnalysisPackage
-            ?? throw new AnalysisContentValidationException("The requested version is not an analysis package.");
+        => await AnalysisContentTelemetry.TrackAsync(
+            AnalysisContentTelemetry.OperationsNames.SubmitAnalysisPackage,
+            async activity =>
+            {
+                var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
+                var package = contentVersion.AnalysisPackage
+                    ?? throw new AnalysisContentValidationException("The requested version is not an analysis package.");
+                AnalysisContentTelemetry.SetContentTags(
+                    activity,
+                    contentVersion.ItemId,
+                    contentVersion.Kind,
+                    contentVersion.Version,
+                    contentVersion.VersionId);
 
-        var metadata = BuildJobMetadata(contentVersion, package, command.Parameters);
-        var job = await geoprocessingJobService.SubmitJobAsync(
-            package.Plan,
-            command.IdempotencyKey,
-            principal,
-            metadata,
-            cancellationToken).ConfigureAwait(false);
+                var metadata = BuildJobMetadata(contentVersion, package, command.Parameters);
+                var job = await geoprocessingJobService.SubmitJobAsync(
+                    package.Plan,
+                    command.IdempotencyKey,
+                    principal,
+                    metadata,
+                    cancellationToken).ConfigureAwait(false);
 
-        Log.AnalysisPackageSubmitted(logger, itemId, version, job.OperationId);
-        return new AnalysisContentJobResult(job, contentVersion);
-    }
+                Log.AnalysisPackageSubmitted(logger, itemId, version, job.OperationId);
+                activity?.SetTag(Honua.ServiceDefaults.HonuaTelemetry.Tags.JobId, job.OperationId);
+                return new AnalysisContentJobResult(job, contentVersion);
+            }).ConfigureAwait(false);
 
     public async Task<AnalysisContentJobResult> RerunAnalysisPackageAsync(
         string itemId,
@@ -263,130 +341,162 @@ internal sealed partial class AnalysisContentService(
         RerunAnalysisContentVersionCommand command,
         ClaimsPrincipal principal,
         CancellationToken cancellationToken)
-    {
-        var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
-        var package = contentVersion.AnalysisPackage
-            ?? throw new AnalysisContentValidationException("The requested version is not an analysis package.");
-
-        var submittedVersion = contentVersion;
-        if (command.ParameterOverrides is { Count: > 0 })
-        {
-            var merged = new Dictionary<string, string>(package.Parameters, StringComparer.Ordinal);
-            foreach (var pair in command.ParameterOverrides)
+        => await AnalysisContentTelemetry.TrackAsync(
+            AnalysisContentTelemetry.OperationsNames.RerunAnalysisPackage,
+            async activity =>
             {
-                if (!string.IsNullOrWhiteSpace(pair.Key))
+                var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
+                var package = contentVersion.AnalysisPackage
+                    ?? throw new AnalysisContentValidationException("The requested version is not an analysis package.");
+                AnalysisContentTelemetry.SetContentTags(
+                    activity,
+                    contentVersion.ItemId,
+                    contentVersion.Kind,
+                    contentVersion.Version,
+                    contentVersion.VersionId);
+
+                var submittedVersion = contentVersion;
+                if (command.ParameterOverrides is { Count: > 0 })
                 {
-                    merged[pair.Key] = pair.Value;
+                    package = ApplyExecutableParameterOverrides(package, command.ParameterOverrides);
+                    var next = new CreateAnalysisContentVersionCommand(
+                        SavedQuery: null,
+                        AnalysisPackage: package,
+                        BasedOnVersionId: contentVersion.VersionId,
+                        CreatedFromJobId: NormalizeOptional(command.RerunOfJobId),
+                        CreatedFromArtifactIds: []);
+                    var result = await AddVersionAsync(itemId, next, principal, cancellationToken).ConfigureAwait(false);
+                    submittedVersion = result.Version;
+                    package = submittedVersion.AnalysisPackage!;
+                    AnalysisContentTelemetry.SetContentTags(
+                        activity,
+                        submittedVersion.ItemId,
+                        submittedVersion.Kind,
+                        submittedVersion.Version,
+                        submittedVersion.VersionId);
                 }
-            }
 
-            var next = new CreateAnalysisContentVersionCommand(
-                SavedQuery: null,
-                AnalysisPackage: package with { Parameters = merged },
-                BasedOnVersionId: contentVersion.VersionId,
-                CreatedFromJobId: NormalizeOptional(command.RerunOfJobId),
-                CreatedFromArtifactIds: []);
-            var result = await AddVersionAsync(itemId, next, principal, cancellationToken).ConfigureAwait(false);
-            submittedVersion = result.Version;
-            package = submittedVersion.AnalysisPackage!;
-        }
+                var metadata = BuildJobMetadata(submittedVersion, package, runtimeParameters: null);
+                if (!string.IsNullOrWhiteSpace(command.RerunOfJobId))
+                {
+                    metadata[AnalysisContentMetadataKeys.RerunOfJobId] = command.RerunOfJobId.Trim();
+                }
 
-        var metadata = BuildJobMetadata(submittedVersion, package, runtimeParameters: null);
-        if (!string.IsNullOrWhiteSpace(command.RerunOfJobId))
-        {
-            metadata[AnalysisContentMetadataKeys.RerunOfJobId] = command.RerunOfJobId.Trim();
-        }
+                if (!string.IsNullOrWhiteSpace(command.RerunOfResultPackageId))
+                {
+                    metadata[AnalysisContentMetadataKeys.RerunOfResultPackageId] = command.RerunOfResultPackageId.Trim();
+                }
 
-        if (!string.IsNullOrWhiteSpace(command.RerunOfResultPackageId))
-        {
-            metadata[AnalysisContentMetadataKeys.RerunOfResultPackageId] = command.RerunOfResultPackageId.Trim();
-        }
+                var job = await geoprocessingJobService.SubmitJobAsync(
+                    package.Plan,
+                    command.IdempotencyKey,
+                    principal,
+                    metadata,
+                    cancellationToken).ConfigureAwait(false);
 
-        var job = await geoprocessingJobService.SubmitJobAsync(
-            package.Plan,
-            command.IdempotencyKey,
-            principal,
-            metadata,
-            cancellationToken).ConfigureAwait(false);
-
-        Log.AnalysisPackageRerunSubmitted(logger, itemId, submittedVersion.Version, job.OperationId);
-        return new AnalysisContentJobResult(job, submittedVersion);
-    }
+                Log.AnalysisPackageRerunSubmitted(logger, itemId, submittedVersion.Version, job.OperationId);
+                activity?.SetTag(Honua.ServiceDefaults.HonuaTelemetry.Tags.JobId, job.OperationId);
+                return new AnalysisContentJobResult(job, submittedVersion);
+            }).ConfigureAwait(false);
 
     public async Task<ResultArtifactRecord> GetArtifactAsync(
         string artifactId,
         CancellationToken cancellationToken)
-    {
-        var artifact = await store.GetArtifactAsync(artifactId, cancellationToken).ConfigureAwait(false);
-        return artifact ?? throw new AnalysisContentNotFoundException($"Artifact '{artifactId}' was not found.");
-    }
+        => await AnalysisContentTelemetry.TrackAsync(
+            AnalysisContentTelemetry.OperationsNames.GetArtifact,
+            async activity =>
+            {
+                activity?.SetTag(AnalysisContentTelemetry.Tags.ArtifactId, artifactId);
+                var artifact = await store.GetArtifactAsync(artifactId, cancellationToken).ConfigureAwait(false);
+                if (artifact is null)
+                {
+                    throw new AnalysisContentNotFoundException($"Artifact '{artifactId}' was not found.");
+                }
+
+                activity?.SetTag(AnalysisContentTelemetry.Tags.ContentItemId, artifact.SourceItemId);
+                activity?.SetTag(AnalysisContentTelemetry.Tags.ContentVersion, artifact.SourceVersion);
+                activity?.SetTag(AnalysisContentTelemetry.Tags.ContentVersionId, artifact.SourceVersionId);
+                return artifact;
+            }).ConfigureAwait(false);
 
     public async Task<AnalysisJobLogs> GetJobLogsAsync(
         string jobId,
         int? limit,
         CancellationToken cancellationToken)
-    {
-        var resolvedLimit = ResolveLimit(limit, DefaultLogLimit, MaxLogLimit);
-        if (_logStore is null)
-        {
-            return new AnalysisJobLogs
+        => await AnalysisContentTelemetry.TrackAsync(
+            AnalysisContentTelemetry.OperationsNames.GetJobLogs,
+            async activity =>
             {
-                JobId = jobId,
-                Entries = [],
-                TotalCount = 0,
-                Truncated = false
-            };
-        }
+                var resolvedLimit = ResolveLimit(limit, DefaultLogLimit, MaxLogLimit);
+                activity?.SetTag(Honua.ServiceDefaults.HonuaTelemetry.Tags.JobId, jobId);
+                activity?.SetTag(AnalysisContentTelemetry.Tags.LogLimit, resolvedLimit);
+                if (_logStore is null)
+                {
+                    return new AnalysisJobLogs
+                    {
+                        JobId = jobId,
+                        Entries = [],
+                        TotalCount = 0,
+                        Truncated = false
+                    };
+                }
 
-        var logs = await _logStore.GetLogsAsync(jobId, cancellationToken).ConfigureAwait(false);
-        var bounded = logs.TakeLast(resolvedLimit)
-            .Select(entry => new AnalysisJobLogEntry
-            {
-                Timestamp = entry.Timestamp,
-                Level = entry.Level,
-                Message = SanitizeDiagnostic(entry.Message),
-                Phase = SanitizePhase(entry.Phase),
-                Metadata = SanitizeMetadata(entry.Metadata)
-            })
-            .ToArray();
+                var tail = await _logStore.TailAsync(jobId, resolvedLimit, cancellationToken).ConfigureAwait(false);
+                var bounded = tail.Items
+                    .Select(entry => new AnalysisJobLogEntry
+                    {
+                        Timestamp = entry.Timestamp,
+                        Level = entry.Level,
+                        Message = SanitizeDiagnostic(entry.Message),
+                        Phase = SanitizePhase(entry.Phase),
+                        Metadata = SanitizeMetadata(entry.Metadata)
+                    })
+                    .ToArray();
 
-        return new AnalysisJobLogs
-        {
-            JobId = jobId,
-            Entries = bounded,
-            TotalCount = logs.Count,
-            Truncated = logs.Count > bounded.Length
-        };
-    }
+                return new AnalysisJobLogs
+                {
+                    JobId = jobId,
+                    Entries = bounded,
+                    TotalCount = tail.TotalCount,
+                    Truncated = tail.TotalCount > bounded.Length
+                };
+            }).ConfigureAwait(false);
 
     public async Task<AnalysisJobFailure> GetJobFailureAsync(
         string jobId,
         ClaimsPrincipal principal,
         CancellationToken cancellationToken)
-    {
-        var job = await geoprocessingJobService.GetJobAsync(jobId, principal, cancellationToken).ConfigureAwait(false);
+        => await AnalysisContentTelemetry.TrackAsync(
+            AnalysisContentTelemetry.OperationsNames.GetJobFailure,
+            async activity =>
+            {
+                activity?.SetTag(Honua.ServiceDefaults.HonuaTelemetry.Tags.JobId, jobId);
+                var job = await geoprocessingJobService.GetJobAsync(jobId, principal, cancellationToken).ConfigureAwait(false);
 
-        return job.Status switch
-        {
-            ExecutionJobStatus.Failed => new AnalysisJobFailure
-            {
-                JobId = job.OperationId,
-                Classification = ClassifyFailure(job.ErrorMessage),
-                Message = SanitizeFailureMessage(job.ErrorMessage),
-                IsTerminal = true,
-                FailedAt = job.CompletedAt
-            },
-            ExecutionJobStatus.Cancelled => new AnalysisJobFailure
-            {
-                JobId = job.OperationId,
-                Classification = AnalysisJobFailureClassification.Cancelled,
-                Message = "The analysis job was cancelled.",
-                IsTerminal = true,
-                FailedAt = job.CompletedAt
-            },
-            _ => throw new AnalysisContentConflictException("The requested job has not failed.")
-        };
-    }
+                AnalysisJobFailure failure = job.Status switch
+                {
+                    ExecutionJobStatus.Failed => new AnalysisJobFailure
+                    {
+                        JobId = job.OperationId,
+                        Classification = ClassifyFailure(job.ErrorMessage),
+                        Message = SanitizeFailureMessage(job.ErrorMessage),
+                        IsTerminal = true,
+                        FailedAt = job.CompletedAt
+                    },
+                    ExecutionJobStatus.Cancelled => new AnalysisJobFailure
+                    {
+                        JobId = job.OperationId,
+                        Classification = AnalysisJobFailureClassification.Cancelled,
+                        Message = "The analysis job was cancelled.",
+                        IsTerminal = true,
+                        FailedAt = job.CompletedAt
+                    },
+                    _ => throw new AnalysisContentConflictException("The requested job has not failed.")
+                };
+
+                activity?.SetTag("honua.analysis_content.failure_classification", failure.Classification.ToString());
+                return failure;
+            }).ConfigureAwait(false);
 
     private async Task<AnalysisContentItem> GetRequiredItemAsync(
         string itemId,
@@ -452,6 +562,72 @@ internal sealed partial class AnalysisContentService(
             default:
                 throw new AnalysisContentValidationException("Unsupported analysis content kind.");
         }
+    }
+
+    private static AnalysisPackageContent ApplyExecutableParameterOverrides(
+        AnalysisPackageContent package,
+        IReadOnlyDictionary<string, string> overrides)
+    {
+        var normalizedOverrides = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var pair in overrides)
+        {
+            if (string.IsNullOrWhiteSpace(pair.Key))
+            {
+                throw new AnalysisContentValidationException("Parameter override keys are required.");
+            }
+
+            normalizedOverrides[pair.Key.Trim()] = pair.Value;
+        }
+
+        var matchedKeys = new HashSet<string>(StringComparer.Ordinal);
+        var updatedSteps = new AnalysisPlanStep[package.Plan.Steps.Count];
+        for (var index = 0; index < package.Plan.Steps.Count; index++)
+        {
+            var step = package.Plan.Steps[index];
+            if (step.Inputs.Count == 0)
+            {
+                updatedSteps[index] = step;
+                continue;
+            }
+
+            Dictionary<string, string>? updatedInputs = null;
+            foreach (var pair in normalizedOverrides)
+            {
+                if (!step.Inputs.ContainsKey(pair.Key))
+                {
+                    continue;
+                }
+
+                updatedInputs ??= new Dictionary<string, string>(step.Inputs, StringComparer.Ordinal);
+                updatedInputs[pair.Key] = pair.Value;
+                matchedKeys.Add(pair.Key);
+            }
+
+            updatedSteps[index] = updatedInputs is null
+                ? step
+                : step with { Inputs = updatedInputs };
+        }
+
+        foreach (var pair in normalizedOverrides)
+        {
+            if (!matchedKeys.Contains(pair.Key))
+            {
+                throw new AnalysisContentValidationException(
+                    $"Parameter override '{pair.Key}' does not match an executable analysis plan input.");
+            }
+        }
+
+        var mergedParameters = new Dictionary<string, string>(package.Parameters, StringComparer.Ordinal);
+        foreach (var pair in normalizedOverrides)
+        {
+            mergedParameters[pair.Key] = pair.Value;
+        }
+
+        return package with
+        {
+            Parameters = mergedParameters,
+            Plan = package.Plan with { Steps = updatedSteps }
+        };
     }
 
     private static AnalysisContentVersion CreateVersion(
@@ -699,5 +875,8 @@ internal sealed partial class AnalysisContentService(
 
         [LoggerMessage(12005, LogLevel.Information, "Submitted analysis package rerun {ItemId} version {Version} as job {JobId}")]
         public static partial void AnalysisPackageRerunSubmitted(ILogger logger, string itemId, int version, string jobId);
+
+        [LoggerMessage(12006, LogLevel.Debug, "Retrying analysis content version creation for {ItemId} after conflict on attempt {Attempt}")]
+        public static partial void ContentVersionConflictRetry(ILogger logger, string itemId, int attempt);
     }
 }

--- a/src/Honua.Server/Features/AnalysisContent/AnalysisContentService.cs
+++ b/src/Honua.Server/Features/AnalysisContent/AnalysisContentService.cs
@@ -422,6 +422,7 @@ internal sealed partial class AnalysisContentService(
     public async Task<AnalysisJobLogs> GetJobLogsAsync(
         string jobId,
         int? limit,
+        ClaimsPrincipal principal,
         CancellationToken cancellationToken)
         => await AnalysisContentTelemetry.TrackAsync(
             AnalysisContentTelemetry.OperationsNames.GetJobLogs,
@@ -430,6 +431,13 @@ internal sealed partial class AnalysisContentService(
                 var resolvedLimit = ResolveLimit(limit, DefaultLogLimit, MaxLogLimit);
                 activity?.SetTag(Honua.ServiceDefaults.HonuaTelemetry.Tags.JobId, jobId);
                 activity?.SetTag(AnalysisContentTelemetry.Tags.LogLimit, resolvedLimit);
+
+                // Resolve the job through the job service first so unknown ids return not-found
+                // (instead of 200 with empty logs) and the same job-read authorization enforced by
+                // the failure endpoint is applied before any log content is returned.
+                _ = await geoprocessingJobService.GetJobAsync(jobId, principal, cancellationToken)
+                    .ConfigureAwait(false);
+
                 if (_logStore is null)
                 {
                     return new AnalysisJobLogs
@@ -803,6 +811,22 @@ internal sealed partial class AnalysisContentService(
             : sanitized;
     }
 
+    private static readonly string[] SensitiveDiagnosticMarkers =
+    [
+        "Npgsql",
+        "connection string",
+        "password",
+        "pwd=",
+        "secret",
+        "token",
+        "credential",
+        "api key",
+        "apikey",
+        "api_key",
+        "bearer",
+        "private key"
+    ];
+
     private static string SanitizeDiagnostic(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -811,17 +835,35 @@ internal sealed partial class AnalysisContentService(
         }
 
         var sanitized = value.ReplaceLineEndings(" ").Trim();
-        if (sanitized.Contains(" at ", StringComparison.Ordinal) ||
-            sanitized.Contains("Npgsql", StringComparison.OrdinalIgnoreCase) ||
-            sanitized.Contains("connection string", StringComparison.OrdinalIgnoreCase) ||
-            sanitized.Contains("password", StringComparison.OrdinalIgnoreCase))
+        if (ContainsSensitiveMarker(sanitized))
         {
-            sanitized = "The analysis job failed. See server logs for details.";
+            return "The analysis job failed. See server logs for details.";
         }
 
         return sanitized.Length <= MaxDiagnosticLength
             ? sanitized
             : sanitized[..MaxDiagnosticLength];
+    }
+
+    private static bool ContainsSensitiveMarker(string value)
+    {
+        // " at " (case-sensitive) catches stack-trace frames; the remaining markers catch
+        // provider internals and secret-bearing fragments (secret/token/credential/api key/
+        // bearer) regardless of case, including values embedded in otherwise innocuous keys.
+        if (value.Contains(" at ", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        foreach (var marker in SensitiveDiagnosticMarkers)
+        {
+            if (value.Contains(marker, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string? SanitizePhase(string? value)

--- a/src/Honua.Server/Features/AnalysisContent/AnalysisContentServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/AnalysisContent/AnalysisContentServiceCollectionExtensions.cs
@@ -16,7 +16,17 @@ internal static class AnalysisContentServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(configuration);
 
         services.TryAddSingleton(TimeProvider.System);
-        services.TryAddScoped<IAnalysisContentStore, InMemoryAnalysisContentStore>();
+
+        // In-memory baseline store for hosts without a durable provider (e.g. DuckDB/MySQL
+        // profiles or tests). It must be a process-wide singleton: the concrete store keeps all
+        // content in instance fields, so a scoped registration would resolve a fresh empty store
+        // per request and silently lose items written by an earlier request. The interface stays
+        // scoped (resolving the singleton) to match the durable Postgres store's lifetime, so the
+        // Postgres registration cleanly replaces it when configured. Data does not survive a
+        // restart; durable persistence requires the Postgres-backed store.
+        services.TryAddSingleton<InMemoryAnalysisContentStore>();
+        services.TryAddScoped<IAnalysisContentStore>(sp =>
+            sp.GetRequiredService<InMemoryAnalysisContentStore>());
         services.TryAddScoped<IAnalysisContentService, AnalysisContentService>();
 
         return services;

--- a/src/Honua.Server/Features/AnalysisContent/AnalysisContentServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/AnalysisContent/AnalysisContentServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.AnalysisContent.Abstractions;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Features.AnalysisContent;
+
+internal static class AnalysisContentServiceCollectionExtensions
+{
+    public static IServiceCollection AddAnalysisContent(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.TryAddSingleton(TimeProvider.System);
+        services.TryAddScoped<IAnalysisContentStore, InMemoryAnalysisContentStore>();
+        services.TryAddScoped<IAnalysisContentService, AnalysisContentService>();
+
+        return services;
+    }
+}

--- a/src/Honua.Server/Features/AnalysisContent/AnalysisContentTelemetry.cs
+++ b/src/Honua.Server/Features/AnalysisContent/AnalysisContentTelemetry.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.ServiceDefaults;
+
+namespace Honua.Server.Features.AnalysisContent;
+
+internal static class AnalysisContentTelemetry
+{
+    private const string SuccessResult = "success";
+    private const string ErrorResult = "error";
+
+    private static readonly Counter<long> Operations = HonuaTelemetry.Meter.CreateCounter<long>(
+        "honua.analysis_content.operations_total",
+        "operations",
+        "Number of analysis content operations by operation and result.");
+
+    internal static class OperationsNames
+    {
+        public const string CreateItem = "create_item";
+        public const string GetItem = "get_item";
+        public const string GetVersion = "get_version";
+        public const string AddVersion = "add_version";
+        public const string PreviewSavedQuery = "preview_saved_query";
+        public const string SubmitAnalysisPackage = "submit_analysis_package";
+        public const string RerunAnalysisPackage = "rerun_analysis_package";
+        public const string GetArtifact = "get_artifact";
+        public const string GetJobLogs = "get_job_logs";
+        public const string GetJobFailure = "get_job_failure";
+    }
+
+    internal static class Tags
+    {
+        public const string ContentItemId = "honua.analysis_content.item_id";
+        public const string ContentKind = "honua.analysis_content.kind";
+        public const string ContentVersion = "honua.analysis_content.version";
+        public const string ContentVersionId = "honua.analysis_content.version_id";
+        public const string ArtifactId = "honua.analysis_content.artifact_id";
+        public const string Result = "honua.analysis_content.result";
+        public const string LogLimit = "honua.analysis_content.log_limit";
+    }
+
+    public static async Task<T> TrackAsync<T>(
+        string operation,
+        Func<Activity?, Task<T>> action)
+    {
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity(
+            $"honua.analysis_content.{operation}",
+            ActivityKind.Internal);
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.Admin);
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, operation);
+
+        try
+        {
+            var result = await action(activity).ConfigureAwait(false);
+            activity?.SetTag(Tags.Result, SuccessResult);
+            HonuaTelemetry.SetSuccess(activity);
+            Operations.Add(
+                1,
+                new KeyValuePair<string, object?>(HonuaTelemetry.Tags.Operation, operation),
+                new KeyValuePair<string, object?>(Tags.Result, SuccessResult));
+            return result;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetTag(Tags.Result, ErrorResult);
+            HonuaTelemetry.RecordException(activity, ex);
+            Operations.Add(
+                1,
+                new KeyValuePair<string, object?>(HonuaTelemetry.Tags.Operation, operation),
+                new KeyValuePair<string, object?>(Tags.Result, ErrorResult));
+            throw;
+        }
+    }
+
+    public static void SetContentTags(
+        Activity? activity,
+        string itemId,
+        AnalysisContentKind kind,
+        int? version = null,
+        string? versionId = null)
+    {
+        activity?.SetTag(Tags.ContentItemId, itemId);
+        activity?.SetTag(Tags.ContentKind, kind.ToString());
+        if (version.HasValue)
+        {
+            activity?.SetTag(Tags.ContentVersion, version.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(versionId))
+        {
+            activity?.SetTag(Tags.ContentVersionId, versionId);
+        }
+    }
+}

--- a/src/Honua.Server/Features/AnalysisContent/IAnalysisContentService.cs
+++ b/src/Honua.Server/Features/AnalysisContent/IAnalysisContentService.cs
@@ -56,6 +56,7 @@ internal interface IAnalysisContentService
     Task<AnalysisJobLogs> GetJobLogsAsync(
         string jobId,
         int? limit,
+        ClaimsPrincipal principal,
         CancellationToken cancellationToken);
 
     Task<AnalysisJobFailure> GetJobFailureAsync(

--- a/src/Honua.Server/Features/AnalysisContent/IAnalysisContentService.cs
+++ b/src/Honua.Server/Features/AnalysisContent/IAnalysisContentService.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Server.Features.AnalysisContent;
+
+internal interface IAnalysisContentService
+{
+    Task<AnalysisContentItemResult> CreateItemAsync(
+        CreateAnalysisContentItemCommand command,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken);
+
+    Task<AnalysisContentItemResult> GetItemAsync(
+        string itemId,
+        CancellationToken cancellationToken);
+
+    Task<AnalysisContentVersionResult> GetVersionAsync(
+        string itemId,
+        int? version,
+        CancellationToken cancellationToken);
+
+    Task<AnalysisContentVersionResult> AddVersionAsync(
+        string itemId,
+        CreateAnalysisContentVersionCommand command,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken);
+
+    Task<SavedQueryPreviewResult> PreviewSavedQueryAsync(
+        string itemId,
+        int version,
+        int? limit,
+        CancellationToken cancellationToken);
+
+    Task<AnalysisContentJobResult> SubmitAnalysisPackageAsync(
+        string itemId,
+        int version,
+        RunAnalysisContentVersionCommand command,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken);
+
+    Task<AnalysisContentJobResult> RerunAnalysisPackageAsync(
+        string itemId,
+        int version,
+        RerunAnalysisContentVersionCommand command,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken);
+
+    Task<ResultArtifactRecord> GetArtifactAsync(
+        string artifactId,
+        CancellationToken cancellationToken);
+
+    Task<AnalysisJobLogs> GetJobLogsAsync(
+        string jobId,
+        int? limit,
+        CancellationToken cancellationToken);
+
+    Task<AnalysisJobFailure> GetJobFailureAsync(
+        string jobId,
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken);
+}
+
+internal sealed record AnalysisContentItemResult(
+    AnalysisContentItem Item,
+    AnalysisContentVersion Version);
+
+internal sealed record AnalysisContentVersionResult(
+    AnalysisContentItem Item,
+    AnalysisContentVersion Version);
+
+internal sealed record AnalysisContentJobResult(
+    ExecutionJobRecord Job,
+    AnalysisContentVersion Version);
+
+internal sealed record CreateAnalysisContentItemCommand(
+    AnalysisContentKind Kind,
+    string Name,
+    string? Title,
+    SavedQueryContent? SavedQuery,
+    AnalysisPackageContent? AnalysisPackage);
+
+internal sealed record CreateAnalysisContentVersionCommand(
+    SavedQueryContent? SavedQuery,
+    AnalysisPackageContent? AnalysisPackage,
+    string? BasedOnVersionId,
+    string? CreatedFromJobId,
+    IReadOnlyList<string>? CreatedFromArtifactIds);
+
+internal sealed record RunAnalysisContentVersionCommand(
+    string? IdempotencyKey,
+    IReadOnlyDictionary<string, string>? Parameters);
+
+internal sealed record RerunAnalysisContentVersionCommand(
+    string? IdempotencyKey,
+    string? RerunOfJobId,
+    string? RerunOfResultPackageId,
+    IReadOnlyDictionary<string, string>? ParameterOverrides);

--- a/src/Honua.Server/Features/AnalysisContent/InMemoryAnalysisContentStore.cs
+++ b/src/Honua.Server/Features/AnalysisContent/InMemoryAnalysisContentStore.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using Honua.Core.Features.AnalysisContent.Abstractions;
+using Honua.Core.Features.AnalysisContent.Domain;
+
+namespace Honua.Server.Features.AnalysisContent;
+
+internal sealed class InMemoryAnalysisContentStore : IAnalysisContentStore
+{
+    private readonly ConcurrentDictionary<string, AnalysisContentItem> _items = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, SortedDictionary<int, AnalysisContentVersion>> _versions =
+        new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, ResultArtifactRecord> _artifacts = new(StringComparer.Ordinal);
+    private readonly object _gate = new();
+
+    public Task<AnalysisContentItem> CreateItemAsync(
+        AnalysisContentItem item,
+        AnalysisContentVersion version,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(version);
+
+        lock (_gate)
+        {
+            if (_items.ContainsKey(item.ItemId))
+            {
+                throw new InvalidOperationException("Analysis content item already exists.");
+            }
+
+            _items[item.ItemId] = item;
+            _versions[item.ItemId] = new SortedDictionary<int, AnalysisContentVersion>
+            {
+                [version.Version] = version
+            };
+        }
+
+        return Task.FromResult(item);
+    }
+
+    public Task<AnalysisContentItem?> GetItemAsync(
+        string itemId,
+        CancellationToken cancellationToken = default)
+    {
+        _items.TryGetValue(itemId, out var item);
+        return Task.FromResult(item);
+    }
+
+    public Task<AnalysisContentVersion> AddVersionAsync(
+        string itemId,
+        AnalysisContentVersion version,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(version);
+
+        lock (_gate)
+        {
+            if (!_items.TryGetValue(itemId, out var item))
+            {
+                throw new KeyNotFoundException("Analysis content item was not found.");
+            }
+
+            if (!_versions.TryGetValue(itemId, out var versions))
+            {
+                versions = new SortedDictionary<int, AnalysisContentVersion>();
+                _versions[itemId] = versions;
+            }
+
+            if (versions.ContainsKey(version.Version))
+            {
+                throw new InvalidOperationException("Analysis content version already exists.");
+            }
+
+            versions[version.Version] = version;
+            _items[itemId] = item with
+            {
+                CurrentVersion = version.Version,
+                CurrentVersionId = version.VersionId,
+                UpdatedAt = version.CreatedAt
+            };
+        }
+
+        return Task.FromResult(version);
+    }
+
+    public Task<AnalysisContentVersion?> GetVersionAsync(
+        string itemId,
+        int? version = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_versions.TryGetValue(itemId, out var versions) || versions.Count == 0)
+        {
+            return Task.FromResult<AnalysisContentVersion?>(null);
+        }
+
+        AnalysisContentVersion? resolved;
+        lock (_gate)
+        {
+            resolved = version.HasValue
+                ? versions.GetValueOrDefault(version.Value)
+                : versions.LastOrDefault().Value;
+        }
+
+        return Task.FromResult(resolved);
+    }
+
+    public Task<IReadOnlyList<AnalysisContentVersion>> ListVersionsAsync(
+        string itemId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_versions.TryGetValue(itemId, out var versions))
+        {
+            return Task.FromResult<IReadOnlyList<AnalysisContentVersion>>(Array.Empty<AnalysisContentVersion>());
+        }
+
+        AnalysisContentVersion[] snapshot;
+        lock (_gate)
+        {
+            snapshot = versions.Values.ToArray();
+        }
+
+        return Task.FromResult<IReadOnlyList<AnalysisContentVersion>>(snapshot);
+    }
+
+    public Task<ResultArtifactRecord> UpsertArtifactAsync(
+        ResultArtifactRecord artifact,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+        _artifacts[artifact.ArtifactId] = artifact;
+        return Task.FromResult(artifact);
+    }
+
+    public Task<ResultArtifactRecord?> GetArtifactAsync(
+        string artifactId,
+        CancellationToken cancellationToken = default)
+    {
+        _artifacts.TryGetValue(artifactId, out var artifact);
+        return Task.FromResult(artifact);
+    }
+
+    public Task<IReadOnlyList<ResultArtifactRecord>> ListArtifactsForJobAsync(
+        string jobId,
+        CancellationToken cancellationToken = default)
+    {
+        var artifacts = _artifacts.Values
+            .Where(artifact => string.Equals(artifact.JobId, jobId, StringComparison.Ordinal))
+            .OrderBy(artifact => artifact.CreatedAt)
+            .ToArray();
+        return Task.FromResult<IReadOnlyList<ResultArtifactRecord>>(artifacts);
+    }
+}

--- a/src/Honua.Server/Features/AnalysisContent/InMemoryAnalysisContentStore.cs
+++ b/src/Honua.Server/Features/AnalysisContent/InMemoryAnalysisContentStore.cs
@@ -27,7 +27,7 @@ internal sealed class InMemoryAnalysisContentStore : IAnalysisContentStore
         {
             if (_items.ContainsKey(item.ItemId))
             {
-                throw new InvalidOperationException("Analysis content item already exists.");
+                throw new AnalysisContentStoreConflictException("Analysis content item already exists.");
             }
 
             _items[item.ItemId] = item;
@@ -70,7 +70,7 @@ internal sealed class InMemoryAnalysisContentStore : IAnalysisContentStore
 
             if (versions.ContainsKey(version.Version))
             {
-                throw new InvalidOperationException("Analysis content version already exists.");
+                throw new AnalysisContentStoreConflictException("Analysis content version already exists.");
             }
 
             versions[version.Version] = version;

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobTerminalCallback.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobTerminalCallback.cs
@@ -3,6 +3,9 @@
 
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.AnalysisContent;
+using Honua.Core.Features.AnalysisContent.Abstractions;
+using Honua.Core.Features.AnalysisContent.Domain;
 using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
@@ -19,6 +22,7 @@ internal sealed partial class GeoprocessingJobTerminalCallback(
     IUniversalProgressStore progressStore,
     IProcessCatalog processCatalog,
     IGeoprocessingResultPackageStore? resultPackageStore,
+    IAnalysisContentStore? analysisContentStore,
     ILogger<GeoprocessingJobTerminalCallback> logger) : IJobTerminalCallback
 {
     private static readonly TimeSpan ProgressRetention = TimeSpan.FromDays(7);
@@ -32,13 +36,27 @@ internal sealed partial class GeoprocessingJobTerminalCallback(
 
         try
         {
-            if (resultPackageStore != null)
+            AnalysisResultPackage? package = null;
+            if (resultPackageStore != null || analysisContentStore != null && HasAnalysisContentSource(job))
             {
-                var package = GeoprocessingResultPackageFactory.Create(job, processCatalog);
+                package = GeoprocessingResultPackageFactory.Create(job, processCatalog);
+            }
+
+            if (resultPackageStore != null && package != null)
+            {
                 await resultPackageStore.SetAsync(
                     job.OperationId,
                     package,
                     ProgressRetention,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            if (analysisContentStore != null && package != null)
+            {
+                await PersistAnalysisContentArtifactsAsync(
+                    analysisContentStore,
+                    job,
+                    package,
                     cancellationToken).ConfigureAwait(false);
             }
         }
@@ -94,6 +112,95 @@ internal sealed partial class GeoprocessingJobTerminalCallback(
         catch (Exception ex)
         {
             Log.ProgressSyncFailed(logger, job.OperationId, ex);
+        }
+    }
+
+    private static bool HasAnalysisContentSource(ExecutionJobRecord job)
+        => job.Spec.Parameters.ContainsKey(AnalysisContentMetadataKeys.ItemId)
+           && job.Spec.Parameters.ContainsKey(AnalysisContentMetadataKeys.Version)
+           && job.Spec.Parameters.ContainsKey(AnalysisContentMetadataKeys.VersionId);
+
+    private static async Task PersistAnalysisContentArtifactsAsync(
+        IAnalysisContentStore artifactStore,
+        ExecutionJobRecord job,
+        AnalysisResultPackage package,
+        CancellationToken cancellationToken)
+    {
+        if (!HasAnalysisContentSource(job) ||
+            !int.TryParse(
+                job.Spec.Parameters[AnalysisContentMetadataKeys.Version],
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var sourceVersion))
+        {
+            return;
+        }
+
+        var sourceItemId = job.Spec.Parameters[AnalysisContentMetadataKeys.ItemId];
+        var sourceVersionId = job.Spec.Parameters[AnalysisContentMetadataKeys.VersionId];
+        var now = job.CompletedAt ?? DateTimeOffset.UtcNow;
+
+        foreach (var artifact in package.Artifacts)
+        {
+            var metadata = new Dictionary<string, string>(artifact.Metadata, StringComparer.Ordinal)
+            {
+                ["resultPackageId"] = package.ResultPackageId
+            };
+            var provenance = BuildArtifactProvenance(job, package);
+            var record = new ResultArtifactRecord
+            {
+                ArtifactId = artifact.ArtifactId,
+                ResultPackageId = package.ResultPackageId,
+                JobId = job.OperationId,
+                SourceItemId = sourceItemId,
+                SourceVersion = sourceVersion,
+                SourceVersionId = sourceVersionId,
+                Kind = artifact.Kind,
+                Label = artifact.Label,
+                Uri = artifact.Uri,
+                ContentType = artifact.ContentType,
+                Metadata = metadata,
+                Provenance = provenance,
+                RetentionState = ResultArtifactRetentionState.Retained,
+                CreatedAt = now
+            };
+
+            await artifactStore.UpsertArtifactAsync(record, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static Dictionary<string, string> BuildArtifactProvenance(
+        ExecutionJobRecord job,
+        AnalysisResultPackage package)
+    {
+        var provenance = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [AnalysisContentMetadataKeys.ItemId] = job.Spec.Parameters[AnalysisContentMetadataKeys.ItemId],
+            [AnalysisContentMetadataKeys.Version] = job.Spec.Parameters[AnalysisContentMetadataKeys.Version],
+            [AnalysisContentMetadataKeys.VersionId] = job.Spec.Parameters[AnalysisContentMetadataKeys.VersionId],
+            ["jobId"] = job.OperationId,
+            ["resultPackageId"] = package.ResultPackageId,
+            ["processDefinitions"] = string.Join(",", package.Provenance.ProcessDefinitions),
+            ["generatedArtifactIds"] = string.Join(",", package.Provenance.GeneratedArtifactIds)
+        };
+
+        CopyIfPresent(job, provenance, AnalysisContentMetadataKeys.Kind);
+        CopyIfPresent(job, provenance, AnalysisContentMetadataKeys.SourceSrid);
+        CopyIfPresent(job, provenance, AnalysisContentMetadataKeys.SourceUnits);
+        CopyIfPresent(job, provenance, AnalysisContentMetadataKeys.RerunOfJobId);
+        CopyIfPresent(job, provenance, AnalysisContentMetadataKeys.RerunOfResultPackageId);
+
+        return provenance;
+    }
+
+    private static void CopyIfPresent(
+        ExecutionJobRecord job,
+        Dictionary<string, string> target,
+        string key)
+    {
+        if (job.Spec.Parameters.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value))
+        {
+            target[key] = value;
         }
     }
 

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobTerminalCallback.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingJobTerminalCallback.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Server.Features.Geoprocessing;
 
@@ -22,7 +23,7 @@ internal sealed partial class GeoprocessingJobTerminalCallback(
     IUniversalProgressStore progressStore,
     IProcessCatalog processCatalog,
     IGeoprocessingResultPackageStore? resultPackageStore,
-    IAnalysisContentStore? analysisContentStore,
+    IServiceScopeFactory serviceScopeFactory,
     ILogger<GeoprocessingJobTerminalCallback> logger) : IJobTerminalCallback
 {
     private static readonly TimeSpan ProgressRetention = TimeSpan.FromDays(7);
@@ -37,7 +38,8 @@ internal sealed partial class GeoprocessingJobTerminalCallback(
         try
         {
             AnalysisResultPackage? package = null;
-            if (resultPackageStore != null || analysisContentStore != null && HasAnalysisContentSource(job))
+            var hasAnalysisContentSource = HasAnalysisContentSource(job);
+            if (resultPackageStore != null || hasAnalysisContentSource)
             {
                 package = GeoprocessingResultPackageFactory.Create(job, processCatalog);
             }
@@ -51,13 +53,10 @@ internal sealed partial class GeoprocessingJobTerminalCallback(
                     cancellationToken).ConfigureAwait(false);
             }
 
-            if (analysisContentStore != null && package != null)
+            if (hasAnalysisContentSource && package != null)
             {
-                await PersistAnalysisContentArtifactsAsync(
-                    analysisContentStore,
-                    job,
-                    package,
-                    cancellationToken).ConfigureAwait(false);
+                await PersistAnalysisContentArtifactsWithScopedStoreAsync(job, package, cancellationToken)
+                    .ConfigureAwait(false);
             }
         }
         catch (Exception ex)
@@ -119,6 +118,25 @@ internal sealed partial class GeoprocessingJobTerminalCallback(
         => job.Spec.Parameters.ContainsKey(AnalysisContentMetadataKeys.ItemId)
            && job.Spec.Parameters.ContainsKey(AnalysisContentMetadataKeys.Version)
            && job.Spec.Parameters.ContainsKey(AnalysisContentMetadataKeys.VersionId);
+
+    private async Task PersistAnalysisContentArtifactsWithScopedStoreAsync(
+        ExecutionJobRecord job,
+        AnalysisResultPackage package,
+        CancellationToken cancellationToken)
+    {
+        using var scope = serviceScopeFactory.CreateScope();
+        var artifactStore = scope.ServiceProvider.GetService<IAnalysisContentStore>();
+        if (artifactStore == null)
+        {
+            return;
+        }
+
+        await PersistAnalysisContentArtifactsAsync(
+            artifactStore,
+            job,
+            package,
+            cancellationToken).ConfigureAwait(false);
+    }
 
     private static async Task PersistAnalysisContentArtifactsAsync(
         IAnalysisContentStore artifactStore,

--- a/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisExecutionLogStore.cs
+++ b/src/Honua.Server/Features/Infrastructure/ControlPlane/RedisExecutionLogStore.cs
@@ -72,6 +72,46 @@ internal sealed partial class RedisExecutionLogStore(
         return entries;
     }
 
+    public async Task<ExecutionLogTail> TailAsync(
+        string operationId,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var boundedLimit = Math.Clamp(limit, MinQueryLimit, MaxQueryLimit);
+        var key = GetLogKey(operationId);
+        var length = await _database.ListLengthAsync(key).ConfigureAwait(false);
+        if (length <= 0)
+        {
+            return new ExecutionLogTail { Items = [], TotalCount = 0 };
+        }
+
+        var start = Math.Max(0, length - boundedLimit);
+        var values = await _database.ListRangeAsync(key, start, -1).ConfigureAwait(false);
+        var entries = new List<ExecutionLogEntry>(values.Length);
+
+        foreach (var value in values)
+        {
+            if (!value.HasValue)
+            {
+                continue;
+            }
+
+            var entry = JsonSerializer.Deserialize(value.ToString(), ControlPlaneJsonContext.Default.ExecutionLogEntry);
+            if (entry != null)
+            {
+                entries.Add(entry);
+            }
+        }
+
+        return new ExecutionLogTail
+        {
+            Items = entries,
+            TotalCount = checked((int)Math.Min(length, int.MaxValue))
+        };
+    }
+
     public async Task<ExecutionLogPage> QueryAsync(
         string operationId,
         ExecutionLogQuery query,

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -5,6 +5,7 @@ using Honua.Core.Features.Compliance;
 using Honua.Core.Features.Metadata;
 using Honua.Postgres.Features.Scene;
 using Honua.Server.Features.Admin;
+using Honua.Server.Features.AnalysisContent;
 using Honua.Server.Features.Infrastructure.Scene;
 using Honua.Server.Features.Alerts;
 using Honua.Server.Features.CloudDemo;
@@ -94,6 +95,7 @@ internal static class FeatureRegistrationExtensions
         services.AddSceneGeneration(configuration);
         services.AddPrintingTools();
         services.AddGeoprocessing(configuration);
+        services.AddAnalysisContent(configuration);
         services.AddAnalysisReporting(configuration);
         services.AddMcpOperatorSurface(configuration);
         services.AddSpecGrounding();
@@ -159,6 +161,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapSpatialAnalyticsRestEndpoints();
         endpoints.MapSpatialAnalyticsOgcEndpoints();
         endpoints.MapGPServerEndpoints();
+        endpoints.MapAnalysisContentEndpoints();
         endpoints.MapAnalysisReporting();
         endpoints.MapMcpOperatorSurface();
         endpoints.MapSpecGroundingEndpoints();

--- a/src/Honua.Server/Migrations/035_CreateAnalysisContent.sql
+++ b/src/Honua.Server/Migrations/035_CreateAnalysisContent.sql
@@ -1,0 +1,93 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Durable saved-query and analysis-package content versions plus job artifact
+-- metadata for downstream map/dashboard/report/app/workflow bindings (#1182).
+
+CREATE TABLE IF NOT EXISTS honua.analysis_content_items (
+    item_id            TEXT        PRIMARY KEY,
+    kind               TEXT        NOT NULL,
+    name               TEXT        NOT NULL,
+    title              TEXT        NULL,
+    owner_id           TEXT        NULL,
+    visibility         TEXT        NOT NULL DEFAULT 'organization',
+    current_version    INT         NOT NULL,
+    current_version_id TEXT        NOT NULL,
+    lifecycle          TEXT        NOT NULL DEFAULT 'Active',
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by         TEXT        NULL,
+    CONSTRAINT analysis_content_items_kind
+        CHECK (kind IN ('SavedQuery', 'AnalysisPackage')),
+    CONSTRAINT analysis_content_items_lifecycle
+        CHECK (lifecycle IN ('Active', 'Archived', 'Deleted')),
+    CONSTRAINT analysis_content_items_version_positive
+        CHECK (current_version > 0),
+    CONSTRAINT analysis_content_items_name_not_empty
+        CHECK (length(btrim(name)) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_analysis_content_items_kind_updated
+    ON honua.analysis_content_items (kind, updated_at DESC, item_id);
+
+CREATE INDEX IF NOT EXISTS idx_analysis_content_items_owner_updated
+    ON honua.analysis_content_items (owner_id, updated_at DESC, item_id);
+
+CREATE TABLE IF NOT EXISTS honua.analysis_content_versions (
+    version_id    TEXT        PRIMARY KEY,
+    item_id       TEXT        NOT NULL REFERENCES honua.analysis_content_items(item_id) ON DELETE CASCADE,
+    version       INT         NOT NULL,
+    kind          TEXT        NOT NULL,
+    content_hash  TEXT        NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by    TEXT        NULL,
+    version_body  JSONB       NOT NULL,
+    CONSTRAINT analysis_content_versions_item_version UNIQUE (item_id, version),
+    CONSTRAINT analysis_content_versions_kind
+        CHECK (kind IN ('SavedQuery', 'AnalysisPackage')),
+    CONSTRAINT analysis_content_versions_version_positive
+        CHECK (version > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_analysis_content_versions_item_created
+    ON honua.analysis_content_versions (item_id, version DESC);
+
+CREATE INDEX IF NOT EXISTS idx_analysis_content_versions_hash
+    ON honua.analysis_content_versions (content_hash);
+
+CREATE TABLE IF NOT EXISTS honua.analysis_result_artifacts (
+    artifact_id       TEXT        PRIMARY KEY,
+    result_package_id TEXT        NOT NULL,
+    job_id            TEXT        NOT NULL,
+    source_item_id    TEXT        NOT NULL,
+    source_version    INT         NOT NULL,
+    source_version_id TEXT        NOT NULL,
+    kind              TEXT        NOT NULL,
+    retention_state   TEXT        NOT NULL DEFAULT 'Retained',
+    promotion_state   TEXT        NOT NULL DEFAULT 'None',
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at        TIMESTAMPTZ NULL,
+    artifact_body     JSONB       NOT NULL,
+    CONSTRAINT analysis_result_artifacts_source_version_positive
+        CHECK (source_version > 0),
+    CONSTRAINT analysis_result_artifacts_retention
+        CHECK (retention_state IN ('Preview', 'Retained', 'Promoted', 'Expired')),
+    CONSTRAINT analysis_result_artifacts_promotion
+        CHECK (promotion_state IN ('None', 'Promoted'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_analysis_result_artifacts_job_created
+    ON honua.analysis_result_artifacts (job_id, created_at, artifact_id);
+
+CREATE INDEX IF NOT EXISTS idx_analysis_result_artifacts_source
+    ON honua.analysis_result_artifacts (source_item_id, source_version, artifact_id);
+
+CREATE INDEX IF NOT EXISTS idx_analysis_result_artifacts_retention
+    ON honua.analysis_result_artifacts (retention_state, expires_at);
+
+COMMENT ON TABLE honua.analysis_content_items IS
+    'Durable roots for saved-query and analysis-package content items (#1182).';
+COMMENT ON TABLE honua.analysis_content_versions IS
+    'Immutable analysis content versions (#1182).';
+COMMENT ON TABLE honua.analysis_result_artifacts IS
+    'Stable artifact metadata produced by saved-query previews and analysis jobs (#1182).';

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -566,6 +566,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Console.Models.ConsoleJsonContext.Default,
         Honua.Server.Features.Studio.Models.StudioApiJsonContext.Default,
         Honua.Core.Features.Studio.Domain.StudioJsonContext.Default,
+        Honua.Server.Features.AnalysisContent.AnalysisContentApiJsonContext.Default,
         Honua.Server.Features.Admin.Models.AdminApiKeyJsonContext.Default,
         Honua.Server.Features.Admin.Models.SceneDatasetJsonContext.Default,
         Honua.Server.Features.Admin.Models.SceneGenerationJsonContext.Default,

--- a/src/Honua.Server/Startup/JsonContextRegistration.cs
+++ b/src/Honua.Server/Startup/JsonContextRegistration.cs
@@ -56,6 +56,7 @@ internal static class JsonContextRegistration
                 Honua.Server.Features.Admin.Models.RoleJsonContext.Default,
                 Honua.Server.Features.Studio.Models.StudioApiJsonContext.Default,
                 Honua.Core.Features.Studio.Domain.StudioJsonContext.Default,
+                Honua.Server.Features.AnalysisContent.AnalysisContentApiJsonContext.Default,
                 Honua.Server.Features.Admin.Models.AdminApiKeyJsonContext.Default,
                 Honua.Server.Features.Admin.Models.SceneDatasetJsonContext.Default,
                 Honua.Server.Features.Admin.Models.SceneGenerationJsonContext.Default,

--- a/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
@@ -19,6 +19,7 @@ public sealed class VerticalSliceIsolationTests
     private static readonly string[] _featureNames =
     {
         "Admin",
+        "AnalysisContent",
         "AiBuilder",
         "Alerts",
         "CloudDemo",
@@ -59,6 +60,7 @@ public sealed class VerticalSliceIsolationTests
         {
             ["Mcp"] = new[] { "Geoprocessing", "Grounding", "Reporting" },
             ["Grounding"] = new[] { "Geoprocessing" },
+            ["AnalysisContent"] = new[] { "Geoprocessing" },
             ["NlQuery"] = new[] { "AiBuilder" },
             ["Reporting"] = new[] { "Geoprocessing" }
         };

--- a/tests/dotnet/Honua.Postgres.Tests/Features/AnalysisContent/PostgresAnalysisContentStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/AnalysisContent/PostgresAnalysisContentStoreTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data.Common;
+using FluentAssertions;
+using Honua.Core.Features.AnalysisContent.Abstractions;
+using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.AnalysisContent;
+using Npgsql;
+using NSubstitute;
+
+namespace Honua.Postgres.Tests.Features.AnalysisContent;
+
+/// <summary>
+/// Verifies that <see cref="PostgresAnalysisContentStore"/> maps provider connectivity failures
+/// (Postgres down / unreachable / auth-backend outage) to
+/// <see cref="AnalysisContentStoreUnavailableException"/> across read, write, and artifact entry
+/// points, so a store outage surfaces as a retryable 503 instead of a generic 500. The connection
+/// open itself is the failure point the analysis-content API explicitly models as store-unavailable.
+/// </summary>
+public sealed class PostgresAnalysisContentStoreTests
+{
+    [Fact]
+    public async Task GetItemAsync_WhenConnectionFails_ThrowsStoreUnavailable()
+    {
+        var store = CreateStoreWithUnavailableConnection();
+
+        var act = () => store.GetItemAsync("item-1");
+
+        await act.Should().ThrowAsync<AnalysisContentStoreUnavailableException>();
+    }
+
+    [Fact]
+    public async Task CreateItemAsync_WhenConnectionFails_ThrowsStoreUnavailable()
+    {
+        var store = CreateStoreWithUnavailableConnection();
+
+        var act = () => store.CreateItemAsync(CreateItem(), CreateVersion());
+
+        await act.Should().ThrowAsync<AnalysisContentStoreUnavailableException>();
+    }
+
+    [Fact]
+    public async Task GetVersionAsync_WhenConnectionFails_ThrowsStoreUnavailable()
+    {
+        var store = CreateStoreWithUnavailableConnection();
+
+        var act = () => store.GetVersionAsync("item-1");
+
+        await act.Should().ThrowAsync<AnalysisContentStoreUnavailableException>();
+    }
+
+    [Fact]
+    public async Task GetArtifactAsync_WhenConnectionFails_ThrowsStoreUnavailable()
+    {
+        var store = CreateStoreWithUnavailableConnection();
+
+        var act = () => store.GetArtifactAsync("artifact-1");
+
+        await act.Should().ThrowAsync<AnalysisContentStoreUnavailableException>();
+    }
+
+    private static PostgresAnalysisContentStore CreateStoreWithUnavailableConnection()
+    {
+        var provider = Substitute.For<IDatabaseConnectionProvider>();
+        provider.OpenConnectionAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DbConnection>(
+                new NpgsqlException("Failed to connect to 10.0.0.1:5432")));
+        return new PostgresAnalysisContentStore(provider);
+    }
+
+    private static AnalysisContentItem CreateItem() => new()
+    {
+        ItemId = "item-1",
+        Kind = AnalysisContentKind.SavedQuery,
+        Name = "name",
+        CurrentVersion = 1,
+        CurrentVersionId = "item-1:v1",
+        CreatedAt = DateTimeOffset.UtcNow,
+        UpdatedAt = DateTimeOffset.UtcNow
+    };
+
+    private static AnalysisContentVersion CreateVersion() => new()
+    {
+        VersionId = "item-1:v1",
+        ItemId = "item-1",
+        Version = 1,
+        Kind = AnalysisContentKind.SavedQuery,
+        SavedQuery = new SavedQueryContent { LayerId = 0, NaturalLanguageQuery = "q" },
+        ContentHash = "hash-1",
+        CreatedAt = DateTimeOffset.UtcNow
+    };
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/AnalysisContent/PostgresAnalysisContentStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/AnalysisContent/PostgresAnalysisContentStoreTests.cs
@@ -3,8 +3,10 @@
 
 using System.Data.Common;
 using FluentAssertions;
+using Honua.Core.Exceptions;
 using Honua.Core.Features.AnalysisContent.Abstractions;
 using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Postgres.Features.AnalysisContent;
 using Npgsql;
@@ -61,12 +63,54 @@ public sealed class PostgresAnalysisContentStoreTests
         await act.Should().ThrowAsync<AnalysisContentStoreUnavailableException>();
     }
 
+    [Fact]
+    public async Task CreateItemAsync_WhenConnectionProviderReportsServiceUnavailable_ThrowsStoreUnavailable()
+    {
+        // The production PostgresDatabaseConnectionProvider classifies connect failures and broken
+        // circuits as ServiceUnavailableException (not a raw NpgsqlException), so the store must map
+        // that real-outage signal to the documented retryable 503 as well.
+        var store = CreateStoreWithServiceUnavailableConnection();
+
+        var act = () => store.CreateItemAsync(CreateItem(), CreateVersion());
+
+        await act.Should().ThrowAsync<AnalysisContentStoreUnavailableException>();
+    }
+
+    [Fact]
+    public async Task GetItemAsync_WhenConnectionProviderReportsServiceUnavailable_ThrowsStoreUnavailable()
+    {
+        var store = CreateStoreWithServiceUnavailableConnection();
+
+        var act = () => store.GetItemAsync("item-1");
+
+        await act.Should().ThrowAsync<AnalysisContentStoreUnavailableException>();
+    }
+
+    [Fact]
+    public async Task UpsertArtifactAsync_WhenConnectionProviderReportsServiceUnavailable_ThrowsStoreUnavailable()
+    {
+        var store = CreateStoreWithServiceUnavailableConnection();
+
+        var act = () => store.UpsertArtifactAsync(CreateArtifact());
+
+        await act.Should().ThrowAsync<AnalysisContentStoreUnavailableException>();
+    }
+
     private static PostgresAnalysisContentStore CreateStoreWithUnavailableConnection()
     {
         var provider = Substitute.For<IDatabaseConnectionProvider>();
         provider.OpenConnectionAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromException<DbConnection>(
                 new NpgsqlException("Failed to connect to 10.0.0.1:5432")));
+        return new PostgresAnalysisContentStore(provider);
+    }
+
+    private static PostgresAnalysisContentStore CreateStoreWithServiceUnavailableConnection()
+    {
+        var provider = Substitute.For<IDatabaseConnectionProvider>();
+        provider.OpenConnectionAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<DbConnection>(
+                new ServiceUnavailableException("Database connection failed.")));
         return new PostgresAnalysisContentStore(provider);
     }
 
@@ -89,6 +133,19 @@ public sealed class PostgresAnalysisContentStoreTests
         Kind = AnalysisContentKind.SavedQuery,
         SavedQuery = new SavedQueryContent { LayerId = 0, NaturalLanguageQuery = "q" },
         ContentHash = "hash-1",
+        CreatedAt = DateTimeOffset.UtcNow
+    };
+
+    private static ResultArtifactRecord CreateArtifact() => new()
+    {
+        ArtifactId = "artifact-1",
+        ResultPackageId = "item-1:v1:preview",
+        JobId = "preview",
+        SourceItemId = "item-1",
+        SourceVersion = 1,
+        SourceVersionId = "item-1:v1",
+        Kind = ArtifactKind.FeatureLayer,
+        Label = "preview",
         CreatedAt = DateTimeOffset.UtcNow
     };
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/Jobs/ConsoleJobEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/Jobs/ConsoleJobEndpointsTests.cs
@@ -513,6 +513,19 @@ public sealed class ConsoleJobEndpointsTests : IAsyncLifetime
         public Task<IReadOnlyList<ExecutionLogEntry>> GetLogsAsync(string operationId, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionLogEntry>>(_logs.TryGetValue(operationId, out var entries) ? entries : Array.Empty<ExecutionLogEntry>());
 
+        public Task<ExecutionLogTail> TailAsync(
+            string operationId,
+            int limit,
+            CancellationToken cancellationToken = default)
+        {
+            var entries = _logs.TryGetValue(operationId, out var found) ? found : Array.Empty<ExecutionLogEntry>();
+            return Task.FromResult(new ExecutionLogTail
+            {
+                Items = entries.TakeLast(Math.Max(1, limit)).ToArray(),
+                TotalCount = entries.Length
+            });
+        }
+
         public Task<ExecutionLogPage> QueryAsync(string operationId, ExecutionLogQuery query, CancellationToken cancellationToken = default)
         {
             var offset = DecodeOffset(query.Cursor);

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
@@ -85,10 +85,8 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
             }
         };
 
-        var created = await PostAndReadAsync<AnalysisContentItemResponse>(
-            "/api/v1/analysis/content/items",
-            create,
-            HttpStatusCode.Created);
+        var createResponse = await _client.PostAsJsonAsync("/api/v1/analysis/content/items", create, JsonOptions);
+        var created = await ReadJsonAsync<AnalysisContentItemResponse>(createResponse, HttpStatusCode.Created);
 
         Assert.NotNull(created);
         Assert.Equal(1, created!.Version.Version);
@@ -103,32 +101,38 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
             }
         };
 
-        var second = await PostAndReadAsync<AnalysisContentVersionResponse>(
+        var secondResponse = await _client.PostAsJsonAsync(
             $"/api/v1/analysis/content/items/{created.Item.ItemId}/versions",
             createVersion,
-            HttpStatusCode.Created);
+            JsonOptions);
+        var second = await ReadJsonAsync<AnalysisContentVersionResponse>(secondResponse, HttpStatusCode.Created);
 
         Assert.NotNull(second);
         Assert.Equal(2, second!.Version.Version);
         Assert.NotEqual(created.Version.ContentHash, second.Version.ContentHash);
         Assert.Equal(created.Version.VersionId, second.Version.BasedOnVersionId);
 
-        var latest = await ReadAsync<AnalysisContentVersionResponse>(
+        var latestResponse = await _client.GetAsync(
             $"/api/v1/analysis/content/items/{created.Item.ItemId}/versions/latest");
+        var latest = await ReadJsonAsync<AnalysisContentVersionResponse>(latestResponse, HttpStatusCode.OK);
         Assert.Equal(2, latest!.Version.Version);
 
-        var explicitVersion = await ReadAsync<AnalysisContentVersionResponse>(
+        var explicitVersionResponse = await _client.GetAsync(
             $"/api/v1/analysis/content/items/{created.Item.ItemId}/versions/1");
+        var explicitVersion = await ReadJsonAsync<AnalysisContentVersionResponse>(
+            explicitVersionResponse,
+            HttpStatusCode.OK);
         Assert.Equal(created.Version.VersionId, explicitVersion!.Version.VersionId);
 
-        var item = await ReadAsync<AnalysisContentItemResponse>(
-            $"/api/v1/analysis/content/items/{created.Item.ItemId}");
+        var itemResponse = await _client.GetAsync($"/api/v1/analysis/content/items/{created.Item.ItemId}");
+        var item = await ReadJsonAsync<AnalysisContentItemResponse>(itemResponse, HttpStatusCode.OK);
         Assert.Equal(2, item!.Item.CurrentVersion);
 
-        var preview = await PostAndReadAsync<SavedQueryPreviewResult>(
+        var previewResponse = await _client.PostAsJsonAsync(
             $"/api/v1/analysis/content/items/{created.Item.ItemId}/versions/2/preview",
             new PreviewSavedQueryRequest { Limit = 1 },
-            HttpStatusCode.OK);
+            JsonOptions);
+        var preview = await ReadJsonAsync<SavedQueryPreviewResult>(previewResponse, HttpStatusCode.OK);
 
         Assert.NotNull(preview);
         Assert.Equal(created.Item.ItemId, preview!.Binding.SourceItemId);
@@ -137,8 +141,11 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
         Assert.NotEmpty(preview.PreviewArtifactId);
         Assert.True(preview.Features.Count <= 1);
 
-        var artifact = await ReadAsync<AnalysisArtifactResponse>(
-            $"/api/v1/analysis/artifacts/{preview.PreviewArtifactId}");
+        var artifactResponse = await _client.GetAsync($"/api/v1/analysis/artifacts/{preview.PreviewArtifactId}");
+        Assert.Equal(HttpStatusCode.OK, artifactResponse.StatusCode);
+        var artifact = JsonSerializer.Deserialize<AnalysisArtifactResponse>(
+            await artifactResponse.Content.ReadAsStringAsync(),
+            JsonOptions);
         Assert.Equal(preview.PreviewArtifactId, artifact!.Artifact.ArtifactId);
         Assert.Equal(created.Item.ItemId, artifact.Binding.SourceItemId);
         Assert.Equal("dataSource", artifact.Binding.Role);
@@ -171,19 +178,18 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
             }
         };
 
-        var created = await PostAndReadAsync<AnalysisContentItemResponse>(
-            "/api/v1/analysis/content/items",
-            create,
-            HttpStatusCode.Created);
+        var createResponse = await _client.PostAsJsonAsync("/api/v1/analysis/content/items", create, JsonOptions);
+        var created = await ReadJsonAsync<AnalysisContentItemResponse>(createResponse, HttpStatusCode.Created);
 
-        var run = await PostAndReadAsync<AnalysisContentJobResponse>(
+        var runResponse = await _client.PostAsJsonAsync(
             $"/api/v1/analysis/content/items/{created!.Item.ItemId}/versions/1/runs",
             new RunAnalysisContentVersionRequest
             {
                 IdempotencyKey = "run-1",
                 Parameters = new Dictionary<string, string> { ["format"] = "geojson" }
             },
-            HttpStatusCode.OK);
+            JsonOptions);
+        var run = await ReadJsonAsync<AnalysisContentJobResponse>(runResponse, HttpStatusCode.OK);
 
         Assert.Equal(ExecutionJobStatus.Queued, run!.Status);
         var submitted = _jobs.SubmittedJobs.Single(job => job.OperationId == run.JobId);
@@ -192,7 +198,7 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
         Assert.Equal("10", submitted.Spec.Parameters["analysis.content.parameter.distance"]);
         Assert.Equal("geojson", submitted.Spec.Parameters["analysis.content.runtime_parameter.format"]);
 
-        var rerun = await PostAndReadAsync<AnalysisContentJobResponse>(
+        var rerunResponse = await _client.PostAsJsonAsync(
             $"/api/v1/analysis/content/items/{created.Item.ItemId}/versions/1/reruns",
             new RerunAnalysisContentVersionRequest
             {
@@ -201,7 +207,8 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
                 RerunOfResultPackageId = $"{run.JobId}:v0",
                 ParameterOverrides = new Dictionary<string, string> { ["distance"] = "20" }
             },
-            HttpStatusCode.OK);
+            JsonOptions);
+        var rerun = await ReadJsonAsync<AnalysisContentJobResponse>(rerunResponse, HttpStatusCode.OK);
 
         Assert.Equal(2, rerun!.Version.Version);
         var rerunJob = _jobs.SubmittedJobs.Single(job => job.OperationId == rerun.JobId);
@@ -216,13 +223,15 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
     [Endpoint("GET /api/v1/analysis/jobs/{jobId}/failure")]
     public async Task FailedJobDiagnostics_ReturnSafeClassificationAndBoundedLogs()
     {
-        var failure = await ReadAsync<AnalysisJobFailure>("/api/v1/analysis/jobs/failed-job/failure");
+        var failureResponse = await _client.GetAsync("/api/v1/analysis/jobs/failed-job/failure");
+        var failure = await ReadJsonAsync<AnalysisJobFailure>(failureResponse, HttpStatusCode.OK);
 
         Assert.Equal(AnalysisJobFailureClassification.ValidationFailed, failure!.Classification);
         Assert.True(failure.IsTerminal);
         Assert.DoesNotContain("password", failure.Message, StringComparison.OrdinalIgnoreCase);
 
-        var logs = await ReadAsync<AnalysisJobLogs>("/api/v1/analysis/jobs/failed-job/logs?limit=1");
+        var logsResponse = await _client.GetAsync("/api/v1/analysis/jobs/failed-job/logs?limit=1");
+        var logs = await ReadJsonAsync<AnalysisJobLogs>(logsResponse, HttpStatusCode.OK);
 
         Assert.Equal(2, logs!.TotalCount);
         Assert.True(logs.Truncated);
@@ -230,16 +239,8 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
         Assert.DoesNotContain("password", JsonSerializer.Serialize(logs, JsonOptions), StringComparison.OrdinalIgnoreCase);
     }
 
-    private async Task<T?> ReadAsync<T>(string path)
+    private static async Task<T?> ReadJsonAsync<T>(HttpResponseMessage response, HttpStatusCode expectedStatus)
     {
-        var response = await _client.GetAsync(path);
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        return JsonSerializer.Deserialize<T>(await response.Content.ReadAsStringAsync(), JsonOptions);
-    }
-
-    private async Task<T?> PostAndReadAsync<T>(string path, object payload, HttpStatusCode expectedStatus)
-    {
-        var response = await _client.PostAsJsonAsync(path, payload, JsonOptions);
         var body = await response.Content.ReadAsStringAsync();
         Assert.True(
             response.StatusCode == expectedStatus,

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
@@ -20,6 +20,7 @@ using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using StackExchange.Redis;
 
 namespace Honua.Server.Tests.Features.AnalysisContent;
 
@@ -277,6 +278,20 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.NotFound, failureResponse.StatusCode);
     }
 
+    [IntegrationTest]
+    [Operation(Operations.JobStatus)]
+    [Endpoint("GET /api/v1/analysis/jobs/{jobId}/logs")]
+    public async Task JobLogs_WhenLogStoreUnavailable_ReturnsServiceUnavailable()
+    {
+        // The job resolves, but the Redis-backed log store is down. The documented contract is a
+        // retryable 503 for an unavailable log store, not a generic 500.
+        _logs.FailWithStoreOutage = true;
+
+        var response = await _client.GetAsync("/api/v1/analysis/jobs/failed-job/logs?limit=1");
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+    }
+
     private static async Task<T?> ReadJsonAsync<T>(HttpResponseMessage response, HttpStatusCode expectedStatus)
     {
         var body = await response.Content.ReadAsStringAsync();
@@ -424,6 +439,9 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
 
         public int TailReadCount { get; private set; }
 
+        // When set, TailAsync simulates a Redis-backed log store outage.
+        public bool FailWithStoreOutage { get; set; }
+
         public void SeedFailureLogs()
         {
             _entries["failed-job"] =
@@ -483,6 +501,11 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
             CancellationToken cancellationToken = default)
         {
             TailReadCount++;
+            if (FailWithStoreOutage)
+            {
+                throw new RedisConnectionException(ConnectionFailureType.SocketFailure, "redis unavailable");
+            }
+
             var entries = _entries.TryGetValue(operationId, out var found) ? found : [];
             var bounded = entries.TakeLast(Math.Max(1, limit)).ToArray();
             return Task.FromResult(new ExecutionLogTail

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
@@ -1,0 +1,417 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Json;
+using Honua.Core.Features.AnalysisContent;
+using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Server.Features.AnalysisContent;
+using Honua.Server.Features.Geoprocessing;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Tests.Features.AnalysisContent;
+
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private readonly FakeGeoprocessingJobService _jobs = new();
+    private readonly FakeExecutionLogStore _logs = new();
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public AnalysisContentEndpointsTests()
+    {
+        _fixture = new WebAppFixture()
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IGeoprocessingJobService>();
+                services.AddSingleton<IGeoprocessingJobService>(_jobs);
+                services.RemoveAll<IExecutionLogStore>();
+                services.AddSingleton<IExecutionLogStore>(_logs);
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        _logs.SeedFailureLogs();
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /api/v1/analysis/content/items")]
+    [Endpoint("POST /api/v1/analysis/content/items/{itemId}/versions")]
+    [Endpoint("GET /api/v1/analysis/content/items/{itemId}")]
+    [Endpoint("GET /api/v1/analysis/content/items/{itemId}/versions/latest")]
+    [Endpoint("GET /api/v1/analysis/content/items/{itemId}/versions/{contentVersion}")]
+    [Endpoint("POST /api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/preview")]
+    [Endpoint("GET /api/v1/analysis/artifacts/{artifactId}")]
+    public async Task SavedQuery_SaveVersionReopenPreviewAndArtifactBinding_ReturnsStableContracts()
+    {
+        var create = new CreateAnalysisContentItemRequest
+        {
+            Kind = AnalysisContentKind.SavedQuery,
+            Name = "incidents-by-type",
+            Title = "Incidents by Type",
+            SavedQuery = new SavedQueryContent
+            {
+                LayerId = WebAppFixture.TestLayerId,
+                ServiceName = WebAppFixture.TestServiceId,
+                NaturalLanguageQuery = "show incidents",
+                PreviewLimit = 2,
+                OutputSrid = 4326,
+                Units = "meters"
+            }
+        };
+
+        var created = await PostAndReadAsync<AnalysisContentItemResponse>(
+            "/api/v1/analysis/content/items",
+            create,
+            HttpStatusCode.Created);
+
+        Assert.NotNull(created);
+        Assert.Equal(1, created!.Version.Version);
+        Assert.Equal(created.Item.ItemId, created.Version.ItemId);
+
+        var createVersion = new CreateAnalysisContentVersionRequest
+        {
+            SavedQuery = create.SavedQuery with
+            {
+                NaturalLanguageQuery = "show incidents preview",
+                PreviewLimit = 1
+            }
+        };
+
+        var second = await PostAndReadAsync<AnalysisContentVersionResponse>(
+            $"/api/v1/analysis/content/items/{created.Item.ItemId}/versions",
+            createVersion,
+            HttpStatusCode.Created);
+
+        Assert.NotNull(second);
+        Assert.Equal(2, second!.Version.Version);
+        Assert.NotEqual(created.Version.ContentHash, second.Version.ContentHash);
+        Assert.Equal(created.Version.VersionId, second.Version.BasedOnVersionId);
+
+        var latest = await ReadAsync<AnalysisContentVersionResponse>(
+            $"/api/v1/analysis/content/items/{created.Item.ItemId}/versions/latest");
+        Assert.Equal(2, latest!.Version.Version);
+
+        var explicitVersion = await ReadAsync<AnalysisContentVersionResponse>(
+            $"/api/v1/analysis/content/items/{created.Item.ItemId}/versions/1");
+        Assert.Equal(created.Version.VersionId, explicitVersion!.Version.VersionId);
+
+        var item = await ReadAsync<AnalysisContentItemResponse>(
+            $"/api/v1/analysis/content/items/{created.Item.ItemId}");
+        Assert.Equal(2, item!.Item.CurrentVersion);
+
+        var preview = await PostAndReadAsync<SavedQueryPreviewResult>(
+            $"/api/v1/analysis/content/items/{created.Item.ItemId}/versions/2/preview",
+            new PreviewSavedQueryRequest { Limit = 1 },
+            HttpStatusCode.OK);
+
+        Assert.NotNull(preview);
+        Assert.Equal(created.Item.ItemId, preview!.Binding.SourceItemId);
+        Assert.Equal(2, preview.Binding.SourceVersion);
+        Assert.Equal("preview", preview.Binding.Role);
+        Assert.NotEmpty(preview.PreviewArtifactId);
+        Assert.True(preview.Features.Count <= 1);
+
+        var artifact = await ReadAsync<AnalysisArtifactResponse>(
+            $"/api/v1/analysis/artifacts/{preview.PreviewArtifactId}");
+        Assert.Equal(preview.PreviewArtifactId, artifact!.Artifact.ArtifactId);
+        Assert.Equal(created.Item.ItemId, artifact.Binding.SourceItemId);
+        Assert.Equal("dataSource", artifact.Binding.Role);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ProcessExecution)]
+    [Endpoint("POST /api/v1/analysis/content/items")]
+    [Endpoint("POST /api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/runs")]
+    [Endpoint("POST /api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/reruns")]
+    public async Task AnalysisPackage_SubmitAndRerun_StampsVersionAndProvenanceMetadata()
+    {
+        var create = new CreateAnalysisContentItemRequest
+        {
+            Kind = AnalysisContentKind.AnalysisPackage,
+            Name = "buffer-package",
+            AnalysisPackage = new AnalysisPackageContent
+            {
+                Intent = new AnalysisIntent
+                {
+                    IntentId = "intent-1",
+                    Goal = "buffer incidents",
+                    RequestedOutputs = [ArtifactKind.FeatureLayer]
+                },
+                Plan = CreatePlan(),
+                Parameters = new Dictionary<string, string> { ["distance"] = "10" },
+                RequestedArtifacts = [ArtifactKind.FeatureLayer],
+                SpatialReferenceId = 4326,
+                Units = "meters"
+            }
+        };
+
+        var created = await PostAndReadAsync<AnalysisContentItemResponse>(
+            "/api/v1/analysis/content/items",
+            create,
+            HttpStatusCode.Created);
+
+        var run = await PostAndReadAsync<AnalysisContentJobResponse>(
+            $"/api/v1/analysis/content/items/{created!.Item.ItemId}/versions/1/runs",
+            new RunAnalysisContentVersionRequest
+            {
+                IdempotencyKey = "run-1",
+                Parameters = new Dictionary<string, string> { ["format"] = "geojson" }
+            },
+            HttpStatusCode.OK);
+
+        Assert.Equal(ExecutionJobStatus.Queued, run!.Status);
+        var submitted = _jobs.SubmittedJobs.Single(job => job.OperationId == run.JobId);
+        Assert.Equal(created.Item.ItemId, submitted.Spec.Parameters[AnalysisContentMetadataKeys.ItemId]);
+        Assert.Equal("1", submitted.Spec.Parameters[AnalysisContentMetadataKeys.Version]);
+        Assert.Equal("10", submitted.Spec.Parameters["analysis.content.parameter.distance"]);
+        Assert.Equal("geojson", submitted.Spec.Parameters["analysis.content.runtime_parameter.format"]);
+
+        var rerun = await PostAndReadAsync<AnalysisContentJobResponse>(
+            $"/api/v1/analysis/content/items/{created.Item.ItemId}/versions/1/reruns",
+            new RerunAnalysisContentVersionRequest
+            {
+                IdempotencyKey = "rerun-1",
+                RerunOfJobId = run.JobId,
+                RerunOfResultPackageId = $"{run.JobId}:v0",
+                ParameterOverrides = new Dictionary<string, string> { ["distance"] = "20" }
+            },
+            HttpStatusCode.OK);
+
+        Assert.Equal(2, rerun!.Version.Version);
+        var rerunJob = _jobs.SubmittedJobs.Single(job => job.OperationId == rerun.JobId);
+        Assert.Equal("2", rerunJob.Spec.Parameters[AnalysisContentMetadataKeys.Version]);
+        Assert.Equal(run.JobId, rerunJob.Spec.Parameters[AnalysisContentMetadataKeys.RerunOfJobId]);
+        Assert.Equal("20", rerunJob.Spec.Parameters["analysis.content.parameter.distance"]);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.JobStatus)]
+    [Endpoint("GET /api/v1/analysis/jobs/{jobId}/logs")]
+    [Endpoint("GET /api/v1/analysis/jobs/{jobId}/failure")]
+    public async Task FailedJobDiagnostics_ReturnSafeClassificationAndBoundedLogs()
+    {
+        var failure = await ReadAsync<AnalysisJobFailure>("/api/v1/analysis/jobs/failed-job/failure");
+
+        Assert.Equal(AnalysisJobFailureClassification.ValidationFailed, failure!.Classification);
+        Assert.True(failure.IsTerminal);
+        Assert.DoesNotContain("password", failure.Message, StringComparison.OrdinalIgnoreCase);
+
+        var logs = await ReadAsync<AnalysisJobLogs>("/api/v1/analysis/jobs/failed-job/logs?limit=1");
+
+        Assert.Equal(2, logs!.TotalCount);
+        Assert.True(logs.Truncated);
+        Assert.Single(logs.Entries);
+        Assert.DoesNotContain("password", JsonSerializer.Serialize(logs, JsonOptions), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<T?> ReadAsync<T>(string path)
+    {
+        var response = await _client.GetAsync(path);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        return JsonSerializer.Deserialize<T>(await response.Content.ReadAsStringAsync(), JsonOptions);
+    }
+
+    private async Task<T?> PostAndReadAsync<T>(string path, object payload, HttpStatusCode expectedStatus)
+    {
+        var response = await _client.PostAsJsonAsync(path, payload, JsonOptions);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.True(
+            response.StatusCode == expectedStatus,
+            $"Expected {expectedStatus}, got {response.StatusCode}. Body: {body}");
+        return JsonSerializer.Deserialize<T>(body, JsonOptions);
+    }
+
+    private static AnalysisPlan CreatePlan()
+        => new()
+        {
+            PlanId = "plan-1",
+            IntentId = "intent-1",
+            Steps =
+            [
+                new AnalysisPlanStep
+                {
+                    StepId = "step-1",
+                    Kind = AnalysisPlanStepKind.Geoprocess,
+                    ProcessId = "geometry.buffer",
+                    Inputs = new Dictionary<string, string> { ["distance"] = "10" }
+                }
+            ],
+            Outputs = [ArtifactKind.FeatureLayer]
+        };
+
+    private sealed class FakeGeoprocessingJobService : IGeoprocessingJobService
+    {
+        private readonly Dictionary<string, ExecutionJobRecord> _jobs = new(StringComparer.Ordinal);
+        private int _sequence;
+
+        public List<ExecutionJobRecord> SubmittedJobs { get; } = [];
+
+        public FakeGeoprocessingJobService()
+        {
+            var failed = CreateJob(
+                "failed-job",
+                ExecutionJobStatus.Failed,
+                new Dictionary<string, string>(),
+                "validation failed: invalid buffer distance");
+            _jobs[failed.OperationId] = failed;
+        }
+
+        public void EnsureCallerAuthorized(
+            ClaimsPrincipal principal,
+            OperatorResourceType resourceType,
+            OperatorOperation operation)
+        {
+        }
+
+        public PlanValidationResult ValidatePlan(AnalysisPlan plan, ClaimsPrincipal principal)
+            => new() { IsExecutable = true };
+
+        public DryRunResult DryRunPlan(AnalysisPlan plan, ClaimsPrincipal principal)
+            => new() { EstimatedArtifacts = plan.Outputs };
+
+        public Task<ExecutionJobRecord> SubmitJobAsync(
+            AnalysisPlan plan,
+            string? idempotencyKey,
+            ClaimsPrincipal principal,
+            IReadOnlyDictionary<string, string>? protocolMetadata = null,
+            CancellationToken cancellationToken = default)
+        {
+            var job = CreateJob(
+                idempotencyKey ?? $"analysis-job-{++_sequence}",
+                ExecutionJobStatus.Queued,
+                protocolMetadata ?? new Dictionary<string, string>());
+            SubmittedJobs.Add(job);
+            _jobs[job.OperationId] = job;
+            return Task.FromResult(job);
+        }
+
+        public Task<ExecutionJobRecord> GetJobAsync(
+            string jobId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(_jobs[jobId]);
+
+        public Task<AnalysisResultPackage> GetJobResultsAsync(
+            string jobId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task CancelJobAsync(
+            string jobId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        private static ExecutionJobRecord CreateJob(
+            string jobId,
+            ExecutionJobStatus status,
+            IReadOnlyDictionary<string, string> parameters,
+            string? errorMessage = null)
+        {
+            var now = DateTimeOffset.UtcNow;
+            return new ExecutionJobRecord
+            {
+                OperationId = jobId,
+                Status = status,
+                CreatedAt = now,
+                UpdatedAt = now,
+                CompletedAt = status is ExecutionJobStatus.Failed or ExecutionJobStatus.Cancelled or ExecutionJobStatus.Succeeded
+                    ? now
+                    : null,
+                ErrorMessage = errorMessage,
+                Spec = new ExecutionJobSpec
+                {
+                    TargetKind = BatchComputeTargetKind.KubernetesJob,
+                    Backend = "test",
+                    Kind = ExecutionJobKind.Geoprocessing,
+                    WorkloadName = "test geoprocessing",
+                    Parameters = parameters
+                }
+            };
+        }
+    }
+
+    private sealed class FakeExecutionLogStore : IExecutionLogStore
+    {
+        private readonly Dictionary<string, List<ExecutionLogEntry>> _entries = new(StringComparer.Ordinal);
+
+        public void SeedFailureLogs()
+        {
+            _entries["failed-job"] =
+            [
+                new ExecutionLogEntry
+                {
+                    Timestamp = DateTimeOffset.UtcNow.AddSeconds(-2),
+                    Level = ExecutionLogLevel.Info,
+                    Message = "validating request",
+                    Phase = "validation"
+                },
+                new ExecutionLogEntry
+                {
+                    Timestamp = DateTimeOffset.UtcNow.AddSeconds(-1),
+                    Level = ExecutionLogLevel.Error,
+                    Message = "validation failed",
+                    Phase = "validation",
+                    Metadata = new Dictionary<string, string>
+                    {
+                        ["password"] = "secret",
+                        ["code"] = "invalid-distance"
+                    }
+                }
+            ];
+        }
+
+        public Task AppendAsync(
+            string operationId,
+            ExecutionLogEntry entry,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_entries.TryGetValue(operationId, out var entries))
+            {
+                entries = [];
+                _entries[operationId] = entries;
+            }
+
+            entries.Add(entry);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<ExecutionLogEntry>> GetLogsAsync(
+            string operationId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<ExecutionLogEntry>>(
+                _entries.TryGetValue(operationId, out var entries) ? entries : []);
+
+        public Task SetRetentionAsync(
+            string operationId,
+            TimeSpan ttl,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
@@ -250,9 +250,31 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
         Assert.Equal(2, logs!.TotalCount);
         Assert.True(logs.Truncated);
         Assert.Single(logs.Entries);
-        Assert.DoesNotContain("password", JsonSerializer.Serialize(logs, JsonOptions), StringComparison.OrdinalIgnoreCase);
+        var serializedLogs = JsonSerializer.Serialize(logs, JsonOptions);
+        Assert.DoesNotContain("password", serializedLogs, StringComparison.OrdinalIgnoreCase);
+        // Secret-bearing metadata value under a non-sensitive key must be redacted by value, not
+        // only by key filtering.
+        Assert.DoesNotContain("topsecret123", serializedLogs, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("client_secret", serializedLogs, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(1, _logs.TailReadCount);
         Assert.Equal(0, _logs.GetLogsReadCount);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.JobStatus)]
+    [Endpoint("GET /api/v1/analysis/jobs/{jobId}/logs")]
+    [Endpoint("GET /api/v1/analysis/jobs/{jobId}/failure")]
+    public async Task JobDiagnostics_ForUnknownJob_ReturnNotFound()
+    {
+        // Both job-scoped diagnostic endpoints must resolve the job first so an unknown id is a
+        // 404, not a 200 with empty logs (logs) or a misleading conflict (failure).
+        var logsResponse = await _client.GetAsync("/api/v1/analysis/jobs/missing-job/logs");
+        Assert.Equal(HttpStatusCode.NotFound, logsResponse.StatusCode);
+        // The log store must not be read when the job does not exist.
+        Assert.Equal(0, _logs.TailReadCount);
+
+        var failureResponse = await _client.GetAsync("/api/v1/analysis/jobs/missing-job/failure");
+        Assert.Equal(HttpStatusCode.NotFound, failureResponse.StatusCode);
     }
 
     private static async Task<T?> ReadJsonAsync<T>(HttpResponseMessage response, HttpStatusCode expectedStatus)
@@ -349,7 +371,9 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
             string jobId,
             ClaimsPrincipal principal,
             CancellationToken cancellationToken = default)
-            => Task.FromResult(_jobs[jobId]);
+            => _jobs.TryGetValue(jobId, out var job)
+                ? Task.FromResult(job)
+                : throw new GeoprocessingNotFoundException($"Job '{jobId}' not found.");
 
         public Task<AnalysisResultPackage> GetJobResultsAsync(
             string jobId,
@@ -420,7 +444,10 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
                     Metadata = new Dictionary<string, string>
                     {
                         ["password"] = "secret",
-                        ["code"] = "invalid-distance"
+                        ["code"] = "invalid-distance",
+                        // Secret-bearing value under an otherwise innocuous key: the key-based
+                        // filter does not catch it, so value-level redaction must.
+                        ["detail"] = "client_secret=topsecret123"
                     }
                 }
             ];

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
@@ -14,6 +14,7 @@ using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Server.Features.AnalysisContent;
 using Honua.Server.Features.Geoprocessing;
+using Honua.Server.Features.Infrastructure.ControlPlane;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -215,6 +216,19 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
         Assert.Equal("2", rerunJob.Spec.Parameters[AnalysisContentMetadataKeys.Version]);
         Assert.Equal(run.JobId, rerunJob.Spec.Parameters[AnalysisContentMetadataKeys.RerunOfJobId]);
         Assert.Equal("20", rerunJob.Spec.Parameters["analysis.content.parameter.distance"]);
+        Assert.Equal("20", rerunJob.Spec.Parameters[$"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.distance"]);
+
+        var rejectedRerunResponse = await _client.PostAsJsonAsync(
+            $"/api/v1/analysis/content/items/{created.Item.ItemId}/versions/1/reruns",
+            new RerunAnalysisContentVersionRequest
+            {
+                IdempotencyKey = "rerun-invalid",
+                ParameterOverrides = new Dictionary<string, string> { ["notAPlanInput"] = "20" }
+            },
+            JsonOptions);
+
+        Assert.Equal(HttpStatusCode.BadRequest, rejectedRerunResponse.StatusCode);
+        Assert.DoesNotContain(_jobs.SubmittedJobs, job => job.OperationId == "rerun-invalid");
     }
 
     [IntegrationTest]
@@ -237,6 +251,8 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
         Assert.True(logs.Truncated);
         Assert.Single(logs.Entries);
         Assert.DoesNotContain("password", JsonSerializer.Serialize(logs, JsonOptions), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, _logs.TailReadCount);
+        Assert.Equal(0, _logs.GetLogsReadCount);
     }
 
     private static async Task<T?> ReadJsonAsync<T>(HttpResponseMessage response, HttpStatusCode expectedStatus)
@@ -303,10 +319,27 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
             IReadOnlyDictionary<string, string>? protocolMetadata = null,
             CancellationToken cancellationToken = default)
         {
+            var parameters = protocolMetadata is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : new Dictionary<string, string>(protocolMetadata, StringComparer.Ordinal);
+            for (var stepIndex = 0; stepIndex < plan.Steps.Count; stepIndex++)
+            {
+                var step = plan.Steps[stepIndex];
+                if (step.Kind != AnalysisPlanStepKind.Geoprocess)
+                {
+                    continue;
+                }
+
+                foreach (var input in step.Inputs)
+                {
+                    parameters[$"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}{stepIndex}.{input.Key}"] = input.Value;
+                }
+            }
+
             var job = CreateJob(
                 idempotencyKey ?? $"analysis-job-{++_sequence}",
                 ExecutionJobStatus.Queued,
-                protocolMetadata ?? new Dictionary<string, string>());
+                parameters);
             SubmittedJobs.Add(job);
             _jobs[job.OperationId] = job;
             return Task.FromResult(job);
@@ -363,6 +396,10 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
     {
         private readonly Dictionary<string, List<ExecutionLogEntry>> _entries = new(StringComparer.Ordinal);
 
+        public int GetLogsReadCount { get; private set; }
+
+        public int TailReadCount { get; private set; }
+
         public void SeedFailureLogs()
         {
             _entries["failed-job"] =
@@ -407,8 +444,26 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
         public Task<IReadOnlyList<ExecutionLogEntry>> GetLogsAsync(
             string operationId,
             CancellationToken cancellationToken = default)
-            => Task.FromResult<IReadOnlyList<ExecutionLogEntry>>(
+        {
+            GetLogsReadCount++;
+            return Task.FromResult<IReadOnlyList<ExecutionLogEntry>>(
                 _entries.TryGetValue(operationId, out var entries) ? entries : []);
+        }
+
+        public Task<ExecutionLogTail> TailAsync(
+            string operationId,
+            int limit,
+            CancellationToken cancellationToken = default)
+        {
+            TailReadCount++;
+            var entries = _entries.TryGetValue(operationId, out var found) ? found : [];
+            var bounded = entries.TakeLast(Math.Max(1, limit)).ToArray();
+            return Task.FromResult(new ExecutionLogTail
+            {
+                Items = bounded,
+                TotalCount = entries.Count
+            });
+        }
 
         public Task<ExecutionLogPage> QueryAsync(
             string operationId,

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
@@ -407,6 +408,27 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
             CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionLogEntry>>(
                 _entries.TryGetValue(operationId, out var entries) ? entries : []);
+
+        public Task<ExecutionLogPage> QueryAsync(
+            string operationId,
+            ExecutionLogQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            var offset = int.TryParse(query.Cursor, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedOffset)
+                && parsedOffset > 0
+                ? parsedOffset
+                : 0;
+            var limit = Math.Max(1, query.Limit);
+            var entries = _entries.TryGetValue(operationId, out var found) ? found : [];
+            var page = entries.Skip(offset).Take(limit + 1).ToArray();
+            var hasMore = page.Length > limit;
+
+            return Task.FromResult(new ExecutionLogPage
+            {
+                Items = hasMore ? page.Take(limit).ToArray() : page,
+                NextCursor = hasMore ? (offset + limit).ToString(CultureInfo.InvariantCulture) : null
+            });
+        }
 
         public Task SetRetentionAsync(
             string operationId,

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentServiceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Security.Claims;
+using Honua.Core.Exceptions;
 using Honua.Core.Features.AnalysisContent.Abstractions;
 using Honua.Core.Features.AnalysisContent.Domain;
 using Honua.Core.Features.Catalog.Abstractions;
@@ -18,6 +19,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using StackExchange.Redis;
 
 namespace Honua.Server.Tests.Features.AnalysisContent;
 
@@ -123,6 +125,101 @@ public sealed class AnalysisContentServiceTests
 
         await logStore.DidNotReceive()
             .TailAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.JobStatus)]
+    public async Task GetJobLogsAsync_WhenLogStoreUnavailable_ThrowsStoreUnavailable()
+    {
+        // A Redis-backed log store outage must surface as the documented retryable 503
+        // (AnalysisContentStoreUnavailableException), not a generic 500.
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        jobService.GetJobAsync("job-logs", Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(CreateFailedJob("job-logs", "validation failed"));
+        var logStore = Substitute.For<IExecutionLogStore>();
+        logStore.TailAsync("job-logs", Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Throws(new RedisConnectionException(ConnectionFailureType.SocketFailure, "redis unavailable"));
+        var sut = CreateService(jobService: jobService, logStores: [logStore]);
+
+        await Assert.ThrowsAsync<AnalysisContentStoreUnavailableException>(
+            () => sut.GetJobLogsAsync("job-logs", 50, Principal(), CancellationToken.None));
+    }
+
+    [UnitTest]
+    [Operation(Operations.JobStatus)]
+    public async Task GetJobLogsAsync_WhenJobStoreUnavailable_ThrowsStoreUnavailable()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        jobService.GetJobAsync("job-logs", Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Throws(new ServiceUnavailableException("job store unavailable"));
+        var logStore = Substitute.For<IExecutionLogStore>();
+        var sut = CreateService(jobService: jobService, logStores: [logStore]);
+
+        await Assert.ThrowsAsync<AnalysisContentStoreUnavailableException>(
+            () => sut.GetJobLogsAsync("job-logs", 50, Principal(), CancellationToken.None));
+
+        // The job resolve failed, so the log store must not be read.
+        await logStore.DidNotReceive()
+            .TailAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.JobStatus)]
+    public async Task GetJobFailureAsync_WhenJobStoreUnavailable_ThrowsStoreUnavailable()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        jobService.GetJobAsync("job-failure", Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Throws(new RedisConnectionException(ConnectionFailureType.SocketFailure, "redis unavailable"));
+        var sut = CreateService(jobService: jobService);
+
+        await Assert.ThrowsAsync<AnalysisContentStoreUnavailableException>(
+            () => sut.GetJobFailureAsync("job-failure", Principal(), CancellationToken.None));
+    }
+
+    [UnitTest]
+    [Operation(Operations.JobStatus)]
+    public async Task GetJobLogsAsync_WithSecretBearingMetadataKey_DropsEntireEntry()
+    {
+        // The value is opaque (no secret marker), so value-only inspection cannot catch it; the
+        // sensitive key name must drop the entry while non-sensitive keys are preserved.
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        jobService.GetJobAsync("job-logs", Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(CreateFailedJob("job-logs", "validation failed"));
+        var logStore = Substitute.For<IExecutionLogStore>();
+        logStore.TailAsync("job-logs", Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new ExecutionLogTail
+            {
+                Items =
+                [
+                    new ExecutionLogEntry
+                    {
+                        Timestamp = DateTimeOffset.UtcNow,
+                        Level = ExecutionLogLevel.Error,
+                        Message = "request rejected",
+                        Metadata = new Dictionary<string, string>
+                        {
+                            ["token"] = "abc123xyz",
+                            ["apiKey"] = "opaque-value",
+                            ["region"] = "us-west-2"
+                        }
+                    }
+                ],
+                TotalCount = 1
+            });
+        var sut = CreateService(jobService: jobService, logStores: [logStore]);
+
+        var logs = await sut.GetJobLogsAsync("job-logs", 50, Principal(), CancellationToken.None);
+
+        var entry = Assert.Single(logs.Entries);
+        Assert.NotNull(entry.Metadata);
+        Assert.False(entry.Metadata!.ContainsKey("token"));
+        Assert.False(entry.Metadata.ContainsKey("apiKey"));
+        Assert.DoesNotContain(
+            "abc123xyz",
+            string.Join("|", entry.Metadata.Values),
+            StringComparison.OrdinalIgnoreCase);
+        // Non-sensitive metadata still passes through.
+        Assert.Equal("us-west-2", entry.Metadata["region"]);
     }
 
     [UnitTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentServiceTests.cs
@@ -6,14 +6,18 @@ using Honua.Core.Features.AnalysisContent.Abstractions;
 using Honua.Core.Features.AnalysisContent.Domain;
 using Honua.Core.Features.Catalog.Abstractions;
 using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.Query;
 using Honua.Server.Features.AnalysisContent;
 using Honua.Server.Features.Geoprocessing;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Honua.Server.Tests.Features.AnalysisContent;
 
@@ -50,6 +54,160 @@ public sealed class AnalysisContentServiceTests
         Assert.Equal(3, result.Version.Version);
         Assert.Equal("analysis-content-conflict:v2", result.Version.BasedOnVersionId);
         Assert.Equal(3, result.Item.CurrentVersion);
+    }
+
+    [UnitTest]
+    [Operation(Operations.JobStatus)]
+    public async Task GetJobFailureAsync_WithSecretBearingErrorMessage_RedactsMessage()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        jobService.GetJobAsync("job-secret", Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(CreateFailedJob(
+                "job-secret",
+                "Auth refused: client_secret=topsecret123 rejected by the token endpoint"));
+        var sut = CreateService(jobService: jobService);
+
+        var failure = await sut.GetJobFailureAsync("job-secret", Principal(), CancellationToken.None);
+
+        Assert.True(failure.IsTerminal);
+        Assert.DoesNotContain("topsecret123", failure.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("client_secret", failure.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [UnitTest]
+    [Operation(Operations.JobStatus)]
+    public async Task GetJobLogsAsync_WithSecretBearingMetadataValue_RedactsValue()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        jobService.GetJobAsync("job-logs", Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(CreateFailedJob("job-logs", "validation failed"));
+        var logStore = Substitute.For<IExecutionLogStore>();
+        logStore.TailAsync("job-logs", Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new ExecutionLogTail
+            {
+                Items =
+                [
+                    new ExecutionLogEntry
+                    {
+                        Timestamp = DateTimeOffset.UtcNow,
+                        Level = ExecutionLogLevel.Error,
+                        Message = "token exchange failed",
+                        // Secret-bearing value under a non-sensitive key.
+                        Metadata = new Dictionary<string, string> { ["detail"] = "api_key=abc123xyz" }
+                    }
+                ],
+                TotalCount = 1
+            });
+        var sut = CreateService(jobService: jobService, logStores: [logStore]);
+
+        var logs = await sut.GetJobLogsAsync("job-logs", 50, Principal(), CancellationToken.None);
+
+        var entry = Assert.Single(logs.Entries);
+        Assert.DoesNotContain("token exchange failed", entry.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(entry.Metadata);
+        Assert.DoesNotContain("abc123xyz", entry.Metadata!["detail"], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [UnitTest]
+    [Operation(Operations.JobStatus)]
+    public async Task GetJobLogsAsync_WhenJobNotFound_PropagatesNotFoundWithoutReadingLogs()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        jobService.GetJobAsync("missing", Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Throws(new GeoprocessingNotFoundException("Job 'missing' not found."));
+        var logStore = Substitute.For<IExecutionLogStore>();
+        var sut = CreateService(jobService: jobService, logStores: [logStore]);
+
+        await Assert.ThrowsAsync<GeoprocessingNotFoundException>(
+            () => sut.GetJobLogsAsync("missing", null, Principal(), CancellationToken.None));
+
+        await logStore.DidNotReceive()
+            .TailAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    public async Task AddAnalysisContent_InMemoryFallbackStore_PersistsAcrossRequestScopes()
+    {
+        // The in-memory fallback must be a process-wide singleton: an item written in one request
+        // scope has to remain visible from a later scope. A scoped-per-instance registration would
+        // resolve a fresh empty store and silently lose the item.
+        var services = new ServiceCollection();
+        services.AddAnalysisContent(new ConfigurationBuilder().Build());
+        await using var provider = services.BuildServiceProvider();
+
+        const string itemId = "analysis-content-scope-test";
+        var item = new AnalysisContentItem
+        {
+            ItemId = itemId,
+            Kind = AnalysisContentKind.SavedQuery,
+            Name = "scope-test",
+            CurrentVersion = 1,
+            CurrentVersionId = $"{itemId}:v1",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        var version = new AnalysisContentVersion
+        {
+            VersionId = $"{itemId}:v1",
+            ItemId = itemId,
+            Version = 1,
+            Kind = AnalysisContentKind.SavedQuery,
+            SavedQuery = CreateSavedQuery("scope-test"),
+            ContentHash = "hash-1",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        await using (var writeScope = provider.CreateAsyncScope())
+        {
+            var store = writeScope.ServiceProvider.GetRequiredService<IAnalysisContentStore>();
+            await store.CreateItemAsync(item, version, CancellationToken.None);
+        }
+
+        await using (var readScope = provider.CreateAsyncScope())
+        {
+            var store = readScope.ServiceProvider.GetRequiredService<IAnalysisContentStore>();
+            var resolved = await store.GetItemAsync(itemId, CancellationToken.None);
+            Assert.NotNull(resolved);
+            Assert.Equal(itemId, resolved!.ItemId);
+        }
+    }
+
+    private static AnalysisContentService CreateService(
+        IGeoprocessingJobService? jobService = null,
+        IEnumerable<IExecutionLogStore>? logStores = null)
+        => new(
+            Substitute.For<IAnalysisContentStore>(),
+            Substitute.For<ILayerCatalog>(),
+            Substitute.For<IQueryProcessor>(),
+            Substitute.For<IFeatureReader>(),
+            jobService ?? Substitute.For<IGeoprocessingJobService>(),
+            logStores ?? Array.Empty<IExecutionLogStore>(),
+            TimeProvider.System,
+            NullLogger<AnalysisContentService>.Instance);
+
+    private static ClaimsPrincipal Principal() => new(new ClaimsIdentity("Test"));
+
+    private static ExecutionJobRecord CreateFailedJob(string jobId, string errorMessage)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new ExecutionJobRecord
+        {
+            OperationId = jobId,
+            Status = ExecutionJobStatus.Failed,
+            CreatedAt = now,
+            UpdatedAt = now,
+            CompletedAt = now,
+            ErrorMessage = errorMessage,
+            Spec = new ExecutionJobSpec
+            {
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "test",
+                Kind = ExecutionJobKind.Geoprocessing,
+                WorkloadName = "test",
+                Parameters = new Dictionary<string, string>()
+            }
+        };
     }
 
     private static SavedQueryContent CreateSavedQuery(string query)

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentServiceTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using Honua.Core.Features.AnalysisContent.Abstractions;
+using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.Catalog.Abstractions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.Query;
+using Honua.Server.Features.AnalysisContent;
+using Honua.Server.Features.Geoprocessing;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.AnalysisContent;
+
+[Protocol(TestProtocols.Admin)]
+public sealed class AnalysisContentServiceTests
+{
+    [UnitTest]
+    [Operation(Operations.Create)]
+    public async Task AddVersionAsync_WhenStoreConflicts_RereadsLatestAndCreatesNextVersion()
+    {
+        var store = new ConflictOnceAnalysisContentStore();
+        var sut = new AnalysisContentService(
+            store,
+            Substitute.For<ILayerCatalog>(),
+            Substitute.For<IQueryProcessor>(),
+            Substitute.For<IFeatureReader>(),
+            Substitute.For<IGeoprocessingJobService>(),
+            Array.Empty<IExecutionLogStore>(),
+            TimeProvider.System,
+            NullLogger<AnalysisContentService>.Instance);
+
+        var result = await sut.AddVersionAsync(
+            ConflictOnceAnalysisContentStore.ItemId,
+            new CreateAnalysisContentVersionCommand(
+                SavedQuery: CreateSavedQuery("after conflict"),
+                AnalysisPackage: null,
+                BasedOnVersionId: null,
+                CreatedFromJobId: null,
+                CreatedFromArtifactIds: []),
+            new ClaimsPrincipal(new ClaimsIdentity("Test")),
+            CancellationToken.None);
+
+        Assert.Equal(2, store.AddVersionAttempts);
+        Assert.Equal(3, result.Version.Version);
+        Assert.Equal("analysis-content-conflict:v2", result.Version.BasedOnVersionId);
+        Assert.Equal(3, result.Item.CurrentVersion);
+    }
+
+    private static SavedQueryContent CreateSavedQuery(string query)
+        => new()
+        {
+            LayerId = 0,
+            NaturalLanguageQuery = query
+        };
+
+    private sealed class ConflictOnceAnalysisContentStore : IAnalysisContentStore
+    {
+        public const string ItemId = "analysis-content-conflict";
+
+        private readonly SortedDictionary<int, AnalysisContentVersion> _versions = new()
+        {
+            [1] = CreateVersion(1, "initial")
+        };
+
+        private AnalysisContentItem _item = new()
+        {
+            ItemId = ItemId,
+            Kind = AnalysisContentKind.SavedQuery,
+            Name = "conflict-test",
+            CurrentVersion = 1,
+            CurrentVersionId = "analysis-content-conflict:v1",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        private bool _conflictPending = true;
+
+        public int AddVersionAttempts { get; private set; }
+
+        public Task<AnalysisContentItem> CreateItemAsync(
+            AnalysisContentItem item,
+            AnalysisContentVersion version,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<AnalysisContentItem?> GetItemAsync(
+            string itemId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<AnalysisContentItem?>(string.Equals(itemId, ItemId, StringComparison.Ordinal) ? _item : null);
+
+        public Task<AnalysisContentVersion> AddVersionAsync(
+            string itemId,
+            AnalysisContentVersion version,
+            CancellationToken cancellationToken = default)
+        {
+            AddVersionAttempts++;
+            if (_conflictPending)
+            {
+                _conflictPending = false;
+                StoreVersion(CreateVersion(2, "external"));
+                throw new AnalysisContentStoreConflictException("version conflict");
+            }
+
+            StoreVersion(version);
+            return Task.FromResult(version);
+        }
+
+        public Task<AnalysisContentVersion?> GetVersionAsync(
+            string itemId,
+            int? version = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (!string.Equals(itemId, ItemId, StringComparison.Ordinal))
+            {
+                return Task.FromResult<AnalysisContentVersion?>(null);
+            }
+
+            var resolved = version.HasValue
+                ? _versions.GetValueOrDefault(version.Value)
+                : _versions.Last().Value;
+            return Task.FromResult(resolved);
+        }
+
+        public Task<IReadOnlyList<AnalysisContentVersion>> ListVersionsAsync(
+            string itemId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<AnalysisContentVersion>>(_versions.Values.ToArray());
+
+        public Task<ResultArtifactRecord> UpsertArtifactAsync(
+            ResultArtifactRecord artifact,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<ResultArtifactRecord?> GetArtifactAsync(
+            string artifactId,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<ResultArtifactRecord>> ListArtifactsForJobAsync(
+            string jobId,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        private void StoreVersion(AnalysisContentVersion version)
+        {
+            _versions[version.Version] = version;
+            _item = _item with
+            {
+                CurrentVersion = version.Version,
+                CurrentVersionId = version.VersionId,
+                UpdatedAt = version.CreatedAt
+            };
+        }
+
+        private static AnalysisContentVersion CreateVersion(int version, string query)
+            => new()
+            {
+                VersionId = $"analysis-content-conflict:v{version}",
+                ItemId = ItemId,
+                Version = version,
+                Kind = AnalysisContentKind.SavedQuery,
+                SavedQuery = CreateSavedQuery(query),
+                ContentHash = $"hash-{version}",
+                CreatedAt = DateTimeOffset.UtcNow
+            };
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/GeoprocessingArtifactPersistenceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/GeoprocessingArtifactPersistenceTests.cs
@@ -20,7 +20,7 @@ namespace Honua.Server.Tests.Features.AnalysisContent;
 [Protocol(TestProtocols.Admin)]
 public sealed class GeoprocessingArtifactPersistenceTests
 {
-    [IntegrationTest]
+    [UnitTest]
     [Operation(Operations.ProcessExecution)]
     public async Task TerminalCallback_WithAnalysisContentMetadata_PersistsDurableArtifactRecord()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/GeoprocessingArtifactPersistenceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/GeoprocessingArtifactPersistenceTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.AnalysisContent;
+using Honua.Core.Features.AnalysisContent.Abstractions;
 using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Geoprocessing.Domain;
@@ -13,6 +15,8 @@ using Honua.Server.Features.Geoprocessing;
 using Honua.Server.Features.Infrastructure.ControlPlane;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Honua.Server.Tests.Features.AnalysisContent;
@@ -22,21 +26,32 @@ public sealed class GeoprocessingArtifactPersistenceTests
 {
     [UnitTest]
     [Operation(Operations.ProcessExecution)]
-    public async Task TerminalCallback_WithAnalysisContentMetadata_PersistsDurableArtifactRecord()
+    public async Task TerminalCallback_WithScopedAnalysisContentStore_PersistsDurableArtifactRecord()
     {
-        var store = new InMemoryAnalysisContentStore();
-        var callback = new GeoprocessingJobTerminalCallback(
-            new NullProgressStore(),
-            new EmptyProcessCatalog(),
-            resultPackageStore: null,
-            analysisContentStore: store,
+        var artifacts = new Dictionary<string, ResultArtifactRecord>(StringComparer.Ordinal);
+        var services = new ServiceCollection();
+        services.AddSingleton<IUniversalProgressStore, NullProgressStore>();
+        services.AddSingleton<IProcessCatalog, EmptyProcessCatalog>();
+        services.AddSingleton<IGeoprocessingResultPackageStore, NullResultPackageStore>();
+        services.AddScoped<IAnalysisContentStore>(_ => new RecordingAnalysisContentStore(artifacts));
+        services.AddSingleton<ILogger<GeoprocessingJobTerminalCallback>>(
             NullLogger<GeoprocessingJobTerminalCallback>.Instance);
+        services.AddSingleton<IJobTerminalCallback, GeoprocessingJobTerminalCallback>();
+
+        using var provider = services.BuildServiceProvider(
+            new ServiceProviderOptions
+            {
+                ValidateOnBuild = true,
+                ValidateScopes = true
+            });
+
+        var callback = provider.GetRequiredService<IJobTerminalCallback>();
 
         var job = CreateTerminalJob();
 
         await callback.OnTerminalAsync(job, CancellationToken.None);
 
-        var artifact = await store.GetArtifactAsync("job-1182:artifact:1");
+        artifacts.TryGetValue("job-1182:artifact:1", out var artifact);
 
         Assert.NotNull(artifact);
         Assert.Equal("content-1182", artifact!.SourceItemId);
@@ -125,5 +140,71 @@ public sealed class GeoprocessingArtifactPersistenceTests
         public IReadOnlyList<ProcessDefinition> ListProcesses() => [];
 
         public IReadOnlyList<ProcessDefinition> GetProcessesByCategory(string category) => [];
+    }
+
+    private sealed class NullResultPackageStore : IGeoprocessingResultPackageStore
+    {
+        public Task<AnalysisResultPackage?> GetAsync(
+            string jobId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<AnalysisResultPackage?>(null);
+
+        public Task SetAsync(
+            string jobId,
+            AnalysisResultPackage package,
+            TimeSpan? ttl = null,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class RecordingAnalysisContentStore(
+        Dictionary<string, ResultArtifactRecord> artifacts) : IAnalysisContentStore
+    {
+        public Task<AnalysisContentItem> CreateItemAsync(
+            AnalysisContentItem item,
+            AnalysisContentVersion version,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<AnalysisContentItem?> GetItemAsync(
+            string itemId,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<AnalysisContentVersion> AddVersionAsync(
+            string itemId,
+            AnalysisContentVersion version,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<AnalysisContentVersion?> GetVersionAsync(
+            string itemId,
+            int? version = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<AnalysisContentVersion>> ListVersionsAsync(
+            string itemId,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<ResultArtifactRecord> UpsertArtifactAsync(
+            ResultArtifactRecord artifact,
+            CancellationToken cancellationToken = default)
+        {
+            artifacts[artifact.ArtifactId] = artifact;
+            return Task.FromResult(artifact);
+        }
+
+        public Task<ResultArtifactRecord?> GetArtifactAsync(
+            string artifactId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(artifacts.GetValueOrDefault(artifactId));
+
+        public Task<IReadOnlyList<ResultArtifactRecord>> ListArtifactsForJobAsync(
+            string jobId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<ResultArtifactRecord>>(
+                artifacts.Values.Where(artifact => artifact.JobId == jobId).ToArray());
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/GeoprocessingArtifactPersistenceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/GeoprocessingArtifactPersistenceTests.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.AnalysisContent;
+using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Domain;
+using Honua.Server.Features.AnalysisContent;
+using Honua.Server.Features.Geoprocessing;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Features.AnalysisContent;
+
+[Protocol(TestProtocols.Admin)]
+public sealed class GeoprocessingArtifactPersistenceTests
+{
+    [IntegrationTest]
+    [Operation(Operations.ProcessExecution)]
+    public async Task TerminalCallback_WithAnalysisContentMetadata_PersistsDurableArtifactRecord()
+    {
+        var store = new InMemoryAnalysisContentStore();
+        var callback = new GeoprocessingJobTerminalCallback(
+            new NullProgressStore(),
+            new EmptyProcessCatalog(),
+            resultPackageStore: null,
+            analysisContentStore: store,
+            NullLogger<GeoprocessingJobTerminalCallback>.Instance);
+
+        var job = CreateTerminalJob();
+
+        await callback.OnTerminalAsync(job, CancellationToken.None);
+
+        var artifact = await store.GetArtifactAsync("job-1182:artifact:1");
+
+        Assert.NotNull(artifact);
+        Assert.Equal("content-1182", artifact!.SourceItemId);
+        Assert.Equal(3, artifact.SourceVersion);
+        Assert.Equal("content-1182:v3", artifact.SourceVersionId);
+        Assert.Equal("job-1182", artifact.JobId);
+        Assert.Equal(ResultArtifactRetentionState.Retained, artifact.RetentionState);
+        Assert.Equal("4326", artifact.Provenance[AnalysisContentMetadataKeys.SourceSrid]);
+        Assert.Equal("meters", artifact.Provenance[AnalysisContentMetadataKeys.SourceUnits]);
+    }
+
+    private static ExecutionJobRecord CreateTerminalJob()
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new ExecutionJobRecord
+        {
+            OperationId = "job-1182",
+            Version = 7,
+            Status = ExecutionJobStatus.Succeeded,
+            CreatedAt = now.AddMinutes(-1),
+            UpdatedAt = now,
+            CompletedAt = now,
+            ArtifactReferences = ["s3://bucket/result.geojson"],
+            Spec = new ExecutionJobSpec
+            {
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "test",
+                Kind = ExecutionJobKind.Geoprocessing,
+                WorkloadName = "test analysis",
+                Parameters = new Dictionary<string, string>
+                {
+                    [AnalysisContentMetadataKeys.ItemId] = "content-1182",
+                    [AnalysisContentMetadataKeys.Version] = "3",
+                    [AnalysisContentMetadataKeys.VersionId] = "content-1182:v3",
+                    [AnalysisContentMetadataKeys.Kind] = "AnalysisPackage",
+                    [AnalysisContentMetadataKeys.SourceSrid] = "4326",
+                    [AnalysisContentMetadataKeys.SourceUnits] = "meters",
+                    [ExecutionJobParameterKeys.GeoprocessingPlanId] = "plan-1182",
+                    [ExecutionJobParameterKeys.GeoprocessingOutputArtifactKinds] = "FeatureLayer"
+                }
+            }
+        };
+    }
+
+    private sealed class NullProgressStore : IUniversalProgressStore
+    {
+        public Task SetProgressAsync(
+            string operationId,
+            IOperationProgress progress,
+            TimeSpan? ttl = null,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<TProgress?> GetProgressAsync<TProgress>(
+            string operationId,
+            CancellationToken cancellationToken = default)
+            where TProgress : class, IOperationProgress
+            => Task.FromResult<TProgress?>(null);
+
+        public Task<IOperationProgress?> GetProgressAsync(
+            string operationId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IOperationProgress?>(null);
+
+        public Task DeleteProgressAsync(
+            string operationId,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<IReadOnlyList<string>> GetActiveOperationIdsAsync(
+            OperationType? operationType = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+
+        public Task<IReadOnlyList<TProgress>> GetActiveOperationsAsync<TProgress>(
+            OperationType operationType,
+            CancellationToken cancellationToken = default)
+            where TProgress : class, IOperationProgress
+            => Task.FromResult<IReadOnlyList<TProgress>>(Array.Empty<TProgress>());
+    }
+
+    private sealed class EmptyProcessCatalog : IProcessCatalog
+    {
+        public ProcessDefinition? GetProcess(string processId) => null;
+
+        public IReadOnlyList<ProcessDefinition> ListProcesses() => [];
+
+        public IReadOnlyList<ProcessDefinition> GetProcessesByCategory(string category) => [];
+    }
+}

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -76,6 +76,64 @@ sql:
       );
   - "ALTER TABLE IF EXISTS honua.layer_fields ADD COLUMN IF NOT EXISTS hidden BOOLEAN NOT NULL DEFAULT FALSE;"
   - |
+      CREATE TABLE IF NOT EXISTS honua.analysis_content_items (
+          item_id            TEXT        PRIMARY KEY,
+          kind               TEXT        NOT NULL,
+          name               TEXT        NOT NULL,
+          title              TEXT        NULL,
+          owner_id           TEXT        NULL,
+          visibility         TEXT        NOT NULL DEFAULT 'organization',
+          current_version    INT         NOT NULL,
+          current_version_id TEXT        NOT NULL,
+          lifecycle          TEXT        NOT NULL DEFAULT 'Active',
+          created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          created_by         TEXT        NULL,
+          CONSTRAINT analysis_content_items_kind CHECK (kind IN ('SavedQuery', 'AnalysisPackage')),
+          CONSTRAINT analysis_content_items_lifecycle CHECK (lifecycle IN ('Active', 'Archived', 'Deleted')),
+          CONSTRAINT analysis_content_items_version_positive CHECK (current_version > 0),
+          CONSTRAINT analysis_content_items_name_not_empty CHECK (length(btrim(name)) > 0)
+      );
+  - "CREATE INDEX IF NOT EXISTS idx_analysis_content_items_kind_updated ON honua.analysis_content_items (kind, updated_at DESC, item_id);"
+  - "CREATE INDEX IF NOT EXISTS idx_analysis_content_items_owner_updated ON honua.analysis_content_items (owner_id, updated_at DESC, item_id);"
+  - |
+      CREATE TABLE IF NOT EXISTS honua.analysis_content_versions (
+          version_id    TEXT        PRIMARY KEY,
+          item_id       TEXT        NOT NULL REFERENCES honua.analysis_content_items(item_id) ON DELETE CASCADE,
+          version       INT         NOT NULL,
+          kind          TEXT        NOT NULL,
+          content_hash  TEXT        NOT NULL,
+          created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          created_by    TEXT        NULL,
+          version_body  JSONB       NOT NULL,
+          CONSTRAINT analysis_content_versions_item_version UNIQUE (item_id, version),
+          CONSTRAINT analysis_content_versions_kind CHECK (kind IN ('SavedQuery', 'AnalysisPackage')),
+          CONSTRAINT analysis_content_versions_version_positive CHECK (version > 0)
+      );
+  - "CREATE INDEX IF NOT EXISTS idx_analysis_content_versions_item_created ON honua.analysis_content_versions (item_id, version DESC);"
+  - "CREATE INDEX IF NOT EXISTS idx_analysis_content_versions_hash ON honua.analysis_content_versions (content_hash);"
+  - |
+      CREATE TABLE IF NOT EXISTS honua.analysis_result_artifacts (
+          artifact_id       TEXT        PRIMARY KEY,
+          result_package_id TEXT        NOT NULL,
+          job_id            TEXT        NOT NULL,
+          source_item_id    TEXT        NOT NULL,
+          source_version    INT         NOT NULL,
+          source_version_id TEXT        NOT NULL,
+          kind              TEXT        NOT NULL,
+          retention_state   TEXT        NOT NULL DEFAULT 'Retained',
+          promotion_state   TEXT        NOT NULL DEFAULT 'None',
+          created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          expires_at        TIMESTAMPTZ NULL,
+          artifact_body     JSONB       NOT NULL,
+          CONSTRAINT analysis_result_artifacts_source_version_positive CHECK (source_version > 0),
+          CONSTRAINT analysis_result_artifacts_retention CHECK (retention_state IN ('Preview', 'Retained', 'Promoted', 'Expired')),
+          CONSTRAINT analysis_result_artifacts_promotion CHECK (promotion_state IN ('None', 'Promoted'))
+      );
+  - "CREATE INDEX IF NOT EXISTS idx_analysis_result_artifacts_job_created ON honua.analysis_result_artifacts (job_id, created_at, artifact_id);"
+  - "CREATE INDEX IF NOT EXISTS idx_analysis_result_artifacts_source ON honua.analysis_result_artifacts (source_item_id, source_version, artifact_id);"
+  - "CREATE INDEX IF NOT EXISTS idx_analysis_result_artifacts_retention ON honua.analysis_result_artifacts (retention_state, expires_at);"
+  - |
       CREATE TABLE IF NOT EXISTS honua.relationships (
           id SERIAL PRIMARY KEY,
           layer_id INT NOT NULL REFERENCES honua.layers(layer_id) ON DELETE CASCADE,


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #1182
## Summary

I followed the established cross-cutting pattern: `ServiceUnavailableException` is the codebase's canonical "→503" signal (mapped by `ExceptionMapper`/`GlobalExceptionMiddleware`), translated to the feature's domain exception at the store/service boundary — exactly how the sibling `ConsoleJob*` feature does it.
## Changes Made

- I followed the established cross-cutting pattern: `ServiceUnavailableException` is the codebase's canonical "→503" signal (mapped by `ExceptionMapper`/`GlobalExceptionMiddleware`), translated to the feature's domain exception at the store/service boundary — exactly how the sibling `ConsoleJob*` feature does it.
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/ci/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
