### PR TITLE
feat(scene/analysis): line-of-sight and viewshed on elevation surfaces (#1203)

### DIFF
--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -178,6 +178,10 @@ public static class FeatureCatalog
             HonuaEdition.Pro, "Compute solar position from date/time/location and cast the shadow extent against the elevation surface."),
         new("analytics.slice", "Slice/Volumetric Analysis", Categories.Analytics,
             HonuaEdition.Pro, "Intersect a vertical slice plane with the elevation surface and return cross-section metadata."),
+        new("analytics.line-of-sight", "Line of Sight", Categories.Analytics,
+            HonuaEdition.Pro, "Determine terrain visibility between an observer and target over the elevation surface."),
+        new("analytics.viewshed", "Viewshed", Categories.Analytics,
+            HonuaEdition.Pro, "Compute the radially-sampled visible area around an observer over the elevation surface."),
 
         // Temporal — Community (basic discovery)
         new("temporal.filtering", "Temporal Query Filtering", Categories.Temporal,

--- a/src/Honua.Core/Features/Raster/Abstractions/IVisibilityAnalysisService.cs
+++ b/src/Honua.Core/Features/Raster/Abstractions/IVisibilityAnalysisService.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Raster.Domain;
+
+namespace Honua.Core.Features.Raster.Abstractions;
+
+/// <summary>
+/// Computes 3D visibility analyses (line-of-sight and viewshed) against a
+/// registered elevation/terrain surface.
+/// </summary>
+/// <remarks>
+/// Implementations build on the elevation profile sampler
+/// (<see cref="IElevationService.QueryProfileAsync"/>) rather than reading the
+/// DEM directly, so they inherit the geodesic profile geometry, mosaic merge
+/// strategy, and no-data handling already established for the elevation API.
+/// </remarks>
+public interface IVisibilityAnalysisService
+{
+    /// <summary>
+    /// Determines whether <paramref name="target"/> is visible from
+    /// <paramref name="observer"/> over the elevation surface, returning the
+    /// first terrain obstruction when the target is blocked.
+    /// </summary>
+    /// <param name="layerId">Layer that owns the elevation source.</param>
+    /// <param name="observer">Observer position and height offset.</param>
+    /// <param name="target">Target position and height offset.</param>
+    /// <param name="sampleCount">
+    /// Requested number of profile samples along the sight line. <c>null</c>
+    /// applies the configured default. Clamped to the elevation sampling limit.
+    /// </param>
+    /// <param name="mergeStrategy">Mosaic merge strategy applied across overlapping rasters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<LineOfSightResult> ComputeLineOfSightAsync(
+        int layerId,
+        VisibilityPoint observer,
+        VisibilityPoint target,
+        int? sampleCount,
+        RasterMergeStrategy mergeStrategy,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Computes which radially-sampled points around <paramref name="observer"/>
+    /// are visible over the elevation surface within the requested radius.
+    /// </summary>
+    /// <param name="layerId">Layer that owns the elevation source.</param>
+    /// <param name="observer">Observer longitude/latitude (height comes from <paramref name="options"/>).</param>
+    /// <param name="options">Radius, ray count, sample resolution, and height offsets.</param>
+    /// <param name="mergeStrategy">Mosaic merge strategy applied across overlapping rasters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<ViewshedResult> ComputeViewshedAsync(
+        int layerId,
+        VisibilityPoint observer,
+        ViewshedOptions options,
+        RasterMergeStrategy mergeStrategy,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Raster/Domain/VisibilityAnalysisDomain.cs
+++ b/src/Honua.Core/Features/Raster/Domain/VisibilityAnalysisDomain.cs
@@ -1,0 +1,241 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Raster.Domain;
+
+/// <summary>
+/// A geographic observer or target position used by visibility analysis,
+/// expressed in WGS 84 longitude/latitude with an optional height offset above
+/// the sampled terrain surface (in meters).
+/// </summary>
+public readonly record struct VisibilityPoint
+{
+    /// <summary>
+    /// Longitude in WGS 84 decimal degrees.
+    /// </summary>
+    public required double Longitude { get; init; }
+
+    /// <summary>
+    /// Latitude in WGS 84 decimal degrees.
+    /// </summary>
+    public required double Latitude { get; init; }
+
+    /// <summary>
+    /// Height offset above the terrain surface, in meters. Defaults to 0.
+    /// For an observer this models antenna/eye height; for a target it models
+    /// the height of the object being observed.
+    /// </summary>
+    public double HeightOffsetMeters { get; init; }
+}
+
+/// <summary>
+/// The first point along a line of sight where the terrain surface rises above
+/// the sight line, blocking visibility.
+/// </summary>
+public sealed record LineOfSightObstruction
+{
+    /// <summary>
+    /// Longitude of the obstruction in WGS 84 decimal degrees.
+    /// </summary>
+    public required double Longitude { get; init; }
+
+    /// <summary>
+    /// Latitude of the obstruction in WGS 84 decimal degrees.
+    /// </summary>
+    public required double Latitude { get; init; }
+
+    /// <summary>
+    /// Terrain elevation at the obstruction, in meters.
+    /// </summary>
+    public required double Elevation { get; init; }
+
+    /// <summary>
+    /// Distance from the observer to the obstruction, in meters, measured along
+    /// the geodesic arc.
+    /// </summary>
+    public required double DistanceMeters { get; init; }
+}
+
+/// <summary>
+/// Result of a line-of-sight analysis between an observer and a target.
+/// </summary>
+public sealed record LineOfSightResult
+{
+    /// <summary>
+    /// Layer that owns the elevation source.
+    /// </summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>
+    /// Whether the target is visible from the observer with no terrain
+    /// obstruction along the sight line.
+    /// </summary>
+    public required bool Visible { get; init; }
+
+    /// <summary>
+    /// First terrain obstruction along the sight line, or <c>null</c> when the
+    /// target is visible.
+    /// </summary>
+    public LineOfSightObstruction? Obstruction { get; init; }
+
+    /// <summary>
+    /// Terrain elevation at the observer position, in meters.
+    /// </summary>
+    public required double ObserverGroundElevation { get; init; }
+
+    /// <summary>
+    /// Absolute observer elevation including the height offset, in meters.
+    /// </summary>
+    public required double ObserverElevation { get; init; }
+
+    /// <summary>
+    /// Terrain elevation at the target position, in meters.
+    /// </summary>
+    public required double TargetGroundElevation { get; init; }
+
+    /// <summary>
+    /// Absolute target elevation including the height offset, in meters.
+    /// </summary>
+    public required double TargetElevation { get; init; }
+
+    /// <summary>
+    /// Geodesic distance from observer to target, in meters.
+    /// </summary>
+    public required double DistanceMeters { get; init; }
+
+    /// <summary>
+    /// Number of profile samples evaluated along the sight line.
+    /// </summary>
+    public required int SampleCount { get; init; }
+
+    /// <summary>
+    /// Whether one or more profile samples between observer and target resolved
+    /// to a no-data pixel. Visibility is reported on a best-effort basis when
+    /// true: no-data samples are skipped during the obstruction test.
+    /// </summary>
+    public required bool HasNoDataSamples { get; init; }
+}
+
+/// <summary>
+/// A single radial sample produced by a viewshed analysis.
+/// </summary>
+public readonly record struct ViewshedSample
+{
+    /// <summary>
+    /// Longitude of the sample in WGS 84 decimal degrees.
+    /// </summary>
+    public required double Longitude { get; init; }
+
+    /// <summary>
+    /// Latitude of the sample in WGS 84 decimal degrees.
+    /// </summary>
+    public required double Latitude { get; init; }
+
+    /// <summary>
+    /// Azimuth from the observer to the sample, in degrees clockwise from north
+    /// (0 = north, 90 = east).
+    /// </summary>
+    public required double AzimuthDegrees { get; init; }
+
+    /// <summary>
+    /// Distance from the observer to the sample, in meters.
+    /// </summary>
+    public required double DistanceMeters { get; init; }
+
+    /// <summary>
+    /// Terrain elevation at the sample, in meters. <c>null</c> when the sample
+    /// resolved to a no-data pixel.
+    /// </summary>
+    public double? Elevation { get; init; }
+
+    /// <summary>
+    /// Whether this sample is visible from the observer.
+    /// </summary>
+    public required bool Visible { get; init; }
+}
+
+/// <summary>
+/// Result of a viewshed analysis: the set of radially-sampled points around an
+/// observer, each flagged visible or obstructed.
+/// </summary>
+public sealed record ViewshedResult
+{
+    /// <summary>
+    /// Layer that owns the elevation source.
+    /// </summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>
+    /// Terrain elevation at the observer position, in meters.
+    /// </summary>
+    public required double ObserverGroundElevation { get; init; }
+
+    /// <summary>
+    /// Absolute observer elevation including the height offset, in meters.
+    /// </summary>
+    public required double ObserverElevation { get; init; }
+
+    /// <summary>
+    /// Analysis radius in meters.
+    /// </summary>
+    public required double RadiusMeters { get; init; }
+
+    /// <summary>
+    /// Number of azimuth rays cast around the observer.
+    /// </summary>
+    public required int RayCount { get; init; }
+
+    /// <summary>
+    /// Number of range samples per ray (excluding the observer position).
+    /// </summary>
+    public required int SamplesPerRay { get; init; }
+
+    /// <summary>
+    /// All radial samples, ordered by azimuth then range.
+    /// </summary>
+    public required ViewshedSample[] Samples { get; init; }
+
+    /// <summary>
+    /// Count of samples flagged visible.
+    /// </summary>
+    public required int VisibleSampleCount { get; init; }
+
+    /// <summary>
+    /// Whether the observer position itself resolved to a no-data pixel, which
+    /// makes the analysis indeterminate.
+    /// </summary>
+    public required bool ObserverNoData { get; init; }
+}
+
+/// <summary>
+/// Options controlling a viewshed analysis.
+/// </summary>
+public readonly record struct ViewshedOptions
+{
+    /// <summary>
+    /// Analysis radius in meters. Must be strictly positive.
+    /// </summary>
+    public required double RadiusMeters { get; init; }
+
+    /// <summary>
+    /// Number of azimuth rays cast around the observer. Clamped to
+    /// <c>[MinRayCount, MaxRayCount]</c>.
+    /// </summary>
+    public int? RayCount { get; init; }
+
+    /// <summary>
+    /// Number of range samples per ray. Clamped to
+    /// <c>[2, MaxSamplesPerRay]</c>.
+    /// </summary>
+    public int? SamplesPerRay { get; init; }
+
+    /// <summary>
+    /// Observer height offset above the terrain surface, in meters.
+    /// </summary>
+    public double ObserverHeightOffsetMeters { get; init; }
+
+    /// <summary>
+    /// Height offset applied to every sampled target point, in meters.
+    /// </summary>
+    public double TargetHeightOffsetMeters { get; init; }
+}

--- a/src/Honua.Core/Features/Raster/VisibilityAnalysisService.cs
+++ b/src/Honua.Core/Features/Raster/VisibilityAnalysisService.cs
@@ -1,0 +1,443 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Shared.Models;
+
+namespace Honua.Core.Features.Raster;
+
+/// <summary>
+/// Default <see cref="IVisibilityAnalysisService"/> implementation. Builds on
+/// the elevation profile sampler so it inherits the geodesic profile geometry,
+/// mosaic merge strategy, and no-data handling of the elevation API and does
+/// not re-implement DEM sampling.
+/// </summary>
+public sealed class VisibilityAnalysisService : IVisibilityAnalysisService
+{
+    private const int Wgs84Srid = SpatialConstants.DefaultSrid;
+
+    /// <summary>
+    /// Default number of profile samples taken along a line of sight when the
+    /// caller does not supply an explicit count.
+    /// </summary>
+    public const int DefaultLineOfSightSampleCount = 128;
+
+    /// <summary>
+    /// Default and bounding values for viewshed ray casting. The defaults keep
+    /// a full-radius viewshed at a few thousand profile samples to avoid
+    /// runaway cost.
+    /// </summary>
+    public const int DefaultRayCount = 120;
+
+    /// <summary>Lower bound on viewshed ray count.</summary>
+    public const int MinRayCount = 8;
+
+    /// <summary>Upper bound on viewshed ray count.</summary>
+    public const int MaxRayCount = 720;
+
+    /// <summary>Default range samples per viewshed ray.</summary>
+    public const int DefaultSamplesPerRay = 64;
+
+    /// <summary>Upper bound on viewshed range samples per ray.</summary>
+    public const int MaxSamplesPerRay = 512;
+
+    private readonly IElevationService _elevationService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VisibilityAnalysisService"/> class.
+    /// </summary>
+    /// <param name="elevationService">Elevation profile sampler.</param>
+    public VisibilityAnalysisService(IElevationService elevationService)
+    {
+        _elevationService = elevationService ?? throw new ArgumentNullException(nameof(elevationService));
+    }
+
+    /// <inheritdoc />
+    public async Task<LineOfSightResult> ComputeLineOfSightAsync(
+        int layerId,
+        VisibilityPoint observer,
+        VisibilityPoint target,
+        int? sampleCount,
+        RasterMergeStrategy mergeStrategy,
+        CancellationToken cancellationToken = default)
+    {
+        var resolvedSampleCount = sampleCount is { } count && count >= 2
+            ? count
+            : DefaultLineOfSightSampleCount;
+
+        var profile = await SampleLineAsync(
+            layerId,
+            observer.Longitude,
+            observer.Latitude,
+            target.Longitude,
+            target.Latitude,
+            resolvedSampleCount,
+            mergeStrategy,
+            cancellationToken).ConfigureAwait(false);
+
+        var samples = profile.Samples;
+        if (samples.Length < 2)
+        {
+            throw new ElevationQueryException(
+                ElevationFailureKind.InvalidGeometry,
+                "Line of sight requires at least two profile samples.");
+        }
+
+        var observerGround = samples[0].Elevation ?? 0.0;
+        var targetGround = samples[^1].Elevation ?? 0.0;
+        var observerHeight = observerGround + observer.HeightOffsetMeters;
+        var targetHeight = targetGround + target.HeightOffsetMeters;
+        var totalDistance = profile.LineLengthMeters;
+
+        var (visible, obstructionIndex, hasNoData) = EvaluateSightLine(
+            samples,
+            observerHeight,
+            targetHeight,
+            totalDistance);
+
+        LineOfSightObstruction? obstruction = null;
+        if (!visible && obstructionIndex >= 0)
+        {
+            var sample = samples[obstructionIndex];
+            var fraction = totalDistance > 0 ? sample.DistanceMeters / totalDistance : 0.0;
+            var (lon, lat) = InterpolateGeodesic(
+                observer.Longitude,
+                observer.Latitude,
+                target.Longitude,
+                target.Latitude,
+                fraction);
+
+            obstruction = new LineOfSightObstruction
+            {
+                Longitude = lon,
+                Latitude = lat,
+                Elevation = sample.Elevation ?? observerGround,
+                DistanceMeters = sample.DistanceMeters
+            };
+        }
+
+        return new LineOfSightResult
+        {
+            LayerId = layerId,
+            Visible = visible,
+            Obstruction = obstruction,
+            ObserverGroundElevation = observerGround,
+            ObserverElevation = observerHeight,
+            TargetGroundElevation = targetGround,
+            TargetElevation = targetHeight,
+            DistanceMeters = totalDistance,
+            SampleCount = samples.Length,
+            HasNoDataSamples = hasNoData
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<ViewshedResult> ComputeViewshedAsync(
+        int layerId,
+        VisibilityPoint observer,
+        ViewshedOptions options,
+        RasterMergeStrategy mergeStrategy,
+        CancellationToken cancellationToken = default)
+    {
+        if (!double.IsFinite(options.RadiusMeters) || options.RadiusMeters <= 0)
+        {
+            throw new ElevationQueryException(
+                ElevationFailureKind.InvalidGeometry,
+                "Viewshed radius must be a positive finite distance in meters.");
+        }
+
+        var rayCount = Math.Clamp(options.RayCount ?? DefaultRayCount, MinRayCount, MaxRayCount);
+        var samplesPerRay = Math.Clamp(options.SamplesPerRay ?? DefaultSamplesPerRay, 2, MaxSamplesPerRay);
+
+        // Sample the observer ground elevation once via a degenerate-but-valid
+        // short profile starting at the observer. Reuse the first sample of the
+        // first ray instead of a separate point query so the merge strategy and
+        // no-data handling stay identical across the whole analysis.
+        double? observerGround = null;
+        var observerHeight = 0.0;
+        var observerNoData = true;
+        var samples = new List<ViewshedSample>(rayCount * samplesPerRay);
+        var visibleCount = 0;
+
+        for (var ray = 0; ray < rayCount; ray++)
+        {
+            var azimuth = ray * 360.0 / rayCount;
+            var (endLon, endLat) = DestinationPoint(
+                observer.Longitude,
+                observer.Latitude,
+                azimuth,
+                options.RadiusMeters);
+
+            var profile = await SampleLineAsync(
+                layerId,
+                observer.Longitude,
+                observer.Latitude,
+                endLon,
+                endLat,
+                samplesPerRay + 1,
+                mergeStrategy,
+                cancellationToken).ConfigureAwait(false);
+
+            var raySamples = profile.Samples;
+            if (raySamples.Length == 0)
+            {
+                continue;
+            }
+
+            if (observerGround is null)
+            {
+                observerGround = raySamples[0].Elevation;
+                observerNoData = !raySamples[0].Elevation.HasValue;
+                observerHeight = (observerGround ?? 0.0) + options.ObserverHeightOffsetMeters;
+            }
+
+            // Cumulative max vertical angle along the ray. A sample is visible
+            // when its own vertical angle (from the observer eye to the target,
+            // including the target height offset) meets or exceeds the maximum
+            // vertical angle of all closer terrain along the ray.
+            var maxAngle = double.NegativeInfinity;
+            for (var i = 1; i < raySamples.Length; i++)
+            {
+                var sample = raySamples[i];
+                var distance = sample.DistanceMeters;
+                if (distance <= 0)
+                {
+                    continue;
+                }
+
+                var fraction = profile.LineLengthMeters > 0
+                    ? distance / profile.LineLengthMeters
+                    : 0.0;
+                var (lon, lat) = InterpolateGeodesic(
+                    observer.Longitude,
+                    observer.Latitude,
+                    endLon,
+                    endLat,
+                    fraction);
+
+                bool visible;
+                if (!sample.Elevation.HasValue)
+                {
+                    // No-data terrain does not occlude and is not itself a
+                    // visible surface target.
+                    visible = false;
+                }
+                else
+                {
+                    var terrainAngle = Math.Atan2(sample.Elevation.Value - observerHeight, distance);
+                    var targetAngle = Math.Atan2(
+                        sample.Elevation.Value + options.TargetHeightOffsetMeters - observerHeight,
+                        distance);
+                    visible = targetAngle >= maxAngle;
+                    if (terrainAngle > maxAngle)
+                    {
+                        maxAngle = terrainAngle;
+                    }
+                }
+
+                if (visible)
+                {
+                    visibleCount++;
+                }
+
+                samples.Add(new ViewshedSample
+                {
+                    Longitude = lon,
+                    Latitude = lat,
+                    AzimuthDegrees = azimuth,
+                    DistanceMeters = distance,
+                    Elevation = sample.Elevation,
+                    Visible = visible
+                });
+            }
+        }
+
+        return new ViewshedResult
+        {
+            LayerId = layerId,
+            ObserverGroundElevation = observerGround ?? 0.0,
+            ObserverElevation = observerHeight,
+            RadiusMeters = options.RadiusMeters,
+            RayCount = rayCount,
+            SamplesPerRay = samplesPerRay,
+            Samples = samples.ToArray(),
+            VisibleSampleCount = visibleCount,
+            ObserverNoData = observerNoData
+        };
+    }
+
+    /// <summary>
+    /// Evaluates the sight line against the intermediate terrain samples.
+    /// Returns whether the target is visible, the index of the first
+    /// obstruction (or -1), and whether any intermediate sample was no-data.
+    /// </summary>
+    internal static (bool Visible, int ObstructionIndex, bool HasNoData) EvaluateSightLine(
+        ElevationSample[] samples,
+        double observerHeight,
+        double targetHeight,
+        double totalDistance)
+    {
+        var hasNoData = false;
+
+        // Compare each intermediate terrain sample against the straight sight
+        // line interpolated by distance fraction. The endpoints are the
+        // observer and target themselves and are excluded.
+        for (var i = 1; i < samples.Length - 1; i++)
+        {
+            var sample = samples[i];
+            if (!sample.Elevation.HasValue)
+            {
+                hasNoData = true;
+                continue;
+            }
+
+            var fraction = totalDistance > 0 ? sample.DistanceMeters / totalDistance : 0.0;
+            var sightHeight = observerHeight + (targetHeight - observerHeight) * fraction;
+
+            // Small tolerance so floating-point noise on flat terrain does not
+            // register a phantom obstruction.
+            if (sample.Elevation.Value > sightHeight + ObstructionToleranceMeters)
+            {
+                return (false, i, hasNoData);
+            }
+        }
+
+        return (true, -1, hasNoData);
+    }
+
+    private const double ObstructionToleranceMeters = 1e-6;
+
+    private Task<ElevationProfileResult> SampleLineAsync(
+        int layerId,
+        double startLon,
+        double startLat,
+        double endLon,
+        double endLat,
+        int sampleCount,
+        RasterMergeStrategy mergeStrategy,
+        CancellationToken cancellationToken)
+    {
+        var lineWkb = BuildLineWkb(startLon, startLat, endLon, endLat);
+        var options = new ProfileSamplingOptions
+        {
+            SampleCount = sampleCount,
+            IntervalMeters = null,
+            DefaultSampleCount = sampleCount,
+            MaxSampleCount = Math.Max(sampleCount, 2)
+        };
+
+        return _elevationService.QueryProfileAsync(
+            layerId,
+            lineWkb,
+            Wgs84Srid,
+            options,
+            mergeStrategy,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Builds a 2-point 2D LineString WKB (little-endian) for a geodesic
+    /// profile between two WGS 84 coordinates.
+    /// </summary>
+    internal static byte[] BuildLineWkb(double startLon, double startLat, double endLon, double endLat)
+    {
+        // Byte order (1) + type (4) + numPoints (4) + 2 * (x,y as float8) = 41 bytes.
+        var buffer = new byte[41];
+        buffer[0] = 1; // little-endian
+        buffer[1] = 0x02; // geometry type = 2 (LineString)
+        // numPoints = 2
+        buffer[5] = 0x02;
+        BitConverter.TryWriteBytes(buffer.AsSpan(9, 8), startLon);
+        BitConverter.TryWriteBytes(buffer.AsSpan(17, 8), startLat);
+        BitConverter.TryWriteBytes(buffer.AsSpan(25, 8), endLon);
+        BitConverter.TryWriteBytes(buffer.AsSpan(33, 8), endLat);
+        return buffer;
+    }
+
+    /// <summary>
+    /// Spherical great-circle interpolation between two WGS 84 coordinates.
+    /// Used to report obstruction/sample coordinates; sub-meter divergence from
+    /// the geodesic path used by the profile sampler is negligible at the
+    /// distances this analysis targets.
+    /// </summary>
+    internal static (double Longitude, double Latitude) InterpolateGeodesic(
+        double startLon,
+        double startLat,
+        double endLon,
+        double endLat,
+        double fraction)
+    {
+        fraction = Math.Clamp(fraction, 0.0, 1.0);
+        if (fraction <= 0)
+        {
+            return (startLon, startLat);
+        }
+
+        if (fraction >= 1)
+        {
+            return (endLon, endLat);
+        }
+
+        var phi1 = DegToRad(startLat);
+        var lambda1 = DegToRad(startLon);
+        var phi2 = DegToRad(endLat);
+        var lambda2 = DegToRad(endLon);
+
+        var deltaPhi = phi2 - phi1;
+        var deltaLambda = lambda2 - lambda1;
+        var a = Math.Sin(deltaPhi / 2) * Math.Sin(deltaPhi / 2)
+            + Math.Cos(phi1) * Math.Cos(phi2) * Math.Sin(deltaLambda / 2) * Math.Sin(deltaLambda / 2);
+        var angular = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+        if (angular == 0)
+        {
+            return (startLon, startLat);
+        }
+
+        var sinAngular = Math.Sin(angular);
+        var aFactor = Math.Sin((1 - fraction) * angular) / sinAngular;
+        var bFactor = Math.Sin(fraction * angular) / sinAngular;
+
+        var x = aFactor * Math.Cos(phi1) * Math.Cos(lambda1) + bFactor * Math.Cos(phi2) * Math.Cos(lambda2);
+        var y = aFactor * Math.Cos(phi1) * Math.Sin(lambda1) + bFactor * Math.Cos(phi2) * Math.Sin(lambda2);
+        var z = aFactor * Math.Sin(phi1) + bFactor * Math.Sin(phi2);
+
+        var phi = Math.Atan2(z, Math.Sqrt(x * x + y * y));
+        var lambda = Math.Atan2(y, x);
+        return (RadToDeg(lambda), RadToDeg(phi));
+    }
+
+    /// <summary>
+    /// Computes the destination WGS 84 coordinate reached by travelling
+    /// <paramref name="distanceMeters"/> along <paramref name="azimuthDegrees"/>
+    /// (clockwise from north) from the start, using the spherical
+    /// great-circle direct formula.
+    /// </summary>
+    internal static (double Longitude, double Latitude) DestinationPoint(
+        double startLon,
+        double startLat,
+        double azimuthDegrees,
+        double distanceMeters)
+    {
+        var angular = distanceMeters / SpatialConstants.EarthRadius;
+        var theta = DegToRad(azimuthDegrees);
+        var phi1 = DegToRad(startLat);
+        var lambda1 = DegToRad(startLon);
+
+        var sinPhi2 = Math.Sin(phi1) * Math.Cos(angular)
+            + Math.Cos(phi1) * Math.Sin(angular) * Math.Cos(theta);
+        var phi2 = Math.Asin(Math.Clamp(sinPhi2, -1.0, 1.0));
+        var lambda2 = lambda1 + Math.Atan2(
+            Math.Sin(theta) * Math.Sin(angular) * Math.Cos(phi1),
+            Math.Cos(angular) - Math.Sin(phi1) * sinPhi2);
+
+        var lon = RadToDeg(lambda2);
+        // Normalize longitude to [-180, 180].
+        lon = ((lon + 540.0) % 360.0) - 180.0;
+        return (lon, RadToDeg(phi2));
+    }
+
+    private static double DegToRad(double degrees) => degrees * Math.PI / 180.0;
+
+    private static double RadToDeg(double radians) => radians * 180.0 / Math.PI;
+}

--- a/src/Honua.Core/Features/Raster/VisibilityAnalysisService.cs
+++ b/src/Honua.Core/Features/Raster/VisibilityAnalysisService.cs
@@ -84,8 +84,27 @@ public sealed class VisibilityAnalysisService : IVisibilityAnalysisService
                 "Line of sight requires at least two profile samples.");
         }
 
-        var observerGround = samples[0].Elevation ?? 0.0;
-        var targetGround = samples[^1].Elevation ?? 0.0;
+        // The observer and target ground elevations anchor the whole sight line.
+        // When either endpoint resolves to no-data (a no-data pixel or a point
+        // outside the raster coverage) we cannot fabricate a ground/eye height:
+        // coercing to 0.0 (sea level) silently invents terrain and tends to
+        // report a bogus visible=true. Fail the request the same way the
+        // elevation profile path signals missing terrain so the endpoint maps it
+        // to an unambiguous error rather than a fabricated answer.
+        if (samples[0].Elevation is not { } observerGround)
+        {
+            throw new ElevationQueryException(
+                ElevationFailureKind.SourceUnavailable,
+                "Observer position has no elevation data (no-data pixel or outside raster coverage); line of sight is indeterminate.");
+        }
+
+        if (samples[^1].Elevation is not { } targetGround)
+        {
+            throw new ElevationQueryException(
+                ElevationFailureKind.SourceUnavailable,
+                "Target position has no elevation data (no-data pixel or outside raster coverage); line of sight is indeterminate.");
+        }
+
         var observerHeight = observerGround + observer.HeightOffsetMeters;
         var targetHeight = targetGround + target.HeightOffsetMeters;
         var totalDistance = profile.LineLengthMeters;

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -579,6 +579,9 @@ public static class EndpointRegistry
         // Scene analysis on the elevation surface (#1204).
         new("POST", "/elevation/{datasetId}/sun-shadow"),
         new("POST", "/elevation/{datasetId}/slice"),
+        // 3D visibility analysis on the elevation surface (#1203).
+        new("POST", "/elevation/{datasetId}/line-of-sight"),
+        new("POST", "/elevation/{datasetId}/viewshed"),
 
         new("GET", "/api/styles/{layerId}.json"),
 

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -149,6 +149,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapSceneDatasetEndpoints();
         endpoints.MapElevationEndpoints();
         endpoints.MapSceneAnalysisEndpoints();
+        endpoints.MapVisibilityAnalysisEndpoints();
         endpoints.MapSceneGenerationEndpoints();
         endpoints.MapPMTilesProxyEndpoints();
         endpoints.MapStyleEndpoints();

--- a/src/Honua.Server/Features/Protocols/Elevation/ElevationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Protocols/Elevation/ElevationServiceCollectionExtensions.cs
@@ -19,6 +19,11 @@ internal static class ElevationServiceCollectionExtensions
         // an elevation service is available.
         services.TryAddScoped<ISceneAnalysisService>(sp =>
             new SceneAnalysisService(sp.GetRequiredService<IElevationService>()));
+        // 3D visibility analysis (line-of-sight + viewshed) builds on the
+        // elevation profile sampler and is provider-agnostic, so it is
+        // registered wherever an elevation service is available.
+        services.TryAddScoped<IVisibilityAnalysisService>(sp =>
+            new VisibilityAnalysisService(sp.GetRequiredService<IElevationService>()));
         return services;
     }
 

--- a/src/Honua.Server/Features/Protocols/Elevation/VisibilityAnalysisEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Elevation/VisibilityAnalysisEndpoints.cs
@@ -28,6 +28,12 @@ internal static class VisibilityAnalysisEndpoints
 
     public static IEndpointRouteBuilder MapVisibilityAnalysisEndpoints(this IEndpointRouteBuilder endpoints)
     {
+        // HANDLER-AUTHORIZED (#1144): these POST routes mirror the read-only
+        // elevation API (GET /elevation/{datasetId}/profile). Access is enforced
+        // inside the handler — LicenseGate.RequireEntitlement gates the Pro-tier
+        // entitlement, and ValidateDatasetAsync runs the layer access check
+        // (AccessScope.Read) before any analysis. Marked AllowAnonymous so the
+        // audit architecture guard records the explicit (read-only) decision.
         endpoints.MapPost("/elevation/{datasetId}/line-of-sight", HandleLineOfSight)
             .WithDisplayName("Compute Line of Sight")
             .WithName("ComputeLineOfSight")
@@ -41,8 +47,13 @@ internal static class VisibilityAnalysisEndpoints
             .Produces(StatusCodes.Status402PaymentRequired)
             .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)
-            .Produces(StatusCodes.Status422UnprocessableEntity);
+            .Produces(StatusCodes.Status422UnprocessableEntity)
+            .AllowAnonymous();
 
+        // HANDLER-AUTHORIZED (#1144): see the line-of-sight route above —
+        // LicenseGate.RequireEntitlement + ValidateDatasetAsync (AccessScope.Read)
+        // enforce access inside the handler. Marked AllowAnonymous so the audit
+        // architecture guard records the explicit (read-only) decision.
         endpoints.MapPost("/elevation/{datasetId}/viewshed", HandleViewshed)
             .WithDisplayName("Compute Viewshed")
             .WithName("ComputeViewshed")
@@ -56,7 +67,8 @@ internal static class VisibilityAnalysisEndpoints
             .Produces(StatusCodes.Status402PaymentRequired)
             .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)
-            .Produces(StatusCodes.Status422UnprocessableEntity);
+            .Produces(StatusCodes.Status422UnprocessableEntity)
+            .AllowAnonymous();
 
         return endpoints;
     }

--- a/src/Honua.Server/Features/Protocols/Elevation/VisibilityAnalysisEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Elevation/VisibilityAnalysisEndpoints.cs
@@ -1,0 +1,433 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Security.Domain;
+using Honua.Server.Features.Infrastructure.Licensing;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Raster;
+using Honua.Server.Features.Infrastructure.Validation;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Server.Features.Protocols.Elevation;
+
+/// <summary>
+/// Pro-tier 3D visibility analysis endpoints (line-of-sight and viewshed) that
+/// build on the elevation profile sampler. Registered alongside the elevation
+/// API and gated through <see cref="LicenseGate"/>.
+/// </summary>
+internal static class VisibilityAnalysisEndpoints
+{
+    private const string JsonContentType = "application/json";
+    private const string LineOfSightEntitlement = "analytics.line-of-sight";
+    private const string ViewshedEntitlement = "analytics.viewshed";
+
+    public static IEndpointRouteBuilder MapVisibilityAnalysisEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost("/elevation/{datasetId}/line-of-sight", HandleLineOfSight)
+            .WithDisplayName("Compute Line of Sight")
+            .WithName("ComputeLineOfSight")
+            .WithSummary("Determine terrain visibility between an observer and a target")
+            .WithDescription("Samples the elevation profile between an observer and target and reports whether the target is visible, returning the first terrain obstruction when blocked")
+            .WithTags("Elevation")
+            .Accepts<LineOfSightRequest>(JsonContentType)
+            .Produces<LineOfSightResponse>(StatusCodes.Status200OK, JsonContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status402PaymentRequired)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status422UnprocessableEntity);
+
+        endpoints.MapPost("/elevation/{datasetId}/viewshed", HandleViewshed)
+            .WithDisplayName("Compute Viewshed")
+            .WithName("ComputeViewshed")
+            .WithSummary("Compute the visible area around an observer over the elevation surface")
+            .WithDescription("Casts azimuth rays around an observer and reports which radially-sampled points are visible over the elevation surface within a radius")
+            .WithTags("Elevation")
+            .Accepts<ViewshedRequest>(JsonContentType)
+            .Produces<ViewshedResponse>(StatusCodes.Status200OK, JsonContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status402PaymentRequired)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status422UnprocessableEntity);
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleLineOfSight(
+        string datasetId,
+        HttpContext context,
+        IVisibilityAnalysisService visibilityService,
+        CancellationToken cancellationToken)
+    {
+        var logger = context.RequestServices.GetService<ILoggerFactory>()?
+            .CreateLogger("Honua.Elevation.Visibility");
+
+        var gate = LicenseGate.RequireEntitlement(context, LineOfSightEntitlement, "Line of sight", logger);
+        if (gate is not null)
+        {
+            return gate;
+        }
+
+        LineOfSightRequest? request;
+        try
+        {
+            request = await context.Request.ReadFromJsonAsync(
+                VisibilityJsonContext.Default.LineOfSightRequest,
+                cancellationToken);
+        }
+        catch
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body must be valid JSON.");
+        }
+
+        if (request is null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body is required.");
+        }
+
+        if (!TryResolveCoordinate(request.ObserverLon, request.ObserverLat, out var observerLon, out var observerLat))
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                "Observer 'observerLon' and 'observerLat' are required and must be finite WGS 84 coordinates within longitude [-180, 180] and latitude [-90, 90].");
+        }
+
+        if (!TryResolveCoordinate(request.TargetLon, request.TargetLat, out var targetLon, out var targetLat))
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                "Target 'targetLon' and 'targetLat' are required and must be finite WGS 84 coordinates within longitude [-180, 180] and latitude [-90, 90].");
+        }
+
+        if (!TryResolveHeight(request.ObserverHeight, out var observerHeight)
+            || !TryResolveHeight(request.TargetHeight, out var targetHeight))
+        {
+            return StandardErrorHelpers.CreateUnprocessableEntity(
+                context,
+                "Height offsets must be finite, non-negative values in meters.");
+        }
+
+        if (request.SampleCount is { } sampleCount && sampleCount < 2)
+        {
+            return StandardErrorHelpers.CreateUnprocessableEntity(
+                context,
+                "'sampleCount' must be at least 2 when supplied.");
+        }
+
+        if (observerLon == targetLon && observerLat == targetLat)
+        {
+            return StandardErrorHelpers.CreateUnprocessableEntity(
+                context,
+                "Observer and target must be distinct coordinates.");
+        }
+
+        var validation = await ValidateDatasetAsync(context, datasetId, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return validation.ErrorResult!;
+        }
+
+        var layer = validation.Layer!;
+        var mergeStrategy = RasterMosaicUtilities.ResolveMergeStrategy(layer.Metadata, request.MosaicRule);
+
+        using var activity = HonuaTelemetry.StartActivity("honua.elevation.line_of_sight");
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.Elevation);
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, "elevation.line-of-sight");
+        activity?.SetTag(HonuaTelemetry.Tags.LayerId, layer.Id);
+        activity?.SetTag(HonuaTelemetry.Tags.CollectionId, datasetId);
+
+        try
+        {
+            var result = await visibilityService.ComputeLineOfSightAsync(
+                layer.Id,
+                new VisibilityPoint { Longitude = observerLon, Latitude = observerLat, HeightOffsetMeters = observerHeight },
+                new VisibilityPoint { Longitude = targetLon, Latitude = targetLat, HeightOffsetMeters = targetHeight },
+                request.SampleCount,
+                mergeStrategy,
+                cancellationToken);
+
+            activity?.SetTag("honua.elevation.visible", result.Visible);
+            activity?.SetTag("honua.elevation.distance_m", result.DistanceMeters);
+
+            var response = BuildLineOfSightResponse(datasetId, result, mergeStrategy);
+            return Results.Json(response, VisibilityJsonContext.Default.LineOfSightResponse, contentType: JsonContentType);
+        }
+        catch (ElevationQueryException ex)
+        {
+            HonuaTelemetry.RecordException(activity, ex);
+            return MapElevationException(context, ex);
+        }
+    }
+
+    private static async Task<IResult> HandleViewshed(
+        string datasetId,
+        HttpContext context,
+        IVisibilityAnalysisService visibilityService,
+        CancellationToken cancellationToken)
+    {
+        var logger = context.RequestServices.GetService<ILoggerFactory>()?
+            .CreateLogger("Honua.Elevation.Visibility");
+
+        var gate = LicenseGate.RequireEntitlement(context, ViewshedEntitlement, "Viewshed", logger);
+        if (gate is not null)
+        {
+            return gate;
+        }
+
+        ViewshedRequest? request;
+        try
+        {
+            request = await context.Request.ReadFromJsonAsync(
+                VisibilityJsonContext.Default.ViewshedRequest,
+                cancellationToken);
+        }
+        catch
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body must be valid JSON.");
+        }
+
+        if (request is null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body is required.");
+        }
+
+        if (!TryResolveCoordinate(request.ObserverLon, request.ObserverLat, out var observerLon, out var observerLat))
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                "Observer 'observerLon' and 'observerLat' are required and must be finite WGS 84 coordinates within longitude [-180, 180] and latitude [-90, 90].");
+        }
+
+        if (request.RadiusMeters is not { } radius || !double.IsFinite(radius) || radius <= 0)
+        {
+            return StandardErrorHelpers.CreateUnprocessableEntity(
+                context,
+                "'radiusMeters' is required and must be a positive finite distance in meters.");
+        }
+
+        if (!TryResolveHeight(request.ObserverHeight, out var observerHeight)
+            || !TryResolveHeight(request.TargetHeight, out var targetHeight))
+        {
+            return StandardErrorHelpers.CreateUnprocessableEntity(
+                context,
+                "Height offsets must be finite, non-negative values in meters.");
+        }
+
+        if (request.RayCount is { } rayCount && rayCount < 1)
+        {
+            return StandardErrorHelpers.CreateUnprocessableEntity(
+                context,
+                "'rayCount' must be at least 1 when supplied.");
+        }
+
+        if (request.SamplesPerRay is { } samplesPerRay && samplesPerRay < 2)
+        {
+            return StandardErrorHelpers.CreateUnprocessableEntity(
+                context,
+                "'samplesPerRay' must be at least 2 when supplied.");
+        }
+
+        var validation = await ValidateDatasetAsync(context, datasetId, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return validation.ErrorResult!;
+        }
+
+        var layer = validation.Layer!;
+        var mergeStrategy = RasterMosaicUtilities.ResolveMergeStrategy(layer.Metadata, request.MosaicRule);
+
+        using var activity = HonuaTelemetry.StartActivity("honua.elevation.viewshed");
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.Elevation);
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, "elevation.viewshed");
+        activity?.SetTag(HonuaTelemetry.Tags.LayerId, layer.Id);
+        activity?.SetTag(HonuaTelemetry.Tags.CollectionId, datasetId);
+
+        try
+        {
+            var options = new ViewshedOptions
+            {
+                RadiusMeters = radius,
+                RayCount = request.RayCount,
+                SamplesPerRay = request.SamplesPerRay,
+                ObserverHeightOffsetMeters = observerHeight,
+                TargetHeightOffsetMeters = targetHeight
+            };
+
+            var result = await visibilityService.ComputeViewshedAsync(
+                layer.Id,
+                new VisibilityPoint { Longitude = observerLon, Latitude = observerLat, HeightOffsetMeters = observerHeight },
+                options,
+                mergeStrategy,
+                cancellationToken);
+
+            activity?.SetTag("honua.elevation.ray_count", result.RayCount);
+            activity?.SetTag("honua.elevation.visible_samples", result.VisibleSampleCount);
+
+            var response = BuildViewshedResponse(datasetId, result, mergeStrategy);
+            return Results.Json(response, VisibilityJsonContext.Default.ViewshedResponse, contentType: JsonContentType);
+        }
+        catch (ElevationQueryException ex)
+        {
+            HonuaTelemetry.RecordException(activity, ex);
+            return MapElevationException(context, ex);
+        }
+    }
+
+    private static bool TryResolveCoordinate(double? lon, double? lat, out double resolvedLon, out double resolvedLat)
+    {
+        resolvedLon = 0;
+        resolvedLat = 0;
+        if (lon is not { } x || lat is not { } y)
+        {
+            return false;
+        }
+
+        if (!double.IsFinite(x) || !double.IsFinite(y))
+        {
+            return false;
+        }
+
+        if (x < -180 || x > 180 || y < -90 || y > 90)
+        {
+            return false;
+        }
+
+        resolvedLon = x;
+        resolvedLat = y;
+        return true;
+    }
+
+    private static bool TryResolveHeight(double? height, out double resolvedHeight)
+    {
+        resolvedHeight = 0;
+        if (height is not { } value)
+        {
+            return true;
+        }
+
+        if (!double.IsFinite(value) || value < 0)
+        {
+            return false;
+        }
+
+        resolvedHeight = value;
+        return true;
+    }
+
+    private static Task<LayerValidationHelpers.LayerValidationResult> ValidateDatasetAsync(
+        HttpContext context,
+        string datasetId,
+        CancellationToken cancellationToken)
+    {
+        if (int.TryParse(datasetId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId))
+        {
+            return LayerValidationHelpers.ValidateLayerWithAccessAsync(
+                context,
+                layerId,
+                AccessScope.Read,
+                ServiceProtocols.Elevation,
+                cancellationToken);
+        }
+
+        return LayerValidationHelpers.ValidateCollectionWithAccessAsync(
+            context,
+            datasetId,
+            AccessScope.Read,
+            ServiceProtocols.Elevation,
+            cancellationToken);
+    }
+
+    private static IResult MapElevationException(HttpContext context, ElevationQueryException exception)
+        => exception.FailureKind switch
+        {
+            ElevationFailureKind.SourceUnavailable => StandardErrorHelpers.CreateNotFound(context, exception.Message),
+            ElevationFailureKind.UnsupportedCrs => StandardErrorHelpers.CreateUnprocessableEntity(context, exception.Message),
+            ElevationFailureKind.InvalidGeometry => StandardErrorHelpers.CreateUnprocessableEntity(context, exception.Message),
+            _ => StandardErrorHelpers.CreateBadRequest(context, exception.Message)
+        };
+
+    private static LineOfSightResponse BuildLineOfSightResponse(
+        string datasetId,
+        LineOfSightResult result,
+        RasterMergeStrategy mergeStrategy)
+    {
+        return new LineOfSightResponse
+        {
+            DatasetId = datasetId,
+            LayerId = result.LayerId,
+            Visible = result.Visible,
+            DistanceMeters = result.DistanceMeters,
+            ObserverGroundElevation = result.ObserverGroundElevation,
+            ObserverElevation = result.ObserverElevation,
+            TargetGroundElevation = result.TargetGroundElevation,
+            TargetElevation = result.TargetElevation,
+            SampleCount = result.SampleCount,
+            HasNoDataSamples = result.HasNoDataSamples,
+            MosaicRule = FormatMergeStrategy(mergeStrategy),
+            Obstruction = result.Obstruction is { } obstruction
+                ? new LineOfSightObstructionDto
+                {
+                    Lon = obstruction.Longitude,
+                    Lat = obstruction.Latitude,
+                    Elevation = obstruction.Elevation,
+                    DistanceMeters = obstruction.DistanceMeters
+                }
+                : null
+        };
+    }
+
+    private static ViewshedResponse BuildViewshedResponse(
+        string datasetId,
+        ViewshedResult result,
+        RasterMergeStrategy mergeStrategy)
+    {
+        var samples = new ViewshedSampleDto[result.Samples.Length];
+        for (var i = 0; i < result.Samples.Length; i++)
+        {
+            var sample = result.Samples[i];
+            samples[i] = new ViewshedSampleDto
+            {
+                Lon = sample.Longitude,
+                Lat = sample.Latitude,
+                AzimuthDegrees = sample.AzimuthDegrees,
+                DistanceMeters = sample.DistanceMeters,
+                Elevation = sample.Elevation,
+                Visible = sample.Visible
+            };
+        }
+
+        return new ViewshedResponse
+        {
+            DatasetId = datasetId,
+            LayerId = result.LayerId,
+            ObserverGroundElevation = result.ObserverGroundElevation,
+            ObserverElevation = result.ObserverElevation,
+            ObserverNoData = result.ObserverNoData,
+            RadiusMeters = result.RadiusMeters,
+            RayCount = result.RayCount,
+            SamplesPerRay = result.SamplesPerRay,
+            SampleCount = result.Samples.Length,
+            VisibleSampleCount = result.VisibleSampleCount,
+            MosaicRule = FormatMergeStrategy(mergeStrategy),
+            Samples = samples
+        };
+    }
+
+    private static string FormatMergeStrategy(RasterMergeStrategy strategy) => strategy switch
+    {
+        RasterMergeStrategy.Newest => "newest",
+        RasterMergeStrategy.Oldest => "oldest",
+        RasterMergeStrategy.Average => "average",
+        RasterMergeStrategy.Max => "max",
+        RasterMergeStrategy.Min => "min",
+        _ => "newest"
+    };
+}

--- a/src/Honua.Server/Features/Protocols/Elevation/VisibilityJsonContext.cs
+++ b/src/Honua.Server/Features/Protocols/Elevation/VisibilityJsonContext.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Protocols.Elevation;
+
+[JsonSerializable(typeof(LineOfSightRequest))]
+[JsonSerializable(typeof(LineOfSightResponse))]
+[JsonSerializable(typeof(LineOfSightObstructionDto))]
+[JsonSerializable(typeof(ViewshedRequest))]
+[JsonSerializable(typeof(ViewshedResponse))]
+[JsonSerializable(typeof(ViewshedSampleDto))]
+[JsonSerializable(typeof(ViewshedSampleDto[]))]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.Never)]
+internal sealed partial class VisibilityJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Protocols/Elevation/VisibilityModels.cs
+++ b/src/Honua.Server/Features/Protocols/Elevation/VisibilityModels.cs
@@ -1,0 +1,208 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Protocols.Elevation;
+
+/// <summary>
+/// Request body for a line-of-sight analysis between an observer and a target.
+/// </summary>
+internal sealed record LineOfSightRequest
+{
+    /// <summary>Observer longitude in WGS 84 decimal degrees.</summary>
+    [JsonPropertyName("observerLon")]
+    public double? ObserverLon { get; init; }
+
+    /// <summary>Observer latitude in WGS 84 decimal degrees.</summary>
+    [JsonPropertyName("observerLat")]
+    public double? ObserverLat { get; init; }
+
+    /// <summary>Observer height offset above the terrain surface, in meters.</summary>
+    [JsonPropertyName("observerHeight")]
+    public double? ObserverHeight { get; init; }
+
+    /// <summary>Target longitude in WGS 84 decimal degrees.</summary>
+    [JsonPropertyName("targetLon")]
+    public double? TargetLon { get; init; }
+
+    /// <summary>Target latitude in WGS 84 decimal degrees.</summary>
+    [JsonPropertyName("targetLat")]
+    public double? TargetLat { get; init; }
+
+    /// <summary>Target height offset above the terrain surface, in meters.</summary>
+    [JsonPropertyName("targetHeight")]
+    public double? TargetHeight { get; init; }
+
+    /// <summary>Requested number of profile samples along the sight line.</summary>
+    [JsonPropertyName("sampleCount")]
+    public int? SampleCount { get; init; }
+
+    /// <summary>Optional mosaic rule override.</summary>
+    [JsonPropertyName("mosaicRule")]
+    public string? MosaicRule { get; init; }
+}
+
+/// <summary>
+/// Response for a line-of-sight analysis.
+/// </summary>
+internal sealed record LineOfSightResponse
+{
+    [JsonPropertyName("datasetId")]
+    public required string DatasetId { get; init; }
+
+    [JsonPropertyName("layerId")]
+    public required int LayerId { get; init; }
+
+    [JsonPropertyName("visible")]
+    public required bool Visible { get; init; }
+
+    [JsonPropertyName("distanceMeters")]
+    public required double DistanceMeters { get; init; }
+
+    [JsonPropertyName("observerGroundElevation")]
+    public required double ObserverGroundElevation { get; init; }
+
+    [JsonPropertyName("observerElevation")]
+    public required double ObserverElevation { get; init; }
+
+    [JsonPropertyName("targetGroundElevation")]
+    public required double TargetGroundElevation { get; init; }
+
+    [JsonPropertyName("targetElevation")]
+    public required double TargetElevation { get; init; }
+
+    [JsonPropertyName("sampleCount")]
+    public required int SampleCount { get; init; }
+
+    [JsonPropertyName("hasNoDataSamples")]
+    public required bool HasNoDataSamples { get; init; }
+
+    [JsonPropertyName("mosaicRule")]
+    public required string MosaicRule { get; init; }
+
+    [JsonPropertyName("obstruction")]
+    public LineOfSightObstructionDto? Obstruction { get; init; }
+}
+
+/// <summary>
+/// First terrain obstruction along a sight line.
+/// </summary>
+internal sealed record LineOfSightObstructionDto
+{
+    [JsonPropertyName("lon")]
+    public required double Lon { get; init; }
+
+    [JsonPropertyName("lat")]
+    public required double Lat { get; init; }
+
+    [JsonPropertyName("elevation")]
+    public required double Elevation { get; init; }
+
+    [JsonPropertyName("distanceMeters")]
+    public required double DistanceMeters { get; init; }
+}
+
+/// <summary>
+/// Request body for a viewshed analysis around an observer.
+/// </summary>
+internal sealed record ViewshedRequest
+{
+    /// <summary>Observer longitude in WGS 84 decimal degrees.</summary>
+    [JsonPropertyName("observerLon")]
+    public double? ObserverLon { get; init; }
+
+    /// <summary>Observer latitude in WGS 84 decimal degrees.</summary>
+    [JsonPropertyName("observerLat")]
+    public double? ObserverLat { get; init; }
+
+    /// <summary>Observer height offset above the terrain surface, in meters.</summary>
+    [JsonPropertyName("observerHeight")]
+    public double? ObserverHeight { get; init; }
+
+    /// <summary>Height offset applied to each sampled target point, in meters.</summary>
+    [JsonPropertyName("targetHeight")]
+    public double? TargetHeight { get; init; }
+
+    /// <summary>Analysis radius in meters.</summary>
+    [JsonPropertyName("radiusMeters")]
+    public double? RadiusMeters { get; init; }
+
+    /// <summary>Number of azimuth rays cast around the observer.</summary>
+    [JsonPropertyName("rayCount")]
+    public int? RayCount { get; init; }
+
+    /// <summary>Number of range samples per ray.</summary>
+    [JsonPropertyName("samplesPerRay")]
+    public int? SamplesPerRay { get; init; }
+
+    /// <summary>Optional mosaic rule override.</summary>
+    [JsonPropertyName("mosaicRule")]
+    public string? MosaicRule { get; init; }
+}
+
+/// <summary>
+/// Response for a viewshed analysis.
+/// </summary>
+internal sealed record ViewshedResponse
+{
+    [JsonPropertyName("datasetId")]
+    public required string DatasetId { get; init; }
+
+    [JsonPropertyName("layerId")]
+    public required int LayerId { get; init; }
+
+    [JsonPropertyName("observerGroundElevation")]
+    public required double ObserverGroundElevation { get; init; }
+
+    [JsonPropertyName("observerElevation")]
+    public required double ObserverElevation { get; init; }
+
+    [JsonPropertyName("observerNoData")]
+    public required bool ObserverNoData { get; init; }
+
+    [JsonPropertyName("radiusMeters")]
+    public required double RadiusMeters { get; init; }
+
+    [JsonPropertyName("rayCount")]
+    public required int RayCount { get; init; }
+
+    [JsonPropertyName("samplesPerRay")]
+    public required int SamplesPerRay { get; init; }
+
+    [JsonPropertyName("sampleCount")]
+    public required int SampleCount { get; init; }
+
+    [JsonPropertyName("visibleSampleCount")]
+    public required int VisibleSampleCount { get; init; }
+
+    [JsonPropertyName("mosaicRule")]
+    public required string MosaicRule { get; init; }
+
+    [JsonPropertyName("samples")]
+    public required ViewshedSampleDto[] Samples { get; init; }
+}
+
+/// <summary>
+/// A single radial viewshed sample.
+/// </summary>
+internal sealed record ViewshedSampleDto
+{
+    [JsonPropertyName("lon")]
+    public required double Lon { get; init; }
+
+    [JsonPropertyName("lat")]
+    public required double Lat { get; init; }
+
+    [JsonPropertyName("azimuthDegrees")]
+    public required double AzimuthDegrees { get; init; }
+
+    [JsonPropertyName("distanceMeters")]
+    public required double DistanceMeters { get; init; }
+
+    [JsonPropertyName("elevation")]
+    public double? Elevation { get; init; }
+
+    [JsonPropertyName("visible")]
+    public required bool Visible { get; init; }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -609,6 +609,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Protocols.Zarr.ZarrJsonContext.Default,
         Honua.Server.Features.Protocols.SpatialAnalytics.Models.SpatialAnalyticsJsonContext.Default,
         Honua.Server.Features.Protocols.Elevation.SceneAnalysisJsonContext.Default,
+        Honua.Server.Features.Protocols.Elevation.VisibilityJsonContext.Default,
         Honua.Server.Features.Collaboration.Sessions.CollaborationSessionJsonContext.Default,
         Honua.Server.Features.Collaboration.FeatureLocks.FeatureLockJsonContext.Default,
         Honua.Core.Features.Authorization.Domain.OperatorAuthorizationJsonContext.Default,

--- a/tests/dotnet/Honua.Core.Tests/Features/Raster/VisibilityAnalysisServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Raster/VisibilityAnalysisServiceTests.cs
@@ -1,0 +1,367 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Raster;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Raster;
+
+/// <summary>
+/// Unit tests for the line-of-sight / viewshed analysis math. The DEM is
+/// modeled by a synthetic <see cref="IElevationService"/> stub so the analysis
+/// can be exercised deterministically without a live database. The stub
+/// decodes the 2-point LineString WKB the analysis service builds and samples a
+/// terrain function along it, exactly the contract the real
+/// <c>PostgresElevationService</c> fulfills via <c>ST_LineInterpolatePoint</c>.
+/// </summary>
+public sealed class VisibilityAnalysisServiceTests
+{
+    private const int LayerId = 7;
+
+    [UnitTest]
+    public void EvaluateSightLine_FlatTerrainBelowSightLine_IsVisible()
+    {
+        // Observer at 100 m, target at 100 m, flat ground at 10 m the whole way.
+        var samples = BuildSamples([10, 10, 10, 10, 10], totalDistance: 1000);
+
+        var (visible, index, hasNoData) =
+            VisibilityAnalysisService.EvaluateSightLine(samples, observerHeight: 110, targetHeight: 110, totalDistance: 1000);
+
+        visible.Should().BeTrue();
+        index.Should().Be(-1);
+        hasNoData.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void EvaluateSightLine_RidgeAboveSightLine_IsObstructed()
+    {
+        // Sight line runs from 50 m down to 50 m; a 200 m ridge in the middle blocks it.
+        var samples = BuildSamples([0, 5, 200, 5, 0], totalDistance: 1000);
+
+        var (visible, index, _) =
+            VisibilityAnalysisService.EvaluateSightLine(samples, observerHeight: 50, targetHeight: 50, totalDistance: 1000);
+
+        visible.Should().BeFalse();
+        // The 200 m sample is at index 2.
+        index.Should().Be(2);
+    }
+
+    [UnitTest]
+    public void EvaluateSightLine_HighEnoughObserver_ClearsTheRidge()
+    {
+        // Same 200 m ridge, but observer/target are raised above it so the
+        // straight sight line passes over the obstruction.
+        var samples = BuildSamples([0, 5, 200, 5, 0], totalDistance: 1000);
+
+        var (visible, index, _) =
+            VisibilityAnalysisService.EvaluateSightLine(samples, observerHeight: 300, targetHeight: 300, totalDistance: 1000);
+
+        visible.Should().BeTrue();
+        index.Should().Be(-1);
+    }
+
+    [UnitTest]
+    public void EvaluateSightLine_NoDataSamples_AreSkippedAndFlagged()
+    {
+        var samples = new ElevationSample[]
+        {
+            new() { DistanceMeters = 0, Elevation = 10, NoData = false },
+            new() { DistanceMeters = 500, Elevation = null, NoData = true },
+            new() { DistanceMeters = 1000, Elevation = 10, NoData = false }
+        };
+
+        var (visible, index, hasNoData) =
+            VisibilityAnalysisService.EvaluateSightLine(samples, observerHeight: 110, targetHeight: 110, totalDistance: 1000);
+
+        visible.Should().BeTrue();
+        index.Should().Be(-1);
+        hasNoData.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public async Task ComputeLineOfSightAsync_ClearGround_ReportsVisible()
+    {
+        var service = new VisibilityAnalysisService(new FlatTerrainElevationService(elevation: 100));
+
+        var result = await service.ComputeLineOfSightAsync(
+            LayerId,
+            new VisibilityPoint { Longitude = 0, Latitude = 0, HeightOffsetMeters = 2 },
+            new VisibilityPoint { Longitude = 0.1, Latitude = 0, HeightOffsetMeters = 2 },
+            sampleCount: 32,
+            RasterMergeStrategy.Newest);
+
+        result.Visible.Should().BeTrue();
+        result.Obstruction.Should().BeNull();
+        result.ObserverGroundElevation.Should().Be(100);
+        result.ObserverElevation.Should().Be(102);
+        result.DistanceMeters.Should().BeGreaterThan(0);
+    }
+
+    [UnitTest]
+    public async Task ComputeLineOfSightAsync_RidgeBetween_ReportsObstruction()
+    {
+        // Terrain spikes to 5000 m in the middle of the path; low observer/target
+        // cannot see over it.
+        var service = new VisibilityAnalysisService(new RidgeTerrainElevationService(
+            baseElevation: 100,
+            ridgeElevation: 5000));
+
+        var result = await service.ComputeLineOfSightAsync(
+            LayerId,
+            new VisibilityPoint { Longitude = 0, Latitude = 0, HeightOffsetMeters = 2 },
+            new VisibilityPoint { Longitude = 0.2, Latitude = 0, HeightOffsetMeters = 2 },
+            sampleCount: 64,
+            RasterMergeStrategy.Newest);
+
+        result.Visible.Should().BeFalse();
+        result.Obstruction.Should().NotBeNull();
+        result.Obstruction!.Elevation.Should().BeGreaterThan(result.ObserverElevation);
+        result.Obstruction.DistanceMeters.Should().BeGreaterThan(0);
+        result.Obstruction.DistanceMeters.Should().BeLessThan(result.DistanceMeters);
+        // Obstruction longitude should land between observer and target.
+        result.Obstruction.Longitude.Should().BeInRange(0, 0.2);
+    }
+
+    [UnitTest]
+    public async Task ComputeLineOfSightAsync_RaisingObserver_ClearsTheRidge()
+    {
+        var service = new VisibilityAnalysisService(new RidgeTerrainElevationService(
+            baseElevation: 100,
+            ridgeElevation: 5000));
+
+        var blocked = await service.ComputeLineOfSightAsync(
+            LayerId,
+            new VisibilityPoint { Longitude = 0, Latitude = 0, HeightOffsetMeters = 2 },
+            new VisibilityPoint { Longitude = 0.2, Latitude = 0, HeightOffsetMeters = 2 },
+            sampleCount: 64,
+            RasterMergeStrategy.Newest);
+        blocked.Visible.Should().BeFalse();
+
+        // Raise both observer and target far above the ridge: now visible.
+        var cleared = await service.ComputeLineOfSightAsync(
+            LayerId,
+            new VisibilityPoint { Longitude = 0, Latitude = 0, HeightOffsetMeters = 10_000 },
+            new VisibilityPoint { Longitude = 0.2, Latitude = 0, HeightOffsetMeters = 10_000 },
+            sampleCount: 64,
+            RasterMergeStrategy.Newest);
+
+        cleared.Visible.Should().BeTrue();
+        cleared.Obstruction.Should().BeNull();
+        cleared.ObserverElevation.Should().Be(10_100);
+    }
+
+    [UnitTest]
+    public async Task ComputeViewshedAsync_FlatTerrainElevatedObserver_SeesEverything()
+    {
+        var service = new VisibilityAnalysisService(new FlatTerrainElevationService(elevation: 50));
+
+        var result = await service.ComputeViewshedAsync(
+            LayerId,
+            new VisibilityPoint { Longitude = 0, Latitude = 0 },
+            new ViewshedOptions
+            {
+                RadiusMeters = 5000,
+                RayCount = 16,
+                SamplesPerRay = 16,
+                ObserverHeightOffsetMeters = 100
+            },
+            RasterMergeStrategy.Newest);
+
+        result.Samples.Should().NotBeEmpty();
+        result.RayCount.Should().Be(16);
+        result.SamplesPerRay.Should().Be(16);
+        result.ObserverNoData.Should().BeFalse();
+        // On flat terrain with an elevated observer every sampled point is visible.
+        result.VisibleSampleCount.Should().Be(result.Samples.Length);
+        // Each sample lies within (approximately) the requested radius.
+        foreach (var sample in result.Samples)
+        {
+            sample.DistanceMeters.Should().BeLessThanOrEqualTo(5000 + 1);
+            sample.Visible.Should().BeTrue();
+        }
+    }
+
+    [UnitTest]
+    public async Task ComputeViewshedAsync_CraterRim_OccludesFartherTerrain()
+    {
+        // A tall rim at mid-radius should hide the lower terrain beyond it for a
+        // ground-level observer, so not every sample is visible.
+        var service = new VisibilityAnalysisService(new ConcentricRimElevationService(
+            baseElevation: 10,
+            rimElevation: 3000,
+            rimStartMeters: 1500,
+            rimEndMeters: 2000));
+
+        var result = await service.ComputeViewshedAsync(
+            LayerId,
+            new VisibilityPoint { Longitude = 0, Latitude = 0 },
+            new ViewshedOptions
+            {
+                RadiusMeters = 5000,
+                RayCount = 24,
+                SamplesPerRay = 40,
+                ObserverHeightOffsetMeters = 2
+            },
+            RasterMergeStrategy.Newest);
+
+        result.Samples.Should().NotBeEmpty();
+        result.VisibleSampleCount.Should().BeGreaterThan(0);
+        result.VisibleSampleCount.Should().BeLessThan(result.Samples.Length,
+            "terrain beyond a tall rim must be occluded for a ground-level observer");
+
+        // Samples just inside the rim are visible; the lowest terrain well
+        // beyond the rim should contain occluded samples.
+        var beyondRim = result.Samples.Where(s => s.DistanceMeters > 2500).ToArray();
+        beyondRim.Should().Contain(s => !s.Visible);
+    }
+
+    [UnitTest]
+    public void DestinationPoint_DueEast_IncreasesLongitude()
+    {
+        var (lon, lat) = VisibilityAnalysisService.DestinationPoint(0, 0, azimuthDegrees: 90, distanceMeters: 111_320);
+
+        lon.Should().BeApproximately(1.0, 0.02);
+        lat.Should().BeApproximately(0.0, 0.001);
+    }
+
+    [UnitTest]
+    public void DestinationPoint_DueNorth_IncreasesLatitude()
+    {
+        var (lon, lat) = VisibilityAnalysisService.DestinationPoint(0, 0, azimuthDegrees: 0, distanceMeters: 111_320);
+
+        lat.Should().BeApproximately(1.0, 0.02);
+        lon.Should().BeApproximately(0.0, 0.001);
+    }
+
+    private static ElevationSample[] BuildSamples(double[] elevations, double totalDistance)
+    {
+        var samples = new ElevationSample[elevations.Length];
+        var step = totalDistance / (elevations.Length - 1);
+        for (var i = 0; i < elevations.Length; i++)
+        {
+            samples[i] = new ElevationSample
+            {
+                DistanceMeters = i * step,
+                Elevation = elevations[i],
+                NoData = false
+            };
+        }
+
+        return samples;
+    }
+
+    /// <summary>
+    /// Base test elevation service. Decodes the 2-point LineString WKB built by
+    /// the analysis service and produces a profile by sampling a terrain
+    /// function along the geodesic line.
+    /// </summary>
+    private abstract class TerrainElevationServiceBase : IElevationService
+    {
+        public Task<ElevationPointResult> QueryPointAsync(
+            int layerId, double x, double y, int? srid, RasterMergeStrategy mergeStrategy, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Point queries are not used by the visibility analysis.");
+
+        public Task<ElevationProfileResult> QueryProfileAsync(
+            int layerId,
+            byte[] lineWkb,
+            int lineSrid,
+            ProfileSamplingOptions options,
+            RasterMergeStrategy mergeStrategy,
+            CancellationToken cancellationToken = default)
+        {
+            var (startLon, startLat, endLon, endLat) = DecodeLine(lineWkb);
+            var lengthMeters = HaversineMeters(startLon, startLat, endLon, endLat);
+
+            var sampleCount = options.SampleCount ?? options.DefaultSampleCount;
+            sampleCount = Math.Max(2, sampleCount);
+
+            var samples = new ElevationSample[sampleCount];
+            for (var i = 0; i < sampleCount; i++)
+            {
+                var fraction = (double)i / (sampleCount - 1);
+                var lon = startLon + (endLon - startLon) * fraction;
+                var lat = startLat + (endLat - startLat) * fraction;
+                var distance = fraction * lengthMeters;
+                var elevation = ElevationAt(lon, lat, distance);
+                samples[i] = new ElevationSample
+                {
+                    DistanceMeters = distance,
+                    Elevation = elevation,
+                    NoData = !elevation.HasValue
+                };
+            }
+
+            var result = new ElevationProfileResult
+            {
+                Samples = samples,
+                LineLengthMeters = lengthMeters,
+                SampleCount = sampleCount,
+                LayerId = layerId,
+                RasterIds = [1],
+                SourceSrid = 4326,
+                PixelType = "32BF",
+                NoDataValue = null,
+                VerticalUnit = null,
+                VerticalDatum = null,
+                IsAllNoData = samples.All(s => s.NoData)
+            };
+
+            return Task.FromResult(result);
+        }
+
+        protected abstract double? ElevationAt(double lon, double lat, double distanceFromStartMeters);
+
+        private static (double StartLon, double StartLat, double EndLon, double EndLat) DecodeLine(byte[] wkb)
+        {
+            // Little-endian LineString: byteOrder(1) + type(4) + numPoints(4) then points.
+            var startLon = BitConverter.ToDouble(wkb, 9);
+            var startLat = BitConverter.ToDouble(wkb, 17);
+            var endLon = BitConverter.ToDouble(wkb, 25);
+            var endLat = BitConverter.ToDouble(wkb, 33);
+            return (startLon, startLat, endLon, endLat);
+        }
+
+        private static double HaversineMeters(double lon1, double lat1, double lon2, double lat2)
+        {
+            const double r = 6378137.0;
+            var phi1 = lat1 * Math.PI / 180.0;
+            var phi2 = lat2 * Math.PI / 180.0;
+            var dPhi = (lat2 - lat1) * Math.PI / 180.0;
+            var dLambda = (lon2 - lon1) * Math.PI / 180.0;
+            var a = Math.Sin(dPhi / 2) * Math.Sin(dPhi / 2)
+                + Math.Cos(phi1) * Math.Cos(phi2) * Math.Sin(dLambda / 2) * Math.Sin(dLambda / 2);
+            return r * 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+        }
+    }
+
+    private sealed class FlatTerrainElevationService(double elevation) : TerrainElevationServiceBase
+    {
+        protected override double? ElevationAt(double lon, double lat, double distanceFromStartMeters) => elevation;
+    }
+
+    private sealed class RidgeTerrainElevationService(double baseElevation, double ridgeElevation)
+        : TerrainElevationServiceBase
+    {
+        protected override double? ElevationAt(double lon, double lat, double distanceFromStartMeters)
+        {
+            // Ridge centered on longitude 0.1 (midpoint of the 0 -> 0.2 paths).
+            var distFromRidge = Math.Abs(lon - 0.1);
+            return distFromRidge < 0.01 ? ridgeElevation : baseElevation;
+        }
+    }
+
+    private sealed class ConcentricRimElevationService(
+        double baseElevation,
+        double rimElevation,
+        double rimStartMeters,
+        double rimEndMeters) : TerrainElevationServiceBase
+    {
+        protected override double? ElevationAt(double lon, double lat, double distanceFromStartMeters)
+            => distanceFromStartMeters >= rimStartMeters && distanceFromStartMeters <= rimEndMeters
+                ? rimElevation
+                : baseElevation;
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Raster/VisibilityAnalysisServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Raster/VisibilityAnalysisServiceTests.cs
@@ -219,6 +219,88 @@ public sealed class VisibilityAnalysisServiceTests
     }
 
     [UnitTest]
+    public async Task ComputeLineOfSightAsync_ObserverOnNoData_FailsAndDoesNotReportVisible()
+    {
+        // The observer endpoint resolves to no-data (outside coverage / no-data
+        // pixel). The service must fail rather than fabricate a 0.0 ground/eye
+        // height and report a bogus visible=true.
+        var service = new VisibilityAnalysisService(
+            new EndpointNoDataElevationService(observerNoData: true, targetNoData: false, baseElevation: 100));
+
+        var act = async () => await service.ComputeLineOfSightAsync(
+            LayerId,
+            new VisibilityPoint { Longitude = 0, Latitude = 0, HeightOffsetMeters = 2 },
+            new VisibilityPoint { Longitude = 0.1, Latitude = 0, HeightOffsetMeters = 2 },
+            sampleCount: 32,
+            RasterMergeStrategy.Newest);
+
+        var exception = await act.Should().ThrowAsync<ElevationQueryException>();
+        exception.Which.FailureKind.Should().Be(ElevationFailureKind.SourceUnavailable);
+        exception.Which.Message.Should().Contain("Observer");
+    }
+
+    [UnitTest]
+    public async Task ComputeLineOfSightAsync_TargetOnNoData_FailsAndDoesNotReportVisible()
+    {
+        var service = new VisibilityAnalysisService(
+            new EndpointNoDataElevationService(observerNoData: false, targetNoData: true, baseElevation: 100));
+
+        var act = async () => await service.ComputeLineOfSightAsync(
+            LayerId,
+            new VisibilityPoint { Longitude = 0, Latitude = 0, HeightOffsetMeters = 2 },
+            new VisibilityPoint { Longitude = 0.1, Latitude = 0, HeightOffsetMeters = 2 },
+            sampleCount: 32,
+            RasterMergeStrategy.Newest);
+
+        var exception = await act.Should().ThrowAsync<ElevationQueryException>();
+        exception.Which.FailureKind.Should().Be(ElevationFailureKind.SourceUnavailable);
+        exception.Which.Message.Should().Contain("Target");
+    }
+
+    [UnitTest]
+    public async Task ComputeLineOfSightAsync_SampleCountTwoBothNoData_Fails()
+    {
+        // Regression: with sampleCount==2 there are no intermediate samples, so
+        // HasNoDataSamples (which only inspects interior samples) stays false.
+        // The previous code coerced both endpoints to 0.0 and reported
+        // visible=true. The service must now fail on the no-data endpoints.
+        var service = new VisibilityAnalysisService(
+            new EndpointNoDataElevationService(observerNoData: true, targetNoData: true, baseElevation: 100));
+
+        var act = async () => await service.ComputeLineOfSightAsync(
+            LayerId,
+            new VisibilityPoint { Longitude = 0, Latitude = 0, HeightOffsetMeters = 2 },
+            new VisibilityPoint { Longitude = 0.1, Latitude = 0, HeightOffsetMeters = 2 },
+            sampleCount: 2,
+            RasterMergeStrategy.Newest);
+
+        var exception = await act.Should().ThrowAsync<ElevationQueryException>();
+        exception.Which.FailureKind.Should().Be(ElevationFailureKind.SourceUnavailable);
+    }
+
+    [UnitTest]
+    public async Task ComputeLineOfSightAsync_CoveredEndpointsWithNoDataInterior_FlagsHasNoDataSamples()
+    {
+        // Both endpoints have valid terrain; an interior stretch is no-data.
+        // The request succeeds (endpoints anchor the sight line) but the result
+        // must mark the interior no-data so callers know visibility is
+        // best-effort.
+        var service = new VisibilityAnalysisService(
+            new InteriorNoDataElevationService(baseElevation: 100));
+
+        var result = await service.ComputeLineOfSightAsync(
+            LayerId,
+            new VisibilityPoint { Longitude = 0, Latitude = 0, HeightOffsetMeters = 2 },
+            new VisibilityPoint { Longitude = 0.2, Latitude = 0, HeightOffsetMeters = 2 },
+            sampleCount: 32,
+            RasterMergeStrategy.Newest);
+
+        result.HasNoDataSamples.Should().BeTrue();
+        result.ObserverGroundElevation.Should().Be(100);
+        result.TargetGroundElevation.Should().Be(100);
+    }
+
+    [UnitTest]
     public void DestinationPoint_DueEast_IncreasesLongitude()
     {
         var (lon, lat) = VisibilityAnalysisService.DestinationPoint(0, 0, azimuthDegrees: 90, distanceMeters: 111_320);
@@ -294,6 +376,8 @@ public sealed class VisibilityAnalysisServiceTests
                 };
             }
 
+            TransformSamples(samples);
+
             var result = new ElevationProfileResult
             {
                 Samples = samples,
@@ -313,6 +397,14 @@ public sealed class VisibilityAnalysisServiceTests
         }
 
         protected abstract double? ElevationAt(double lon, double lat, double distanceFromStartMeters);
+
+        /// <summary>
+        /// Optional index-aware post-processing of the generated samples (e.g.
+        /// to mark specific endpoints as no-data). Default is a no-op.
+        /// </summary>
+        protected virtual void TransformSamples(ElevationSample[] samples)
+        {
+        }
 
         private static (double StartLon, double StartLat, double EndLon, double EndLat) DecodeLine(byte[] wkb)
         {
@@ -363,5 +455,57 @@ public sealed class VisibilityAnalysisServiceTests
             => distanceFromStartMeters >= rimStartMeters && distanceFromStartMeters <= rimEndMeters
                 ? rimElevation
                 : baseElevation;
+    }
+
+    /// <summary>
+    /// Valid terrain everywhere, then marks the observer (first sample) and/or
+    /// target (last sample) endpoint as no-data, modeling an observer/target
+    /// that falls on a no-data pixel or outside the raster coverage.
+    /// </summary>
+    private sealed class EndpointNoDataElevationService(
+        bool observerNoData,
+        bool targetNoData,
+        double baseElevation) : TerrainElevationServiceBase
+    {
+        protected override double? ElevationAt(double lon, double lat, double distanceFromStartMeters)
+            => baseElevation;
+
+        protected override void TransformSamples(ElevationSample[] samples)
+        {
+            if (samples.Length == 0)
+            {
+                return;
+            }
+
+            if (observerNoData)
+            {
+                samples[0] = samples[0] with { Elevation = null, NoData = true };
+            }
+
+            if (targetNoData)
+            {
+                samples[^1] = samples[^1] with { Elevation = null, NoData = true };
+            }
+        }
+    }
+
+    /// <summary>
+    /// Valid terrain at both endpoints but no-data across the interior of the
+    /// profile, exercising the best-effort <c>HasNoDataSamples</c> flag.
+    /// </summary>
+    private sealed class InteriorNoDataElevationService(double baseElevation) : TerrainElevationServiceBase
+    {
+        protected override double? ElevationAt(double lon, double lat, double distanceFromStartMeters)
+            => baseElevation;
+
+        protected override void TransformSamples(ElevationSample[] samples)
+        {
+            // Keep the first and last samples (the observer/target endpoints)
+            // valid; null out every interior sample.
+            for (var i = 1; i < samples.Length - 1; i++)
+            {
+                samples[i] = samples[i] with { Elevation = null, NoData = true };
+            }
+        }
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/VisibilityAnalysisEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/VisibilityAnalysisEndpointTests.cs
@@ -1,0 +1,248 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Server.Tests.Features.Licensing;
+using Honua.Server.Tests.Infrastructure;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Protocols.Elevation;
+
+/// <summary>
+/// Endpoint-level integration tests for the Pro-tier 3D visibility analysis
+/// endpoints (line-of-sight and viewshed). The fixture is provisioned with a Pro
+/// license so the <c>analytics.line-of-sight</c> / <c>analytics.viewshed</c>
+/// entitlements are active; without these the endpoints return 402 before any
+/// analysis runs.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Elevation)]
+public sealed class VisibilityAnalysisEndpointTests : IAsyncLifetime
+{
+    private const double WebMercatorExtent = 20037508.342789244;
+
+    private readonly WebAppFixture _fixture = new WebAppFixture()
+        .WithTestLicense(HonuaEdition.Pro);
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /elevation/{datasetId}/line-of-sight")]
+    public async Task PostLineOfSight_WithCoveredFlatTerrain_ReportsVisible()
+    {
+        await SeedFullWorldRasterAsync(100);
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/line-of-sight",
+            new
+            {
+                observerLon = 0.0,
+                observerLat = 0.0,
+                observerHeight = 2.0,
+                targetLon = 0.1,
+                targetLat = 0.0,
+                targetHeight = 2.0,
+                sampleCount = 32
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+
+        root.GetProperty("datasetId").GetString().Should().Be("0");
+        root.GetProperty("layerId").GetInt32().Should().Be(0);
+        root.GetProperty("visible").GetBoolean().Should().BeTrue();
+        root.GetProperty("observerGroundElevation").GetDouble().Should().BeApproximately(100, 0.0001);
+        root.GetProperty("observerElevation").GetDouble().Should().BeApproximately(102, 0.0001);
+        root.GetProperty("hasNoDataSamples").GetBoolean().Should().BeFalse();
+        root.GetProperty("distanceMeters").GetDouble().Should().BeGreaterThan(0);
+        root.GetProperty("obstruction").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /elevation/{datasetId}/line-of-sight")]
+    public async Task PostLineOfSight_ObserverEqualsTarget_ReturnsUnprocessableEntity()
+    {
+        await SeedFullWorldRasterAsync(100);
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/line-of-sight",
+            new
+            {
+                observerLon = 0.0,
+                observerLat = 0.0,
+                targetLon = 0.0,
+                targetLat = 0.0
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /elevation/{datasetId}/line-of-sight")]
+    public async Task PostLineOfSight_MissingCoordinates_ReturnsBadRequest()
+    {
+        await SeedFullWorldRasterAsync(100);
+
+        var response = await _fixture.Client.PostAsync(
+            "/elevation/0/line-of-sight",
+            new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /elevation/{datasetId}/line-of-sight")]
+    public async Task PostLineOfSight_EndpointOutsideCoverage_ReturnsNotFoundAndNotVisible()
+    {
+        // Regression: an observer/target ground sample that resolves to no-data
+        // (outside coverage) must not be coerced to 0.0 and reported visible.
+        // The service now fails the request rather than fabricating sea-level
+        // terrain, so the endpoint maps it to a 404 and never claims visibility.
+        await SeedSeQuadrantRasterAsync(50);
+
+        // Both endpoints are in the uncovered north-west quadrant.
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/line-of-sight",
+            new
+            {
+                observerLon = -150.0,
+                observerLat = 80.0,
+                targetLon = -140.0,
+                targetLat = 80.0,
+                sampleCount = 2
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().NotContain("\"visible\":true");
+        body.Should().Contain("no elevation data");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /elevation/{datasetId}/viewshed")]
+    public async Task PostViewshed_WithCoveredFlatTerrain_ReturnsVisibleSamples()
+    {
+        await SeedFullWorldRasterAsync(50);
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/viewshed",
+            new
+            {
+                observerLon = 0.0,
+                observerLat = 0.0,
+                observerHeight = 100.0,
+                radiusMeters = 5000.0,
+                rayCount = 16,
+                samplesPerRay = 16
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+
+        root.GetProperty("datasetId").GetString().Should().Be("0");
+        root.GetProperty("layerId").GetInt32().Should().Be(0);
+        root.GetProperty("rayCount").GetInt32().Should().Be(16);
+        root.GetProperty("samplesPerRay").GetInt32().Should().Be(16);
+        root.GetProperty("observerNoData").GetBoolean().Should().BeFalse();
+        root.GetProperty("observerGroundElevation").GetDouble().Should().BeApproximately(50, 0.0001);
+        root.GetProperty("sampleCount").GetInt32().Should().BeGreaterThan(0);
+        // On flat terrain with an elevated observer every sampled point is visible.
+        root.GetProperty("visibleSampleCount").GetInt32().Should().Be(root.GetProperty("sampleCount").GetInt32());
+        root.GetProperty("samples").GetArrayLength().Should().Be(root.GetProperty("sampleCount").GetInt32());
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /elevation/{datasetId}/viewshed")]
+    public async Task PostViewshed_NonPositiveRadius_ReturnsUnprocessableEntity()
+    {
+        await SeedFullWorldRasterAsync(50);
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/viewshed",
+            new
+            {
+                observerLon = 0.0,
+                observerLat = 0.0,
+                radiusMeters = 0.0
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("radiusMeters");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /elevation/{datasetId}/viewshed")]
+    public async Task PostViewshed_MissingObserver_ReturnsBadRequest()
+    {
+        await SeedFullWorldRasterAsync(50);
+
+        var response = await _fixture.Client.PostAsync(
+            "/elevation/0/viewshed",
+            new StringContent("{\"radiusMeters\":1000}", Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+    }
+
+    private Task SeedFullWorldRasterAsync(double elevationMeters)
+        => RasterIntegrationTestData.ReplaceLayerRastersAsync(
+            _fixture,
+            WebAppFixture.TestLayerId,
+            new RasterSeed(
+                Name: "world-dem",
+                Width: 2,
+                Height: 2,
+                UpperLeftX: -WebMercatorExtent,
+                UpperLeftY: WebMercatorExtent,
+                ScaleX: WebMercatorExtent,
+                ScaleY: -WebMercatorExtent,
+                Value: elevationMeters,
+                AcquisitionDate: RasterIntegrationTestData.WestAcquisition,
+                CreatedAt: RasterIntegrationTestData.WestAcquisition,
+                Srid: 3857));
+
+    private Task SeedSeQuadrantRasterAsync(double elevationMeters)
+        => RasterIntegrationTestData.ReplaceLayerRastersAsync(
+            _fixture,
+            WebAppFixture.TestLayerId,
+            new RasterSeed(
+                Name: "se-quadrant-dem",
+                Width: 1,
+                Height: 1,
+                UpperLeftX: 0,
+                UpperLeftY: 0,
+                ScaleX: WebMercatorExtent,
+                ScaleY: -WebMercatorExtent,
+                Value: elevationMeters,
+                AcquisitionDate: RasterIntegrationTestData.WestAcquisition,
+                CreatedAt: RasterIntegrationTestData.WestAcquisition,
+                Srid: 3857));
+}


### PR DESCRIPTION
## Issue Link
Fixes #1203

## Summary
Pro-tier 3D visibility analysis built on the existing elevation profile sampler (no DEM re-implementation). Adds line-of-sight and viewshed over elevation surfaces, the first slice of the 3D analysis suite for Epic #530.

## Changes Made
- `VisibilityAnalysisService` (Honua.Core, DB-free): line-of-sight with obstruction detection + geodesic obstruction point; bounded radial viewshed ray casting.
- `POST /elevation/{datasetId}/line-of-sight` and `POST /elevation/{datasetId}/viewshed` endpoints.
- `LicenseGate` entitlements `analytics.line-of-sight` / `analytics.viewshed`; problem-details errors + source-generated JSON.
- 11 unit tests (visible/obstructed cases, height offsets, viewshed on a synthetic DEM).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

> Note: branch is based on a trunk-ancestor and is behind trunk tip; diff is clean (single feature commit) but may need a rebase before merge. Build verified locally (Release, warnings-as-errors) and `dotnet format --verify-no-changes` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
