### PR TITLE
feat(scene/analysis): sun/shadow + slice/volumetric analysis (#1204)

### DIFF
--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -174,6 +174,10 @@ public static class FeatureCatalog
             HonuaEdition.Pro, "Buffer features by a fixed distance and dissolve or aggregate per group."),
         new("analytics.density", "Density Binning", Categories.Analytics,
             HonuaEdition.Pro, "Hex or square grid density (heatmap) binning over a filtered subset."),
+        new("analytics.sun-shadow", "Sun/Shadow Analysis", Categories.Analytics,
+            HonuaEdition.Pro, "Compute solar position from date/time/location and cast the shadow extent against the elevation surface."),
+        new("analytics.slice", "Slice/Volumetric Analysis", Categories.Analytics,
+            HonuaEdition.Pro, "Intersect a vertical slice plane with the elevation surface and return cross-section metadata."),
 
         // Temporal — Community (basic discovery)
         new("temporal.filtering", "Temporal Query Filtering", Categories.Temporal,

--- a/src/Honua.Core/Features/Raster/Abstractions/ISceneAnalysisService.cs
+++ b/src/Honua.Core/Features/Raster/Abstractions/ISceneAnalysisService.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Raster.Domain;
+
+namespace Honua.Core.Features.Raster.Abstractions;
+
+/// <summary>
+/// Computes scene analyses (sun/shadow and slice/volumetric cross-sections)
+/// against a registered elevation/terrain surface.
+/// </summary>
+/// <remarks>
+/// Implementations build on the elevation profile sampler
+/// (<see cref="IElevationService.QueryProfileAsync"/>) rather than reading the
+/// DEM directly, so they inherit the geodesic profile geometry, mosaic merge
+/// strategy, and no-data handling already established for the elevation API.
+/// The solar position math is independent of the elevation surface and is pure.
+/// </remarks>
+public interface ISceneAnalysisService
+{
+    /// <summary>
+    /// Computes the solar position for <paramref name="observer"/> at the
+    /// requested UTC instant, then casts the resulting shadow against the
+    /// elevation surface in the anti-solar direction.
+    /// </summary>
+    /// <param name="layerId">Layer that owns the elevation source.</param>
+    /// <param name="observer">Observer position and object height.</param>
+    /// <param name="options">Solar instant and shadow-ray tracing options.</param>
+    /// <param name="mergeStrategy">Mosaic merge strategy applied across overlapping rasters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<SunShadowResult> ComputeSunShadowAsync(
+        int layerId,
+        ShadowObserver observer,
+        SunShadowOptions options,
+        RasterMergeStrategy mergeStrategy,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Computes the intersection of a vertical slice plane with the elevation
+    /// surface, returning the sampled profile plus min/max/length metadata.
+    /// </summary>
+    /// <param name="layerId">Layer that owns the elevation source.</param>
+    /// <param name="plane">Start/end definition of the vertical slice plane.</param>
+    /// <param name="sampleCount">
+    /// Requested number of samples along the slice. <c>null</c> applies the
+    /// configured default. Clamped to the slice sampling limit.
+    /// </param>
+    /// <param name="mergeStrategy">Mosaic merge strategy applied across overlapping rasters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<SliceResult> ComputeSliceAsync(
+        int layerId,
+        SlicePlane plane,
+        int? sampleCount,
+        RasterMergeStrategy mergeStrategy,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Raster/Domain/SceneAnalysisDomain.cs
+++ b/src/Honua.Core/Features/Raster/Domain/SceneAnalysisDomain.cs
@@ -1,0 +1,269 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Raster.Domain;
+
+/// <summary>
+/// The position of the sun in the local sky for an observer, computed from a
+/// UTC instant and a WGS 84 longitude/latitude using the NOAA solar position
+/// algorithm.
+/// </summary>
+public readonly record struct SolarPosition
+{
+    /// <summary>
+    /// Solar altitude (elevation) above the horizon, in degrees. Negative when
+    /// the sun is below the horizon. Not corrected for atmospheric refraction.
+    /// </summary>
+    public required double AltitudeDegrees { get; init; }
+
+    /// <summary>
+    /// Solar azimuth in degrees clockwise from true north (0 = north, 90 = east,
+    /// 180 = south, 270 = west).
+    /// </summary>
+    public required double AzimuthDegrees { get; init; }
+
+    /// <summary>
+    /// Solar declination in degrees for the instant.
+    /// </summary>
+    public required double DeclinationDegrees { get; init; }
+
+    /// <summary>
+    /// Equation of time in minutes for the instant.
+    /// </summary>
+    public required double EquationOfTimeMinutes { get; init; }
+
+    /// <summary>
+    /// Hour angle of the sun in degrees (0 at solar noon, negative before,
+    /// positive after).
+    /// </summary>
+    public required double HourAngleDegrees { get; init; }
+
+    /// <summary>
+    /// Whether the sun is above the horizon (<see cref="AltitudeDegrees"/> &gt; 0).
+    /// </summary>
+    public bool IsAboveHorizon => AltitudeDegrees > 0;
+}
+
+/// <summary>
+/// A geographic observer used by a sun/shadow analysis, expressed in WGS 84
+/// longitude/latitude with an optional height above the terrain surface (in
+/// meters) — for example a structure or pole whose shadow is being cast.
+/// </summary>
+public readonly record struct ShadowObserver
+{
+    /// <summary>
+    /// Longitude in WGS 84 decimal degrees.
+    /// </summary>
+    public required double Longitude { get; init; }
+
+    /// <summary>
+    /// Latitude in WGS 84 decimal degrees.
+    /// </summary>
+    public required double Latitude { get; init; }
+
+    /// <summary>
+    /// Height of the object above the terrain surface, in meters. The shadow is
+    /// cast from the top of this object. Defaults to 0.
+    /// </summary>
+    public double HeightMeters { get; init; }
+}
+
+/// <summary>
+/// A single sample along the cast shadow, walking away from the observer in the
+/// anti-solar direction until the falling shadow ray meets the terrain surface.
+/// </summary>
+public readonly record struct ShadowSample
+{
+    /// <summary>Longitude of the sample in WGS 84 decimal degrees.</summary>
+    public required double Longitude { get; init; }
+
+    /// <summary>Latitude of the sample in WGS 84 decimal degrees.</summary>
+    public required double Latitude { get; init; }
+
+    /// <summary>Distance from the observer to the sample, in meters.</summary>
+    public required double DistanceMeters { get; init; }
+
+    /// <summary>
+    /// Terrain elevation at the sample, in meters. <c>null</c> when the sample
+    /// resolved to a no-data pixel.
+    /// </summary>
+    public double? TerrainElevation { get; init; }
+
+    /// <summary>
+    /// Height of the falling shadow ray at this distance, in meters absolute.
+    /// </summary>
+    public required double RayElevation { get; init; }
+}
+
+/// <summary>
+/// Result of a sun/shadow analysis: the solar position plus, when the sun is
+/// above the horizon, the cast shadow extent against the elevation surface.
+/// </summary>
+public sealed record SunShadowResult
+{
+    /// <summary>Layer that owns the elevation source.</summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>The computed solar position for the requested instant/location.</summary>
+    public required SolarPosition SolarPosition { get; init; }
+
+    /// <summary>
+    /// Whether a shadow was cast. <c>false</c> when the sun is at or below the
+    /// horizon, in which case <see cref="Samples"/> is empty and
+    /// <see cref="ShadowLengthMeters"/> is 0.
+    /// </summary>
+    public required bool ShadowCast { get; init; }
+
+    /// <summary>
+    /// Human-readable explanation when no shadow was cast (for example the sun
+    /// being below the horizon), otherwise <c>null</c>.
+    /// </summary>
+    public string? NoShadowReason { get; init; }
+
+    /// <summary>Terrain elevation at the observer position, in meters.</summary>
+    public required double ObserverGroundElevation { get; init; }
+
+    /// <summary>
+    /// Absolute elevation of the top of the observer object (ground + height),
+    /// in meters.
+    /// </summary>
+    public required double ObserverTopElevation { get; init; }
+
+    /// <summary>
+    /// Azimuth the shadow is cast toward, in degrees clockwise from north
+    /// (anti-solar: <c>solarAzimuth + 180</c>). 0 when no shadow is cast.
+    /// </summary>
+    public required double ShadowAzimuthDegrees { get; init; }
+
+    /// <summary>
+    /// Length of the shadow from the observer to the point where the falling
+    /// shadow ray meets the terrain, in meters. 0 when no shadow is cast.
+    /// </summary>
+    public required double ShadowLengthMeters { get; init; }
+
+    /// <summary>
+    /// Longitude of the shadow tip in WGS 84 decimal degrees, or <c>null</c>
+    /// when no shadow is cast.
+    /// </summary>
+    public double? TipLongitude { get; init; }
+
+    /// <summary>
+    /// Latitude of the shadow tip in WGS 84 decimal degrees, or <c>null</c> when
+    /// no shadow is cast.
+    /// </summary>
+    public double? TipLatitude { get; init; }
+
+    /// <summary>
+    /// Samples along the shadow ray from the observer to the shadow tip, ordered
+    /// by increasing distance. Empty when no shadow is cast.
+    /// </summary>
+    public required ShadowSample[] Samples { get; init; }
+}
+
+/// <summary>
+/// Options controlling a sun/shadow analysis.
+/// </summary>
+public readonly record struct SunShadowOptions
+{
+    /// <summary>UTC instant for which the solar position is computed.</summary>
+    public required DateTimeOffset InstantUtc { get; init; }
+
+    /// <summary>
+    /// Maximum distance the shadow ray is traced before giving up, in meters.
+    /// Must be strictly positive.
+    /// </summary>
+    public required double MaxShadowLengthMeters { get; init; }
+
+    /// <summary>
+    /// Number of range samples taken along the shadow ray. Clamped to
+    /// <c>[2, MaxShadowSamples]</c>.
+    /// </summary>
+    public int? SampleCount { get; init; }
+}
+
+/// <summary>
+/// Definition of a vertical slice plane used by a cross-section analysis. The
+/// plane is anchored by a start and end coordinate and is extruded vertically,
+/// so the surface intersection is the terrain profile along the start→end line.
+/// </summary>
+public readonly record struct SlicePlane
+{
+    /// <summary>Start longitude in WGS 84 decimal degrees.</summary>
+    public required double StartLongitude { get; init; }
+
+    /// <summary>Start latitude in WGS 84 decimal degrees.</summary>
+    public required double StartLatitude { get; init; }
+
+    /// <summary>End longitude in WGS 84 decimal degrees.</summary>
+    public required double EndLongitude { get; init; }
+
+    /// <summary>End latitude in WGS 84 decimal degrees.</summary>
+    public required double EndLatitude { get; init; }
+}
+
+/// <summary>
+/// A single sample where the slice plane intersects the terrain surface.
+/// </summary>
+public readonly record struct SliceSample
+{
+    /// <summary>Longitude of the sample in WGS 84 decimal degrees.</summary>
+    public required double Longitude { get; init; }
+
+    /// <summary>Latitude of the sample in WGS 84 decimal degrees.</summary>
+    public required double Latitude { get; init; }
+
+    /// <summary>
+    /// Distance from the slice start along the plane, in meters.
+    /// </summary>
+    public required double DistanceMeters { get; init; }
+
+    /// <summary>
+    /// Terrain elevation where the plane meets the surface, in meters.
+    /// <c>null</c> when the sample resolved to a no-data pixel.
+    /// </summary>
+    public double? Elevation { get; init; }
+}
+
+/// <summary>
+/// Result of a slice/volumetric cross-section analysis: the polyline where the
+/// slice plane intersects the terrain surface plus summary metadata.
+/// </summary>
+public sealed record SliceResult
+{
+    /// <summary>Layer that owns the elevation source.</summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>Length of the slice line along the surface, in meters.</summary>
+    public required double LengthMeters { get; init; }
+
+    /// <summary>Number of intersection samples produced.</summary>
+    public required int SampleCount { get; init; }
+
+    /// <summary>
+    /// Minimum terrain elevation along the intersection, in meters. <c>null</c>
+    /// when every sample was no-data.
+    /// </summary>
+    public double? MinElevation { get; init; }
+
+    /// <summary>
+    /// Maximum terrain elevation along the intersection, in meters. <c>null</c>
+    /// when every sample was no-data.
+    /// </summary>
+    public double? MaxElevation { get; init; }
+
+    /// <summary>
+    /// Elevation relief (max minus min) along the intersection, in meters.
+    /// <c>null</c> when every sample was no-data.
+    /// </summary>
+    public double? ReliefMeters { get; init; }
+
+    /// <summary>
+    /// Whether one or more samples along the slice resolved to a no-data pixel.
+    /// </summary>
+    public required bool HasNoDataSamples { get; init; }
+
+    /// <summary>
+    /// Intersection samples ordered by increasing distance from the slice start.
+    /// </summary>
+    public required SliceSample[] Samples { get; init; }
+}

--- a/src/Honua.Core/Features/Raster/SceneAnalysisService.cs
+++ b/src/Honua.Core/Features/Raster/SceneAnalysisService.cs
@@ -78,9 +78,19 @@ public sealed class SceneAnalysisService : ISceneAnalysisService
             mergeStrategy,
             cancellationToken).ConfigureAwait(false);
 
-        var observerGround = groundProfile.Samples.Length > 0
-            ? groundProfile.Samples[0].Elevation ?? 0.0
-            : 0.0;
+        // The observer ground elevation anchors the entire shadow cast. If the
+        // observer lands on a no-data pixel or outside raster coverage, there is
+        // no surface to anchor to: coercing it to 0.0 would fabricate an
+        // observer/shadow that does not exist. Fail explicitly instead, matching
+        // how the elevation API signals an unusable sampling location.
+        if (groundProfile.Samples.Length == 0
+            || groundProfile.Samples[0].Elevation is not { } observerGround)
+        {
+            throw new ElevationQueryException(
+                ElevationFailureKind.InvalidGeometry,
+                "The observer location has no elevation data (it lands on a no-data pixel or outside raster coverage); a sun/shadow cannot be computed there.");
+        }
+
         var observerTop = observerGround + observer.HeightMeters;
 
         if (!solar.IsAboveHorizon)

--- a/src/Honua.Core/Features/Raster/SceneAnalysisService.cs
+++ b/src/Honua.Core/Features/Raster/SceneAnalysisService.cs
@@ -1,0 +1,552 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Shared.Models;
+
+namespace Honua.Core.Features.Raster;
+
+/// <summary>
+/// Default <see cref="ISceneAnalysisService"/> implementation. The solar
+/// position is computed with the NOAA solar position algorithm (pure math); the
+/// shadow extent and slice cross-section build on the elevation profile sampler
+/// so they inherit the geodesic profile geometry, mosaic merge strategy, and
+/// no-data handling of the elevation API and do not re-implement DEM sampling.
+/// </summary>
+public sealed class SceneAnalysisService : ISceneAnalysisService
+{
+    private const int Wgs84Srid = SpatialConstants.DefaultSrid;
+
+    /// <summary>Default number of samples traced along a shadow ray.</summary>
+    public const int DefaultShadowSampleCount = 128;
+
+    /// <summary>Upper bound on shadow-ray samples.</summary>
+    public const int MaxShadowSamples = 1024;
+
+    /// <summary>Default number of samples taken along a slice plane.</summary>
+    public const int DefaultSliceSampleCount = 128;
+
+    /// <summary>Upper bound on slice samples.</summary>
+    public const int MaxSliceSamples = 2048;
+
+    private readonly IElevationService _elevationService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SceneAnalysisService"/> class.
+    /// </summary>
+    /// <param name="elevationService">Elevation profile sampler.</param>
+    public SceneAnalysisService(IElevationService elevationService)
+    {
+        _elevationService = elevationService ?? throw new ArgumentNullException(nameof(elevationService));
+    }
+
+    /// <inheritdoc />
+    public async Task<SunShadowResult> ComputeSunShadowAsync(
+        int layerId,
+        ShadowObserver observer,
+        SunShadowOptions options,
+        RasterMergeStrategy mergeStrategy,
+        CancellationToken cancellationToken = default)
+    {
+        if (!double.IsFinite(options.MaxShadowLengthMeters) || options.MaxShadowLengthMeters <= 0)
+        {
+            throw new ElevationQueryException(
+                ElevationFailureKind.InvalidGeometry,
+                "Maximum shadow length must be a positive finite distance in meters.");
+        }
+
+        if (observer.Longitude < -180 || observer.Longitude > 180
+            || observer.Latitude < -90 || observer.Latitude > 90)
+        {
+            throw new ElevationQueryException(
+                ElevationFailureKind.InvalidGeometry,
+                "Observer must be a finite WGS 84 coordinate within longitude [-180, 180] and latitude [-90, 90].");
+        }
+
+        var solar = ComputeSolarPosition(options.InstantUtc, observer.Longitude, observer.Latitude);
+
+        // Sample the observer ground elevation. A short profile that starts at
+        // the observer reuses the elevation API's no-data and mosaic handling.
+        var groundProfile = await SampleLineAsync(
+            layerId,
+            observer.Longitude,
+            observer.Latitude,
+            observer.Longitude,
+            observer.Latitude,
+            2,
+            mergeStrategy,
+            cancellationToken).ConfigureAwait(false);
+
+        var observerGround = groundProfile.Samples.Length > 0
+            ? groundProfile.Samples[0].Elevation ?? 0.0
+            : 0.0;
+        var observerTop = observerGround + observer.HeightMeters;
+
+        if (!solar.IsAboveHorizon)
+        {
+            return new SunShadowResult
+            {
+                LayerId = layerId,
+                SolarPosition = solar,
+                ShadowCast = false,
+                NoShadowReason = "The sun is at or below the horizon; no shadow is cast.",
+                ObserverGroundElevation = observerGround,
+                ObserverTopElevation = observerTop,
+                ShadowAzimuthDegrees = 0,
+                ShadowLengthMeters = 0,
+                TipLongitude = null,
+                TipLatitude = null,
+                Samples = []
+            };
+        }
+
+        // The shadow falls in the anti-solar direction. The top of the falling
+        // ray descends at the solar altitude angle as we walk away from the
+        // observer; the shadow tip is where that ray meets the terrain.
+        var shadowAzimuth = NormalizeAzimuth(solar.AzimuthDegrees + 180.0);
+        var altitudeRad = DegToRad(solar.AltitudeDegrees);
+        var tanAltitude = Math.Tan(altitudeRad);
+
+        var sampleCount = Math.Clamp(
+            options.SampleCount ?? DefaultShadowSampleCount,
+            2,
+            MaxShadowSamples);
+
+        var (endLon, endLat) = DestinationPoint(
+            observer.Longitude,
+            observer.Latitude,
+            shadowAzimuth,
+            options.MaxShadowLengthMeters);
+
+        var profile = await SampleLineAsync(
+            layerId,
+            observer.Longitude,
+            observer.Latitude,
+            endLon,
+            endLat,
+            sampleCount,
+            mergeStrategy,
+            cancellationToken).ConfigureAwait(false);
+
+        var samples = new List<ShadowSample>(profile.Samples.Length);
+        double tipDistance = 0;
+        double? tipLon = null;
+        double? tipLat = null;
+        var lineLength = profile.LineLengthMeters;
+
+        foreach (var sample in profile.Samples)
+        {
+            var distance = sample.DistanceMeters;
+            // Falling shadow ray height at this distance from the observer top.
+            var rayElevation = observerTop - distance * tanAltitude;
+
+            var fraction = lineLength > 0 ? distance / lineLength : 0.0;
+            var (lon, lat) = InterpolateGeodesic(
+                observer.Longitude,
+                observer.Latitude,
+                endLon,
+                endLat,
+                fraction);
+
+            samples.Add(new ShadowSample
+            {
+                Longitude = lon,
+                Latitude = lat,
+                DistanceMeters = distance,
+                TerrainElevation = sample.Elevation,
+                RayElevation = rayElevation
+            });
+
+            // The shadow ends at the first point (past the observer) where the
+            // falling ray reaches or drops below the terrain surface.
+            if (distance > 0 && sample.Elevation.HasValue && rayElevation <= sample.Elevation.Value)
+            {
+                tipDistance = distance;
+                tipLon = lon;
+                tipLat = lat;
+                break;
+            }
+        }
+
+        // If the ray never met the terrain within the traced extent, the shadow
+        // tip is the far end of the traced ray.
+        if (tipLon is null && samples.Count > 0)
+        {
+            var last = samples[^1];
+            tipDistance = last.DistanceMeters;
+            tipLon = last.Longitude;
+            tipLat = last.Latitude;
+        }
+
+        return new SunShadowResult
+        {
+            LayerId = layerId,
+            SolarPosition = solar,
+            ShadowCast = true,
+            NoShadowReason = null,
+            ObserverGroundElevation = observerGround,
+            ObserverTopElevation = observerTop,
+            ShadowAzimuthDegrees = shadowAzimuth,
+            ShadowLengthMeters = tipDistance,
+            TipLongitude = tipLon,
+            TipLatitude = tipLat,
+            Samples = samples.ToArray()
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<SliceResult> ComputeSliceAsync(
+        int layerId,
+        SlicePlane plane,
+        int? sampleCount,
+        RasterMergeStrategy mergeStrategy,
+        CancellationToken cancellationToken = default)
+    {
+        if (plane.StartLongitude == plane.EndLongitude && plane.StartLatitude == plane.EndLatitude)
+        {
+            throw new ElevationQueryException(
+                ElevationFailureKind.InvalidGeometry,
+                "Slice plane start and end must be distinct coordinates.");
+        }
+
+        var resolvedSampleCount = Math.Clamp(
+            sampleCount ?? DefaultSliceSampleCount,
+            2,
+            MaxSliceSamples);
+
+        var profile = await SampleLineAsync(
+            layerId,
+            plane.StartLongitude,
+            plane.StartLatitude,
+            plane.EndLongitude,
+            plane.EndLatitude,
+            resolvedSampleCount,
+            mergeStrategy,
+            cancellationToken).ConfigureAwait(false);
+
+        var lineLength = profile.LineLengthMeters;
+        var samples = new SliceSample[profile.Samples.Length];
+        double? minElevation = null;
+        double? maxElevation = null;
+        var hasNoData = false;
+
+        for (var i = 0; i < profile.Samples.Length; i++)
+        {
+            var sample = profile.Samples[i];
+            var fraction = lineLength > 0 ? sample.DistanceMeters / lineLength : 0.0;
+            var (lon, lat) = InterpolateGeodesic(
+                plane.StartLongitude,
+                plane.StartLatitude,
+                plane.EndLongitude,
+                plane.EndLatitude,
+                fraction);
+
+            if (sample.Elevation.HasValue)
+            {
+                var elevation = sample.Elevation.Value;
+                minElevation = minElevation is { } min ? Math.Min(min, elevation) : elevation;
+                maxElevation = maxElevation is { } max ? Math.Max(max, elevation) : elevation;
+            }
+            else
+            {
+                hasNoData = true;
+            }
+
+            samples[i] = new SliceSample
+            {
+                Longitude = lon,
+                Latitude = lat,
+                DistanceMeters = sample.DistanceMeters,
+                Elevation = sample.Elevation
+            };
+        }
+
+        double? relief = minElevation is { } lo && maxElevation is { } hi ? hi - lo : null;
+
+        return new SliceResult
+        {
+            LayerId = layerId,
+            LengthMeters = lineLength,
+            SampleCount = samples.Length,
+            MinElevation = minElevation,
+            MaxElevation = maxElevation,
+            ReliefMeters = relief,
+            HasNoDataSamples = hasNoData,
+            Samples = samples
+        };
+    }
+
+    /// <summary>
+    /// Computes the solar position (altitude + azimuth, plus the intermediate
+    /// declination, equation of time, and hour angle) for a UTC instant and a
+    /// WGS 84 longitude/latitude using the NOAA solar position algorithm.
+    /// The result is not corrected for atmospheric refraction.
+    /// </summary>
+    /// <remarks>
+    /// Implements the NOAA Solar Calculator equations: Julian day → Julian
+    /// century → geometric mean longitude/anomaly of the sun → equation of
+    /// center → true longitude → apparent longitude → obliquity → declination
+    /// and equation of time → true solar time → hour angle → solar zenith →
+    /// altitude and azimuth.
+    /// </remarks>
+    public static SolarPosition ComputeSolarPosition(DateTimeOffset instant, double longitude, double latitude)
+    {
+        var utc = instant.ToUniversalTime();
+
+        // Julian day at the instant (UTC). The NOAA spreadsheet works in days
+        // since the J2000.0-anchored 2415018.5 epoch; we compute the full
+        // Julian date and the Julian century directly.
+        var julianDay = ToJulianDay(utc);
+        var julianCentury = (julianDay - 2451545.0) / 36525.0;
+
+        var geomMeanLongSun = Mod360(280.46646 + julianCentury * (36000.76983 + julianCentury * 0.0003032));
+        var geomMeanAnomSun = 357.52911 + julianCentury * (35999.05029 - 0.0001537 * julianCentury);
+        var eccentEarthOrbit = 0.016708634 - julianCentury * (0.000042037 + 0.0000001267 * julianCentury);
+
+        var meanAnomRad = DegToRad(geomMeanAnomSun);
+        var sunEqOfCenter =
+            Math.Sin(meanAnomRad) * (1.914602 - julianCentury * (0.004817 + 0.000014 * julianCentury))
+            + Math.Sin(2 * meanAnomRad) * (0.019993 - 0.000101 * julianCentury)
+            + Math.Sin(3 * meanAnomRad) * 0.000289;
+
+        var sunTrueLong = geomMeanLongSun + sunEqOfCenter;
+        var sunAppLong = sunTrueLong - 0.00569 - 0.00478 * Math.Sin(DegToRad(125.04 - 1934.136 * julianCentury));
+
+        var meanObliqEcliptic = 23.0 + (26.0 + (21.448
+            - julianCentury * (46.815 + julianCentury * (0.00059 - julianCentury * 0.001813))) / 60.0) / 60.0;
+        var obliqCorr = meanObliqEcliptic + 0.00256 * Math.Cos(DegToRad(125.04 - 1934.136 * julianCentury));
+
+        var sunDeclinationRad = Math.Asin(
+            Math.Sin(DegToRad(obliqCorr)) * Math.Sin(DegToRad(sunAppLong)));
+        var sunDeclinationDeg = RadToDeg(sunDeclinationRad);
+
+        // Equation of time (minutes).
+        var varY = Math.Tan(DegToRad(obliqCorr / 2.0)) * Math.Tan(DegToRad(obliqCorr / 2.0));
+        var geomMeanLongRad = DegToRad(geomMeanLongSun);
+        var eqOfTime = 4.0 * RadToDeg(
+            varY * Math.Sin(2 * geomMeanLongRad)
+            - 2 * eccentEarthOrbit * Math.Sin(meanAnomRad)
+            + 4 * eccentEarthOrbit * varY * Math.Sin(meanAnomRad) * Math.Cos(2 * geomMeanLongRad)
+            - 0.5 * varY * varY * Math.Sin(4 * geomMeanLongRad)
+            - 1.25 * eccentEarthOrbit * eccentEarthOrbit * Math.Sin(2 * meanAnomRad));
+
+        // True solar time (minutes) at the location. The NOAA sheet subtracts
+        // the timezone offset and adds it back via local time; working directly
+        // in UTC, the timezone term is zero.
+        var minutesUtc = utc.TimeOfDay.TotalMinutes;
+        var trueSolarTime = Mod1440(minutesUtc + eqOfTime + 4.0 * longitude);
+
+        // Hour angle (degrees): 0 at solar noon, negative before noon.
+        var hourAngle = trueSolarTime / 4.0 < 0
+            ? trueSolarTime / 4.0 + 180.0
+            : trueSolarTime / 4.0 - 180.0;
+
+        var latRad = DegToRad(latitude);
+        var hourAngleRad = DegToRad(hourAngle);
+
+        // Solar zenith angle.
+        var cosZenith = Math.Sin(latRad) * Math.Sin(sunDeclinationRad)
+            + Math.Cos(latRad) * Math.Cos(sunDeclinationRad) * Math.Cos(hourAngleRad);
+        cosZenith = Math.Clamp(cosZenith, -1.0, 1.0);
+        var zenithRad = Math.Acos(cosZenith);
+        var altitudeDeg = 90.0 - RadToDeg(zenithRad);
+
+        // Solar azimuth, clockwise from north.
+        double azimuthDeg;
+        var sinZenith = Math.Sin(zenithRad);
+        if (sinZenith < 1e-9)
+        {
+            // Sun directly overhead (or at nadir): azimuth is degenerate.
+            azimuthDeg = 0.0;
+        }
+        else
+        {
+            var cosAzimuth = (Math.Sin(latRad) * Math.Cos(zenithRad) - Math.Sin(sunDeclinationRad))
+                / (Math.Cos(latRad) * sinZenith);
+            cosAzimuth = Math.Clamp(cosAzimuth, -1.0, 1.0);
+            var azimuthFromSouth = RadToDeg(Math.Acos(cosAzimuth));
+
+            // NOAA convention: when the hour angle is positive (afternoon), the
+            // azimuth is measured the other way around from north.
+            azimuthDeg = hourAngle > 0
+                ? Mod360(azimuthFromSouth + 180.0)
+                : Mod360(540.0 - azimuthFromSouth);
+        }
+
+        return new SolarPosition
+        {
+            AltitudeDegrees = altitudeDeg,
+            AzimuthDegrees = azimuthDeg,
+            DeclinationDegrees = sunDeclinationDeg,
+            EquationOfTimeMinutes = eqOfTime,
+            HourAngleDegrees = hourAngle
+        };
+    }
+
+    /// <summary>
+    /// Converts a UTC instant to its Julian day number (with fractional day).
+    /// </summary>
+    internal static double ToJulianDay(DateTimeOffset utc)
+    {
+        var year = utc.Year;
+        var month = utc.Month;
+        double day = utc.Day
+            + (utc.Hour + (utc.Minute + (utc.Second + utc.Millisecond / 1000.0) / 60.0) / 60.0) / 24.0;
+
+        if (month <= 2)
+        {
+            year -= 1;
+            month += 12;
+        }
+
+        var a = Math.Floor(year / 100.0);
+        var b = 2 - a + Math.Floor(a / 4.0);
+
+        return Math.Floor(365.25 * (year + 4716))
+            + Math.Floor(30.6001 * (month + 1))
+            + day + b - 1524.5;
+    }
+
+    private Task<ElevationProfileResult> SampleLineAsync(
+        int layerId,
+        double startLon,
+        double startLat,
+        double endLon,
+        double endLat,
+        int sampleCount,
+        RasterMergeStrategy mergeStrategy,
+        CancellationToken cancellationToken)
+    {
+        var lineWkb = BuildLineWkb(startLon, startLat, endLon, endLat);
+        var options = new ProfileSamplingOptions
+        {
+            SampleCount = sampleCount,
+            IntervalMeters = null,
+            DefaultSampleCount = sampleCount,
+            MaxSampleCount = Math.Max(sampleCount, 2)
+        };
+
+        return _elevationService.QueryProfileAsync(
+            layerId,
+            lineWkb,
+            Wgs84Srid,
+            options,
+            mergeStrategy,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Builds a 2-point 2D LineString WKB (little-endian) for a geodesic profile
+    /// between two WGS 84 coordinates.
+    /// </summary>
+    internal static byte[] BuildLineWkb(double startLon, double startLat, double endLon, double endLat)
+    {
+        // Byte order (1) + type (4) + numPoints (4) + 2 * (x,y as float8) = 41 bytes.
+        var buffer = new byte[41];
+        buffer[0] = 1; // little-endian
+        buffer[1] = 0x02; // geometry type = 2 (LineString)
+        buffer[5] = 0x02; // numPoints = 2
+        BitConverter.TryWriteBytes(buffer.AsSpan(9, 8), startLon);
+        BitConverter.TryWriteBytes(buffer.AsSpan(17, 8), startLat);
+        BitConverter.TryWriteBytes(buffer.AsSpan(25, 8), endLon);
+        BitConverter.TryWriteBytes(buffer.AsSpan(33, 8), endLat);
+        return buffer;
+    }
+
+    /// <summary>
+    /// Spherical great-circle interpolation between two WGS 84 coordinates.
+    /// </summary>
+    internal static (double Longitude, double Latitude) InterpolateGeodesic(
+        double startLon,
+        double startLat,
+        double endLon,
+        double endLat,
+        double fraction)
+    {
+        fraction = Math.Clamp(fraction, 0.0, 1.0);
+        if (fraction <= 0)
+        {
+            return (startLon, startLat);
+        }
+
+        if (fraction >= 1)
+        {
+            return (endLon, endLat);
+        }
+
+        var phi1 = DegToRad(startLat);
+        var lambda1 = DegToRad(startLon);
+        var phi2 = DegToRad(endLat);
+        var lambda2 = DegToRad(endLon);
+
+        var deltaPhi = phi2 - phi1;
+        var deltaLambda = lambda2 - lambda1;
+        var a = Math.Sin(deltaPhi / 2) * Math.Sin(deltaPhi / 2)
+            + Math.Cos(phi1) * Math.Cos(phi2) * Math.Sin(deltaLambda / 2) * Math.Sin(deltaLambda / 2);
+        var angular = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+        if (angular == 0)
+        {
+            return (startLon, startLat);
+        }
+
+        var sinAngular = Math.Sin(angular);
+        var aFactor = Math.Sin((1 - fraction) * angular) / sinAngular;
+        var bFactor = Math.Sin(fraction * angular) / sinAngular;
+
+        var x = aFactor * Math.Cos(phi1) * Math.Cos(lambda1) + bFactor * Math.Cos(phi2) * Math.Cos(lambda2);
+        var y = aFactor * Math.Cos(phi1) * Math.Sin(lambda1) + bFactor * Math.Cos(phi2) * Math.Sin(lambda2);
+        var z = aFactor * Math.Sin(phi1) + bFactor * Math.Sin(phi2);
+
+        var phi = Math.Atan2(z, Math.Sqrt(x * x + y * y));
+        var lambda = Math.Atan2(y, x);
+        return (RadToDeg(lambda), RadToDeg(phi));
+    }
+
+    /// <summary>
+    /// Computes the destination WGS 84 coordinate reached by travelling
+    /// <paramref name="distanceMeters"/> along <paramref name="azimuthDegrees"/>
+    /// (clockwise from north) from the start, using the spherical great-circle
+    /// direct formula.
+    /// </summary>
+    internal static (double Longitude, double Latitude) DestinationPoint(
+        double startLon,
+        double startLat,
+        double azimuthDegrees,
+        double distanceMeters)
+    {
+        var angular = distanceMeters / SpatialConstants.EarthRadius;
+        var theta = DegToRad(azimuthDegrees);
+        var phi1 = DegToRad(startLat);
+        var lambda1 = DegToRad(startLon);
+
+        var sinPhi2 = Math.Sin(phi1) * Math.Cos(angular)
+            + Math.Cos(phi1) * Math.Sin(angular) * Math.Cos(theta);
+        var phi2 = Math.Asin(Math.Clamp(sinPhi2, -1.0, 1.0));
+        var lambda2 = lambda1 + Math.Atan2(
+            Math.Sin(theta) * Math.Sin(angular) * Math.Cos(phi1),
+            Math.Cos(angular) - Math.Sin(phi1) * sinPhi2);
+
+        var lon = RadToDeg(lambda2);
+        lon = ((lon + 540.0) % 360.0) - 180.0;
+        return (lon, RadToDeg(phi2));
+    }
+
+    private static double NormalizeAzimuth(double azimuth) => Mod360(azimuth);
+
+    private static double Mod360(double value)
+    {
+        var result = value % 360.0;
+        return result < 0 ? result + 360.0 : result;
+    }
+
+    private static double Mod1440(double value)
+    {
+        var result = value % 1440.0;
+        return result < 0 ? result + 1440.0 : result;
+    }
+
+    private static double DegToRad(double degrees) => degrees * Math.PI / 180.0;
+
+    private static double RadToDeg(double radians) => radians * 180.0 / Math.PI;
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -576,6 +576,10 @@ public static class EndpointRegistry
         new("GET", "/elevation/{datasetId}/value"),
         new("GET", "/elevation/{datasetId}/profile"),
 
+        // Scene analysis on the elevation surface (#1204).
+        new("POST", "/elevation/{datasetId}/sun-shadow"),
+        new("POST", "/elevation/{datasetId}/slice"),
+
         new("GET", "/api/styles/{layerId}.json"),
 
         // Durable PMTiles publish range proxy (#845).

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -148,6 +148,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapSceneEndpoints();
         endpoints.MapSceneDatasetEndpoints();
         endpoints.MapElevationEndpoints();
+        endpoints.MapSceneAnalysisEndpoints();
         endpoints.MapSceneGenerationEndpoints();
         endpoints.MapPMTilesProxyEndpoints();
         endpoints.MapStyleEndpoints();

--- a/src/Honua.Server/Features/Protocols/Elevation/ElevationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Protocols/Elevation/ElevationServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Raster;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -12,6 +13,12 @@ internal static class ElevationServiceCollectionExtensions
     public static IServiceCollection AddElevation(this IServiceCollection services)
     {
         services.TryAddScoped<IElevationService, UnsupportedElevationService>();
+
+        // Scene analysis (sun/shadow + slice/volumetric) builds on the elevation
+        // profile sampler and is provider-agnostic, so it is registered wherever
+        // an elevation service is available.
+        services.TryAddScoped<ISceneAnalysisService>(sp =>
+            new SceneAnalysisService(sp.GetRequiredService<IElevationService>()));
         return services;
     }
 

--- a/src/Honua.Server/Features/Protocols/Elevation/SceneAnalysisEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Elevation/SceneAnalysisEndpoints.cs
@@ -20,6 +20,18 @@ namespace Honua.Server.Features.Protocols.Elevation;
 /// cross-section) that build on the elevation profile sampler. Registered
 /// alongside the elevation API and gated through <see cref="LicenseGate"/>.
 /// </summary>
+/// <remarks>
+/// Like the other protocol mutation surfaces, these POST routes use
+/// <c>AllowAnonymous()</c> to bypass the application-wide authorization policy
+/// so the per-layer access check can run. Every handler invokes
+/// <c>LayerValidationHelpers.ValidateLayerWithAccessAsync(... AccessScope.Read)</c>
+/// (via <see cref="ValidateDatasetAsync"/>) plus the <see cref="LicenseGate"/>
+/// entitlement check before touching the elevation surface, which is what
+/// returns 401/403/402 for unauthenticated, unauthorized, or unlicensed
+/// callers. Removing <c>AllowAnonymous()</c> without first moving the per-layer
+/// gate into the pipeline would lock out every caller whose permissions live on
+/// the layer rather than on a global role.
+/// </remarks>
 internal static class SceneAnalysisEndpoints
 {
     private const string JsonContentType = "application/json";
@@ -41,7 +53,8 @@ internal static class SceneAnalysisEndpoints
             .Produces(StatusCodes.Status402PaymentRequired)
             .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)
-            .Produces(StatusCodes.Status422UnprocessableEntity);
+            .Produces(StatusCodes.Status422UnprocessableEntity)
+            .AllowAnonymous();
 
         endpoints.MapPost("/elevation/{datasetId}/slice", HandleSlice)
             .WithDisplayName("Compute Slice Cross-Section")
@@ -56,7 +69,8 @@ internal static class SceneAnalysisEndpoints
             .Produces(StatusCodes.Status402PaymentRequired)
             .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)
-            .Produces(StatusCodes.Status422UnprocessableEntity);
+            .Produces(StatusCodes.Status422UnprocessableEntity)
+            .AllowAnonymous();
 
         return endpoints;
     }

--- a/src/Honua.Server/Features/Protocols/Elevation/SceneAnalysisEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Elevation/SceneAnalysisEndpoints.cs
@@ -1,0 +1,437 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Security.Domain;
+using Honua.Server.Features.Infrastructure.Licensing;
+using Honua.Server.Features.Infrastructure.Models;
+using Honua.Server.Features.Infrastructure.Raster;
+using Honua.Server.Features.Infrastructure.Validation;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Server.Features.Protocols.Elevation;
+
+/// <summary>
+/// Pro-tier scene analysis endpoints (sun/shadow and slice/volumetric
+/// cross-section) that build on the elevation profile sampler. Registered
+/// alongside the elevation API and gated through <see cref="LicenseGate"/>.
+/// </summary>
+internal static class SceneAnalysisEndpoints
+{
+    private const string JsonContentType = "application/json";
+    private const string SunShadowEntitlement = "analytics.sun-shadow";
+    private const string SliceEntitlement = "analytics.slice";
+
+    public static IEndpointRouteBuilder MapSceneAnalysisEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost("/elevation/{datasetId}/sun-shadow", HandleSunShadow)
+            .WithDisplayName("Compute Sun/Shadow")
+            .WithName("ComputeSunShadow")
+            .WithSummary("Compute the solar position and cast shadow extent over the elevation surface")
+            .WithDescription("Computes the solar altitude/azimuth for a UTC instant and location, then casts the shadow against the elevation surface in the anti-solar direction")
+            .WithTags("Elevation")
+            .Accepts<SunShadowRequest>(JsonContentType)
+            .Produces<SunShadowResponse>(StatusCodes.Status200OK, JsonContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status402PaymentRequired)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status422UnprocessableEntity);
+
+        endpoints.MapPost("/elevation/{datasetId}/slice", HandleSlice)
+            .WithDisplayName("Compute Slice Cross-Section")
+            .WithName("ComputeSlice")
+            .WithSummary("Compute a slice plane's intersection with the elevation surface")
+            .WithDescription("Samples the elevation surface along a vertical slice plane and returns the intersection profile with min/max/length metadata")
+            .WithTags("Elevation")
+            .Accepts<SliceRequest>(JsonContentType)
+            .Produces<SliceResponse>(StatusCodes.Status200OK, JsonContentType)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status402PaymentRequired)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status422UnprocessableEntity);
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleSunShadow(
+        string datasetId,
+        HttpContext context,
+        ISceneAnalysisService sceneService,
+        CancellationToken cancellationToken)
+    {
+        var logger = context.RequestServices.GetService<ILoggerFactory>()?
+            .CreateLogger("Honua.Elevation.SceneAnalysis");
+
+        var gate = LicenseGate.RequireEntitlement(context, SunShadowEntitlement, "Sun/Shadow Analysis", logger);
+        if (gate is not null)
+        {
+            return gate;
+        }
+
+        SunShadowRequest? request;
+        try
+        {
+            request = await context.Request.ReadFromJsonAsync(
+                SceneAnalysisJsonContext.Default.SunShadowRequest,
+                cancellationToken);
+        }
+        catch
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body must be valid JSON.");
+        }
+
+        if (request is null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body is required.");
+        }
+
+        if (!TryResolveCoordinate(request.ObserverLon, request.ObserverLat, out var observerLon, out var observerLat))
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                "Observer 'observerLon' and 'observerLat' are required and must be finite WGS 84 coordinates within longitude [-180, 180] and latitude [-90, 90].");
+        }
+
+        if (request.Timestamp is not { } timestamp)
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                "'timestamp' is required and must be an ISO 8601 date/time.");
+        }
+
+        if (!TryResolveHeight(request.ObserverHeight, out var observerHeight))
+        {
+            return StandardErrorHelpers.CreateUnprocessableEntity(
+                context,
+                "'observerHeight' must be a finite, non-negative value in meters.");
+        }
+
+        if (request.MaxShadowLengthMeters is not { } maxShadowLength
+            || !double.IsFinite(maxShadowLength) || maxShadowLength <= 0)
+        {
+            return StandardErrorHelpers.CreateUnprocessableEntity(
+                context,
+                "'maxShadowLengthMeters' is required and must be a positive finite distance in meters.");
+        }
+
+        if (request.SampleCount is { } sampleCount && sampleCount < 2)
+        {
+            return StandardErrorHelpers.CreateUnprocessableEntity(
+                context,
+                "'sampleCount' must be at least 2 when supplied.");
+        }
+
+        var validation = await ValidateDatasetAsync(context, datasetId, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return validation.ErrorResult!;
+        }
+
+        var layer = validation.Layer!;
+        var mergeStrategy = RasterMosaicUtilities.ResolveMergeStrategy(layer.Metadata, request.MosaicRule);
+
+        using var activity = HonuaTelemetry.StartActivity("honua.elevation.sun_shadow");
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.Elevation);
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, "elevation.sun-shadow");
+        activity?.SetTag(HonuaTelemetry.Tags.LayerId, layer.Id);
+        activity?.SetTag(HonuaTelemetry.Tags.CollectionId, datasetId);
+
+        try
+        {
+            var result = await sceneService.ComputeSunShadowAsync(
+                layer.Id,
+                new ShadowObserver { Longitude = observerLon, Latitude = observerLat, HeightMeters = observerHeight },
+                new SunShadowOptions
+                {
+                    InstantUtc = timestamp,
+                    MaxShadowLengthMeters = maxShadowLength,
+                    SampleCount = request.SampleCount
+                },
+                mergeStrategy,
+                cancellationToken);
+
+            activity?.SetTag("honua.elevation.sun_altitude", result.SolarPosition.AltitudeDegrees);
+            activity?.SetTag("honua.elevation.shadow_length_m", result.ShadowLengthMeters);
+
+            var response = BuildSunShadowResponse(datasetId, result, mergeStrategy);
+            return Results.Json(response, SceneAnalysisJsonContext.Default.SunShadowResponse, contentType: JsonContentType);
+        }
+        catch (ElevationQueryException ex)
+        {
+            HonuaTelemetry.RecordException(activity, ex);
+            return MapElevationException(context, ex);
+        }
+    }
+
+    private static async Task<IResult> HandleSlice(
+        string datasetId,
+        HttpContext context,
+        ISceneAnalysisService sceneService,
+        CancellationToken cancellationToken)
+    {
+        var logger = context.RequestServices.GetService<ILoggerFactory>()?
+            .CreateLogger("Honua.Elevation.SceneAnalysis");
+
+        var gate = LicenseGate.RequireEntitlement(context, SliceEntitlement, "Slice Analysis", logger);
+        if (gate is not null)
+        {
+            return gate;
+        }
+
+        SliceRequest? request;
+        try
+        {
+            request = await context.Request.ReadFromJsonAsync(
+                SceneAnalysisJsonContext.Default.SliceRequest,
+                cancellationToken);
+        }
+        catch
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body must be valid JSON.");
+        }
+
+        if (request is null)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context, "Request body is required.");
+        }
+
+        if (!TryResolveCoordinate(request.StartLon, request.StartLat, out var startLon, out var startLat))
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                "Slice 'startLon' and 'startLat' are required and must be finite WGS 84 coordinates within longitude [-180, 180] and latitude [-90, 90].");
+        }
+
+        if (!TryResolveCoordinate(request.EndLon, request.EndLat, out var endLon, out var endLat))
+        {
+            return StandardErrorHelpers.CreateBadRequest(
+                context,
+                "Slice 'endLon' and 'endLat' are required and must be finite WGS 84 coordinates within longitude [-180, 180] and latitude [-90, 90].");
+        }
+
+        if (request.SampleCount is { } sampleCount && sampleCount < 2)
+        {
+            return StandardErrorHelpers.CreateUnprocessableEntity(
+                context,
+                "'sampleCount' must be at least 2 when supplied.");
+        }
+
+        if (startLon == endLon && startLat == endLat)
+        {
+            return StandardErrorHelpers.CreateUnprocessableEntity(
+                context,
+                "Slice plane start and end must be distinct coordinates.");
+        }
+
+        var validation = await ValidateDatasetAsync(context, datasetId, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return validation.ErrorResult!;
+        }
+
+        var layer = validation.Layer!;
+        var mergeStrategy = RasterMosaicUtilities.ResolveMergeStrategy(layer.Metadata, request.MosaicRule);
+
+        using var activity = HonuaTelemetry.StartActivity("honua.elevation.slice");
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.Elevation);
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, "elevation.slice");
+        activity?.SetTag(HonuaTelemetry.Tags.LayerId, layer.Id);
+        activity?.SetTag(HonuaTelemetry.Tags.CollectionId, datasetId);
+
+        try
+        {
+            var result = await sceneService.ComputeSliceAsync(
+                layer.Id,
+                new SlicePlane
+                {
+                    StartLongitude = startLon,
+                    StartLatitude = startLat,
+                    EndLongitude = endLon,
+                    EndLatitude = endLat
+                },
+                request.SampleCount,
+                mergeStrategy,
+                cancellationToken);
+
+            activity?.SetTag("honua.elevation.slice_length_m", result.LengthMeters);
+            activity?.SetTag("honua.elevation.sample_count", result.SampleCount);
+
+            var response = BuildSliceResponse(datasetId, result, mergeStrategy);
+            return Results.Json(response, SceneAnalysisJsonContext.Default.SliceResponse, contentType: JsonContentType);
+        }
+        catch (ElevationQueryException ex)
+        {
+            HonuaTelemetry.RecordException(activity, ex);
+            return MapElevationException(context, ex);
+        }
+    }
+
+    private static bool TryResolveCoordinate(double? lon, double? lat, out double resolvedLon, out double resolvedLat)
+    {
+        resolvedLon = 0;
+        resolvedLat = 0;
+        if (lon is not { } x || lat is not { } y)
+        {
+            return false;
+        }
+
+        if (!double.IsFinite(x) || !double.IsFinite(y))
+        {
+            return false;
+        }
+
+        if (x < -180 || x > 180 || y < -90 || y > 90)
+        {
+            return false;
+        }
+
+        resolvedLon = x;
+        resolvedLat = y;
+        return true;
+    }
+
+    private static bool TryResolveHeight(double? height, out double resolvedHeight)
+    {
+        resolvedHeight = 0;
+        if (height is not { } value)
+        {
+            return true;
+        }
+
+        if (!double.IsFinite(value) || value < 0)
+        {
+            return false;
+        }
+
+        resolvedHeight = value;
+        return true;
+    }
+
+    private static Task<LayerValidationHelpers.LayerValidationResult> ValidateDatasetAsync(
+        HttpContext context,
+        string datasetId,
+        CancellationToken cancellationToken)
+    {
+        if (int.TryParse(datasetId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId))
+        {
+            return LayerValidationHelpers.ValidateLayerWithAccessAsync(
+                context,
+                layerId,
+                AccessScope.Read,
+                ServiceProtocols.Elevation,
+                cancellationToken);
+        }
+
+        return LayerValidationHelpers.ValidateCollectionWithAccessAsync(
+            context,
+            datasetId,
+            AccessScope.Read,
+            ServiceProtocols.Elevation,
+            cancellationToken);
+    }
+
+    private static IResult MapElevationException(HttpContext context, ElevationQueryException exception)
+        => exception.FailureKind switch
+        {
+            ElevationFailureKind.SourceUnavailable => StandardErrorHelpers.CreateNotFound(context, exception.Message),
+            ElevationFailureKind.UnsupportedCrs => StandardErrorHelpers.CreateUnprocessableEntity(context, exception.Message),
+            ElevationFailureKind.InvalidGeometry => StandardErrorHelpers.CreateUnprocessableEntity(context, exception.Message),
+            _ => StandardErrorHelpers.CreateBadRequest(context, exception.Message)
+        };
+
+    private static SunShadowResponse BuildSunShadowResponse(
+        string datasetId,
+        SunShadowResult result,
+        RasterMergeStrategy mergeStrategy)
+    {
+        var samples = new ShadowSampleDto[result.Samples.Length];
+        for (var i = 0; i < result.Samples.Length; i++)
+        {
+            var sample = result.Samples[i];
+            samples[i] = new ShadowSampleDto
+            {
+                Lon = sample.Longitude,
+                Lat = sample.Latitude,
+                DistanceMeters = sample.DistanceMeters,
+                TerrainElevation = sample.TerrainElevation,
+                RayElevation = sample.RayElevation
+            };
+        }
+
+        return new SunShadowResponse
+        {
+            DatasetId = datasetId,
+            LayerId = result.LayerId,
+            SolarPosition = new SolarPositionDto
+            {
+                AltitudeDegrees = result.SolarPosition.AltitudeDegrees,
+                AzimuthDegrees = result.SolarPosition.AzimuthDegrees,
+                DeclinationDegrees = result.SolarPosition.DeclinationDegrees,
+                EquationOfTimeMinutes = result.SolarPosition.EquationOfTimeMinutes,
+                HourAngleDegrees = result.SolarPosition.HourAngleDegrees,
+                AboveHorizon = result.SolarPosition.IsAboveHorizon
+            },
+            ShadowCast = result.ShadowCast,
+            NoShadowReason = result.NoShadowReason,
+            ObserverGroundElevation = result.ObserverGroundElevation,
+            ObserverTopElevation = result.ObserverTopElevation,
+            ShadowAzimuthDegrees = result.ShadowAzimuthDegrees,
+            ShadowLengthMeters = result.ShadowLengthMeters,
+            TipLon = result.TipLongitude,
+            TipLat = result.TipLatitude,
+            MosaicRule = FormatMergeStrategy(mergeStrategy),
+            Samples = samples
+        };
+    }
+
+    private static SliceResponse BuildSliceResponse(
+        string datasetId,
+        SliceResult result,
+        RasterMergeStrategy mergeStrategy)
+    {
+        var samples = new SliceSampleDto[result.Samples.Length];
+        for (var i = 0; i < result.Samples.Length; i++)
+        {
+            var sample = result.Samples[i];
+            samples[i] = new SliceSampleDto
+            {
+                Lon = sample.Longitude,
+                Lat = sample.Latitude,
+                DistanceMeters = sample.DistanceMeters,
+                Elevation = sample.Elevation
+            };
+        }
+
+        return new SliceResponse
+        {
+            DatasetId = datasetId,
+            LayerId = result.LayerId,
+            LengthMeters = result.LengthMeters,
+            SampleCount = result.SampleCount,
+            MinElevation = result.MinElevation,
+            MaxElevation = result.MaxElevation,
+            ReliefMeters = result.ReliefMeters,
+            HasNoDataSamples = result.HasNoDataSamples,
+            MosaicRule = FormatMergeStrategy(mergeStrategy),
+            Samples = samples
+        };
+    }
+
+    private static string FormatMergeStrategy(RasterMergeStrategy strategy) => strategy switch
+    {
+        RasterMergeStrategy.Newest => "newest",
+        RasterMergeStrategy.Oldest => "oldest",
+        RasterMergeStrategy.Average => "average",
+        RasterMergeStrategy.Max => "max",
+        RasterMergeStrategy.Min => "min",
+        _ => "newest"
+    };
+}

--- a/src/Honua.Server/Features/Protocols/Elevation/SceneAnalysisJsonContext.cs
+++ b/src/Honua.Server/Features/Protocols/Elevation/SceneAnalysisJsonContext.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Protocols.Elevation;
+
+[JsonSerializable(typeof(SunShadowRequest))]
+[JsonSerializable(typeof(SunShadowResponse))]
+[JsonSerializable(typeof(SolarPositionDto))]
+[JsonSerializable(typeof(ShadowSampleDto))]
+[JsonSerializable(typeof(ShadowSampleDto[]))]
+[JsonSerializable(typeof(SliceRequest))]
+[JsonSerializable(typeof(SliceResponse))]
+[JsonSerializable(typeof(SliceSampleDto))]
+[JsonSerializable(typeof(SliceSampleDto[]))]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.Never)]
+internal sealed partial class SceneAnalysisJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Protocols/Elevation/SceneAnalysisModels.cs
+++ b/src/Honua.Server/Features/Protocols/Elevation/SceneAnalysisModels.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Protocols.Elevation;
+
+/// <summary>
+/// Request body for a sun/shadow analysis.
+/// </summary>
+internal sealed record SunShadowRequest
+{
+    /// <summary>Observer longitude in WGS 84 decimal degrees.</summary>
+    [JsonPropertyName("observerLon")]
+    public double? ObserverLon { get; init; }
+
+    /// <summary>Observer latitude in WGS 84 decimal degrees.</summary>
+    [JsonPropertyName("observerLat")]
+    public double? ObserverLat { get; init; }
+
+    /// <summary>Height of the object casting the shadow, above the terrain, in meters.</summary>
+    [JsonPropertyName("observerHeight")]
+    public double? ObserverHeight { get; init; }
+
+    /// <summary>UTC instant for which the solar position is computed (ISO 8601).</summary>
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset? Timestamp { get; init; }
+
+    /// <summary>Maximum distance to trace the shadow ray, in meters.</summary>
+    [JsonPropertyName("maxShadowLengthMeters")]
+    public double? MaxShadowLengthMeters { get; init; }
+
+    /// <summary>Requested number of samples along the shadow ray.</summary>
+    [JsonPropertyName("sampleCount")]
+    public int? SampleCount { get; init; }
+
+    /// <summary>Optional mosaic rule override.</summary>
+    [JsonPropertyName("mosaicRule")]
+    public string? MosaicRule { get; init; }
+}
+
+/// <summary>
+/// Solar position metadata for a sun/shadow analysis.
+/// </summary>
+internal sealed record SolarPositionDto
+{
+    [JsonPropertyName("altitudeDegrees")]
+    public required double AltitudeDegrees { get; init; }
+
+    [JsonPropertyName("azimuthDegrees")]
+    public required double AzimuthDegrees { get; init; }
+
+    [JsonPropertyName("declinationDegrees")]
+    public required double DeclinationDegrees { get; init; }
+
+    [JsonPropertyName("equationOfTimeMinutes")]
+    public required double EquationOfTimeMinutes { get; init; }
+
+    [JsonPropertyName("hourAngleDegrees")]
+    public required double HourAngleDegrees { get; init; }
+
+    [JsonPropertyName("aboveHorizon")]
+    public required bool AboveHorizon { get; init; }
+}
+
+/// <summary>
+/// A single sample along the cast shadow ray.
+/// </summary>
+internal sealed record ShadowSampleDto
+{
+    [JsonPropertyName("lon")]
+    public required double Lon { get; init; }
+
+    [JsonPropertyName("lat")]
+    public required double Lat { get; init; }
+
+    [JsonPropertyName("distanceMeters")]
+    public required double DistanceMeters { get; init; }
+
+    [JsonPropertyName("terrainElevation")]
+    public double? TerrainElevation { get; init; }
+
+    [JsonPropertyName("rayElevation")]
+    public required double RayElevation { get; init; }
+}
+
+/// <summary>
+/// Response for a sun/shadow analysis.
+/// </summary>
+internal sealed record SunShadowResponse
+{
+    [JsonPropertyName("datasetId")]
+    public required string DatasetId { get; init; }
+
+    [JsonPropertyName("layerId")]
+    public required int LayerId { get; init; }
+
+    [JsonPropertyName("solarPosition")]
+    public required SolarPositionDto SolarPosition { get; init; }
+
+    [JsonPropertyName("shadowCast")]
+    public required bool ShadowCast { get; init; }
+
+    [JsonPropertyName("noShadowReason")]
+    public string? NoShadowReason { get; init; }
+
+    [JsonPropertyName("observerGroundElevation")]
+    public required double ObserverGroundElevation { get; init; }
+
+    [JsonPropertyName("observerTopElevation")]
+    public required double ObserverTopElevation { get; init; }
+
+    [JsonPropertyName("shadowAzimuthDegrees")]
+    public required double ShadowAzimuthDegrees { get; init; }
+
+    [JsonPropertyName("shadowLengthMeters")]
+    public required double ShadowLengthMeters { get; init; }
+
+    [JsonPropertyName("tipLon")]
+    public double? TipLon { get; init; }
+
+    [JsonPropertyName("tipLat")]
+    public double? TipLat { get; init; }
+
+    [JsonPropertyName("mosaicRule")]
+    public required string MosaicRule { get; init; }
+
+    [JsonPropertyName("samples")]
+    public required ShadowSampleDto[] Samples { get; init; }
+}
+
+/// <summary>
+/// Request body for a slice/volumetric cross-section analysis.
+/// </summary>
+internal sealed record SliceRequest
+{
+    /// <summary>Slice start longitude in WGS 84 decimal degrees.</summary>
+    [JsonPropertyName("startLon")]
+    public double? StartLon { get; init; }
+
+    /// <summary>Slice start latitude in WGS 84 decimal degrees.</summary>
+    [JsonPropertyName("startLat")]
+    public double? StartLat { get; init; }
+
+    /// <summary>Slice end longitude in WGS 84 decimal degrees.</summary>
+    [JsonPropertyName("endLon")]
+    public double? EndLon { get; init; }
+
+    /// <summary>Slice end latitude in WGS 84 decimal degrees.</summary>
+    [JsonPropertyName("endLat")]
+    public double? EndLat { get; init; }
+
+    /// <summary>Requested number of samples along the slice plane.</summary>
+    [JsonPropertyName("sampleCount")]
+    public int? SampleCount { get; init; }
+
+    /// <summary>Optional mosaic rule override.</summary>
+    [JsonPropertyName("mosaicRule")]
+    public string? MosaicRule { get; init; }
+}
+
+/// <summary>
+/// A single intersection sample along a slice plane.
+/// </summary>
+internal sealed record SliceSampleDto
+{
+    [JsonPropertyName("lon")]
+    public required double Lon { get; init; }
+
+    [JsonPropertyName("lat")]
+    public required double Lat { get; init; }
+
+    [JsonPropertyName("distanceMeters")]
+    public required double DistanceMeters { get; init; }
+
+    [JsonPropertyName("elevation")]
+    public double? Elevation { get; init; }
+}
+
+/// <summary>
+/// Response for a slice/volumetric cross-section analysis.
+/// </summary>
+internal sealed record SliceResponse
+{
+    [JsonPropertyName("datasetId")]
+    public required string DatasetId { get; init; }
+
+    [JsonPropertyName("layerId")]
+    public required int LayerId { get; init; }
+
+    [JsonPropertyName("lengthMeters")]
+    public required double LengthMeters { get; init; }
+
+    [JsonPropertyName("sampleCount")]
+    public required int SampleCount { get; init; }
+
+    [JsonPropertyName("minElevation")]
+    public double? MinElevation { get; init; }
+
+    [JsonPropertyName("maxElevation")]
+    public double? MaxElevation { get; init; }
+
+    [JsonPropertyName("reliefMeters")]
+    public double? ReliefMeters { get; init; }
+
+    [JsonPropertyName("hasNoDataSamples")]
+    public required bool HasNoDataSamples { get; init; }
+
+    [JsonPropertyName("mosaicRule")]
+    public required string MosaicRule { get; init; }
+
+    [JsonPropertyName("samples")]
+    public required SliceSampleDto[] Samples { get; init; }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -608,6 +608,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Protocols.Coverages.Multidimensional.MultidimensionalCoverageJsonContext.Default,
         Honua.Server.Features.Protocols.Zarr.ZarrJsonContext.Default,
         Honua.Server.Features.Protocols.SpatialAnalytics.Models.SpatialAnalyticsJsonContext.Default,
+        Honua.Server.Features.Protocols.Elevation.SceneAnalysisJsonContext.Default,
         Honua.Server.Features.Collaboration.Sessions.CollaborationSessionJsonContext.Default,
         Honua.Server.Features.Collaboration.FeatureLocks.FeatureLockJsonContext.Default,
         Honua.Core.Features.Authorization.Domain.OperatorAuthorizationJsonContext.Default,

--- a/tests/dotnet/Honua.Core.Tests/Features/Raster/SceneAnalysisServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Raster/SceneAnalysisServiceTests.cs
@@ -1,0 +1,422 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Raster;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Raster;
+
+/// <summary>
+/// Unit tests for the scene analysis math: NOAA solar position, sun/shadow
+/// casting, and slice cross-section. The solar position is pure math validated
+/// against published reference values. The DEM is modeled by a synthetic
+/// <see cref="IElevationService"/> stub (the same contract the real
+/// <c>PostgresElevationService</c> fulfills) so the surface analyses run
+/// deterministically without a live database.
+/// </summary>
+public sealed class SceneAnalysisServiceTests
+{
+    private const int LayerId = 7;
+
+    // ---- Solar position (NOAA) ----------------------------------------------
+
+    [UnitTest]
+    public void ComputeSolarPosition_EquatorEquinoxNoon_IsNearZenith()
+    {
+        // March equinox 2026, ~solar noon at longitude 0 (UTC noon at the prime
+        // meridian is close to local solar noon). The sun should be nearly
+        // overhead at the equator on an equinox.
+        var instant = new DateTimeOffset(2026, 3, 20, 12, 0, 0, TimeSpan.Zero);
+
+        var solar = SceneAnalysisService.ComputeSolarPosition(instant, longitude: 0, latitude: 0);
+
+        solar.AltitudeDegrees.Should().BeGreaterThan(87.0);
+        solar.AltitudeDegrees.Should().BeLessThanOrEqualTo(90.0);
+        solar.IsAboveHorizon.Should().BeTrue();
+        // Declination is near zero on the equinox.
+        solar.DeclinationDegrees.Should().BeApproximately(0.0, 1.0);
+    }
+
+    [UnitTest]
+    public void ComputeSolarPosition_JuneSolstice_DeclinationNearTropicOfCancer()
+    {
+        // On the June solstice the solar declination is at its maximum, ~+23.44.
+        var instant = new DateTimeOffset(2026, 6, 21, 12, 0, 0, TimeSpan.Zero);
+
+        var solar = SceneAnalysisService.ComputeSolarPosition(instant, longitude: 0, latitude: 0);
+
+        solar.DeclinationDegrees.Should().BeApproximately(23.44, 0.2);
+    }
+
+    [UnitTest]
+    public void ComputeSolarPosition_DecemberSolstice_DeclinationNearTropicOfCapricorn()
+    {
+        var instant = new DateTimeOffset(2026, 12, 21, 12, 0, 0, TimeSpan.Zero);
+
+        var solar = SceneAnalysisService.ComputeSolarPosition(instant, longitude: 0, latitude: 0);
+
+        solar.DeclinationDegrees.Should().BeApproximately(-23.44, 0.2);
+    }
+
+    [UnitTest]
+    public void ComputeSolarPosition_KnownReference_GreenwichSummerNoon()
+    {
+        // Reference: NOAA Solar Calculator for 2020-06-21 12:00 UTC at
+        // lat 51.4769, lon 0 (Greenwich). Solar noon there is ~12:01 UTC, so
+        // near noon the sun is high to the south (azimuth ~178-182, altitude
+        // ~61.5-62.0). Validate against those published bounds.
+        var instant = new DateTimeOffset(2020, 6, 21, 12, 0, 0, TimeSpan.Zero);
+
+        var solar = SceneAnalysisService.ComputeSolarPosition(instant, longitude: 0.0, latitude: 51.4769);
+
+        solar.AltitudeDegrees.Should().BeApproximately(61.9, 1.0);
+        solar.AzimuthDegrees.Should().BeInRange(170.0, 190.0);
+        solar.IsAboveHorizon.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void ComputeSolarPosition_Midnight_SunBelowHorizon()
+    {
+        // Local midnight at longitude 0: the sun is well below the horizon.
+        var instant = new DateTimeOffset(2026, 3, 20, 0, 0, 0, TimeSpan.Zero);
+
+        var solar = SceneAnalysisService.ComputeSolarPosition(instant, longitude: 0, latitude: 51.5);
+
+        solar.AltitudeDegrees.Should().BeLessThan(0.0);
+        solar.IsAboveHorizon.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void ComputeSolarPosition_AfternoonAzimuth_IsWesterly()
+    {
+        // Mid-afternoon at the equator: the sun has passed solar noon and should
+        // sit in the western half of the sky (azimuth > 180).
+        var instant = new DateTimeOffset(2026, 3, 20, 15, 0, 0, TimeSpan.Zero);
+
+        var solar = SceneAnalysisService.ComputeSolarPosition(instant, longitude: 0, latitude: 0);
+
+        solar.HourAngleDegrees.Should().BeGreaterThan(0.0);
+        solar.AzimuthDegrees.Should().BeInRange(180.0, 360.0);
+    }
+
+    [UnitTest]
+    public void ComputeSolarPosition_MorningAzimuth_IsEasterly()
+    {
+        var instant = new DateTimeOffset(2026, 3, 20, 9, 0, 0, TimeSpan.Zero);
+
+        var solar = SceneAnalysisService.ComputeSolarPosition(instant, longitude: 0, latitude: 0);
+
+        solar.HourAngleDegrees.Should().BeLessThan(0.0);
+        solar.AzimuthDegrees.Should().BeInRange(0.0, 180.0);
+    }
+
+    [UnitTest]
+    public void ToJulianDay_J2000Epoch_Is2451545()
+    {
+        // J2000.0 = 2000-01-01 12:00 TT ≈ Julian day 2451545.0.
+        var instant = new DateTimeOffset(2000, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+        var jd = SceneAnalysisService.ToJulianDay(instant);
+
+        jd.Should().BeApproximately(2451545.0, 1e-6);
+    }
+
+    // ---- Sun/shadow casting -------------------------------------------------
+
+    [UnitTest]
+    public async Task ComputeSunShadowAsync_SunBelowHorizon_ReportsNoShadow()
+    {
+        var service = new SceneAnalysisService(new FlatTerrainElevationService(elevation: 0));
+
+        // Local midnight at a high latitude => sun below horizon.
+        var result = await service.ComputeSunShadowAsync(
+            LayerId,
+            new ShadowObserver { Longitude = 0, Latitude = 51.5, HeightMeters = 10 },
+            new SunShadowOptions
+            {
+                InstantUtc = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                MaxShadowLengthMeters = 1000
+            },
+            RasterMergeStrategy.Newest);
+
+        result.ShadowCast.Should().BeFalse();
+        result.NoShadowReason.Should().NotBeNullOrEmpty();
+        result.ShadowLengthMeters.Should().Be(0);
+        result.Samples.Should().BeEmpty();
+        result.SolarPosition.IsAboveHorizon.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task ComputeSunShadowAsync_FlatGroundLowSun_CastsLongShadowAwayFromSun()
+    {
+        var service = new SceneAnalysisService(new FlatTerrainElevationService(elevation: 0));
+
+        // Late afternoon at the equator on the equinox: sun low in the west,
+        // shadow should fall toward the east and exceed the object height.
+        var result = await service.ComputeSunShadowAsync(
+            LayerId,
+            new ShadowObserver { Longitude = 0, Latitude = 0, HeightMeters = 10 },
+            new SunShadowOptions
+            {
+                InstantUtc = new DateTimeOffset(2026, 3, 20, 17, 30, 0, TimeSpan.Zero),
+                MaxShadowLengthMeters = 5000,
+                SampleCount = 256
+            },
+            RasterMergeStrategy.Newest);
+
+        result.ShadowCast.Should().BeTrue();
+        result.SolarPosition.IsAboveHorizon.Should().BeTrue();
+        // The sun is in the west (afternoon), so the shadow is cast to the east.
+        result.ShadowAzimuthDegrees.Should().BeInRange(0.0, 180.0);
+        // Low sun => shadow longer than the object's 10 m height.
+        result.ShadowLengthMeters.Should().BeGreaterThan(10.0);
+        result.ObserverTopElevation.Should().Be(10.0);
+        result.TipLongitude.Should().NotBeNull();
+        result.TipLatitude.Should().NotBeNull();
+    }
+
+    [UnitTest]
+    public async Task ComputeSunShadowAsync_ShadowLengthMatchesTrigOnFlatGround()
+    {
+        var service = new SceneAnalysisService(new FlatTerrainElevationService(elevation: 0));
+        var instant = new DateTimeOffset(2026, 3, 20, 8, 0, 0, TimeSpan.Zero);
+        const double height = 10.0;
+
+        var result = await service.ComputeSunShadowAsync(
+            LayerId,
+            new ShadowObserver { Longitude = 0, Latitude = 0, HeightMeters = height },
+            new SunShadowOptions
+            {
+                InstantUtc = instant,
+                MaxShadowLengthMeters = 20000,
+                SampleCount = 1024
+            },
+            RasterMergeStrategy.Newest);
+
+        result.ShadowCast.Should().BeTrue();
+
+        // On flat ground the shadow length L satisfies tan(altitude) = height / L.
+        var altitudeRad = result.SolarPosition.AltitudeDegrees * Math.PI / 180.0;
+        var expectedLength = height / Math.Tan(altitudeRad);
+
+        // Discretization tolerance: shadow is found at the nearest sample step.
+        result.ShadowLengthMeters.Should().BeApproximately(expectedLength, 100.0);
+    }
+
+    [UnitTest]
+    public async Task ComputeSunShadowAsync_RejectsNonPositiveMaxLength()
+    {
+        var service = new SceneAnalysisService(new FlatTerrainElevationService(elevation: 0));
+
+        var act = async () => await service.ComputeSunShadowAsync(
+            LayerId,
+            new ShadowObserver { Longitude = 0, Latitude = 0, HeightMeters = 10 },
+            new SunShadowOptions
+            {
+                InstantUtc = new DateTimeOffset(2026, 3, 20, 12, 0, 0, TimeSpan.Zero),
+                MaxShadowLengthMeters = 0
+            },
+            RasterMergeStrategy.Newest);
+
+        await act.Should().ThrowAsync<ElevationQueryException>();
+    }
+
+    // ---- Slice / volumetric -------------------------------------------------
+
+    [UnitTest]
+    public async Task ComputeSliceAsync_RampTerrain_ReturnsIntersectionMetadata()
+    {
+        // Terrain ramps from 0 m up to ~1000 m along the slice line.
+        var service = new SceneAnalysisService(new RampTerrainElevationService(
+            startElevation: 0,
+            endElevation: 1000));
+
+        var result = await service.ComputeSliceAsync(
+            LayerId,
+            new SlicePlane
+            {
+                StartLongitude = 0,
+                StartLatitude = 0,
+                EndLongitude = 0.1,
+                EndLatitude = 0
+            },
+            sampleCount: 50,
+            RasterMergeStrategy.Newest);
+
+        result.SampleCount.Should().Be(50);
+        result.Samples.Should().HaveCount(50);
+        result.LengthMeters.Should().BeGreaterThan(0);
+        result.MinElevation.Should().BeApproximately(0.0, 1.0);
+        result.MaxElevation.Should().BeApproximately(1000.0, 25.0);
+        result.ReliefMeters.Should().BeApproximately(result.MaxElevation!.Value - result.MinElevation!.Value, 1e-6);
+        result.HasNoDataSamples.Should().BeFalse();
+
+        // Samples are ordered by increasing distance from the slice start.
+        for (var i = 1; i < result.Samples.Length; i++)
+        {
+            result.Samples[i].DistanceMeters.Should().BeGreaterThanOrEqualTo(result.Samples[i - 1].DistanceMeters);
+        }
+
+        // Endpoints land on the requested coordinates.
+        result.Samples[0].Longitude.Should().BeApproximately(0.0, 1e-6);
+        result.Samples[^1].Longitude.Should().BeApproximately(0.1, 1e-3);
+    }
+
+    [UnitTest]
+    public async Task ComputeSliceAsync_NoDataSamples_AreFlagged()
+    {
+        var service = new SceneAnalysisService(new HoleTerrainElevationService(
+            baseElevation: 100,
+            holeStartMeters: 1000,
+            holeEndMeters: 2000));
+
+        var result = await service.ComputeSliceAsync(
+            LayerId,
+            new SlicePlane
+            {
+                StartLongitude = 0,
+                StartLatitude = 0,
+                EndLongitude = 0.1,
+                EndLatitude = 0
+            },
+            sampleCount: 64,
+            RasterMergeStrategy.Newest);
+
+        result.HasNoDataSamples.Should().BeTrue();
+        // No-data samples are excluded from min/max but the surrounding terrain
+        // still reports a valid extent.
+        result.MinElevation.Should().NotBeNull();
+        result.MaxElevation.Should().NotBeNull();
+        result.Samples.Should().Contain(s => !s.Elevation.HasValue);
+    }
+
+    [UnitTest]
+    public async Task ComputeSliceAsync_DegeneratePlane_Throws()
+    {
+        var service = new SceneAnalysisService(new FlatTerrainElevationService(elevation: 0));
+
+        var act = async () => await service.ComputeSliceAsync(
+            LayerId,
+            new SlicePlane
+            {
+                StartLongitude = 1,
+                StartLatitude = 1,
+                EndLongitude = 1,
+                EndLatitude = 1
+            },
+            sampleCount: 10,
+            RasterMergeStrategy.Newest);
+
+        await act.Should().ThrowAsync<ElevationQueryException>();
+    }
+
+    // ---- Test elevation service stubs ---------------------------------------
+
+    private abstract class TerrainElevationServiceBase : IElevationService
+    {
+        public Task<ElevationPointResult> QueryPointAsync(
+            int layerId, double x, double y, int? srid, RasterMergeStrategy mergeStrategy, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Point queries are not used by the scene analysis.");
+
+        public Task<ElevationProfileResult> QueryProfileAsync(
+            int layerId,
+            byte[] lineWkb,
+            int lineSrid,
+            ProfileSamplingOptions options,
+            RasterMergeStrategy mergeStrategy,
+            CancellationToken cancellationToken = default)
+        {
+            var (startLon, startLat, endLon, endLat) = DecodeLine(lineWkb);
+            var lengthMeters = HaversineMeters(startLon, startLat, endLon, endLat);
+
+            var sampleCount = options.SampleCount ?? options.DefaultSampleCount;
+            sampleCount = Math.Max(2, sampleCount);
+
+            var samples = new ElevationSample[sampleCount];
+            for (var i = 0; i < sampleCount; i++)
+            {
+                var fraction = (double)i / (sampleCount - 1);
+                var lon = startLon + (endLon - startLon) * fraction;
+                var lat = startLat + (endLat - startLat) * fraction;
+                var distance = fraction * lengthMeters;
+                var elevation = ElevationAt(lon, lat, distance);
+                samples[i] = new ElevationSample
+                {
+                    DistanceMeters = distance,
+                    Elevation = elevation,
+                    NoData = !elevation.HasValue
+                };
+            }
+
+            var result = new ElevationProfileResult
+            {
+                Samples = samples,
+                LineLengthMeters = lengthMeters,
+                SampleCount = sampleCount,
+                LayerId = layerId,
+                RasterIds = [1],
+                SourceSrid = 4326,
+                PixelType = "32BF",
+                NoDataValue = null,
+                VerticalUnit = null,
+                VerticalDatum = null,
+                IsAllNoData = samples.All(s => s.NoData)
+            };
+
+            return Task.FromResult(result);
+        }
+
+        protected abstract double? ElevationAt(double lon, double lat, double distanceFromStartMeters);
+
+        private static (double StartLon, double StartLat, double EndLon, double EndLat) DecodeLine(byte[] wkb)
+        {
+            var startLon = BitConverter.ToDouble(wkb, 9);
+            var startLat = BitConverter.ToDouble(wkb, 17);
+            var endLon = BitConverter.ToDouble(wkb, 25);
+            var endLat = BitConverter.ToDouble(wkb, 33);
+            return (startLon, startLat, endLon, endLat);
+        }
+
+        private static double HaversineMeters(double lon1, double lat1, double lon2, double lat2)
+        {
+            const double r = 6378137.0;
+            var phi1 = lat1 * Math.PI / 180.0;
+            var phi2 = lat2 * Math.PI / 180.0;
+            var dPhi = (lat2 - lat1) * Math.PI / 180.0;
+            var dLambda = (lon2 - lon1) * Math.PI / 180.0;
+            var a = Math.Sin(dPhi / 2) * Math.Sin(dPhi / 2)
+                + Math.Cos(phi1) * Math.Cos(phi2) * Math.Sin(dLambda / 2) * Math.Sin(dLambda / 2);
+            return r * 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+        }
+    }
+
+    private sealed class FlatTerrainElevationService(double elevation) : TerrainElevationServiceBase
+    {
+        protected override double? ElevationAt(double lon, double lat, double distanceFromStartMeters) => elevation;
+    }
+
+    private sealed class RampTerrainElevationService(double startElevation, double endElevation)
+        : TerrainElevationServiceBase
+    {
+        // Ramp keyed to longitude over the 0 -> 0.1 test path.
+        protected override double? ElevationAt(double lon, double lat, double distanceFromStartMeters)
+        {
+            var fraction = Math.Clamp(lon / 0.1, 0.0, 1.0);
+            return startElevation + (endElevation - startElevation) * fraction;
+        }
+    }
+
+    private sealed class HoleTerrainElevationService(
+        double baseElevation,
+        double holeStartMeters,
+        double holeEndMeters) : TerrainElevationServiceBase
+    {
+        protected override double? ElevationAt(double lon, double lat, double distanceFromStartMeters)
+            => distanceFromStartMeters >= holeStartMeters && distanceFromStartMeters <= holeEndMeters
+                ? null
+                : baseElevation;
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Raster/SceneAnalysisServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Raster/SceneAnalysisServiceTests.cs
@@ -224,6 +224,78 @@ public sealed class SceneAnalysisServiceTests
         await act.Should().ThrowAsync<ElevationQueryException>();
     }
 
+    [UnitTest]
+    public async Task ComputeSunShadowAsync_ObserverOnNoData_ThrowsAndFabricatesNothing()
+    {
+        // The observer point itself lands on a no-data pixel / outside coverage.
+        // The whole shadow is anchored on the observer ground elevation, so the
+        // request must fail explicitly rather than coerce the missing elevation
+        // to 0.0 and fabricate an observer top + shadow.
+        var service = new SceneAnalysisService(new ObserverNoDataElevationService(terrainElevation: 50));
+
+        var act = async () => await service.ComputeSunShadowAsync(
+            LayerId,
+            new ShadowObserver { Longitude = 0, Latitude = 0, HeightMeters = 10 },
+            new SunShadowOptions
+            {
+                // Late afternoon equinox: sun is up, so a shadow *would* be cast
+                // if the observer had a valid ground elevation.
+                InstantUtc = new DateTimeOffset(2026, 3, 20, 17, 30, 0, TimeSpan.Zero),
+                MaxShadowLengthMeters = 5000,
+                SampleCount = 256
+            },
+            RasterMergeStrategy.Newest);
+
+        var exception = await act.Should().ThrowAsync<ElevationQueryException>();
+        exception.Which.FailureKind.Should().Be(ElevationFailureKind.InvalidGeometry);
+    }
+
+    [UnitTest]
+    public async Task ComputeSunShadowAsync_ObserverOnNoDataAtNight_ThrowsBeforeFabricatingResult()
+    {
+        // Even when the sun is below the horizon (the early no-shadow return
+        // path), a no-data observer must not fabricate an observer ground/top
+        // elevation in the result.
+        var service = new SceneAnalysisService(new ObserverNoDataElevationService(terrainElevation: 50));
+
+        var act = async () => await service.ComputeSunShadowAsync(
+            LayerId,
+            new ShadowObserver { Longitude = 0, Latitude = 51.5, HeightMeters = 10 },
+            new SunShadowOptions
+            {
+                InstantUtc = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                MaxShadowLengthMeters = 1000
+            },
+            RasterMergeStrategy.Newest);
+
+        var exception = await act.Should().ThrowAsync<ElevationQueryException>();
+        exception.Which.FailureKind.Should().Be(ElevationFailureKind.InvalidGeometry);
+    }
+
+    [UnitTest]
+    public async Task ComputeSliceAsync_StartOnNoData_FlagsNoDataWithoutFabrication()
+    {
+        // The slice path must not fabricate elevation when the start (or any)
+        // sample is no-data: the missing sample stays null and is flagged.
+        var service = new SceneAnalysisService(new ObserverNoDataElevationService(terrainElevation: 50));
+
+        var result = await service.ComputeSliceAsync(
+            LayerId,
+            new SlicePlane
+            {
+                StartLongitude = 0,
+                StartLatitude = 0,
+                EndLongitude = 0.1,
+                EndLatitude = 0
+            },
+            sampleCount: 64,
+            RasterMergeStrategy.Newest);
+
+        result.HasNoDataSamples.Should().BeTrue();
+        // The first sample (the no-data start) is preserved as null, never 0.0.
+        result.Samples[0].Elevation.Should().BeNull();
+    }
+
     // ---- Slice / volumetric -------------------------------------------------
 
     [UnitTest]
@@ -407,6 +479,16 @@ public sealed class SceneAnalysisServiceTests
             var fraction = Math.Clamp(lon / 0.1, 0.0, 1.0);
             return startElevation + (endElevation - startElevation) * fraction;
         }
+    }
+
+    private sealed class ObserverNoDataElevationService(double terrainElevation)
+        : TerrainElevationServiceBase
+    {
+        // The first sample (the observer / slice start at distance 0) is
+        // no-data; the remaining terrain has a valid elevation. This models the
+        // observer landing on a no-data pixel or outside raster coverage.
+        protected override double? ElevationAt(double lon, double lat, double distanceFromStartMeters)
+            => distanceFromStartMeters <= 0 ? null : terrainElevation;
     }
 
     private sealed class HoleTerrainElevationService(

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/SceneAnalysisEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/SceneAnalysisEndpointTests.cs
@@ -1,0 +1,248 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Server.Tests.Features.Licensing;
+using Honua.Server.Tests.Infrastructure;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Protocols.Elevation;
+
+/// <summary>
+/// Integration coverage for the Pro-tier scene analysis endpoints (#1204):
+/// <c>POST /elevation/{datasetId}/sun-shadow</c> and
+/// <c>POST /elevation/{datasetId}/slice</c>. The sun/shadow + slice math itself
+/// is unit-tested in <c>Honua.Core.Tests</c>; these tests exercise the HTTP
+/// pipeline (license gate, validation, JSON contract) against a seeded DEM.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Elevation)]
+public sealed class SceneAnalysisEndpointTests : IAsyncLifetime
+{
+    private const double WebMercatorExtent = 20037508.342789244;
+
+    private readonly WebAppFixture _fixture = new WebAppFixture()
+        .WithTestLicense(HonuaEdition.Pro);
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /elevation/{datasetId}/sun-shadow")]
+    public async Task PostSunShadow_DaytimeSun_CastsShadowOverSurface()
+    {
+        await SeedFullWorldRasterAsync(0);
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/sun-shadow",
+            new
+            {
+                observerLon = 0.0,
+                observerLat = 0.0,
+                observerHeight = 25.0,
+                timestamp = "2026-03-20T08:00:00Z",
+                maxShadowLengthMeters = 20000.0,
+                sampleCount = 256
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+
+        root.GetProperty("datasetId").GetString().Should().Be("0");
+        root.GetProperty("shadowCast").GetBoolean().Should().BeTrue();
+        root.GetProperty("solarPosition").GetProperty("aboveHorizon").GetBoolean().Should().BeTrue();
+        root.GetProperty("solarPosition").GetProperty("altitudeDegrees").GetDouble().Should().BeGreaterThan(0);
+        root.GetProperty("shadowLengthMeters").GetDouble().Should().BeGreaterThan(0);
+        root.GetProperty("observerTopElevation").GetDouble().Should().BeApproximately(25.0, 0.0001);
+        root.GetProperty("samples").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /elevation/{datasetId}/sun-shadow")]
+    public async Task PostSunShadow_SunBelowHorizon_ReportsNoShadow()
+    {
+        await SeedFullWorldRasterAsync(0);
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/sun-shadow",
+            new
+            {
+                observerLon = 0.0,
+                observerLat = 51.5,
+                observerHeight = 10.0,
+                // Local midnight at longitude 0 in winter => sun below horizon.
+                timestamp = "2026-01-01T00:00:00Z",
+                maxShadowLengthMeters = 1000.0
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+
+        root.GetProperty("shadowCast").GetBoolean().Should().BeFalse();
+        root.GetProperty("solarPosition").GetProperty("aboveHorizon").GetBoolean().Should().BeFalse();
+        root.GetProperty("shadowLengthMeters").GetDouble().Should().Be(0);
+        root.GetProperty("noShadowReason").GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /elevation/{datasetId}/sun-shadow")]
+    public async Task PostSunShadow_MissingTimestamp_ReturnsBadRequest()
+    {
+        await SeedFullWorldRasterAsync(0);
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/sun-shadow",
+            new
+            {
+                observerLon = 0.0,
+                observerLat = 0.0,
+                maxShadowLengthMeters = 1000.0
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /elevation/{datasetId}/sun-shadow")]
+    public async Task PostSunShadow_WithoutProLicense_ReturnsPaymentRequired()
+    {
+        await using var community = new WebAppFixture().WithTestLicense(HonuaEdition.Community);
+        await community.InitializeAsync();
+
+        var response = await community.Client.PostAsJsonAsync(
+            "/elevation/0/sun-shadow",
+            new
+            {
+                observerLon = 0.0,
+                observerLat = 0.0,
+                observerHeight = 10.0,
+                timestamp = "2026-03-20T12:00:00Z",
+                maxShadowLengthMeters = 1000.0
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /elevation/{datasetId}/slice")]
+    public async Task PostSlice_OverSurface_ReturnsIntersectionMetadata()
+    {
+        await SeedFullWorldRasterAsync(123.0);
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/slice",
+            new
+            {
+                startLon = 0.0,
+                startLat = 0.0,
+                endLon = 1.0,
+                endLat = 1.0,
+                sampleCount = 25
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+
+        root.GetProperty("datasetId").GetString().Should().Be("0");
+        root.GetProperty("layerId").GetInt32().Should().Be(0);
+        root.GetProperty("sampleCount").GetInt32().Should().Be(25);
+        root.GetProperty("lengthMeters").GetDouble().Should().BeGreaterThan(0);
+        root.GetProperty("minElevation").GetDouble().Should().BeApproximately(123.0, 0.0001);
+        root.GetProperty("maxElevation").GetDouble().Should().BeApproximately(123.0, 0.0001);
+        root.GetProperty("reliefMeters").GetDouble().Should().BeApproximately(0.0, 0.0001);
+        root.GetProperty("hasNoDataSamples").GetBoolean().Should().BeFalse();
+
+        var samples = root.GetProperty("samples");
+        samples.GetArrayLength().Should().Be(25);
+
+        double previousDistance = -1;
+        foreach (var sample in samples.EnumerateArray())
+        {
+            var distance = sample.GetProperty("distanceMeters").GetDouble();
+            distance.Should().BeGreaterThanOrEqualTo(previousDistance);
+            previousDistance = distance;
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /elevation/{datasetId}/slice")]
+    public async Task PostSlice_DegeneratePlane_ReturnsUnprocessableEntity()
+    {
+        await SeedFullWorldRasterAsync(0);
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/slice",
+            new
+            {
+                startLon = 0.0,
+                startLat = 0.0,
+                endLon = 0.0,
+                endLat = 0.0,
+                sampleCount = 10
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /elevation/{datasetId}/slice")]
+    public async Task PostSlice_WithoutProLicense_ReturnsPaymentRequired()
+    {
+        await using var community = new WebAppFixture().WithTestLicense(HonuaEdition.Community);
+        await community.InitializeAsync();
+
+        var response = await community.Client.PostAsJsonAsync(
+            "/elevation/0/slice",
+            new
+            {
+                startLon = 0.0,
+                startLat = 0.0,
+                endLon = 1.0,
+                endLat = 1.0
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+    }
+
+    private Task SeedFullWorldRasterAsync(double elevationMeters)
+        => RasterIntegrationTestData.ReplaceLayerRastersAsync(
+            _fixture,
+            WebAppFixture.TestLayerId,
+            new RasterSeed(
+                Name: "world-dem",
+                Width: 2,
+                Height: 2,
+                UpperLeftX: -WebMercatorExtent,
+                UpperLeftY: WebMercatorExtent,
+                ScaleX: WebMercatorExtent,
+                ScaleY: -WebMercatorExtent,
+                Value: elevationMeters,
+                AcquisitionDate: RasterIntegrationTestData.WestAcquisition,
+                CreatedAt: RasterIntegrationTestData.WestAcquisition,
+                Srid: 3857));
+}


### PR DESCRIPTION
## Issue Link
Fixes #1204

## Summary
Completes the core 3D analysis suite alongside line-of-sight/viewshed: sun/shadow analysis (NOAA solar position → shadow extent cast against the elevation surface) and slice/volumetric cross-section analysis. Pro edition, server-only. Part of Epic #530.

## Changes Made
- `SceneAnalysisService` (Honua.Core, DB-free): NOAA solar-position model (declination, equation of time, hour angle → altitude/azimuth) from date/time + lat/lon; shadow extent over the elevation surface; vertical slice-plane intersection with the DEM (profile + min/max/relief/length).
- `POST /elevation/{datasetId}/sun-shadow` and `POST /elevation/{datasetId}/slice` endpoints.
- Pro `LicenseGate` entitlements `analytics.sun-shadow` / `analytics.slice`; source-generated JSON.
- 27 tests: 15 core (solar position validated vs published NOAA references, shadow trig, slice metadata, degenerate-plane guards), 7 endpoint, 5 registry-drift.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

> Note: solar altitude is geometric (no atmospheric-refraction correction); surface-based slice (full 3D-Tiles mesh slicing out of scope per issue). Branch is based on a trunk-ancestor and behind trunk tip (clean single-commit diff; may need rebase). Build verified locally (Release, warnings-as-errors); `dotnet format --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
