### PR TITLE
feat(scene): attribute-driven 3D symbology engine for 3D Tiles generation (#1206 server)

### DIFF
--- a/src/Honua.Core/Features/Catalog/Domain/CatalogJsonContext.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/CatalogJsonContext.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Serialization;
 using System.Text.Json;
+using Honua.Core.Features.Scene.Domain;
 using Honua.Core.Features.Security.Domain;
 
 namespace Honua.Core.Features.Catalog.Domain;
@@ -16,6 +17,8 @@ namespace Honua.Core.Features.Catalog.Domain;
 [JsonSerializable(typeof(LayerTimeInfo))]
 [JsonSerializable(typeof(LayerPermanentFilter))]
 [JsonSerializable(typeof(LayerExtrusionInfo))]
+[JsonSerializable(typeof(Symbology3D))]
+[JsonSerializable(typeof(Symbology3DRule))]
 [JsonSerializable(typeof(MapServerConfig))]
 [JsonSerializable(typeof(RasterMosaicSettings))]
 [JsonSerializable(typeof(StacCatalogMetadata))]

--- a/src/Honua.Core/Features/Catalog/Domain/CatalogMetadata.cs
+++ b/src/Honua.Core/Features/Catalog/Domain/CatalogMetadata.cs
@@ -51,6 +51,16 @@ public sealed record CatalogMetadata
     public LayerExtrusionInfo? Extrusion { get; init; }
 
     /// <summary>
+    /// Optional attribute-driven 3D symbology for scene / 3D Tiles generation.
+    /// Null for layers with no thematic 3D styling; the generator then bakes a
+    /// plain opaque-white material. When present, the generator bakes the
+    /// resolved per-feature color into the tile content and emits the
+    /// equivalent <c>3d-tiles-styling</c> style-metadata contract alongside the
+    /// tileset.
+    /// </summary>
+    public Honua.Core.Features.Scene.Domain.Symbology3D? Symbology3D { get; init; }
+
+    /// <summary>
     /// Optional operator-managed filter that is always applied to public feature output.
     /// </summary>
     public LayerPermanentFilter? PermanentFilter { get; init; }

--- a/src/Honua.Core/Features/Scene/Domain/Symbology3D.cs
+++ b/src/Honua.Core/Features/Scene/Domain/Symbology3D.cs
@@ -1,0 +1,332 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+
+namespace Honua.Core.Features.Scene.Domain;
+
+/// <summary>
+/// Attribute-driven 3D symbology configuration stored with a feature layer
+/// definition and consumed by the 3D Tiles generation pipeline.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the authoring-side model: an operator supplies a default material
+/// (base color + opacity) plus an ordered set of <see cref="Rules"/> that
+/// recolor / dim / hide features based on a single attribute condition each.
+/// The generator both bakes the resolved per-feature color into the emitted
+/// GLB (vertex <c>COLOR_0</c> + a <c>baseColorFactor</c> material) and projects
+/// the equivalent declarative expression into the tileset's
+/// <see cref="TileStyleSpec"/> so a client runtime (CesiumJS 3D Tiles Styling)
+/// can re-evaluate the rules dynamically.
+/// </para>
+/// <para>
+/// Rules are evaluated in declaration order; the FIRST rule whose condition
+/// matches a feature wins (last-write-wins is intentionally avoided so the
+/// authoring order maps cleanly onto the ordered <c>conditions</c> array of the
+/// 3D Tiles Styling expression language). When no rule matches, the
+/// <see cref="DefaultColor"/> / <see cref="DefaultOpacity"/> apply.
+/// </para>
+/// </remarks>
+public sealed record Symbology3D
+{
+    /// <summary>
+    /// Default base color applied to features that match no rule. When null,
+    /// the generator falls back to opaque white so the tileset is always
+    /// renderable.
+    /// </summary>
+    public Symbology3DColor? DefaultColor { get; init; }
+
+    /// <summary>
+    /// Default opacity in [0, 1] applied to features that match no rule and
+    /// to rules that omit an explicit opacity. Null is treated as fully opaque.
+    /// </summary>
+    public double? DefaultOpacity { get; init; }
+
+    /// <summary>
+    /// Ordered attribute-driven rules. The first matching rule wins.
+    /// </summary>
+    public IReadOnlyList<Symbology3DRule> Rules { get; init; } = [];
+}
+
+/// <summary>
+/// One attribute-driven symbology rule: when the feature's
+/// <see cref="Attribute"/> satisfies the <see cref="Comparison"/> against
+/// <see cref="Value"/>, the rule contributes its color / opacity / visibility.
+/// </summary>
+public sealed record Symbology3DRule
+{
+    /// <summary>
+    /// Source attribute (feature field) name the condition is evaluated
+    /// against. Matched case-insensitively against the feature's attribute bag.
+    /// </summary>
+    public required string Attribute { get; init; }
+
+    /// <summary>Comparison operator applied between the attribute and <see cref="Value"/>.</summary>
+    public Symbology3DComparison Comparison { get; init; } = Symbology3DComparison.Equals;
+
+    /// <summary>
+    /// Right-hand comparison operand. Numeric comparisons parse this as a
+    /// number; equality/inequality fall back to ordinal string comparison when
+    /// either side is non-numeric.
+    /// </summary>
+    public string? Value { get; init; }
+
+    /// <summary>Color applied when the rule matches. Null leaves the color unchanged.</summary>
+    public Symbology3DColor? Color { get; init; }
+
+    /// <summary>Opacity in [0, 1] applied when the rule matches. Null inherits the default.</summary>
+    public double? Opacity { get; init; }
+
+    /// <summary>
+    /// Visibility applied when the rule matches. Null means "visible". A false
+    /// value hides the feature (maps onto the 3D Tiles Styling <c>show</c>
+    /// expression).
+    /// </summary>
+    public bool? Visible { get; init; }
+}
+
+/// <summary>
+/// Comparison operators supported by an attribute-driven symbology rule. The
+/// set is deliberately a subset of the 3D Tiles Styling expression operators
+/// so every rule maps onto a single emittable condition expression.
+/// </summary>
+public enum Symbology3DComparison
+{
+    /// <summary>Attribute equals the operand (numeric, else ordinal string).</summary>
+    Equals,
+
+    /// <summary>Attribute does not equal the operand.</summary>
+    NotEquals,
+
+    /// <summary>Attribute is numerically greater than the operand.</summary>
+    GreaterThan,
+
+    /// <summary>Attribute is numerically greater than or equal to the operand.</summary>
+    GreaterThanOrEqual,
+
+    /// <summary>Attribute is numerically less than the operand.</summary>
+    LessThan,
+
+    /// <summary>Attribute is numerically less than or equal to the operand.</summary>
+    LessThanOrEqual
+}
+
+/// <summary>
+/// An sRGB color with 8-bit channels. Stored as discrete channels (rather than
+/// a packed hex string) so the value is unambiguous across the .NET authoring
+/// side and the JavaScript runtime, and so it can be baked directly into a glTF
+/// normalized <c>COLOR_0</c> attribute without string parsing.
+/// </summary>
+public readonly record struct Symbology3DColor(byte Red, byte Green, byte Blue)
+{
+    /// <summary>Opaque white — the renderable fallback when no color is configured.</summary>
+    public static Symbology3DColor White => new(255, 255, 255);
+
+    /// <summary>
+    /// Emits the CSS-style hex literal (<c>#rrggbb</c>) consumed by the
+    /// 3D Tiles Styling <c>color()</c> expression.
+    /// </summary>
+    public string ToHex() => string.Create(
+        7,
+        this,
+        static (span, color) =>
+        {
+            span[0] = '#';
+            WriteHexByte(span, 1, color.Red);
+            WriteHexByte(span, 3, color.Green);
+            WriteHexByte(span, 5, color.Blue);
+        });
+
+    private static void WriteHexByte(Span<char> span, int index, byte value)
+    {
+        const string Hex = "0123456789abcdef";
+        span[index] = Hex[value >> 4];
+        span[index + 1] = Hex[value & 0x0F];
+    }
+}
+
+/// <summary>
+/// The resolved symbology for a single feature after evaluating a
+/// <see cref="Symbology3D"/> against that feature's attributes.
+/// </summary>
+public readonly record struct ResolvedSymbology(Symbology3DColor Color, double Opacity, bool Visible)
+{
+    /// <summary>
+    /// The default resolved symbology (opaque white, visible) used when no
+    /// symbology is configured for a layer.
+    /// </summary>
+    public static ResolvedSymbology Default => new(Symbology3DColor.White, 1.0, true);
+}
+
+/// <summary>
+/// Pure, DB-free resolver that evaluates a <see cref="Symbology3D"/> against a
+/// feature's attributes. Shared by the generator (to bake per-feature color)
+/// and by tests; carries no I/O so it is freely unit-testable.
+/// </summary>
+public static class Symbology3DResolver
+{
+    /// <summary>
+    /// Resolves the color / opacity / visibility for a single feature. The
+    /// first matching rule wins; unmatched features take the configured
+    /// defaults (falling back to opaque white when no default is set).
+    /// </summary>
+    public static ResolvedSymbology Resolve(
+        Symbology3D? symbology,
+        IReadOnlyDictionary<string, object?> attributes)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+
+        var color = symbology?.DefaultColor ?? Symbology3DColor.White;
+        var opacity = ClampOpacity(symbology?.DefaultOpacity ?? 1.0);
+        var visible = true;
+
+        if (symbology?.Rules is { Count: > 0 } rules)
+        {
+            foreach (var rule in rules)
+            {
+                if (!Matches(rule, attributes))
+                {
+                    continue;
+                }
+
+                if (rule.Color is { } ruleColor)
+                {
+                    color = ruleColor;
+                }
+                if (rule.Opacity is { } ruleOpacity)
+                {
+                    opacity = ClampOpacity(ruleOpacity);
+                }
+                if (rule.Visible is { } ruleVisible)
+                {
+                    visible = ruleVisible;
+                }
+
+                // First match wins so the resolved state aligns with the
+                // ordered conditions array emitted into the style spec.
+                break;
+            }
+        }
+
+        return new ResolvedSymbology(color, opacity, visible);
+    }
+
+    /// <summary>
+    /// Evaluates a single rule's condition against a feature's attributes.
+    /// </summary>
+    public static bool Matches(Symbology3DRule rule, IReadOnlyDictionary<string, object?> attributes)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        ArgumentNullException.ThrowIfNull(attributes);
+
+        var raw = LookupAttribute(attributes, rule.Attribute);
+
+        var leftIsNumber = TryToDouble(raw, out var left);
+        var rightIsNumber = TryParseDouble(rule.Value, out var right);
+
+        // Numeric path when both operands are numeric — covers all ordered
+        // comparisons and numeric (in)equality.
+        if (leftIsNumber && rightIsNumber)
+        {
+            return rule.Comparison switch
+            {
+                Symbology3DComparison.Equals => left == right,
+                Symbology3DComparison.NotEquals => left != right,
+                Symbology3DComparison.GreaterThan => left > right,
+                Symbology3DComparison.GreaterThanOrEqual => left >= right,
+                Symbology3DComparison.LessThan => left < right,
+                Symbology3DComparison.LessThanOrEqual => left <= right,
+                _ => false
+            };
+        }
+
+        // Ordered comparisons require numeric operands; a non-numeric side
+        // can never satisfy them.
+        if (rule.Comparison is not (Symbology3DComparison.Equals or Symbology3DComparison.NotEquals))
+        {
+            return false;
+        }
+
+        // String (in)equality fallback. A null attribute compares equal only
+        // to a null/empty operand.
+        var leftText = raw?.ToString();
+        var equal = string.Equals(leftText, rule.Value, StringComparison.Ordinal)
+            || (string.IsNullOrEmpty(leftText) && string.IsNullOrEmpty(rule.Value));
+        return rule.Comparison == Symbology3DComparison.Equals ? equal : !equal;
+    }
+
+    private static object? LookupAttribute(IReadOnlyDictionary<string, object?> attributes, string name)
+    {
+        if (attributes.TryGetValue(name, out var value))
+        {
+            return value;
+        }
+
+        // Feature attribute bags are typically ordinal-keyed; fall back to a
+        // case-insensitive scan so authoring-side casing does not silently
+        // drop a rule.
+        foreach (var pair in attributes)
+        {
+            if (string.Equals(pair.Key, name, StringComparison.OrdinalIgnoreCase))
+            {
+                return pair.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private static double ClampOpacity(double value)
+    {
+        if (double.IsNaN(value))
+        {
+            return 1.0;
+        }
+        return Math.Clamp(value, 0.0, 1.0);
+    }
+
+    private static bool TryToDouble(object? value, out double result)
+    {
+        switch (value)
+        {
+            case null:
+                result = 0;
+                return false;
+            case double d:
+                result = d;
+                return true;
+            case float f:
+                result = f;
+                return true;
+            case int i:
+                result = i;
+                return true;
+            case long l:
+                result = l;
+                return true;
+            case short s:
+                result = s;
+                return true;
+            case decimal m:
+                result = (double)m;
+                return true;
+            case string str:
+                return TryParseDouble(str, out result);
+            default:
+                result = 0;
+                return false;
+        }
+    }
+
+    private static bool TryParseDouble(string? text, out double result)
+    {
+        if (!string.IsNullOrEmpty(text)
+            && double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out result))
+        {
+            return true;
+        }
+        result = 0;
+        return false;
+    }
+}

--- a/src/Honua.Core/Features/Scene/Domain/TileStyleSpec.cs
+++ b/src/Honua.Core/Features/Scene/Domain/TileStyleSpec.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Scene.Domain;
+
+/// <summary>
+/// The style-metadata contract emitted alongside a generated 3D Tiles tileset.
+/// This is the stable shape the JavaScript client consumes to apply
+/// attribute-driven symbology at runtime.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The document is a thin, deliberately-stable wrapper around the
+/// <see href="https://github.com/CesiumGS/3d-tiles/tree/main/specification/Styling">
+/// 3D Tiles Styling expression language</see>. The <see cref="Style"/> block is
+/// directly assignable to a CesiumJS <c>Cesium3DTileStyle</c> (its
+/// <see cref="TileStyleExpressions.Color"/> and <see cref="TileStyleExpressions.Show"/>
+/// strings ARE the styling expressions). The wrapper adds an explicit
+/// <see cref="Version"/>, the resolved <see cref="DefaultMaterial"/> the server
+/// already baked into the GLB, and the <see cref="Encoding"/> tag so the client
+/// can branch on the symbology contract version without sniffing the GLB.
+/// </para>
+/// <para>
+/// Determinism: the document contains no dictionaries; all collections are
+/// ordered lists written in authoring order, so serialization is byte-stable
+/// across runs given identical input.
+/// </para>
+/// </remarks>
+public sealed class TileStyleSpec
+{
+    /// <summary>
+    /// Encoding discriminator. Always <c>3d-tiles-styling</c> — the recognized
+    /// encoding this contract finally gives an engine to.
+    /// </summary>
+    [JsonPropertyName("encoding")]
+    public string Encoding { get; set; } = TileStyleSpecDefaults.Encoding;
+
+    /// <summary>Contract version. Bumped when the emitted shape changes.</summary>
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = TileStyleSpecDefaults.Version;
+
+    /// <summary>
+    /// The default material the server baked into the tile content. The client
+    /// can use this for legends or non-3D-Tiles fallbacks; it is already
+    /// reflected in the GLB so a viewer that ignores the style block still
+    /// renders the intended base color.
+    /// </summary>
+    [JsonPropertyName("defaultMaterial")]
+    public TileStyleMaterial DefaultMaterial { get; set; } = new();
+
+    /// <summary>
+    /// The 3D Tiles Styling expression block. Directly assignable to a
+    /// CesiumJS <c>Cesium3DTileStyle</c>.
+    /// </summary>
+    [JsonPropertyName("style")]
+    public TileStyleExpressions Style { get; set; } = new();
+}
+
+/// <summary>
+/// Resolved default material baked into the generated tile content.
+/// </summary>
+public sealed class TileStyleMaterial
+{
+    /// <summary>Base color as a CSS hex literal, e.g. <c>#ffffff</c>.</summary>
+    [JsonPropertyName("color")]
+    public string Color { get; set; } = Symbology3DColor.White.ToHex();
+
+    /// <summary>Opacity in [0, 1].</summary>
+    [JsonPropertyName("opacity")]
+    public double Opacity { get; set; } = 1.0;
+}
+
+/// <summary>
+/// 3D Tiles Styling expression block. The <see cref="Color"/> and
+/// <see cref="Show"/> strings are styling expressions (conditions on
+/// <c>${attribute}</c>) per the 3D Tiles Styling spec.
+/// </summary>
+public sealed class TileStyleExpressions
+{
+    /// <summary>
+    /// A <c>color</c> conditions expression. Omitted when no attribute-driven
+    /// color rules are configured (the baked GLB color then stands alone).
+    /// </summary>
+    [JsonPropertyName("color")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public TileStyleConditions? Color { get; set; }
+
+    /// <summary>
+    /// A <c>show</c> conditions expression controlling per-feature visibility.
+    /// Omitted when no visibility rules are configured.
+    /// </summary>
+    [JsonPropertyName("show")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public TileStyleConditions? Show { get; set; }
+}
+
+/// <summary>
+/// A 3D Tiles Styling <c>conditions</c> expression: an ordered list of
+/// [test-expression, result-expression] pairs evaluated top-to-bottom. The
+/// shape mirrors the spec's <c>{"conditions": [[cond, value], ...]}</c> form.
+/// </summary>
+public sealed class TileStyleConditions
+{
+    /// <summary>
+    /// Ordered condition pairs. Each entry is exactly a two-element array:
+    /// index 0 is the boolean test expression, index 1 is the result
+    /// expression returned for the first matching test.
+    /// </summary>
+    [JsonPropertyName("conditions")]
+    public IReadOnlyList<string[]> Conditions { get; set; } = [];
+}
+
+/// <summary>Stable defaults for the style-metadata contract.</summary>
+public static class TileStyleSpecDefaults
+{
+    /// <summary>Recognized encoding discriminator for the 3D symbology contract.</summary>
+    public const string Encoding = "3d-tiles-styling";
+
+    /// <summary>Current contract version.</summary>
+    public const string Version = "1.0";
+
+    /// <summary>Conventional file name the generator writes the spec to.</summary>
+    public const string FileName = "style.json";
+}
+
+/// <summary>
+/// Source-generated JSON serialization context for the 3D symbology
+/// style-metadata contract. Deterministic, AOT-safe, no reflection.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(TileStyleSpec))]
+[JsonSerializable(typeof(TileStyleMaterial))]
+[JsonSerializable(typeof(TileStyleExpressions))]
+[JsonSerializable(typeof(TileStyleConditions))]
+public sealed partial class TileStyleSpecJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Core/Features/Scene/Domain/TilesetDocument.cs
+++ b/src/Honua.Core/Features/Scene/Domain/TilesetDocument.cs
@@ -22,6 +22,47 @@ public sealed class TilesetDocument
     /// <summary>Root tile.</summary>
     [JsonPropertyName("root")]
     public TileNode Root { get; set; } = new();
+
+    /// <summary>
+    /// Tileset-level non-normative metadata. v1 uses the <c>extras</c> block to
+    /// advertise the attribute-driven 3D symbology style-metadata contract
+    /// (<c>honua_style</c>) so a client can discover and fetch the
+    /// <c>style.json</c> sidecar without sniffing the GLB.
+    /// </summary>
+    [JsonPropertyName("extras")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public TilesetExtras? Extras { get; set; }
+}
+
+/// <summary>
+/// Tileset <c>extras</c> block carrying Honua-specific discovery metadata.
+/// </summary>
+public sealed class TilesetExtras
+{
+    /// <summary>
+    /// Reference to the emitted 3D symbology style-metadata contract.
+    /// </summary>
+    [JsonPropertyName("honua_style")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public TilesetStyleReference? Style { get; set; }
+}
+
+/// <summary>
+/// Pointer the client uses to locate and version the style-metadata contract.
+/// </summary>
+public sealed class TilesetStyleReference
+{
+    /// <summary>Encoding discriminator, always <c>3d-tiles-styling</c>.</summary>
+    [JsonPropertyName("encoding")]
+    public string Encoding { get; set; } = string.Empty;
+
+    /// <summary>Style-metadata contract version.</summary>
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = string.Empty;
+
+    /// <summary>Relative URI of the style spec sidecar (e.g. <c>style.json</c>).</summary>
+    [JsonPropertyName("uri")]
+    public string Uri { get; set; } = string.Empty;
 }
 
 /// <summary>
@@ -103,6 +144,8 @@ public sealed class TileContent
 [JsonSerializable(typeof(BoundingVolume))]
 [JsonSerializable(typeof(TileContent))]
 [JsonSerializable(typeof(TilesetAsset))]
+[JsonSerializable(typeof(TilesetExtras))]
+[JsonSerializable(typeof(TilesetStyleReference))]
 public sealed partial class TilesetJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Core/Features/Scene/Generation/GeometryTileBuilder.cs
+++ b/src/Honua.Core/Features/Scene/Generation/GeometryTileBuilder.cs
@@ -49,13 +49,23 @@ public static class GeometryTileBuilder
     /// <param name="extrusion">Optional extrusion that converts polygons into vertical prisms.</param>
     /// <param name="generatorTag">Optional generator label (omitted when null/empty).</param>
     /// <param name="warnings">Optional sink for non-fatal coercion warnings (e.g., int64 → int32 clamping).</param>
+    /// <param name="perFeatureSymbology">
+    /// Optional resolved per-feature symbology, indexed parallel to
+    /// <paramref name="features"/>. When supplied, the builder bakes the
+    /// resolved RGBA color into a normalized <c>COLOR_0</c> vertex attribute and
+    /// switches the primitive material to a metallic-roughness material with a
+    /// neutral <c>baseColorFactor</c> so per-vertex colors multiply through.
+    /// When null the builder emits the legacy single double-sided white
+    /// material with no vertex colors.
+    /// </param>
     /// <returns>A deterministic GLB byte sequence.</returns>
     public static byte[] BuildGlb(
         IReadOnlyList<SceneFeature> features,
         IReadOnlyList<SceneAttributeSchema> metadataAttributes,
         LayerExtrusionInfo? extrusion,
         string? generatorTag = null,
-        IList<string>? warnings = null)
+        IList<string>? warnings = null,
+        IReadOnlyList<ResolvedSymbology>? perFeatureSymbology = null)
     {
         ArgumentNullException.ThrowIfNull(features);
         ArgumentNullException.ThrowIfNull(metadataAttributes);
@@ -63,6 +73,13 @@ public static class GeometryTileBuilder
         if (features.Count == 0)
         {
             throw new ArgumentException("At least one feature is required to build a tile.", nameof(features));
+        }
+
+        if (perFeatureSymbology is not null && perFeatureSymbology.Count != features.Count)
+        {
+            throw new ArgumentException(
+                "perFeatureSymbology must have exactly one entry per feature.",
+                nameof(perFeatureSymbology));
         }
 
         var kind = features[0].Geometry.Kind;
@@ -102,11 +119,31 @@ public static class GeometryTileBuilder
         // 2. Build the per-feature property table buffers.
         var propertyTable = SceneMetadataTable.Build(features, metadataAttributes, warnings);
 
-        // 3. Lay out the binary buffer: positions, feature ids, then each property column.
+        // 2b. Bake per-vertex colors from the resolved symbology (if any). The
+        // color for vertex v is the resolved color of the feature that owns v;
+        // featureIds already carries that ownership in vertex order, so the
+        // color buffer stays in lockstep with positions deterministically.
+        byte[]? colorBytes = null;
+        if (perFeatureSymbology is not null)
+        {
+            colorBytes = new byte[vertexCount * 4];
+            for (var v = 0; v < vertexCount; v++)
+            {
+                var symbology = perFeatureSymbology[(int)featureIds[v]];
+                var alpha = (byte)Math.Clamp((int)Math.Round(symbology.Opacity * 255.0), 0, 255);
+                colorBytes[v * 4] = symbology.Color.Red;
+                colorBytes[v * 4 + 1] = symbology.Color.Green;
+                colorBytes[v * 4 + 2] = symbology.Color.Blue;
+                colorBytes[v * 4 + 3] = alpha;
+            }
+        }
+
+        // 3. Lay out the binary buffer: positions, feature ids, optional vertex
+        // colors, then each property column.
         var positionBytes = AsByteSpan(positions);
         var featureIdBytes = AsByteSpan(featureIds);
 
-        var bufferViews = new List<BufferViewDescriptor>(2 + propertyTable.Columns.Count);
+        var bufferViews = new List<BufferViewDescriptor>(3 + propertyTable.Columns.Count);
         var binaryWriter = new BinaryBufferBuilder();
 
         var positionView = binaryWriter.Append(positionBytes);
@@ -114,6 +151,14 @@ public static class GeometryTileBuilder
 
         var featureIdView = binaryWriter.Append(featureIdBytes);
         bufferViews.Add(new BufferViewDescriptor(featureIdView, BufferViewTarget.ArrayBuffer));
+
+        var colorViewIndex = -1;
+        if (colorBytes is not null)
+        {
+            var colorView = binaryWriter.Append(colorBytes);
+            colorViewIndex = bufferViews.Count;
+            bufferViews.Add(new BufferViewDescriptor(colorView, BufferViewTarget.ArrayBuffer));
+        }
 
         var propertyViewIndices = new int[propertyTable.Columns.Count];
         for (var i = 0; i < propertyTable.Columns.Count; i++)
@@ -141,6 +186,7 @@ public static class GeometryTileBuilder
             bufferViews,
             positionViewIndex: 0,
             featureIdViewIndex: 1,
+            colorViewIndex,
             featureCount: features.Count,
             propertyTable,
             propertyViewIndices,
@@ -380,12 +426,14 @@ public static class GeometryTileBuilder
         List<BufferViewDescriptor> bufferViews,
         int positionViewIndex,
         int featureIdViewIndex,
+        int colorViewIndex,
         int featureCount,
         SceneMetadataTable propertyTable,
         int[] propertyViewIndices,
         int totalBinaryLength,
         string? generatorTag)
     {
+        var hasVertexColors = colorViewIndex >= 0;
         var (minX, minY, minZ, maxX, maxY, maxZ) = ComputePositionBounds(positions);
 
         using var stream = new MemoryStream();
@@ -431,6 +479,11 @@ public static class GeometryTileBuilder
             writer.WriteStartObject("attributes");
             writer.WriteNumber("POSITION", 0);
             writer.WriteNumber("_FEATURE_ID_0", 1);
+            if (hasVertexColors)
+            {
+                // Accessor 2 holds the baked normalized RGBA vertex colors.
+                writer.WriteNumber("COLOR_0", 2);
+            }
             writer.WriteEndObject();
 
             writer.WriteNumber("mode", primitiveMode);
@@ -482,6 +535,20 @@ public static class GeometryTileBuilder
             writer.WriteNumber("count", vertexCount);
             writer.WriteString("type", "SCALAR");
             writer.WriteEndObject();
+
+            if (hasVertexColors)
+            {
+                // COLOR_0 accessor: normalized unsigned-byte RGBA. glTF readers
+                // expand a VEC4 UBYTE accessor with normalized=true to [0,1]
+                // floats, so the baked 0-255 channels render at full fidelity.
+                writer.WriteStartObject();
+                writer.WriteNumber("bufferView", colorViewIndex);
+                writer.WriteNumber("componentType", 5121); // UNSIGNED_BYTE
+                writer.WriteBoolean("normalized", true);
+                writer.WriteNumber("count", vertexCount);
+                writer.WriteString("type", "VEC4");
+                writer.WriteEndObject();
+            }
             writer.WriteEndArray();
 
             // Default double-sided material — referenced by `material: 0`
@@ -495,6 +562,25 @@ public static class GeometryTileBuilder
             writer.WriteStartObject();
             writer.WriteString("name", "honua_default");
             writer.WriteBoolean("doubleSided", true);
+            if (hasVertexColors)
+            {
+                // Per-vertex COLOR_0 multiplies against baseColorFactor in the
+                // glTF PBR model. A neutral white, fully-rough, non-metal base
+                // lets the baked symbology color pass through unaltered while
+                // staying a valid metallic-roughness material. alphaMode BLEND
+                // honors the per-vertex alpha channel (resolved opacity).
+                writer.WriteStartObject("pbrMetallicRoughness");
+                writer.WriteStartArray("baseColorFactor");
+                writer.WriteNumberValue(1.0);
+                writer.WriteNumberValue(1.0);
+                writer.WriteNumberValue(1.0);
+                writer.WriteNumberValue(1.0);
+                writer.WriteEndArray();
+                writer.WriteNumber("metallicFactor", 0.0);
+                writer.WriteNumber("roughnessFactor", 1.0);
+                writer.WriteEndObject();
+                writer.WriteString("alphaMode", "BLEND");
+            }
             writer.WriteEndObject();
             writer.WriteEndArray();
 

--- a/src/Honua.Core/Features/Scene/Generation/TileStyleSpecWriter.cs
+++ b/src/Honua.Core/Features/Scene/Generation/TileStyleSpecWriter.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.Scene.Domain;
+
+namespace Honua.Core.Features.Scene.Generation;
+
+/// <summary>
+/// Translates a layer's authoring-side <see cref="Symbology3D"/> into the
+/// emitted <see cref="TileStyleSpec"/> style-metadata contract, mapping each
+/// rule onto a 3D Tiles Styling <c>conditions</c> expression.
+/// </summary>
+/// <remarks>
+/// The translation is deterministic and order-preserving: rules become ordered
+/// condition pairs in authoring order, with a trailing <c>true</c> fallback
+/// that yields the default material so the client expression is total (every
+/// feature resolves to a value). This mirrors <see cref="Symbology3DResolver"/>'s
+/// first-match-wins semantics exactly, so a client that evaluates the emitted
+/// expression sees the same result the server baked into the GLB.
+/// </remarks>
+public static class TileStyleSpecWriter
+{
+    /// <summary>
+    /// Builds the style-metadata contract for a layer's symbology. Returns a
+    /// spec whose default material is always populated; the <c>color</c> /
+    /// <c>show</c> expressions are present only when the symbology declares
+    /// rules that affect them.
+    /// </summary>
+    public static TileStyleSpec Build(Symbology3D? symbology)
+    {
+        var defaultColor = symbology?.DefaultColor ?? Symbology3DColor.White;
+        var defaultOpacity = ClampOpacity(symbology?.DefaultOpacity ?? 1.0);
+
+        var spec = new TileStyleSpec
+        {
+            DefaultMaterial = new TileStyleMaterial
+            {
+                Color = defaultColor.ToHex(),
+                Opacity = defaultOpacity
+            }
+        };
+
+        var rules = symbology?.Rules;
+        if (rules is not { Count: > 0 })
+        {
+            return spec;
+        }
+
+        var colorConditions = new List<string[]>();
+        var showConditions = new List<string[]>();
+        var hasColorRule = false;
+        var hasShowRule = false;
+
+        foreach (var rule in rules)
+        {
+            var test = BuildTestExpression(rule);
+
+            if (rule.Color is { } ruleColor)
+            {
+                hasColorRule = true;
+                var opacity = ClampOpacity(rule.Opacity ?? defaultOpacity);
+                colorConditions.Add([test, BuildColorExpression(ruleColor, opacity)]);
+            }
+            else if (rule.Opacity is { } ruleOpacity)
+            {
+                // Opacity-only rule still recolors via the default RGB with the
+                // rule's alpha so the emitted expression matches the baked GLB.
+                hasColorRule = true;
+                colorConditions.Add([test, BuildColorExpression(defaultColor, ClampOpacity(ruleOpacity))]);
+            }
+
+            if (rule.Visible is { } ruleVisible)
+            {
+                hasShowRule = true;
+                showConditions.Add([test, ruleVisible ? "true" : "false"]);
+            }
+        }
+
+        if (hasColorRule)
+        {
+            colorConditions.Add(["true", BuildColorExpression(defaultColor, defaultOpacity)]);
+            spec.Style.Color = new TileStyleConditions { Conditions = colorConditions };
+        }
+
+        if (hasShowRule)
+        {
+            showConditions.Add(["true", "true"]);
+            spec.Style.Show = new TileStyleConditions { Conditions = showConditions };
+        }
+
+        return spec;
+    }
+
+    /// <summary>
+    /// Serializes the style-metadata contract to a deterministic UTF-8 byte
+    /// sequence using the source-generated context.
+    /// </summary>
+    public static byte[] Serialize(TileStyleSpec spec)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+        return JsonSerializer.SerializeToUtf8Bytes(spec, TileStyleSpecJsonContext.Default.TileStyleSpec);
+    }
+
+    private static string BuildTestExpression(Symbology3DRule rule)
+    {
+        // 3D Tiles Styling references a feature property as ${propertyName}.
+        var lhs = "${" + rule.Attribute + "}";
+        var op = rule.Comparison switch
+        {
+            Symbology3DComparison.Equals => "===",
+            Symbology3DComparison.NotEquals => "!==",
+            Symbology3DComparison.GreaterThan => ">",
+            Symbology3DComparison.GreaterThanOrEqual => ">=",
+            Symbology3DComparison.LessThan => "<",
+            Symbology3DComparison.LessThanOrEqual => "<=",
+            _ => "==="
+        };
+
+        return string.Concat(lhs, " ", op, " ", BuildOperand(rule));
+    }
+
+    private static string BuildOperand(Symbology3DRule rule)
+    {
+        // Numeric operands are emitted bare; non-numeric operands are quoted as
+        // string literals. Ordered comparisons only make sense numerically, so
+        // they always emit the numeric form (mirroring the resolver, which only
+        // matches an ordered comparison when both sides are numeric).
+        if (double.TryParse(rule.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var numeric))
+        {
+            return numeric.ToString(CultureInfo.InvariantCulture);
+        }
+
+        return QuoteStringLiteral(rule.Value ?? string.Empty);
+    }
+
+    private static string BuildColorExpression(Symbology3DColor color, double opacity)
+    {
+        // color('#rrggbb', alpha) is the 3D Tiles Styling form for an
+        // alpha-blended constant color.
+        return string.Concat(
+            "color('",
+            color.ToHex(),
+            "', ",
+            opacity.ToString("0.###", CultureInfo.InvariantCulture),
+            ")");
+    }
+
+    private static string QuoteStringLiteral(string value)
+    {
+        var builder = new StringBuilder(value.Length + 2);
+        builder.Append('\'');
+        foreach (var c in value)
+        {
+            if (c is '\'' or '\\')
+            {
+                builder.Append('\\');
+            }
+            builder.Append(c);
+        }
+        builder.Append('\'');
+        return builder.ToString();
+    }
+
+    private static double ClampOpacity(double value)
+    {
+        if (double.IsNaN(value))
+        {
+            return 1.0;
+        }
+        return Math.Clamp(value, 0.0, 1.0);
+    }
+}

--- a/src/Honua.Core/Features/Scene/Generation/TileStyleSpecWriter.cs
+++ b/src/Honua.Core/Features/Scene/Generation/TileStyleSpecWriter.cs
@@ -29,7 +29,20 @@ public static class TileStyleSpecWriter
     /// <c>show</c> expressions are present only when the symbology declares
     /// rules that affect them.
     /// </summary>
-    public static TileStyleSpec Build(Symbology3D? symbology)
+    /// <param name="symbology">The authoring-side symbology to translate.</param>
+    /// <param name="attributeSchemas">
+    /// Optional metadata-schema entries produced by the publish executor. When
+    /// supplied, the emitted <c>${...}</c> property references are rewritten
+    /// from each rule's raw authoring attribute name to the sanitized /
+    /// de-duplicated <see cref="SceneAttributeSchema.PropertyId"/> that is
+    /// actually written into the tile's <c>EXT_structural_metadata</c> schema,
+    /// so the runtime expression resolves against a property that exists. When
+    /// null (or a rule's attribute has no matching schema entry), the raw
+    /// attribute name is emitted unchanged.
+    /// </param>
+    public static TileStyleSpec Build(
+        Symbology3D? symbology,
+        IReadOnlyList<SceneAttributeSchema>? attributeSchemas = null)
     {
         var defaultColor = symbology?.DefaultColor ?? Symbology3DColor.White;
         var defaultOpacity = ClampOpacity(symbology?.DefaultOpacity ?? 1.0);
@@ -49,6 +62,8 @@ public static class TileStyleSpecWriter
             return spec;
         }
 
+        var propertyIdByFieldName = BuildPropertyIdMap(attributeSchemas);
+
         var colorConditions = new List<string[]>();
         var showConditions = new List<string[]>();
         var hasColorRule = false;
@@ -56,8 +71,17 @@ public static class TileStyleSpecWriter
 
         foreach (var rule in rules)
         {
-            var test = BuildTestExpression(rule);
+            var test = BuildTestExpression(rule, propertyIdByFieldName);
 
+            // Color conditions must replicate Symbology3DResolver's
+            // first-match-wins exactly: the resolver stops at the FIRST matching
+            // rule regardless of which fields it sets, then keeps the default
+            // color for any field that rule leaves unset. So EVERY rule must
+            // terminate color evaluation here — emitting the color that rule
+            // actually produces — otherwise a colorless rule that matches first
+            // (e.g. visibility-only) would be skipped and a later color rule
+            // would erroneously recolor the feature, diverging from the baked
+            // GLB color the resolver computed.
             if (rule.Color is { } ruleColor)
             {
                 hasColorRule = true;
@@ -71,6 +95,14 @@ public static class TileStyleSpecWriter
                 hasColorRule = true;
                 colorConditions.Add([test, BuildColorExpression(defaultColor, ClampOpacity(ruleOpacity))]);
             }
+            else
+            {
+                // Rule sets neither color nor opacity (e.g. visibility-only). It
+                // still wins the resolver's first-match, leaving the feature at
+                // the default color, so the emitted branch must yield the same
+                // default to terminate color evaluation at this rule.
+                colorConditions.Add([test, BuildColorExpression(defaultColor, defaultOpacity)]);
+            }
 
             if (rule.Visible is { } ruleVisible)
             {
@@ -79,6 +111,11 @@ public static class TileStyleSpecWriter
             }
         }
 
+        // Only emit a color expression when at least one rule actually changes
+        // the color or opacity. When every rule is visibility-only, the resolver
+        // always yields the default color, so the placeholder default branches
+        // accumulated above are dropped and the client falls back to the
+        // default material — matching the resolver without redundant output.
         if (hasColorRule)
         {
             colorConditions.Add(["true", BuildColorExpression(defaultColor, defaultOpacity)]);
@@ -95,6 +132,29 @@ public static class TileStyleSpecWriter
     }
 
     /// <summary>
+    /// Builds a case-insensitive map from a source field name to the sanitized
+    /// metadata property id the publish executor emitted for it. Returns null
+    /// when no schema mapping is supplied so the caller emits raw names.
+    /// </summary>
+    private static Dictionary<string, string>? BuildPropertyIdMap(
+        IReadOnlyList<SceneAttributeSchema>? attributeSchemas)
+    {
+        if (attributeSchemas is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        var map = new Dictionary<string, string>(attributeSchemas.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var schema in attributeSchemas)
+        {
+            // First-writer wins on a casing collision, mirroring the executor's
+            // declaration-order de-duplication so the reference stays stable.
+            map.TryAdd(schema.FieldName, schema.PropertyId);
+        }
+        return map;
+    }
+
+    /// <summary>
     /// Serializes the style-metadata contract to a deterministic UTF-8 byte
     /// sequence using the source-generated context.
     /// </summary>
@@ -104,10 +164,23 @@ public static class TileStyleSpecWriter
         return JsonSerializer.SerializeToUtf8Bytes(spec, TileStyleSpecJsonContext.Default.TileStyleSpec);
     }
 
-    private static string BuildTestExpression(Symbology3DRule rule)
+    private static string BuildTestExpression(
+        Symbology3DRule rule,
+        Dictionary<string, string>? propertyIdByFieldName)
     {
-        // 3D Tiles Styling references a feature property as ${propertyName}.
-        var lhs = "${" + rule.Attribute + "}";
+        // 3D Tiles Styling references a feature property as ${propertyId}. The
+        // property id is the sanitized/de-duplicated name actually written into
+        // the tile metadata schema, which may differ from the raw authoring
+        // attribute (e.g. "road-class" -> "road_class"); fall back to the raw
+        // name when no schema mapping is available.
+        var propertyName = rule.Attribute;
+        if (propertyIdByFieldName is not null
+            && propertyIdByFieldName.TryGetValue(rule.Attribute, out var mapped))
+        {
+            propertyName = mapped;
+        }
+
+        var lhs = "${" + propertyName + "}";
         var op = rule.Comparison switch
         {
             Symbology3DComparison.Equals => "===",

--- a/src/Honua.Core/Features/Scene/Generation/TilesetDocumentWriter.cs
+++ b/src/Honua.Core/Features/Scene/Generation/TilesetDocumentWriter.cs
@@ -27,13 +27,19 @@ public static class TilesetDocumentWriter
     /// <param name="geometricError">Geometric error in meters.</param>
     /// <param name="tileContentUris">Ordered relative URIs of child tile content (e.g. <c>tile_0000.glb</c>).</param>
     /// <param name="generatorTag">Optional generator label written into the asset block.</param>
+    /// <param name="styleReference">
+    /// Optional reference to the emitted style-metadata contract sidecar. When
+    /// supplied it is advertised under the root <c>extras.honua_style</c> block
+    /// so a client can discover the attribute-driven symbology spec.
+    /// </param>
     public static TilesetDocument Build(
         double[] boundingRegionDegrees,
         double minHeightMeters,
         double maxHeightMeters,
         double geometricError,
         IReadOnlyList<string> tileContentUris,
-        string? generatorTag = null)
+        string? generatorTag = null,
+        TilesetStyleReference? styleReference = null)
     {
         ArgumentNullException.ThrowIfNull(boundingRegionDegrees);
         ArgumentNullException.ThrowIfNull(tileContentUris);
@@ -80,7 +86,10 @@ public static class TilesetDocumentWriter
                 GeometricError = geometricError,
                 Refine = "ADD",
                 Children = children
-            }
+            },
+            Extras = styleReference is null
+                ? null
+                : new TilesetExtras { Style = styleReference }
         };
     }
 

--- a/src/Honua.Server/Features/Infrastructure/Scene/SceneTilesPublishExecutor.cs
+++ b/src/Honua.Server/Features/Infrastructure/Scene/SceneTilesPublishExecutor.cs
@@ -178,6 +178,7 @@ internal sealed partial class SceneTilesPublishExecutor : IPublishExecutor
             await PreflightSceneRegistrationConflictAsync(sceneId, cancellationToken).ConfigureAwait(false);
 
             var extrusion = generationOptions.ExtrusionOverride ?? layer.Metadata?.Extrusion;
+            var symbology = layer.Metadata?.Symbology3D;
             var attributeSchemas = BuildAttributeSchemas(layer, includeAttributes);
             var collected = await CollectFeaturesAsync(
                 layer, includeAttributes, maxFeatures, cancellationToken).ConfigureAwait(false);
@@ -242,18 +243,46 @@ internal sealed partial class SceneTilesPublishExecutor : IPublishExecutor
             {
                 Directory.CreateDirectory(stagingDirectory);
 
+                // Resolve attribute-driven 3D symbology per feature (when a
+                // layer declares it) so the GLB carries baked color/opacity and
+                // the tileset advertises the matching style-metadata contract.
+                // Resolution is parallel to collected.Features and is null when
+                // the layer has no symbology (legacy white-material output).
+                var perFeatureSymbology = ResolvePerFeatureSymbology(symbology, collected.Features);
+
                 var glb = GeometryTileBuilder.BuildGlb(
                     collected.Features,
                     attributeSchemas,
                     extrusion,
                     serverOptions.GeneratorTag,
-                    collected.Warnings);
+                    collected.Warnings,
+                    perFeatureSymbology);
 
                 var tileFileName = "tile_0000.glb";
                 await File.WriteAllBytesAsync(
                     Path.Combine(stagingDirectory, tileFileName),
                     glb,
                     cancellationToken).ConfigureAwait(false);
+
+                // Emit the style-metadata contract sidecar and advertise it from
+                // the tileset's extras so the JS client can apply the
+                // attribute-driven 3D Tiles Styling expressions at runtime.
+                TilesetStyleReference? styleReference = null;
+                if (symbology is not null)
+                {
+                    var styleSpec = TileStyleSpecWriter.Build(symbology);
+                    var styleBytes = TileStyleSpecWriter.Serialize(styleSpec);
+                    await File.WriteAllBytesAsync(
+                        Path.Combine(stagingDirectory, TileStyleSpecDefaults.FileName),
+                        styleBytes,
+                        cancellationToken).ConfigureAwait(false);
+                    styleReference = new TilesetStyleReference
+                    {
+                        Encoding = TileStyleSpecDefaults.Encoding,
+                        Version = TileStyleSpecDefaults.Version,
+                        Uri = TileStyleSpecDefaults.FileName
+                    };
+                }
 
                 var geometricError = ComputeGeometricError(bounds, minHeight, maxHeight);
                 var tileset = TilesetDocumentWriter.Build(
@@ -262,7 +291,8 @@ internal sealed partial class SceneTilesPublishExecutor : IPublishExecutor
                     maxHeight,
                     geometricError,
                     tileContentUris: [tileFileName],
-                    serverOptions.GeneratorTag);
+                    serverOptions.GeneratorTag,
+                    styleReference);
                 var tilesetBytes = TilesetDocumentWriter.Serialize(tileset);
                 await File.WriteAllBytesAsync(
                     Path.Combine(stagingDirectory, "tileset.json"),
@@ -594,6 +624,29 @@ internal sealed partial class SceneTilesPublishExecutor : IPublishExecutor
             MaxFeatureCount = maxFeatures,
             CacheMaxAgeSeconds = cacheMaxAge
         };
+    }
+
+    /// <summary>
+    /// Resolves the per-feature 3D symbology (color / opacity / visibility) for
+    /// every collected feature, indexed parallel to <paramref name="features"/>.
+    /// Returns null when the layer declares no symbology so the GLB builder
+    /// keeps its legacy single-material path.
+    /// </summary>
+    private static ResolvedSymbology[]? ResolvePerFeatureSymbology(
+        Symbology3D? symbology,
+        List<SceneFeature> features)
+    {
+        if (symbology is null)
+        {
+            return null;
+        }
+
+        var resolved = new ResolvedSymbology[features.Count];
+        for (var i = 0; i < features.Count; i++)
+        {
+            resolved[i] = Symbology3DResolver.Resolve(symbology, features[i].Attributes);
+        }
+        return resolved;
     }
 
     private static List<SceneAttributeSchema> BuildAttributeSchemas(

--- a/src/Honua.Server/Features/Infrastructure/Scene/SceneTilesPublishExecutor.cs
+++ b/src/Honua.Server/Features/Infrastructure/Scene/SceneTilesPublishExecutor.cs
@@ -270,7 +270,7 @@ internal sealed partial class SceneTilesPublishExecutor : IPublishExecutor
                 TilesetStyleReference? styleReference = null;
                 if (symbology is not null)
                 {
-                    var styleSpec = TileStyleSpecWriter.Build(symbology);
+                    var styleSpec = TileStyleSpecWriter.Build(symbology, attributeSchemas);
                     var styleBytes = TileStyleSpecWriter.Serialize(styleSpec);
                     await File.WriteAllBytesAsync(
                         Path.Combine(stagingDirectory, TileStyleSpecDefaults.FileName),

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Domain/Symbology3DResolverTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Domain/Symbology3DResolverTests.cs
@@ -1,0 +1,240 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Scene.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.Domain;
+
+/// <summary>
+/// Unit tests for the attribute-driven 3D symbology resolver. Verifies that a
+/// <see cref="Symbology3D"/> config resolves to the expected per-feature color,
+/// opacity, and visibility for sample features.
+/// </summary>
+public sealed class Symbology3DResolverTests
+{
+    [UnitTest]
+    public void Resolve_NoSymbology_ReturnsOpaqueWhiteVisible()
+    {
+        var resolved = Symbology3DResolver.Resolve(null, Attributes(("status", "ok")));
+
+        resolved.Color.Should().Be(Symbology3DColor.White);
+        resolved.Opacity.Should().Be(1.0);
+        resolved.Visible.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Resolve_NoMatchingRule_FallsBackToDefaults()
+    {
+        var symbology = new Symbology3D
+        {
+            DefaultColor = new Symbology3DColor(10, 20, 30),
+            DefaultOpacity = 0.5,
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "kind",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "tree",
+                    Color = new Symbology3DColor(0, 255, 0)
+                }
+            ]
+        };
+
+        var resolved = Symbology3DResolver.Resolve(symbology, Attributes(("kind", "building")));
+
+        resolved.Color.Should().Be(new Symbology3DColor(10, 20, 30));
+        resolved.Opacity.Should().Be(0.5);
+        resolved.Visible.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Resolve_StringEqualityRule_AppliesColor()
+    {
+        var symbology = new Symbology3D
+        {
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "kind",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "tree",
+                    Color = new Symbology3DColor(0, 128, 0),
+                    Opacity = 0.8
+                }
+            ]
+        };
+
+        var resolved = Symbology3DResolver.Resolve(symbology, Attributes(("kind", "tree")));
+
+        resolved.Color.Should().Be(new Symbology3DColor(0, 128, 0));
+        resolved.Opacity.Should().Be(0.8);
+        resolved.Visible.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Resolve_NumericGreaterThanRule_AppliesColor()
+    {
+        var symbology = new Symbology3D
+        {
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "height",
+                    Comparison = Symbology3DComparison.GreaterThan,
+                    Value = "100",
+                    Color = new Symbology3DColor(255, 0, 0)
+                }
+            ]
+        };
+
+        var tall = Symbology3DResolver.Resolve(symbology, Attributes(("height", 150.0)));
+        var shortFeature = Symbology3DResolver.Resolve(symbology, Attributes(("height", 50.0)));
+
+        tall.Color.Should().Be(new Symbology3DColor(255, 0, 0));
+        shortFeature.Color.Should().Be(Symbology3DColor.White, "features that miss every rule take the default color.");
+    }
+
+    [UnitTest]
+    public void Resolve_NumericStringAttribute_ParsesForComparison()
+    {
+        // Postgres projects JSONB attributes as TEXT, so a numeric attribute can
+        // arrive as a string; the resolver must parse it for ordered comparison.
+        var symbology = new Symbology3D
+        {
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "floors",
+                    Comparison = Symbology3DComparison.GreaterThanOrEqual,
+                    Value = "10",
+                    Color = new Symbology3DColor(0, 0, 255)
+                }
+            ]
+        };
+
+        var resolved = Symbology3DResolver.Resolve(symbology, Attributes(("floors", "12")));
+
+        resolved.Color.Should().Be(new Symbology3DColor(0, 0, 255));
+    }
+
+    [UnitTest]
+    public void Resolve_VisibilityRule_HidesFeature()
+    {
+        var symbology = new Symbology3D
+        {
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "demolished",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "true",
+                    Visible = false
+                }
+            ]
+        };
+
+        var resolved = Symbology3DResolver.Resolve(symbology, Attributes(("demolished", "true")));
+
+        resolved.Visible.Should().BeFalse();
+        resolved.Color.Should().Be(Symbology3DColor.White, "a visibility-only rule leaves the color at the default.");
+    }
+
+    [UnitTest]
+    public void Resolve_FirstMatchingRuleWins()
+    {
+        var symbology = new Symbology3D
+        {
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "height",
+                    Comparison = Symbology3DComparison.GreaterThan,
+                    Value = "50",
+                    Color = new Symbology3DColor(255, 0, 0)
+                },
+                new Symbology3DRule
+                {
+                    Attribute = "height",
+                    Comparison = Symbology3DComparison.GreaterThan,
+                    Value = "10",
+                    Color = new Symbology3DColor(0, 255, 0)
+                }
+            ]
+        };
+
+        var resolved = Symbology3DResolver.Resolve(symbology, Attributes(("height", 100.0)));
+
+        resolved.Color.Should().Be(new Symbology3DColor(255, 0, 0),
+            "the first rule in declaration order that matches must win.");
+    }
+
+    [UnitTest]
+    public void Resolve_ClampsOpacityIntoUnitRange()
+    {
+        var symbology = new Symbology3D
+        {
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "kind",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "glass",
+                    Color = new Symbology3DColor(200, 200, 255),
+                    Opacity = 2.5
+                }
+            ]
+        };
+
+        var resolved = Symbology3DResolver.Resolve(symbology, Attributes(("kind", "glass")));
+
+        resolved.Opacity.Should().Be(1.0, "out-of-range opacity must clamp into [0, 1].");
+    }
+
+    [UnitTest]
+    public void Resolve_CaseInsensitiveAttributeLookup()
+    {
+        var symbology = new Symbology3D
+        {
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "Status",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "active",
+                    Color = new Symbology3DColor(1, 2, 3)
+                }
+            ]
+        };
+
+        // Attribute bag is ordinal-keyed with a different casing.
+        var resolved = Symbology3DResolver.Resolve(symbology, Attributes(("status", "active")));
+
+        resolved.Color.Should().Be(new Symbology3DColor(1, 2, 3));
+    }
+
+    [UnitTest]
+    public void Color_ToHex_ProducesLowercaseCssLiteral()
+    {
+        new Symbology3DColor(255, 10, 0).ToHex().Should().Be("#ff0a00");
+        Symbology3DColor.White.ToHex().Should().Be("#ffffff");
+    }
+
+    private static Dictionary<string, object?> Attributes(params (string Key, object? Value)[] pairs)
+    {
+        var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var (key, value) in pairs)
+        {
+            dict[key] = value;
+        }
+        return dict;
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/GeometryTileBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/GeometryTileBuilderTests.cs
@@ -423,6 +423,91 @@ public sealed class GeometryTileBuilderTests
     }
 
     [UnitTest]
+    public void BuildGlb_WithSymbology_BakesPerFeatureColor0Attribute()
+    {
+        var features = NumericFeaturePair(
+            new Dictionary<string, object?>(StringComparer.Ordinal) { ["name"] = "a" },
+            new Dictionary<string, object?>(StringComparer.Ordinal) { ["name"] = "b" });
+
+        var schemas = new[]
+        {
+            new SceneAttributeSchema { PropertyId = "name", FieldName = "name", SchemaType = "STRING", SchemaComponentType = string.Empty }
+        };
+
+        // Feature 0 = opaque red, feature 1 = half-opacity blue.
+        var symbology = new[]
+        {
+            new ResolvedSymbology(new Symbology3DColor(255, 0, 0), 1.0, true),
+            new ResolvedSymbology(new Symbology3DColor(0, 0, 255), 0.5, true)
+        };
+
+        var glb = GeometryTileBuilder.BuildGlb(features, schemas, extrusion: null, perFeatureSymbology: symbology);
+        var json = ExtractJsonChunk(glb);
+
+        using var doc = JsonDocument.Parse(json);
+
+        // The primitive must reference the COLOR_0 attribute (accessor 2).
+        var primitive = doc.RootElement.GetProperty("meshes")[0].GetProperty("primitives")[0];
+        primitive.GetProperty("attributes").GetProperty("COLOR_0").GetInt32().Should().Be(2);
+
+        // The COLOR_0 accessor is a normalized UNSIGNED_BYTE VEC4.
+        var colorAccessor = doc.RootElement.GetProperty("accessors")[2];
+        colorAccessor.GetProperty("componentType").GetInt32().Should().Be(5121);
+        colorAccessor.GetProperty("normalized").GetBoolean().Should().BeTrue();
+        colorAccessor.GetProperty("type").GetString().Should().Be("VEC4");
+
+        // The material switches to PBR with BLEND so vertex alpha is honored.
+        var material = doc.RootElement.GetProperty("materials")[0];
+        material.GetProperty("alphaMode").GetString().Should().Be("BLEND");
+        material.GetProperty("pbrMetallicRoughness").GetProperty("baseColorFactor")
+            .EnumerateArray().Select(e => e.GetDouble()).Should().Equal(1.0, 1.0, 1.0, 1.0);
+
+        // Read the baked RGBA bytes for the first vertex of each feature.
+        var colorView = colorAccessor.GetProperty("bufferView").GetInt32();
+        var byteOffset = doc.RootElement.GetProperty("bufferViews")[colorView].GetProperty("byteOffset").GetInt32();
+        var bin = ExtractBinChunk(glb);
+
+        // Vertex 0 belongs to feature 0 (red, opaque).
+        bin[byteOffset + 0].Should().Be(255);
+        bin[byteOffset + 1].Should().Be(0);
+        bin[byteOffset + 2].Should().Be(0);
+        bin[byteOffset + 3].Should().Be(255);
+    }
+
+    [UnitTest]
+    public void BuildGlb_WithoutSymbology_OmitsColor0AndKeepsLegacyMaterial()
+    {
+        var glb = BuildSimpleSquare();
+        var json = ExtractJsonChunk(glb);
+
+        using var doc = JsonDocument.Parse(json);
+        var primitive = doc.RootElement.GetProperty("meshes")[0].GetProperty("primitives")[0];
+        primitive.GetProperty("attributes").TryGetProperty("COLOR_0", out _).Should().BeFalse();
+
+        var material = doc.RootElement.GetProperty("materials")[0];
+        material.TryGetProperty("alphaMode", out _).Should().BeFalse(
+            "the legacy white double-sided material has no alphaMode override.");
+        material.GetProperty("doubleSided").GetBoolean().Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void BuildGlb_SymbologyCountMismatch_Throws()
+    {
+        var features = NumericFeaturePair(
+            new Dictionary<string, object?>(StringComparer.Ordinal),
+            new Dictionary<string, object?>(StringComparer.Ordinal));
+        var symbology = new[] { ResolvedSymbology.Default };
+
+        var act = () => GeometryTileBuilder.BuildGlb(
+            features,
+            metadataAttributes: Array.Empty<SceneAttributeSchema>(),
+            extrusion: null,
+            perFeatureSymbology: symbology);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*one entry per feature*");
+    }
+
+    [UnitTest]
     public void BuildGlb_Int32Column_DecimalMaxValueClampsWithoutThrowing()
     {
         // Companion fix: (int)decimal cast also throws on out-of-range

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/TileStyleSpecWriterTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/TileStyleSpecWriterTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.Scene.Domain;
+using Honua.Core.Features.Scene.Generation;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Scene.Generation;
+
+/// <summary>
+/// Unit tests for the style-metadata contract writer that translates a layer's
+/// <see cref="Symbology3D"/> into the emitted <see cref="TileStyleSpec"/> and
+/// its 3D Tiles Styling expressions.
+/// </summary>
+public sealed class TileStyleSpecWriterTests
+{
+    [UnitTest]
+    public void Build_NoSymbology_EmitsDefaultMaterialOnlyNoExpressions()
+    {
+        var spec = TileStyleSpecWriter.Build(null);
+
+        spec.Encoding.Should().Be("3d-tiles-styling");
+        spec.Version.Should().Be("1.0");
+        spec.DefaultMaterial.Color.Should().Be("#ffffff");
+        spec.DefaultMaterial.Opacity.Should().Be(1.0);
+        spec.Style.Color.Should().BeNull();
+        spec.Style.Show.Should().BeNull();
+    }
+
+    [UnitTest]
+    public void Build_DefaultColorAndOpacity_FlowIntoMaterial()
+    {
+        var symbology = new Symbology3D
+        {
+            DefaultColor = new Symbology3DColor(16, 32, 48),
+            DefaultOpacity = 0.25
+        };
+
+        var spec = TileStyleSpecWriter.Build(symbology);
+
+        spec.DefaultMaterial.Color.Should().Be("#102030");
+        spec.DefaultMaterial.Opacity.Should().Be(0.25);
+        spec.Style.Color.Should().BeNull("a symbology with no rules emits no conditions expression.");
+    }
+
+    [UnitTest]
+    public void Build_ColorRule_EmitsOrderedConditionsWithTrailingFallback()
+    {
+        var symbology = new Symbology3D
+        {
+            DefaultColor = new Symbology3DColor(255, 255, 255),
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "height",
+                    Comparison = Symbology3DComparison.GreaterThan,
+                    Value = "100",
+                    Color = new Symbology3DColor(255, 0, 0)
+                }
+            ]
+        };
+
+        var spec = TileStyleSpecWriter.Build(symbology);
+
+        spec.Style.Color.Should().NotBeNull();
+        var conditions = spec.Style.Color!.Conditions;
+        conditions.Should().HaveCount(2, "one rule plus the trailing default fallback.");
+        conditions[0][0].Should().Be("${height} > 100");
+        conditions[0][1].Should().Be("color('#ff0000', 1)");
+        conditions[1][0].Should().Be("true", "the last condition is the catch-all default.");
+        conditions[1][1].Should().Be("color('#ffffff', 1)");
+    }
+
+    [UnitTest]
+    public void Build_StringEqualityRule_QuotesOperand()
+    {
+        var symbology = new Symbology3D
+        {
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "kind",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "tree",
+                    Color = new Symbology3DColor(0, 128, 0)
+                }
+            ]
+        };
+
+        var spec = TileStyleSpecWriter.Build(symbology);
+
+        spec.Style.Color!.Conditions[0][0].Should().Be("${kind} === 'tree'");
+    }
+
+    [UnitTest]
+    public void Build_VisibilityRule_EmitsShowConditions()
+    {
+        var symbology = new Symbology3D
+        {
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "demolished",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "true",
+                    Visible = false
+                }
+            ]
+        };
+
+        var spec = TileStyleSpecWriter.Build(symbology);
+
+        spec.Style.Show.Should().NotBeNull();
+        var conditions = spec.Style.Show!.Conditions;
+        conditions[0][0].Should().Be("${demolished} === 'true'");
+        conditions[0][1].Should().Be("false");
+        conditions[^1].Should().Equal("true", "true");
+        spec.Style.Color.Should().BeNull("a visibility-only rule emits no color expression.");
+    }
+
+    [UnitTest]
+    public void Serialize_RoundTripsContract()
+    {
+        var symbology = new Symbology3D
+        {
+            DefaultColor = new Symbology3DColor(10, 20, 30),
+            DefaultOpacity = 0.5,
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "height",
+                    Comparison = Symbology3DComparison.GreaterThanOrEqual,
+                    Value = "50",
+                    Color = new Symbology3DColor(200, 100, 50),
+                    Opacity = 0.9
+                },
+                new Symbology3DRule
+                {
+                    Attribute = "hidden",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "yes",
+                    Visible = false
+                }
+            ]
+        };
+
+        var spec = TileStyleSpecWriter.Build(symbology);
+        var bytes = TileStyleSpecWriter.Serialize(spec);
+
+        var roundTripped = JsonSerializer.Deserialize(
+            bytes, TileStyleSpecJsonContext.Default.TileStyleSpec);
+
+        roundTripped.Should().NotBeNull();
+        roundTripped!.Encoding.Should().Be("3d-tiles-styling");
+        roundTripped.DefaultMaterial.Color.Should().Be("#0a141e");
+        roundTripped.DefaultMaterial.Opacity.Should().Be(0.5);
+        roundTripped.Style.Color!.Conditions[0][1].Should().Be("color('#c86432', 0.9)");
+        roundTripped.Style.Show!.Conditions[0][0].Should().Be("${hidden} === 'yes'");
+    }
+
+    [UnitTest]
+    public void Serialize_IsByteIdenticalAcrossRuns()
+    {
+        var symbology = new Symbology3D
+        {
+            DefaultColor = new Symbology3DColor(1, 2, 3),
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "x",
+                    Comparison = Symbology3DComparison.LessThan,
+                    Value = "5",
+                    Color = new Symbology3DColor(9, 9, 9)
+                }
+            ]
+        };
+
+        var bytes1 = TileStyleSpecWriter.Serialize(TileStyleSpecWriter.Build(symbology));
+        var bytes2 = TileStyleSpecWriter.Serialize(TileStyleSpecWriter.Build(symbology));
+
+        bytes1.Should().Equal(bytes2);
+    }
+
+    [UnitTest]
+    public void Serialize_ProducesExpectedJsonShape()
+    {
+        var symbology = new Symbology3D
+        {
+            DefaultColor = new Symbology3DColor(255, 255, 255),
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "height",
+                    Comparison = Symbology3DComparison.GreaterThan,
+                    Value = "100",
+                    Color = new Symbology3DColor(255, 0, 0)
+                }
+            ]
+        };
+
+        var bytes = TileStyleSpecWriter.Serialize(TileStyleSpecWriter.Build(symbology));
+
+        using var json = JsonDocument.Parse(Encoding.UTF8.GetString(bytes));
+        var root = json.RootElement;
+        root.GetProperty("encoding").GetString().Should().Be("3d-tiles-styling");
+        root.GetProperty("defaultMaterial").GetProperty("color").GetString().Should().Be("#ffffff");
+        var conditions = root.GetProperty("style").GetProperty("color").GetProperty("conditions");
+        conditions.GetArrayLength().Should().Be(2);
+        conditions[0][0].GetString().Should().Be("${height} > 100");
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/TileStyleSpecWriterTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/TileStyleSpecWriterTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Honua.Core.Features.Scene.Domain;
@@ -124,6 +125,176 @@ public sealed class TileStyleSpecWriterTests
     }
 
     [UnitTest]
+    public void Build_EarlyVisibilityOnlyRuleBeforeColorRule_EmittedColorMatchesResolver()
+    {
+        // An early visibility-only rule matches FIRST in the resolver and wins
+        // (leaving the default color), so a later color rule must NOT recolor the
+        // feature. The emitted color conditions have to replicate that
+        // first-match-wins, otherwise baked GLB color and style.json diverge.
+        var symbology = new Symbology3D
+        {
+            DefaultColor = new Symbology3DColor(10, 20, 30),
+            DefaultOpacity = 0.4,
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "status",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "hidden",
+                    Visible = false
+                },
+                new Symbology3DRule
+                {
+                    Attribute = "status",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "hidden",
+                    Color = new Symbology3DColor(255, 0, 0)
+                }
+            ]
+        };
+
+        var spec = TileStyleSpecWriter.Build(symbology);
+
+        // A feature matching the early visibility-only rule.
+        var attributes = Attributes(("status", "hidden"));
+        var resolved = Symbology3DResolver.Resolve(symbology, attributes);
+
+        // Resolver keeps the DEFAULT color because the first matching rule sets
+        // no color.
+        resolved.Color.Should().Be(new Symbology3DColor(10, 20, 30));
+
+        var emitted = EvaluateColor(spec.Style.Color!, attributes);
+        emitted.Should().Be(
+            $"color('{resolved.Color.ToHex()}', {resolved.Opacity.ToString("0.###", CultureInfo.InvariantCulture)})",
+            "the emitted color expression must yield the same color the resolver/GLB bake produces.");
+
+        // The first condition is the visibility-only rule terminating color
+        // evaluation at the resolver's default color, NOT the later red rule.
+        spec.Style.Color!.Conditions[0][1].Should().Be("color('#0a141e', 0.4)");
+    }
+
+    [UnitTest]
+    public void Build_EmittedColorMatchesResolverForEveryFeature_OpacityOnlyEarlyRule()
+    {
+        // Early opacity-only rule matches first for "warn"; a later color rule on
+        // the same attribute must not apply. Verify across several feature values.
+        var symbology = new Symbology3D
+        {
+            DefaultColor = new Symbology3DColor(255, 255, 255),
+            DefaultOpacity = 1.0,
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "level",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "warn",
+                    Opacity = 0.2
+                },
+                new Symbology3DRule
+                {
+                    Attribute = "level",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "warn",
+                    Color = new Symbology3DColor(0, 0, 255)
+                },
+                new Symbology3DRule
+                {
+                    Attribute = "level",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "error",
+                    Color = new Symbology3DColor(255, 0, 0)
+                }
+            ]
+        };
+
+        var spec = TileStyleSpecWriter.Build(symbology);
+
+        foreach (var value in new[] { "warn", "error", "info", "" })
+        {
+            var attributes = Attributes(("level", value));
+            var resolved = Symbology3DResolver.Resolve(symbology, attributes);
+            var expected =
+                $"color('{resolved.Color.ToHex()}', {resolved.Opacity.ToString("0.###", CultureInfo.InvariantCulture)})";
+
+            EvaluateColor(spec.Style.Color!, attributes).Should().Be(
+                expected,
+                $"emitted color for level='{value}' must match the resolver.");
+        }
+    }
+
+    [UnitTest]
+    public void Build_WithAttributeSchemas_EmitsSanitizedPropertyIds()
+    {
+        // The publish executor sanitizes "road-class" -> "road_class" before
+        // writing it into the tile metadata schema, so the emitted ${...} must
+        // reference the sanitized id, not the raw authoring name.
+        var symbology = new Symbology3D
+        {
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "road-class",
+                    Comparison = Symbology3DComparison.Equals,
+                    Value = "primary",
+                    Color = new Symbology3DColor(0, 128, 0)
+                }
+            ]
+        };
+
+        var schemas = new[]
+        {
+            new SceneAttributeSchema
+            {
+                PropertyId = "road_class",
+                FieldName = "road-class",
+                SchemaType = "STRING"
+            }
+        };
+
+        var spec = TileStyleSpecWriter.Build(symbology, schemas);
+
+        spec.Style.Color!.Conditions[0][0].Should().Be(
+            "${road_class} === 'primary'",
+            "the style expression must reference the sanitized metadata property id.");
+    }
+
+    [UnitTest]
+    public void Build_WithAttributeSchemas_FallsBackToRawNameWhenUnmapped()
+    {
+        var symbology = new Symbology3D
+        {
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "height",
+                    Comparison = Symbology3DComparison.GreaterThan,
+                    Value = "10",
+                    Color = new Symbology3DColor(0, 0, 0)
+                }
+            ]
+        };
+
+        // Schema mapping that does not cover "height".
+        var schemas = new[]
+        {
+            new SceneAttributeSchema
+            {
+                PropertyId = "other",
+                FieldName = "other",
+                SchemaType = "STRING"
+            }
+        };
+
+        var spec = TileStyleSpecWriter.Build(symbology, schemas);
+
+        spec.Style.Color!.Conditions[0][0].Should().Be("${height} > 10");
+    }
+
+    [UnitTest]
     public void Serialize_RoundTripsContract()
     {
         var symbology = new Symbology3D
@@ -215,5 +386,91 @@ public sealed class TileStyleSpecWriterTests
         var conditions = root.GetProperty("style").GetProperty("color").GetProperty("conditions");
         conditions.GetArrayLength().Should().Be(2);
         conditions[0][0].GetString().Should().Be("${height} > 100");
+    }
+
+    private static Dictionary<string, object?> Attributes(params (string Key, object? Value)[] pairs)
+    {
+        var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var (key, value) in pairs)
+        {
+            dict[key] = value;
+        }
+        return dict;
+    }
+
+    /// <summary>
+    /// Evaluates an emitted 3D Tiles Styling <c>conditions</c> array against a
+    /// feature's attributes using first-match-wins semantics (exactly how a
+    /// client runtime applies it), returning the value expression of the first
+    /// matching branch. Mirrors the styling expression grammar the writer emits.
+    /// </summary>
+    private static string EvaluateColor(
+        TileStyleConditions conditions,
+        IReadOnlyDictionary<string, object?> attributes)
+    {
+        foreach (var pair in conditions.Conditions)
+        {
+            if (EvaluateTest(pair[0], attributes))
+            {
+                return pair[1];
+            }
+        }
+
+        throw new InvalidOperationException("conditions array is not total (no trailing true branch).");
+    }
+
+    private static bool EvaluateTest(string test, IReadOnlyDictionary<string, object?> attributes)
+    {
+        if (test == "true")
+        {
+            return true;
+        }
+
+        // Parse "${prop} OP operand"; the operand is a quoted string or a bare number.
+        var propStart = test.IndexOf("${", StringComparison.Ordinal) + 2;
+        var propEnd = test.IndexOf('}', propStart);
+        var propName = test[propStart..propEnd];
+
+        var rest = test[(propEnd + 1)..].Trim();
+        var spaceIdx = rest.IndexOf(' ', StringComparison.Ordinal);
+        var op = rest[..spaceIdx];
+        var operand = rest[(spaceIdx + 1)..].Trim();
+
+        attributes.TryGetValue(propName, out var raw);
+
+        if (operand.StartsWith('\''))
+        {
+            // String operand: unquote and compare ordinally for === / !==.
+            var literal = operand.Trim('\'').Replace("\\'", "'", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+            var leftText = raw?.ToString() ?? string.Empty;
+            var equal = string.Equals(leftText, literal, StringComparison.Ordinal);
+            return op == "===" ? equal : !equal;
+        }
+
+        var right = double.Parse(operand, CultureInfo.InvariantCulture);
+        var left = raw switch
+        {
+            double d => d,
+            int i => i,
+            long l => l,
+            string s when double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var v) => v,
+            _ => double.NaN
+        };
+        if (double.IsNaN(left))
+        {
+            return false;
+        }
+
+        return op switch
+        {
+            "===" => left == right,
+            "!==" => left != right,
+            ">" => left > right,
+            ">=" => left >= right,
+            "<" => left < right,
+            "<=" => left <= right,
+            _ => false
+        };
     }
 }

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/TilesetDocumentWriterTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/TilesetDocumentWriterTests.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using System.Text.Json;
+using Honua.Core.Features.Scene.Domain;
 using Honua.Core.Features.Scene.Generation;
 using Honua.TestKit.Attributes;
 
@@ -76,5 +77,40 @@ public sealed class TilesetDocumentWriterTests
         json.RootElement.GetProperty("geometricError").GetDouble().Should().Be(100.0);
         json.RootElement.GetProperty("root").GetProperty("refine").GetString().Should().Be("ADD");
         json.RootElement.GetProperty("root").GetProperty("children").GetArrayLength().Should().Be(1);
+    }
+
+    [UnitTest]
+    public void Build_NoStyleReference_OmitsExtras()
+    {
+        var doc = TilesetDocumentWriter.Build(
+            [-1, -1, 1, 1], 0.0, 1.0, 100.0, ["tile_0000.glb"], "honua");
+
+        doc.Extras.Should().BeNull();
+
+        var bytes = TilesetDocumentWriter.Serialize(doc);
+        using var json = JsonDocument.Parse(Encoding.UTF8.GetString(bytes));
+        json.RootElement.TryGetProperty("extras", out _).Should().BeFalse(
+            "a tileset without symbology must not emit an empty extras block.");
+    }
+
+    [UnitTest]
+    public void Build_WithStyleReference_AdvertisesStyleMetadataContract()
+    {
+        var styleRef = new TilesetStyleReference
+        {
+            Encoding = "3d-tiles-styling",
+            Version = "1.0",
+            Uri = "style.json"
+        };
+
+        var doc = TilesetDocumentWriter.Build(
+            [-1, -1, 1, 1], 0.0, 1.0, 100.0, ["tile_0000.glb"], "honua", styleRef);
+
+        var bytes = TilesetDocumentWriter.Serialize(doc);
+        using var json = JsonDocument.Parse(Encoding.UTF8.GetString(bytes));
+        var style = json.RootElement.GetProperty("extras").GetProperty("honua_style");
+        style.GetProperty("encoding").GetString().Should().Be("3d-tiles-styling");
+        style.GetProperty("version").GetString().Should().Be("1.0");
+        style.GetProperty("uri").GetString().Should().Be("style.json");
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/SceneTilesPublishExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/SceneTilesPublishExecutorTests.cs
@@ -106,6 +106,74 @@ public sealed class SceneTilesPublishExecutorTests : IDisposable
     }
 
     [UnitTest]
+    public async Task Execute_WithSymbology_EmitsStyleSidecarAndAdvertisesItInTileset()
+    {
+        var symbology = new Symbology3D
+        {
+            DefaultColor = new Symbology3DColor(255, 255, 255),
+            Rules =
+            [
+                new Symbology3DRule
+                {
+                    Attribute = "height",
+                    Comparison = Symbology3DComparison.GreaterThan,
+                    Value = "30",
+                    Color = new Symbology3DColor(255, 0, 0)
+                }
+            ]
+        };
+        _catalog.Layer = BuildLayer(symbology: symbology);
+        _featureSource.Features = SamplePolygons();
+
+        var outcome = await _executor.RunDirectAsync(BuildIntent(), CancellationToken.None);
+
+        // style.json sidecar is emitted with the contract shape.
+        var stylePath = Path.Combine(outcome.Result.AssetRoot, "style.json");
+        File.Exists(stylePath).Should().BeTrue("a layer with symbology must emit the style-metadata contract.");
+        using (var styleJson = JsonDocument.Parse(await File.ReadAllBytesAsync(stylePath)))
+        {
+            styleJson.RootElement.GetProperty("encoding").GetString().Should().Be("3d-tiles-styling");
+            var conditions = styleJson.RootElement.GetProperty("style").GetProperty("color").GetProperty("conditions");
+            conditions[0][0].GetString().Should().Be("${height} > 30");
+            conditions[0][1].GetString().Should().Be("color('#ff0000', 1)");
+        }
+
+        // tileset.json advertises the style contract via extras.
+        var tilesetBytes = await File.ReadAllBytesAsync(Path.Combine(outcome.Result.AssetRoot, "tileset.json"));
+        using (var tilesetJson = JsonDocument.Parse(tilesetBytes))
+        {
+            var style = tilesetJson.RootElement.GetProperty("extras").GetProperty("honua_style");
+            style.GetProperty("encoding").GetString().Should().Be("3d-tiles-styling");
+            style.GetProperty("uri").GetString().Should().Be("style.json");
+        }
+
+        // GLB bakes a COLOR_0 attribute; feature B (height 50 > 30) resolves to red.
+        var tile = await File.ReadAllBytesAsync(Path.Combine(outcome.Result.AssetRoot, "tile_0000.glb"));
+        var glbJson = ExtractJsonChunk(tile);
+        using var doc = JsonDocument.Parse(glbJson);
+        doc.RootElement.GetProperty("meshes")[0].GetProperty("primitives")[0]
+            .GetProperty("attributes").TryGetProperty("COLOR_0", out _).Should().BeTrue(
+            "a symbology-driven tileset must bake per-feature vertex colors.");
+        doc.RootElement.GetProperty("materials")[0].GetProperty("alphaMode").GetString().Should().Be("BLEND");
+    }
+
+    [UnitTest]
+    public async Task Execute_NoSymbology_OmitsStyleSidecarAndExtras()
+    {
+        _catalog.Layer = BuildLayer();
+        _featureSource.Features = SamplePolygons();
+
+        var outcome = await _executor.RunDirectAsync(BuildIntent(), CancellationToken.None);
+
+        File.Exists(Path.Combine(outcome.Result.AssetRoot, "style.json")).Should().BeFalse(
+            "a layer with no symbology must not emit a style sidecar.");
+
+        var tilesetBytes = await File.ReadAllBytesAsync(Path.Combine(outcome.Result.AssetRoot, "tileset.json"));
+        using var tilesetJson = JsonDocument.Parse(tilesetBytes);
+        tilesetJson.RootElement.TryGetProperty("extras", out _).Should().BeFalse();
+    }
+
+    [UnitTest]
     public async Task Execute_RegistersSceneWithBoundsCoveringAllFeatures()
     {
         _catalog.Layer = BuildLayer();
@@ -934,7 +1002,8 @@ public sealed class SceneTilesPublishExecutorTests : IDisposable
     private LayerDefinition BuildLayer(
         SpatialReference? spatialReference = null,
         LayerExtrusionInfo? extrusion = null,
-        AccessPolicy? accessPolicy = null)
+        AccessPolicy? accessPolicy = null,
+        Symbology3D? symbology = null)
     {
         var sr = spatialReference ?? SpatialReference.Create(4326, 4326);
         var fields = new[]
@@ -944,10 +1013,10 @@ public sealed class SceneTilesPublishExecutorTests : IDisposable
             new FieldDefinition("name", FieldType.String, Length: 64, Nullable: true),
             new FieldDefinition("height", FieldType.Integer, Length: null, Nullable: true)
         };
-        var metadata = (extrusion, accessPolicy) switch
+        var metadata = (extrusion, accessPolicy, symbology) switch
         {
-            (null, null) => null,
-            _ => new CatalogMetadata { Extrusion = extrusion, AccessPolicy = accessPolicy }
+            (null, null, null) => null,
+            _ => new CatalogMetadata { Extrusion = extrusion, AccessPolicy = accessPolicy, Symbology3D = symbology }
         };
         return new LayerDefinition(
             LayerId,


### PR DESCRIPTION
## Issue Link
Fixes #1206

## Summary
Server side of the 3D symbology engine (Epic #530): the `3d-tiles-styling` encoding now has a real engine. The 3D Tiles generator emits per-feature material/color from layer config plus a documented style-metadata contract the JS client consumes. (Client side: honua-sdk-js `feat/1206-3d-symbology-client`.)

## Changes Made
- `Symbology3D` layer config + pure `Symbology3DResolver` (first-match-wins attribute rules → color/opacity/visibility; numeric + string comparisons).
- Generator bakes resolved per-feature RGBA into a normalized `COLOR_0` vertex attribute and switches to a PBR material with `alphaMode: BLEND`.
- Emits a `TileStyleSpec` → `style.json` sidecar, advertised via the tileset root `extras.honua_style` (directly assignable to a CesiumJS `Cesium3DTileStyle`).
- Tests: 11 resolver, 8 style-writer, 3 GLB color, 3 tileset-extras, 2 executor (Core + Server suites green; architecture tests confirm Core stayed DB-free).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

> Note: per-feature color is baked as vertex colors (single-primitive generator); `show=false` is emitted to the style spec for client-side application, not baked into geometry. Pairs with the honua-sdk-js client PR. Branch based on a trunk-ancestor, behind trunk tip (clean single-commit diff; may need rebase). Build verified locally (Release, warnings-as-errors); `dotnet format --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
