### PR TITLE
feat(geoetl): GeoETL 80/20 — sources, transforms, sinks over the durable job substrate

### DIFF
--- a/docs/contributor/geoetl-roadmap.md
+++ b/docs/contributor/geoetl-roadmap.md
@@ -192,6 +192,23 @@ late is expensive, so it is fully scoped in Child Ticket A.
 - **Scheduling**: cron scheduler background service submits
   `ExtractTransformLoad` jobs to `IJobQueue` (same shape as
   `WorkflowSchedulerBackgroundService`).
+
+  > **Baseline status (geoetl-baseline branch).** On-demand triggering is
+  > built: `PipelineExecutionLauncher` is the single submission path behind the
+  > run and dry-run endpoints, stamping `RuntimeProfile=managed` and enqueuing
+  > on `IJobQueue` so the substrate's `JobExecutionService` claims and runs the
+  > job. **Cron scheduling is deliberately NOT built in the baseline** and is
+  > deferred to Child Ticket E. It is not a cheap substrate add: it requires a
+  > `schedule` (cron expression + time zone) field on `PipelineDefinition` plus
+  > a migration, a scheduled-list / durable-cursor / atomic fire-claim API on
+  > `IPipelineDefinitionStore` (and on both the in-memory and Postgres store
+  > implementations), and a distributed-safe background service mirroring the
+  > replay-protection and claim/cursor semantics of
+  > `WorkflowSchedulerBackgroundService` (~350 lines, multi-replica safe). That
+  > is a self-contained ticket, not a baseline slice — half-building it would
+  > ship an unsafe scheduler. The launcher and the durable `IJobQueue` path it
+  > already uses are exactly what a future scheduler tick will call, so Child
+  > Ticket E adds the scheduler on top without reshaping the submission path.
 - **Event triggers**: file-upload events and CDC events from `#316` enqueue
   the same job kind through the same queue.
 - **Execution worker**: Child Ticket E ships

--- a/src/Honua.Core/Features/GeoETL/Abstractions/IFeatureSinkWriter.cs
+++ b/src/Honua.Core/Features/GeoETL/Abstractions/IFeatureSinkWriter.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Abstractions;
+
+/// <summary>
+/// Provider-neutral seam for the Honua-layer / PostGIS sink. The Honua.Postgres
+/// implementation mirrors the <c>StreamingFileImportService</c> insert path
+/// (<c>honua.create_import_table</c> + <c>honua.insert_import_feature</c>), keeping
+/// Honua.Core free of Npgsql so the GeoETL slice stays on the lean managed path.
+/// </summary>
+/// <remarks>
+/// This abstraction is the reuse boundary called out in the roadmap ("Honua-layer
+/// sink reuses StreamingFileImportService insert path"). The sink connector lives in
+/// Honua.Core and depends only on this seam; the durable insert lives in Honua.Postgres.
+/// </remarks>
+public interface IFeatureSinkWriter
+{
+    /// <summary>
+    /// Ensures the target table exists for the given schema / table / SRID, creating it
+    /// through the canonical import-table function when absent.
+    /// </summary>
+    /// <param name="schema">Target schema name.</param>
+    /// <param name="table">Target table name.</param>
+    /// <param name="targetSrid">SRID the geometry column is stored in.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task EnsureTargetAsync(
+        string schema,
+        string table,
+        int targetSrid,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Inserts a batch of features into the target table, tagging each row with
+    /// <paramref name="batchId"/> for soft-delete rollback. Geometries are reprojected
+    /// from <paramref name="sourceSrid"/> to the table SRID by the insert function.
+    /// </summary>
+    /// <param name="schema">Target schema name.</param>
+    /// <param name="table">Target table name.</param>
+    /// <param name="features">Features to insert.</param>
+    /// <param name="sourceSrid">SRID of the incoming geometries.</param>
+    /// <param name="targetSrid">SRID the geometry column is stored in.</param>
+    /// <param name="batchId">Batch identifier tagged on every inserted row.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Number of rows inserted (features with null geometry are skipped).</returns>
+    Task<long> InsertBatchAsync(
+        string schema,
+        string table,
+        IReadOnlyList<IFeature> features,
+        int sourceSrid,
+        int targetSrid,
+        string batchId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/GeoETL/Abstractions/ISchemaAwareTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Abstractions/ISchemaAwareTransform.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Domain;
+
+namespace Honua.Core.Features.GeoETL.Abstractions;
+
+/// <summary>
+/// The effect a transform has on the attribute schema flowing through a pipeline. The
+/// stage-chain validator uses this to fail a pipeline fast — at CRUD / pre-execution
+/// time rather than mid-run — when a stage requires an attribute field that no upstream
+/// stage produces. See the GeoETL roadmap § Transform library and ADR-0038
+/// § Stage-chain validation.
+/// </summary>
+/// <param name="RequiredFields">
+/// Attribute field names this transform reads. The validator reports a hard failure when
+/// a required field is neither declared by the source nor produced by an earlier stage.
+/// </param>
+/// <param name="ProducedFields">
+/// Attribute field names this transform adds to the output schema.
+/// </param>
+/// <param name="RemovedFields">
+/// Attribute field names this transform removes from the output schema (for example a
+/// rename removes the source key). Empty when the transform removes nothing.
+/// </param>
+public sealed record TransformSchemaEffect(
+    IReadOnlyList<string> RequiredFields,
+    IReadOnlyList<string> ProducedFields,
+    IReadOnlyList<string> RemovedFields)
+{
+    /// <summary>
+    /// A schema effect that neither requires, produces, nor removes any field.
+    /// </summary>
+    public static readonly TransformSchemaEffect None = new([], [], []);
+}
+
+/// <summary>
+/// Implemented by transforms that can describe their attribute-schema effect so the
+/// stage-chain validator can check field reachability before a pipeline runs. Transforms
+/// that do not implement this interface are treated as schema-passthrough (no required,
+/// produced, or removed fields) and never block validation.
+/// </summary>
+public interface ISchemaAwareTransform
+{
+    /// <summary>
+    /// Describes how this transform reads and reshapes the attribute schema for the given
+    /// configuration.
+    /// </summary>
+    /// <param name="config">The transform configuration.</param>
+    /// <returns>The transform's schema effect.</returns>
+    TransformSchemaEffect DescribeSchema(TransformConfig config);
+}

--- a/src/Honua.Core/Features/GeoETL/Abstractions/PipelineConnectors.cs
+++ b/src/Honua.Core/Features/GeoETL/Abstractions/PipelineConnectors.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Abstractions;
+
+/// <summary>
+/// A source connector extracts a streaming feature set from an external source. Phase 1
+/// implementations wrap the existing managed format readers in
+/// <c>Honua.Core/Features/Import/Services/</c> and never materialize the full set in
+/// memory. See the GeoETL roadmap § Connector phasing.
+/// </summary>
+public interface IPipelineSourceConnector
+{
+    /// <summary>
+    /// Connector type discriminator matching <see cref="ConnectorConfig.Type"/>.
+    /// </summary>
+    string Type { get; }
+
+    /// <summary>
+    /// Worker runtime profile this connector requires. Phase 1 connectors are
+    /// <see cref="ConnectorRuntimeProfile.Managed"/>.
+    /// </summary>
+    ConnectorRuntimeProfile RuntimeProfile { get; }
+
+    /// <summary>
+    /// Streams features from the configured source. Features are yielded one at a time
+    /// to maintain constant memory usage and honour <paramref name="cancellationToken"/>.
+    /// </summary>
+    /// <param name="config">Source connector configuration.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>The extracted feature stream.</returns>
+    IAsyncEnumerable<IFeature> ReadAsync(ConnectorConfig config, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// A transform maps an input feature stream to an output feature stream. Transforms are
+/// pure streaming operators and never materialize the full set in memory. Row-level
+/// errors route to the quarantine channel rather than aborting the run (ADR-0038).
+/// </summary>
+public interface IPipelineTransform
+{
+    /// <summary>
+    /// Transform type discriminator matching <see cref="TransformConfig.Type"/>.
+    /// </summary>
+    string Type { get; }
+
+    /// <summary>
+    /// Applies the transform to <paramref name="source"/>, yielding the transformed stream.
+    /// </summary>
+    /// <param name="config">Transform configuration.</param>
+    /// <param name="source">Input feature stream.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>The transformed feature stream.</returns>
+    IAsyncEnumerable<IFeature> TransformAsync(
+        TransformConfig config,
+        IAsyncEnumerable<IFeature> source,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Summary returned by a sink after it consumes the feature stream.
+/// </summary>
+public sealed record SinkWriteResult
+{
+    /// <summary>
+    /// Number of features the sink committed.
+    /// </summary>
+    public long FeaturesWritten { get; init; }
+
+    /// <summary>
+    /// Number of features the sink rejected (for example null geometry).
+    /// </summary>
+    public long FeaturesRejected { get; init; }
+}
+
+/// <summary>
+/// A sink connector loads a streaming feature set into a durable target. The Phase 1
+/// Honua-layer / PostGIS sink reuses the <c>StreamingFileImportService</c> insert path.
+/// The dry-run preview sink counts features without writing.
+/// </summary>
+public interface IPipelineSinkConnector
+{
+    /// <summary>
+    /// Connector type discriminator matching <see cref="ConnectorConfig.Type"/>.
+    /// </summary>
+    string Type { get; }
+
+    /// <summary>
+    /// Worker runtime profile this connector requires. Phase 1 sinks are
+    /// <see cref="ConnectorRuntimeProfile.Managed"/>.
+    /// </summary>
+    ConnectorRuntimeProfile RuntimeProfile { get; }
+
+    /// <summary>
+    /// Consumes the feature stream and writes it to the configured target.
+    /// </summary>
+    /// <param name="config">Sink connector configuration.</param>
+    /// <param name="features">The feature stream to load.</param>
+    /// <param name="batchId">
+    /// Batch identifier tagged on every write so a failed run can soft-delete its rows.
+    /// </param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>The write summary.</returns>
+    Task<SinkWriteResult> WriteAsync(
+        ConnectorConfig config,
+        IAsyncEnumerable<IFeature> features,
+        string batchId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Resolves <see cref="IPipelineSourceConnector"/>, <see cref="IPipelineTransform"/>,
+/// and <see cref="IPipelineSinkConnector"/> instances by their type discriminators.
+/// </summary>
+public interface IPipelineComponentFactory
+{
+    /// <summary>
+    /// Resolves the source connector for the given type, or null when unknown.
+    /// </summary>
+    /// <param name="type">Source connector type discriminator.</param>
+    IPipelineSourceConnector? ResolveSource(string type);
+
+    /// <summary>
+    /// Resolves the transform for the given type, or null when unknown.
+    /// </summary>
+    /// <param name="type">Transform type discriminator.</param>
+    IPipelineTransform? ResolveTransform(string type);
+
+    /// <summary>
+    /// Resolves the sink connector for the given type, or null when unknown.
+    /// </summary>
+    /// <param name="type">Sink connector type discriminator.</param>
+    IPipelineSinkConnector? ResolveSink(string type);
+}

--- a/src/Honua.Core/Features/GeoETL/Abstractions/PipelineStores.cs
+++ b/src/Honua.Core/Features/GeoETL/Abstractions/PipelineStores.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Domain;
+
+namespace Honua.Core.Features.GeoETL.Abstractions;
+
+/// <summary>
+/// Durable store for pipeline definitions. Backed by <c>honua.pipeline_definitions</c>
+/// in PostgreSQL (Child Ticket A) with an in-memory implementation for the baseline slice.
+/// </summary>
+public interface IPipelineDefinitionStore
+{
+    /// <summary>
+    /// Persists a new pipeline definition.
+    /// </summary>
+    /// <param name="definition">Definition to create.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task CreateAsync(PipelineDefinition definition, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the current version of a pipeline definition, or null when not found.
+    /// </summary>
+    /// <param name="id">Pipeline identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<PipelineDefinition?> GetAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Replaces a pipeline definition, incrementing its version. Returns the stored
+    /// definition with the new version, or null when the pipeline does not exist.
+    /// </summary>
+    /// <param name="definition">Updated definition.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<PipelineDefinition?> UpdateAsync(PipelineDefinition definition, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a pipeline definition. Returns true when a definition was removed.
+    /// </summary>
+    /// <param name="id">Pipeline identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<bool> DeleteAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all pipeline definitions (current versions).
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<PipelineDefinition>> ListAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Durable store for pipeline execution records. Backed by <c>honua.pipeline_executions</c>
+/// in PostgreSQL (Child Ticket A) with an in-memory implementation for the baseline slice.
+/// </summary>
+public interface IPipelineExecutionStore
+{
+    /// <summary>
+    /// Persists a new execution record.
+    /// </summary>
+    /// <param name="execution">Execution to create.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task CreateAsync(PipelineExecution execution, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persists the latest execution state.
+    /// </summary>
+    /// <param name="execution">Execution to upsert.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task UpdateAsync(PipelineExecution execution, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves an execution record, or null when not found.
+    /// </summary>
+    /// <param name="id">Execution identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<PipelineExecution?> GetAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists executions for a pipeline, newest first.
+    /// </summary>
+    /// <param name="pipelineId">Pipeline identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<PipelineExecution>> ListForPipelineAsync(
+        string pipelineId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/GeoETL/Domain/PipelineDefinition.cs
+++ b/src/Honua.Core/Features/GeoETL/Domain/PipelineDefinition.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.GeoETL.Domain;
+
+/// <summary>
+/// The kind of a single stage in a pipeline. A pipeline is a linear chain of
+/// <see cref="Source"/> followed by zero or more <see cref="Transform"/> stages
+/// and terminated by a single <see cref="Sink"/>.
+/// </summary>
+public enum PipelineStageKind
+{
+    /// <summary>
+    /// Extract stage that produces a feature stream from an external source.
+    /// </summary>
+    Source,
+
+    /// <summary>
+    /// Transform stage that maps an input feature stream to an output feature stream.
+    /// </summary>
+    Transform,
+
+    /// <summary>
+    /// Load stage that writes the feature stream to a durable target.
+    /// </summary>
+    Sink
+}
+
+/// <summary>
+/// Worker runtime profile required to execute a connector. The serving image runs
+/// only <see cref="Managed"/> connectors; <see cref="RequiresNativeGeo"/> connectors
+/// run on the dedicated <c>honua-worker-etl</c> image (Child Ticket F). See ADR-0038.
+/// </summary>
+public enum ConnectorRuntimeProfile
+{
+    /// <summary>
+    /// Managed connector with no native GDAL/PROJ/GEOS dependency. Runs in the lean
+    /// serving image.
+    /// </summary>
+    Managed,
+
+    /// <summary>
+    /// Connector that requires native geospatial libraries (GDAL/OGR). Runs only on
+    /// the heavyweight worker profile.
+    /// </summary>
+    RequiresNativeGeo
+}
+
+/// <summary>
+/// Typed configuration for a source or sink connector stage. Carries the connector
+/// type discriminator plus an opaque, source-generation-friendly string option bag.
+/// </summary>
+/// <remarks>
+/// The option bag is intentionally <see cref="string"/>-keyed and -valued so that the
+/// definition remains trim/AOT safe and source-generated polymorphic JSON stays flat.
+/// Connector factories interpret <see cref="Options"/> per connector type.
+/// </remarks>
+public sealed record ConnectorConfig
+{
+    /// <summary>
+    /// Stable connector type discriminator, for example <c>geojson</c>, <c>shapefile</c>,
+    /// or <c>honua-layer</c>. Resolved by the connector factory.
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Opaque connector-specific options interpreted by the connector factory.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Options { get; init; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+}
+
+/// <summary>
+/// Typed configuration for a transform stage. Carries the transform type discriminator
+/// plus an opaque, source-generation-friendly string option bag.
+/// </summary>
+public sealed record TransformConfig
+{
+    /// <summary>
+    /// Stable transform type discriminator, for example <c>reproject</c> or
+    /// <c>attribute-filter</c>. Resolved by the transform factory.
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Opaque transform-specific options interpreted by the transform factory.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Options { get; init; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+}
+
+/// <summary>
+/// A single stage in a pipeline. Exactly one of <see cref="Connector"/> or
+/// <see cref="Transform"/> is populated depending on <see cref="Kind"/>.
+/// </summary>
+public sealed record PipelineStage
+{
+    /// <summary>
+    /// The stage kind. Determines which of <see cref="Connector"/> or
+    /// <see cref="Transform"/> carries this stage's configuration.
+    /// </summary>
+    public required PipelineStageKind Kind { get; init; }
+
+    /// <summary>
+    /// Connector configuration for <see cref="PipelineStageKind.Source"/> and
+    /// <see cref="PipelineStageKind.Sink"/> stages. Null for transform stages.
+    /// </summary>
+    public ConnectorConfig? Connector { get; init; }
+
+    /// <summary>
+    /// Transform configuration for <see cref="PipelineStageKind.Transform"/> stages.
+    /// Null for source and sink stages.
+    /// </summary>
+    public TransformConfig? Transform { get; init; }
+}
+
+/// <summary>
+/// A declarative GeoETL pipeline: a single source, zero or more transforms, and a
+/// single sink. Stored in <c>honua.pipeline_definitions</c> and executed as an
+/// <see cref="Honua.Core.Features.ControlPlane.Domain.ExecutionJobKind.ExtractTransformLoad"/>
+/// job through the durable substrate (#681). See the GeoETL roadmap and ADR-0038.
+/// </summary>
+public sealed record PipelineDefinition
+{
+    /// <summary>
+    /// Schema version of the definition document. Lives on the root from day one so
+    /// that stored definitions remain readable across discriminated-union evolutions.
+    /// </summary>
+    public int SchemaVersion { get; init; } = 1;
+
+    /// <summary>
+    /// Stable pipeline identifier. Assigned at creation time.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Human-readable pipeline name.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Optional free-form description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Definition version. Incremented on every successful update. Older versions
+    /// remain readable for audit and rollback.
+    /// </summary>
+    public int Version { get; init; } = 1;
+
+    /// <summary>
+    /// Ordered stage chain: Source then []Transform then Sink.
+    /// </summary>
+    public IReadOnlyList<PipelineStage> Stages { get; init; } = [];
+
+    /// <summary>
+    /// UTC creation timestamp.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>
+    /// UTC timestamp of the most recent update.
+    /// </summary>
+    public DateTimeOffset UpdatedAt { get; init; }
+
+    /// <summary>
+    /// Returns the single source stage, or null when the chain is malformed.
+    /// </summary>
+    public PipelineStage? Source =>
+        Stages.Count > 0 && Stages[0].Kind == PipelineStageKind.Source ? Stages[0] : null;
+
+    /// <summary>
+    /// Returns the single sink stage, or null when the chain is malformed.
+    /// </summary>
+    public PipelineStage? Sink =>
+        Stages.Count > 0 && Stages[^1].Kind == PipelineStageKind.Sink ? Stages[^1] : null;
+
+    /// <summary>
+    /// Returns the ordered transform stages between the source and sink.
+    /// </summary>
+    public IReadOnlyList<PipelineStage> Transforms =>
+        Stages.Where(s => s.Kind == PipelineStageKind.Transform).ToArray();
+}

--- a/src/Honua.Core/Features/GeoETL/Domain/PipelineExecution.cs
+++ b/src/Honua.Core/Features/GeoETL/Domain/PipelineExecution.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.GeoETL.Domain;
+
+/// <summary>
+/// Terminal and in-flight status values for a pipeline execution. These mirror the
+/// substrate's job lifecycle so a pipeline execution record stays in lockstep with
+/// the underlying <see cref="Honua.Core.Features.ControlPlane.Domain.ExecutionJobStatus"/>.
+/// </summary>
+public enum PipelineExecutionStatus
+{
+    /// <summary>
+    /// Execution has been recorded but the job has not started running yet.
+    /// </summary>
+    Pending,
+
+    /// <summary>
+    /// The stage runner is actively processing the feature stream.
+    /// </summary>
+    Running,
+
+    /// <summary>
+    /// The pipeline completed successfully and the sink committed its writes.
+    /// </summary>
+    Succeeded,
+
+    /// <summary>
+    /// The pipeline failed. <see cref="PipelineExecution.ErrorMessage"/> carries the reason.
+    /// </summary>
+    Failed,
+
+    /// <summary>
+    /// The pipeline was cancelled by an operator or the worker shut down.
+    /// </summary>
+    Cancelled
+}
+
+/// <summary>
+/// Durable record of a single pipeline run. Stored in <c>honua.pipeline_executions</c>
+/// and correlated to the substrate <c>ExecutionJobRecord</c> by
+/// <see cref="ExecutionJobId"/>.
+/// </summary>
+public sealed record PipelineExecution
+{
+    /// <summary>
+    /// Stable execution identifier. Used as the substrate operation id so the
+    /// pipeline execution and the job record share one key.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Identifier of the pipeline definition that was executed.
+    /// </summary>
+    public required string PipelineId { get; init; }
+
+    /// <summary>
+    /// Version of the pipeline definition that was executed.
+    /// </summary>
+    public int PipelineVersion { get; init; }
+
+    /// <summary>
+    /// Substrate execution job id (<c>ExecutionJobRecord.OperationId</c>) backing this run.
+    /// </summary>
+    public required string ExecutionJobId { get; init; }
+
+    /// <summary>
+    /// Current execution status.
+    /// </summary>
+    public PipelineExecutionStatus Status { get; init; } = PipelineExecutionStatus.Pending;
+
+    /// <summary>
+    /// Whether this run is a dry run that routes the sink to the null preview sink and
+    /// never writes to durable targets.
+    /// </summary>
+    public bool IsDryRun { get; init; }
+
+    /// <summary>
+    /// Number of features read from the source.
+    /// </summary>
+    public long FeaturesRead { get; init; }
+
+    /// <summary>
+    /// Number of features written to the sink (or counted by the dry-run null sink).
+    /// </summary>
+    public long FeaturesWritten { get; init; }
+
+    /// <summary>
+    /// Number of features routed to the quarantine sink due to row-level errors.
+    /// </summary>
+    public long FeaturesQuarantined { get; init; }
+
+    /// <summary>
+    /// Batch identifier tagged on every sink write so a failed run can soft-delete its
+    /// own rows. See ADR-0038 § Rollback strategy.
+    /// </summary>
+    public string? BatchId { get; init; }
+
+    /// <summary>
+    /// Error message when <see cref="Status"/> is <see cref="PipelineExecutionStatus.Failed"/>.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// UTC creation timestamp.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>
+    /// UTC timestamp the run reached a terminal state, or null while in flight.
+    /// </summary>
+    public DateTimeOffset? CompletedAt { get; init; }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Connectors/CsvSourceConnector.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Connectors/CsvSourceConnector.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.Import.Services;
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Services.Connectors;
+
+/// <summary>
+/// Phase 1 CSV source connector. Wraps the existing managed <see cref="CsvFormatReader"/>
+/// — it does not reimplement CSV parsing. The reader streams features one record at a
+/// time, deriving geometry from either a WKT column or longitude/latitude coordinate
+/// columns, so the connector keeps constant memory and requires no native dependency.
+/// </summary>
+/// <remarks>
+/// Supported <see cref="ConnectorConfig.Options"/>:
+/// <list type="bullet">
+/// <item><c>path</c> — absolute path to a CSV file.</item>
+/// <item><c>inline</c> — a CSV document supplied directly (used by tests and inline
+/// enrichment workloads).</item>
+/// <item><c>delimiter</c> — optional single-character delimiter override; when omitted the
+/// reader auto-detects from <c>, \t ; |</c>.</item>
+/// </list>
+/// Exactly one of <c>path</c> or <c>inline</c> must be present. Geometry columns are
+/// auto-detected: a WKT column (<c>wkt</c>, <c>geom</c>, <c>geometry</c>, <c>shape</c>, …)
+/// or a longitude/latitude pair (<c>lon</c>/<c>lng</c>/<c>x</c> and <c>lat</c>/<c>y</c>).
+/// </remarks>
+public sealed class CsvSourceConnector : IPipelineSourceConnector
+{
+    /// <summary>
+    /// The connector type discriminator.
+    /// </summary>
+    public const string ConnectorType = "csv";
+
+    /// <inheritdoc />
+    public string Type => ConnectorType;
+
+    /// <inheritdoc />
+    public ConnectorRuntimeProfile RuntimeProfile => ConnectorRuntimeProfile.Managed;
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> ReadAsync(
+        ConnectorConfig config,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var delimiterOverride = ReadDelimiterOverride(config);
+        await using var stream = OpenStream(config);
+
+        await foreach (var feature in CsvFormatReader
+                           .ReadStreamingAsync(stream, delimiterOverride, cancellationToken)
+                           .ConfigureAwait(false))
+        {
+            yield return feature;
+        }
+    }
+
+    private static char? ReadDelimiterOverride(ConnectorConfig config)
+    {
+        if (config.Options.TryGetValue("delimiter", out var delimiter) && delimiter.Length == 1)
+        {
+            return delimiter[0];
+        }
+
+        return null;
+    }
+
+    private static Stream OpenStream(ConnectorConfig config)
+    {
+        if (config.Options.TryGetValue("inline", out var inline) && !string.IsNullOrEmpty(inline))
+        {
+            return new MemoryStream(Encoding.UTF8.GetBytes(inline), writable: false);
+        }
+
+        if (config.Options.TryGetValue("path", out var path) && !string.IsNullOrWhiteSpace(path))
+        {
+            return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 65536,
+                useAsync: true);
+        }
+
+        throw new InvalidOperationException(
+            "CSV source connector requires either an 'inline' document or a 'path' option.");
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Connectors/GeoJsonFileSinkConnector.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Connectors/GeoJsonFileSinkConnector.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+using Newtonsoft.Json;
+
+namespace Honua.Core.Features.GeoETL.Services.Connectors;
+
+/// <summary>
+/// Phase 1 GeoJSON file sink. Streams the feature set to a GeoJSON <c>FeatureCollection</c>
+/// file, writing one feature at a time so the sink keeps constant memory regardless of
+/// feature count. Uses the managed <see cref="GeoJsonWriter"/> (NetTopologySuite.IO.GeoJSON)
+/// — no native dependency. See the GeoETL roadmap § Sink phasing.
+/// </summary>
+/// <remarks>
+/// Required <see cref="ConnectorConfig.Options"/>: <c>path</c> — absolute output file path
+/// (overwritten if it exists). Features with null geometry are still written (GeoJSON
+/// permits a null geometry member) but counted as rejected so the run summary reflects
+/// them.
+/// </remarks>
+public sealed class GeoJsonFileSinkConnector : IPipelineSinkConnector
+{
+    /// <summary>
+    /// The connector type discriminator.
+    /// </summary>
+    public const string ConnectorType = "geojson-file";
+
+    /// <inheritdoc />
+    public string Type => ConnectorType;
+
+    /// <inheritdoc />
+    public ConnectorRuntimeProfile RuntimeProfile => ConnectorRuntimeProfile.Managed;
+
+    /// <inheritdoc />
+    public async Task<SinkWriteResult> WriteAsync(
+        ConnectorConfig config,
+        IAsyncEnumerable<IFeature> features,
+        string batchId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(features);
+
+        if (!config.Options.TryGetValue("path", out var path) || string.IsNullOrWhiteSpace(path))
+        {
+            throw new InvalidOperationException("GeoJSON file sink requires a 'path' option.");
+        }
+
+        var geoJsonWriter = new GeoJsonWriter();
+        long written = 0;
+        long rejected = 0;
+
+        await using var stream = new FileStream(
+            path, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 65536, useAsync: true);
+        await using var textWriter = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        using var jsonWriter = new JsonTextWriter(textWriter);
+
+        await jsonWriter.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+        await jsonWriter.WritePropertyNameAsync("type", cancellationToken).ConfigureAwait(false);
+        await jsonWriter.WriteValueAsync("FeatureCollection", cancellationToken).ConfigureAwait(false);
+        await jsonWriter.WritePropertyNameAsync("features", cancellationToken).ConfigureAwait(false);
+        await jsonWriter.WriteStartArrayAsync(cancellationToken).ConfigureAwait(false);
+
+        await foreach (var feature in features.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            // The GeoJsonWriter overload accepts the concrete Feature type; wrap when needed.
+            var concrete = feature as Feature ?? new Feature(feature.Geometry, feature.Attributes);
+            geoJsonWriter.Write(concrete, jsonWriter);
+
+            if (feature.Geometry is null)
+            {
+                rejected++;
+            }
+            else
+            {
+                written++;
+            }
+        }
+
+        await jsonWriter.WriteEndArrayAsync(cancellationToken).ConfigureAwait(false);
+        await jsonWriter.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+        await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        return new SinkWriteResult { FeaturesWritten = written, FeaturesRejected = rejected };
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Connectors/GeoJsonSourceConnector.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Connectors/GeoJsonSourceConnector.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.Import.Services;
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Services.Connectors;
+
+/// <summary>
+/// Phase 1 GeoJSON source connector. Wraps the existing managed
+/// <see cref="StreamingGeoJsonReader"/> — it does not reimplement GeoJSON parsing.
+/// The reader streams features one at a time so the connector keeps constant memory.
+/// </summary>
+/// <remarks>
+/// Supported <see cref="ConnectorConfig.Options"/>:
+/// <list type="bullet">
+/// <item><c>path</c> — absolute path to a GeoJSON FeatureCollection file.</item>
+/// <item><c>inline</c> — a GeoJSON FeatureCollection document supplied directly (used by
+/// the inline-enrichment proof workload and by tests).</item>
+/// </list>
+/// Exactly one of <c>path</c> or <c>inline</c> must be present.
+/// </remarks>
+public sealed class GeoJsonSourceConnector : IPipelineSourceConnector
+{
+    /// <summary>
+    /// The connector type discriminator.
+    /// </summary>
+    public const string ConnectorType = "geojson";
+
+    /// <inheritdoc />
+    public string Type => ConnectorType;
+
+    /// <inheritdoc />
+    public ConnectorRuntimeProfile RuntimeProfile => ConnectorRuntimeProfile.Managed;
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> ReadAsync(
+        ConnectorConfig config,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var reader = new StreamingGeoJsonReader();
+        await using var stream = OpenStream(config);
+
+        await foreach (var feature in reader.ReadFeaturesAsync(stream, cancellationToken).ConfigureAwait(false))
+        {
+            yield return feature;
+        }
+    }
+
+    private static Stream OpenStream(ConnectorConfig config)
+    {
+        if (config.Options.TryGetValue("inline", out var inline) && !string.IsNullOrEmpty(inline))
+        {
+            return new MemoryStream(Encoding.UTF8.GetBytes(inline), writable: false);
+        }
+
+        if (config.Options.TryGetValue("path", out var path) && !string.IsNullOrWhiteSpace(path))
+        {
+            return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 65536,
+                useAsync: true);
+        }
+
+        throw new InvalidOperationException(
+            "GeoJSON source connector requires either an 'inline' document or a 'path' option.");
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Connectors/HonuaLayerSinkConnector.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Connectors/HonuaLayerSinkConnector.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Services.Connectors;
+
+/// <summary>
+/// Phase 1 Honua-layer / PostGIS sink. Batches the feature stream and writes through
+/// <see cref="IFeatureSinkWriter"/>, which mirrors the <c>StreamingFileImportService</c>
+/// insert path (<c>honua.create_import_table</c> + <c>honua.insert_import_feature</c>).
+/// Every row is tagged with the run batch id for soft-delete rollback (ADR-0038).
+/// </summary>
+/// <remarks>
+/// Required <see cref="ConnectorConfig.Options"/>: <c>schema</c>, <c>table</c>,
+/// <c>targetSrid</c>. Optional <c>sourceSrid</c> (defaults to the target SRID) and
+/// <c>batchSize</c> (defaults to 1000).
+/// </remarks>
+public sealed class HonuaLayerSinkConnector(IFeatureSinkWriter writer) : IPipelineSinkConnector
+{
+    /// <summary>
+    /// The connector type discriminator.
+    /// </summary>
+    public const string ConnectorType = "honua-layer";
+
+    private const int DefaultBatchSize = 1000;
+
+    /// <inheritdoc />
+    public string Type => ConnectorType;
+
+    /// <inheritdoc />
+    public ConnectorRuntimeProfile RuntimeProfile => ConnectorRuntimeProfile.Managed;
+
+    /// <inheritdoc />
+    public async Task<SinkWriteResult> WriteAsync(
+        ConnectorConfig config,
+        IAsyncEnumerable<IFeature> features,
+        string batchId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(features);
+
+        var schema = RequireOption(config, "schema");
+        var table = RequireOption(config, "table");
+        var targetSrid = RequireIntOption(config, "targetSrid");
+        var sourceSrid = config.Options.TryGetValue("sourceSrid", out var raw)
+            && int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : targetSrid;
+        var batchSize = config.Options.TryGetValue("batchSize", out var rawBatch)
+            && int.TryParse(rawBatch, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedBatch)
+            && parsedBatch > 0
+            ? parsedBatch
+            : DefaultBatchSize;
+
+        await writer.EnsureTargetAsync(schema, table, targetSrid, cancellationToken).ConfigureAwait(false);
+
+        long written = 0;
+        long rejected = 0;
+        var buffer = new List<IFeature>(batchSize);
+
+        await foreach (var feature in features.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            if (feature.Geometry is null)
+            {
+                rejected++;
+                continue;
+            }
+
+            buffer.Add(feature);
+            if (buffer.Count >= batchSize)
+            {
+                written += await writer
+                    .InsertBatchAsync(schema, table, buffer, sourceSrid, targetSrid, batchId, cancellationToken)
+                    .ConfigureAwait(false);
+                buffer.Clear();
+            }
+        }
+
+        if (buffer.Count > 0)
+        {
+            written += await writer
+                .InsertBatchAsync(schema, table, buffer, sourceSrid, targetSrid, batchId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return new SinkWriteResult { FeaturesWritten = written, FeaturesRejected = rejected };
+    }
+
+    private static string RequireOption(ConnectorConfig config, string key)
+    {
+        if (!config.Options.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"Honua-layer sink requires a '{key}' option.");
+        }
+
+        return value;
+    }
+
+    private static int RequireIntOption(ConnectorConfig config, string key)
+    {
+        if (!config.Options.TryGetValue(key, out var raw) ||
+            !int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) ||
+            value <= 0)
+        {
+            throw new InvalidOperationException($"Honua-layer sink requires a positive integer '{key}' option.");
+        }
+
+        return value;
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Connectors/NullPreviewSinkConnector.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Connectors/NullPreviewSinkConnector.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Services.Connectors;
+
+/// <summary>
+/// Phase 1 dry-run null preview sink. Drains the feature stream and counts rows without
+/// writing to any durable target, so a dry run exercises every preceding stage exactly
+/// like production while leaving sink targets untouched. See ADR-0038 § Observability of
+/// dry runs.
+/// </summary>
+public sealed class NullPreviewSinkConnector : IPipelineSinkConnector
+{
+    /// <summary>
+    /// The connector type discriminator.
+    /// </summary>
+    public const string ConnectorType = "null-preview";
+
+    /// <inheritdoc />
+    public string Type => ConnectorType;
+
+    /// <inheritdoc />
+    public ConnectorRuntimeProfile RuntimeProfile => ConnectorRuntimeProfile.Managed;
+
+    /// <inheritdoc />
+    public async Task<SinkWriteResult> WriteAsync(
+        ConnectorConfig config,
+        IAsyncEnumerable<IFeature> features,
+        string batchId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+
+        long counted = 0;
+        long rejected = 0;
+        await foreach (var feature in features.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            if (feature.Geometry is null)
+            {
+                rejected++;
+                continue;
+            }
+
+            counted++;
+        }
+
+        return new SinkWriteResult { FeaturesWritten = counted, FeaturesRejected = rejected };
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Connectors/QuarantineSinkConnector.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Connectors/QuarantineSinkConnector.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+using Newtonsoft.Json;
+
+namespace Honua.Core.Features.GeoETL.Services.Connectors;
+
+/// <summary>
+/// Phase 1 quarantine / dead-letter sink. Writes every feature it receives to a companion
+/// GeoJSON artifact, tagging each with the run batch id and an optional rejection reason,
+/// and never throws on a malformed row — a single bad feature is captured rather than
+/// killing the whole job. This is the sink half of the ADR-0038 row-level-error contract:
+/// rows that fail validation or a transform route here instead of aborting the run, and
+/// the execution summary reports the quarantined count. The serialization of any single
+/// feature that itself fails to serialize is caught and recorded as a minimal placeholder
+/// so the artifact is always complete.
+/// </summary>
+/// <remarks>
+/// Required <see cref="ConnectorConfig.Options"/>: <c>path</c> — absolute output file path
+/// for the dead-letter GeoJSON FeatureCollection (overwritten if it exists). Optional
+/// <c>reasonField</c> — the attribute name carrying a per-row reason string (defaults to
+/// <c>_quarantine_reason</c>); when present it is preserved, otherwise a
+/// <c>_batch_id</c> tag is still added so quarantined rows trace back to their run.
+/// </remarks>
+public sealed class QuarantineSinkConnector : IPipelineSinkConnector
+{
+    /// <summary>
+    /// The connector type discriminator.
+    /// </summary>
+    public const string ConnectorType = "quarantine";
+
+    private const string DefaultReasonField = "_quarantine_reason";
+
+    /// <inheritdoc />
+    public string Type => ConnectorType;
+
+    /// <inheritdoc />
+    public ConnectorRuntimeProfile RuntimeProfile => ConnectorRuntimeProfile.Managed;
+
+    /// <inheritdoc />
+    public async Task<SinkWriteResult> WriteAsync(
+        ConnectorConfig config,
+        IAsyncEnumerable<IFeature> features,
+        string batchId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(features);
+
+        if (!config.Options.TryGetValue("path", out var path) || string.IsNullOrWhiteSpace(path))
+        {
+            throw new InvalidOperationException("Quarantine sink requires a 'path' option.");
+        }
+
+        var reasonField = config.Options.TryGetValue("reasonField", out var rawReason)
+            && !string.IsNullOrWhiteSpace(rawReason)
+            ? rawReason
+            : DefaultReasonField;
+
+        var geoJsonWriter = new GeoJsonWriter();
+        long quarantined = 0;
+
+        await using var stream = new FileStream(
+            path, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 65536, useAsync: true);
+        await using var textWriter = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        using var jsonWriter = new JsonTextWriter(textWriter);
+
+        await jsonWriter.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+        await jsonWriter.WritePropertyNameAsync("type", cancellationToken).ConfigureAwait(false);
+        await jsonWriter.WriteValueAsync("FeatureCollection", cancellationToken).ConfigureAwait(false);
+        await jsonWriter.WritePropertyNameAsync("features", cancellationToken).ConfigureAwait(false);
+        await jsonWriter.WriteStartArrayAsync(cancellationToken).ConfigureAwait(false);
+
+        await foreach (var feature in features.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            var tagged = Tag(feature, batchId, reasonField);
+            try
+            {
+                geoJsonWriter.Write(tagged, jsonWriter);
+            }
+            catch (Exception ex) when (ex is JsonException or ArgumentException or InvalidOperationException)
+            {
+                // Even the dead-letter write must not abort the job — record a minimal placeholder.
+                geoJsonWriter.Write(Placeholder(batchId, reasonField, ex.Message), jsonWriter);
+            }
+
+            quarantined++;
+        }
+
+        await jsonWriter.WriteEndArrayAsync(cancellationToken).ConfigureAwait(false);
+        await jsonWriter.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+        await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        // Quarantined rows are not "written" to a durable target — they are rejects.
+        return new SinkWriteResult { FeaturesWritten = 0, FeaturesRejected = quarantined };
+    }
+
+    private static Feature Tag(IFeature feature, string batchId, string reasonField)
+    {
+        var attributes = new AttributesTable();
+        if (feature.Attributes is not null)
+        {
+            foreach (var name in feature.Attributes.GetNames())
+            {
+                attributes.Add(name, feature.Attributes.GetOptionalValue(name));
+            }
+        }
+
+        if (!attributes.Exists("_batch_id"))
+        {
+            attributes.Add("_batch_id", batchId);
+        }
+
+        if (!attributes.Exists(reasonField))
+        {
+            attributes.Add(reasonField, "unspecified");
+        }
+
+        return new Feature(feature.Geometry, attributes);
+    }
+
+    private static Feature Placeholder(string batchId, string reasonField, string detail)
+    {
+        var attributes = new AttributesTable
+        {
+            { "_batch_id", batchId },
+            { reasonField, $"serialization-failed: {detail}" }
+        };
+        return new Feature(null, attributes);
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/InMemoryPipelineStores.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/InMemoryPipelineStores.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+
+namespace Honua.Core.Features.GeoETL.Services;
+
+/// <summary>
+/// In-memory <see cref="IPipelineDefinitionStore"/> for the baseline slice and tests.
+/// The durable PostgreSQL-backed store (<c>honua.pipeline_definitions</c>) is Child
+/// Ticket A's remaining EF/DbUp work; this implementation preserves the same contract.
+/// </summary>
+public sealed class InMemoryPipelineDefinitionStore : IPipelineDefinitionStore
+{
+    private readonly ConcurrentDictionary<string, PipelineDefinition> _store =
+        new(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public Task CreateAsync(PipelineDefinition definition, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        if (!_store.TryAdd(definition.Id, definition))
+        {
+            throw new InvalidOperationException($"Pipeline '{definition.Id}' already exists.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<PipelineDefinition?> GetAsync(string id, CancellationToken cancellationToken = default)
+        => Task.FromResult(_store.TryGetValue(id, out var definition) ? definition : null);
+
+    /// <inheritdoc />
+    public Task<PipelineDefinition?> UpdateAsync(PipelineDefinition definition, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        if (!_store.TryGetValue(definition.Id, out var existing))
+        {
+            return Task.FromResult<PipelineDefinition?>(null);
+        }
+
+        var updated = definition with
+        {
+            Version = existing.Version + 1,
+            CreatedAt = existing.CreatedAt,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        _store[definition.Id] = updated;
+        return Task.FromResult<PipelineDefinition?>(updated);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> DeleteAsync(string id, CancellationToken cancellationToken = default)
+        => Task.FromResult(_store.TryRemove(id, out _));
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<PipelineDefinition>> ListAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<PipelineDefinition>>(_store.Values.OrderBy(d => d.Name, StringComparer.Ordinal).ToArray());
+}
+
+/// <summary>
+/// In-memory <see cref="IPipelineExecutionStore"/> for the baseline slice and tests.
+/// The durable PostgreSQL-backed store (<c>honua.pipeline_executions</c>) is Child
+/// Ticket A's remaining EF/DbUp work; this implementation preserves the same contract.
+/// </summary>
+public sealed class InMemoryPipelineExecutionStore : IPipelineExecutionStore
+{
+    private readonly ConcurrentDictionary<string, PipelineExecution> _store =
+        new(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public Task CreateAsync(PipelineExecution execution, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(execution);
+        if (!_store.TryAdd(execution.Id, execution))
+        {
+            throw new InvalidOperationException($"Execution '{execution.Id}' already exists.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task UpdateAsync(PipelineExecution execution, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(execution);
+        _store[execution.Id] = execution;
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<PipelineExecution?> GetAsync(string id, CancellationToken cancellationToken = default)
+        => Task.FromResult(_store.TryGetValue(id, out var execution) ? execution : null);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<PipelineExecution>> ListForPipelineAsync(
+        string pipelineId,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<PipelineExecution>>(
+            _store.Values
+                .Where(e => string.Equals(e.PipelineId, pipelineId, StringComparison.Ordinal))
+                .OrderByDescending(e => e.CreatedAt)
+                .ToArray());
+}

--- a/src/Honua.Core/Features/GeoETL/Services/PipelineComponentFactory.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/PipelineComponentFactory.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using Honua.Core.Features.GeoETL.Abstractions;
+
+namespace Honua.Core.Features.GeoETL.Services;
+
+/// <summary>
+/// Resolves pipeline components by type discriminator from the registered connector and
+/// transform sets. Built once over the DI-provided enumerables, mirroring the
+/// geoprocessing dispatch-by-id pattern.
+/// </summary>
+public sealed class PipelineComponentFactory : IPipelineComponentFactory
+{
+    private readonly FrozenDictionary<string, IPipelineSourceConnector> _sources;
+    private readonly FrozenDictionary<string, IPipelineTransform> _transforms;
+    private readonly FrozenDictionary<string, IPipelineSinkConnector> _sinks;
+
+    /// <summary>
+    /// Builds the factory over the registered components.
+    /// </summary>
+    /// <param name="sources">Registered source connectors.</param>
+    /// <param name="transforms">Registered transforms.</param>
+    /// <param name="sinks">Registered sink connectors.</param>
+    public PipelineComponentFactory(
+        IEnumerable<IPipelineSourceConnector> sources,
+        IEnumerable<IPipelineTransform> transforms,
+        IEnumerable<IPipelineSinkConnector> sinks)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+        ArgumentNullException.ThrowIfNull(transforms);
+        ArgumentNullException.ThrowIfNull(sinks);
+
+        _sources = sources.ToFrozenDictionary(c => c.Type, StringComparer.Ordinal);
+        _transforms = transforms.ToFrozenDictionary(t => t.Type, StringComparer.Ordinal);
+        _sinks = sinks.ToFrozenDictionary(c => c.Type, StringComparer.Ordinal);
+    }
+
+    /// <inheritdoc />
+    public IPipelineSourceConnector? ResolveSource(string type)
+        => _sources.TryGetValue(type, out var connector) ? connector : null;
+
+    /// <inheritdoc />
+    public IPipelineTransform? ResolveTransform(string type)
+        => _transforms.TryGetValue(type, out var transform) ? transform : null;
+
+    /// <inheritdoc />
+    public IPipelineSinkConnector? ResolveSink(string type)
+        => _sinks.TryGetValue(type, out var connector) ? connector : null;
+}

--- a/src/Honua.Core/Features/GeoETL/Services/PipelineStageRunner.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/PipelineStageRunner.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services.Connectors;
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Services;
+
+/// <summary>
+/// A progress / log observer the stage runner calls so the caller (the substrate
+/// executor) can forward progress and structured logs through the per-job
+/// <c>IJobExecutionContext</c> without the runner taking a substrate dependency.
+/// </summary>
+public interface IPipelineRunObserver
+{
+    /// <summary>
+    /// Reports completion percentage and a phase label.
+    /// </summary>
+    /// <param name="percentComplete">Completion percentage (0-100), or null if indeterminate.</param>
+    /// <param name="phase">Phase label.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ReportProgressAsync(double? percentComplete, string phase, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Appends an informational log line.
+    /// </summary>
+    /// <param name="message">Log message.</param>
+    /// <param name="phase">Phase label.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task LogAsync(string message, string phase, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Outcome of running a pipeline through the stage runner.
+/// </summary>
+public sealed record PipelineRunResult
+{
+    /// <summary>Number of features read from the source.</summary>
+    public long FeaturesRead { get; init; }
+
+    /// <summary>Number of features written by the sink (or counted by the dry-run sink).</summary>
+    public long FeaturesWritten { get; init; }
+
+    /// <summary>Number of features rejected by the sink (for example null geometry).</summary>
+    public long FeaturesRejected { get; init; }
+
+    /// <summary>Batch id tagged on every sink write for soft-delete rollback.</summary>
+    public required string BatchId { get; init; }
+}
+
+/// <summary>
+/// Executes a <see cref="PipelineDefinition"/> as a linear Source → []Transform → Sink
+/// chain over a streaming <see cref="IAsyncEnumerable{IFeature}"/>. The runner is
+/// substrate-agnostic: it reports progress and logs through <see cref="IPipelineRunObserver"/>
+/// and is driven by the <c>PipelineJobExecutor</c> that the substrate's
+/// <c>JobExecutionService</c> claims. Cancellation flows through every stage.
+/// </summary>
+public sealed class PipelineStageRunner(IPipelineComponentFactory factory)
+{
+    /// <summary>
+    /// Runs the pipeline. When <paramref name="dryRun"/> is true the configured sink is
+    /// replaced with the null preview sink so no durable target is written.
+    /// </summary>
+    /// <param name="definition">Pipeline definition to run.</param>
+    /// <param name="batchId">Batch id tagged on every sink write.</param>
+    /// <param name="dryRun">Whether to route the sink to the null preview sink.</param>
+    /// <param name="observer">Optional progress / log observer.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>The run result.</returns>
+    public async Task<PipelineRunResult> RunAsync(
+        PipelineDefinition definition,
+        string batchId,
+        bool dryRun,
+        IPipelineRunObserver? observer,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentException.ThrowIfNullOrEmpty(batchId);
+
+        var sourceStage = definition.Source
+            ?? throw new InvalidOperationException("Pipeline has no source stage.");
+        var sinkStage = definition.Sink
+            ?? throw new InvalidOperationException("Pipeline has no sink stage.");
+        var sourceConfig = sourceStage.Connector
+            ?? throw new InvalidOperationException("Source stage has no connector configuration.");
+        var sinkConfig = sinkStage.Connector
+            ?? throw new InvalidOperationException("Sink stage has no connector configuration.");
+
+        var source = factory.ResolveSource(sourceConfig.Type)
+            ?? throw new InvalidOperationException($"Source connector '{sourceConfig.Type}' is not registered.");
+
+        IPipelineSinkConnector sink;
+        if (dryRun)
+        {
+            sink = new NullPreviewSinkConnector();
+        }
+        else
+        {
+            sink = factory.ResolveSink(sinkConfig.Type)
+                ?? throw new InvalidOperationException($"Sink connector '{sinkConfig.Type}' is not registered.");
+        }
+
+        await ReportAsync(observer, 5, "Extract", "pipeline.started", cancellationToken).ConfigureAwait(false);
+
+        var readCounter = new FeatureCounter();
+        IAsyncEnumerable<IFeature> stream = CountReads(source.ReadAsync(sourceConfig, cancellationToken), readCounter);
+
+        var transformStages = definition.Transforms;
+        for (var i = 0; i < transformStages.Count; i++)
+        {
+            var transformConfig = transformStages[i].Transform
+                ?? throw new InvalidOperationException("Transform stage has no transform configuration.");
+            var transform = factory.ResolveTransform(transformConfig.Type)
+                ?? throw new InvalidOperationException($"Transform '{transformConfig.Type}' is not registered.");
+
+            stream = transform.TransformAsync(transformConfig, stream, cancellationToken);
+            await LogAsync(
+                observer,
+                $"Transform stage {i + 1}/{transformStages.Count}: {transformConfig.Type}",
+                "pipeline.stage.completed",
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        await ReportAsync(observer, 50, "Load", "pipeline.stage.completed", cancellationToken).ConfigureAwait(false);
+
+        var writeResult = await sink.WriteAsync(sinkConfig, stream, batchId, cancellationToken).ConfigureAwait(false);
+
+        await ReportAsync(observer, 100, "Completed", "pipeline.completed", cancellationToken).ConfigureAwait(false);
+
+        return new PipelineRunResult
+        {
+            FeaturesRead = readCounter.Count,
+            FeaturesWritten = writeResult.FeaturesWritten,
+            FeaturesRejected = writeResult.FeaturesRejected,
+            BatchId = batchId
+        };
+    }
+
+    private static async IAsyncEnumerable<IFeature> CountReads(
+        IAsyncEnumerable<IFeature> source,
+        FeatureCounter counter)
+    {
+        await foreach (var feature in source.ConfigureAwait(false))
+        {
+            counter.Count++;
+            yield return feature;
+        }
+    }
+
+    private static Task ReportAsync(
+        IPipelineRunObserver? observer,
+        double percent,
+        string phase,
+        string @event,
+        CancellationToken cancellationToken)
+        => observer is null
+            ? Task.CompletedTask
+            : Task.WhenAll(
+                observer.ReportProgressAsync(percent, phase, cancellationToken),
+                observer.LogAsync(@event, phase, cancellationToken));
+
+    private static Task LogAsync(
+        IPipelineRunObserver? observer,
+        string message,
+        string phase,
+        CancellationToken cancellationToken)
+        => observer?.LogAsync(message, phase, cancellationToken) ?? Task.CompletedTask;
+
+    private sealed class FeatureCounter
+    {
+        public long Count;
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/PipelineStageSerializer.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/PipelineStageSerializer.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Core.Features.GeoETL.Domain;
+
+namespace Honua.Core.Features.GeoETL.Services;
+
+/// <summary>
+/// Source-generated JSON context for persisting a pipeline's stage chain as a JSONB
+/// document in <c>honua.pipeline_definitions.stages_json</c>. Kept separate from the
+/// HTTP DTO context so the durable storage shape evolves independently of the wire shape
+/// and stays AOT/trim safe (no reflection-based serialization). See ADR-0038 §
+/// Discriminated-union versioning.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true)]
+[JsonSerializable(typeof(PipelineStage[]))]
+[JsonSerializable(typeof(PipelineStage))]
+[JsonSerializable(typeof(ConnectorConfig))]
+[JsonSerializable(typeof(TransformConfig))]
+internal sealed partial class PipelineStageJsonContext : JsonSerializerContext
+{
+}
+
+/// <summary>
+/// Serializes and deserializes a pipeline's ordered stage chain to and from the JSONB
+/// document persisted by the PostgreSQL definition store. Centralizes the round-trip so
+/// the durable store and its tests share one contract.
+/// </summary>
+public static class PipelineStageSerializer
+{
+    /// <summary>
+    /// Serializes the stage chain to its JSONB document string.
+    /// </summary>
+    /// <param name="stages">Ordered stage chain.</param>
+    /// <returns>The JSON document.</returns>
+    public static string Serialize(IReadOnlyList<PipelineStage> stages)
+    {
+        ArgumentNullException.ThrowIfNull(stages);
+        var array = stages as PipelineStage[] ?? stages.ToArray();
+        return JsonSerializer.Serialize(array, PipelineStageJsonContext.Default.PipelineStageArray);
+    }
+
+    /// <summary>
+    /// Deserializes a stage-chain JSONB document back into the domain stage list.
+    /// </summary>
+    /// <param name="json">The JSON document.</param>
+    /// <returns>The deserialized stage chain (empty when the document is null or blank).</returns>
+    public static IReadOnlyList<PipelineStage> Deserialize(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return [];
+        }
+
+        return JsonSerializer.Deserialize(json, PipelineStageJsonContext.Default.PipelineStageArray) ?? [];
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/PipelineValidator.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/PipelineValidator.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+
+namespace Honua.Core.Features.GeoETL.Services;
+
+/// <summary>
+/// A single validation problem produced by <see cref="PipelineValidator"/>. Hard
+/// failures block storage and execution; advisories are non-blocking (for example a
+/// connector that requires a native worker profile that is not yet registered).
+/// </summary>
+/// <param name="Code">Stable machine-readable code.</param>
+/// <param name="Message">Human-readable description.</param>
+/// <param name="IsAdvisory">True when the problem is advisory and does not block.</param>
+public sealed record PipelineValidationIssue(string Code, string Message, bool IsAdvisory);
+
+/// <summary>
+/// Result of validating a <see cref="PipelineDefinition"/>.
+/// </summary>
+/// <param name="Issues">All validation issues, hard and advisory.</param>
+public sealed record PipelineValidationResult(IReadOnlyList<PipelineValidationIssue> Issues)
+{
+    /// <summary>
+    /// True when there are no hard-failure issues. Advisory issues do not affect validity.
+    /// </summary>
+    public bool IsValid => !Issues.Any(i => !i.IsAdvisory);
+
+    /// <summary>
+    /// The subset of issues that block storage and execution.
+    /// </summary>
+    public IReadOnlyList<PipelineValidationIssue> Errors =>
+        Issues.Where(i => !i.IsAdvisory).ToArray();
+
+    /// <summary>
+    /// The subset of issues that are advisory only.
+    /// </summary>
+    public IReadOnlyList<PipelineValidationIssue> Advisories =>
+        Issues.Where(i => i.IsAdvisory).ToArray();
+}
+
+/// <summary>
+/// Validates the structural shape and connector/transform resolvability of a pipeline
+/// definition. Structural shape and component resolvability are hard fails; a connector
+/// that needs a native worker profile produces an advisory only (CRUD stores regardless),
+/// matching the three-layer capability-detection model in ADR-0038.
+/// </summary>
+public sealed class PipelineValidator(IPipelineComponentFactory factory)
+{
+    /// <summary>
+    /// Validates the definition against the registered component factory.
+    /// </summary>
+    /// <param name="definition">Definition to validate.</param>
+    /// <returns>The validation result.</returns>
+    public PipelineValidationResult Validate(PipelineDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        var issues = new List<PipelineValidationIssue>();
+
+        if (string.IsNullOrWhiteSpace(definition.Id))
+        {
+            issues.Add(new PipelineValidationIssue("EMPTY_ID", "Pipeline id is required.", false));
+        }
+
+        if (string.IsNullOrWhiteSpace(definition.Name))
+        {
+            issues.Add(new PipelineValidationIssue("EMPTY_NAME", "Pipeline name is required.", false));
+        }
+
+        if (definition.Stages.Count < 2)
+        {
+            issues.Add(new PipelineValidationIssue(
+                "TOO_FEW_STAGES",
+                "A pipeline must contain at least a source and a sink stage.",
+                false));
+            return new PipelineValidationResult(issues);
+        }
+
+        // First stage must be the source; last must be the sink; the middle must be transforms.
+        if (definition.Stages[0].Kind != PipelineStageKind.Source)
+        {
+            issues.Add(new PipelineValidationIssue(
+                "MISSING_SOURCE", "The first stage must be a source stage.", false));
+        }
+
+        if (definition.Stages[^1].Kind != PipelineStageKind.Sink)
+        {
+            issues.Add(new PipelineValidationIssue(
+                "MISSING_SINK", "The last stage must be a sink stage.", false));
+        }
+
+        for (var i = 1; i < definition.Stages.Count - 1; i++)
+        {
+            if (definition.Stages[i].Kind != PipelineStageKind.Transform)
+            {
+                issues.Add(new PipelineValidationIssue(
+                    "UNEXPECTED_STAGE",
+                    $"Stage {i} must be a transform stage (only one source and one sink are allowed).",
+                    false));
+            }
+        }
+
+        ValidateSource(definition, issues);
+        ValidateTransforms(definition, issues);
+        ValidateSink(definition, issues);
+
+        return new PipelineValidationResult(issues);
+    }
+
+    private void ValidateSource(PipelineDefinition definition, List<PipelineValidationIssue> issues)
+    {
+        var source = definition.Stages[0];
+        if (source.Kind != PipelineStageKind.Source)
+        {
+            return;
+        }
+
+        if (source.Connector is null)
+        {
+            issues.Add(new PipelineValidationIssue(
+                "SOURCE_CONFIG_MISSING", "Source stage has no connector configuration.", false));
+            return;
+        }
+
+        var connector = factory.ResolveSource(source.Connector.Type);
+        if (connector is null)
+        {
+            issues.Add(new PipelineValidationIssue(
+                "UNKNOWN_SOURCE",
+                $"Source connector type '{source.Connector.Type}' is not registered.",
+                false));
+            return;
+        }
+
+        if (connector.RuntimeProfile == ConnectorRuntimeProfile.RequiresNativeGeo)
+        {
+            issues.Add(new PipelineValidationIssue(
+                "SOURCE_REQUIRES_NATIVE_WORKER",
+                $"Source connector '{source.Connector.Type}' requires the native worker profile " +
+                "(honua-worker-etl), which is not part of the Phase 1 serving image.",
+                true));
+        }
+    }
+
+    private void ValidateTransforms(PipelineDefinition definition, List<PipelineValidationIssue> issues)
+    {
+        foreach (var stage in definition.Transforms)
+        {
+            if (stage.Transform is null)
+            {
+                issues.Add(new PipelineValidationIssue(
+                    "TRANSFORM_CONFIG_MISSING", "Transform stage has no transform configuration.", false));
+                continue;
+            }
+
+            if (factory.ResolveTransform(stage.Transform.Type) is null)
+            {
+                issues.Add(new PipelineValidationIssue(
+                    "UNKNOWN_TRANSFORM",
+                    $"Transform type '{stage.Transform.Type}' is not registered.",
+                    false));
+            }
+        }
+    }
+
+    private void ValidateSink(PipelineDefinition definition, List<PipelineValidationIssue> issues)
+    {
+        var sink = definition.Stages[^1];
+        if (sink.Kind != PipelineStageKind.Sink)
+        {
+            return;
+        }
+
+        if (sink.Connector is null)
+        {
+            issues.Add(new PipelineValidationIssue(
+                "SINK_CONFIG_MISSING", "Sink stage has no connector configuration.", false));
+            return;
+        }
+
+        var connector = factory.ResolveSink(sink.Connector.Type);
+        if (connector is null)
+        {
+            issues.Add(new PipelineValidationIssue(
+                "UNKNOWN_SINK",
+                $"Sink connector type '{sink.Connector.Type}' is not registered.",
+                false));
+            return;
+        }
+
+        if (connector.RuntimeProfile == ConnectorRuntimeProfile.RequiresNativeGeo)
+        {
+            issues.Add(new PipelineValidationIssue(
+                "SINK_REQUIRES_NATIVE_WORKER",
+                $"Sink connector '{sink.Connector.Type}' requires the native worker profile " +
+                "(honua-worker-etl), which is not part of the Phase 1 serving image.",
+                true));
+        }
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/PipelineValidator.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/PipelineValidator.cs
@@ -105,8 +105,90 @@ public sealed class PipelineValidator(IPipelineComponentFactory factory)
         ValidateSource(definition, issues);
         ValidateTransforms(definition, issues);
         ValidateSink(definition, issues);
+        ValidateStageChainSchema(definition, issues);
 
         return new PipelineValidationResult(issues);
+    }
+
+    /// <summary>
+    /// Stage-chain schema-compatibility check (ADR-0038 § Stage-chain validation). When the
+    /// source declares its output fields (a <c>declaredFields</c> connector option, a
+    /// comma-separated list), the validator threads the field set through each
+    /// schema-aware transform and reports a hard failure for any transform that requires a
+    /// field neither the source declared nor an earlier stage produced — so the pipeline
+    /// fails fast at CRUD / pre-execution time rather than mid-run. Sources that do not
+    /// declare fields use the documented permissive passthrough mode: the check is skipped
+    /// because the schema is dynamic and only knowable at runtime.
+    /// </summary>
+    private void ValidateStageChainSchema(PipelineDefinition definition, List<PipelineValidationIssue> issues)
+    {
+        var source = definition.Source;
+        if (source?.Connector is null)
+        {
+            return;
+        }
+
+        if (!source.Connector.Options.TryGetValue("declaredFields", out var declared) ||
+            string.IsNullOrWhiteSpace(declared))
+        {
+            // Permissive passthrough: source schema is dynamic, defer to runtime.
+            return;
+        }
+
+        var available = new HashSet<string>(
+            declared.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+            StringComparer.Ordinal);
+
+        var stageIndex = 0;
+        foreach (var stage in definition.Transforms)
+        {
+            stageIndex++;
+            if (stage.Transform is null)
+            {
+                continue;
+            }
+
+            if (factory.ResolveTransform(stage.Transform.Type) is not ISchemaAwareTransform schemaAware)
+            {
+                continue;
+            }
+
+            TransformSchemaEffect effect;
+            try
+            {
+                effect = schemaAware.DescribeSchema(stage.Transform);
+            }
+            catch (InvalidOperationException ex)
+            {
+                issues.Add(new PipelineValidationIssue(
+                    "TRANSFORM_CONFIG_INVALID",
+                    $"Transform stage {stageIndex} ('{stage.Transform.Type}') is misconfigured: {ex.Message}",
+                    false));
+                continue;
+            }
+
+            foreach (var required in effect.RequiredFields)
+            {
+                if (!available.Contains(required))
+                {
+                    issues.Add(new PipelineValidationIssue(
+                        "SCHEMA_FIELD_UNAVAILABLE",
+                        $"Transform stage {stageIndex} ('{stage.Transform.Type}') requires attribute " +
+                        $"'{required}', which the source does not declare and no earlier stage produces.",
+                        false));
+                }
+            }
+
+            foreach (var removed in effect.RemovedFields)
+            {
+                available.Remove(removed);
+            }
+
+            foreach (var produced in effect.ProducedFields)
+            {
+                available.Add(produced);
+            }
+        }
     }
 
     private void ValidateSource(PipelineDefinition definition, List<PipelineValidationIssue> issues)

--- a/src/Honua.Core/Features/GeoETL/Services/Transforms/AttributeCastTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Transforms/AttributeCastTransform.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Services.Transforms;
+
+/// <summary>
+/// Phase 1 attribute cast / type-coerce transform. Coerces one attribute to a target CLR
+/// type (<c>int</c>, <c>long</c>, <c>double</c>, <c>bool</c>, or <c>string</c>). Streaming
+/// and constant-memory. A row whose value cannot be coerced is a row-level data error: it
+/// is dropped from the stream rather than aborting the run, matching the ADR-0038
+/// row-level-error contract (the quarantine sink captures rejected rows downstream).
+/// </summary>
+/// <remarks>
+/// Required <see cref="TransformConfig.Options"/>:
+/// <list type="bullet">
+/// <item><c>field</c> — attribute name to cast.</item>
+/// <item><c>to</c> — one of <c>int</c>, <c>long</c>, <c>double</c>, <c>bool</c>,
+/// <c>string</c>.</item>
+/// </list>
+/// Optional <c>onError</c> — <c>drop</c> (default) drops uncoercible rows; <c>null</c>
+/// sets the attribute to null and keeps the row; <c>keep</c> leaves the original value.
+/// </remarks>
+public sealed class AttributeCastTransform : IPipelineTransform, ISchemaAwareTransform
+{
+    /// <summary>
+    /// The transform type discriminator.
+    /// </summary>
+    public const string TransformType = "attribute-cast";
+
+    /// <inheritdoc />
+    public string Type => TransformType;
+
+    /// <inheritdoc />
+    public TransformSchemaEffect DescribeSchema(TransformConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        var field = RequireOption(config, "field");
+        // Validate the target type early so an unknown 'to' fails at CRUD time.
+        _ = RequireOption(config, "to");
+        return new TransformSchemaEffect(RequiredFields: [field], ProducedFields: [field], RemovedFields: []);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> TransformAsync(
+        TransformConfig config,
+        IAsyncEnumerable<IFeature> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(source);
+
+        var field = RequireOption(config, "field");
+        var to = RequireOption(config, "to").ToLowerInvariant();
+        var onError = config.Options.TryGetValue("onError", out var rawError) ? rawError.ToLowerInvariant() : "drop";
+
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var attributes = feature.Attributes;
+            if (attributes is null || !attributes.Exists(field))
+            {
+                yield return feature;
+                continue;
+            }
+
+            var raw = attributes.GetOptionalValue(field);
+            if (TryCoerce(raw, to, out var coerced))
+            {
+                attributes[field] = coerced!;
+                yield return feature;
+                continue;
+            }
+
+            switch (onError)
+            {
+                case "null":
+                    attributes[field] = null!;
+                    yield return feature;
+                    break;
+                case "keep":
+                    yield return feature;
+                    break;
+                default:
+                    // drop: row-level error, omit the feature from the stream.
+                    break;
+            }
+        }
+    }
+
+    private static bool TryCoerce(object? value, string to, out object? result)
+    {
+        result = null;
+        var text = Convert.ToString(value, CultureInfo.InvariantCulture);
+
+        switch (to)
+        {
+            case "string":
+                result = text;
+                return true;
+            case "int":
+                if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i))
+                {
+                    result = i;
+                    return true;
+                }
+
+                return false;
+            case "long":
+                if (long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var l))
+                {
+                    result = l;
+                    return true;
+                }
+
+                return false;
+            case "double":
+                if (double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var d))
+                {
+                    result = d;
+                    return true;
+                }
+
+                return false;
+            case "bool":
+                if (bool.TryParse(text, out var b))
+                {
+                    result = b;
+                    return true;
+                }
+
+                if (string.Equals(text, "1", StringComparison.Ordinal))
+                {
+                    result = true;
+                    return true;
+                }
+
+                if (string.Equals(text, "0", StringComparison.Ordinal))
+                {
+                    result = false;
+                    return true;
+                }
+
+                return false;
+            default:
+                throw new InvalidOperationException(
+                    $"Attribute-cast target type '{to}' is not supported. " +
+                    "Supported: int, long, double, bool, string.");
+        }
+    }
+
+    private static string RequireOption(TransformConfig config, string key)
+    {
+        if (!config.Options.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"Attribute-cast transform requires a '{key}' option.");
+        }
+
+        return value;
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Transforms/AttributeFilterTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Transforms/AttributeFilterTransform.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Services.Transforms;
+
+/// <summary>
+/// Phase 1 attribute-filter transform. Passes through only features whose attribute
+/// satisfies a simple comparison, dropping the rest. Streaming and constant-memory.
+/// </summary>
+/// <remarks>
+/// Required <see cref="TransformConfig.Options"/>:
+/// <list type="bullet">
+/// <item><c>field</c> — attribute name to test.</item>
+/// <item><c>op</c> — one of <c>eq</c>, <c>neq</c>, <c>gt</c>, <c>gte</c>, <c>lt</c>,
+/// <c>lte</c>, <c>contains</c>, <c>exists</c>.</item>
+/// <item><c>value</c> — comparison operand (omitted for <c>exists</c>).</item>
+/// </list>
+/// Numeric operators parse both operands as doubles; string operators compare ordinally.
+/// </remarks>
+public sealed class AttributeFilterTransform : IPipelineTransform
+{
+    /// <summary>
+    /// The transform type discriminator.
+    /// </summary>
+    public const string TransformType = "attribute-filter";
+
+    /// <inheritdoc />
+    public string Type => TransformType;
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> TransformAsync(
+        TransformConfig config,
+        IAsyncEnumerable<IFeature> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(source);
+
+        if (!config.Options.TryGetValue("field", out var field) || string.IsNullOrWhiteSpace(field))
+        {
+            throw new InvalidOperationException("Attribute-filter transform requires a 'field' option.");
+        }
+
+        var op = config.Options.TryGetValue("op", out var rawOp) ? rawOp : "eq";
+        config.Options.TryGetValue("value", out var value);
+
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (Matches(feature, field, op, value))
+            {
+                yield return feature;
+            }
+        }
+    }
+
+    private static bool Matches(IFeature feature, string field, string op, string? value)
+    {
+        var attributes = feature.Attributes;
+        var present = attributes is not null && attributes.Exists(field);
+
+        if (string.Equals(op, "exists", StringComparison.OrdinalIgnoreCase))
+        {
+            return present;
+        }
+
+        if (!present)
+        {
+            return false;
+        }
+
+        var actual = attributes!.GetOptionalValue(field);
+
+        return op.ToLowerInvariant() switch
+        {
+            "eq" => StringEquals(actual, value),
+            "neq" => !StringEquals(actual, value),
+            "contains" => actual?.ToString()?.Contains(value ?? "", StringComparison.OrdinalIgnoreCase) ?? false,
+            "gt" => CompareNumeric(actual, value) > 0,
+            "gte" => CompareNumeric(actual, value) >= 0,
+            "lt" => CompareNumeric(actual, value) < 0,
+            "lte" => CompareNumeric(actual, value) <= 0,
+            _ => throw new InvalidOperationException($"Attribute-filter operator '{op}' is not supported.")
+        };
+    }
+
+    private static bool StringEquals(object? actual, string? expected)
+        => string.Equals(
+            Convert.ToString(actual, CultureInfo.InvariantCulture),
+            expected,
+            StringComparison.Ordinal);
+
+    private static int CompareNumeric(object? actual, string? expected)
+    {
+        if (!TryToDouble(actual, out var a) ||
+            !double.TryParse(expected, NumberStyles.Float, CultureInfo.InvariantCulture, out var b))
+        {
+            // Non-numeric operands never satisfy a numeric comparison.
+            return int.MinValue;
+        }
+
+        return a.CompareTo(b);
+    }
+
+    private static bool TryToDouble(object? value, out double result)
+    {
+        switch (value)
+        {
+            case null:
+                result = 0;
+                return false;
+            case double d:
+                result = d;
+                return true;
+            case long l:
+                result = l;
+                return true;
+            case int i:
+                result = i;
+                return true;
+            default:
+                return double.TryParse(
+                    Convert.ToString(value, CultureInfo.InvariantCulture),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out result);
+        }
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Transforms/AttributeFilterTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Transforms/AttributeFilterTransform.cs
@@ -23,7 +23,7 @@ namespace Honua.Core.Features.GeoETL.Services.Transforms;
 /// </list>
 /// Numeric operators parse both operands as doubles; string operators compare ordinally.
 /// </remarks>
-public sealed class AttributeFilterTransform : IPipelineTransform
+public sealed class AttributeFilterTransform : IPipelineTransform, ISchemaAwareTransform
 {
     /// <summary>
     /// The transform type discriminator.
@@ -32,6 +32,19 @@ public sealed class AttributeFilterTransform : IPipelineTransform
 
     /// <inheritdoc />
     public string Type => TransformType;
+
+    /// <inheritdoc />
+    public TransformSchemaEffect DescribeSchema(TransformConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        if (!config.Options.TryGetValue("field", out var field) || string.IsNullOrWhiteSpace(field))
+        {
+            throw new InvalidOperationException("Attribute-filter transform requires a 'field' option.");
+        }
+
+        // A filter reads the field but does not change the schema (rows are dropped, not columns).
+        return new TransformSchemaEffect(RequiredFields: [field], ProducedFields: [], RemovedFields: []);
+    }
 
     /// <inheritdoc />
     public async IAsyncEnumerable<IFeature> TransformAsync(

--- a/src/Honua.Core/Features/GeoETL/Services/Transforms/AttributeRenameTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Transforms/AttributeRenameTransform.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Services.Transforms;
+
+/// <summary>
+/// Phase 1 attribute-rename transform. Renames one attribute key to another on every
+/// feature, preserving the value. Streaming and constant-memory.
+/// </summary>
+/// <remarks>
+/// Required <see cref="TransformConfig.Options"/>:
+/// <list type="bullet">
+/// <item><c>from</c> — existing attribute name.</item>
+/// <item><c>to</c> — new attribute name.</item>
+/// </list>
+/// Features that do not carry the <c>from</c> attribute pass through unchanged. The
+/// stage-chain validator declares <c>from</c> as a required input field and <c>to</c> as
+/// a produced output field so a downstream stage that needs <c>to</c> validates.
+/// </remarks>
+public sealed class AttributeRenameTransform : IPipelineTransform, ISchemaAwareTransform
+{
+    /// <summary>
+    /// The transform type discriminator.
+    /// </summary>
+    public const string TransformType = "attribute-rename";
+
+    /// <inheritdoc />
+    public string Type => TransformType;
+
+    /// <inheritdoc />
+    public TransformSchemaEffect DescribeSchema(TransformConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        var from = RequireOption(config, "from");
+        var to = RequireOption(config, "to");
+        return new TransformSchemaEffect(RequiredFields: [from], ProducedFields: [to], RemovedFields: [from]);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> TransformAsync(
+        TransformConfig config,
+        IAsyncEnumerable<IFeature> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(source);
+
+        var from = RequireOption(config, "from");
+        var to = RequireOption(config, "to");
+
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var attributes = feature.Attributes;
+            if (attributes is null || !attributes.Exists(from))
+            {
+                yield return feature;
+                continue;
+            }
+
+            var rebuilt = new AttributesTable();
+            foreach (var name in attributes.GetNames())
+            {
+                var key = string.Equals(name, from, StringComparison.Ordinal) ? to : name;
+                rebuilt.Add(key, attributes.GetOptionalValue(name));
+            }
+
+            yield return new Feature(feature.Geometry, rebuilt);
+        }
+    }
+
+    private static string RequireOption(TransformConfig config, string key)
+    {
+        if (!config.Options.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"Attribute-rename transform requires a '{key}' option.");
+        }
+
+        return value;
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Transforms/ClipTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Transforms/ClipTransform.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Core.Features.GeoETL.Services.Transforms;
+
+/// <summary>
+/// Phase 1 clip transform. Clips each feature's geometry to an area-of-interest region
+/// (the geometric intersection), dropping features that fall entirely outside the region.
+/// Pure managed NetTopologySuite overlay — no GEOS native dependency. Streaming and
+/// constant-memory.
+/// </summary>
+/// <remarks>
+/// Region (one required):
+/// <list type="bullet">
+/// <item><c>bbox</c> — <c>minX,minY,maxX,maxY</c> in the feature CRS.</item>
+/// <item><c>wkt</c> — an arbitrary clip region as WKT.</item>
+/// </list>
+/// A feature whose clipped geometry is empty is dropped. The clipped geometry keeps the
+/// source feature's SRID. Attributes are preserved unchanged.
+/// </remarks>
+public sealed class ClipTransform : IPipelineTransform
+{
+    /// <summary>
+    /// The transform type discriminator.
+    /// </summary>
+    public const string TransformType = "clip";
+
+    /// <inheritdoc />
+    public string Type => TransformType;
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> TransformAsync(
+        TransformConfig config,
+        IAsyncEnumerable<IFeature> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(source);
+
+        var region = ReadRegion(config);
+
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var geometry = feature.Geometry;
+            if (geometry is null || geometry.IsEmpty)
+            {
+                continue;
+            }
+
+            // Cheap envelope reject before the overlay for features clearly outside the region.
+            if (!geometry.EnvelopeInternal.Intersects(region.EnvelopeInternal))
+            {
+                continue;
+            }
+
+            NtsGeometry clipped;
+            try
+            {
+                clipped = geometry.Intersection(region);
+            }
+            catch (TopologyException)
+            {
+                // Row-level geometry error: drop the row rather than aborting the run (ADR-0038).
+                continue;
+            }
+
+            if (clipped.IsEmpty)
+            {
+                continue;
+            }
+
+            clipped.SRID = geometry.SRID;
+            yield return new Feature(clipped, feature.Attributes);
+        }
+    }
+
+    private static NtsGeometry ReadRegion(TransformConfig config)
+    {
+        if (config.Options.TryGetValue("wkt", out var wkt) && !string.IsNullOrWhiteSpace(wkt))
+        {
+            return new WKTReader().Read(wkt);
+        }
+
+        if (config.Options.TryGetValue("bbox", out var bbox) && !string.IsNullOrWhiteSpace(bbox))
+        {
+            var parts = bbox.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 4 &&
+                double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var minX) &&
+                double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var minY) &&
+                double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var maxX) &&
+                double.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var maxY))
+            {
+                var factory = new GeometryFactory();
+                return factory.ToGeometry(new Envelope(minX, maxX, minY, maxY));
+            }
+
+            throw new InvalidOperationException(
+                "Clip 'bbox' must be 'minX,minY,maxX,maxY' with four numeric values.");
+        }
+
+        throw new InvalidOperationException(
+            "Clip transform requires a 'bbox' (minX,minY,maxX,maxY) or a 'wkt' region option.");
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Transforms/ComputedFieldTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Transforms/ComputedFieldTransform.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Services.Transforms;
+
+/// <summary>
+/// Phase 1 computed / calculated field transform. Adds a new attribute derived from the
+/// existing attributes via a small, AOT-safe operation set — no expression engine, no
+/// reflection. Streaming and constant-memory.
+/// </summary>
+/// <remarks>
+/// Required <see cref="TransformConfig.Options"/>:
+/// <list type="bullet">
+/// <item><c>target</c> — the attribute name to write the computed value to.</item>
+/// <item><c>op</c> — one of <c>concat</c>, <c>add</c>, <c>subtract</c>, <c>multiply</c>,
+/// <c>divide</c>, <c>const</c>.</item>
+/// </list>
+/// For <c>concat</c>: <c>fields</c> (comma-separated source field names) joined by an
+/// optional <c>separator</c>. For the arithmetic ops: <c>left</c> and <c>right</c>, each
+/// either a source field name or, when prefixed with <c>=</c>, a numeric literal. For
+/// <c>const</c>: <c>value</c> (a literal string assigned to <c>target</c>). Rows whose
+/// arithmetic operands are non-numeric are dropped as row-level data errors (ADR-0038).
+/// </remarks>
+public sealed class ComputedFieldTransform : IPipelineTransform, ISchemaAwareTransform
+{
+    /// <summary>
+    /// The transform type discriminator.
+    /// </summary>
+    public const string TransformType = "computed-field";
+
+    /// <inheritdoc />
+    public string Type => TransformType;
+
+    /// <inheritdoc />
+    public TransformSchemaEffect DescribeSchema(TransformConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        var target = RequireOption(config, "target");
+        var op = RequireOption(config, "op").ToLowerInvariant();
+        var required = ResolveRequiredFields(config, op);
+        return new TransformSchemaEffect(RequiredFields: required, ProducedFields: [target], RemovedFields: []);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> TransformAsync(
+        TransformConfig config,
+        IAsyncEnumerable<IFeature> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(source);
+
+        var target = RequireOption(config, "target");
+        var op = RequireOption(config, "op").ToLowerInvariant();
+
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var attributes = feature.Attributes ?? new AttributesTable();
+            if (TryCompute(config, op, attributes, out var value))
+            {
+                if (attributes.Exists(target))
+                {
+                    attributes[target] = value!;
+                }
+                else
+                {
+                    attributes.Add(target, value);
+                }
+
+                yield return new Feature(feature.Geometry, attributes);
+            }
+
+            // else: row-level data error (non-numeric operand) — drop the row.
+        }
+    }
+
+    private static bool TryCompute(
+        TransformConfig config,
+        string op,
+        IAttributesTable attributes,
+        out object? value)
+    {
+        value = null;
+
+        if (op == "const")
+        {
+            value = config.Options.TryGetValue("value", out var constValue) ? constValue : string.Empty;
+            return true;
+        }
+
+        if (op == "concat")
+        {
+            var fields = SplitFields(config, "fields");
+            var separator = config.Options.TryGetValue("separator", out var sep) ? sep : string.Empty;
+            var parts = fields.Select(f =>
+                attributes.Exists(f)
+                    ? Convert.ToString(attributes.GetOptionalValue(f), CultureInfo.InvariantCulture) ?? string.Empty
+                    : string.Empty);
+            value = string.Join(separator, parts);
+            return true;
+        }
+
+        if (!TryReadOperand(config, "left", attributes, out var left) ||
+            !TryReadOperand(config, "right", attributes, out var right))
+        {
+            return false;
+        }
+
+        double result;
+        switch (op)
+        {
+            case "add":
+                result = left + right;
+                break;
+            case "subtract":
+                result = left - right;
+                break;
+            case "multiply":
+                result = left * right;
+                break;
+            case "divide":
+                if (right == 0)
+                {
+                    return false;
+                }
+
+                result = left / right;
+                break;
+            default:
+                throw new InvalidOperationException(
+                    $"Computed-field operation '{op}' is not supported. " +
+                    "Supported: concat, add, subtract, multiply, divide, const.");
+        }
+
+        value = result;
+        return true;
+    }
+
+    private static bool TryReadOperand(
+        TransformConfig config,
+        string key,
+        IAttributesTable attributes,
+        out double result)
+    {
+        result = 0;
+        var token = RequireOption(config, key);
+
+        if (token.StartsWith('='))
+        {
+            return double.TryParse(
+                token.AsSpan(1), NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+        }
+
+        if (!attributes.Exists(token))
+        {
+            return false;
+        }
+
+        return double.TryParse(
+            Convert.ToString(attributes.GetOptionalValue(token), CultureInfo.InvariantCulture),
+            NumberStyles.Float,
+            CultureInfo.InvariantCulture,
+            out result);
+    }
+
+    private static IReadOnlyList<string> ResolveRequiredFields(TransformConfig config, string op)
+    {
+        switch (op)
+        {
+            case "const":
+                return [];
+            case "concat":
+                return SplitFields(config, "fields");
+            default:
+                var required = new List<string>(2);
+                AddFieldOperand(config, "left", required);
+                AddFieldOperand(config, "right", required);
+                return required;
+        }
+    }
+
+    private static void AddFieldOperand(TransformConfig config, string key, List<string> into)
+    {
+        var token = RequireOption(config, key);
+        if (!token.StartsWith('='))
+        {
+            into.Add(token);
+        }
+    }
+
+    private static string[] SplitFields(TransformConfig config, string key)
+    {
+        var raw = RequireOption(config, key);
+        return raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private static string RequireOption(TransformConfig config, string key)
+    {
+        if (!config.Options.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"Computed-field transform requires a '{key}' option.");
+        }
+
+        return value;
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Transforms/DedupTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Transforms/DedupTransform.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Services.Transforms;
+
+/// <summary>
+/// Phase 1 dedup transform. Emits the first feature for each distinct key and drops later
+/// duplicates. The key is built from one or more attribute fields, the geometry, or both.
+/// Pure managed — no native dependency. The transform keeps a hash set of seen keys, so
+/// memory grows with the number of distinct keys rather than the total feature count.
+/// </summary>
+/// <remarks>
+/// Key composition (at least one required):
+/// <list type="bullet">
+/// <item><c>keys</c> — comma-separated attribute field names whose values form the key.
+/// </item>
+/// <item><c>geometry</c> — <c>true</c> to include the geometry (its normalized WKT) in the
+/// key.</item>
+/// </list>
+/// When both are present the key combines the attribute values and the geometry. When
+/// neither is present the transform throws at configuration time.
+/// </remarks>
+public sealed class DedupTransform : IPipelineTransform, ISchemaAwareTransform
+{
+    /// <summary>
+    /// The transform type discriminator.
+    /// </summary>
+    public const string TransformType = "dedup";
+
+    // Unit-separator control char between key parts so distinct field boundaries never
+    // collide (for example {"ab","c"} versus {"a","bc"}).
+    private const char Separator = '\u001F';
+    private const char NullMarker = '\u00A0';
+
+    /// <inheritdoc />
+    public string Type => TransformType;
+
+    /// <inheritdoc />
+    public TransformSchemaEffect DescribeSchema(TransformConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        var (keys, _) = ReadKeySpec(config);
+        return new TransformSchemaEffect(RequiredFields: keys, ProducedFields: [], RemovedFields: []);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> TransformAsync(
+        TransformConfig config,
+        IAsyncEnumerable<IFeature> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(source);
+
+        var (keys, useGeometry) = ReadKeySpec(config);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var key = BuildKey(feature, keys, useGeometry);
+            if (seen.Add(key))
+            {
+                yield return feature;
+            }
+        }
+    }
+
+    private static string BuildKey(IFeature feature, IReadOnlyList<string> keys, bool useGeometry)
+    {
+        var builder = new StringBuilder();
+        var attributes = feature.Attributes;
+
+        foreach (var field in keys)
+        {
+            var value = attributes is not null && attributes.Exists(field)
+                ? Convert.ToString(attributes.GetOptionalValue(field), CultureInfo.InvariantCulture)
+                : null;
+            if (value is null)
+            {
+                builder.Append(NullMarker);
+            }
+            else
+            {
+                builder.Append(value);
+            }
+
+            builder.Append(Separator);
+        }
+
+        if (useGeometry)
+        {
+            var geometry = feature.Geometry;
+            if (geometry is null || geometry.IsEmpty)
+            {
+                builder.Append(NullMarker);
+            }
+            else
+            {
+                var normalized = geometry.Normalized();
+                builder.Append(normalized.AsText());
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static (IReadOnlyList<string> Keys, bool UseGeometry) ReadKeySpec(TransformConfig config)
+    {
+        var useGeometry = config.Options.TryGetValue("geometry", out var rawGeometry)
+            && bool.TryParse(rawGeometry, out var parsed) && parsed;
+
+        string[] keys = [];
+        if (config.Options.TryGetValue("keys", out var rawKeys) && !string.IsNullOrWhiteSpace(rawKeys))
+        {
+            keys = rawKeys.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        }
+
+        if (keys.Length == 0 && !useGeometry)
+        {
+            throw new InvalidOperationException(
+                "Dedup transform requires a 'keys' attribute list, 'geometry=true', or both.");
+        }
+
+        return (keys, useGeometry);
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Transforms/ReprojectTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Transforms/ReprojectTransform.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Core.Features.GeoETL.Services.Transforms;
+
+/// <summary>
+/// Phase 1 managed reproject transform. Reprojects each feature's geometry between
+/// SRIDs on the lean, GDAL-free path: identity, Web Mercator aliases, and
+/// WGS 84 (4326) ↔ Web Mercator (3857 and aliases). This mirrors the managed
+/// in-memory transform the geoprocessing <c>geometry.project</c> executor uses.
+/// Datum-shift pairs that require <c>ST_Transform</c> / PROJ are deferred to the
+/// native worker profile (Child Ticket F) and are rejected here with a clear error.
+/// </summary>
+/// <remarks>
+/// Required <see cref="TransformConfig.Options"/>: <c>fromSrid</c>, <c>toSrid</c>
+/// (positive integers). Heavy spatial transforms continue to delegate to PostGIS
+/// per ADR-0038; this transform exists so the common WGS 84 ↔ Web Mercator case runs
+/// in-process without a database round-trip.
+/// </remarks>
+public sealed class ReprojectTransform : IPipelineTransform
+{
+    /// <summary>
+    /// The transform type discriminator.
+    /// </summary>
+    public const string TransformType = "reproject";
+
+    private static readonly int[] WebMercatorAliases = [3857, 900913, 102100, 102113, 3785];
+    private const double EarthRadius = 6378137.0;
+
+    /// <inheritdoc />
+    public string Type => TransformType;
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> TransformAsync(
+        TransformConfig config,
+        IAsyncEnumerable<IFeature> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(source);
+
+        var fromSrid = ReadSrid(config, "fromSrid");
+        var toSrid = ReadSrid(config, "toSrid");
+
+        if (!IsSupported(fromSrid, toSrid))
+        {
+            throw new NotSupportedException(
+                $"Reproject from SRID {fromSrid} to {toSrid} is not supported by the managed Phase 1 " +
+                "transform path. Supported: identity, Web Mercator aliases, and WGS 84 (4326) ↔ Web Mercator. " +
+                "Datum-shift transforms require the native worker profile (honua-worker-etl).");
+        }
+
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (feature.Geometry is null || feature.Geometry.IsEmpty)
+            {
+                yield return feature;
+                continue;
+            }
+
+            var projected = Reproject(feature.Geometry, fromSrid, toSrid);
+            yield return new Feature(projected, feature.Attributes);
+        }
+    }
+
+    private static NtsGeometry Reproject(NtsGeometry geometry, int fromSrid, int toSrid)
+    {
+        if (fromSrid == toSrid ||
+            (Array.IndexOf(WebMercatorAliases, fromSrid) >= 0 && Array.IndexOf(WebMercatorAliases, toSrid) >= 0))
+        {
+            var copy = geometry.Copy();
+            copy.SRID = toSrid;
+            return copy;
+        }
+
+        Func<double, double, (double X, double Y)> transform =
+            IsWgs84(fromSrid)
+                ? LonLatToWebMercator
+                : WebMercatorToLonLat;
+
+        var filter = new DelegateCoordinateFilter(transform);
+        var result = geometry.Copy();
+        result.Apply(filter);
+        result.GeometryChanged();
+        result.SRID = toSrid;
+        return result;
+    }
+
+    private static (double X, double Y) LonLatToWebMercator(double lon, double lat)
+    {
+        var x = EarthRadius * (lon * Math.PI / 180.0);
+        var clampedLat = Math.Max(Math.Min(lat, 89.99), -89.99);
+        var y = EarthRadius * Math.Log(Math.Tan((90.0 + clampedLat) * Math.PI / 360.0));
+        return (x, y);
+    }
+
+    private static (double X, double Y) WebMercatorToLonLat(double x, double y)
+    {
+        var lon = (x / EarthRadius) * 180.0 / Math.PI;
+        var lat = (2.0 * Math.Atan(Math.Exp(y / EarthRadius)) - Math.PI / 2.0) * 180.0 / Math.PI;
+        return (lon, lat);
+    }
+
+    private static bool IsSupported(int fromSrid, int toSrid)
+    {
+        if (fromSrid == toSrid)
+        {
+            return true;
+        }
+
+        var fromMerc = Array.IndexOf(WebMercatorAliases, fromSrid) >= 0;
+        var toMerc = Array.IndexOf(WebMercatorAliases, toSrid) >= 0;
+        if (fromMerc && toMerc)
+        {
+            return true;
+        }
+
+        return (IsWgs84(fromSrid) && toMerc) || (fromMerc && IsWgs84(toSrid));
+    }
+
+    private static bool IsWgs84(int srid) => srid is 4326 or 4979 or 0;
+
+    private static int ReadSrid(TransformConfig config, string key)
+    {
+        if (!config.Options.TryGetValue(key, out var raw) ||
+            !int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var srid) ||
+            srid < 0)
+        {
+            throw new InvalidOperationException(
+                $"Reproject transform requires a non-negative integer '{key}' option.");
+        }
+
+        return srid;
+    }
+
+    private sealed class DelegateCoordinateFilter(Func<double, double, (double X, double Y)> transform)
+        : ICoordinateSequenceFilter
+    {
+        public bool Done => false;
+
+        public bool GeometryChanged => true;
+
+        public void Filter(CoordinateSequence seq, int i)
+        {
+            var (x, y) = transform(seq.GetX(i), seq.GetY(i));
+            seq.SetOrdinate(i, Ordinate.X, x);
+            seq.SetOrdinate(i, Ordinate.Y, y);
+        }
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Transforms/SpatialFilterTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Transforms/SpatialFilterTransform.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Core.Features.GeoETL.Services.Transforms;
+
+/// <summary>
+/// Phase 1 spatial-filter transform. Passes through only features whose geometry
+/// satisfies a spatial predicate against a bounding box or an arbitrary WKT region,
+/// dropping the rest. Pure managed NetTopologySuite — no GEOS native dependency.
+/// Streaming and constant-memory.
+/// </summary>
+/// <remarks>
+/// Region (one required):
+/// <list type="bullet">
+/// <item><c>bbox</c> — <c>minX,minY,maxX,maxY</c> in the feature CRS.</item>
+/// <item><c>wkt</c> — an arbitrary region geometry as WKT.</item>
+/// </list>
+/// Optional <c>predicate</c> — <c>intersects</c> (default) or <c>within</c> (feature must
+/// be entirely inside the region). Features with null/empty geometry are dropped.
+/// </remarks>
+public sealed class SpatialFilterTransform : IPipelineTransform
+{
+    /// <summary>
+    /// The transform type discriminator.
+    /// </summary>
+    public const string TransformType = "spatial-filter";
+
+    /// <inheritdoc />
+    public string Type => TransformType;
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> TransformAsync(
+        TransformConfig config,
+        IAsyncEnumerable<IFeature> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(source);
+
+        var region = ReadRegion(config);
+        var within = config.Options.TryGetValue("predicate", out var predicate)
+            && string.Equals(predicate, "within", StringComparison.OrdinalIgnoreCase);
+
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var geometry = feature.Geometry;
+            if (geometry is null || geometry.IsEmpty)
+            {
+                continue;
+            }
+
+            var keep = within ? geometry.Within(region) : geometry.Intersects(region);
+            if (keep)
+            {
+                yield return feature;
+            }
+        }
+    }
+
+    private static NtsGeometry ReadRegion(TransformConfig config)
+    {
+        if (config.Options.TryGetValue("wkt", out var wkt) && !string.IsNullOrWhiteSpace(wkt))
+        {
+            return new WKTReader().Read(wkt);
+        }
+
+        if (config.Options.TryGetValue("bbox", out var bbox) && !string.IsNullOrWhiteSpace(bbox))
+        {
+            var parts = bbox.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 4 &&
+                double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var minX) &&
+                double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var minY) &&
+                double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var maxX) &&
+                double.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var maxY))
+            {
+                var factory = new GeometryFactory();
+                return factory.ToGeometry(new Envelope(minX, maxX, minY, maxY));
+            }
+
+            throw new InvalidOperationException(
+                "Spatial-filter 'bbox' must be 'minX,minY,maxX,maxY' with four numeric values.");
+        }
+
+        throw new InvalidOperationException(
+            "Spatial-filter transform requires a 'bbox' (minX,minY,maxX,maxY) or a 'wkt' region option.");
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Transforms/SpatialJoinTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Transforms/SpatialJoinTransform.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.Import.Services;
+using NetTopologySuite.Features;
+using NetTopologySuite.Index.Strtree;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Core.Features.GeoETL.Services.Transforms;
+
+/// <summary>
+/// Phase 1 spatial-join enrichment transform. For each streaming feature, finds the first
+/// reference feature whose geometry intersects (or contains, for point-in-polygon) and
+/// copies selected reference attributes onto the feature. The reference set is a GeoJSON
+/// FeatureCollection loaded once into an in-memory <see cref="STRtree{T}"/> spatial index.
+/// Pure managed NetTopologySuite — no GEOS native dependency. The streamed (left) side
+/// stays constant-memory; only the reference (right) side is materialized, which suits the
+/// "small lookup polygons, large feature stream" enrichment shape (ADR-0038 delegates
+/// large spatial joins to PostGIS).
+/// </summary>
+/// <remarks>
+/// Reference set (one required): <c>referenceInline</c> (a GeoJSON FeatureCollection
+/// document) or <c>referencePath</c> (a GeoJSON file path). Optional:
+/// <list type="bullet">
+/// <item><c>predicate</c> — <c>intersects</c> (default) or <c>contains</c> (the reference
+/// geometry must contain the feature, the point-in-polygon case).</item>
+/// <item><c>transfer</c> — comma-separated reference attribute names to copy; when omitted
+/// all reference attributes are copied.</item>
+/// <item><c>prefix</c> — prepended to each transferred attribute name to avoid collisions.
+/// </item>
+/// <item><c>keepUnmatched</c> — <c>true</c> (default) passes unmatched features through
+/// unchanged; <c>false</c> drops them (inner join).</item>
+/// </list>
+/// </remarks>
+public sealed class SpatialJoinTransform : IPipelineTransform
+{
+    /// <summary>
+    /// The transform type discriminator.
+    /// </summary>
+    public const string TransformType = "spatial-join";
+
+    /// <inheritdoc />
+    public string Type => TransformType;
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> TransformAsync(
+        TransformConfig config,
+        IAsyncEnumerable<IFeature> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(source);
+
+        var contains = config.Options.TryGetValue("predicate", out var predicate)
+            && string.Equals(predicate, "contains", StringComparison.OrdinalIgnoreCase);
+        var prefix = config.Options.TryGetValue("prefix", out var rawPrefix) ? rawPrefix : string.Empty;
+        var keepUnmatched = !config.Options.TryGetValue("keepUnmatched", out var rawKeep)
+            || !bool.TryParse(rawKeep, out var keep) || keep;
+        string[]? transfer = config.Options.TryGetValue("transfer", out var rawTransfer)
+            && !string.IsNullOrWhiteSpace(rawTransfer)
+            ? rawTransfer.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            : null;
+
+        var index = await BuildIndexAsync(config, cancellationToken).ConfigureAwait(false);
+
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var geometry = feature.Geometry;
+            if (geometry is null || geometry.IsEmpty)
+            {
+                if (keepUnmatched)
+                {
+                    yield return feature;
+                }
+
+                continue;
+            }
+
+            var match = FindMatch(index, geometry, contains);
+            if (match is null)
+            {
+                if (keepUnmatched)
+                {
+                    yield return feature;
+                }
+
+                continue;
+            }
+
+            yield return Enrich(feature, match.Attributes, transfer, prefix);
+        }
+    }
+
+    private static Feature Enrich(
+        IFeature feature,
+        IAttributesTable? referenceAttributes,
+        string[]? transfer,
+        string prefix)
+    {
+        var merged = new AttributesTable();
+        if (feature.Attributes is not null)
+        {
+            foreach (var name in feature.Attributes.GetNames())
+            {
+                merged.Add(name, feature.Attributes.GetOptionalValue(name));
+            }
+        }
+
+        if (referenceAttributes is not null)
+        {
+            var names = transfer ?? referenceAttributes.GetNames();
+            foreach (var name in names)
+            {
+                if (!referenceAttributes.Exists(name))
+                {
+                    continue;
+                }
+
+                var key = string.IsNullOrEmpty(prefix) ? name : prefix + name;
+                if (merged.Exists(key))
+                {
+                    merged[key] = referenceAttributes.GetOptionalValue(name);
+                }
+                else
+                {
+                    merged.Add(key, referenceAttributes.GetOptionalValue(name));
+                }
+            }
+        }
+
+        return new Feature(feature.Geometry, merged);
+    }
+
+    private static IFeature? FindMatch(STRtree<IFeature> index, NtsGeometry geometry, bool contains)
+    {
+        var candidates = index.Query(geometry.EnvelopeInternal);
+        foreach (var candidate in candidates)
+        {
+            var referenceGeometry = candidate.Geometry;
+            if (referenceGeometry is null)
+            {
+                continue;
+            }
+
+            var matched = contains
+                ? referenceGeometry.Contains(geometry)
+                : referenceGeometry.Intersects(geometry);
+            if (matched)
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<STRtree<IFeature>> BuildIndexAsync(
+        TransformConfig config,
+        CancellationToken cancellationToken)
+    {
+        var index = new STRtree<IFeature>();
+        var reader = new StreamingGeoJsonReader();
+
+        await using var stream = OpenReferenceStream(config);
+        await foreach (var feature in reader.ReadFeaturesAsync(stream, cancellationToken).ConfigureAwait(false))
+        {
+            if (feature.Geometry is not null && !feature.Geometry.IsEmpty)
+            {
+                index.Insert(feature.Geometry.EnvelopeInternal, feature);
+            }
+        }
+
+        index.Build();
+        return index;
+    }
+
+    private static Stream OpenReferenceStream(TransformConfig config)
+    {
+        if (config.Options.TryGetValue("referenceInline", out var inline) && !string.IsNullOrEmpty(inline))
+        {
+            return new MemoryStream(Encoding.UTF8.GetBytes(inline), writable: false);
+        }
+
+        if (config.Options.TryGetValue("referencePath", out var path) && !string.IsNullOrWhiteSpace(path))
+        {
+            return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 65536,
+                useAsync: true);
+        }
+
+        throw new InvalidOperationException(
+            "Spatial-join transform requires a 'referenceInline' GeoJSON document or a 'referencePath' option.");
+    }
+}

--- a/src/Honua.Postgres/Features/GeoETL/Services/Connectors/ExternalPostgisSinkConnector.cs
+++ b/src/Honua.Postgres/Features/GeoETL/Services/Connectors/ExternalPostgisSinkConnector.cs
@@ -1,0 +1,230 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Postgres.Features.Import;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.GeoETL.Services.Connectors;
+
+/// <summary>
+/// Phase 1 external PostGIS sink. Writes the feature set to a PostGIS database identified
+/// by a connector-supplied connection string that is <b>not</b> the Honua catalog — this
+/// is the "load into a customer's own PostGIS" sink, distinct from
+/// <c>HonuaLayerSinkConnector</c> which writes through the catalog's
+/// <c>honua.create_import_table</c> insert path. Managed Npgsql + WKB, no GDAL.
+/// </summary>
+/// <remarks>
+/// Required <see cref="ConnectorConfig.Options"/>:
+/// <list type="bullet">
+/// <item><c>connectionString</c> — the external PostGIS connection string.</item>
+/// <item><c>table</c> — destination table name (created if missing).</item>
+/// <item><c>targetSrid</c> — geometry SRID for the destination column.</item>
+/// </list>
+/// Optional <c>schema</c> (defaults to <c>public</c>), <c>geometryColumn</c> (defaults to
+/// <c>geom</c>), and <c>batchSize</c> (defaults to 1000). Every row's <c>attributes</c>
+/// JSONB carries a reserved <c>__pipeline_batch_id</c> key so a failed run can soft-delete
+/// its rows (the ADR-0038 Phase 1 rollback contract). Table/schema/column identifiers are
+/// validated against a strict pattern before being interpolated, since they cannot be
+/// parameterized.
+/// </remarks>
+public sealed partial class ExternalPostgisSinkConnector : IPipelineSinkConnector
+{
+    /// <summary>
+    /// The connector type discriminator.
+    /// </summary>
+    public const string ConnectorType = "external-postgis";
+
+    /// <summary>Reserved attribute key tagging every row with its run batch id.</summary>
+    public const string BatchIdPropertyKey = "__pipeline_batch_id";
+
+    private const int DefaultBatchSize = 1000;
+
+    /// <inheritdoc />
+    public string Type => ConnectorType;
+
+    /// <inheritdoc />
+    public ConnectorRuntimeProfile RuntimeProfile => ConnectorRuntimeProfile.Managed;
+
+    /// <inheritdoc />
+    public async Task<SinkWriteResult> WriteAsync(
+        ConnectorConfig config,
+        IAsyncEnumerable<IFeature> features,
+        string batchId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(features);
+
+        var connectionString = RequireOption(config, "connectionString");
+        var schema = Identifier(config.Options.TryGetValue("schema", out var rawSchema)
+            && !string.IsNullOrWhiteSpace(rawSchema) ? rawSchema : "public");
+        var table = Identifier(RequireOption(config, "table"));
+        var geometryColumn = Identifier(config.Options.TryGetValue("geometryColumn", out var rawGeom)
+            && !string.IsNullOrWhiteSpace(rawGeom) ? rawGeom : "geom");
+        var targetSrid = RequireIntOption(config, "targetSrid");
+        var batchSize = config.Options.TryGetValue("batchSize", out var rawBatch)
+            && int.TryParse(rawBatch, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            && parsed > 0
+            ? parsed
+            : DefaultBatchSize;
+
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        await EnsureTableAsync(connection, schema, table, geometryColumn, targetSrid, cancellationToken)
+            .ConfigureAwait(false);
+
+        var wkbWriter = new WKBWriter();
+        long written = 0;
+        long rejected = 0;
+        var buffer = new List<IFeature>(batchSize);
+
+        await foreach (var feature in features.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            if (feature.Geometry is null)
+            {
+                rejected++;
+                continue;
+            }
+
+            buffer.Add(feature);
+            if (buffer.Count >= batchSize)
+            {
+                written += await InsertBatchAsync(
+                        connection, schema, table, geometryColumn, targetSrid, buffer, batchId, wkbWriter, cancellationToken)
+                    .ConfigureAwait(false);
+                buffer.Clear();
+            }
+        }
+
+        if (buffer.Count > 0)
+        {
+            written += await InsertBatchAsync(
+                    connection, schema, table, geometryColumn, targetSrid, buffer, batchId, wkbWriter, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return new SinkWriteResult { FeaturesWritten = written, FeaturesRejected = rejected };
+    }
+
+    private static async Task EnsureTableAsync(
+        NpgsqlConnection connection,
+        string schema,
+        string table,
+        string geometryColumn,
+        int targetSrid,
+        CancellationToken cancellationToken)
+    {
+        var sql = $"""
+            CREATE SCHEMA IF NOT EXISTS "{schema}";
+            CREATE TABLE IF NOT EXISTS "{schema}"."{table}" (
+                id          BIGSERIAL PRIMARY KEY,
+                "{geometryColumn}" geometry(Geometry, {targetSrid.ToString(CultureInfo.InvariantCulture)}),
+                attributes  JSONB NOT NULL
+            );
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<long> InsertBatchAsync(
+        NpgsqlConnection connection,
+        string schema,
+        string table,
+        string geometryColumn,
+        int targetSrid,
+        List<IFeature> features,
+        string batchId,
+        WKBWriter wkbWriter,
+        CancellationToken cancellationToken)
+    {
+        var wkbs = new byte[features.Count][];
+        var attributes = new string[features.Count];
+        for (var i = 0; i < features.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            wkbs[i] = wkbWriter.Write(features[i].Geometry!);
+            attributes[i] = BuildAttributesJson(features[i], batchId);
+        }
+
+        var sql = $"""
+            INSERT INTO "{schema}"."{table}" ("{geometryColumn}", attributes)
+            SELECT ST_SetSRID(ST_GeomFromWKB(payload.wkb), {targetSrid.ToString(CultureInfo.InvariantCulture)}),
+                   payload.attributes
+            FROM unnest(@wkbs, @attributes) AS payload(wkb, attributes)
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.Add("wkbs", NpgsqlDbType.Array | NpgsqlDbType.Bytea).Value = wkbs;
+        command.Parameters.Add("attributes", NpgsqlDbType.Array | NpgsqlDbType.Jsonb).Value = attributes;
+
+        var affected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return affected;
+    }
+
+    private static string BuildAttributesJson(IFeature feature, string batchId)
+    {
+        var properties = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            [BatchIdPropertyKey] = batchId
+        };
+
+        if (feature.Attributes is { } table)
+        {
+            var names = table.GetNames();
+            var values = table.GetValues();
+            for (var i = 0; i < names.Length; i++)
+            {
+                properties[names[i]] = values[i];
+            }
+        }
+
+        return JsonSerializer.Serialize(properties, ImportJsonContext.Default.DictionaryStringObject);
+    }
+
+    private static string Identifier(string value)
+    {
+        if (!IdentifierRegex().IsMatch(value))
+        {
+            throw new InvalidOperationException(
+                $"External PostGIS sink identifier '{value}' is invalid. Identifiers must match " +
+                "^[A-Za-z_][A-Za-z0-9_]*$ (they cannot be parameterized in DDL/DML).");
+        }
+
+        return value;
+    }
+
+    private static string RequireOption(ConnectorConfig config, string key)
+    {
+        if (!config.Options.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"External PostGIS sink requires a '{key}' option.");
+        }
+
+        return value;
+    }
+
+    private static int RequireIntOption(ConnectorConfig config, string key)
+    {
+        if (!config.Options.TryGetValue(key, out var raw) ||
+            !int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) ||
+            value <= 0)
+        {
+            throw new InvalidOperationException($"External PostGIS sink requires a positive integer '{key}' option.");
+        }
+
+        return value;
+    }
+
+    [GeneratedRegex("^[A-Za-z_][A-Za-z0-9_]*$")]
+    private static partial Regex IdentifierRegex();
+}

--- a/src/Honua.Postgres/Features/GeoETL/Services/Connectors/GeoPackageSourceConnector.cs
+++ b/src/Honua.Postgres/Features/GeoETL/Services/Connectors/GeoPackageSourceConnector.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Microsoft.Data.Sqlite;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Postgres.Features.GeoETL.Services.Connectors;
+
+/// <summary>
+/// Phase 1 GeoPackage source connector. Reads a <c>.gpkg</c> file through the managed
+/// <c>Microsoft.Data.Sqlite</c> + <c>NetTopologySuite.IO.GeoPackage</c> path — the same
+/// managed libraries the <c>StreamingFileImportService</c> GeoPackage import path uses —
+/// so it carries no GDAL/OGR dependency and runs inside the lean serving image. The
+/// connector lives in <c>Honua.Postgres</c> because that is where those managed readers
+/// are referenced.
+/// </summary>
+/// <remarks>
+/// Required <see cref="ConnectorConfig.Options"/>: <c>path</c> — absolute path to the
+/// <c>.gpkg</c> file. Optional <c>layer</c> — the feature table to read; required when
+/// the GeoPackage contains more than one feature layer, otherwise the single layer is
+/// used automatically. Features stream one row at a time so memory stays constant.
+/// </remarks>
+public sealed partial class GeoPackageSourceConnector : IPipelineSourceConnector
+{
+    /// <summary>
+    /// The connector type discriminator.
+    /// </summary>
+    public const string ConnectorType = "geopackage";
+
+    /// <inheritdoc />
+    public string Type => ConnectorType;
+
+    /// <inheritdoc />
+    public ConnectorRuntimeProfile RuntimeProfile => ConnectorRuntimeProfile.Managed;
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> ReadAsync(
+        ConnectorConfig config,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (!config.Options.TryGetValue("path", out var path) || string.IsNullOrWhiteSpace(path))
+        {
+            throw new InvalidOperationException(
+                "GeoPackage source connector requires a 'path' option pointing at the .gpkg file.");
+        }
+
+        config.Options.TryGetValue("layer", out var requestedLayer);
+
+        var layers = await GetLayersAsync(path, cancellationToken).ConfigureAwait(false);
+        var layer = ResolveLayer(layers, requestedLayer);
+
+        await foreach (var feature in ReadLayerAsync(path, layer, cancellationToken).ConfigureAwait(false))
+        {
+            yield return feature;
+        }
+    }
+
+    private static GeoPackageLayer ResolveLayer(IReadOnlyList<GeoPackageLayer> layers, string? requested)
+    {
+        if (layers.Count == 0)
+        {
+            throw new InvalidDataException("GeoPackage does not contain any feature layers.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(requested))
+        {
+            return layers.FirstOrDefault(l => string.Equals(l.TableName, requested, StringComparison.Ordinal))
+                ?? throw new InvalidDataException(
+                    $"GeoPackage does not contain a feature layer named '{requested}'. " +
+                    $"Available: {string.Join(", ", layers.Select(l => l.TableName))}.");
+        }
+
+        if (layers.Count > 1)
+        {
+            throw new InvalidDataException(
+                "GeoPackage contains multiple feature layers " +
+                $"({string.Join(", ", layers.Select(l => l.TableName))}). " +
+                "Specify a 'layer' option to select one.");
+        }
+
+        return layers[0];
+    }
+
+    private static async Task<IReadOnlyList<GeoPackageLayer>> GetLayersAsync(
+        string filePath,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new SqliteConnection($"Data Source={filePath};Mode=ReadOnly;");
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        const string sql = """
+            SELECT c.table_name, g.column_name, g.srs_id
+            FROM gpkg_contents c
+            JOIN gpkg_geometry_columns g ON c.table_name = g.table_name
+            WHERE c.data_type = 'features'
+            ORDER BY c.table_name
+            """;
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var layers = new List<GeoPackageLayer>();
+
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var tableName = reader.GetString(0);
+            var geometryColumn = reader.GetString(1);
+            var srid = reader.IsDBNull(2) ? (int?)null : reader.GetInt32(2);
+            layers.Add(new GeoPackageLayer(tableName, geometryColumn, srid is > 0 ? srid : null));
+        }
+
+        return layers;
+    }
+
+    private static async IAsyncEnumerable<IFeature> ReadLayerAsync(
+        string filePath,
+        GeoPackageLayer layer,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        if (!TableNameRegex().IsMatch(layer.TableName))
+        {
+            throw new InvalidOperationException("GeoPackage contains table name with unsupported characters.");
+        }
+
+        await using var connection = new SqliteConnection($"Data Source={filePath};Mode=ReadOnly;");
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT * FROM \"{layer.TableName.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var geometryOrdinal = reader.GetOrdinal(layer.GeometryColumn);
+        var geoReader = new GeoPackageGeoReader
+        {
+            HandleSRID = true,
+            RepairRings = true
+        };
+
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            NtsGeometry? geometry = null;
+            if (!reader.IsDBNull(geometryOrdinal))
+            {
+                var blob = reader.GetFieldValue<byte[]>(geometryOrdinal);
+                geometry = geoReader.Read(blob);
+                if (geometry is not null && layer.Srid.HasValue && geometry.SRID <= 0)
+                {
+                    geometry.SRID = layer.Srid.Value;
+                }
+            }
+
+            var attributes = new AttributesTable();
+            for (var i = 0; i < reader.FieldCount; i++)
+            {
+                if (i == geometryOrdinal)
+                {
+                    continue;
+                }
+
+                var name = reader.GetName(i);
+                var value = reader.IsDBNull(i) ? null : reader.GetValue(i);
+                attributes.Add(name, value);
+            }
+
+            yield return new Feature(geometry, attributes);
+        }
+    }
+
+    [GeneratedRegex("^[A-Za-z_][A-Za-z0-9_]*$")]
+    private static partial Regex TableNameRegex();
+
+    private sealed record GeoPackageLayer(string TableName, string GeometryColumn, int? Srid);
+}

--- a/src/Honua.Postgres/Features/GeoETL/Services/Connectors/ShapefileSourceConnector.cs
+++ b/src/Honua.Postgres/Features/GeoETL/Services/Connectors/ShapefileSourceConnector.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO.Esri;
+using NetTopologySuite.IO.Esri.Shapefiles.Readers;
+
+namespace Honua.Postgres.Features.GeoETL.Services.Connectors;
+
+/// <summary>
+/// Phase 1 Shapefile source connector. Reads an Esri shapefile through the managed
+/// <c>NetTopologySuite.IO.Esri</c> reader — the same managed library the
+/// <c>StreamingFileImportService</c> shapefile import path uses — so it carries no
+/// GDAL/OGR dependency and runs inside the lean serving image. The connector lives in
+/// <c>Honua.Postgres</c> because that is where the managed Esri reader is referenced.
+/// </summary>
+/// <remarks>
+/// Required <see cref="ConnectorConfig.Options"/>: <c>path</c> — absolute path to the
+/// <c>.shp</c> file (its sidecar <c>.dbf</c> / <c>.shx</c> / <c>.prj</c> must sit beside
+/// it). Reads stream one record at a time, skipping deleted records, so memory stays
+/// constant for large shapefiles.
+/// </remarks>
+public sealed class ShapefileSourceConnector : IPipelineSourceConnector
+{
+    /// <summary>
+    /// The connector type discriminator.
+    /// </summary>
+    public const string ConnectorType = "shapefile";
+
+    /// <inheritdoc />
+    public string Type => ConnectorType;
+
+    /// <inheritdoc />
+    public ConnectorRuntimeProfile RuntimeProfile => ConnectorRuntimeProfile.Managed;
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> ReadAsync(
+        ConnectorConfig config,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (!config.Options.TryGetValue("path", out var path) || string.IsNullOrWhiteSpace(path))
+        {
+            throw new InvalidOperationException(
+                "Shapefile source connector requires a 'path' option pointing at the .shp file.");
+        }
+
+        var options = new ShapefileReaderOptions
+        {
+            GeometryBuilderMode = GeometryBuilderMode.QuickFixInvalidShapes
+        };
+
+        using var reader = Shapefile.OpenRead(path, options);
+        var recordIndex = 0;
+
+        while (reader.Read(out var deleted, out var feature))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (deleted || feature is null)
+            {
+                continue;
+            }
+
+            yield return feature;
+
+            if (++recordIndex % 256 == 0)
+            {
+                await Task.Yield();
+            }
+        }
+    }
+}

--- a/src/Honua.Postgres/Features/GeoETL/Services/PostgresFeatureSinkWriter.cs
+++ b/src/Honua.Postgres/Features/GeoETL/Services/PostgresFeatureSinkWriter.cs
@@ -1,0 +1,153 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Import;
+using Honua.Postgres.Features.Infrastructure;
+using Microsoft.Extensions.Logging;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.GeoETL.Services;
+
+/// <summary>
+/// PostgreSQL / PostGIS implementation of <see cref="IFeatureSinkWriter"/> for the
+/// GeoETL Honua-layer sink. Mirrors the <c>StreamingFileImportService</c> insert path:
+/// it ensures the target through <c>honua.create_import_table</c> and inserts batches
+/// through <c>honua.insert_import_feature</c> using the same WKB + properties JSONB
+/// projection and the same set-based <c>unnest</c> insert shape.
+/// </summary>
+/// <remarks>
+/// Phase 1 rollback is the soft-delete batch id (ADR-0038). Each row's properties
+/// JSONB carries a reserved <c>__pipeline_batch_id</c> key so a failed run can
+/// <c>DELETE ... WHERE properties->>'__pipeline_batch_id' = @batchId</c>. The dedicated
+/// <c>pipeline_batch_id</c> column escalation is documented as remaining work.
+/// </remarks>
+internal sealed partial class PostgresFeatureSinkWriter(
+    IDatabaseConnectionProvider connectionProvider,
+    ILogger<PostgresFeatureSinkWriter> logger) : IFeatureSinkWriter
+{
+    /// <summary>Reserved property key tagging every row with its run batch id.</summary>
+    public const string BatchIdPropertyKey = "__pipeline_batch_id";
+
+    private const string CreateImportTableSql =
+        "SELECT honua.create_import_table(@schema_name, @table_name, @target_srid)";
+
+    private const string InsertBatchSql = """
+        SELECT honua.insert_import_feature(
+            @schema_name,
+            @table_name,
+            payload.wkb,
+            payload.source_srid,
+            @target_srid,
+            payload.properties)
+        FROM unnest(@wkbs, @source_srids, @properties) AS payload(wkb, source_srid, properties)
+        """;
+
+    /// <inheritdoc />
+    public async Task EnsureTargetAsync(
+        string schema,
+        string table,
+        int targetSrid,
+        CancellationToken cancellationToken = default)
+    {
+        await using var lease = await connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        NpgsqlConnection connection = lease;
+
+        await using var command = new NpgsqlCommand(CreateImportTableSql, connection);
+        command.Parameters.AddWithValue("schema_name", schema);
+        command.Parameters.AddWithValue("table_name", table);
+        command.Parameters.AddWithValue("target_srid", targetSrid);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+        Log.TargetEnsured(logger, schema, table, targetSrid);
+    }
+
+    /// <inheritdoc />
+    public async Task<long> InsertBatchAsync(
+        string schema,
+        string table,
+        IReadOnlyList<IFeature> features,
+        int sourceSrid,
+        int targetSrid,
+        string batchId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+        if (features.Count == 0)
+        {
+            return 0;
+        }
+
+        var wkbWriter = new WKBWriter();
+        var wkbs = new byte[]?[features.Count];
+        var sourceSrids = new int[features.Count];
+        var properties = new string[features.Count];
+
+        for (var i = 0; i < features.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var feature = features[i];
+            wkbs[i] = feature.Geometry is null ? null : wkbWriter.Write(feature.Geometry);
+            var featureSrid = feature.Geometry?.SRID;
+            sourceSrids[i] = featureSrid is > 0 ? featureSrid.Value : sourceSrid;
+            properties[i] = BuildPropertiesJson(feature, batchId);
+        }
+
+        await using var lease = await connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        NpgsqlConnection connection = lease;
+
+        await using var command = new NpgsqlCommand(InsertBatchSql, connection);
+        command.Parameters.AddWithValue("schema_name", schema);
+        command.Parameters.AddWithValue("table_name", table);
+        command.Parameters.Add("target_srid", NpgsqlDbType.Integer).Value = targetSrid;
+        command.Parameters.Add("wkbs", NpgsqlDbType.Array | NpgsqlDbType.Bytea).Value = wkbs;
+        command.Parameters.Add("source_srids", NpgsqlDbType.Array | NpgsqlDbType.Integer).Value = sourceSrids;
+        command.Parameters.Add("properties", NpgsqlDbType.Array | NpgsqlDbType.Jsonb).Value = properties;
+
+        long inserted = 0;
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            inserted++;
+        }
+
+        Log.BatchInserted(logger, inserted, schema, table, batchId);
+        return inserted;
+    }
+
+    private static string BuildPropertiesJson(IFeature feature, string batchId)
+    {
+        var properties = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            [BatchIdPropertyKey] = batchId
+        };
+
+        if (feature.Attributes is { } attributes)
+        {
+            var names = attributes.GetNames();
+            var values = attributes.GetValues();
+            for (var i = 0; i < names.Length; i++)
+            {
+                properties[names[i]] = values[i];
+            }
+        }
+
+        return JsonSerializer.Serialize(properties, ImportJsonContext.Default.DictionaryStringObject);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9700, LogLevel.Information,
+            "GeoETL sink ensured target {Schema}.{Table} (SRID {TargetSrid})")]
+        public static partial void TargetEnsured(ILogger logger, string schema, string table, int targetSrid);
+
+        [LoggerMessage(9701, LogLevel.Information,
+            "GeoETL sink inserted {Count} feature(s) into {Schema}.{Table} (batch {BatchId})")]
+        public static partial void BatchInserted(ILogger logger, long count, string schema, string table, string batchId);
+    }
+}

--- a/src/Honua.Postgres/Features/GeoETL/Services/PostgresPipelineDefinitionStore.cs
+++ b/src/Honua.Postgres/Features/GeoETL/Services/PostgresPipelineDefinitionStore.cs
@@ -1,0 +1,196 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Infrastructure;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.GeoETL.Services;
+
+/// <summary>
+/// PostgreSQL-backed <see cref="IPipelineDefinitionStore"/>. Persists definitions to
+/// <c>honua.pipeline_definitions</c>, storing the discriminated-union stage chain as a
+/// JSONB document via <see cref="PipelineStageSerializer"/> so the connector / transform
+/// config shapes evolve without a schema migration (#361 Child Ticket A — durable
+/// persistence). Replaces the in-memory baseline store when a PostgreSQL provider is wired.
+/// </summary>
+internal sealed class PostgresPipelineDefinitionStore : IPipelineDefinitionStore
+{
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly TimeProvider _timeProvider;
+    private readonly string _table;
+
+    public PostgresPipelineDefinitionStore(
+        IDatabaseConnectionProvider connectionProvider,
+        TimeProvider timeProvider,
+        string? schemaName = null)
+    {
+        ArgumentNullException.ThrowIfNull(connectionProvider);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        _connectionProvider = connectionProvider;
+        _timeProvider = timeProvider;
+        _table = SchemaSearchPath.QualifyTable("pipeline_definitions", schemaName);
+    }
+
+    public async Task CreateAsync(PipelineDefinition definition, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentException.ThrowIfNullOrWhiteSpace(definition.Id);
+
+        var sql = $"""
+            INSERT INTO {_table} (
+                id, name, description, schema_version, version, stages_json, created_at, updated_at
+            ) VALUES (
+                @id, @name, @description, @schema_version, @version, @stages_json, @created_at, @updated_at
+            )
+            """;
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        NpgsqlConnection connection = lease;
+        await using var command = new NpgsqlCommand(sql, connection);
+        BindDefinition(command, definition);
+
+        try
+        {
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
+        {
+            throw new InvalidOperationException($"Pipeline '{definition.Id}' already exists.", ex);
+        }
+    }
+
+    public async Task<PipelineDefinition?> GetAsync(string id, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+
+        var sql = $"""
+            SELECT id, name, description, schema_version, version, stages_json, created_at, updated_at
+            FROM {_table}
+            WHERE id = @id
+            """;
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        NpgsqlConnection connection = lease;
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@id", id);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return ReadDefinition(reader);
+    }
+
+    public async Task<PipelineDefinition?> UpdateAsync(PipelineDefinition definition, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentException.ThrowIfNullOrWhiteSpace(definition.Id);
+
+        // Increment version and preserve the original created_at, mirroring the in-memory store.
+        var sql = $"""
+            UPDATE {_table}
+            SET name           = @name,
+                description    = @description,
+                schema_version = @schema_version,
+                version        = version + 1,
+                stages_json    = @stages_json,
+                updated_at     = @updated_at
+            WHERE id = @id
+            RETURNING id, name, description, schema_version, version, stages_json, created_at, updated_at
+            """;
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        NpgsqlConnection connection = lease;
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@id", definition.Id);
+        command.Parameters.AddWithValue("@name", definition.Name);
+        command.Parameters.AddWithValue("@description", (object?)definition.Description ?? DBNull.Value);
+        command.Parameters.AddWithValue("@schema_version", definition.SchemaVersion);
+        command.Parameters.Add(new NpgsqlParameter("@stages_json", NpgsqlDbType.Jsonb)
+        {
+            Value = PipelineStageSerializer.Serialize(definition.Stages)
+        });
+        command.Parameters.AddWithValue("@updated_at", _timeProvider.GetUtcNow());
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return ReadDefinition(reader);
+    }
+
+    public async Task<bool> DeleteAsync(string id, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+
+        var sql = $"DELETE FROM {_table} WHERE id = @id";
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        NpgsqlConnection connection = lease;
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@id", id);
+
+        var affected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return affected > 0;
+    }
+
+    public async Task<IReadOnlyList<PipelineDefinition>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SELECT id, name, description, schema_version, version, stages_json, created_at, updated_at
+            FROM {_table}
+            ORDER BY name ASC, id ASC
+            """;
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        NpgsqlConnection connection = lease;
+        await using var command = new NpgsqlCommand(sql, connection);
+
+        var results = new List<PipelineDefinition>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            results.Add(ReadDefinition(reader));
+        }
+
+        return results;
+    }
+
+    private void BindDefinition(NpgsqlCommand command, PipelineDefinition definition)
+    {
+        var now = _timeProvider.GetUtcNow();
+        command.Parameters.AddWithValue("@id", definition.Id);
+        command.Parameters.AddWithValue("@name", definition.Name);
+        command.Parameters.AddWithValue("@description", (object?)definition.Description ?? DBNull.Value);
+        command.Parameters.AddWithValue("@schema_version", definition.SchemaVersion);
+        command.Parameters.AddWithValue("@version", definition.Version);
+        command.Parameters.Add(new NpgsqlParameter("@stages_json", NpgsqlDbType.Jsonb)
+        {
+            Value = PipelineStageSerializer.Serialize(definition.Stages)
+        });
+        command.Parameters.AddWithValue("@created_at", definition.CreatedAt == default ? now : definition.CreatedAt);
+        command.Parameters.AddWithValue("@updated_at", definition.UpdatedAt == default ? now : definition.UpdatedAt);
+    }
+
+    private static PipelineDefinition ReadDefinition(NpgsqlDataReader reader)
+        => new()
+        {
+            Id = reader.GetString(0),
+            Name = reader.GetString(1),
+            Description = reader.IsDBNull(2) ? null : reader.GetString(2),
+            SchemaVersion = reader.GetInt32(3),
+            Version = reader.GetInt32(4),
+            Stages = PipelineStageSerializer.Deserialize(reader.GetString(5)),
+            CreatedAt = reader.GetFieldValue<DateTimeOffset>(6),
+            UpdatedAt = reader.GetFieldValue<DateTimeOffset>(7)
+        };
+}

--- a/src/Honua.Postgres/Features/GeoETL/Services/PostgresPipelineExecutionStore.cs
+++ b/src/Honua.Postgres/Features/GeoETL/Services/PostgresPipelineExecutionStore.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Infrastructure;
+using Npgsql;
+
+namespace Honua.Postgres.Features.GeoETL.Services;
+
+/// <summary>
+/// PostgreSQL-backed <see cref="IPipelineExecutionStore"/>. Persists execution records to
+/// <c>honua.pipeline_executions</c> (#361 Child Ticket A — durable persistence). The
+/// status is stored as its enum name and correlated to the substrate job by
+/// <c>execution_job_id</c>. <see cref="UpdateAsync"/> upserts so a job that resumes after
+/// a worker restart converges on the latest state.
+/// </summary>
+internal sealed class PostgresPipelineExecutionStore : IPipelineExecutionStore
+{
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly string _table;
+
+    public PostgresPipelineExecutionStore(
+        IDatabaseConnectionProvider connectionProvider,
+        string? schemaName = null)
+    {
+        ArgumentNullException.ThrowIfNull(connectionProvider);
+        _connectionProvider = connectionProvider;
+        _table = SchemaSearchPath.QualifyTable("pipeline_executions", schemaName);
+    }
+
+    public async Task CreateAsync(PipelineExecution execution, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(execution);
+        ArgumentException.ThrowIfNullOrWhiteSpace(execution.Id);
+
+        var sql = $"""
+            INSERT INTO {_table} (
+                id, pipeline_id, pipeline_version, execution_job_id, status, is_dry_run,
+                features_read, features_written, features_quarantined, batch_id, error_message,
+                created_at, completed_at
+            ) VALUES (
+                @id, @pipeline_id, @pipeline_version, @execution_job_id, @status, @is_dry_run,
+                @features_read, @features_written, @features_quarantined, @batch_id, @error_message,
+                @created_at, @completed_at
+            )
+            """;
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        NpgsqlConnection connection = lease;
+        await using var command = new NpgsqlCommand(sql, connection);
+        BindExecution(command, execution);
+
+        try
+        {
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
+        {
+            throw new InvalidOperationException($"Execution '{execution.Id}' already exists.", ex);
+        }
+    }
+
+    public async Task UpdateAsync(PipelineExecution execution, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(execution);
+        ArgumentException.ThrowIfNullOrWhiteSpace(execution.Id);
+
+        var sql = $"""
+            INSERT INTO {_table} (
+                id, pipeline_id, pipeline_version, execution_job_id, status, is_dry_run,
+                features_read, features_written, features_quarantined, batch_id, error_message,
+                created_at, completed_at
+            ) VALUES (
+                @id, @pipeline_id, @pipeline_version, @execution_job_id, @status, @is_dry_run,
+                @features_read, @features_written, @features_quarantined, @batch_id, @error_message,
+                @created_at, @completed_at
+            )
+            ON CONFLICT (id) DO UPDATE SET
+                pipeline_id          = EXCLUDED.pipeline_id,
+                pipeline_version     = EXCLUDED.pipeline_version,
+                execution_job_id     = EXCLUDED.execution_job_id,
+                status               = EXCLUDED.status,
+                is_dry_run           = EXCLUDED.is_dry_run,
+                features_read        = EXCLUDED.features_read,
+                features_written     = EXCLUDED.features_written,
+                features_quarantined = EXCLUDED.features_quarantined,
+                batch_id             = EXCLUDED.batch_id,
+                error_message        = EXCLUDED.error_message,
+                completed_at         = EXCLUDED.completed_at
+            """;
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        NpgsqlConnection connection = lease;
+        await using var command = new NpgsqlCommand(sql, connection);
+        BindExecution(command, execution);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<PipelineExecution?> GetAsync(string id, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+
+        var sql = $"{SelectColumns()} FROM {_table} WHERE id = @id";
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        NpgsqlConnection connection = lease;
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@id", id);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return ReadExecution(reader);
+    }
+
+    public async Task<IReadOnlyList<PipelineExecution>> ListForPipelineAsync(
+        string pipelineId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pipelineId);
+
+        var sql = $"""
+            {SelectColumns()}
+            FROM {_table}
+            WHERE pipeline_id = @pipeline_id
+            ORDER BY created_at DESC, id DESC
+            """;
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        NpgsqlConnection connection = lease;
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@pipeline_id", pipelineId);
+
+        var results = new List<PipelineExecution>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            results.Add(ReadExecution(reader));
+        }
+
+        return results;
+    }
+
+    private static string SelectColumns() =>
+        """
+        SELECT id, pipeline_id, pipeline_version, execution_job_id, status, is_dry_run,
+               features_read, features_written, features_quarantined, batch_id, error_message,
+               created_at, completed_at
+        """;
+
+    private static void BindExecution(NpgsqlCommand command, PipelineExecution execution)
+    {
+        command.Parameters.AddWithValue("@id", execution.Id);
+        command.Parameters.AddWithValue("@pipeline_id", execution.PipelineId);
+        command.Parameters.AddWithValue("@pipeline_version", execution.PipelineVersion);
+        command.Parameters.AddWithValue("@execution_job_id", execution.ExecutionJobId);
+        command.Parameters.AddWithValue("@status", execution.Status.ToString());
+        command.Parameters.AddWithValue("@is_dry_run", execution.IsDryRun);
+        command.Parameters.AddWithValue("@features_read", execution.FeaturesRead);
+        command.Parameters.AddWithValue("@features_written", execution.FeaturesWritten);
+        command.Parameters.AddWithValue("@features_quarantined", execution.FeaturesQuarantined);
+        command.Parameters.AddWithValue("@batch_id", (object?)execution.BatchId ?? DBNull.Value);
+        command.Parameters.AddWithValue("@error_message", (object?)execution.ErrorMessage ?? DBNull.Value);
+        command.Parameters.AddWithValue("@created_at", execution.CreatedAt);
+        command.Parameters.AddWithValue("@completed_at", (object?)execution.CompletedAt ?? DBNull.Value);
+    }
+
+    private static PipelineExecution ReadExecution(NpgsqlDataReader reader)
+        => new()
+        {
+            Id = reader.GetString(0),
+            PipelineId = reader.GetString(1),
+            PipelineVersion = reader.GetInt32(2),
+            ExecutionJobId = reader.GetString(3),
+            Status = Enum.Parse<PipelineExecutionStatus>(reader.GetString(4), ignoreCase: true),
+            IsDryRun = reader.GetBoolean(5),
+            FeaturesRead = reader.GetInt64(6),
+            FeaturesWritten = reader.GetInt64(7),
+            FeaturesQuarantined = reader.GetInt64(8),
+            BatchId = reader.IsDBNull(9) ? null : reader.GetString(9),
+            ErrorMessage = reader.IsDBNull(10) ? null : reader.GetString(10),
+            CreatedAt = reader.GetFieldValue<DateTimeOffset>(11),
+            CompletedAt = reader.IsDBNull(12) ? null : reader.GetFieldValue<DateTimeOffset>(12)
+        };
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -314,6 +314,22 @@ internal static class ServiceCollectionExtensions
         services.AddScoped<Core.Features.GeoETL.Abstractions.IFeatureSinkWriter,
             Features.GeoETL.Services.PostgresFeatureSinkWriter>();
 
+        // GeoETL durable definition / execution stores (#361 Child Ticket A). Registered
+        // here so they precede the in-memory baseline stores that AddGeoEtl falls back to
+        // via TryAdd when no PostgreSQL provider is wired. Persists definitions and
+        // executions to honua.pipeline_definitions / honua.pipeline_executions.
+        // Scoped to match the scoped IDatabaseConnectionProvider (avoids a captive
+        // dependency). The PipelineJobExecutor and launcher resolve these inside a
+        // per-job DI scope, so the lifetime aligns with the unit of work.
+        services.TryAddSingleton<TimeProvider>(TimeProvider.System);
+        services.AddScoped<Core.Features.GeoETL.Abstractions.IPipelineDefinitionStore>(sp =>
+            new Features.GeoETL.Services.PostgresPipelineDefinitionStore(
+                sp.GetRequiredService<IDatabaseConnectionProvider>(),
+                sp.GetRequiredService<TimeProvider>()));
+        services.AddScoped<Core.Features.GeoETL.Abstractions.IPipelineExecutionStore>(sp =>
+            new Features.GeoETL.Services.PostgresPipelineExecutionStore(
+                sp.GetRequiredService<IDatabaseConnectionProvider>()));
+
         // Register universal import job service using unified progress store
         // This replaces the in-memory job service with one that uses centralized progress tracking
         services.AddSingleton<IImportJobService>(serviceProvider =>

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -328,6 +328,14 @@ internal static class ServiceCollectionExtensions
             Core.Features.GeoETL.Abstractions.IPipelineSourceConnector,
             Features.GeoETL.Services.Connectors.GeoPackageSourceConnector>());
 
+        // GeoETL external PostGIS sink — writes to a customer-supplied PostGIS connection
+        // that is NOT the Honua catalog (distinct from the HonuaLayerSinkConnector that
+        // writes via honua.create_import_table). Managed Npgsql + WKB, no GDAL. Stateless,
+        // so an enumerable singleton collected by the component factory.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            Core.Features.GeoETL.Abstractions.IPipelineSinkConnector,
+            Features.GeoETL.Services.Connectors.ExternalPostgisSinkConnector>());
+
         // GeoETL durable definition / execution stores (#361 Child Ticket A). Registered
         // here so they precede the in-memory baseline stores that AddGeoEtl falls back to
         // via TryAdd when no PostgreSQL provider is wired. Persists definitions and

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -308,6 +308,12 @@ internal static class ServiceCollectionExtensions
                 serviceProvider.GetRequiredService<PostgresSchemaConfiguration>());
         });
 
+        // GeoETL Honua-layer sink writer (#361 Child Ticket D / baseline slice). Reuses
+        // the same honua.create_import_table / honua.insert_import_feature path the import
+        // service uses, so the pipeline Honua-layer sink does not duplicate the insert code.
+        services.AddScoped<Core.Features.GeoETL.Abstractions.IFeatureSinkWriter,
+            Features.GeoETL.Services.PostgresFeatureSinkWriter>();
+
         // Register universal import job service using unified progress store
         // This replaces the in-memory job service with one that uses centralized progress tracking
         services.AddSingleton<IImportJobService>(serviceProvider =>

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -314,6 +314,20 @@ internal static class ServiceCollectionExtensions
         services.AddScoped<Core.Features.GeoETL.Abstractions.IFeatureSinkWriter,
             Features.GeoETL.Services.PostgresFeatureSinkWriter>();
 
+        // GeoETL managed file source connectors that depend on this project's managed
+        // readers (NetTopologySuite.IO.Esri for shapefiles, Microsoft.Data.Sqlite +
+        // NetTopologySuite.IO.GeoPackage for GeoPackage). They live here — not in
+        // Honua.Core alongside the GeoJSON/CSV connectors — because those managed reader
+        // packages are referenced by Honua.Postgres. Both are GDAL-free Phase 1 managed
+        // connectors. Stateless, so registered as enumerable singletons; the component
+        // factory collects them together with the Core connectors.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            Core.Features.GeoETL.Abstractions.IPipelineSourceConnector,
+            Features.GeoETL.Services.Connectors.ShapefileSourceConnector>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            Core.Features.GeoETL.Abstractions.IPipelineSourceConnector,
+            Features.GeoETL.Services.Connectors.GeoPackageSourceConnector>());
+
         // GeoETL durable definition / execution stores (#361 Child Ticket A). Registered
         // here so they precede the in-memory baseline stores that AddGeoEtl falls back to
         // via TryAdd when no PostgreSQL provider is wired. Persists definitions and

--- a/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
@@ -65,6 +65,11 @@ internal static class GeoEtlServiceCollectionExtensions
         // Honua-layer / PostGIS sink registers only when a feature sink writer exists.
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IPipelineSinkConnector, NullPreviewSinkConnector>());
+        // Managed file + dead-letter sinks (no native deps, always available).
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineSinkConnector, GeoJsonFileSinkConnector>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineSinkConnector, QuarantineSinkConnector>());
         if (services.Any(d => d.ServiceType == typeof(IFeatureSinkWriter)))
         {
             services.TryAddEnumerable(ServiceDescriptor.Scoped<IPipelineSinkConnector>(

--- a/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Services;
+using Honua.Core.Features.GeoETL.Services.Connectors;
+using Honua.Core.Features.GeoETL.Services.Transforms;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Features.GeoETL;
+
+/// <summary>
+/// Registers the GeoETL baseline vertical slice: pipeline stores, the Phase 1
+/// managed connectors and transforms, the component factory and validator, the stage
+/// runner, and the <see cref="PipelineJobExecutor"/> the substrate's
+/// <c>JobExecutionService</c> discovers for <c>ExtractTransformLoad</c> jobs.
+/// </summary>
+internal static class GeoEtlServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers GeoETL services on the serving image (managed profile only). The
+    /// Honua-layer sink's <see cref="IFeatureSinkWriter"/> is supplied by the storage
+    /// provider (Honua.Postgres); when absent the sink is not registered and pipelines
+    /// that target it fail validation, while the dry-run null sink still runs.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddGeoEtl(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // Definition / execution stores. In-memory baseline; the durable
+        // PostgreSQL-backed stores are Child Ticket A's remaining EF/DbUp work.
+        services.TryAddSingleton<IPipelineDefinitionStore, InMemoryPipelineDefinitionStore>();
+        services.TryAddSingleton<IPipelineExecutionStore, InMemoryPipelineExecutionStore>();
+
+        // Phase 1 managed source connectors.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineSourceConnector, GeoJsonSourceConnector>());
+
+        // Phase 1 managed transforms.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineTransform, ReprojectTransform>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineTransform, AttributeFilterTransform>());
+
+        // Phase 1 sinks. The dry-run null preview sink is always available; the
+        // Honua-layer / PostGIS sink registers only when a feature sink writer exists.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineSinkConnector, NullPreviewSinkConnector>());
+        if (services.Any(d => d.ServiceType == typeof(IFeatureSinkWriter)))
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Scoped<IPipelineSinkConnector>(
+                sp => new HonuaLayerSinkConnector(sp.GetRequiredService<IFeatureSinkWriter>())));
+        }
+
+        // Factory + validator + stage runner.
+        services.TryAddScoped<IPipelineComponentFactory>(sp => new PipelineComponentFactory(
+            sp.GetServices<IPipelineSourceConnector>(),
+            sp.GetServices<IPipelineTransform>(),
+            sp.GetServices<IPipelineSinkConnector>()));
+        services.TryAddScoped<PipelineValidator>();
+        services.TryAddScoped<PipelineStageRunner>();
+
+        // Submission launcher (execution-submission path through the substrate).
+        services.TryAddSingleton<TimeProvider>(TimeProvider.System);
+        services.TryAddScoped<PipelineExecutionLauncher>();
+
+        // The single managed-profile executor for ExtractTransformLoad jobs. The
+        // substrate's JobExecutionService is a singleton that builds its executor map
+        // once, so the executor is a singleton that opens a DI scope per job to resolve
+        // scoped stage components.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IJobExecutor, PipelineJobExecutor>());
+
+        return services;
+    }
+}

--- a/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
@@ -38,6 +38,8 @@ internal static class GeoEtlServiceCollectionExtensions
         // Phase 1 managed source connectors.
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IPipelineSourceConnector, GeoJsonSourceConnector>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineSourceConnector, CsvSourceConnector>());
 
         // Phase 1 managed transforms.
         services.TryAddEnumerable(

--- a/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
@@ -52,6 +52,14 @@ internal static class GeoEtlServiceCollectionExtensions
             ServiceDescriptor.Singleton<IPipelineTransform, AttributeCastTransform>());
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IPipelineTransform, ComputedFieldTransform>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineTransform, SpatialFilterTransform>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineTransform, ClipTransform>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineTransform, SpatialJoinTransform>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineTransform, DedupTransform>());
 
         // Phase 1 sinks. The dry-run null preview sink is always available; the
         // Honua-layer / PostGIS sink registers only when a feature sink writer exists.

--- a/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
@@ -46,6 +46,12 @@ internal static class GeoEtlServiceCollectionExtensions
             ServiceDescriptor.Singleton<IPipelineTransform, ReprojectTransform>());
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IPipelineTransform, AttributeFilterTransform>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineTransform, AttributeRenameTransform>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineTransform, AttributeCastTransform>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineTransform, ComputedFieldTransform>());
 
         // Phase 1 sinks. The dry-run null preview sink is always available; the
         // Honua-layer / PostGIS sink registers only when a feature sink writer exists.

--- a/src/Honua.Server/Features/GeoETL/Models/PipelineDtos.cs
+++ b/src/Honua.Server/Features/GeoETL/Models/PipelineDtos.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.GeoETL.Models;
+
+/// <summary>
+/// Wire representation of a connector configuration (source or sink).
+/// </summary>
+public sealed record ConnectorConfigDto
+{
+    /// <summary>Connector type discriminator.</summary>
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "";
+
+    /// <summary>Connector-specific options.</summary>
+    [JsonPropertyName("options")]
+    public Dictionary<string, string> Options { get; init; } = new(StringComparer.Ordinal);
+}
+
+/// <summary>
+/// Wire representation of a transform configuration.
+/// </summary>
+public sealed record TransformConfigDto
+{
+    /// <summary>Transform type discriminator.</summary>
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "";
+
+    /// <summary>Transform-specific options.</summary>
+    [JsonPropertyName("options")]
+    public Dictionary<string, string> Options { get; init; } = new(StringComparer.Ordinal);
+}
+
+/// <summary>
+/// Wire representation of a single pipeline stage.
+/// </summary>
+public sealed record PipelineStageDto
+{
+    /// <summary>Stage kind: <c>source</c>, <c>transform</c>, or <c>sink</c>.</summary>
+    [JsonPropertyName("kind")]
+    public string Kind { get; init; } = "";
+
+    /// <summary>Connector configuration for source / sink stages.</summary>
+    [JsonPropertyName("connector")]
+    public ConnectorConfigDto? Connector { get; init; }
+
+    /// <summary>Transform configuration for transform stages.</summary>
+    [JsonPropertyName("transform")]
+    public TransformConfigDto? Transform { get; init; }
+}
+
+/// <summary>
+/// Request body for creating or updating a pipeline definition.
+/// </summary>
+public sealed record PipelineDefinitionRequest
+{
+    /// <summary>Schema version of the definition document.</summary>
+    [JsonPropertyName("schema_version")]
+    public int SchemaVersion { get; init; } = 1;
+
+    /// <summary>Human-readable pipeline name.</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = "";
+
+    /// <summary>Optional description.</summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>Ordered stage chain.</summary>
+    [JsonPropertyName("stages")]
+    public List<PipelineStageDto> Stages { get; init; } = [];
+}
+
+/// <summary>
+/// Response body for a pipeline definition.
+/// </summary>
+public sealed record PipelineDefinitionResponse
+{
+    /// <summary>Schema version.</summary>
+    [JsonPropertyName("schema_version")]
+    public int SchemaVersion { get; init; }
+
+    /// <summary>Pipeline id.</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = "";
+
+    /// <summary>Pipeline name.</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = "";
+
+    /// <summary>Description.</summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>Definition version.</summary>
+    [JsonPropertyName("version")]
+    public int Version { get; init; }
+
+    /// <summary>Stage chain.</summary>
+    [JsonPropertyName("stages")]
+    public List<PipelineStageDto> Stages { get; init; } = [];
+
+    /// <summary>Creation timestamp.</summary>
+    [JsonPropertyName("created_at")]
+    public DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>Last update timestamp.</summary>
+    [JsonPropertyName("updated_at")]
+    public DateTimeOffset UpdatedAt { get; init; }
+
+    /// <summary>Advisory validation warnings (non-blocking), for example native-worker requirements.</summary>
+    [JsonPropertyName("advisories")]
+    public List<string> Advisories { get; init; } = [];
+}
+
+/// <summary>
+/// Response body listing pipeline definitions.
+/// </summary>
+public sealed record PipelineListResponse
+{
+    /// <summary>The pipeline definitions.</summary>
+    [JsonPropertyName("pipelines")]
+    public List<PipelineDefinitionResponse> Pipelines { get; init; } = [];
+}
+
+/// <summary>
+/// Response body for a pipeline execution record.
+/// </summary>
+public sealed record PipelineExecutionResponse
+{
+    /// <summary>Execution id.</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = "";
+
+    /// <summary>Pipeline id.</summary>
+    [JsonPropertyName("pipeline_id")]
+    public string PipelineId { get; init; } = "";
+
+    /// <summary>Pipeline definition version executed.</summary>
+    [JsonPropertyName("pipeline_version")]
+    public int PipelineVersion { get; init; }
+
+    /// <summary>Substrate execution job id.</summary>
+    [JsonPropertyName("execution_job_id")]
+    public string ExecutionJobId { get; init; } = "";
+
+    /// <summary>Execution status.</summary>
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = "";
+
+    /// <summary>Whether this was a dry run.</summary>
+    [JsonPropertyName("is_dry_run")]
+    public bool IsDryRun { get; init; }
+
+    /// <summary>Features read from the source.</summary>
+    [JsonPropertyName("features_read")]
+    public long FeaturesRead { get; init; }
+
+    /// <summary>Features written by the sink.</summary>
+    [JsonPropertyName("features_written")]
+    public long FeaturesWritten { get; init; }
+
+    /// <summary>Features routed to quarantine.</summary>
+    [JsonPropertyName("features_quarantined")]
+    public long FeaturesQuarantined { get; init; }
+
+    /// <summary>Soft-delete rollback batch id.</summary>
+    [JsonPropertyName("batch_id")]
+    public string? BatchId { get; init; }
+
+    /// <summary>Error message when failed.</summary>
+    [JsonPropertyName("error_message")]
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Creation timestamp.</summary>
+    [JsonPropertyName("created_at")]
+    public DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>Terminal timestamp, when complete.</summary>
+    [JsonPropertyName("completed_at")]
+    public DateTimeOffset? CompletedAt { get; init; }
+}
+
+/// <summary>
+/// Response body listing pipeline executions.
+/// </summary>
+public sealed record PipelineExecutionListResponse
+{
+    /// <summary>The execution records.</summary>
+    [JsonPropertyName("executions")]
+    public List<PipelineExecutionResponse> Executions { get; init; } = [];
+}

--- a/src/Honua.Server/Features/GeoETL/Models/PipelineJsonContext.cs
+++ b/src/Honua.Server/Features/GeoETL/Models/PipelineJsonContext.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Server.Features.Infrastructure.Models;
+
+namespace Honua.Server.Features.GeoETL.Models;
+
+/// <summary>
+/// Source-generated JSON context for the GeoETL pipeline API DTOs. Keeps the GeoETL
+/// HTTP surface AOT/trim safe per ADR-0038 (no reflection-based serialization).
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(PipelineDefinitionRequest))]
+[JsonSerializable(typeof(PipelineDefinitionResponse))]
+[JsonSerializable(typeof(PipelineListResponse))]
+[JsonSerializable(typeof(PipelineExecutionResponse))]
+[JsonSerializable(typeof(PipelineExecutionListResponse))]
+[JsonSerializable(typeof(ApiResponse<PipelineDefinitionResponse>))]
+[JsonSerializable(typeof(ApiResponse<PipelineListResponse>))]
+[JsonSerializable(typeof(ApiResponse<PipelineExecutionResponse>))]
+[JsonSerializable(typeof(ApiResponse<PipelineExecutionListResponse>))]
+internal sealed partial class PipelineJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/GeoETL/PipelineEndpoints.cs
+++ b/src/Honua.Server/Features/GeoETL/PipelineEndpoints.cs
@@ -1,0 +1,391 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services;
+using Honua.Server.Features.GeoETL.Models;
+using Honua.Server.Features.Infrastructure;
+using Honua.Server.Features.Infrastructure.Authentication;
+using Honua.Server.Features.Infrastructure.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.GeoETL;
+
+/// <summary>
+/// Minimal API surface for GeoETL pipeline authoring and execution. CRUD is
+/// edition-agnostic (operators may stage definitions ahead of an upgrade); the run and
+/// dry-run endpoints submit an <c>ExtractTransformLoad</c> job through the durable
+/// substrate (#681). See the GeoETL roadmap § Child Ticket A and ADR-0038.
+/// </summary>
+internal static class PipelineEndpoints
+{
+    /// <summary>
+    /// Maps the GeoETL pipeline endpoints under <c>/api/v{version}/admin/geoetl/pipelines</c>.
+    /// </summary>
+    /// <param name="endpoints">The route builder.</param>
+    public static void MapGeoEtlPipelineEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/geoetl/pipelines")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "GeoETL")
+            .RequireAdminAuthorization();
+
+        group.MapGet("/", HandleListPipelines)
+            .WithName("ListGeoEtlPipelines")
+            .WithSummary("List GeoETL pipeline definitions")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        group.MapPost("/", HandleCreatePipeline)
+            .WithName("CreateGeoEtlPipeline")
+            .WithSummary("Create a GeoETL pipeline definition")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+
+        group.MapGet("/{id}", HandleGetPipeline)
+            .WithName("GetGeoEtlPipeline")
+            .WithSummary("Get a GeoETL pipeline definition")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        group.MapPut("/{id}", HandleUpdatePipeline)
+            .WithName("UpdateGeoEtlPipeline")
+            .WithSummary("Replace a GeoETL pipeline definition")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Put }));
+
+        group.MapDelete("/{id}", HandleDeletePipeline)
+            .WithName("DeleteGeoEtlPipeline")
+            .WithSummary("Delete a GeoETL pipeline definition")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Delete }));
+
+        group.MapPost("/{id}/run", HandleRunPipeline)
+            .WithName("RunGeoEtlPipeline")
+            .WithSummary("Submit a GeoETL pipeline run through the durable substrate")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+
+        group.MapPost("/{id}/dry-run", HandleDryRunPipeline)
+            .WithName("DryRunGeoEtlPipeline")
+            .WithSummary("Submit a GeoETL pipeline dry run (null preview sink)")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+
+        group.MapGet("/{id}/executions", HandleListExecutions)
+            .WithName("ListGeoEtlPipelineExecutions")
+            .WithSummary("List executions for a GeoETL pipeline")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        group.MapGet("/{id}/executions/{executionId}", HandleGetExecution)
+            .WithName("GetGeoEtlPipelineExecution")
+            .WithSummary("Get a single GeoETL pipeline execution")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+    }
+
+    private static async Task<IResult> HandleListPipelines(
+        [FromServices] IPipelineDefinitionStore store,
+        CancellationToken cancellationToken)
+    {
+        var definitions = await store.ListAsync(cancellationToken).ConfigureAwait(false);
+        var payload = new PipelineListResponse
+        {
+            Pipelines = definitions.Select(ToResponse).ToList()
+        };
+        return Results.Json(
+            ApiResponse<PipelineListResponse>.CreateSuccess(payload),
+            PipelineJsonContext.Default.ApiResponsePipelineListResponse);
+    }
+
+    private static async Task<IResult> HandleCreatePipeline(
+        HttpContext context,
+        [FromServices] IPipelineDefinitionStore store,
+        [FromServices] PipelineValidator validator,
+        CancellationToken cancellationToken)
+    {
+        var request = await ReadRequestAsync(context).ConfigureAwait(false);
+        if (request is null)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context, StatusCodes.Status400BadRequest, "Invalid or missing request body.");
+        }
+
+        var id = $"pl-{Guid.NewGuid():N}";
+        var now = DateTimeOffset.UtcNow;
+        var definition = ToDefinition(request, id, version: 1, now, now);
+
+        var validation = validator.Validate(definition);
+        if (!validation.IsValid)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status400BadRequest,
+                string.Join("; ", validation.Errors.Select(e => $"{e.Code}: {e.Message}")));
+        }
+
+        await store.CreateAsync(definition, cancellationToken).ConfigureAwait(false);
+
+        var response = ToResponse(definition) with
+        {
+            Advisories = validation.Advisories.Select(a => a.Message).ToList()
+        };
+        return Results.Json(
+            ApiResponse<PipelineDefinitionResponse>.CreateSuccess(response),
+            PipelineJsonContext.Default.ApiResponsePipelineDefinitionResponse,
+            statusCode: StatusCodes.Status201Created);
+    }
+
+    private static async Task<IResult> HandleGetPipeline(
+        string id,
+        HttpContext context,
+        [FromServices] IPipelineDefinitionStore store,
+        CancellationToken cancellationToken)
+    {
+        var definition = await store.GetAsync(id, cancellationToken).ConfigureAwait(false);
+        if (definition is null)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context, StatusCodes.Status404NotFound, $"Pipeline '{id}' not found.");
+        }
+
+        return Results.Json(
+            ApiResponse<PipelineDefinitionResponse>.CreateSuccess(ToResponse(definition)),
+            PipelineJsonContext.Default.ApiResponsePipelineDefinitionResponse);
+    }
+
+    private static async Task<IResult> HandleUpdatePipeline(
+        string id,
+        HttpContext context,
+        [FromServices] IPipelineDefinitionStore store,
+        [FromServices] PipelineValidator validator,
+        CancellationToken cancellationToken)
+    {
+        var existing = await store.GetAsync(id, cancellationToken).ConfigureAwait(false);
+        if (existing is null)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context, StatusCodes.Status404NotFound, $"Pipeline '{id}' not found.");
+        }
+
+        var request = await ReadRequestAsync(context).ConfigureAwait(false);
+        if (request is null)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context, StatusCodes.Status400BadRequest, "Invalid or missing request body.");
+        }
+
+        var candidate = ToDefinition(request, id, existing.Version, existing.CreatedAt, DateTimeOffset.UtcNow);
+        var validation = validator.Validate(candidate);
+        if (!validation.IsValid)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status400BadRequest,
+                string.Join("; ", validation.Errors.Select(e => $"{e.Code}: {e.Message}")));
+        }
+
+        var updated = await store.UpdateAsync(candidate, cancellationToken).ConfigureAwait(false);
+        if (updated is null)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context, StatusCodes.Status404NotFound, $"Pipeline '{id}' not found.");
+        }
+
+        var response = ToResponse(updated) with
+        {
+            Advisories = validation.Advisories.Select(a => a.Message).ToList()
+        };
+        return Results.Json(
+            ApiResponse<PipelineDefinitionResponse>.CreateSuccess(response),
+            PipelineJsonContext.Default.ApiResponsePipelineDefinitionResponse);
+    }
+
+    private static async Task<IResult> HandleDeletePipeline(
+        string id,
+        HttpContext context,
+        [FromServices] IPipelineDefinitionStore store,
+        CancellationToken cancellationToken)
+    {
+        var deleted = await store.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+        return deleted
+            ? Results.NoContent()
+            : ProblemDetailsHelpers.CreateAdminProblem(
+                context, StatusCodes.Status404NotFound, $"Pipeline '{id}' not found.");
+    }
+
+    private static Task<IResult> HandleRunPipeline(
+        string id,
+        HttpContext context,
+        [FromServices] IPipelineDefinitionStore store,
+        [FromServices] PipelineExecutionLauncher launcher,
+        CancellationToken cancellationToken)
+        => SubmitAsync(id, context, store, launcher, dryRun: false, cancellationToken);
+
+    private static Task<IResult> HandleDryRunPipeline(
+        string id,
+        HttpContext context,
+        [FromServices] IPipelineDefinitionStore store,
+        [FromServices] PipelineExecutionLauncher launcher,
+        CancellationToken cancellationToken)
+        => SubmitAsync(id, context, store, launcher, dryRun: true, cancellationToken);
+
+    private static async Task<IResult> SubmitAsync(
+        string id,
+        HttpContext context,
+        IPipelineDefinitionStore store,
+        PipelineExecutionLauncher launcher,
+        bool dryRun,
+        CancellationToken cancellationToken)
+    {
+        var definition = await store.GetAsync(id, cancellationToken).ConfigureAwait(false);
+        if (definition is null)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context, StatusCodes.Status404NotFound, $"Pipeline '{id}' not found.");
+        }
+
+        var execution = await launcher
+            .LaunchAsync(definition, dryRun, context.User.Identity?.Name, cancellationToken)
+            .ConfigureAwait(false);
+
+        return Results.Json(
+            ApiResponse<PipelineExecutionResponse>.CreateSuccess(ToResponse(execution)),
+            PipelineJsonContext.Default.ApiResponsePipelineExecutionResponse,
+            statusCode: StatusCodes.Status202Accepted);
+    }
+
+    private static async Task<IResult> HandleListExecutions(
+        string id,
+        [FromServices] IPipelineExecutionStore store,
+        CancellationToken cancellationToken)
+    {
+        var executions = await store.ListForPipelineAsync(id, cancellationToken).ConfigureAwait(false);
+        var payload = new PipelineExecutionListResponse
+        {
+            Executions = executions.Select(ToResponse).ToList()
+        };
+        return Results.Json(
+            ApiResponse<PipelineExecutionListResponse>.CreateSuccess(payload),
+            PipelineJsonContext.Default.ApiResponsePipelineExecutionListResponse);
+    }
+
+    private static async Task<IResult> HandleGetExecution(
+        string id,
+        string executionId,
+        HttpContext context,
+        [FromServices] IPipelineExecutionStore store,
+        CancellationToken cancellationToken)
+    {
+        var execution = await store.GetAsync(executionId, cancellationToken).ConfigureAwait(false);
+        if (execution is null || !string.Equals(execution.PipelineId, id, StringComparison.Ordinal))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context, StatusCodes.Status404NotFound, $"Execution '{executionId}' not found for pipeline '{id}'.");
+        }
+
+        return Results.Json(
+            ApiResponse<PipelineExecutionResponse>.CreateSuccess(ToResponse(execution)),
+            PipelineJsonContext.Default.ApiResponsePipelineExecutionResponse);
+    }
+
+    private static async Task<PipelineDefinitionRequest?> ReadRequestAsync(HttpContext context)
+    {
+        try
+        {
+            return await context.Request
+                .ReadFromJsonAsync(PipelineJsonContext.Default.PipelineDefinitionRequest, context.RequestAborted)
+                .ConfigureAwait(false);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static PipelineDefinition ToDefinition(
+        PipelineDefinitionRequest request,
+        string id,
+        int version,
+        DateTimeOffset createdAt,
+        DateTimeOffset updatedAt)
+        => new()
+        {
+            SchemaVersion = request.SchemaVersion,
+            Id = id,
+            Name = request.Name,
+            Description = request.Description,
+            Version = version,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
+            Stages = request.Stages.Select(ToStage).ToArray()
+        };
+
+    private static PipelineStage ToStage(PipelineStageDto dto)
+    {
+        var kind = dto.Kind.ToLowerInvariant() switch
+        {
+            "source" => PipelineStageKind.Source,
+            "transform" => PipelineStageKind.Transform,
+            "sink" => PipelineStageKind.Sink,
+            _ => throw new InvalidOperationException($"Unknown stage kind '{dto.Kind}'.")
+        };
+
+        return new PipelineStage
+        {
+            Kind = kind,
+            Connector = dto.Connector is null
+                ? null
+                : new ConnectorConfig { Type = dto.Connector.Type, Options = dto.Connector.Options },
+            Transform = dto.Transform is null
+                ? null
+                : new TransformConfig { Type = dto.Transform.Type, Options = dto.Transform.Options }
+        };
+    }
+
+    private static PipelineDefinitionResponse ToResponse(PipelineDefinition definition)
+        => new()
+        {
+            SchemaVersion = definition.SchemaVersion,
+            Id = definition.Id,
+            Name = definition.Name,
+            Description = definition.Description,
+            Version = definition.Version,
+            CreatedAt = definition.CreatedAt,
+            UpdatedAt = definition.UpdatedAt,
+            Stages = definition.Stages.Select(ToStageDto).ToList()
+        };
+
+    private static PipelineStageDto ToStageDto(PipelineStage stage)
+        => new()
+        {
+            Kind = stage.Kind.ToString().ToLowerInvariant(),
+            Connector = stage.Connector is null
+                ? null
+                : new ConnectorConfigDto
+                {
+                    Type = stage.Connector.Type,
+                    Options = new Dictionary<string, string>(stage.Connector.Options, StringComparer.Ordinal)
+                },
+            Transform = stage.Transform is null
+                ? null
+                : new TransformConfigDto
+                {
+                    Type = stage.Transform.Type,
+                    Options = new Dictionary<string, string>(stage.Transform.Options, StringComparer.Ordinal)
+                }
+        };
+
+    private static PipelineExecutionResponse ToResponse(PipelineExecution execution)
+        => new()
+        {
+            Id = execution.Id,
+            PipelineId = execution.PipelineId,
+            PipelineVersion = execution.PipelineVersion,
+            ExecutionJobId = execution.ExecutionJobId,
+            Status = execution.Status.ToString(),
+            IsDryRun = execution.IsDryRun,
+            FeaturesRead = execution.FeaturesRead,
+            FeaturesWritten = execution.FeaturesWritten,
+            FeaturesQuarantined = execution.FeaturesQuarantined,
+            BatchId = execution.BatchId,
+            ErrorMessage = execution.ErrorMessage,
+            CreatedAt = execution.CreatedAt,
+            CompletedAt = execution.CompletedAt
+        };
+}

--- a/src/Honua.Server/Features/GeoETL/PipelineExecutionLauncher.cs
+++ b/src/Honua.Server/Features/GeoETL/PipelineExecutionLauncher.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+
+namespace Honua.Server.Features.GeoETL;
+
+/// <summary>
+/// Builds and submits an <see cref="ExecutionJobKind.ExtractTransformLoad"/> job for a
+/// pipeline through the durable substrate. Creates the durable
+/// <see cref="PipelineExecution"/> record and the substrate
+/// <see cref="ExecutionJobRecord"/> sharing one operation id, then enqueues the job on
+/// <see cref="IJobQueue"/> so the substrate's <c>JobExecutionService</c> claims and runs
+/// it through <see cref="PipelineJobExecutor"/>. This is the single submission path used
+/// by both the run and dry-run endpoints — the execution-submission gate (ADR-0038)
+/// belongs here.
+/// </summary>
+internal sealed class PipelineExecutionLauncher(
+    IExecutionJobStore jobStore,
+    IJobQueue jobQueue,
+    IPipelineExecutionStore executionStore,
+    TimeProvider timeProvider)
+{
+    /// <summary>
+    /// Submits a pipeline run.
+    /// </summary>
+    /// <param name="definition">Pipeline definition to run.</param>
+    /// <param name="dryRun">Whether to run as a dry run (null preview sink).</param>
+    /// <param name="requestedBy">Operator identity, when known.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created pipeline execution record.</returns>
+    public async Task<PipelineExecution> LaunchAsync(
+        PipelineDefinition definition,
+        bool dryRun,
+        string? requestedBy,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        var now = timeProvider.GetUtcNow();
+        var executionId = $"geoetl-{Guid.NewGuid():N}";
+
+        var execution = new PipelineExecution
+        {
+            Id = executionId,
+            PipelineId = definition.Id,
+            PipelineVersion = definition.Version,
+            ExecutionJobId = executionId,
+            Status = PipelineExecutionStatus.Pending,
+            IsDryRun = dryRun,
+            BatchId = executionId,
+            CreatedAt = now
+        };
+
+        await executionStore.CreateAsync(execution, cancellationToken).ConfigureAwait(false);
+
+        var spec = new ExecutionJobSpec
+        {
+            Kind = ExecutionJobKind.ExtractTransformLoad,
+            TargetKind = BatchComputeTargetKind.KubernetesJob,
+            Backend = LocalBatchComputeBackend.BackendId,
+            WorkloadName = $"geoetl:{definition.Id}",
+            // Phase 1 baseline runs only managed connectors in the serving image.
+            RuntimeProfile = "managed",
+            Parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [PipelineJobExecutor.PipelineIdKey] = definition.Id,
+                [PipelineJobExecutor.ExecutionIdKey] = executionId,
+                [PipelineJobExecutor.DryRunKey] = dryRun ? "true" : "false"
+            }
+        };
+
+        var jobRecord = new ExecutionJobRecord
+        {
+            OperationId = executionId,
+            Status = ExecutionJobStatus.Queued,
+            CreatedAt = now,
+            UpdatedAt = now,
+            CurrentPhase = "Queued",
+            Audit = new OperationAuditInfo { RequestedBy = requestedBy },
+            Spec = spec
+        };
+
+        var created = await jobStore.TryCreateAsync(jobRecord, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        if (!created)
+        {
+            throw new InvalidOperationException($"Failed to create execution job '{executionId}'.");
+        }
+
+        await jobQueue.EnqueueAsync(executionId, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return execution;
+    }
+}

--- a/src/Honua.Server/Features/GeoETL/PipelineJobExecutor.cs
+++ b/src/Honua.Server/Features/GeoETL/PipelineJobExecutor.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services;
+
+namespace Honua.Server.Features.GeoETL;
+
+/// <summary>
+/// The GeoETL execution engine, registered as the single
+/// <see cref="IJobExecutor"/> for <see cref="ExecutionJobKind.ExtractTransformLoad"/>.
+/// The substrate's <c>JobExecutionService</c> discovers it via DI and owns the
+/// worker-side polling loop, claim, lease, heartbeat, cancellation propagation, retry,
+/// and finalization (ADR-0038 § Substrate consumption). This executor only runs the
+/// Source → []Transform → Sink stage chain over <see cref="IPipelineRunObserver"/>,
+/// updating the pipeline execution record and emitting the canonical
+/// <c>pipeline.*</c> telemetry events through the per-job context.
+/// </summary>
+/// <remarks>
+/// Registered as a singleton (the substrate hosts a singleton
+/// <c>JobExecutionService</c> that builds its executor map once). It opens a DI scope
+/// per job so scoped stage components — notably the Honua-layer sink's scoped
+/// <see cref="IFeatureSinkWriter"/> over the database connection provider — resolve
+/// correctly for each run.
+/// </remarks>
+internal sealed partial class PipelineJobExecutor(
+    IServiceScopeFactory scopeFactory,
+    ILogger<PipelineJobExecutor> logger) : IJobExecutor
+{
+    /// <summary>Spec parameter key carrying the pipeline definition id.</summary>
+    internal const string PipelineIdKey = "geoetl.pipelineId";
+
+    /// <summary>Spec parameter key carrying the pipeline execution record id.</summary>
+    internal const string ExecutionIdKey = "geoetl.executionId";
+
+    /// <summary>Spec parameter key flagging a dry run (value <c>true</c>/<c>false</c>).</summary>
+    internal const string DryRunKey = "geoetl.dryRun";
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.ExtractTransformLoad;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var definitionStore = scope.ServiceProvider.GetRequiredService<IPipelineDefinitionStore>();
+        var executionStore = scope.ServiceProvider.GetRequiredService<IPipelineExecutionStore>();
+        var stageRunner = scope.ServiceProvider.GetRequiredService<PipelineStageRunner>();
+
+        var parameters = job.Spec.Parameters;
+        if (!parameters.TryGetValue(PipelineIdKey, out var pipelineId) || string.IsNullOrWhiteSpace(pipelineId))
+        {
+            return JobExecutionResult.Failed("ExtractTransformLoad job is missing the pipeline id parameter.");
+        }
+
+        var executionId = parameters.TryGetValue(ExecutionIdKey, out var execId) && !string.IsNullOrWhiteSpace(execId)
+            ? execId
+            : job.OperationId;
+        var dryRun = parameters.TryGetValue(DryRunKey, out var dryRaw)
+            && bool.TryParse(dryRaw, out var parsedDry) && parsedDry;
+
+        var definition = await definitionStore.GetAsync(pipelineId, cancellationToken).ConfigureAwait(false);
+        if (definition is null)
+        {
+            return JobExecutionResult.Failed($"Pipeline '{pipelineId}' was not found.");
+        }
+
+        var execution = await executionStore.GetAsync(executionId, cancellationToken).ConfigureAwait(false);
+        var batchId = execution?.BatchId ?? executionId;
+
+        Log.PipelineStarted(logger, pipelineId, definition.Version, executionId, dryRun);
+        await context.AppendLogAsync(InfoEntry(
+            $"pipeline.started pipeline={pipelineId} version={definition.Version} dryRun={dryRun}",
+            "Extract"), cancellationToken).ConfigureAwait(false);
+
+        if (execution is not null)
+        {
+            await executionStore.UpdateAsync(
+                execution with { Status = PipelineExecutionStatus.Running },
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        var observer = new ContextRunObserver(context);
+
+        try
+        {
+            var result = await stageRunner
+                .RunAsync(definition, batchId, dryRun, observer, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (execution is not null)
+            {
+                await executionStore.UpdateAsync(
+                    execution with
+                    {
+                        Status = PipelineExecutionStatus.Succeeded,
+                        FeaturesRead = result.FeaturesRead,
+                        FeaturesWritten = result.FeaturesWritten,
+                        FeaturesQuarantined = result.FeaturesRejected,
+                        BatchId = result.BatchId,
+                        CompletedAt = DateTimeOffset.UtcNow
+                    },
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            Log.PipelineCompleted(logger, pipelineId, result.FeaturesRead, result.FeaturesWritten);
+            await context.AppendLogAsync(InfoEntry(
+                $"pipeline.completed read={result.FeaturesRead} written={result.FeaturesWritten} " +
+                $"rejected={result.FeaturesRejected}",
+                "Completed"), cancellationToken).ConfigureAwait(false);
+
+            return JobExecutionResult.Succeeded();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            if (execution is not null)
+            {
+                await executionStore.UpdateAsync(
+                    execution with { Status = PipelineExecutionStatus.Cancelled, CompletedAt = DateTimeOffset.UtcNow },
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Log.PipelineFailed(logger, pipelineId, ex);
+            await context.AppendLogAsync(
+                new ExecutionLogEntry
+                {
+                    Timestamp = DateTimeOffset.UtcNow,
+                    Level = ExecutionLogLevel.Error,
+                    Message = $"pipeline.failed {ex.Message}",
+                    Phase = "Failed"
+                },
+                CancellationToken.None).ConfigureAwait(false);
+
+            if (execution is not null)
+            {
+                await executionStore.UpdateAsync(
+                    execution with
+                    {
+                        Status = PipelineExecutionStatus.Failed,
+                        ErrorMessage = ex.Message,
+                        CompletedAt = DateTimeOffset.UtcNow
+                    },
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+
+            return JobExecutionResult.Failed(ex.Message);
+        }
+    }
+
+    private static ExecutionLogEntry InfoEntry(string message, string phase)
+        => new()
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Level = ExecutionLogLevel.Info,
+            Message = message,
+            Phase = phase
+        };
+
+    /// <summary>
+    /// Bridges <see cref="IPipelineRunObserver"/> to the substrate's per-job
+    /// <see cref="IJobExecutionContext"/> so progress and logs flow through the
+    /// substrate channels rather than a GeoETL-owned store.
+    /// </summary>
+    private sealed class ContextRunObserver(IJobExecutionContext context) : IPipelineRunObserver
+    {
+        public Task ReportProgressAsync(double? percentComplete, string phase, CancellationToken cancellationToken)
+            => context.ReportProgressAsync(percentComplete, phase, cancellationToken);
+
+        public Task LogAsync(string message, string phase, CancellationToken cancellationToken)
+            => context.AppendLogAsync(
+                new ExecutionLogEntry
+                {
+                    Timestamp = DateTimeOffset.UtcNow,
+                    Level = ExecutionLogLevel.Info,
+                    Message = message,
+                    Phase = phase
+                },
+                cancellationToken);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9710, LogLevel.Information,
+            "pipeline.started pipeline={PipelineId} version={Version} execution={ExecutionId} dryRun={DryRun}")]
+        public static partial void PipelineStarted(
+            ILogger logger, string pipelineId, int version, string executionId, bool dryRun);
+
+        [LoggerMessage(9711, LogLevel.Information,
+            "pipeline.completed pipeline={PipelineId} read={FeaturesRead} written={FeaturesWritten}")]
+        public static partial void PipelineCompleted(
+            ILogger logger, string pipelineId, long featuresRead, long featuresWritten);
+
+        [LoggerMessage(9712, LogLevel.Error, "pipeline.failed pipeline={PipelineId}")]
+        public static partial void PipelineFailed(ILogger logger, string pipelineId, Exception exception);
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -3,6 +3,7 @@
 
 using Honua.Postgres.Features.Scene;
 using Honua.Server.Features.Admin;
+using Honua.Server.Features.GeoETL;
 using Honua.Server.Features.Infrastructure.Scene;
 using Honua.Server.Features.Alerts;
 using Honua.Server.Features.CloudDemo;
@@ -91,6 +92,7 @@ internal static class FeatureRegistrationExtensions
         services.AddSceneGeneration(configuration);
         services.AddPrintingTools();
         services.AddGeoprocessing(configuration);
+        services.AddGeoEtl();
         services.AddAnalysisReporting(configuration);
         services.AddMcpOperatorSurface(configuration);
         services.AddSpecGrounding();
@@ -157,6 +159,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapMcpOperatorSurface();
         endpoints.MapSpecGroundingEndpoints();
         endpoints.MapSpecEndpoints();
+        endpoints.MapGeoEtlPipelineEndpoints();
 
         return endpoints;
     }

--- a/src/Honua.Server/Migrations/033_CreateGeoEtlPipelineCatalog.sql
+++ b/src/Honua.Server/Migrations/033_CreateGeoEtlPipelineCatalog.sql
@@ -1,0 +1,67 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- GeoETL durable pipeline catalog (#361 Child Ticket A — durable persistence).
+-- Replaces the in-memory baseline stores with PostgreSQL-backed definition and
+-- execution stores. The stage chain (Source -> []Transform -> Sink) is persisted
+-- as a JSONB document so the ConnectorConfig / TransformConfig discriminated
+-- unions can evolve without a schema migration; the definition root carries a
+-- schema_version column denormalized from the document for forward-compat reads.
+
+CREATE TABLE IF NOT EXISTS honua.pipeline_definitions (
+    id              VARCHAR(128) PRIMARY KEY,
+    name            VARCHAR(256) NOT NULL,
+    description     TEXT,
+    schema_version  INTEGER NOT NULL DEFAULT 1,
+    version         INTEGER NOT NULL DEFAULT 1,
+    stages_json     JSONB NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_definitions_name
+    ON honua.pipeline_definitions (name);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_definitions_updated_at
+    ON honua.pipeline_definitions (updated_at DESC);
+
+COMMENT ON TABLE  honua.pipeline_definitions IS
+    'GeoETL pipeline definitions (#361). Declarative Source -> []Transform -> Sink chains executed as ExtractTransformLoad jobs on the #681 substrate.';
+COMMENT ON COLUMN honua.pipeline_definitions.schema_version IS
+    'Definition document schema version; lives on the root so stored definitions stay readable across discriminated-union evolutions.';
+COMMENT ON COLUMN honua.pipeline_definitions.version IS
+    'Definition version; incremented on every successful update. Older versions remain readable for audit and rollback.';
+COMMENT ON COLUMN honua.pipeline_definitions.stages_json IS
+    'Ordered stage chain (PipelineStage[]) persisted as JSONB so ConnectorConfig / TransformConfig unions evolve without a schema migration.';
+
+CREATE TABLE IF NOT EXISTS honua.pipeline_executions (
+    id                      VARCHAR(128) PRIMARY KEY,
+    pipeline_id             VARCHAR(128) NOT NULL,
+    pipeline_version        INTEGER NOT NULL DEFAULT 1,
+    execution_job_id        VARCHAR(128) NOT NULL,
+    status                  VARCHAR(32) NOT NULL,
+    is_dry_run              BOOLEAN NOT NULL DEFAULT FALSE,
+    features_read           BIGINT NOT NULL DEFAULT 0,
+    features_written        BIGINT NOT NULL DEFAULT 0,
+    features_quarantined    BIGINT NOT NULL DEFAULT 0,
+    batch_id                VARCHAR(128),
+    error_message           TEXT,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at            TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_executions_pipeline_id
+    ON honua.pipeline_executions (pipeline_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_executions_status
+    ON honua.pipeline_executions (status);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_executions_job_id
+    ON honua.pipeline_executions (execution_job_id);
+
+COMMENT ON TABLE  honua.pipeline_executions IS
+    'GeoETL pipeline execution records (#361). Correlated to the substrate ExecutionJobRecord by execution_job_id; status mirrors the job lifecycle.';
+COMMENT ON COLUMN honua.pipeline_executions.execution_job_id IS
+    'Substrate execution job id (ExecutionJobRecord.OperationId) backing this run.';
+COMMENT ON COLUMN honua.pipeline_executions.batch_id IS
+    'Batch identifier tagged on every sink write so a failed run can soft-delete its own rows (ADR-0038).';

--- a/tests/dotnet/Honua.Core.Tests/Features/GeoETL/AttributeTransformTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/GeoETL/AttributeTransformTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services.Transforms;
+using Honua.TestKit.Attributes;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Core.Tests.Features.GeoETL;
+
+/// <summary>
+/// Unit coverage for the managed attribute transforms: rename, cast / type-coerce, and
+/// the computed / calculated field transform. All run in-memory over NetTopologySuite
+/// features with no native dependency.
+/// </summary>
+public sealed class AttributeTransformTests
+{
+    private static readonly GeometryFactory Factory = new(new PrecisionModel(), 4326);
+
+    [UnitTest]
+    public async Task Rename_MovesAttributeValueToNewKey()
+    {
+        var transform = new AttributeRenameTransform();
+        var config = new TransformConfig
+        {
+            Type = AttributeRenameTransform.TransformType,
+            Options = new Dictionary<string, string> { ["from"] = "old", ["to"] = "new" }
+        };
+        var feature = new Feature(Factory.CreatePoint(new Coordinate(0, 0)),
+            new AttributesTable { { "old", "value" }, { "keep", 1L } });
+
+        var result = (await Collect(transform.TransformAsync(config, Single(feature)))).Single();
+
+        result.Attributes!.Exists("old").Should().BeFalse();
+        result.Attributes!.GetOptionalValue("new").Should().Be("value");
+        result.Attributes!.GetOptionalValue("keep").Should().Be(1L);
+    }
+
+    [UnitTest]
+    public async Task Cast_CoercesStringToDouble()
+    {
+        var transform = new AttributeCastTransform();
+        var config = new TransformConfig
+        {
+            Type = AttributeCastTransform.TransformType,
+            Options = new Dictionary<string, string> { ["field"] = "n", ["to"] = "double" }
+        };
+        var feature = new Feature(Factory.CreatePoint(new Coordinate(0, 0)),
+            new AttributesTable { { "n", "42.5" } });
+
+        var result = (await Collect(transform.TransformAsync(config, Single(feature)))).Single();
+
+        result.Attributes!.GetOptionalValue("n").Should().Be(42.5d);
+    }
+
+    [UnitTest]
+    public async Task Cast_DropsUncoercibleRowByDefault()
+    {
+        var transform = new AttributeCastTransform();
+        var config = new TransformConfig
+        {
+            Type = AttributeCastTransform.TransformType,
+            Options = new Dictionary<string, string> { ["field"] = "n", ["to"] = "int" }
+        };
+        var good = new Feature(Factory.CreatePoint(new Coordinate(0, 0)),
+            new AttributesTable { { "n", "10" } });
+        var bad = new Feature(Factory.CreatePoint(new Coordinate(1, 1)),
+            new AttributesTable { { "n", "not-a-number" } });
+
+        var results = await Collect(transform.TransformAsync(config, Many(good, bad)));
+
+        results.Should().HaveCount(1);
+        results.Single().Attributes!.GetOptionalValue("n").Should().Be(10);
+    }
+
+    [UnitTest]
+    public async Task ComputedField_AddsArithmeticResult()
+    {
+        var transform = new ComputedFieldTransform();
+        var config = new TransformConfig
+        {
+            Type = ComputedFieldTransform.TransformType,
+            Options = new Dictionary<string, string>
+            {
+                ["target"] = "area", ["op"] = "multiply", ["left"] = "w", ["right"] = "h"
+            }
+        };
+        var feature = new Feature(Factory.CreatePoint(new Coordinate(0, 0)),
+            new AttributesTable { { "w", 3L }, { "h", 4L } });
+
+        var result = (await Collect(transform.TransformAsync(config, Single(feature)))).Single();
+
+        result.Attributes!.GetOptionalValue("area").Should().Be(12d);
+    }
+
+    [UnitTest]
+    public async Task ComputedField_ConcatJoinsFieldsWithSeparator()
+    {
+        var transform = new ComputedFieldTransform();
+        var config = new TransformConfig
+        {
+            Type = ComputedFieldTransform.TransformType,
+            Options = new Dictionary<string, string>
+            {
+                ["target"] = "full", ["op"] = "concat", ["fields"] = "first,last", ["separator"] = " "
+            }
+        };
+        var feature = new Feature(Factory.CreatePoint(new Coordinate(0, 0)),
+            new AttributesTable { { "first", "Ada" }, { "last", "Lovelace" } });
+
+        var result = (await Collect(transform.TransformAsync(config, Single(feature)))).Single();
+
+        result.Attributes!.GetOptionalValue("full").Should().Be("Ada Lovelace");
+    }
+
+    [UnitTest]
+    public async Task ComputedField_DropsRowOnDivideByZero()
+    {
+        var transform = new ComputedFieldTransform();
+        var config = new TransformConfig
+        {
+            Type = ComputedFieldTransform.TransformType,
+            Options = new Dictionary<string, string>
+            {
+                ["target"] = "ratio", ["op"] = "divide", ["left"] = "n", ["right"] = "d"
+            }
+        };
+        var feature = new Feature(Factory.CreatePoint(new Coordinate(0, 0)),
+            new AttributesTable { { "n", 1L }, { "d", 0L } });
+
+        var results = await Collect(transform.TransformAsync(config, Single(feature)));
+
+        results.Should().BeEmpty();
+    }
+
+    private static async Task<List<IFeature>> Collect(IAsyncEnumerable<IFeature> source)
+    {
+        var list = new List<IFeature>();
+        await foreach (var feature in source)
+        {
+            list.Add(feature);
+        }
+
+        return list;
+    }
+
+    private static async IAsyncEnumerable<IFeature> Single(IFeature feature)
+    {
+        yield return feature;
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<IFeature> Many(params IFeature[] features)
+    {
+        foreach (var feature in features)
+        {
+            yield return feature;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/GeoETL/CsvSourceConnectorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/GeoETL/CsvSourceConnectorTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services.Connectors;
+using Honua.TestKit.Attributes;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Core.Tests.Features.GeoETL;
+
+/// <summary>
+/// Unit coverage for the managed CSV source connector. Exercises the lon/lat coordinate
+/// and WKT geometry encodings wrapped from the existing <c>CsvFormatReader</c>, with no
+/// native dependency.
+/// </summary>
+public sealed class CsvSourceConnectorTests
+{
+    [UnitTest]
+    public async Task ReadAsync_LonLatColumns_ProducesPointFeatures()
+    {
+        const string csv = """
+            name,lon,lat,score
+            origin,0,0,10
+            berlin,13.405,52.52,90
+            """;
+        var connector = new CsvSourceConnector();
+        var config = new ConnectorConfig
+        {
+            Type = CsvSourceConnector.ConnectorType,
+            Options = new Dictionary<string, string> { ["inline"] = csv }
+        };
+
+        var features = new List<IFeature>();
+        await foreach (var feature in connector.ReadAsync(config))
+        {
+            features.Add(feature);
+        }
+
+        features.Should().HaveCount(2);
+        var berlin = features.Single(f =>
+            string.Equals(f.Attributes!.GetOptionalValue("name")?.ToString(), "berlin", StringComparison.Ordinal));
+        var point = (Point)berlin.Geometry!;
+        point.X.Should().BeApproximately(13.405, 0.0001);
+        point.Y.Should().BeApproximately(52.52, 0.0001);
+        berlin.Attributes!.GetOptionalValue("score").Should().Be("90");
+    }
+
+    [UnitTest]
+    public async Task ReadAsync_WktColumn_ParsesGeometry()
+    {
+        const string csv = """
+            id;wkt
+            1;POINT (30 10)
+            2;LINESTRING (0 0, 1 1)
+            """;
+        var connector = new CsvSourceConnector();
+        var config = new ConnectorConfig
+        {
+            Type = CsvSourceConnector.ConnectorType,
+            Options = new Dictionary<string, string> { ["inline"] = csv }
+        };
+
+        var features = new List<IFeature>();
+        await foreach (var feature in connector.ReadAsync(config))
+        {
+            features.Add(feature);
+        }
+
+        features.Should().HaveCount(2);
+        features[0].Geometry.Should().BeOfType<Point>();
+        features[1].Geometry.Should().BeOfType<LineString>();
+    }
+
+    [UnitTest]
+    public async Task ReadAsync_WithoutPathOrInline_Throws()
+    {
+        var connector = new CsvSourceConnector();
+        var config = new ConnectorConfig { Type = CsvSourceConnector.ConnectorType };
+
+        var act = async () =>
+        {
+            await foreach (var _ in connector.ReadAsync(config))
+            {
+            }
+        };
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/GeoETL/FileSinkConnectorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/GeoETL/FileSinkConnectorTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services.Connectors;
+using Honua.TestKit.Attributes;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace Honua.Core.Tests.Features.GeoETL;
+
+/// <summary>
+/// Unit coverage for the managed (GDAL-free) GeoETL file sinks: the GeoJSON file export
+/// sink and the quarantine / dead-letter sink. Both write to a temp file and read it back
+/// with the managed GeoJSON reader to assert the round-trip.
+/// </summary>
+public sealed class FileSinkConnectorTests
+{
+    private static readonly GeometryFactory Factory = new(new PrecisionModel(), 4326);
+
+    [UnitTest]
+    public async Task GeoJsonFileSink_WritesFeatureCollectionRoundTrip()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"honua-geoetl-sink-{Guid.NewGuid():N}.geojson");
+
+        try
+        {
+            var sink = new GeoJsonFileSinkConnector();
+            var config = new ConnectorConfig
+            {
+                Type = GeoJsonFileSinkConnector.ConnectorType,
+                Options = new Dictionary<string, string> { ["path"] = path }
+            };
+
+            var result = await sink.WriteAsync(config, Features(
+                new Feature(Factory.CreatePoint(new Coordinate(13.405, 52.52)),
+                    new AttributesTable { { "name", "berlin" } }),
+                new Feature(Factory.CreatePoint(new Coordinate(-122.4, 37.6)),
+                    new AttributesTable { { "name", "sf" } })), "batch-1");
+
+            result.FeaturesWritten.Should().Be(2);
+            result.FeaturesRejected.Should().Be(0);
+
+            var json = await File.ReadAllTextAsync(path);
+            var collection = new GeoJsonReader().Read<FeatureCollection>(json);
+            collection.Count.Should().Be(2);
+            collection.Select(f => f.Attributes.GetOptionalValue("name")?.ToString())
+                .Should().BeEquivalentTo(["berlin", "sf"]);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [UnitTest]
+    public async Task QuarantineSink_TagsBatchIdAndReason_AndNeverThrows()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"honua-geoetl-dlq-{Guid.NewGuid():N}.geojson");
+
+        try
+        {
+            var sink = new QuarantineSinkConnector();
+            var config = new ConnectorConfig
+            {
+                Type = QuarantineSinkConnector.ConnectorType,
+                Options = new Dictionary<string, string> { ["path"] = path }
+            };
+
+            var withReason = new Feature(Factory.CreatePoint(new Coordinate(0, 0)),
+                new AttributesTable { { "_quarantine_reason", "bad cast" } });
+            var nullGeometry = new Feature(null, new AttributesTable { { "id", 7L } });
+
+            var result = await sink.WriteAsync(config, Features(withReason, nullGeometry), "batch-dlq");
+
+            // Quarantined rows are rejects, not durable writes.
+            result.FeaturesWritten.Should().Be(0);
+            result.FeaturesRejected.Should().Be(2);
+
+            var json = await File.ReadAllTextAsync(path);
+            var collection = new GeoJsonReader().Read<FeatureCollection>(json);
+            collection.Count.Should().Be(2);
+            collection.Should().AllSatisfy(f =>
+                f.Attributes.GetOptionalValue("_batch_id").Should().Be("batch-dlq"));
+            collection.Select(f => Convert.ToString(
+                    f.Attributes.GetOptionalValue("_quarantine_reason"),
+                    System.Globalization.CultureInfo.InvariantCulture))
+                .Should().Contain("bad cast");
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    private static async IAsyncEnumerable<IFeature> Features(params IFeature[] features)
+    {
+        foreach (var feature in features)
+        {
+            yield return feature;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/GeoETL/PipelineComponentTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/GeoETL/PipelineComponentTests.cs
@@ -20,7 +20,13 @@ public sealed class PipelineComponentTests
 {
     private static PipelineComponentFactory BuildFactory() => new(
         [new GeoJsonSourceConnector()],
-        [new ReprojectTransform(), new AttributeFilterTransform()],
+        [
+            new ReprojectTransform(),
+            new AttributeFilterTransform(),
+            new AttributeRenameTransform(),
+            new AttributeCastTransform(),
+            new ComputedFieldTransform()
+        ],
         [new NullPreviewSinkConnector()]);
 
     private static PipelineDefinition ValidPipeline() => new()
@@ -182,6 +188,135 @@ public sealed class PipelineComponentTests
 
         results.Should().HaveCount(1);
         results.Single().Attributes!.GetOptionalValue("score").Should().Be(90L);
+    }
+
+    [UnitTest]
+    public void Validator_FailsFast_WhenTransformRequiresFieldSourceDoesNotDeclare()
+    {
+        var validator = new PipelineValidator(BuildFactory());
+        var pipeline = ValidPipeline() with
+        {
+            Stages =
+            [
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Source,
+                    Connector = new ConnectorConfig
+                    {
+                        Type = GeoJsonSourceConnector.ConnectorType,
+                        Options = new Dictionary<string, string> { ["declaredFields"] = "name,score" }
+                    }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Transform,
+                    Transform = new TransformConfig
+                    {
+                        Type = AttributeRenameTransform.TransformType,
+                        Options = new Dictionary<string, string> { ["from"] = "missing", ["to"] = "renamed" }
+                    }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Sink,
+                    Connector = new ConnectorConfig { Type = NullPreviewSinkConnector.ConnectorType }
+                }
+            ]
+        };
+
+        var result = validator.Validate(pipeline);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Code == "SCHEMA_FIELD_UNAVAILABLE");
+    }
+
+    [UnitTest]
+    public void Validator_PassesSchemaChain_WhenEarlierStageProducesRequiredField()
+    {
+        var validator = new PipelineValidator(BuildFactory());
+        var pipeline = ValidPipeline() with
+        {
+            Stages =
+            [
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Source,
+                    Connector = new ConnectorConfig
+                    {
+                        Type = GeoJsonSourceConnector.ConnectorType,
+                        Options = new Dictionary<string, string> { ["declaredFields"] = "first,last" }
+                    }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Transform,
+                    Transform = new TransformConfig
+                    {
+                        Type = ComputedFieldTransform.TransformType,
+                        Options = new Dictionary<string, string>
+                        {
+                            ["target"] = "full", ["op"] = "concat", ["fields"] = "first,last"
+                        }
+                    }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Transform,
+                    Transform = new TransformConfig
+                    {
+                        Type = AttributeFilterTransform.TransformType,
+                        Options = new Dictionary<string, string> { ["field"] = "full", ["op"] = "exists" }
+                    }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Sink,
+                    Connector = new ConnectorConfig { Type = NullPreviewSinkConnector.ConnectorType }
+                }
+            ]
+        };
+
+        var result = validator.Validate(pipeline);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public void Validator_SkipsSchemaChain_WhenSourceDeclaresNoFields()
+    {
+        // Permissive passthrough: a source with a dynamic schema (no declaredFields) must
+        // not be blocked by stage-chain field reachability.
+        var validator = new PipelineValidator(BuildFactory());
+        var pipeline = ValidPipeline() with
+        {
+            Stages =
+            [
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Source,
+                    Connector = new ConnectorConfig { Type = GeoJsonSourceConnector.ConnectorType }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Transform,
+                    Transform = new TransformConfig
+                    {
+                        Type = AttributeRenameTransform.TransformType,
+                        Options = new Dictionary<string, string> { ["from"] = "whatever", ["to"] = "x" }
+                    }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Sink,
+                    Connector = new ConnectorConfig { Type = NullPreviewSinkConnector.ConnectorType }
+                }
+            ]
+        };
+
+        var result = validator.Validate(pipeline);
+
+        result.IsValid.Should().BeTrue();
     }
 
     private static async IAsyncEnumerable<IFeature> Single(IFeature feature)

--- a/tests/dotnet/Honua.Core.Tests/Features/GeoETL/PipelineComponentTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/GeoETL/PipelineComponentTests.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services;
+using Honua.Core.Features.GeoETL.Services.Connectors;
+using Honua.Core.Features.GeoETL.Services.Transforms;
+using Honua.TestKit.Attributes;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Core.Tests.Features.GeoETL;
+
+/// <summary>
+/// Unit coverage for the GeoETL baseline domain components: the pipeline validator,
+/// the reproject transform, and the attribute-filter transform.
+/// </summary>
+public sealed class PipelineComponentTests
+{
+    private static PipelineComponentFactory BuildFactory() => new(
+        [new GeoJsonSourceConnector()],
+        [new ReprojectTransform(), new AttributeFilterTransform()],
+        [new NullPreviewSinkConnector()]);
+
+    private static PipelineDefinition ValidPipeline() => new()
+    {
+        Id = "pl-1",
+        Name = "test",
+        Stages =
+        [
+            new PipelineStage
+            {
+                Kind = PipelineStageKind.Source,
+                Connector = new ConnectorConfig { Type = GeoJsonSourceConnector.ConnectorType }
+            },
+            new PipelineStage
+            {
+                Kind = PipelineStageKind.Transform,
+                Transform = new TransformConfig { Type = ReprojectTransform.TransformType }
+            },
+            new PipelineStage
+            {
+                Kind = PipelineStageKind.Sink,
+                Connector = new ConnectorConfig { Type = NullPreviewSinkConnector.ConnectorType }
+            }
+        ]
+    };
+
+    [UnitTest]
+    public void Validator_AcceptsWellFormedPipeline()
+    {
+        var validator = new PipelineValidator(BuildFactory());
+
+        var result = validator.Validate(ValidPipeline());
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public void Validator_RejectsUnknownConnector()
+    {
+        var validator = new PipelineValidator(BuildFactory());
+        var pipeline = ValidPipeline() with
+        {
+            Stages =
+            [
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Source,
+                    Connector = new ConnectorConfig { Type = "does-not-exist" }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Sink,
+                    Connector = new ConnectorConfig { Type = NullPreviewSinkConnector.ConnectorType }
+                }
+            ]
+        };
+
+        var result = validator.Validate(pipeline);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Code == "UNKNOWN_SOURCE");
+    }
+
+    [UnitTest]
+    public void Validator_RejectsMissingSinkStage()
+    {
+        var validator = new PipelineValidator(BuildFactory());
+        var pipeline = ValidPipeline() with
+        {
+            Stages =
+            [
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Source,
+                    Connector = new ConnectorConfig { Type = GeoJsonSourceConnector.ConnectorType }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Transform,
+                    Transform = new TransformConfig { Type = ReprojectTransform.TransformType }
+                }
+            ]
+        };
+
+        var result = validator.Validate(pipeline);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Code == "MISSING_SINK");
+    }
+
+    [UnitTest]
+    public async Task Reproject_Wgs84ToWebMercator_ConvertsToMeters()
+    {
+        var transform = new ReprojectTransform();
+        var config = new TransformConfig
+        {
+            Type = ReprojectTransform.TransformType,
+            Options = new Dictionary<string, string> { ["fromSrid"] = "4326", ["toSrid"] = "3857" }
+        };
+        var factory = new GeometryFactory(new PrecisionModel(), 4326);
+        var source = Single(new Feature(factory.CreatePoint(new Coordinate(13.405, 52.52)), new AttributesTable()));
+
+        var results = new List<IFeature>();
+        await foreach (var feature in transform.TransformAsync(config, source))
+        {
+            results.Add(feature);
+        }
+
+        var point = (Point)results.Single().Geometry!;
+        point.SRID.Should().Be(3857);
+        point.X.Should().BeApproximately(1_492_273, 2000);
+        point.Y.Should().BeApproximately(6_894_582, 5000);
+    }
+
+    [UnitTest]
+    public async Task Reproject_RejectsUnsupportedDatumShift()
+    {
+        var transform = new ReprojectTransform();
+        var config = new TransformConfig
+        {
+            Type = ReprojectTransform.TransformType,
+            Options = new Dictionary<string, string> { ["fromSrid"] = "4326", ["toSrid"] = "27700" }
+        };
+        var factory = new GeometryFactory(new PrecisionModel(), 4326);
+        var source = Single(new Feature(factory.CreatePoint(new Coordinate(0, 0)), new AttributesTable()));
+
+        var act = async () =>
+        {
+            await foreach (var _ in transform.TransformAsync(config, source))
+            {
+            }
+        };
+
+        await act.Should().ThrowAsync<NotSupportedException>();
+    }
+
+    [UnitTest]
+    public async Task AttributeFilter_KeepsOnlyMatchingFeatures()
+    {
+        var transform = new AttributeFilterTransform();
+        var config = new TransformConfig
+        {
+            Type = AttributeFilterTransform.TransformType,
+            Options = new Dictionary<string, string> { ["field"] = "score", ["op"] = "gte", ["value"] = "50" }
+        };
+        var factory = new GeometryFactory(new PrecisionModel(), 4326);
+
+        var low = new Feature(factory.CreatePoint(new Coordinate(0, 0)),
+            new AttributesTable { { "score", 10L } });
+        var high = new Feature(factory.CreatePoint(new Coordinate(1, 1)),
+            new AttributesTable { { "score", 90L } });
+
+        var results = new List<IFeature>();
+        await foreach (var feature in transform.TransformAsync(config, Many(low, high)))
+        {
+            results.Add(feature);
+        }
+
+        results.Should().HaveCount(1);
+        results.Single().Attributes!.GetOptionalValue("score").Should().Be(90L);
+    }
+
+    private static async IAsyncEnumerable<IFeature> Single(IFeature feature)
+    {
+        yield return feature;
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<IFeature> Many(params IFeature[] features)
+    {
+        foreach (var feature in features)
+        {
+            yield return feature;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/GeoETL/SpatialTransformTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/GeoETL/SpatialTransformTests.cs
@@ -1,0 +1,201 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services.Transforms;
+using Honua.TestKit.Attributes;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Core.Tests.Features.GeoETL;
+
+/// <summary>
+/// Unit coverage for the managed (NetTopologySuite, GEOS-free) spatial transforms:
+/// spatial filter, clip, spatial-join enrichment, and dedup. All run in-memory.
+/// </summary>
+public sealed class SpatialTransformTests
+{
+    private static readonly GeometryFactory Factory = new(new PrecisionModel(), 4326);
+
+    [UnitTest]
+    public async Task SpatialFilter_BboxKeepsOnlyFeaturesInside()
+    {
+        var transform = new SpatialFilterTransform();
+        var config = new TransformConfig
+        {
+            Type = SpatialFilterTransform.TransformType,
+            Options = new Dictionary<string, string> { ["bbox"] = "0,0,10,10" }
+        };
+        var inside = new Feature(Factory.CreatePoint(new Coordinate(5, 5)), new AttributesTable());
+        var outside = new Feature(Factory.CreatePoint(new Coordinate(20, 20)), new AttributesTable());
+
+        var results = await Collect(transform.TransformAsync(config, Many(inside, outside)));
+
+        results.Should().HaveCount(1);
+        ((Point)results.Single().Geometry!).X.Should().Be(5);
+    }
+
+    [UnitTest]
+    public async Task Clip_TrimsGeometryToRegionAndDropsOutside()
+    {
+        var transform = new ClipTransform();
+        var config = new TransformConfig
+        {
+            Type = ClipTransform.TransformType,
+            Options = new Dictionary<string, string> { ["bbox"] = "0,0,10,10" }
+        };
+
+        // A line crossing the clip boundary should be trimmed to the region.
+        var crossing = new Feature(
+            Factory.CreateLineString([new Coordinate(-5, 5), new Coordinate(15, 5)]),
+            new AttributesTable { { "id", 1L } });
+        var outside = new Feature(
+            Factory.CreatePoint(new Coordinate(50, 50)),
+            new AttributesTable { { "id", 2L } });
+
+        var results = await Collect(transform.TransformAsync(config, Many(crossing, outside)));
+
+        results.Should().HaveCount(1);
+        var clipped = results.Single().Geometry!;
+        clipped.SRID.Should().Be(4326);
+        clipped.EnvelopeInternal.MinX.Should().BeApproximately(0, 0.0001);
+        clipped.EnvelopeInternal.MaxX.Should().BeApproximately(10, 0.0001);
+    }
+
+    [UnitTest]
+    public async Task SpatialJoin_TransfersReferenceAttributesForPointInPolygon()
+    {
+        const string reference = """
+            {
+              "type": "FeatureCollection",
+              "features": [
+                { "type": "Feature",
+                  "geometry": { "type": "Polygon",
+                    "coordinates": [[[0,0],[0,10],[10,10],[10,0],[0,0]]] },
+                  "properties": { "zone": "A", "pop": 100 } }
+              ]
+            }
+            """;
+        var transform = new SpatialJoinTransform();
+        var config = new TransformConfig
+        {
+            Type = SpatialJoinTransform.TransformType,
+            Options = new Dictionary<string, string>
+            {
+                ["referenceInline"] = reference,
+                ["predicate"] = "contains",
+                ["transfer"] = "zone",
+                ["prefix"] = "ref_"
+            }
+        };
+        var inZone = new Feature(Factory.CreatePoint(new Coordinate(5, 5)),
+            new AttributesTable { { "name", "p1" } });
+        var outOfZone = new Feature(Factory.CreatePoint(new Coordinate(50, 50)),
+            new AttributesTable { { "name", "p2" } });
+
+        var results = await Collect(transform.TransformAsync(config, Many(inZone, outOfZone)));
+
+        results.Should().HaveCount(2);
+        var enriched = results.Single(f =>
+            string.Equals(f.Attributes!.GetOptionalValue("name")?.ToString(), "p1", StringComparison.Ordinal));
+        enriched.Attributes!.GetOptionalValue("ref_zone").Should().Be("A");
+
+        var unmatched = results.Single(f =>
+            string.Equals(f.Attributes!.GetOptionalValue("name")?.ToString(), "p2", StringComparison.Ordinal));
+        unmatched.Attributes!.Exists("ref_zone").Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task SpatialJoin_InnerJoinDropsUnmatched()
+    {
+        const string reference = """
+            {
+              "type": "FeatureCollection",
+              "features": [
+                { "type": "Feature",
+                  "geometry": { "type": "Polygon",
+                    "coordinates": [[[0,0],[0,10],[10,10],[10,0],[0,0]]] },
+                  "properties": { "zone": "A" } }
+              ]
+            }
+            """;
+        var transform = new SpatialJoinTransform();
+        var config = new TransformConfig
+        {
+            Type = SpatialJoinTransform.TransformType,
+            Options = new Dictionary<string, string>
+            {
+                ["referenceInline"] = reference,
+                ["keepUnmatched"] = "false"
+            }
+        };
+        var inZone = new Feature(Factory.CreatePoint(new Coordinate(5, 5)), new AttributesTable());
+        var outOfZone = new Feature(Factory.CreatePoint(new Coordinate(50, 50)), new AttributesTable());
+
+        var results = await Collect(transform.TransformAsync(config, Many(inZone, outOfZone)));
+
+        results.Should().HaveCount(1);
+        results.Single().Attributes!.GetOptionalValue("zone").Should().Be("A");
+    }
+
+    [UnitTest]
+    public async Task Dedup_ByAttributeKey_KeepsFirstOnly()
+    {
+        var transform = new DedupTransform();
+        var config = new TransformConfig
+        {
+            Type = DedupTransform.TransformType,
+            Options = new Dictionary<string, string> { ["keys"] = "id" }
+        };
+        var a1 = new Feature(Factory.CreatePoint(new Coordinate(0, 0)),
+            new AttributesTable { { "id", "x" }, { "seq", 1L } });
+        var a2 = new Feature(Factory.CreatePoint(new Coordinate(1, 1)),
+            new AttributesTable { { "id", "x" }, { "seq", 2L } });
+        var b1 = new Feature(Factory.CreatePoint(new Coordinate(2, 2)),
+            new AttributesTable { { "id", "y" }, { "seq", 3L } });
+
+        var results = await Collect(transform.TransformAsync(config, Many(a1, a2, b1)));
+
+        results.Should().HaveCount(2);
+        results.Select(f => f.Attributes!.GetOptionalValue("seq")).Should().BeEquivalentTo([1L, 3L]);
+    }
+
+    [UnitTest]
+    public async Task Dedup_ByGeometry_KeepsDistinctGeometriesOnly()
+    {
+        var transform = new DedupTransform();
+        var config = new TransformConfig
+        {
+            Type = DedupTransform.TransformType,
+            Options = new Dictionary<string, string> { ["geometry"] = "true" }
+        };
+        var p1 = new Feature(Factory.CreatePoint(new Coordinate(1, 1)), new AttributesTable());
+        var p1Dup = new Feature(Factory.CreatePoint(new Coordinate(1, 1)), new AttributesTable());
+        var p2 = new Feature(Factory.CreatePoint(new Coordinate(2, 2)), new AttributesTable());
+
+        var results = await Collect(transform.TransformAsync(config, Many(p1, p1Dup, p2)));
+
+        results.Should().HaveCount(2);
+    }
+
+    private static async Task<List<IFeature>> Collect(IAsyncEnumerable<IFeature> source)
+    {
+        var list = new List<IFeature>();
+        await foreach (var feature in source)
+        {
+            list.Add(feature);
+        }
+
+        return list;
+    }
+
+    private static async IAsyncEnumerable<IFeature> Many(params IFeature[] features)
+    {
+        foreach (var feature in features)
+        {
+            yield return feature;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/GeoETL/ManagedFileSourceConnectorTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/GeoETL/ManagedFileSourceConnectorTests.cs
@@ -1,0 +1,304 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Postgres.Features.GeoETL.Services.Connectors;
+using Microsoft.Data.Sqlite;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NetTopologySuite.IO.Esri;
+
+namespace Honua.Postgres.Tests.Features.GeoETL;
+
+/// <summary>
+/// Unit coverage for the managed (GDAL-free) GeoETL file source connectors that live in
+/// Honua.Postgres because they wrap this project's managed readers: the Esri shapefile
+/// reader and the Microsoft.Data.Sqlite + NetTopologySuite.IO.GeoPackage path. Each test
+/// writes a small fixture with the same managed libraries, then reads it back through the
+/// connector — no native dependency and no live database.
+/// </summary>
+public sealed class ManagedFileSourceConnectorTests
+{
+    [Fact]
+    public async Task Shapefile_ReadsPointFeaturesWithAttributes()
+    {
+        var dir = Directory.CreateTempSubdirectory("honua-geoetl-shp");
+        var shpPath = Path.Combine(dir.FullName, "points.shp");
+
+        try
+        {
+            var factory = new GeometryFactory(new PrecisionModel(), 4326);
+            var features = new IFeature[]
+            {
+                new Feature(factory.CreatePoint(new Coordinate(13.405, 52.52)),
+                    new AttributesTable { { "name", "berlin" } }),
+                new Feature(factory.CreatePoint(new Coordinate(-122.4, 37.6)),
+                    new AttributesTable { { "name", "sf" } })
+            };
+            Shapefile.WriteAllFeatures(features, shpPath);
+
+            var connector = new ShapefileSourceConnector();
+            var config = new ConnectorConfig
+            {
+                Type = ShapefileSourceConnector.ConnectorType,
+                Options = new Dictionary<string, string> { ["path"] = shpPath }
+            };
+
+            var read = new List<IFeature>();
+            await foreach (var feature in connector.ReadAsync(config))
+            {
+                read.Add(feature);
+            }
+
+            read.Should().HaveCount(2);
+            read.Should().AllSatisfy(f => f.Geometry.Should().BeOfType<Point>());
+            read.Select(f => f.Attributes!.GetOptionalValue("name")?.ToString())
+                .Should().BeEquivalentTo(["berlin", "sf"]);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Shapefile_WithoutPath_Throws()
+    {
+        var connector = new ShapefileSourceConnector();
+        var config = new ConnectorConfig { Type = ShapefileSourceConnector.ConnectorType };
+
+        var act = async () =>
+        {
+            await foreach (var _ in connector.ReadAsync(config))
+            {
+            }
+        };
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task GeoPackage_SingleLayer_ReadsFeaturesWithSridAndAttributes()
+    {
+        var filePath = Path.Combine(Path.GetTempPath(), $"honua-geoetl-gpkg-{Guid.NewGuid():N}.gpkg");
+
+        try
+        {
+            CreateGeoPackage(filePath);
+
+            var connector = new GeoPackageSourceConnector();
+            var config = new ConnectorConfig
+            {
+                Type = GeoPackageSourceConnector.ConnectorType,
+                Options = new Dictionary<string, string> { ["path"] = filePath }
+            };
+
+            var read = new List<IFeature>();
+            await foreach (var feature in connector.ReadAsync(config))
+            {
+                read.Add(feature);
+            }
+
+            read.Should().HaveCount(1);
+            var point = (Point)read[0].Geometry!;
+            point.SRID.Should().Be(4326);
+            read[0].Attributes!.GetOptionalValue("name").Should().Be("Test Feature");
+        }
+        finally
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GeoPackage_MultipleLayersWithoutSelection_Throws()
+    {
+        var filePath = Path.Combine(Path.GetTempPath(), $"honua-geoetl-gpkg-{Guid.NewGuid():N}.gpkg");
+
+        try
+        {
+            CreateGeoPackage(filePath, includeSecondLayer: true);
+
+            var connector = new GeoPackageSourceConnector();
+            var config = new ConnectorConfig
+            {
+                Type = GeoPackageSourceConnector.ConnectorType,
+                Options = new Dictionary<string, string> { ["path"] = filePath }
+            };
+
+            var act = async () =>
+            {
+                await foreach (var _ in connector.ReadAsync(config))
+                {
+                }
+            };
+
+            (await act.Should().ThrowAsync<InvalidDataException>())
+                .Which.Message.Should().Contain("multiple feature layers");
+        }
+        finally
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GeoPackage_MultipleLayersWithSelection_ReadsRequestedLayer()
+    {
+        var filePath = Path.Combine(Path.GetTempPath(), $"honua-geoetl-gpkg-{Guid.NewGuid():N}.gpkg");
+
+        try
+        {
+            CreateGeoPackage(filePath, includeSecondLayer: true);
+
+            var connector = new GeoPackageSourceConnector();
+            var config = new ConnectorConfig
+            {
+                Type = GeoPackageSourceConnector.ConnectorType,
+                Options = new Dictionary<string, string>
+                {
+                    ["path"] = filePath,
+                    ["layer"] = "second_layer"
+                }
+            };
+
+            var read = new List<IFeature>();
+            await foreach (var feature in connector.ReadAsync(config))
+            {
+                read.Add(feature);
+            }
+
+            read.Should().HaveCount(1);
+            read[0].Attributes!.GetOptionalValue("name").Should().Be("Second Feature");
+        }
+        finally
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+    }
+
+    private static void CreateGeoPackage(string filePath, bool includeSecondLayer = false)
+    {
+        using var connection = new SqliteConnection($"Data Source={filePath}");
+        connection.Open();
+
+        ExecuteNonQuery(connection, """
+            CREATE TABLE gpkg_spatial_ref_sys (
+                srs_name TEXT NOT NULL,
+                srs_id INTEGER NOT NULL PRIMARY KEY,
+                organization TEXT NOT NULL,
+                organization_coordsys_id INTEGER NOT NULL,
+                definition TEXT NOT NULL,
+                description TEXT
+            );
+            """);
+
+        ExecuteNonQuery(connection, """
+            INSERT INTO gpkg_spatial_ref_sys (srs_name, srs_id, organization, organization_coordsys_id, definition, description)
+            VALUES ('WGS 84', 4326, 'EPSG', 4326, 'EPSG:4326', 'WGS 84');
+            """);
+
+        ExecuteNonQuery(connection, """
+            CREATE TABLE gpkg_contents (
+                table_name TEXT NOT NULL PRIMARY KEY,
+                data_type TEXT NOT NULL,
+                identifier TEXT,
+                description TEXT DEFAULT '',
+                last_change DATETIME NOT NULL,
+                min_x DOUBLE,
+                min_y DOUBLE,
+                max_x DOUBLE,
+                max_y DOUBLE,
+                srs_id INTEGER
+            );
+            """);
+
+        ExecuteNonQuery(connection, """
+            CREATE TABLE gpkg_geometry_columns (
+                table_name TEXT NOT NULL,
+                column_name TEXT NOT NULL,
+                geometry_type_name TEXT NOT NULL,
+                srs_id INTEGER NOT NULL,
+                z TINYINT NOT NULL,
+                m TINYINT NOT NULL,
+                PRIMARY KEY (table_name, column_name)
+            );
+            """);
+
+        ExecuteNonQuery(connection, """
+            CREATE TABLE sample_layer (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                geom BLOB,
+                name TEXT
+            );
+            """);
+
+        ExecuteNonQuery(connection, """
+            INSERT INTO gpkg_contents (table_name, data_type, identifier, description, last_change, srs_id)
+            VALUES ('sample_layer', 'features', 'sample_layer', 'Sample layer', CURRENT_TIMESTAMP, 4326);
+            """);
+
+        ExecuteNonQuery(connection, """
+            INSERT INTO gpkg_geometry_columns (table_name, column_name, geometry_type_name, srs_id, z, m)
+            VALUES ('sample_layer', 'geom', 'POINT', 4326, 0, 0);
+            """);
+
+        if (includeSecondLayer)
+        {
+            ExecuteNonQuery(connection, """
+                CREATE TABLE second_layer (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    geom BLOB,
+                    name TEXT
+                );
+                """);
+
+            ExecuteNonQuery(connection, """
+                INSERT INTO gpkg_contents (table_name, data_type, identifier, description, last_change, srs_id)
+                VALUES ('second_layer', 'features', 'second_layer', 'Second layer', CURRENT_TIMESTAMP, 4326);
+                """);
+
+            ExecuteNonQuery(connection, """
+                INSERT INTO gpkg_geometry_columns (table_name, column_name, geometry_type_name, srs_id, z, m)
+                VALUES ('second_layer', 'geom', 'POINT', 4326, 0, 0);
+                """);
+        }
+
+        var geometry = new GeometryFactory(new PrecisionModel(), 4326)
+            .CreatePoint(new Coordinate(-122.4, 37.6));
+        var writer = new GeoPackageGeoWriter();
+        var geometryBytes = writer.Write(geometry);
+
+        using var insert = connection.CreateCommand();
+        insert.CommandText = "INSERT INTO sample_layer (geom, name) VALUES ($geom, $name);";
+        insert.Parameters.AddWithValue("$geom", geometryBytes);
+        insert.Parameters.AddWithValue("$name", "Test Feature");
+        insert.ExecuteNonQuery();
+
+        if (includeSecondLayer)
+        {
+            using var secondInsert = connection.CreateCommand();
+            secondInsert.CommandText = "INSERT INTO second_layer (geom, name) VALUES ($geom, $name);";
+            secondInsert.Parameters.AddWithValue("$geom", geometryBytes);
+            secondInsert.Parameters.AddWithValue("$name", "Second Feature");
+            secondInsert.ExecuteNonQuery();
+        }
+    }
+
+    private static void ExecuteNonQuery(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/GeoETL/ExternalPostgisSinkTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/GeoETL/ExternalPostgisSinkTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Postgres.Features.GeoETL.Services.Connectors;
+using Honua.Server.Tests.Infrastructure;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using Npgsql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Honua.Server.Tests.Features.GeoETL;
+
+/// <summary>
+/// Testcontainers integration coverage for the external PostGIS sink (#361 Child Ticket
+/// D). Proves the sink creates its destination table in a PostGIS database that is not the
+/// Honua catalog and inserts features (with reprojected-or-tagged geometry and a batch id)
+/// through the managed Npgsql + WKB path — no GDAL. Uses an isolated schema as the
+/// "external" target.
+/// </summary>
+[Collection("Database")]
+public sealed class ExternalPostgisSinkTests : IAsyncLifetime
+{
+    private readonly DatabaseFixtureAdapter _fixture;
+    private readonly ITestOutputHelper _output;
+    private string _schemaName = null!;
+
+    public ExternalPostgisSinkTests(DatabaseFixtureAdapter fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _schemaName = await _fixture.CreateIsolatedSchemaAsync(nameof(ExternalPostgisSinkTests));
+        _output.WriteLine($"Created isolated schema: {_schemaName}");
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DropSchemaAsync(_schemaName);
+    }
+
+    [Fact]
+    public async Task WriteAsync_CreatesTableAndInsertsFeaturesWithBatchTag()
+    {
+        var factory = new GeometryFactory(new PrecisionModel(), 4326);
+        var sink = new ExternalPostgisSinkConnector();
+        var config = new ConnectorConfig
+        {
+            Type = ExternalPostgisSinkConnector.ConnectorType,
+            Options = new Dictionary<string, string>
+            {
+                ["connectionString"] = _fixture.ConnectionString,
+                ["schema"] = _schemaName,
+                ["table"] = "external_out",
+                ["targetSrid"] = "4326"
+            }
+        };
+
+        var features = Features(
+            new Feature(factory.CreatePoint(new Coordinate(13.405, 52.52)),
+                new AttributesTable { { "name", "berlin" } }),
+            new Feature(factory.CreatePoint(new Coordinate(-122.4, 37.6)),
+                new AttributesTable { { "name", "sf" } }),
+            new Feature(null, new AttributesTable { { "name", "no-geom" } }));
+
+        var result = await sink.WriteAsync(config, features, "batch-ext-1");
+
+        Assert.Equal(2, result.FeaturesWritten);
+        Assert.Equal(1, result.FeaturesRejected);
+
+        await using var connection = await _fixture.DataSource.OpenConnectionAsync();
+
+        await using var countCommand = new NpgsqlCommand(
+            $"SELECT COUNT(*) FROM \"{_schemaName}\".external_out", connection);
+        var count = (long)(await countCommand.ExecuteScalarAsync())!;
+        Assert.Equal(2, count);
+
+        // Every row carries the run batch id in its attributes JSONB for soft-delete rollback.
+        await using var batchCommand = new NpgsqlCommand(
+            $"SELECT COUNT(*) FROM \"{_schemaName}\".external_out " +
+            "WHERE attributes->>'__pipeline_batch_id' = 'batch-ext-1'", connection);
+        var tagged = (long)(await batchCommand.ExecuteScalarAsync())!;
+        Assert.Equal(2, tagged);
+
+        // The geometry persisted with the requested SRID.
+        await using var sridCommand = new NpgsqlCommand(
+            $"SELECT DISTINCT ST_SRID(geom) FROM \"{_schemaName}\".external_out", connection);
+        var srid = (int)(await sridCommand.ExecuteScalarAsync())!;
+        Assert.Equal(4326, srid);
+    }
+
+    private static async IAsyncEnumerable<IFeature> Features(params IFeature[] features)
+    {
+        foreach (var feature in features)
+        {
+            yield return feature;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/GeoETL/PipelineEndToEndExecutionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/GeoETL/PipelineEndToEndExecutionTests.cs
@@ -1,0 +1,401 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services;
+using Honua.Core.Features.GeoETL.Services.Connectors;
+using Honua.Core.Features.GeoETL.Services.Transforms;
+using Honua.Server.Features.GeoETL;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Server.Tests.Features.GeoETL;
+
+/// <summary>
+/// End-to-end proof that a GeoETL pipeline (GeoJSON source → reproject → Honua-layer /
+/// PostGIS sink) runs through the durable substrate's worker loop
+/// (<see cref="JobExecutionService"/>) and produces an execution record plus structured
+/// logs. The PostGIS sink is exercised through the same connector the production wiring
+/// uses; its insert path is backed by an in-memory <see cref="IFeatureSinkWriter"/> that
+/// captures the reprojected geometry so the test stays fast and deterministic while
+/// proving the full vertical slice.
+/// </summary>
+public sealed class PipelineEndToEndExecutionTests
+{
+    private const string InlineGeoJson = """
+        {
+          "type": "FeatureCollection",
+          "features": [
+            { "type": "Feature", "geometry": { "type": "Point", "coordinates": [0, 0] },
+              "properties": { "name": "origin", "score": 10 } },
+            { "type": "Feature", "geometry": { "type": "Point", "coordinates": [13.405, 52.52] },
+              "properties": { "name": "berlin", "score": 90 } }
+          ]
+        }
+        """;
+
+    [IntegrationTest]
+    public async Task GeoJsonSource_Reproject_PostgisSink_RunsThroughSubstrate()
+    {
+        // Arrange: the slice's real components, wired exactly as production registers them.
+        var sinkWriter = new CapturingFeatureSinkWriter();
+        var sources = new IPipelineSourceConnector[] { new GeoJsonSourceConnector() };
+        var transforms = new IPipelineTransform[] { new ReprojectTransform(), new AttributeFilterTransform() };
+        var sinks = new IPipelineSinkConnector[]
+        {
+            new NullPreviewSinkConnector(),
+            new HonuaLayerSinkConnector(sinkWriter)
+        };
+        var factory = new PipelineComponentFactory(sources, transforms, sinks);
+        var stageRunner = new PipelineStageRunner(factory);
+
+        var definitionStore = new InMemoryPipelineDefinitionStore();
+        var executionStore = new InMemoryPipelineExecutionStore();
+
+        var pipeline = new PipelineDefinition
+        {
+            Id = "pl-e2e",
+            Name = "GeoJSON to PostGIS",
+            Version = 1,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Stages =
+            [
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Source,
+                    Connector = new ConnectorConfig
+                    {
+                        Type = GeoJsonSourceConnector.ConnectorType,
+                        Options = new Dictionary<string, string> { ["inline"] = InlineGeoJson }
+                    }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Transform,
+                    Transform = new TransformConfig
+                    {
+                        Type = ReprojectTransform.TransformType,
+                        Options = new Dictionary<string, string> { ["fromSrid"] = "4326", ["toSrid"] = "3857" }
+                    }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Sink,
+                    Connector = new ConnectorConfig
+                    {
+                        Type = HonuaLayerSinkConnector.ConnectorType,
+                        Options = new Dictionary<string, string>
+                        {
+                            ["schema"] = "honua",
+                            ["table"] = "pipeline_out",
+                            ["targetSrid"] = "3857",
+                            ["sourceSrid"] = "3857"
+                        }
+                    }
+                }
+            ]
+        };
+        await definitionStore.CreateAsync(pipeline);
+
+        // The execution record + substrate job share one operation id, as the launcher builds them.
+        var operationId = "geoetl-e2e-1";
+        await executionStore.CreateAsync(new PipelineExecution
+        {
+            Id = operationId,
+            PipelineId = pipeline.Id,
+            PipelineVersion = pipeline.Version,
+            ExecutionJobId = operationId,
+            Status = PipelineExecutionStatus.Pending,
+            BatchId = operationId,
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+
+        // The single ExtractTransformLoad executor, registered as production does (singleton
+        // opening a scope per job). The scope resolves the slice's real components.
+        var services = new ServiceCollection();
+        services.AddSingleton<IPipelineDefinitionStore>(definitionStore);
+        services.AddSingleton<IPipelineExecutionStore>(executionStore);
+        services.AddSingleton(stageRunner);
+        var provider = services.BuildServiceProvider();
+
+        var executor = new PipelineJobExecutor(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<PipelineJobExecutor>.Instance);
+
+        var now = DateTimeOffset.UtcNow;
+        var job = new ExecutionJobRecord
+        {
+            OperationId = operationId,
+            // Provisioning is the post-claim state ProcessJobAsync promotes to Running.
+            Status = ExecutionJobStatus.Provisioning,
+            CreatedAt = now,
+            UpdatedAt = now,
+            ClaimedBy = "worker-test",
+            ClaimedAt = now,
+            LastHeartbeatAt = now,
+            AttemptCount = 1,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.ExtractTransformLoad,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoetl:pl-e2e",
+                RuntimeProfile = "managed",
+                Parameters = new Dictionary<string, string>
+                {
+                    [PipelineJobExecutor.PipelineIdKey] = pipeline.Id,
+                    [PipelineJobExecutor.ExecutionIdKey] = operationId,
+                    [PipelineJobExecutor.DryRunKey] = "false"
+                }
+            }
+        };
+
+        var jobStore = new InMemoryExecutionJobStore(job);
+        var jobQueue = new RecordingJobQueue();
+        var logStore = new InMemoryExecutionLogStore();
+        var cancellationTokens = new ExecutionJobCancellationTokens();
+
+        // The real substrate worker loop drives our executor: claim → Running → execute → finalize.
+        var service = new JobExecutionService(
+            jobQueue, jobStore, [executor], cancellationTokens,
+            Array.Empty<IJobTerminalCallback>(), logStore,
+            NullLogger<JobExecutionService>.Instance);
+
+        // Act: run a single claimed job through the substrate's ProcessJobAsync.
+        await InvokeProcessJobAsync(service, operationId, "worker-test");
+
+        // The pipeline execution record reflects the run.
+        var execution = await executionStore.GetAsync(operationId);
+        Assert.NotNull(execution);
+        Assert.True(
+            execution!.Status == PipelineExecutionStatus.Succeeded,
+            $"Pipeline execution did not succeed. Status={execution.Status}, Error={execution.ErrorMessage}");
+
+        // Assert: the substrate finalized the job as Succeeded.
+        var finalJob = await jobStore.GetAsync(operationId);
+        Assert.NotNull(finalJob);
+        Assert.Equal(ExecutionJobStatus.Succeeded, finalJob!.Status);
+        Assert.Equal(2, execution.FeaturesRead);
+        Assert.Equal(2, execution.FeaturesWritten);
+
+        // The PostGIS sink insert path received both features, tagged with the batch id.
+        Assert.Equal("honua", sinkWriter.Schema);
+        Assert.Equal("pipeline_out", sinkWriter.Table);
+        Assert.Equal(operationId, sinkWriter.BatchId);
+        Assert.Equal(2, sinkWriter.Inserted.Count);
+
+        // Reprojection ran: WGS84 (13.405, 52.52) → Web Mercator is far from the lon/lat value.
+        var berlin = sinkWriter.Inserted.Single(f =>
+            string.Equals(f.Attributes?.GetOptionalValue("name")?.ToString(), "berlin", StringComparison.Ordinal));
+        var point = (Point)berlin.Geometry!;
+        Assert.Equal(3857, point.SRID);
+        Assert.True(point.X > 1_000_000, $"Expected reprojected X in meters, got {point.X}.");
+        Assert.True(point.Y > 6_000_000, $"Expected reprojected Y in meters, got {point.Y}.");
+
+        // Structured execution logs captured the pipeline.* telemetry through the substrate.
+        var logs = await logStore.GetLogsAsync(operationId);
+        Assert.Contains(logs, e => e.Message.Contains("pipeline.started", StringComparison.Ordinal));
+        Assert.Contains(logs, e => e.Message.Contains("pipeline.completed", StringComparison.Ordinal));
+    }
+
+    [IntegrationTest]
+    public async Task DryRun_RoutesToNullSink_AndWritesNothingToDurableTarget()
+    {
+        var sinkWriter = new CapturingFeatureSinkWriter();
+        var factory = new PipelineComponentFactory(
+            [new GeoJsonSourceConnector()],
+            [new ReprojectTransform()],
+            [new NullPreviewSinkConnector(), new HonuaLayerSinkConnector(sinkWriter)]);
+        var stageRunner = new PipelineStageRunner(factory);
+
+        var pipeline = new PipelineDefinition
+        {
+            Id = "pl-dry",
+            Name = "Dry run",
+            Stages =
+            [
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Source,
+                    Connector = new ConnectorConfig
+                    {
+                        Type = GeoJsonSourceConnector.ConnectorType,
+                        Options = new Dictionary<string, string> { ["inline"] = InlineGeoJson }
+                    }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Sink,
+                    Connector = new ConnectorConfig
+                    {
+                        Type = HonuaLayerSinkConnector.ConnectorType,
+                        Options = new Dictionary<string, string>
+                        {
+                            ["schema"] = "honua", ["table"] = "ignored", ["targetSrid"] = "4326"
+                        }
+                    }
+                }
+            ]
+        };
+
+        var result = await stageRunner.RunAsync(pipeline, "batch-dry", dryRun: true, observer: null, CancellationToken.None);
+
+        Assert.Equal(2, result.FeaturesRead);
+        Assert.Equal(2, result.FeaturesWritten);
+        // The durable PostGIS sink writer must never be touched on a dry run.
+        Assert.Empty(sinkWriter.Inserted);
+        Assert.False(sinkWriter.EnsureTargetCalled);
+    }
+
+    private static async Task InvokeProcessJobAsync(
+        JobExecutionService service,
+        string operationId,
+        string workerId,
+        CancellationToken stoppingToken = default)
+    {
+        var method = typeof(JobExecutionService).GetMethod(
+            "ProcessJobAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        var task = (Task)method!.Invoke(service, [operationId, workerId, stoppingToken])!;
+        await task.ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// In-memory stand-in for the Honua-layer / PostGIS <see cref="IFeatureSinkWriter"/>.
+    /// Captures the features handed to the canonical insert path so the test can assert
+    /// reprojected geometry and batch tagging without a live PostGIS instance.
+    /// </summary>
+    private sealed class CapturingFeatureSinkWriter : IFeatureSinkWriter
+    {
+        public List<IFeature> Inserted { get; } = [];
+        public string? Schema { get; private set; }
+        public string? Table { get; private set; }
+        public string? BatchId { get; private set; }
+        public bool EnsureTargetCalled { get; private set; }
+
+        public Task EnsureTargetAsync(string schema, string table, int targetSrid, CancellationToken cancellationToken = default)
+        {
+            EnsureTargetCalled = true;
+            Schema = schema;
+            Table = table;
+            return Task.CompletedTask;
+        }
+
+        public Task<long> InsertBatchAsync(
+            string schema,
+            string table,
+            IReadOnlyList<IFeature> features,
+            int sourceSrid,
+            int targetSrid,
+            string batchId,
+            CancellationToken cancellationToken = default)
+        {
+            Schema = schema;
+            Table = table;
+            BatchId = batchId;
+            foreach (var feature in features)
+            {
+                if (feature.Geometry is not null)
+                {
+                    feature.Geometry.SRID = targetSrid;
+                }
+
+                Inserted.Add(feature);
+            }
+
+            return Task.FromResult((long)features.Count);
+        }
+    }
+
+    private sealed class InMemoryExecutionJobStore(params ExecutionJobRecord[] jobs) : IExecutionJobStore
+    {
+        private readonly Dictionary<string, ExecutionJobRecord> _jobs =
+            jobs.ToDictionary(job => job.OperationId, StringComparer.Ordinal);
+
+        public Task<bool> TryAcquireLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task<bool> RenewLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task ReleaseLeaseAsync(string operationId, string ownerId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<bool> TryCreateAsync(ExecutionJobRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            if (_jobs.ContainsKey(operation.OperationId))
+            {
+                return Task.FromResult(false);
+            }
+
+            _jobs[operation.OperationId] = operation;
+            return Task.FromResult(true);
+        }
+
+        public Task<ExecutionJobRecord?> GetAsync(string operationId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_jobs.TryGetValue(operationId, out var job) ? job : null);
+
+        public Task SetAsync(ExecutionJobRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _jobs[operation.OperationId] = operation;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> TrySetAsync(ExecutionJobRecord job, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _jobs[job.OperationId] = job;
+            return Task.FromResult(true);
+        }
+
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(
+                _jobs.Values.Where(job => !kind.HasValue || job.Spec.Kind == kind.Value).ToArray());
+    }
+
+    private sealed class RecordingJobQueue : IJobQueue
+    {
+        public Task EnqueueAsync(string operationId, OperationPriority priority = OperationPriority.Normal, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<string?> TryClaimAsync(string workerId, IReadOnlySet<ExecutionJobKind>? acceptedKinds = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<string?>(null);
+
+        public Task RequeueAsync(string operationId, OperationPriority priority = OperationPriority.Normal, TimeSpan? visibleAfter = null, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task RemoveAsync(string operationId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<long> GetQueueDepthAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(0L);
+    }
+
+    private sealed class InMemoryExecutionLogStore : IExecutionLogStore
+    {
+        private readonly ConcurrentDictionary<string, List<ExecutionLogEntry>> _logs = new(StringComparer.Ordinal);
+
+        public Task AppendAsync(string operationId, ExecutionLogEntry entry, CancellationToken cancellationToken = default)
+        {
+            _logs.GetOrAdd(operationId, _ => []).Add(entry);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<ExecutionLogEntry>> GetLogsAsync(string operationId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<ExecutionLogEntry>>(
+                _logs.TryGetValue(operationId, out var entries) ? entries.ToArray() : []);
+
+        public Task SetRetentionAsync(string operationId, TimeSpan ttl, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/GeoETL/PostgresPipelineStoreTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/GeoETL/PostgresPipelineStoreTests.cs
@@ -1,0 +1,296 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Postgres.Features.GeoETL.Services;
+using Honua.Server.Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Honua.Server.Tests.Features.GeoETL;
+
+/// <summary>
+/// Testcontainers integration coverage for the PostgreSQL-backed GeoETL stores
+/// (#361 Child Ticket A — durable persistence). Proves a pipeline definition CRUD
+/// round-trip (create, get, list, update with version bump, delete) and a pipeline
+/// execution lifecycle round-trip (create → update terminal state) against a real
+/// PostgreSQL instance, with the discriminated-union stage chain persisted as JSONB.
+/// </summary>
+[Collection("Database")]
+public sealed class PostgresPipelineStoreTests : IAsyncLifetime
+{
+    private readonly DatabaseFixtureAdapter _fixture;
+    private readonly ITestOutputHelper _output;
+    private string _schemaName = null!;
+    private PostgresPipelineDefinitionStore _definitionStore = null!;
+    private PostgresPipelineExecutionStore _executionStore = null!;
+
+    public PostgresPipelineStoreTests(DatabaseFixtureAdapter fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _schemaName = await _fixture.CreateIsolatedSchemaAsync(nameof(PostgresPipelineStoreTests));
+
+        // Mirror migration 033's DDL in the isolated test schema so the round-trip runs
+        // with full test isolation (parallel runs never collide on a shared honua schema).
+        await _fixture.ExecuteAsync($"""
+            CREATE TABLE {_schemaName}.pipeline_definitions (
+                id              VARCHAR(128) PRIMARY KEY,
+                name            VARCHAR(256) NOT NULL,
+                description     TEXT,
+                schema_version  INTEGER NOT NULL DEFAULT 1,
+                version         INTEGER NOT NULL DEFAULT 1,
+                stages_json     JSONB NOT NULL,
+                created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+
+            CREATE TABLE {_schemaName}.pipeline_executions (
+                id                      VARCHAR(128) PRIMARY KEY,
+                pipeline_id             VARCHAR(128) NOT NULL,
+                pipeline_version        INTEGER NOT NULL DEFAULT 1,
+                execution_job_id        VARCHAR(128) NOT NULL,
+                status                  VARCHAR(32) NOT NULL,
+                is_dry_run              BOOLEAN NOT NULL DEFAULT FALSE,
+                features_read           BIGINT NOT NULL DEFAULT 0,
+                features_written        BIGINT NOT NULL DEFAULT 0,
+                features_quarantined    BIGINT NOT NULL DEFAULT 0,
+                batch_id                VARCHAR(128),
+                error_message           TEXT,
+                created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                completed_at            TIMESTAMPTZ
+            );
+            """);
+
+        var connectionProvider = new TestDatabaseConnectionProvider(
+            _fixture.DataSource, () => _schemaName);
+        _definitionStore = new PostgresPipelineDefinitionStore(
+            connectionProvider, TimeProvider.System, _schemaName);
+        _executionStore = new PostgresPipelineExecutionStore(connectionProvider, _schemaName);
+
+        _output.WriteLine($"Created isolated schema: {_schemaName}");
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DropSchemaAsync(_schemaName);
+    }
+
+    [Fact]
+    public async Task DefinitionStore_CrudRoundTrip_PreservesStagesAndBumpsVersion()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var definition = new PipelineDefinition
+        {
+            SchemaVersion = 1,
+            Id = "pl-roundtrip",
+            Name = "GeoJSON to PostGIS",
+            Description = "round-trip fixture",
+            Version = 1,
+            CreatedAt = now,
+            UpdatedAt = now,
+            Stages =
+            [
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Source,
+                    Connector = new ConnectorConfig
+                    {
+                        Type = "geojson",
+                        Options = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            ["path"] = "/data/in.geojson"
+                        }
+                    }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Transform,
+                    Transform = new TransformConfig
+                    {
+                        Type = "reproject",
+                        Options = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            ["fromSrid"] = "4326",
+                            ["toSrid"] = "3857"
+                        }
+                    }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Sink,
+                    Connector = new ConnectorConfig
+                    {
+                        Type = "honua-layer",
+                        Options = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            ["schema"] = "honua",
+                            ["table"] = "out",
+                            ["targetSrid"] = "3857"
+                        }
+                    }
+                }
+            ]
+        };
+
+        // Create + Get: stages survive the JSONB round-trip exactly.
+        await _definitionStore.CreateAsync(definition);
+        var fetched = await _definitionStore.GetAsync(definition.Id);
+
+        Assert.NotNull(fetched);
+        Assert.Equal("GeoJSON to PostGIS", fetched!.Name);
+        Assert.Equal("round-trip fixture", fetched.Description);
+        Assert.Equal(1, fetched.SchemaVersion);
+        Assert.Equal(1, fetched.Version);
+        Assert.Equal(3, fetched.Stages.Count);
+
+        Assert.Equal(PipelineStageKind.Source, fetched.Stages[0].Kind);
+        Assert.Equal("geojson", fetched.Stages[0].Connector!.Type);
+        Assert.Equal("/data/in.geojson", fetched.Stages[0].Connector!.Options["path"]);
+
+        Assert.Equal(PipelineStageKind.Transform, fetched.Stages[1].Kind);
+        Assert.Equal("reproject", fetched.Stages[1].Transform!.Type);
+        Assert.Equal("4326", fetched.Stages[1].Transform!.Options["fromSrid"]);
+        Assert.Equal("3857", fetched.Stages[1].Transform!.Options["toSrid"]);
+
+        Assert.Equal(PipelineStageKind.Sink, fetched.Stages[2].Kind);
+        Assert.Equal("honua-layer", fetched.Stages[2].Connector!.Type);
+        Assert.Equal("out", fetched.Stages[2].Connector!.Options["table"]);
+
+        // List returns the created definition.
+        var listed = await _definitionStore.ListAsync();
+        Assert.Single(listed);
+        Assert.Equal(definition.Id, listed[0].Id);
+
+        // Update bumps the version, preserves CreatedAt, and persists the new stage chain.
+        var updated = await _definitionStore.UpdateAsync(definition with
+        {
+            Name = "renamed",
+            Stages = definition.Stages.Take(2).Append(definition.Stages[^1]).ToArray()
+        });
+        Assert.NotNull(updated);
+        Assert.Equal(2, updated!.Version);
+        Assert.Equal("renamed", updated.Name);
+
+        var afterUpdate = await _definitionStore.GetAsync(definition.Id);
+        Assert.Equal(2, afterUpdate!.Version);
+        Assert.Equal("renamed", afterUpdate.Name);
+
+        // Delete removes it.
+        Assert.True(await _definitionStore.DeleteAsync(definition.Id));
+        Assert.Null(await _definitionStore.GetAsync(definition.Id));
+        Assert.False(await _definitionStore.DeleteAsync(definition.Id));
+    }
+
+    [Fact]
+    public async Task DefinitionStore_DuplicateCreate_Throws()
+    {
+        var definition = new PipelineDefinition
+        {
+            Id = "pl-dup",
+            Name = "dup",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Stages =
+            [
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Source,
+                    Connector = new ConnectorConfig { Type = "geojson" }
+                },
+                new PipelineStage
+                {
+                    Kind = PipelineStageKind.Sink,
+                    Connector = new ConnectorConfig { Type = "null-preview" }
+                }
+            ]
+        };
+
+        await _definitionStore.CreateAsync(definition);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _definitionStore.CreateAsync(definition));
+    }
+
+    [Fact]
+    public async Task ExecutionStore_LifecycleRoundTrip_PersistsTerminalState()
+    {
+        var created = DateTimeOffset.UtcNow;
+        var execution = new PipelineExecution
+        {
+            Id = "geoetl-exec-1",
+            PipelineId = "pl-1",
+            PipelineVersion = 1,
+            ExecutionJobId = "geoetl-exec-1",
+            Status = PipelineExecutionStatus.Pending,
+            IsDryRun = false,
+            BatchId = "geoetl-exec-1",
+            CreatedAt = created
+        };
+
+        await _executionStore.CreateAsync(execution);
+
+        // Running update.
+        await _executionStore.UpdateAsync(execution with { Status = PipelineExecutionStatus.Running });
+
+        // Terminal update with counts.
+        var completedAt = created.AddSeconds(5);
+        await _executionStore.UpdateAsync(execution with
+        {
+            Status = PipelineExecutionStatus.Succeeded,
+            FeaturesRead = 42,
+            FeaturesWritten = 40,
+            FeaturesQuarantined = 2,
+            CompletedAt = completedAt
+        });
+
+        var fetched = await _executionStore.GetAsync(execution.Id);
+        Assert.NotNull(fetched);
+        Assert.Equal(PipelineExecutionStatus.Succeeded, fetched!.Status);
+        Assert.Equal(42, fetched.FeaturesRead);
+        Assert.Equal(40, fetched.FeaturesWritten);
+        Assert.Equal(2, fetched.FeaturesQuarantined);
+        Assert.Equal("geoetl-exec-1", fetched.BatchId);
+        Assert.NotNull(fetched.CompletedAt);
+
+        // ListForPipeline returns newest first.
+        await _executionStore.CreateAsync(execution with
+        {
+            Id = "geoetl-exec-2",
+            ExecutionJobId = "geoetl-exec-2",
+            CreatedAt = created.AddSeconds(10)
+        });
+
+        var listed = await _executionStore.ListForPipelineAsync("pl-1");
+        Assert.Equal(2, listed.Count);
+        Assert.Equal("geoetl-exec-2", listed[0].Id);
+        Assert.Equal("geoetl-exec-1", listed[1].Id);
+    }
+
+    [Fact]
+    public async Task ExecutionStore_UpdateBeforeCreate_Upserts()
+    {
+        // UpdateAsync upserts so a worker resuming after a restart converges on state
+        // even if the create write was lost.
+        var execution = new PipelineExecution
+        {
+            Id = "geoetl-exec-upsert",
+            PipelineId = "pl-2",
+            PipelineVersion = 1,
+            ExecutionJobId = "geoetl-exec-upsert",
+            Status = PipelineExecutionStatus.Running,
+            BatchId = "geoetl-exec-upsert",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        await _executionStore.UpdateAsync(execution);
+
+        var fetched = await _executionStore.GetAsync(execution.Id);
+        Assert.NotNull(fetched);
+        Assert.Equal(PipelineExecutionStatus.Running, fetched!.Status);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/DatabaseFixtureAdapter.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/DatabaseFixtureAdapter.cs
@@ -21,6 +21,14 @@ public sealed class DatabaseFixtureAdapter : IDatabaseFixture
 
     public NpgsqlDataSource DataSource => _postgresFixture.DataSource;
 
+    /// <summary>
+    /// The full connection string (including credentials) for the test database. Exposed
+    /// for tests that need to hand a raw connection string to code under test — for
+    /// example the GeoETL external PostGIS sink, which connects with its own
+    /// caller-supplied connection string rather than the shared data source.
+    /// </summary>
+    public string ConnectionString => _postgresFixture.ConnectionString;
+
     public async Task InitializeAsync()
     {
         await _postgresFixture.InitializeAsync();


### PR DESCRIPTION
## What
The GeoETL capability — "the 20% of FME used 80% of the time" — built server-side on the #681 durable job substrate. All managed, **no GDAL in the serving image**.

- **Sources (5):** geojson, csv, shapefile, geopackage (shapefile via `NetTopologySuite.IO.Esri`, gpkg via `Microsoft.Data.Sqlite` — both already referenced, GDAL-free).
- **Transforms (10):** reproject, attribute-filter, attribute-rename, attribute-cast, computed-field, spatial-filter, clip, spatial-join, dedup. Streaming NTS; row-level errors drop (don't abort) per ADR-0038.
- **Sinks (5):** honua-layer (catalog insert path), null-preview, geojson-file, quarantine (dead-letter), external-postgis.
- Durable Postgres definition/execution stores + migration `033_CreateGeoEtlPipelineCatalog.sql`. `PipelineValidator` fails fast (`SCHEMA_FIELD_UNAVAILABLE`) when a stage needs a field no upstream stage provides.
- On-demand run/dry-run endpoints.

## Tests
38 GeoETL tests pass (incl. Testcontainers store tests run locally).

## Notes / follow-ups
- **Cron scheduling deliberately NOT built** — it needs schedule field + migration + atomic-fire-claim + a distributed background service; half-building ships an unsafe scheduler. Noted as Child Ticket E.
- GDAL-only formats (FileGDB/MapInfo/raster/complex GML) are out of scope here → GDAL worker.
- This branch is the base for the GP-layer-execution PR (which reuses this machinery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
