### PR TITLE
feat(gp): feature-collection / layer-level GP execution + group-aware dissolve & spatial-join

### DIFF
--- a/docs/contributor/geoetl-roadmap.md
+++ b/docs/contributor/geoetl-roadmap.md
@@ -742,6 +742,69 @@ the constraints child-ticket implementers should treat as decided.
    only for that role. Large-scale or complex GML schemas remain in
    Phase 2 / Child Ticket F where GDAL/OGR is available.
 
+## Layer-scope geoprocessing reuses this machinery
+
+A geoprocessing (GP) process over a layer **is** a single-transform ETL
+pipeline, so the GP layer-execution path reuses the parts described above
+rather than reinventing them. This closes the historical honesty gap where
+the GP catalog advertised ~45 processes but only the ~12 single-geometry
+`geometry.*` executors actually ran: those executors operate on a single
+base64-WKB geometry (one geometry in, one out) and cannot run the real
+feature-class / layer workloads ArcPy tools expect.
+
+- **Input layer reference.** A GP invocation accepts a `LayerFeatureReference`
+  that is one of: an inline GeoJSON `FeatureCollection`, a catalog layer id,
+  or a stored query result (`ILayerFeatureSource`). The managed
+  `InlineGeoJsonLayerFeatureSource` wraps the existing `StreamingGeoJsonReader`
+  and runs on the lean serving image with no native/DB dependency; the
+  catalog-layer and query-result kinds are a storage-provider seam mirroring
+  `IFeatureSinkWriter` on the write side.
+- **Per-feature operators.** `GeometryOperationTransform` (an
+  `IPipelineTransform`) lifts the single-geometry NetTopologySuite operators
+  (`buffer`, `simplify`, `convex-hull`, `centroid`, `make-valid`,
+  `difference`) so they apply across a streamed feature collection, carrying
+  attributes through. Reproject and clip already exist as their own transforms
+  and are reused directly.
+- **Output layer / artifact.** The `LayerGeometryJobExecutor` emits a GeoJSON
+  `FeatureCollection` artifact; persistence to a durable Honua layer reuses
+  `HonuaLayerSinkConnector` (the `StreamingFileImportService` insert path),
+  not a new insert path.
+- **Catalog == executable (vector).** `GeoprocessingExecutionRoutingClassifier`
+  is the authoritative routing source. `CatalogExecutableConformanceTests`
+  FAILS if a managed-vector process is advertised but has no executor, or if a
+  routed-to-native process leaks into the managed dispatcher. As of this stream
+  16 vector processes execute (12 single-geometry primitives + 4 layer-scope:
+  `generalization.simplify-layer`, `conversion.feature-project`,
+  `geometry.make-valid`, `geometry.difference`).
+
+### Deferred to the GDAL heavyweight worker (integration tasks)
+
+- **Raster / surface families.** `raster.*`, `surface.*`, and raster-output
+  `conversion.*` processes require GDAL and run on the dedicated native worker
+  (`feat/gdal-heavy-worker`), never in the lean serving image. They are
+  classified `RoutedToNativeWorker` and are honestly **not** executable in this
+  baseline. **Integration task (done when `feat/gdal-heavy-worker` merges):**
+  register the GP raster jobs as `native` runtime-profile jobs and wire them to
+  the GDAL worker queue.
+- **Claim-fence for the GP dispatcher.** There is a known latent issue that the
+  lean `GeoprocessingDispatchJobExecutor` has `AcceptedRuntimeProfiles = null`
+  and could therefore claim `native` jobs intended for the GDAL worker. That
+  `AcceptedRuntimeProfiles` concept lives on `feat/gdal-heavy-worker`, **not**
+  this branch (which was cut from trunk-era job interfaces), and this branch's
+  vector executors register **managed** jobs only — so the fence is not needed
+  here and is intentionally not added. **Integration task (done when
+  `feat/gdal-heavy-worker` merges with this branch and GP raster jobs are
+  registered as `native`):** set
+  `GeoprocessingDispatchJobExecutor.AcceptedRuntimeProfiles` to the managed
+  profile so it cannot claim native jobs.
+- **Group-aware vector aggregation.** `analytics.*` (cluster, spatial-join,
+  buffer-aggregate, density), `generalization.dissolve`, destructive
+  `data-management.*`, and scalar `conversion.geometry-format` are vector-data
+  processes whose group-by / spatial-join / mutation semantics exceed a
+  per-feature transform. They are classified `NotYetExecutable` — inventoried
+  for migration review, not advertised as runnable — and are a follow-on, not a
+  GDAL-worker concern.
+
 ## References
 
 - `honua-io/honua-server#361` — this epic.

--- a/src/Honua.Core/Features/GeoETL/Abstractions/ILayerFeatureSource.cs
+++ b/src/Honua.Core/Features/GeoETL/Abstractions/ILayerFeatureSource.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Abstractions;
+
+/// <summary>
+/// How a layer-scope geoprocessing input is supplied. A GP process invocation
+/// accepts an input layer reference that is one of: an inline GeoJSON
+/// FeatureCollection, a catalog layer id, or a stored query result.
+/// </summary>
+public enum LayerFeatureSourceKind
+{
+    /// <summary>
+    /// The features are supplied inline as a GeoJSON FeatureCollection document.
+    /// </summary>
+    InlineGeoJson,
+
+    /// <summary>
+    /// The features come from a catalog layer identified by id, optionally filtered.
+    /// </summary>
+    CatalogLayer,
+
+    /// <summary>
+    /// The features come from a previously materialized query result.
+    /// </summary>
+    QueryResult
+}
+
+/// <summary>
+/// A reference to the input feature collection a layer-scope GP process operates on.
+/// Exactly one of <see cref="InlineGeoJson"/> / <see cref="LayerId"/> /
+/// <see cref="QueryResultId"/> is populated according to <see cref="Kind"/>.
+/// </summary>
+public sealed record LayerFeatureReference
+{
+    /// <summary>
+    /// Discriminator selecting which member carries the reference.
+    /// </summary>
+    public required LayerFeatureSourceKind Kind { get; init; }
+
+    /// <summary>
+    /// Inline GeoJSON FeatureCollection document (for <see cref="LayerFeatureSourceKind.InlineGeoJson"/>).
+    /// </summary>
+    public string? InlineGeoJson { get; init; }
+
+    /// <summary>
+    /// Catalog layer identifier (for <see cref="LayerFeatureSourceKind.CatalogLayer"/>).
+    /// </summary>
+    public string? LayerId { get; init; }
+
+    /// <summary>
+    /// Stored query-result identifier (for <see cref="LayerFeatureSourceKind.QueryResult"/>).
+    /// </summary>
+    public string? QueryResultId { get; init; }
+
+    /// <summary>
+    /// Optional ArcGIS-style SQL filter applied to a catalog layer or query result.
+    /// </summary>
+    public string? Where { get; init; }
+}
+
+/// <summary>
+/// Resolves a <see cref="LayerFeatureReference"/> into a streaming feature set so a
+/// layer-scope geoprocessing process can apply a geometry operation across the
+/// features and emit an output layer / artifact. This is the read-side reuse seam
+/// that mirrors <see cref="IFeatureSinkWriter"/> on the write side: the inline-GeoJSON
+/// case is fully managed and lives in Honua.Core, while the catalog-layer and
+/// query-result cases are provided by a storage provider (Honua.Postgres) so
+/// Honua.Core stays free of Npgsql and the serving image stays on the lean path.
+/// </summary>
+public interface ILayerFeatureSource
+{
+    /// <summary>
+    /// Whether this source can resolve the supplied reference kind.
+    /// </summary>
+    /// <param name="kind">Reference kind to test.</param>
+    bool CanResolve(LayerFeatureSourceKind kind);
+
+    /// <summary>
+    /// Streams the features identified by <paramref name="reference"/> one at a time.
+    /// </summary>
+    /// <param name="reference">The input layer reference.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>The resolved feature stream.</returns>
+    IAsyncEnumerable<IFeature> ReadAsync(
+        LayerFeatureReference reference,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Connectors/InlineGeoJsonLayerFeatureSource.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Connectors/InlineGeoJsonLayerFeatureSource.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.Import.Services;
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Features.GeoETL.Services.Connectors;
+
+/// <summary>
+/// Managed <see cref="ILayerFeatureSource"/> for the inline-GeoJSON input case.
+/// Wraps the existing <see cref="StreamingGeoJsonReader"/> — it does not
+/// reimplement GeoJSON parsing — so a layer-scope GP process can accept an inline
+/// FeatureCollection without any storage provider. The reader streams features one
+/// at a time so the source keeps constant memory.
+/// </summary>
+/// <remarks>
+/// The catalog-layer-id and query-result reference kinds are resolved by a storage
+/// provider implementation (Honua.Postgres); this managed source intentionally
+/// handles only <see cref="LayerFeatureSourceKind.InlineGeoJson"/> so the lean
+/// serving image can run the inline path with no native or database dependency.
+/// </remarks>
+public sealed class InlineGeoJsonLayerFeatureSource : ILayerFeatureSource
+{
+    /// <inheritdoc />
+    public bool CanResolve(LayerFeatureSourceKind kind)
+        => kind == LayerFeatureSourceKind.InlineGeoJson;
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> ReadAsync(
+        LayerFeatureReference reference,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+
+        if (reference.Kind != LayerFeatureSourceKind.InlineGeoJson)
+        {
+            throw new InvalidOperationException(
+                $"InlineGeoJsonLayerFeatureSource cannot resolve reference kind '{reference.Kind}'. " +
+                "Catalog-layer and query-result references require a storage-provider source.");
+        }
+
+        if (string.IsNullOrWhiteSpace(reference.InlineGeoJson))
+        {
+            throw new InvalidOperationException(
+                "Inline-GeoJSON layer reference requires a non-empty FeatureCollection document.");
+        }
+
+        var reader = new StreamingGeoJsonReader();
+        await using var stream = new MemoryStream(
+            Encoding.UTF8.GetBytes(reference.InlineGeoJson), writable: false);
+
+        await foreach (var feature in reader.ReadFeaturesAsync(stream, cancellationToken).ConfigureAwait(false))
+        {
+            yield return feature;
+        }
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Transforms/DissolveTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Transforms/DissolveTransform.cs
@@ -1,0 +1,372 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+using NetTopologySuite.Operation.Union;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Core.Features.GeoETL.Services.Transforms;
+
+/// <summary>
+/// Group-aware dissolve transform — the managed, layer-scope counterpart of the
+/// ArcGIS <c>Dissolve_management</c> tool. Buffers the streamed input by group
+/// key (one or more attribute fields, or a single "dissolve-all" bucket when no
+/// field is supplied), unions each group's geometries with NetTopologySuite
+/// <see cref="UnaryUnionOp"/>, and emits ONE feature per group whose attributes
+/// carry the group-by field values plus optional summary statistics.
+/// </summary>
+/// <remarks>
+/// Unlike the per-feature <see cref="GeometryOperationTransform"/>, dissolve is an
+/// inherently buffering (group-by) operation: it materializes the whole input
+/// before producing output. That is acceptable because layer-scope dissolve runs
+/// as a batch JOB on the durable substrate, not a per-request call. Pure managed
+/// NetTopologySuite — no GEOS/GDAL native dependency.
+///
+/// Options:
+/// <list type="bullet">
+/// <item><c>groupByFields</c> — comma-separated attribute field names. When empty
+/// or omitted, every input feature collapses into a single group ("dissolve all"),
+/// matching <c>Dissolve_management</c> with no dissolve field.</item>
+/// <item><c>statistics</c> — optional summary specification, a semicolon-separated
+/// list of <c>field:stat</c> pairs. Supported stats: <c>count</c> (field ignored;
+/// emitted once per group as <c>COUNT</c>), <c>sum</c>, <c>mean</c>, <c>min</c>,
+/// <c>max</c> (numeric fields), and <c>first</c> (the first encountered value of a
+/// field). Output attribute names follow the ArcGIS convention <c>STAT_field</c>
+/// (e.g. <c>SUM_pop</c>, <c>MEAN_area</c>), with the bare group COUNT emitted as
+/// <c>COUNT</c>.</item>
+/// </list>
+/// A group whose unioned geometry is empty is dropped, matching the overlay
+/// transforms and PostGIS semantics.
+/// </remarks>
+public sealed class DissolveTransform : IPipelineTransform
+{
+    /// <summary>
+    /// The transform type discriminator.
+    /// </summary>
+    public const string TransformType = "dissolve";
+
+    private const string DefaultGroupKey = "__all__";
+
+    // Unit-separator control char between group-key parts so distinct field
+    // boundaries never collide (matching DedupTransform's key composition).
+    private const char Separator = '\u001F';
+    private const char NullMarker = '\u00A0';
+
+    /// <inheritdoc />
+    public string Type => TransformType;
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> TransformAsync(
+        TransformConfig config,
+        IAsyncEnumerable<IFeature> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(source);
+
+        var groupByFields = ReadGroupByFields(config);
+        var stats = ReadStatistics(config);
+
+        // Group-by requires buffering; preserve first-seen order so the output is
+        // deterministic for tests and downstream consumers.
+        var groups = new Dictionary<string, GroupAccumulator>(StringComparer.Ordinal);
+        var orderedKeys = new List<string>();
+
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var geometry = feature.Geometry;
+            if (geometry is null || geometry.IsEmpty)
+            {
+                continue;
+            }
+
+            var key = BuildGroupKey(feature, groupByFields);
+            if (!groups.TryGetValue(key, out var accumulator))
+            {
+                accumulator = new GroupAccumulator(groupByFields.Length);
+                groups[key] = accumulator;
+                orderedKeys.Add(key);
+            }
+
+            accumulator.Add(feature, groupByFields, stats);
+        }
+
+        foreach (var key in orderedKeys)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var accumulator = groups[key];
+            var unioned = UnaryUnionOp.Union(accumulator.Geometries);
+            if (unioned is null || unioned.IsEmpty)
+            {
+                continue;
+            }
+
+            // Carry the SRID of the first geometry in the group (all features in a
+            // layer share one CRS).
+            unioned.SRID = accumulator.Srid;
+
+            var attributes = new AttributesTable();
+
+            // Group-by field values identify the group.
+            for (var i = 0; i < groupByFields.Length; i++)
+            {
+                attributes.Add(groupByFields[i], accumulator.GroupValues[i]);
+            }
+
+            // Summary statistics. The bare per-group COUNT is always available and
+            // emitted as "COUNT" when requested; field-scoped stats use the ArcGIS
+            // STAT_field naming convention.
+            foreach (var spec in stats)
+            {
+                var (name, value) = accumulator.Resolve(spec);
+                if (attributes.Exists(name))
+                {
+                    attributes[name] = value;
+                }
+                else
+                {
+                    attributes.Add(name, value);
+                }
+            }
+
+            yield return new Feature(unioned, attributes);
+        }
+    }
+
+    private static string[] ReadGroupByFields(TransformConfig config)
+    {
+        if (config.Options.TryGetValue("groupByFields", out var raw) && !string.IsNullOrWhiteSpace(raw))
+        {
+            return raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        }
+
+        return [];
+    }
+
+    private static List<StatSpec> ReadStatistics(TransformConfig config)
+    {
+        if (!config.Options.TryGetValue("statistics", out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return [];
+        }
+
+        var specs = new List<StatSpec>();
+        foreach (var token in raw.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var parts = token.Split(':', StringSplitOptions.TrimEntries);
+            var statName = (parts.Length >= 2 ? parts[1] : parts[0]).ToLowerInvariant();
+            var field = parts.Length >= 2 ? parts[0] : string.Empty;
+
+            var kind = statName switch
+            {
+                "count" => StatKind.Count,
+                "sum" => StatKind.Sum,
+                "mean" or "avg" or "average" => StatKind.Mean,
+                "min" => StatKind.Min,
+                "max" => StatKind.Max,
+                "first" => StatKind.First,
+                _ => throw new InvalidOperationException(
+                    $"Dissolve transform does not support statistic '{statName}'. " +
+                    "Supported: count, sum, mean, min, max, first.")
+            };
+
+            if (kind != StatKind.Count && string.IsNullOrWhiteSpace(field))
+            {
+                throw new InvalidOperationException(
+                    $"Dissolve statistic '{statName}' requires a field, e.g. 'fieldName:{statName}'.");
+            }
+
+            specs.Add(new StatSpec(kind, field, OutputName(kind, field)));
+        }
+
+        return specs;
+    }
+
+    private static string OutputName(StatKind kind, string field) => kind switch
+    {
+        StatKind.Count => "COUNT",
+        StatKind.Sum => "SUM_" + field,
+        StatKind.Mean => "MEAN_" + field,
+        StatKind.Min => "MIN_" + field,
+        StatKind.Max => "MAX_" + field,
+        StatKind.First => "FIRST_" + field,
+        _ => field
+    };
+
+    private static string BuildGroupKey(IFeature feature, string[] groupByFields)
+    {
+        if (groupByFields.Length == 0)
+        {
+            return DefaultGroupKey;
+        }
+
+        var builder = new StringBuilder();
+        var attributes = feature.Attributes;
+        foreach (var field in groupByFields)
+        {
+            var value = attributes is not null && attributes.Exists(field)
+                ? Convert.ToString(attributes.GetOptionalValue(field), CultureInfo.InvariantCulture)
+                : null;
+            builder.Append(value ?? NullMarker.ToString());
+            builder.Append(Separator);
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool TryReadNumeric(IFeature feature, string field, out double value)
+    {
+        value = 0;
+        var attributes = feature.Attributes;
+        if (attributes is null || !attributes.Exists(field))
+        {
+            return false;
+        }
+
+        var raw = attributes.GetOptionalValue(field);
+        switch (raw)
+        {
+            case null:
+                return false;
+            case double d:
+                value = d;
+                return true;
+            case float f:
+                value = f;
+                return true;
+            case int i:
+                value = i;
+                return true;
+            case long l:
+                value = l;
+                return true;
+            case short s:
+                value = s;
+                return true;
+            case decimal m:
+                value = (double)m;
+                return true;
+            default:
+                return double.TryParse(
+                    Convert.ToString(raw, CultureInfo.InvariantCulture),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out value);
+        }
+    }
+
+    private enum StatKind
+    {
+        Count,
+        Sum,
+        Mean,
+        Min,
+        Max,
+        First
+    }
+
+    private readonly record struct StatSpec(StatKind Kind, string Field, string OutputName);
+
+    private sealed class GroupAccumulator
+    {
+        private readonly Dictionary<string, double> _sums = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, double> _mins = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, double> _maxs = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, long> _counts = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, object?> _firsts = new(StringComparer.Ordinal);
+
+        public GroupAccumulator(int groupFieldCount)
+        {
+            GroupValues = new object?[groupFieldCount];
+        }
+
+        public List<NtsGeometry> Geometries { get; } = new();
+
+        public object?[] GroupValues { get; }
+
+        public int Srid { get; private set; }
+
+        public long FeatureCount { get; private set; }
+
+        public void Add(IFeature feature, string[] groupByFields, IReadOnlyList<StatSpec> stats)
+        {
+            if (FeatureCount == 0)
+            {
+                Srid = feature.Geometry!.SRID;
+                for (var i = 0; i < groupByFields.Length; i++)
+                {
+                    GroupValues[i] = feature.Attributes is not null && feature.Attributes.Exists(groupByFields[i])
+                        ? feature.Attributes.GetOptionalValue(groupByFields[i])
+                        : null;
+                }
+            }
+
+            Geometries.Add(feature.Geometry!);
+            FeatureCount++;
+
+            // Accumulate each distinct field at most once per feature even when
+            // several specs reference the same field (e.g. pop:sum + pop:mean),
+            // so the running sum/min/max are not multiplied by the spec count.
+            var numericSeen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var spec in stats)
+            {
+                switch (spec.Kind)
+                {
+                    case StatKind.Count:
+                        break; // FeatureCount covers it.
+                    case StatKind.First:
+                        if (!_firsts.ContainsKey(spec.Field))
+                        {
+                            _firsts[spec.Field] = feature.Attributes is not null && feature.Attributes.Exists(spec.Field)
+                                ? feature.Attributes.GetOptionalValue(spec.Field)
+                                : null;
+                        }
+
+                        break;
+                    default:
+                        if (numericSeen.Add(spec.Field) && TryReadNumeric(feature, spec.Field, out var numeric))
+                        {
+                            _sums[spec.Field] = _sums.GetValueOrDefault(spec.Field) + numeric;
+                            _counts[spec.Field] = _counts.GetValueOrDefault(spec.Field) + 1;
+                            _mins[spec.Field] = _mins.TryGetValue(spec.Field, out var min) ? Math.Min(min, numeric) : numeric;
+                            _maxs[spec.Field] = _maxs.TryGetValue(spec.Field, out var max) ? Math.Max(max, numeric) : numeric;
+                        }
+
+                        break;
+                }
+            }
+        }
+
+        public (string Name, object? Value) Resolve(StatSpec spec)
+        {
+            switch (spec.Kind)
+            {
+                case StatKind.Count:
+                    return (spec.OutputName, FeatureCount);
+                case StatKind.Sum:
+                    return (spec.OutputName, _sums.TryGetValue(spec.Field, out var sum) ? sum : null);
+                case StatKind.Mean:
+                    return (spec.OutputName,
+                        _counts.TryGetValue(spec.Field, out var c) && c > 0
+                            ? _sums[spec.Field] / c
+                            : null);
+                case StatKind.Min:
+                    return (spec.OutputName, _mins.TryGetValue(spec.Field, out var min) ? min : null);
+                case StatKind.Max:
+                    return (spec.OutputName, _maxs.TryGetValue(spec.Field, out var max) ? max : null);
+                case StatKind.First:
+                    return (spec.OutputName, _firsts.GetValueOrDefault(spec.Field));
+                default:
+                    return (spec.OutputName, null);
+            }
+        }
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Transforms/GeometryOperationTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Transforms/GeometryOperationTransform.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Core.Features.GeoETL.Services.Transforms;
+
+/// <summary>
+/// Phase 1 per-feature geometry transform. Lifts the single-geometry
+/// NetTopologySuite operators the geoprocessing <c>geometry.*</c> executors use
+/// (buffer, simplify, convex hull, centroid, make-valid, difference against a
+/// fixed region) so they run across a streamed feature collection. Each input
+/// feature's geometry is rewritten in place; attributes are carried through
+/// unchanged so the operation behaves like a layer-scope geoprocessing tool
+/// (one feature in, one feature out) rather than a single-WKB primitive.
+/// </summary>
+/// <remarks>
+/// This is the reuse boundary called out in the GP layer-execution roadmap:
+/// "a GP process over a layer == a single-transform ETL pipeline". The lean
+/// managed reproject and clip operators already exist as their own transforms
+/// (<see cref="ReprojectTransform"/>, <see cref="ClipTransform"/>); this
+/// transform covers the remaining shape operators that previously only ran on a
+/// single base64-WKB geometry. Pure managed NetTopologySuite — no GEOS/GDAL
+/// native dependency. Streaming and constant-memory.
+///
+/// Required <see cref="TransformConfig.Options"/>:
+/// <list type="bullet">
+/// <item><c>op</c> — one of <c>buffer</c>, <c>simplify</c>, <c>convex-hull</c>,
+/// <c>centroid</c>, <c>make-valid</c>, <c>difference</c>.</item>
+/// </list>
+/// Operator-specific options:
+/// <list type="bullet">
+/// <item><c>buffer</c>: <c>distance</c> (required, finite double, CRS units).</item>
+/// <item><c>simplify</c>: <c>tolerance</c> (required, &gt; 0); optional
+/// <c>preserveTopology</c> (default true).</item>
+/// <item><c>difference</c>: <c>regionWkt</c> (required) — the eraser geometry as WKT.</item>
+/// </list>
+/// A feature whose result geometry is empty is dropped, matching the clip /
+/// spatial-filter transforms and PostGIS overlay semantics.
+/// </remarks>
+public sealed class GeometryOperationTransform : IPipelineTransform
+{
+    /// <summary>
+    /// The transform type discriminator.
+    /// </summary>
+    public const string TransformType = "geometry-op";
+
+    /// <inheritdoc />
+    public string Type => TransformType;
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<IFeature> TransformAsync(
+        TransformConfig config,
+        IAsyncEnumerable<IFeature> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(source);
+
+        var op = ReadOperation(config);
+
+        await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var geometry = feature.Geometry;
+            if (geometry is null || geometry.IsEmpty)
+            {
+                continue;
+            }
+
+            NtsGeometry result;
+            try
+            {
+                result = op(geometry);
+            }
+            catch (Exception ex) when (ex is NetTopologySuite.Geometries.TopologyException)
+            {
+                // Row-level geometry error: drop the row rather than aborting the
+                // whole run (ADR-0038), matching the clip transform.
+                continue;
+            }
+
+            if (result is null || result.IsEmpty)
+            {
+                continue;
+            }
+
+            result.SRID = geometry.SRID;
+            yield return new Feature(result, feature.Attributes);
+        }
+    }
+
+    private static Func<NtsGeometry, NtsGeometry> ReadOperation(TransformConfig config)
+    {
+        if (!config.Options.TryGetValue("op", out var op) || string.IsNullOrWhiteSpace(op))
+        {
+            throw new InvalidOperationException(
+                "Geometry-op transform requires an 'op' option " +
+                "(buffer|simplify|convex-hull|centroid|make-valid|difference).");
+        }
+
+        switch (op.Trim().ToLowerInvariant())
+        {
+            case "buffer":
+            {
+                var distance = ReadDouble(config, "distance", requirePositive: false);
+                return g => g.Buffer(distance);
+            }
+
+            case "simplify":
+            {
+                var tolerance = ReadDouble(config, "tolerance", requirePositive: true);
+                var preserveTopology = ReadBool(config, "preserveTopology", defaultValue: true);
+                return g => preserveTopology
+                    ? NetTopologySuite.Simplify.TopologyPreservingSimplifier.Simplify(g, tolerance)
+                    : NetTopologySuite.Simplify.DouglasPeuckerSimplifier.Simplify(g, tolerance);
+            }
+
+            case "convex-hull":
+                return g => g.ConvexHull();
+
+            case "centroid":
+                return g => g.Centroid;
+
+            case "make-valid":
+                // GeometryFixer is the managed NTS equivalent of ST_MakeValid:
+                // it repairs self-intersections, duplicate vertices, and ring
+                // orientation without a PostGIS round-trip.
+                return g => NetTopologySuite.Geometries.Utilities.GeometryFixer.Fix(g);
+
+            case "difference":
+            {
+                var region = ReadRegion(config);
+                return g => g.Difference(region);
+            }
+
+            default:
+                throw new InvalidOperationException(
+                    $"Geometry-op transform does not support op '{op}'. " +
+                    "Supported: buffer, simplify, convex-hull, centroid, make-valid, difference.");
+        }
+    }
+
+    private static NtsGeometry ReadRegion(TransformConfig config)
+    {
+        if (!config.Options.TryGetValue("regionWkt", out var wkt) || string.IsNullOrWhiteSpace(wkt))
+        {
+            throw new InvalidOperationException(
+                "Geometry-op 'difference' requires a 'regionWkt' option (the eraser geometry as WKT).");
+        }
+
+        return new WKTReader().Read(wkt);
+    }
+
+    private static double ReadDouble(TransformConfig config, string key, bool requirePositive)
+    {
+        if (!config.Options.TryGetValue(key, out var raw) ||
+            !double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var value) ||
+            double.IsNaN(value) || double.IsInfinity(value) ||
+            (requirePositive && value <= 0))
+        {
+            throw new InvalidOperationException(
+                requirePositive
+                    ? $"Geometry-op transform requires a positive finite '{key}' option."
+                    : $"Geometry-op transform requires a finite '{key}' option.");
+        }
+
+        return value;
+    }
+
+    private static bool ReadBool(TransformConfig config, string key, bool defaultValue)
+    {
+        if (!config.Options.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return defaultValue;
+        }
+
+        return bool.TryParse(raw, out var parsed) ? parsed : defaultValue;
+    }
+}

--- a/src/Honua.Core/Features/GeoETL/Services/Transforms/SpatialJoinTransform.cs
+++ b/src/Honua.Core/Features/GeoETL/Services/Transforms/SpatialJoinTransform.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Honua.Core.Features.GeoETL.Abstractions;
@@ -13,27 +14,40 @@ using NtsGeometry = NetTopologySuite.Geometries.Geometry;
 namespace Honua.Core.Features.GeoETL.Services.Transforms;
 
 /// <summary>
-/// Phase 1 spatial-join enrichment transform. For each streaming feature, finds the first
-/// reference feature whose geometry intersects (or contains, for point-in-polygon) and
-/// copies selected reference attributes onto the feature. The reference set is a GeoJSON
-/// FeatureCollection loaded once into an in-memory <see cref="STRtree{T}"/> spatial index.
-/// Pure managed NetTopologySuite — no GEOS native dependency. The streamed (left) side
-/// stays constant-memory; only the reference (right) side is materialized, which suits the
-/// "small lookup polygons, large feature stream" enrichment shape (ADR-0038 delegates
-/// large spatial joins to PostGIS).
+/// Spatial-join transform. For each streamed (target) feature it queries the
+/// reference (join) layer through an in-memory <see cref="STRtree{T}"/> spatial
+/// index and either transfers attributes from the first match (the enrichment
+/// mode, default) or — in AGGREGATE mode — summarizes EVERY matched join feature
+/// into per-target statistics (the ArcGIS <c>SpatialJoin_analysis</c>
+/// one-to-one summarizing form). Pure managed NetTopologySuite — no GEOS native
+/// dependency. The streamed (left) side stays constant-memory; only the reference
+/// (right) side is materialized, which suits the "small lookup polygons, large
+/// feature stream" shape (ADR-0038 delegates large spatial joins to PostGIS).
 /// </summary>
 /// <remarks>
 /// Reference set (one required): <c>referenceInline</c> (a GeoJSON FeatureCollection
-/// document) or <c>referencePath</c> (a GeoJSON file path). Optional:
+/// document) or <c>referencePath</c> (a GeoJSON file path). Predicate:
 /// <list type="bullet">
-/// <item><c>predicate</c> — <c>intersects</c> (default) or <c>contains</c> (the reference
-/// geometry must contain the feature, the point-in-polygon case).</item>
-/// <item><c>transfer</c> — comma-separated reference attribute names to copy; when omitted
-/// all reference attributes are copied.</item>
-/// <item><c>prefix</c> — prepended to each transferred attribute name to avoid collisions.
-/// </item>
-/// <item><c>keepUnmatched</c> — <c>true</c> (default) passes unmatched features through
-/// unchanged; <c>false</c> drops them (inner join).</item>
+/// <item><c>predicate</c> — <c>intersects</c> (default), <c>contains</c> (the
+/// reference geometry must contain the feature, the point-in-polygon case), or
+/// <c>within</c> (the feature must contain the reference geometry).</item>
+/// </list>
+/// Enrichment mode (default) options:
+/// <list type="bullet">
+/// <item><c>transfer</c> — comma-separated reference attribute names to copy; when
+/// omitted all reference attributes are copied.</item>
+/// <item><c>prefix</c> — prepended to each transferred attribute name to avoid
+/// collisions.</item>
+/// <item><c>keepUnmatched</c> — <c>true</c> (default) passes unmatched features
+/// through unchanged; <c>false</c> drops them (inner join).</item>
+/// </list>
+/// Aggregate mode (set <c>aggregate=true</c>):
+/// <list type="bullet">
+/// <item><c>statistics</c> — semicolon-separated <c>field:stat</c> pairs over the
+/// matched JOIN features. Supported: <c>count</c> (emitted as <c>JOIN_COUNT</c>),
+/// <c>sum</c>, <c>mean</c>, <c>min</c>, <c>max</c> on numeric join fields, named
+/// <c>STAT_field</c>. A target with zero matches keeps a <c>JOIN_COUNT</c> of 0
+/// and null aggregates — emitted one-to-one (every target is preserved).</item>
 /// </list>
 /// </remarks>
 public sealed class SpatialJoinTransform : IPipelineTransform
@@ -55,8 +69,26 @@ public sealed class SpatialJoinTransform : IPipelineTransform
         ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(source);
 
-        var contains = config.Options.TryGetValue("predicate", out var predicate)
-            && string.Equals(predicate, "contains", StringComparison.OrdinalIgnoreCase);
+        var predicate = ReadPredicate(config);
+        var aggregate = config.Options.TryGetValue("aggregate", out var rawAggregate)
+            && bool.TryParse(rawAggregate, out var parsedAggregate) && parsedAggregate;
+
+        var index = await BuildIndexAsync(config, cancellationToken).ConfigureAwait(false);
+
+        if (aggregate)
+        {
+            var stats = ReadStatistics(config);
+            await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                // One-to-one: every target is preserved with its match summary,
+                // even when zero join features match (JOIN_COUNT = 0).
+                yield return Summarize(feature, index, predicate, stats);
+            }
+
+            yield break;
+        }
+
         var prefix = config.Options.TryGetValue("prefix", out var rawPrefix) ? rawPrefix : string.Empty;
         var keepUnmatched = !config.Options.TryGetValue("keepUnmatched", out var rawKeep)
             || !bool.TryParse(rawKeep, out var keep) || keep;
@@ -64,8 +96,6 @@ public sealed class SpatialJoinTransform : IPipelineTransform
             && !string.IsNullOrWhiteSpace(rawTransfer)
             ? rawTransfer.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             : null;
-
-        var index = await BuildIndexAsync(config, cancellationToken).ConfigureAwait(false);
 
         await foreach (var feature in source.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
@@ -82,7 +112,7 @@ public sealed class SpatialJoinTransform : IPipelineTransform
                 continue;
             }
 
-            var match = FindMatch(index, geometry, contains);
+            var match = FindFirstMatch(index, geometry, predicate);
             if (match is null)
             {
                 if (keepUnmatched)
@@ -94,6 +124,62 @@ public sealed class SpatialJoinTransform : IPipelineTransform
             }
 
             yield return Enrich(feature, match.Attributes, transfer, prefix);
+        }
+    }
+
+    private static Feature Summarize(
+        IFeature target,
+        STRtree<IFeature> index,
+        SpatialPredicate predicate,
+        IReadOnlyList<StatSpec> stats)
+    {
+        var merged = new AttributesTable();
+        if (target.Attributes is not null)
+        {
+            foreach (var name in target.Attributes.GetNames())
+            {
+                merged.Add(name, target.Attributes.GetOptionalValue(name));
+            }
+        }
+
+        var accumulator = new StatAccumulator(stats);
+        var geometry = target.Geometry;
+        if (geometry is not null && !geometry.IsEmpty)
+        {
+            foreach (var candidate in index.Query(geometry.EnvelopeInternal))
+            {
+                if (Matches(candidate.Geometry, geometry, predicate))
+                {
+                    accumulator.Add(candidate);
+                }
+            }
+        }
+
+        // JOIN_COUNT is always emitted so a zero-match target is distinguishable.
+        Upsert(merged, "JOIN_COUNT", accumulator.Count);
+        foreach (var spec in stats)
+        {
+            if (spec.Kind == StatKind.Count)
+            {
+                continue; // JOIN_COUNT already covers the match count.
+            }
+
+            var (name, value) = accumulator.Resolve(spec);
+            Upsert(merged, name, value);
+        }
+
+        return new Feature(target.Geometry, merged);
+    }
+
+    private static void Upsert(AttributesTable table, string name, object? value)
+    {
+        if (table.Exists(name))
+        {
+            table[name] = value;
+        }
+        else
+        {
+            table.Add(name, value);
         }
     }
 
@@ -137,27 +223,217 @@ public sealed class SpatialJoinTransform : IPipelineTransform
         return new Feature(feature.Geometry, merged);
     }
 
-    private static IFeature? FindMatch(STRtree<IFeature> index, NtsGeometry geometry, bool contains)
+    private static IFeature? FindFirstMatch(STRtree<IFeature> index, NtsGeometry geometry, SpatialPredicate predicate)
     {
         var candidates = index.Query(geometry.EnvelopeInternal);
         foreach (var candidate in candidates)
         {
-            var referenceGeometry = candidate.Geometry;
-            if (referenceGeometry is null)
-            {
-                continue;
-            }
-
-            var matched = contains
-                ? referenceGeometry.Contains(geometry)
-                : referenceGeometry.Intersects(geometry);
-            if (matched)
+            if (Matches(candidate.Geometry, geometry, predicate))
             {
                 return candidate;
             }
         }
 
         return null;
+    }
+
+    private static bool Matches(NtsGeometry? referenceGeometry, NtsGeometry targetGeometry, SpatialPredicate predicate)
+    {
+        if (referenceGeometry is null)
+        {
+            return false;
+        }
+
+        return predicate switch
+        {
+            // contains: the reference (join) geometry contains the target —
+            // the classic point-in-polygon case.
+            SpatialPredicate.Contains => referenceGeometry.Contains(targetGeometry),
+            // within: the target contains the reference geometry.
+            SpatialPredicate.Within => targetGeometry.Contains(referenceGeometry),
+            _ => referenceGeometry.Intersects(targetGeometry),
+        };
+    }
+
+    private static SpatialPredicate ReadPredicate(TransformConfig config)
+    {
+        if (!config.Options.TryGetValue("predicate", out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return SpatialPredicate.Intersects;
+        }
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "intersects" => SpatialPredicate.Intersects,
+            "contains" => SpatialPredicate.Contains,
+            "within" => SpatialPredicate.Within,
+            _ => throw new InvalidOperationException(
+                $"Spatial-join transform does not support predicate '{raw}'. " +
+                "Supported: intersects, contains, within."),
+        };
+    }
+
+    private static List<StatSpec> ReadStatistics(TransformConfig config)
+    {
+        if (!config.Options.TryGetValue("statistics", out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return [];
+        }
+
+        var specs = new List<StatSpec>();
+        foreach (var token in raw.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var parts = token.Split(':', StringSplitOptions.TrimEntries);
+            var statName = (parts.Length >= 2 ? parts[1] : parts[0]).ToLowerInvariant();
+            var field = parts.Length >= 2 ? parts[0] : string.Empty;
+
+            var kind = statName switch
+            {
+                "count" => StatKind.Count,
+                "sum" => StatKind.Sum,
+                "mean" or "avg" or "average" => StatKind.Mean,
+                "min" => StatKind.Min,
+                "max" => StatKind.Max,
+                _ => throw new InvalidOperationException(
+                    $"Spatial-join aggregate does not support statistic '{statName}'. " +
+                    "Supported: count, sum, mean, min, max."),
+            };
+
+            if (kind != StatKind.Count && string.IsNullOrWhiteSpace(field))
+            {
+                throw new InvalidOperationException(
+                    $"Spatial-join statistic '{statName}' requires a join field, e.g. 'fieldName:{statName}'.");
+            }
+
+            specs.Add(new StatSpec(kind, field, OutputName(kind, field)));
+        }
+
+        return specs;
+    }
+
+    private static string OutputName(StatKind kind, string field) => kind switch
+    {
+        StatKind.Count => "JOIN_COUNT",
+        StatKind.Sum => "SUM_" + field,
+        StatKind.Mean => "MEAN_" + field,
+        StatKind.Min => "MIN_" + field,
+        StatKind.Max => "MAX_" + field,
+        _ => field,
+    };
+
+    private static bool TryReadNumeric(IFeature feature, string field, out double value)
+    {
+        value = 0;
+        var attributes = feature.Attributes;
+        if (attributes is null || !attributes.Exists(field))
+        {
+            return false;
+        }
+
+        var raw = attributes.GetOptionalValue(field);
+        switch (raw)
+        {
+            case null:
+                return false;
+            case double d:
+                value = d;
+                return true;
+            case float f:
+                value = f;
+                return true;
+            case int i:
+                value = i;
+                return true;
+            case long l:
+                value = l;
+                return true;
+            case short s:
+                value = s;
+                return true;
+            case decimal m:
+                value = (double)m;
+                return true;
+            default:
+                return double.TryParse(
+                    Convert.ToString(raw, CultureInfo.InvariantCulture),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out value);
+        }
+    }
+
+    private enum SpatialPredicate
+    {
+        Intersects,
+        Contains,
+        Within,
+    }
+
+    private enum StatKind
+    {
+        Count,
+        Sum,
+        Mean,
+        Min,
+        Max,
+    }
+
+    private readonly record struct StatSpec(StatKind Kind, string Field, string OutputName);
+
+    private sealed class StatAccumulator
+    {
+        private readonly Dictionary<string, double> _sums = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, double> _mins = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, double> _maxs = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, long> _counts = new(StringComparer.Ordinal);
+        private readonly HashSet<string> _fields;
+
+        public StatAccumulator(IReadOnlyList<StatSpec> stats)
+        {
+            _fields = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var spec in stats)
+            {
+                if (spec.Kind != StatKind.Count && !string.IsNullOrWhiteSpace(spec.Field))
+                {
+                    _fields.Add(spec.Field);
+                }
+            }
+        }
+
+        public long Count { get; private set; }
+
+        public void Add(IFeature joinFeature)
+        {
+            Count++;
+            foreach (var field in _fields)
+            {
+                if (TryReadNumeric(joinFeature, field, out var numeric))
+                {
+                    _sums[field] = _sums.GetValueOrDefault(field) + numeric;
+                    _counts[field] = _counts.GetValueOrDefault(field) + 1;
+                    _mins[field] = _mins.TryGetValue(field, out var min) ? Math.Min(min, numeric) : numeric;
+                    _maxs[field] = _maxs.TryGetValue(field, out var max) ? Math.Max(max, numeric) : numeric;
+                }
+            }
+        }
+
+        public (string Name, object? Value) Resolve(StatSpec spec)
+        {
+            switch (spec.Kind)
+            {
+                case StatKind.Sum:
+                    return (spec.OutputName, _sums.TryGetValue(spec.Field, out var sum) ? sum : null);
+                case StatKind.Mean:
+                    return (spec.OutputName,
+                        _counts.TryGetValue(spec.Field, out var c) && c > 0 ? _sums[spec.Field] / c : null);
+                case StatKind.Min:
+                    return (spec.OutputName, _mins.TryGetValue(spec.Field, out var min) ? min : null);
+                case StatKind.Max:
+                    return (spec.OutputName, _maxs.TryGetValue(spec.Field, out var max) ? max : null);
+                default:
+                    return (spec.OutputName, Count);
+            }
+        }
     }
 
     private static async Task<STRtree<IFeature>> BuildIndexAsync(

--- a/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
@@ -41,6 +41,13 @@ internal static class GeoEtlServiceCollectionExtensions
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IPipelineSourceConnector, CsvSourceConnector>());
 
+        // Managed layer-scope GP input source (inline GeoJSON FeatureCollection).
+        // Catalog-layer / query-result reference kinds are resolved by a storage
+        // provider implementation when present; the inline source always runs on
+        // the lean serving image with no native or database dependency.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<ILayerFeatureSource, InlineGeoJsonLayerFeatureSource>());
+
         // Phase 1 managed transforms.
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IPipelineTransform, ReprojectTransform>());

--- a/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/GeoETL/GeoEtlServiceCollectionExtensions.cs
@@ -60,6 +60,12 @@ internal static class GeoEtlServiceCollectionExtensions
             ServiceDescriptor.Singleton<IPipelineTransform, SpatialJoinTransform>());
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IPipelineTransform, DedupTransform>());
+        // Per-feature geometry operators (buffer / simplify / convex-hull /
+        // centroid / make-valid / difference) lifted to layer scope. Reused by
+        // the layer-scope geoprocessing executors so a GP process over a layer
+        // runs as a single-transform pipeline rather than a single-WKB primitive.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IPipelineTransform, GeometryOperationTransform>());
 
         // Phase 1 sinks. The dry-run null preview sink is always available; the
         // Honua-layer / PostGIS sink registers only when a feature sink writer exists.

--- a/src/Honua.Server/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
+++ b/src/Honua.Server/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
@@ -28,7 +28,20 @@ namespace Honua.Server.Features.Geoprocessing.Execution;
 /// and <c>geometry.snap</c> (vertex conditioning to a reference
 /// geometry). This dispatcher routes between them and emits a single,
 /// consistent "unsupported process id" error for everything outside the
-/// current supported set.
+/// current supported set. The layer-scope <see cref="LayerGeometryJobExecutor"/>
+/// is composed in for the feature-collection vector processes
+/// (generalization.simplify-layer, conversion.feature-project) and the
+/// previously catalog-only single-geometry ops (geometry.make-valid,
+/// geometry.difference).
+///
+/// CLAIM-FENCE INTEGRATION NOTE (deferred to feat/gdal-heavy-worker): all
+/// executors composed here register MANAGED jobs only, so this dispatcher has no
+/// AcceptedRuntimeProfiles filter (that concept lives on feat/gdal-heavy-worker,
+/// not this trunk-era branch). When feat/gdal-heavy-worker merges with this
+/// branch and GP raster jobs are registered as "native", set
+/// AcceptedRuntimeProfiles to the managed profile here so this dispatcher cannot
+/// claim native jobs meant for the GDAL worker. See docs/contributor/geoetl-roadmap.md
+/// § "Deferred to the GDAL heavyweight worker".
 /// </summary>
 internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
 {

--- a/src/Honua.Server/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
+++ b/src/Honua.Server/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
@@ -48,6 +48,7 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
         GeometryDissolveJobExecutor dissolve,
         GeometrySimplifyJobExecutor simplify,
         GeometrySnapJobExecutor snap,
+        LayerGeometryJobExecutor layerGeometry,
         ILogger<GeoprocessingDispatchJobExecutor> logger)
     {
         ArgumentNullException.ThrowIfNull(buffer);
@@ -62,9 +63,10 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
         ArgumentNullException.ThrowIfNull(dissolve);
         ArgumentNullException.ThrowIfNull(simplify);
         ArgumentNullException.ThrowIfNull(snap);
+        ArgumentNullException.ThrowIfNull(layerGeometry);
         ArgumentNullException.ThrowIfNull(logger);
 
-        _handlers = new Dictionary<string, IJobExecutor>(StringComparer.Ordinal)
+        var handlers = new Dictionary<string, IJobExecutor>(StringComparer.Ordinal)
         {
             [GeometryBufferJobExecutor.HandledProcessId] = buffer,
             [GeometryClipJobExecutor.HandledProcessId] = clip,
@@ -78,7 +80,18 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
             [GeometryDissolveJobExecutor.HandledProcessId] = dissolve,
             [GeometrySimplifyJobExecutor.HandledProcessId] = simplify,
             [GeometrySnapJobExecutor.HandledProcessId] = snap,
-        }.ToFrozenDictionary(StringComparer.Ordinal);
+        };
+
+        // Layer-scope (feature-collection) executor handles several process ids;
+        // route each one to the same instance so the catalog's layer-level vector
+        // families (simplify-layer, feature-project) and the previously
+        // catalog-only single-geometry ops (make-valid, difference) execute.
+        foreach (var layerProcessId in LayerGeometryJobExecutor.HandledProcessIds)
+        {
+            handlers[layerProcessId] = layerGeometry;
+        }
+
+        _handlers = handlers.ToFrozenDictionary(StringComparer.Ordinal);
 
         _logger = logger;
     }

--- a/src/Honua.Server/Features/Geoprocessing/Execution/LayerGeometryJobExecutor.cs
+++ b/src/Honua.Server/Features/Geoprocessing/Execution/LayerGeometryJobExecutor.cs
@@ -56,6 +56,7 @@ internal sealed partial class LayerGeometryJobExecutor : IJobExecutor
             "conversion.feature-project",
             "geometry.make-valid",
             "geometry.difference",
+            "generalization.dissolve",
         }.ToFrozenSet(StringComparer.Ordinal);
 
     private const string DataUriPrefix = "data:application/geo+json;base64,";
@@ -63,6 +64,7 @@ internal sealed partial class LayerGeometryJobExecutor : IJobExecutor
     private readonly IEnumerable<ILayerFeatureSource> _sources;
     private readonly GeometryOperationTransform _geometryOp;
     private readonly ReprojectTransform _reproject;
+    private readonly DissolveTransform _dissolve;
     private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options;
     private readonly ILogger<LayerGeometryJobExecutor> _logger;
 
@@ -78,6 +80,7 @@ internal sealed partial class LayerGeometryJobExecutor : IJobExecutor
         _sources = sources;
         _geometryOp = new GeometryOperationTransform();
         _reproject = new ReprojectTransform();
+        _dissolve = new DissolveTransform();
         _options = options;
         _logger = logger;
     }
@@ -235,6 +238,35 @@ internal sealed partial class LayerGeometryJobExecutor : IJobExecutor
                 {
                     Type = GeometryOperationTransform.TransformType,
                     Options = new Dictionary<string, string>(StringComparer.Ordinal) { ["op"] = "make-valid" }
+                };
+                return true;
+            }
+
+            case "generalization.dissolve":
+            {
+                // groupByFields is OPTIONAL: when omitted the transform collapses
+                // every feature into a single group ("dissolve all"), matching
+                // ArcGIS Dissolve_management with no dissolve field.
+                var options = new Dictionary<string, string>(StringComparer.Ordinal);
+                if (parameters.TryGetValue(prefix + "groupByFields", out var groupByFields)
+                    && !string.IsNullOrWhiteSpace(groupByFields))
+                {
+                    options["groupByFields"] = groupByFields;
+                }
+
+                // statistics is the semicolon-separated field:stat summary spec
+                // (e.g. "pop:sum;area:mean;:count"). Optional.
+                if (parameters.TryGetValue(prefix + "statistics", out var statistics)
+                    && !string.IsNullOrWhiteSpace(statistics))
+                {
+                    options["statistics"] = statistics;
+                }
+
+                transform = _dissolve;
+                config = new TransformConfig
+                {
+                    Type = DissolveTransform.TransformType,
+                    Options = options
                 };
                 return true;
             }

--- a/src/Honua.Server/Features/Geoprocessing/Execution/LayerGeometryJobExecutor.cs
+++ b/src/Honua.Server/Features/Geoprocessing/Execution/LayerGeometryJobExecutor.cs
@@ -1,0 +1,422 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services.Transforms;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+
+namespace Honua.Server.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Production <see cref="IJobExecutor"/> for the layer-scope (feature-collection)
+/// vector geoprocessing processes. Where the <c>Geometry*JobExecutor</c> family
+/// operates on a single base64-WKB geometry, this executor takes an INPUT LAYER
+/// reference, streams its features, applies the geometry operation across the
+/// collection (carrying attributes through), and emits an OUTPUT LAYER / artifact.
+///
+/// A GP process over a layer == a single-transform ETL pipeline, so this reuses
+/// the GeoETL machinery already on this branch: the streaming feature model
+/// (<see cref="IFeature"/> over NetTopologySuite), the managed per-feature
+/// <see cref="GeometryOperationTransform"/> / <see cref="ReprojectTransform"/>,
+/// and the inline-GeoJSON <see cref="ILayerFeatureSource"/>. The single-WKB
+/// path stays as a primitive but is no longer the only path.
+///
+/// Input contract (projected onto the canonical step-input bag):
+/// <list type="bullet">
+/// <item><c>inputGeoJson</c> — an inline GeoJSON FeatureCollection (managed path,
+/// always available).</item>
+/// <item><c>layerId</c> — a catalog layer id (resolved when a storage-provider
+/// <see cref="ILayerFeatureSource"/> that can read catalog layers is registered).</item>
+/// </list>
+/// Output: a GeoJSON FeatureCollection artifact on the <c>outputFeatureLayer</c>
+/// slot. (Persisting to a durable Honua layer reuses
+/// <c>HonuaLayerSinkConnector</c>; that path is wired when a target layer name and
+/// an <c>IFeatureSinkWriter</c> are supplied — see the roadmap note.)
+///
+/// Pure managed NetTopologySuite — no GDAL/GEOS. Raster / surface families are
+/// routed to the native GDAL worker and are not handled here.
+/// </summary>
+internal sealed partial class LayerGeometryJobExecutor : IJobExecutor
+{
+    /// <summary>Process ids this executor handles at layer scope.</summary>
+    internal static readonly FrozenSet<string> HandledProcessIds =
+        new HashSet<string>(StringComparer.Ordinal)
+        {
+            "generalization.simplify-layer",
+            "conversion.feature-project",
+            "geometry.make-valid",
+            "geometry.difference",
+        }.ToFrozenSet(StringComparer.Ordinal);
+
+    private const string DataUriPrefix = "data:application/geo+json;base64,";
+
+    private readonly IEnumerable<ILayerFeatureSource> _sources;
+    private readonly GeometryOperationTransform _geometryOp;
+    private readonly ReprojectTransform _reproject;
+    private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options;
+    private readonly ILogger<LayerGeometryJobExecutor> _logger;
+
+    public LayerGeometryJobExecutor(
+        IEnumerable<ILayerFeatureSource> sources,
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<LayerGeometryJobExecutor> logger)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _sources = sources;
+        _geometryOp = new GeometryOperationTransform();
+        _reproject = new ReprojectTransform();
+        _options = options;
+        _logger = logger;
+    }
+
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GeoprocessingDispatchHelper.ResolveProcessId(parameters);
+        if (string.IsNullOrWhiteSpace(processId) || !HandledProcessIds.Contains(processId))
+        {
+            Log.UnsupportedProcessId(_logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the layer-scope geometry executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing layer inputs", cancellationToken).ConfigureAwait(false);
+
+        if (!TryReadReference(parameters, out var reference, out var refError))
+        {
+            Log.InvalidInputs(_logger, job.OperationId, refError);
+            return JobExecutionResult.Failed($"Invalid layer inputs: {refError}");
+        }
+
+        var source = _sources.FirstOrDefault(s => s.CanResolve(reference.Kind));
+        if (source is null)
+        {
+            return JobExecutionResult.Failed(
+                $"No layer feature source is registered for reference kind '{reference.Kind}'. " +
+                "The inline-GeoJSON path is always available; catalog-layer ids require a storage-provider source.");
+        }
+
+        if (!TryBuildTransform(processId!, parameters, out var transform, out var transformConfig, out var opError))
+        {
+            Log.InvalidInputs(_logger, job.OperationId, opError);
+            return JobExecutionResult.Failed($"Invalid layer inputs: {opError}");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(40, "Applying geometry operation across features", cancellationToken)
+            .ConfigureAwait(false);
+
+        var stream = transform.TransformAsync(transformConfig, source.ReadAsync(reference, cancellationToken), cancellationToken);
+
+        byte[] payload;
+        long featureCount;
+        try
+        {
+            (payload, featureCount) = await WriteFeatureCollectionAsync(stream, processId!, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.LayerComputationFailed(_logger, job.OperationId, ex);
+            return JobExecutionResult.Failed($"Layer geometry operation failed: {ex.GetType().Name}: {ex.Message}");
+        }
+
+        if (featureCount == 0)
+        {
+            return JobExecutionResult.Failed(
+                "Layer geometry operation produced no output features; verify the input layer and parameters.");
+        }
+
+        var maxBytes = _options.CurrentValue.MaxArtifactBytes;
+        if (payload.Length > maxBytes)
+        {
+            Log.ArtifactTooLarge(_logger, job.OperationId, payload.Length, maxBytes);
+            return JobExecutionResult.Failed(
+                $"Layer artifact size {payload.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}. " +
+                "Pre-filter the input layer or persist to a durable layer sink instead.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(75, "Encoding output layer artifact", cancellationToken).ConfigureAwait(false);
+
+        var artifactUri = BuildDataUri(payload);
+        await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+        await context.ReportProgressAsync(100, "Layer operation completed", cancellationToken).ConfigureAwait(false);
+
+        return JobExecutionResult.Succeeded();
+    }
+
+    private bool TryBuildTransform(
+        string processId,
+        IReadOnlyDictionary<string, string> parameters,
+        out Core.Features.GeoETL.Abstractions.IPipelineTransform transform,
+        out TransformConfig config,
+        out string error)
+    {
+        transform = _geometryOp;
+        config = null!;
+        error = "";
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+
+        switch (processId)
+        {
+            case "generalization.simplify-layer":
+            {
+                if (!TryReadDouble(parameters, prefix + "tolerance", requirePositive: true, out var tolerance, out error))
+                {
+                    return false;
+                }
+
+                var preserve = ReadBool(parameters, prefix + "preserveTopology", defaultValue: true);
+                transform = _geometryOp;
+                config = new TransformConfig
+                {
+                    Type = GeometryOperationTransform.TransformType,
+                    Options = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["op"] = "simplify",
+                        ["tolerance"] = tolerance.ToString(CultureInfo.InvariantCulture),
+                        ["preserveTopology"] = preserve ? "true" : "false",
+                    }
+                };
+                return true;
+            }
+
+            case "conversion.feature-project":
+            {
+                if (!TryReadInt(parameters, prefix + "targetSrid", out var toSrid, out error))
+                {
+                    error = "missing or invalid input 'targetSrid'; expected a positive integer";
+                    return false;
+                }
+
+                // fromSrid is optional; default to WGS 84 when the input layer's CRS
+                // is not supplied. The managed reproject transform validates the pair.
+                var fromSrid = TryReadInt(parameters, prefix + "fromSrid", out var parsedFrom, out _) ? parsedFrom : 4326;
+                transform = _reproject;
+                config = new TransformConfig
+                {
+                    Type = ReprojectTransform.TransformType,
+                    Options = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["fromSrid"] = fromSrid.ToString(CultureInfo.InvariantCulture),
+                        ["toSrid"] = toSrid.ToString(CultureInfo.InvariantCulture),
+                    }
+                };
+                return true;
+            }
+
+            case "geometry.make-valid":
+            {
+                transform = _geometryOp;
+                config = new TransformConfig
+                {
+                    Type = GeometryOperationTransform.TransformType,
+                    Options = new Dictionary<string, string>(StringComparer.Ordinal) { ["op"] = "make-valid" }
+                };
+                return true;
+            }
+
+            case "geometry.difference":
+            {
+                if (!parameters.TryGetValue(prefix + "regionWkt", out var wkt) || string.IsNullOrWhiteSpace(wkt))
+                {
+                    error = "missing required input 'regionWkt' (the eraser geometry as WKT) for layer-scope difference";
+                    return false;
+                }
+
+                transform = _geometryOp;
+                config = new TransformConfig
+                {
+                    Type = GeometryOperationTransform.TransformType,
+                    Options = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["op"] = "difference",
+                        ["regionWkt"] = wkt,
+                    }
+                };
+                return true;
+            }
+
+            default:
+                error = $"process '{processId}' has no layer-scope transform mapping";
+                return false;
+        }
+    }
+
+    private static bool TryReadReference(
+        IReadOnlyDictionary<string, string> parameters,
+        out LayerFeatureReference reference,
+        out string error)
+    {
+        reference = null!;
+        error = "";
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+
+        if (parameters.TryGetValue(prefix + "inputGeoJson", out var inline) && !string.IsNullOrWhiteSpace(inline))
+        {
+            reference = new LayerFeatureReference
+            {
+                Kind = LayerFeatureSourceKind.InlineGeoJson,
+                InlineGeoJson = inline
+            };
+            return true;
+        }
+
+        if (parameters.TryGetValue(prefix + "layerId", out var layerId) && !string.IsNullOrWhiteSpace(layerId))
+        {
+            parameters.TryGetValue(prefix + "where", out var where);
+            reference = new LayerFeatureReference
+            {
+                Kind = LayerFeatureSourceKind.CatalogLayer,
+                LayerId = layerId,
+                Where = string.IsNullOrWhiteSpace(where) ? null : where
+            };
+            return true;
+        }
+
+        error = "missing input layer reference; supply either 'inputGeoJson' (inline FeatureCollection) or 'layerId'";
+        return false;
+    }
+
+    private static async Task<(byte[] Payload, long Count)> WriteFeatureCollectionAsync(
+        IAsyncEnumerable<IFeature> features,
+        string processId,
+        CancellationToken cancellationToken)
+    {
+        var geoJsonWriter = new GeoJsonWriter();
+        long count = 0;
+
+        using var buffer = new MemoryStream();
+        await using (var textWriter = new StreamWriter(buffer, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), leaveOpen: true))
+        using (var jsonWriter = new Newtonsoft.Json.JsonTextWriter(textWriter))
+        {
+            jsonWriter.WriteStartObject();
+            jsonWriter.WritePropertyName("type");
+            jsonWriter.WriteValue("FeatureCollection");
+            jsonWriter.WritePropertyName("processId");
+            jsonWriter.WriteValue(processId);
+            jsonWriter.WritePropertyName("features");
+            jsonWriter.WriteStartArray();
+
+            await foreach (var feature in features.WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                var concrete = feature as Feature ?? new Feature(feature.Geometry, feature.Attributes);
+                geoJsonWriter.Write(concrete, jsonWriter);
+                count++;
+            }
+
+            jsonWriter.WriteEndArray();
+            jsonWriter.WritePropertyName("featureCount");
+            jsonWriter.WriteValue(count);
+            jsonWriter.WriteEndObject();
+            jsonWriter.Flush();
+        }
+
+        return (buffer.ToArray(), count);
+    }
+
+    private static string BuildDataUri(byte[] payload)
+    {
+        var sb = new StringBuilder(payload.Length * 2 + DataUriPrefix.Length);
+        sb.Append(DataUriPrefix);
+        sb.Append(Convert.ToBase64String(payload));
+        return sb.ToString();
+    }
+
+    private static bool TryReadInt(
+        IReadOnlyDictionary<string, string> parameters,
+        string key,
+        out int value,
+        out string error)
+    {
+        error = "";
+        if (parameters.TryGetValue(key, out var raw)
+            && int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value)
+            && value > 0)
+        {
+            return true;
+        }
+
+        value = 0;
+        error = $"missing or invalid '{key}'";
+        return false;
+    }
+
+    private static bool TryReadDouble(
+        IReadOnlyDictionary<string, string> parameters,
+        string key,
+        bool requirePositive,
+        out double value,
+        out string error)
+    {
+        error = "";
+        if (parameters.TryGetValue(key, out var raw)
+            && double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out value)
+            && !double.IsNaN(value) && !double.IsInfinity(value)
+            && (!requirePositive || value > 0))
+        {
+            return true;
+        }
+
+        value = 0;
+        error = requirePositive
+            ? $"missing or invalid '{key}'; expected a positive finite number"
+            : $"missing or invalid '{key}'; expected a finite number";
+        return false;
+    }
+
+    private static bool ReadBool(
+        IReadOnlyDictionary<string, string> parameters,
+        string key,
+        bool defaultValue)
+    {
+        if (parameters.TryGetValue(key, out var raw) && bool.TryParse(raw, out var parsed))
+        {
+            return parsed;
+        }
+
+        return defaultValue;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9200, LogLevel.Warning,
+            "Layer geometry executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9201, LogLevel.Warning,
+            "Layer geometry executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9202, LogLevel.Error,
+            "Layer geometry executor failed job {OperationId} during the layer operation")]
+        public static partial void LayerComputationFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9203, LogLevel.Warning,
+            "Layer geometry executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+    }
+}

--- a/src/Honua.Server/Features/Geoprocessing/Execution/LayerGeometryJobExecutor.cs
+++ b/src/Honua.Server/Features/Geoprocessing/Execution/LayerGeometryJobExecutor.cs
@@ -57,6 +57,7 @@ internal sealed partial class LayerGeometryJobExecutor : IJobExecutor
             "geometry.make-valid",
             "geometry.difference",
             "generalization.dissolve",
+            "analytics.spatial-join",
         }.ToFrozenSet(StringComparer.Ordinal);
 
     private const string DataUriPrefix = "data:application/geo+json;base64,";
@@ -65,6 +66,7 @@ internal sealed partial class LayerGeometryJobExecutor : IJobExecutor
     private readonly GeometryOperationTransform _geometryOp;
     private readonly ReprojectTransform _reproject;
     private readonly DissolveTransform _dissolve;
+    private readonly SpatialJoinTransform _spatialJoin;
     private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _options;
     private readonly ILogger<LayerGeometryJobExecutor> _logger;
 
@@ -81,6 +83,7 @@ internal sealed partial class LayerGeometryJobExecutor : IJobExecutor
         _geometryOp = new GeometryOperationTransform();
         _reproject = new ReprojectTransform();
         _dissolve = new DissolveTransform();
+        _spatialJoin = new SpatialJoinTransform();
         _options = options;
         _logger = logger;
     }
@@ -266,6 +269,50 @@ internal sealed partial class LayerGeometryJobExecutor : IJobExecutor
                 config = new TransformConfig
                 {
                     Type = DissolveTransform.TransformType,
+                    Options = options
+                };
+                return true;
+            }
+
+            case "analytics.spatial-join":
+            {
+                // The TARGET layer flows through the standard input reference
+                // (inputGeoJson / layerId). The JOIN layer is supplied inline as
+                // 'joinGeoJson' so the managed inline path can carry both layers
+                // without a storage provider.
+                if (!parameters.TryGetValue(prefix + "joinGeoJson", out var joinGeoJson)
+                    || string.IsNullOrWhiteSpace(joinGeoJson))
+                {
+                    error = "missing required input 'joinGeoJson' (the join layer as an inline GeoJSON FeatureCollection) for spatial-join";
+                    return false;
+                }
+
+                var options = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["referenceInline"] = joinGeoJson,
+                    // Summarizing (one-to-one) form: aggregate matched join rows.
+                    ["aggregate"] = "true",
+                };
+
+                if (parameters.TryGetValue(prefix + "predicate", out var predicate)
+                    && !string.IsNullOrWhiteSpace(predicate))
+                {
+                    options["predicate"] = predicate;
+                }
+
+                // statistics is the semicolon-separated field:stat summary spec
+                // (e.g. "value:sum;value:mean;:count"). Optional — JOIN_COUNT is
+                // always emitted regardless.
+                if (parameters.TryGetValue(prefix + "statistics", out var statistics)
+                    && !string.IsNullOrWhiteSpace(statistics))
+                {
+                    options["statistics"] = statistics;
+                }
+
+                transform = _spatialJoin;
+                config = new TransformConfig
+                {
+                    Type = SpatialJoinTransform.TransformType,
                     Options = options
                 };
                 return true;

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingExecutionRouting.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingExecutionRouting.cs
@@ -78,6 +78,7 @@ internal static class GeoprocessingExecutionRoutingClassifier
             "conversion.feature-project",
             // Group-aware vector aggregation lifted to executable layer scope.
             "generalization.dissolve",
+            "analytics.spatial-join",
         }.ToFrozenSet(StringComparer.Ordinal);
 
     public static GeoprocessingExecutionRouting Classify(ProcessDefinition definition)

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingExecutionRouting.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingExecutionRouting.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.Server.Features.Geoprocessing;
+
+/// <summary>
+/// How a catalog process is executed (or why it is not yet executable). This is the
+/// single, authoritative source of truth for catalog honesty: the
+/// catalog==executable conformance test cross-checks this routing against the
+/// processes the <see cref="Execution.GeoprocessingDispatchJobExecutor"/> actually
+/// routes, so the catalog can never silently advertise a managed-vector process
+/// that has no executor.
+///
+/// Kept as a server-side classifier rather than a field on
+/// <see cref="ProcessDefinition"/> so routing policy stays policy-owned and
+/// <c>Honua.Core</c> remains transport-neutral, mirroring
+/// <see cref="ProcessDestructiveClassifier"/>.
+/// </summary>
+internal enum GeoprocessingExecutionRouting
+{
+    /// <summary>
+    /// Pure-managed (NetTopologySuite, GDAL-free) vector process that runs in the
+    /// lean serving image and MUST have a registered executor. These are the
+    /// processes the catalog==executable conformance test enforces.
+    /// </summary>
+    ManagedVectorExecutable,
+
+    /// <summary>
+    /// Raster / surface family routed to the native GDAL heavyweight worker
+    /// (feat/gdal-heavy-worker). Advertised in the catalog as a capability but
+    /// NOT executable in the lean baseline — and the conformance test asserts it
+    /// is honestly absent from the managed dispatcher rather than silently
+    /// advertised as runnable.
+    /// </summary>
+    RoutedToNativeWorker,
+
+    /// <summary>
+    /// A vector-data process whose layer-level aggregation / mutation semantics
+    /// (group-by dissolve, spatial-join, density binning, clustering, destructive
+    /// data-management, scalar format conversion) are not implemented as a managed
+    /// executor in this baseline. Inventoried for migration review; intentionally
+    /// not claimed as executable.
+    /// </summary>
+    NotYetExecutable
+}
+
+/// <summary>
+/// Maps catalog process ids to their <see cref="GeoprocessingExecutionRouting"/>.
+/// </summary>
+internal static class GeoprocessingExecutionRoutingClassifier
+{
+    // Managed-vector processes that MUST have a working executor. This is the
+    // honest "catalog == executable" vector set: every id here is also a key in
+    // GeoprocessingDispatchJobExecutor, enforced by the conformance test.
+    private static readonly FrozenSet<string> ManagedVectorExecutableIds =
+        new HashSet<string>(StringComparer.Ordinal)
+        {
+            // Single-geometry (primitive) vector executors.
+            "geometry.buffer",
+            "geometry.clip",
+            "geometry.intersect",
+            "geometry.project",
+            "geometry.area",
+            "geometry.length",
+            "geometry.centroid",
+            "geometry.convex-hull",
+            "geometry.union",
+            "geometry.dissolve",
+            "geometry.simplify",
+            "geometry.snap",
+            // Layer-scope (feature-collection) executors added by this stream.
+            "geometry.make-valid",
+            "geometry.difference",
+            "generalization.simplify-layer",
+            "conversion.feature-project",
+        }.ToFrozenSet(StringComparer.Ordinal);
+
+    public static GeoprocessingExecutionRouting Classify(ProcessDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        if (ManagedVectorExecutableIds.Contains(definition.ProcessId))
+        {
+            return GeoprocessingExecutionRouting.ManagedVectorExecutable;
+        }
+
+        // Raster + surface families (and raster-output conversions) require GDAL
+        // and run on the native heavyweight worker — never in the lean baseline.
+        if (definition.Category is "raster" or "surface")
+        {
+            return GeoprocessingExecutionRouting.RoutedToNativeWorker;
+        }
+
+        if (definition.Category == "conversion" &&
+            definition.OutputArtifactKinds.Contains(ArtifactKind.Raster))
+        {
+            return GeoprocessingExecutionRouting.RoutedToNativeWorker;
+        }
+
+        // Everything else (analytics aggregation, generalization.dissolve,
+        // data-management mutation, scalar geometry-format conversion) is a
+        // vector-data process whose managed executor is not built in this
+        // baseline. Inventoried, not advertised as executable.
+        return GeoprocessingExecutionRouting.NotYetExecutable;
+    }
+}

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingExecutionRouting.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingExecutionRouting.cs
@@ -76,6 +76,8 @@ internal static class GeoprocessingExecutionRoutingClassifier
             "geometry.difference",
             "generalization.simplify-layer",
             "conversion.feature-project",
+            // Group-aware vector aggregation lifted to executable layer scope.
+            "generalization.dissolve",
         }.ToFrozenSet(StringComparer.Ordinal);
 
     public static GeoprocessingExecutionRouting Classify(ProcessDefinition definition)
@@ -100,10 +102,11 @@ internal static class GeoprocessingExecutionRoutingClassifier
             return GeoprocessingExecutionRouting.RoutedToNativeWorker;
         }
 
-        // Everything else (analytics aggregation, generalization.dissolve,
-        // data-management mutation, scalar geometry-format conversion) is a
-        // vector-data process whose managed executor is not built in this
-        // baseline. Inventoried, not advertised as executable.
+        // Everything else (remaining analytics aggregation such as density /
+        // cluster, data-management mutation, scalar geometry-format conversion)
+        // is a vector-data process whose managed executor is not built in this
+        // baseline. Inventoried, not advertised as executable. (Clustering could
+        // be a future managed increment; density is raster-output → GDAL worker.)
         return GeoprocessingExecutionRouting.NotYetExecutable;
     }
 }

--- a/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -119,6 +119,16 @@ internal static class GeoprocessingServiceCollectionExtensions
         services.TryAddSingleton<GeometryDissolveJobExecutor>();
         services.TryAddSingleton<GeometrySimplifyJobExecutor>();
         services.TryAddSingleton<GeometrySnapJobExecutor>();
+        // Layer-scope (feature-collection) executor: takes an input layer
+        // reference (inline GeoJSON FeatureCollection or catalog layer id),
+        // streams its features, applies the geometry operation across the
+        // collection via the reused GeoETL transforms, and emits an output
+        // layer/artifact. Executes the catalog's layer-level vector families
+        // (generalization.simplify-layer, conversion.feature-project) plus the
+        // previously catalog-only single-geometry ops (geometry.make-valid,
+        // geometry.difference). Depends on the GeoETL ILayerFeatureSource set
+        // registered by AddGeoEtl.
+        services.TryAddSingleton<LayerGeometryJobExecutor>();
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IJobExecutor, GeoprocessingDispatchJobExecutor>());
 

--- a/tests/dotnet/Honua.Core.Tests/Features/GeoETL/DissolveTransformTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/GeoETL/DissolveTransformTests.cs
@@ -1,0 +1,216 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services.Transforms;
+using Honua.TestKit.Attributes;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Core.Tests.Features.GeoETL;
+
+/// <summary>
+/// Unit coverage for the managed (NetTopologySuite, GEOS-free) group-aware
+/// dissolve transform — the layer-scope counterpart of ArcGIS
+/// Dissolve_management. All run in-memory over streamed feature collections.
+/// </summary>
+public sealed class DissolveTransformTests
+{
+    private static readonly GeometryFactory Factory = new(new PrecisionModel(), 4326);
+
+    [UnitTest]
+    public async Task Dissolve_GroupsByField_UnionsGeometriesPerGroup()
+    {
+        var transform = new DissolveTransform();
+        var config = new TransformConfig
+        {
+            Type = DissolveTransform.TransformType,
+            Options = new Dictionary<string, string> { ["groupByFields"] = "region" }
+        };
+
+        // Two adjacent unit squares in region "A" union into one 2x1 polygon;
+        // a separate square in region "B" stays its own group.
+        var features = Many(
+            new Feature(Square(0, 0, 1), Attrs(("region", "A"))),
+            new Feature(Square(1, 0, 1), Attrs(("region", "A"))),
+            new Feature(Square(10, 10, 1), Attrs(("region", "B"))));
+
+        var results = await Collect(transform.TransformAsync(config, features));
+
+        results.Should().HaveCount(2);
+        var groupA = results.Single(f => Equals(f.Attributes!["region"], "A"));
+        groupA.Geometry!.Area.Should().BeApproximately(2.0, 1e-6);
+        groupA.Geometry.SRID.Should().Be(4326);
+        var groupB = results.Single(f => Equals(f.Attributes!["region"], "B"));
+        groupB.Geometry!.Area.Should().BeApproximately(1.0, 1e-6);
+    }
+
+    [UnitTest]
+    public async Task Dissolve_AllWhenNoGroupField_CollapsesToSingleFeature()
+    {
+        var transform = new DissolveTransform();
+        var config = new TransformConfig
+        {
+            Type = DissolveTransform.TransformType,
+            Options = new Dictionary<string, string>()
+        };
+
+        var features = Many(
+            new Feature(Square(0, 0, 1), Attrs(("region", "A"))),
+            new Feature(Square(5, 5, 1), Attrs(("region", "B"))));
+
+        var results = await Collect(transform.TransformAsync(config, features));
+
+        results.Should().ContainSingle();
+        // Two disjoint squares union into a MultiPolygon with combined area 2.
+        results.Single().Geometry!.Area.Should().BeApproximately(2.0, 1e-6);
+    }
+
+    [UnitTest]
+    public async Task Dissolve_ComputesEachStatisticPerGroup()
+    {
+        var transform = new DissolveTransform();
+        var config = new TransformConfig
+        {
+            Type = DissolveTransform.TransformType,
+            Options = new Dictionary<string, string>
+            {
+                ["groupByFields"] = "region",
+                ["statistics"] = ":count;pop:sum;pop:mean;pop:min;pop:max;name:first"
+            }
+        };
+
+        var features = Many(
+            new Feature(Square(0, 0, 1), Attrs(("region", "A"), ("pop", 10), ("name", "x"))),
+            new Feature(Square(1, 0, 1), Attrs(("region", "A"), ("pop", 30), ("name", "y"))),
+            new Feature(Square(10, 10, 1), Attrs(("region", "B"), ("pop", 5), ("name", "z"))));
+
+        var results = await Collect(transform.TransformAsync(config, features));
+
+        var groupA = results.Single(f => Equals(f.Attributes!["region"], "A"));
+        Convert.ToInt64(groupA.Attributes!["COUNT"], CultureInfo.InvariantCulture).Should().Be(2);
+        Convert.ToDouble(groupA.Attributes["SUM_pop"], CultureInfo.InvariantCulture).Should().Be(40.0);
+        Convert.ToDouble(groupA.Attributes["MEAN_pop"], CultureInfo.InvariantCulture).Should().Be(20.0);
+        Convert.ToDouble(groupA.Attributes["MIN_pop"], CultureInfo.InvariantCulture).Should().Be(10.0);
+        Convert.ToDouble(groupA.Attributes["MAX_pop"], CultureInfo.InvariantCulture).Should().Be(30.0);
+        groupA.Attributes["FIRST_name"].Should().Be("x");
+
+        var groupB = results.Single(f => Equals(f.Attributes!["region"], "B"));
+        Convert.ToInt64(groupB.Attributes!["COUNT"], CultureInfo.InvariantCulture).Should().Be(1);
+        Convert.ToDouble(groupB.Attributes["SUM_pop"], CultureInfo.InvariantCulture).Should().Be(5.0);
+    }
+
+    [UnitTest]
+    public async Task Dissolve_SingleFeatureGroup_PassesGeometryThrough()
+    {
+        var transform = new DissolveTransform();
+        var config = new TransformConfig
+        {
+            Type = DissolveTransform.TransformType,
+            Options = new Dictionary<string, string> { ["groupByFields"] = "region", ["statistics"] = ":count" }
+        };
+
+        var results = await Collect(transform.TransformAsync(
+            config,
+            Many(new Feature(Square(0, 0, 2), Attrs(("region", "solo"))))));
+
+        results.Should().ContainSingle();
+        results.Single().Geometry!.Area.Should().BeApproximately(4.0, 1e-6);
+        Convert.ToInt64(results.Single().Attributes!["COUNT"], CultureInfo.InvariantCulture).Should().Be(1);
+    }
+
+    [UnitTest]
+    public async Task Dissolve_EmptyInput_ProducesNoFeatures()
+    {
+        var transform = new DissolveTransform();
+        var config = new TransformConfig
+        {
+            Type = DissolveTransform.TransformType,
+            Options = new Dictionary<string, string> { ["groupByFields"] = "region" }
+        };
+
+        var results = await Collect(transform.TransformAsync(config, Many()));
+
+        results.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public async Task Dissolve_DropsNullAndEmptyGeometries()
+    {
+        var transform = new DissolveTransform();
+        var config = new TransformConfig
+        {
+            Type = DissolveTransform.TransformType,
+            Options = new Dictionary<string, string> { ["statistics"] = ":count" }
+        };
+
+        var features = Many(
+            new Feature(Square(0, 0, 1), new AttributesTable()),
+            new Feature(Factory.CreatePoint(), new AttributesTable()));
+
+        var results = await Collect(transform.TransformAsync(config, features));
+
+        results.Should().ContainSingle();
+        Convert.ToInt64(results.Single().Attributes!["COUNT"], CultureInfo.InvariantCulture).Should().Be(1);
+    }
+
+    [UnitTest]
+    public async Task Dissolve_UnknownStatistic_Throws()
+    {
+        var transform = new DissolveTransform();
+        var config = new TransformConfig
+        {
+            Type = DissolveTransform.TransformType,
+            Options = new Dictionary<string, string> { ["statistics"] = "pop:median" }
+        };
+
+        var act = async () => await Collect(transform.TransformAsync(
+            config,
+            Many(new Feature(Square(0, 0, 1), Attrs(("pop", 1))))));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    private static Polygon Square(double x, double y, double size) =>
+        Factory.CreatePolygon(
+        [
+            new Coordinate(x, y),
+            new Coordinate(x + size, y),
+            new Coordinate(x + size, y + size),
+            new Coordinate(x, y + size),
+            new Coordinate(x, y),
+        ]);
+
+    private static AttributesTable Attrs(params (string Name, object? Value)[] values)
+    {
+        var table = new AttributesTable();
+        foreach (var (name, value) in values)
+        {
+            table.Add(name, value);
+        }
+
+        return table;
+    }
+
+    private static async Task<List<IFeature>> Collect(IAsyncEnumerable<IFeature> source)
+    {
+        var list = new List<IFeature>();
+        await foreach (var feature in source)
+        {
+            list.Add(feature);
+        }
+
+        return list;
+    }
+
+    private static async IAsyncEnumerable<IFeature> Many(params IFeature[] features)
+    {
+        foreach (var feature in features)
+        {
+            yield return feature;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/GeoETL/GeometryOperationTransformTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/GeoETL/GeometryOperationTransformTests.cs
@@ -1,0 +1,217 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services.Transforms;
+using Honua.TestKit.Attributes;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Core.Tests.Features.GeoETL;
+
+/// <summary>
+/// Unit coverage for the managed (NetTopologySuite, GEOS-free) per-feature
+/// geometry-operation transform that lifts the single-geometry geoprocessing
+/// operators to layer scope. All run in-memory over streamed feature collections.
+/// </summary>
+public sealed class GeometryOperationTransformTests
+{
+    private static readonly GeometryFactory Factory = new(new PrecisionModel(), 4326);
+
+    [UnitTest]
+    public async Task Buffer_ExpandsEachGeometryAndCarriesAttributes()
+    {
+        var transform = new GeometryOperationTransform();
+        var config = new TransformConfig
+        {
+            Type = GeometryOperationTransform.TransformType,
+            Options = new Dictionary<string, string> { ["op"] = "buffer", ["distance"] = "1" }
+        };
+        var feature = new Feature(
+            Factory.CreatePoint(new Coordinate(0, 0)),
+            new AttributesTable { { "name", "origin" } });
+
+        var results = await Collect(transform.TransformAsync(config, Many(feature)));
+
+        results.Should().ContainSingle();
+        var buffered = results.Single();
+        buffered.Geometry!.Area.Should().BeApproximately(Math.PI, 0.05);
+        buffered.Geometry.SRID.Should().Be(4326);
+        buffered.Attributes!["name"].Should().Be("origin");
+    }
+
+    [UnitTest]
+    public async Task Simplify_CollapsesBelowToleranceVertices()
+    {
+        var transform = new GeometryOperationTransform();
+        var config = new TransformConfig
+        {
+            Type = GeometryOperationTransform.TransformType,
+            Options = new Dictionary<string, string> { ["op"] = "simplify", ["tolerance"] = "1.0" }
+        };
+        var feature = new Feature(
+            Factory.CreateLineString([new Coordinate(0, 0), new Coordinate(5, 0.001), new Coordinate(10, 0)]),
+            new AttributesTable());
+
+        var results = await Collect(transform.TransformAsync(config, Many(feature)));
+
+        results.Should().ContainSingle();
+        ((LineString)results.Single().Geometry!).NumPoints.Should().Be(2);
+    }
+
+    [UnitTest]
+    public async Task ConvexHull_WrapsEachFeature()
+    {
+        var transform = new GeometryOperationTransform();
+        var config = new TransformConfig
+        {
+            Type = GeometryOperationTransform.TransformType,
+            Options = new Dictionary<string, string> { ["op"] = "convex-hull" }
+        };
+        var multipoint = Factory.CreateMultiPoint(
+        [
+            Factory.CreatePoint(new Coordinate(0, 0)),
+            Factory.CreatePoint(new Coordinate(10, 0)),
+            Factory.CreatePoint(new Coordinate(10, 10)),
+            Factory.CreatePoint(new Coordinate(0, 10)),
+            Factory.CreatePoint(new Coordinate(5, 5)),
+        ]);
+        var feature = new Feature(multipoint, new AttributesTable());
+
+        var results = await Collect(transform.TransformAsync(config, Many(feature)));
+
+        results.Should().ContainSingle();
+        results.Single().Geometry!.Area.Should().BeApproximately(100.0, 1e-6);
+    }
+
+    [UnitTest]
+    public async Task Centroid_ReducesEachFeatureToItsCenterPoint()
+    {
+        var transform = new GeometryOperationTransform();
+        var config = new TransformConfig
+        {
+            Type = GeometryOperationTransform.TransformType,
+            Options = new Dictionary<string, string> { ["op"] = "centroid" }
+        };
+        var box = Factory.CreatePolygon(
+        [
+            new Coordinate(0, 0), new Coordinate(10, 0), new Coordinate(10, 10),
+            new Coordinate(0, 10), new Coordinate(0, 0),
+        ]);
+        var feature = new Feature(box, new AttributesTable { { "id", 7L } });
+
+        var results = await Collect(transform.TransformAsync(config, Many(feature)));
+
+        results.Should().ContainSingle();
+        var point = (Point)results.Single().Geometry!;
+        point.X.Should().BeApproximately(5.0, 1e-9);
+        point.Y.Should().BeApproximately(5.0, 1e-9);
+        results.Single().Attributes!["id"].Should().Be(7L);
+    }
+
+    [UnitTest]
+    public async Task MakeValid_RepairsSelfIntersectingPolygon()
+    {
+        var transform = new GeometryOperationTransform();
+        var config = new TransformConfig
+        {
+            Type = GeometryOperationTransform.TransformType,
+            Options = new Dictionary<string, string> { ["op"] = "make-valid" }
+        };
+        // Bow-tie polygon (self-intersecting) — invalid as input.
+        var bowtie = Factory.CreatePolygon(
+        [
+            new Coordinate(0, 0), new Coordinate(10, 10), new Coordinate(10, 0),
+            new Coordinate(0, 10), new Coordinate(0, 0),
+        ]);
+        bowtie.IsValid.Should().BeFalse();
+        var feature = new Feature(bowtie, new AttributesTable());
+
+        var results = await Collect(transform.TransformAsync(config, Many(feature)));
+
+        results.Should().ContainSingle();
+        results.Single().Geometry!.IsValid.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public async Task Difference_SubtractsRegionFromEachFeature()
+    {
+        var transform = new GeometryOperationTransform();
+        var config = new TransformConfig
+        {
+            Type = GeometryOperationTransform.TransformType,
+            Options = new Dictionary<string, string>
+            {
+                ["op"] = "difference",
+                ["regionWkt"] = "POLYGON((5 0, 15 0, 15 10, 5 10, 5 0))"
+            }
+        };
+        var box = Factory.CreatePolygon(
+        [
+            new Coordinate(0, 0), new Coordinate(10, 0), new Coordinate(10, 10),
+            new Coordinate(0, 10), new Coordinate(0, 0),
+        ]);
+        var feature = new Feature(box, new AttributesTable());
+
+        var results = await Collect(transform.TransformAsync(config, Many(feature)));
+
+        results.Should().ContainSingle();
+        // 10x10 box minus its right half (5..10) leaves the left 5x10 = area 50.
+        results.Single().Geometry!.Area.Should().BeApproximately(50.0, 1e-6);
+    }
+
+    [UnitTest]
+    public async Task Buffer_DropsNullGeometryFeatures()
+    {
+        var transform = new GeometryOperationTransform();
+        var config = new TransformConfig
+        {
+            Type = GeometryOperationTransform.TransformType,
+            Options = new Dictionary<string, string> { ["op"] = "buffer", ["distance"] = "1" }
+        };
+        var withGeometry = new Feature(Factory.CreatePoint(new Coordinate(0, 0)), new AttributesTable());
+        var empty = new Feature(Factory.CreatePoint(), new AttributesTable());
+
+        var results = await Collect(transform.TransformAsync(config, Many(withGeometry, empty)));
+
+        results.Should().ContainSingle();
+    }
+
+    [UnitTest]
+    public async Task UnknownOp_Throws()
+    {
+        var transform = new GeometryOperationTransform();
+        var config = new TransformConfig
+        {
+            Type = GeometryOperationTransform.TransformType,
+            Options = new Dictionary<string, string> { ["op"] = "voronoi" }
+        };
+
+        var act = async () => await Collect(transform.TransformAsync(
+            config,
+            Many(new Feature(Factory.CreatePoint(new Coordinate(0, 0)), new AttributesTable()))));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    private static async Task<List<IFeature>> Collect(IAsyncEnumerable<IFeature> source)
+    {
+        var list = new List<IFeature>();
+        await foreach (var feature in source)
+        {
+            list.Add(feature);
+        }
+
+        return list;
+    }
+
+    private static async IAsyncEnumerable<IFeature> Many(params IFeature[] features)
+    {
+        foreach (var feature in features)
+        {
+            yield return feature;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/GeoETL/InlineGeoJsonLayerFeatureSourceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/GeoETL/InlineGeoJsonLayerFeatureSourceTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.GeoETL.Abstractions;
+using Honua.Core.Features.GeoETL.Services.Connectors;
+using Honua.TestKit.Attributes;
+using NetTopologySuite.Features;
+
+namespace Honua.Core.Tests.Features.GeoETL;
+
+/// <summary>
+/// Unit coverage for the managed inline-GeoJSON layer feature source that resolves
+/// a layer-scope GP input reference into a streamed feature collection.
+/// </summary>
+public sealed class InlineGeoJsonLayerFeatureSourceTests
+{
+    private const string FeatureCollection =
+        "{\"type\":\"FeatureCollection\",\"features\":[" +
+        "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[1,2]}," +
+        "\"properties\":{\"name\":\"a\"}}," +
+        "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[3,4]}," +
+        "\"properties\":{\"name\":\"b\"}}]}";
+
+    [UnitTest]
+    public void CanResolve_OnlyInlineGeoJson()
+    {
+        var source = new InlineGeoJsonLayerFeatureSource();
+
+        source.CanResolve(LayerFeatureSourceKind.InlineGeoJson).Should().BeTrue();
+        source.CanResolve(LayerFeatureSourceKind.CatalogLayer).Should().BeFalse();
+        source.CanResolve(LayerFeatureSourceKind.QueryResult).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task ReadAsync_StreamsEachFeatureWithAttributes()
+    {
+        var source = new InlineGeoJsonLayerFeatureSource();
+        var reference = new LayerFeatureReference
+        {
+            Kind = LayerFeatureSourceKind.InlineGeoJson,
+            InlineGeoJson = FeatureCollection
+        };
+
+        var features = new List<IFeature>();
+        await foreach (var feature in source.ReadAsync(reference))
+        {
+            features.Add(feature);
+        }
+
+        features.Should().HaveCount(2);
+        features[0].Attributes!["name"].Should().Be("a");
+        features[1].Attributes!["name"].Should().Be("b");
+    }
+
+    [UnitTest]
+    public async Task ReadAsync_RejectsNonInlineReference()
+    {
+        var source = new InlineGeoJsonLayerFeatureSource();
+        var reference = new LayerFeatureReference
+        {
+            Kind = LayerFeatureSourceKind.CatalogLayer,
+            LayerId = "100"
+        };
+
+        var act = async () =>
+        {
+            await foreach (var _ in source.ReadAsync(reference))
+            {
+            }
+        };
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [UnitTest]
+    public async Task ReadAsync_RejectsEmptyInlineDocument()
+    {
+        var source = new InlineGeoJsonLayerFeatureSource();
+        var reference = new LayerFeatureReference
+        {
+            Kind = LayerFeatureSourceKind.InlineGeoJson,
+            InlineGeoJson = "   "
+        };
+
+        var act = async () =>
+        {
+            await foreach (var _ in source.ReadAsync(reference))
+            {
+            }
+        };
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/GeoETL/SpatialJoinTransformAggregateTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/GeoETL/SpatialJoinTransformAggregateTests.cs
@@ -1,0 +1,241 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.GeoETL.Domain;
+using Honua.Core.Features.GeoETL.Services.Transforms;
+using Honua.TestKit.Attributes;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Core.Tests.Features.GeoETL;
+
+/// <summary>
+/// Unit coverage for the AGGREGATING (one-to-one summarizing) mode of the
+/// managed spatial-join transform — the layer-scope counterpart of ArcGIS
+/// SpatialJoin_analysis. For each target feature it summarizes every matched
+/// join feature into per-target statistics. All in-memory over NTS feature
+/// collections; the join layer is supplied inline as GeoJSON.
+/// </summary>
+public sealed class SpatialJoinTransformAggregateTests
+{
+    private static readonly GeometryFactory Factory = new(new PrecisionModel(), 4326);
+
+    // Two join points inside the 0..10 square, one inside the 20..30 square.
+    private const string JoinPoints =
+        "{\"type\":\"FeatureCollection\",\"features\":[" +
+        "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[1,1]},\"properties\":{\"value\":10}}," +
+        "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[2,2]},\"properties\":{\"value\":30}}," +
+        "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[25,25]},\"properties\":{\"value\":5}}]}";
+
+    [UnitTest]
+    public async Task Aggregate_Intersects_CountsAndSumsMatchedJoinFeatures()
+    {
+        var transform = new SpatialJoinTransform();
+        var config = new TransformConfig
+        {
+            Type = SpatialJoinTransform.TransformType,
+            Options = new Dictionary<string, string>
+            {
+                ["aggregate"] = "true",
+                ["predicate"] = "intersects",
+                ["referenceInline"] = JoinPoints,
+                ["statistics"] = ":count;value:sum;value:mean;value:min;value:max"
+            }
+        };
+
+        // Two target polygons: one covering both 0..10 points, one covering the lone 20..30 point.
+        var targets = Many(
+            new Feature(Square(0, 0, 10), Attrs(("zone", "A"))),
+            new Feature(Square(20, 20, 10), Attrs(("zone", "B"))));
+
+        var results = await Collect(transform.TransformAsync(config, targets));
+
+        results.Should().HaveCount(2);
+
+        var zoneA = results.Single(f => Equals(f.Attributes!["zone"], "A"));
+        Convert.ToInt64(zoneA.Attributes!["JOIN_COUNT"], CultureInfo.InvariantCulture).Should().Be(2);
+        Convert.ToDouble(zoneA.Attributes["SUM_value"], CultureInfo.InvariantCulture).Should().Be(40.0);
+        Convert.ToDouble(zoneA.Attributes["MEAN_value"], CultureInfo.InvariantCulture).Should().Be(20.0);
+        Convert.ToDouble(zoneA.Attributes["MIN_value"], CultureInfo.InvariantCulture).Should().Be(10.0);
+        Convert.ToDouble(zoneA.Attributes["MAX_value"], CultureInfo.InvariantCulture).Should().Be(30.0);
+
+        var zoneB = results.Single(f => Equals(f.Attributes!["zone"], "B"));
+        Convert.ToInt64(zoneB.Attributes!["JOIN_COUNT"], CultureInfo.InvariantCulture).Should().Be(1);
+        Convert.ToDouble(zoneB.Attributes["SUM_value"], CultureInfo.InvariantCulture).Should().Be(5.0);
+    }
+
+    [UnitTest]
+    public async Task Aggregate_Contains_MatchesPointInPolygon()
+    {
+        var transform = new SpatialJoinTransform();
+        var config = new TransformConfig
+        {
+            Type = SpatialJoinTransform.TransformType,
+            Options = new Dictionary<string, string>
+            {
+                ["aggregate"] = "true",
+                // contains: the join (reference) geometry must contain the target.
+                // Use polygon join features and point targets.
+                ["predicate"] = "contains",
+                ["referenceInline"] =
+                    "{\"type\":\"FeatureCollection\",\"features\":[" +
+                    "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":" +
+                    "[[[0,0],[10,0],[10,10],[0,10],[0,0]]]},\"properties\":{\"value\":7}}]}",
+                ["statistics"] = ":count;value:sum"
+            }
+        };
+
+        var targets = Many(
+            new Feature(Factory.CreatePoint(new Coordinate(5, 5)), Attrs(("id", 1))),
+            new Feature(Factory.CreatePoint(new Coordinate(50, 50)), Attrs(("id", 2))));
+
+        var results = await Collect(transform.TransformAsync(config, targets));
+
+        var inside = results.Single(f => Equals(f.Attributes!["id"], 1));
+        Convert.ToInt64(inside.Attributes!["JOIN_COUNT"], CultureInfo.InvariantCulture).Should().Be(1);
+        Convert.ToDouble(inside.Attributes["SUM_value"], CultureInfo.InvariantCulture).Should().Be(7.0);
+
+        var outside = results.Single(f => Equals(f.Attributes!["id"], 2));
+        Convert.ToInt64(outside.Attributes!["JOIN_COUNT"], CultureInfo.InvariantCulture).Should().Be(0);
+    }
+
+    [UnitTest]
+    public async Task Aggregate_NoMatch_EmitsZeroCountAndPreservesTarget()
+    {
+        var transform = new SpatialJoinTransform();
+        var config = new TransformConfig
+        {
+            Type = SpatialJoinTransform.TransformType,
+            Options = new Dictionary<string, string>
+            {
+                ["aggregate"] = "true",
+                ["referenceInline"] = JoinPoints,
+                ["statistics"] = ":count;value:sum"
+            }
+        };
+
+        var targets = Many(new Feature(Square(100, 100, 1), Attrs(("zone", "empty"))));
+
+        var results = await Collect(transform.TransformAsync(config, targets));
+
+        results.Should().ContainSingle();
+        var only = results.Single();
+        only.Attributes!["zone"].Should().Be("empty");
+        Convert.ToInt64(only.Attributes["JOIN_COUNT"], CultureInfo.InvariantCulture).Should().Be(0);
+        only.Attributes["SUM_value"].Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task EnrichmentMode_StillTransfersFirstMatch_WhenAggregateFalse()
+    {
+        // Guard the preserved (default) attribute-transfer behavior.
+        var transform = new SpatialJoinTransform();
+        var config = new TransformConfig
+        {
+            Type = SpatialJoinTransform.TransformType,
+            Options = new Dictionary<string, string>
+            {
+                ["referenceInline"] =
+                    "{\"type\":\"FeatureCollection\",\"features\":[" +
+                    "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":" +
+                    "[[[0,0],[10,0],[10,10],[0,10],[0,0]]]},\"properties\":{\"region\":\"west\"}}]}",
+                ["predicate"] = "contains",
+                ["transfer"] = "region"
+            }
+        };
+
+        var results = await Collect(transform.TransformAsync(
+            config,
+            Many(new Feature(Factory.CreatePoint(new Coordinate(5, 5)), Attrs(("id", 1))))));
+
+        results.Should().ContainSingle();
+        results.Single().Attributes!["region"].Should().Be("west");
+    }
+
+    [UnitTest]
+    public async Task Aggregate_UnknownStatistic_Throws()
+    {
+        var transform = new SpatialJoinTransform();
+        var config = new TransformConfig
+        {
+            Type = SpatialJoinTransform.TransformType,
+            Options = new Dictionary<string, string>
+            {
+                ["aggregate"] = "true",
+                ["referenceInline"] = JoinPoints,
+                ["statistics"] = "value:stddev"
+            }
+        };
+
+        var act = async () => await Collect(transform.TransformAsync(
+            config,
+            Many(new Feature(Square(0, 0, 10), new AttributesTable()))));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [UnitTest]
+    public async Task UnknownPredicate_Throws()
+    {
+        var transform = new SpatialJoinTransform();
+        var config = new TransformConfig
+        {
+            Type = SpatialJoinTransform.TransformType,
+            Options = new Dictionary<string, string>
+            {
+                ["aggregate"] = "true",
+                ["referenceInline"] = JoinPoints,
+                ["predicate"] = "touches"
+            }
+        };
+
+        var act = async () => await Collect(transform.TransformAsync(
+            config,
+            Many(new Feature(Square(0, 0, 10), new AttributesTable()))));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    private static Polygon Square(double x, double y, double size) =>
+        Factory.CreatePolygon(
+        [
+            new Coordinate(x, y),
+            new Coordinate(x + size, y),
+            new Coordinate(x + size, y + size),
+            new Coordinate(x, y + size),
+            new Coordinate(x, y),
+        ]);
+
+    private static AttributesTable Attrs(params (string Name, object? Value)[] values)
+    {
+        var table = new AttributesTable();
+        foreach (var (name, value) in values)
+        {
+            table.Add(name, value);
+        }
+
+        return table;
+    }
+
+    private static async Task<List<IFeature>> Collect(IAsyncEnumerable<IFeature> source)
+    {
+        var list = new List<IFeature>();
+        await foreach (var feature in source)
+        {
+            list.Add(feature);
+        }
+
+        return list;
+    }
+
+    private static async IAsyncEnumerable<IFeature> Many(params IFeature[] features)
+    {
+        foreach (var feature in features)
+        {
+            yield return feature;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -106,15 +106,16 @@ public sealed class CatalogExecutableConformanceTests
     [UnitTest]
     public void ManagedVectorExecutableCount_CoversTheVectorProcesses()
     {
-        // Documents the closed honesty gap: 17 vector processes now execute
-        // (12 single-geometry primitives + 5 layer-scope), up from the
-        // 12 single-geometry executors before this stream. The fifth layer-scope
-        // process is generalization.dissolve (group-aware aggregation).
+        // Documents the closed honesty gap: 18 vector processes now execute
+        // (12 single-geometry primitives + 6 layer-scope), up from the
+        // 12 single-geometry executors before this stream. The two group-aware
+        // additions are generalization.dissolve and analytics.spatial-join
+        // (aggregating one-to-one summarizing form).
         var managedVector = _catalog.ListProcesses()
             .Count(p => GeoprocessingExecutionRoutingClassifier.Classify(p)
                 == GeoprocessingExecutionRouting.ManagedVectorExecutable);
 
-        managedVector.Should().Be(17);
+        managedVector.Should().Be(18);
     }
 
     private static IReadOnlyCollection<string> DispatcherSupportedProcessIds()

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.GeoETL.Services.Connectors;
+using Honua.Server.Features.Geoprocessing;
+using Honua.Server.Features.Geoprocessing.Execution;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Catalog honesty conformance: every VECTOR process the built-in catalog
+/// advertises as managed-executable must have a working executor registered in
+/// the geoprocessing dispatcher, and every raster/surface process must be
+/// honestly marked routed-to-native-worker rather than silently advertised as
+/// runnable. This is the test that closes the historical "12 of 45 advertised"
+/// gap for the vector families: it FAILS if a managed-vector process is
+/// advertised but not executable, or if a routed-to-native process leaks into
+/// the managed dispatcher.
+/// </summary>
+public sealed class CatalogExecutableConformanceTests
+{
+    private readonly BuiltInProcessCatalog _catalog = new();
+
+    [UnitTest]
+    public void EveryManagedVectorProcess_HasAWorkingExecutor()
+    {
+        var executable = DispatcherSupportedProcessIds();
+
+        var advertisedVector = _catalog.ListProcesses()
+            .Where(p => GeoprocessingExecutionRoutingClassifier.Classify(p)
+                == GeoprocessingExecutionRouting.ManagedVectorExecutable)
+            .Select(p => p.ProcessId)
+            .ToList();
+
+        advertisedVector.Should().NotBeEmpty();
+
+        foreach (var processId in advertisedVector)
+        {
+            executable.Should().Contain(
+                processId,
+                $"catalog advertises managed-vector process '{processId}' which therefore MUST have a working executor");
+        }
+    }
+
+    [UnitTest]
+    public void EveryDispatcherExecutor_IsAnAdvertisedManagedVectorProcess()
+    {
+        var executable = DispatcherSupportedProcessIds();
+
+        foreach (var processId in executable)
+        {
+            var definition = _catalog.GetProcess(processId);
+            definition.Should().NotBeNull(
+                $"dispatcher routes '{processId}' so it must be advertised in the catalog");
+            GeoprocessingExecutionRoutingClassifier.Classify(definition!)
+                .Should().Be(
+                    GeoprocessingExecutionRouting.ManagedVectorExecutable,
+                    $"every executable process '{processId}' must be classified managed-vector-executable");
+        }
+    }
+
+    [UnitTest]
+    public void RasterAndSurfaceProcesses_AreRoutedToNativeWorker_AndAbsentFromManagedDispatcher()
+    {
+        var executable = DispatcherSupportedProcessIds();
+
+        var rasterSurface = _catalog.ListProcesses()
+            .Where(p => p.Category is "raster" or "surface")
+            .ToList();
+
+        rasterSurface.Should().NotBeEmpty();
+
+        foreach (var definition in rasterSurface)
+        {
+            GeoprocessingExecutionRoutingClassifier.Classify(definition)
+                .Should().Be(
+                    GeoprocessingExecutionRouting.RoutedToNativeWorker,
+                    $"raster/surface process '{definition.ProcessId}' must be routed to the native GDAL worker");
+            executable.Should().NotContain(
+                definition.ProcessId,
+                $"raster/surface process '{definition.ProcessId}' must NOT be executable in the lean managed baseline");
+        }
+    }
+
+    [UnitTest]
+    public void EveryCatalogProcess_HasExactlyOneRouting()
+    {
+        // Sanity: the classifier partitions the whole catalog (no process is left
+        // unclassified), so honesty claims cover every advertised process.
+        foreach (var definition in _catalog.ListProcesses())
+        {
+            var routing = GeoprocessingExecutionRoutingClassifier.Classify(definition);
+            routing.Should().BeOneOf(
+                GeoprocessingExecutionRouting.ManagedVectorExecutable,
+                GeoprocessingExecutionRouting.RoutedToNativeWorker,
+                GeoprocessingExecutionRouting.NotYetExecutable);
+        }
+    }
+
+    [UnitTest]
+    public void ManagedVectorExecutableCount_CoversTheSixteenVectorProcesses()
+    {
+        // Documents the closed honesty gap: 16 vector processes now execute
+        // (12 single-geometry primitives + 4 layer-scope), up from the
+        // 12 single-geometry executors before this stream.
+        var managedVector = _catalog.ListProcesses()
+            .Count(p => GeoprocessingExecutionRoutingClassifier.Classify(p)
+                == GeoprocessingExecutionRouting.ManagedVectorExecutable);
+
+        managedVector.Should().Be(16);
+    }
+
+    private static IReadOnlyCollection<string> DispatcherSupportedProcessIds()
+    {
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = 50L * 1024L * 1024L,
+            ResultRetention = TimeSpan.FromDays(7)
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+
+        var dispatcher = new GeoprocessingDispatchJobExecutor(
+            new GeometryBufferJobExecutor(monitor, NullLogger<GeometryBufferJobExecutor>.Instance),
+            new GeometryClipJobExecutor(monitor, NullLogger<GeometryClipJobExecutor>.Instance),
+            new GeometryIntersectJobExecutor(monitor, NullLogger<GeometryIntersectJobExecutor>.Instance),
+            new GeometryProjectJobExecutor(monitor, NullLogger<GeometryProjectJobExecutor>.Instance),
+            new GeometryAreaJobExecutor(monitor, NullLogger<GeometryAreaJobExecutor>.Instance),
+            new GeometryUnionJobExecutor(monitor, NullLogger<GeometryUnionJobExecutor>.Instance),
+            new GeometryCentroidJobExecutor(monitor, NullLogger<GeometryCentroidJobExecutor>.Instance),
+            new GeometryLengthJobExecutor(monitor, NullLogger<GeometryLengthJobExecutor>.Instance),
+            new GeometryConvexHullJobExecutor(monitor, NullLogger<GeometryConvexHullJobExecutor>.Instance),
+            new GeometryDissolveJobExecutor(monitor, NullLogger<GeometryDissolveJobExecutor>.Instance),
+            new GeometrySimplifyJobExecutor(monitor, NullLogger<GeometrySimplifyJobExecutor>.Instance),
+            new GeometrySnapJobExecutor(monitor, NullLogger<GeometrySnapJobExecutor>.Instance),
+            new LayerGeometryJobExecutor(
+                [new InlineGeoJsonLayerFeatureSource()],
+                monitor,
+                NullLogger<LayerGeometryJobExecutor>.Instance),
+            NullLogger<GeoprocessingDispatchJobExecutor>.Instance);
+
+        return dispatcher.SupportedProcessIds;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -104,16 +104,17 @@ public sealed class CatalogExecutableConformanceTests
     }
 
     [UnitTest]
-    public void ManagedVectorExecutableCount_CoversTheSixteenVectorProcesses()
+    public void ManagedVectorExecutableCount_CoversTheVectorProcesses()
     {
-        // Documents the closed honesty gap: 16 vector processes now execute
-        // (12 single-geometry primitives + 4 layer-scope), up from the
-        // 12 single-geometry executors before this stream.
+        // Documents the closed honesty gap: 17 vector processes now execute
+        // (12 single-geometry primitives + 5 layer-scope), up from the
+        // 12 single-geometry executors before this stream. The fifth layer-scope
+        // process is generalization.dissolve (group-aware aggregation).
         var managedVector = _catalog.ListProcesses()
             .Count(p => GeoprocessingExecutionRoutingClassifier.Classify(p)
                 == GeoprocessingExecutionRouting.ManagedVectorExecutable);
 
-        managedVector.Should().Be(16);
+        managedVector.Should().Be(17);
     }
 
     private static IReadOnlyCollection<string> DispatcherSupportedProcessIds()

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
@@ -33,15 +33,15 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         var context = Substitute.For<IJobExecutionContext>();
         context.OperationId.Returns("op-unknown");
 
-        // geometry.difference is still catalog-only after slice 5 — pick it
-        // for the unknown-id smoke so the assertion stays meaningful as the
-        // slice adds geometry.simplify / geometry.dissolve / geometry.snap.
-        var record = CreateJobRecord("geometry.difference");
+        // geometry.difference and geometry.make-valid now execute at layer scope
+        // (LayerGeometryJobExecutor), so pick a raster id that is routed to the
+        // native GDAL worker and never handled by the managed dispatcher.
+        var record = CreateJobRecord("raster.clip");
 
         var result = await dispatcher.ExecuteAsync(record, context, CancellationToken.None);
 
         result.Status.Should().Be(ExecutionJobStatus.Failed);
-        result.ErrorMessage.Should().Contain("geometry.difference");
+        result.ErrorMessage.Should().Contain("raster.clip");
         result.ErrorMessage.Should().Contain("geometry.buffer");
         result.ErrorMessage.Should().Contain("geometry.clip");
         result.ErrorMessage.Should().Contain("geometry.intersect");
@@ -71,8 +71,9 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         result.ErrorMessage.Should().Contain("<none>");
     }
 
-    private static readonly string[] SliceFiveProcessIds =
+    private static readonly string[] SupportedProcessIds =
     {
+        // Single-geometry (primitive) vector executors.
         "geometry.buffer",
         "geometry.clip",
         "geometry.intersect",
@@ -85,13 +86,18 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         "geometry.dissolve",
         "geometry.simplify",
         "geometry.snap",
+        // Layer-scope (feature-collection) executors.
+        "generalization.simplify-layer",
+        "conversion.feature-project",
+        "geometry.make-valid",
+        "geometry.difference",
     };
 
     [UnitTest]
-    public void SupportedProcessIds_ListsSliceFiveExecutors()
+    public void SupportedProcessIds_ListsPrimitiveAndLayerScopeExecutors()
     {
         var dispatcher = CreateDispatcher();
-        dispatcher.SupportedProcessIds.Should().BeEquivalentTo(SliceFiveProcessIds);
+        dispatcher.SupportedProcessIds.Should().BeEquivalentTo(SupportedProcessIds);
     }
 
     [UnitTest]
@@ -124,6 +130,10 @@ public sealed class GeoprocessingDispatchJobExecutorTests
             new GeometryDissolveJobExecutor(monitor, NullLogger<GeometryDissolveJobExecutor>.Instance),
             new GeometrySimplifyJobExecutor(monitor, NullLogger<GeometrySimplifyJobExecutor>.Instance),
             new GeometrySnapJobExecutor(monitor, NullLogger<GeometrySnapJobExecutor>.Instance),
+            new LayerGeometryJobExecutor(
+                [new Honua.Core.Features.GeoETL.Services.Connectors.InlineGeoJsonLayerFeatureSource()],
+                monitor,
+                NullLogger<LayerGeometryJobExecutor>.Instance),
             NullLogger<GeoprocessingDispatchJobExecutor>.Instance);
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
@@ -91,6 +91,9 @@ public sealed class GeoprocessingDispatchJobExecutorTests
         "conversion.feature-project",
         "geometry.make-valid",
         "geometry.difference",
+        // Group-aware vector aggregation lifted to executable layer scope.
+        "generalization.dissolve",
+        "analytics.spatial-join",
     };
 
     [UnitTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/LayerGeometryJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/LayerGeometryJobExecutorTests.cs
@@ -152,6 +152,74 @@ public sealed class LayerGeometryJobExecutorTests
     }
 
     [UnitTest]
+    public async Task ExecuteAsync_Dissolve_GroupsByFieldAndAggregates()
+    {
+        var collection =
+            "{\"type\":\"FeatureCollection\",\"features\":[" +
+            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":" +
+            "[[[0,0],[1,0],[1,1],[0,1],[0,0]]]},\"properties\":{\"region\":\"A\",\"pop\":10}}," +
+            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":" +
+            "[[[1,0],[2,0],[2,1],[1,1],[1,0]]]},\"properties\":{\"region\":\"A\",\"pop\":30}}," +
+            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":" +
+            "[[[10,10],[11,10],[11,11],[10,11],[10,10]]]},\"properties\":{\"region\":\"B\",\"pop\":5}}]}";
+
+        var record = CreateJobRecord(
+            "generalization.dissolve",
+            inputGeoJson: collection,
+            extraInputs: new Dictionary<string, string>
+            {
+                ["groupByFields"] = "region",
+                ["statistics"] = ":count;pop:sum"
+            });
+
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-dissolve");
+        string? published = null;
+        context.When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => published = call.ArgAt<string>(0));
+
+        var result = await CreateExecutor().ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        var doc = ParseCollection(published);
+        doc.RootElement.GetProperty("featureCount").GetInt64().Should().Be(2);
+
+        var features = doc.RootElement.GetProperty("features");
+        JsonElement? groupA = null;
+        foreach (var f in features.EnumerateArray())
+        {
+            if (f.GetProperty("properties").GetProperty("region").GetString() == "A")
+            {
+                groupA = f;
+            }
+        }
+
+        groupA.Should().NotBeNull();
+        groupA!.Value.GetProperty("properties").GetProperty("COUNT").GetInt64().Should().Be(2);
+        groupA.Value.GetProperty("properties").GetProperty("SUM_pop").GetDouble().Should().Be(40.0);
+        var geometry = new GeoJsonReader().Read<Geometry>(groupA.Value.GetProperty("geometry").GetRawText());
+        geometry.Area.Should().BeApproximately(2.0, 1e-6);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_DissolveAll_NoGroupField_CollapsesToOneFeature()
+    {
+        var collection =
+            "{\"type\":\"FeatureCollection\",\"features\":[" +
+            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":" +
+            "[[[0,0],[1,0],[1,1],[0,1],[0,0]]]},\"properties\":{}}," +
+            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":" +
+            "[[[5,5],[6,5],[6,6],[5,6],[5,5]]]},\"properties\":{}}]}";
+
+        var (result, published) = await RunAsync("generalization.dissolve", collection);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        var doc = ParseCollection(published);
+        doc.RootElement.GetProperty("featureCount").GetInt64().Should().Be(1);
+        ReadFirstGeometry(doc).Area.Should().BeApproximately(2.0, 1e-6);
+    }
+
+    [UnitTest]
     public async Task ExecuteAsync_MissingInputReference_FailsCleanly()
     {
         var executor = CreateExecutor();

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/LayerGeometryJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/LayerGeometryJobExecutorTests.cs
@@ -220,6 +220,60 @@ public sealed class LayerGeometryJobExecutorTests
     }
 
     [UnitTest]
+    public async Task ExecuteAsync_SpatialJoin_AggregatesMatchedJoinFeaturesPerTarget()
+    {
+        // Target: one polygon covering 0..10. Join: two points inside it.
+        var targetCollection =
+            "{\"type\":\"FeatureCollection\",\"features\":[" +
+            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":" +
+            "[[[0,0],[10,0],[10,10],[0,10],[0,0]]]},\"properties\":{\"zone\":\"A\"}}]}";
+        var joinCollection =
+            "{\"type\":\"FeatureCollection\",\"features\":[" +
+            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[1,1]},\"properties\":{\"value\":10}}," +
+            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[2,2]},\"properties\":{\"value\":30}}]}";
+
+        var record = CreateJobRecord(
+            "analytics.spatial-join",
+            inputGeoJson: targetCollection,
+            extraInputs: new Dictionary<string, string>
+            {
+                ["joinGeoJson"] = joinCollection,
+                ["predicate"] = "intersects",
+                ["statistics"] = ":count;value:sum"
+            });
+
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-sjoin");
+        string? published = null;
+        context.When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => published = call.ArgAt<string>(0));
+
+        var result = await CreateExecutor().ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        var doc = ParseCollection(published);
+        doc.RootElement.GetProperty("featureCount").GetInt64().Should().Be(1);
+        var props = doc.RootElement.GetProperty("features")[0].GetProperty("properties");
+        props.GetProperty("zone").GetString().Should().Be("A");
+        props.GetProperty("JOIN_COUNT").GetInt64().Should().Be(2);
+        props.GetProperty("SUM_value").GetDouble().Should().Be(40.0);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_SpatialJoin_MissingJoinLayer_FailsCleanly()
+    {
+        var record = CreateJobRecord("analytics.spatial-join", inputGeoJson: TwoPointCollection);
+
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-sjoin-nojoin");
+
+        var result = await CreateExecutor().ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("joinGeoJson");
+    }
+
+    [UnitTest]
     public async Task ExecuteAsync_MissingInputReference_FailsCleanly()
     {
         var executor = CreateExecutor();

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/LayerGeometryJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/LayerGeometryJobExecutorTests.cs
@@ -1,0 +1,294 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.GeoETL.Services.Connectors;
+using Honua.Server.Features.Geoprocessing;
+using Honua.Server.Features.Geoprocessing.Execution;
+using Honua.Server.Features.Infrastructure.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Unit coverage of the layer-scope (feature-collection) geometry executor.
+/// Streams an inline GeoJSON FeatureCollection, applies the geometry operation
+/// across every feature (carrying attributes through), and publishes an output
+/// FeatureCollection artifact. Runs fully in-memory over NetTopologySuite — no
+/// database. Closes the catalog-honesty gap for generalization.simplify-layer,
+/// conversion.feature-project, geometry.make-valid, and geometry.difference.
+/// </summary>
+public sealed class LayerGeometryJobExecutorTests
+{
+    private const string FeatureCollectionUriPrefix = "data:application/geo+json;base64,";
+
+    private const string TwoPointCollection =
+        "{\"type\":\"FeatureCollection\",\"features\":[" +
+        "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[0,0]},\"properties\":{\"name\":\"a\"}}," +
+        "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[10,10]},\"properties\":{\"name\":\"b\"}}]}";
+
+    [UnitTest]
+    public async Task ExecuteAsync_UnsupportedProcessId_FailsWithClassifiedMessage()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-test");
+
+        var record = CreateJobRecord("geometry.buffer", inputGeoJson: TwoPointCollection);
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("layer-scope");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_MakeValid_OverInlineCollection_RepairsEachFeature()
+    {
+        var collection =
+            "{\"type\":\"FeatureCollection\",\"features\":[" +
+            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":" +
+            "[[[0,0],[10,10],[10,0],[0,10],[0,0]]]},\"properties\":{\"id\":1}}]}";
+
+        var (result, published) = await RunAsync("geometry.make-valid", collection);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        var doc = ParseCollection(published);
+        doc.RootElement.GetProperty("processId").GetString().Should().Be("geometry.make-valid");
+        doc.RootElement.GetProperty("featureCount").GetInt64().Should().Be(1);
+        var geometry = ReadFirstGeometry(doc);
+        geometry.IsValid.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_SimplifyLayer_CarriesAttributesAndSimplifies()
+    {
+        var collection =
+            "{\"type\":\"FeatureCollection\",\"features\":[" +
+            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"LineString\",\"coordinates\":" +
+            "[[0,0],[5,0.001],[10,0]]},\"properties\":{\"name\":\"line\"}}]}";
+
+        var record = CreateJobRecord(
+            "generalization.simplify-layer",
+            inputGeoJson: collection,
+            extraInputs: new Dictionary<string, string> { ["tolerance"] = "1.0" });
+
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-simplify");
+        string? published = null;
+        context.When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => published = call.ArgAt<string>(0));
+
+        var result = await CreateExecutor().ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        var doc = ParseCollection(published);
+        doc.RootElement.GetProperty("featureCount").GetInt64().Should().Be(1);
+        var feature = doc.RootElement.GetProperty("features")[0];
+        feature.GetProperty("properties").GetProperty("name").GetString().Should().Be("line");
+        var geometry = new GeoJsonReader().Read<Geometry>(feature.GetProperty("geometry").GetRawText());
+        ((LineString)geometry).NumPoints.Should().Be(2);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_FeatureProject_ReprojectsEveryFeature()
+    {
+        var record = CreateJobRecord(
+            "conversion.feature-project",
+            inputGeoJson: TwoPointCollection,
+            extraInputs: new Dictionary<string, string> { ["fromSrid"] = "4326", ["targetSrid"] = "3857" });
+
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-project");
+        string? published = null;
+        context.When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => published = call.ArgAt<string>(0));
+
+        var result = await CreateExecutor().ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        var doc = ParseCollection(published);
+        doc.RootElement.GetProperty("featureCount").GetInt64().Should().Be(2);
+        // (10,10) in WGS84 projects to ~1.11e6 metres in Web Mercator.
+        var second = ReadGeometryAt(doc, 1);
+        ((Point)second).X.Should().BeApproximately(1113194.9, 1.0);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_Difference_SubtractsRegionFromEachFeature()
+    {
+        var collection =
+            "{\"type\":\"FeatureCollection\",\"features\":[" +
+            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":" +
+            "[[[0,0],[10,0],[10,10],[0,10],[0,0]]]},\"properties\":{}}]}";
+
+        var record = CreateJobRecord(
+            "geometry.difference",
+            inputGeoJson: collection,
+            extraInputs: new Dictionary<string, string>
+            {
+                ["regionWkt"] = "POLYGON((5 0, 15 0, 15 10, 5 10, 5 0))"
+            });
+
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-diff");
+        string? published = null;
+        context.When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => published = call.ArgAt<string>(0));
+
+        var result = await CreateExecutor().ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        var doc = ParseCollection(published);
+        ReadFirstGeometry(doc).Area.Should().BeApproximately(50.0, 1e-6);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_MissingInputReference_FailsCleanly()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-noinput");
+
+        var record = CreateJobRecord("geometry.make-valid", inputGeoJson: null);
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("input layer reference");
+        await context.DidNotReceiveWithAnyArgs().PublishArtifactAsync(default!, default);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_CatalogLayerWithoutProvider_FailsWithSourceMessage()
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-catalog");
+
+        var record = CreateJobRecord(
+            "geometry.make-valid",
+            inputGeoJson: null,
+            extraInputs: new Dictionary<string, string> { ["layerId"] = "100" });
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("CatalogLayer");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_SimplifyLayer_MissingTolerance_FailsCleanly()
+    {
+        var record = CreateJobRecord("generalization.simplify-layer", inputGeoJson: TwoPointCollection);
+
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-no-tol");
+
+        var result = await CreateExecutor().ExecuteAsync(record, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("tolerance");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static async Task<(JobExecutionResult Result, string? Published)> RunAsync(
+        string processId, string inputGeoJson)
+    {
+        var executor = CreateExecutor();
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-run");
+        string? published = null;
+        context.When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => published = call.ArgAt<string>(0));
+
+        var record = CreateJobRecord(processId, inputGeoJson);
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+        return (result, published);
+    }
+
+    private static LayerGeometryJobExecutor CreateExecutor(long maxArtifactBytes = 50L * 1024L * 1024L)
+    {
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = maxArtifactBytes,
+            ResultRetention = TimeSpan.FromDays(7)
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+        return new LayerGeometryJobExecutor(
+            [new InlineGeoJsonLayerFeatureSource()],
+            monitor,
+            NullLogger<LayerGeometryJobExecutor>.Instance);
+    }
+
+    private static JsonDocument ParseCollection(string? published)
+    {
+        published.Should().NotBeNull();
+        published!.Should().StartWith(FeatureCollectionUriPrefix);
+        var bytes = Convert.FromBase64String(published[FeatureCollectionUriPrefix.Length..]);
+        var doc = JsonDocument.Parse(bytes);
+        doc.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        return doc;
+    }
+
+    private static Geometry ReadFirstGeometry(JsonDocument doc) => ReadGeometryAt(doc, 0);
+
+    private static Geometry ReadGeometryAt(JsonDocument doc, int index)
+    {
+        var feature = doc.RootElement.GetProperty("features")[index];
+        return new GeoJsonReader().Read<Geometry>(feature.GetProperty("geometry").GetRawText());
+    }
+
+    private static ExecutionJobRecord CreateJobRecord(
+        string processId,
+        string? inputGeoJson,
+        IReadOnlyDictionary<string, string>? extraInputs = null)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId,
+            ["protocolProcessId"] = processId,
+        };
+
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+        if (inputGeoJson != null)
+        {
+            parameters[prefix + "inputGeoJson"] = inputGeoJson;
+        }
+
+        if (extraInputs != null)
+        {
+            foreach (var (key, value) in extraInputs)
+            {
+                parameters[prefix + key] = value;
+            }
+        }
+
+        return new ExecutionJobRecord
+        {
+            OperationId = "op-test",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:test",
+                Parameters = parameters
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What
**Stacked on `feat/geoetl-baseline`** (review/merge that first). Resolves the core GP gap: `geometry.*` executors ran on a *single* WKB geometry, but ArcPy/real GIS operate on feature classes — so only 12/45 processes executed and the catalog over-promised.

Adds **layer-level GP execution** as the canonical path: a process takes an input layer reference (catalog layer id | inline GeoJSON FeatureCollection | query result) → streams features → applies the op across the collection → emits an output layer/artifact. Reuses the ETL machinery from the base branch (`GeometryOperationTransform`, `ReprojectTransform`, `HonuaLayerSinkConnector` insert path) — GP-over-a-layer == a single-transform ETL pipeline.

- **18 vector processes now execute at layer scope** (was 12 single-geometry), incl. the two highest-value Esri-migration tools: `generalization.dissolve` (group-by + UnaryUnion + COUNT/SUM/MEAN/MIN/MAX/FIRST stats) and `analytics.spatial-join` (one-to-one summarizing, STRtree, intersects/contains/within).
- **Catalog honesty:** `CatalogExecutableConformanceTests` fails the build if a vector process is advertised but not executable. Raster/surface marked routed-to-native-worker.

## Tests
Core 1841 pass, Server Geoprocessing 455 pass. Conformance failure paths verified. No GDAL added (pure NTS: UnaryUnion, STRtree).
**Integration tests (Testcontainers/Redis/Postgres) were NOT run — no Docker on the build box.** Needs a CI pass.

## Notes / follow-ups (integration)
- **Claim-fence:** when the GDAL-worker PR merges with this line, set `GeoprocessingDispatchJobExecutor.AcceptedRuntimeProfiles` to the managed profile and register GP raster jobs as `native`. Note left in code + roadmap.
- **DB-backed `ILayerFeatureSource`:** catalog-layer-id / second-layer (spatial-join *join* side) resolution is a registered seam; only inline-GeoJSON ships here (keeps the branch Npgsql-free). Recommended next increment before GA.
- Group-aware analytics not built: `analytics.cluster` (future managed increment), `analytics.density` (raster → GDAL worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
