### PR TITLE
ci: add Raster & Scene Analysis test shard for targeted 3D CI

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -124,6 +124,24 @@
       ]
     },
     {
+      "name": "Raster & Scene Analysis",
+      "shard_name": "Raster & Scene Analysis",
+      "artifact_suffix": "raster-scene",
+      "log_name": "server-tests-raster-scene",
+      "timeout_minutes": 30,
+      "test_timeout_minutes": 20,
+      "max_cpu_count": "",
+      "upload_operator_eval_report": false,
+      "upload_odata_evidence": false,
+      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Elevation|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Scene",
+      "paths": [
+        "src/Honua.Server/Features/Protocols/Elevation/",
+        "src/Honua.Server/Features/Protocols/Scene/",
+        "tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/",
+        "tests/dotnet/Honua.Server.Tests/Features/Protocols/Scene/"
+      ]
+    },
+    {
       "name": "Import",
       "shard_name": "Import",
       "artifact_suffix": "import",


### PR DESCRIPTION
## Issue Link
Related to #530

## Summary
The Honua.Server.Tests targeted-CI shard matrix (ADR-0037, `.github/ci-shards.json`) has no shard claiming the 3D Raster/Elevation/Scene analysis surface. Per `scripts/ci/honua-server-targeted-tests.sh`, any changed file under a watched source prefix (`src/Honua.Server/`, `tests/dotnet/Honua.Server.Tests/`) that no shard's `paths` claims forces `run_all` with reason `unmapped_source_change`. As a result, every PR touching `src/Honua.Server/Features/Protocols/Elevation/`, `src/Honua.Server/Features/Protocols/Scene/`, or their test dirs trips the full "run everything" matrix. This PR adds a targeted `Raster & Scene Analysis` shard so those 3D PRs route to a single focused shard instead.

## Changes Made
- Added a new shard object `Raster & Scene Analysis` to `.github/ci-shards.json` `shards[]` (inserted before `Import`), with all matrix-runtime fields (`shard_name`, `artifact_suffix: raster-scene`, `log_name: server-tests-raster-scene`, `timeout_minutes: 30`, `test_timeout_minutes: 20`, `max_cpu_count: ""`, both upload flags `false`) matching its siblings.
- `filter`: `FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Elevation|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Scene` — verified against the actual `namespace` declarations in the Elevation and Scene server test files.
- `paths` claims the cleanly-isolated 3D server source + test dirs that were previously unmapped: `src/Honua.Server/Features/Protocols/Elevation/`, `src/Honua.Server/Features/Protocols/Scene/`, `tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/`, `tests/dotnet/Honua.Server.Tests/Features/Protocols/Scene/`.

## Scene-Core coverage decision (the main risk)
The instruction warned that `src/Honua.Core/Features/Scene/` (Symbology3D / TileStyleSpec) and `src/Honua.Core/Features/Raster/` may be exercised by server tests outside `Protocols.Scene`. I investigated:

- **Core Scene** is exercised by tests in three namespaces: `Features.Protocols.Scene`, `Features.Infrastructure.Scene` (`SceneTilesPublishExecutorTests`, `ConstructionDemoGenerationTests`), and `Features.Admin` (`SceneGenerationEndpointsTests`, `SceneDatasetEndpointsTests`). The `Features.Admin.*` Scene tests are matched by **no** shard `filter` today (the "Admin & Infrastructure" filter keys on `Honua.Server.Tests.Admin.`, not `Honua.Server.Tests.Features.Admin.`) — a pre-existing namespace gap outside this PR's scope. Claiming `src/Honua.Core/Features/Scene/` here would create a `paths` entry whose full test coverage this shard's filter cannot guarantee.
- **Core Raster** is exercised extremely broadly (ImageServer, OGC Coverages/WCS/Maps, Terrain, Cog, Geoprocessing, Import, Infrastructure) — ~9 different shards. Claiming it would require a run_all-equivalent filter.

**Decision (option b — scope to the cleanly-isolated surface):** do NOT claim `src/Honua.Core/Features/Raster/` or `src/Honua.Core/Features/Scene/`. A change to either Core area correctly continues to force `run_all` (they are widely-shared dependencies). This shard claims only the server-side `Protocols/Elevation` and `Protocols/Scene` source + test dirs, which I verified are exercised exclusively by their own `Protocols.Elevation` / `Protocols.Scene` test namespaces — so this shard's filter runs every test exercising every path it claims. (`Features.Infrastructure.Scene` Scene-publish tests remain owned by the existing "Infra and Security" filter `Honua.Server.Tests.Features.Infrastructure`.)

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

This is a `.github/ci-shards.json`-only change. There is no automated shard coverage/parity test (ADR-0037 explicitly states "there is no separate parity check because there is no second source of truth to drift from"; no `.cs`/`.bats`/`.py` test references `ci-shards.json`). The meaningful validation for this change is JSON validity + the real targeting-script simulation, both run below:

- `jq . .github/ci-shards.json` → valid JSON.
- Matrix projection: the new entry has all 9 fields the `targeted-shards` jq in `ci.yml` projects (`shard_name, artifact_suffix, log_name, timeout_minutes, test_timeout_minutes, max_cpu_count, upload_operator_eval_report, upload_odata_evidence, filter`).
- Routing simulation via `scripts/ci/honua-server-targeted-tests.sh`:
  - Before: a change under any of the four claimed dirs → `{"run_all":true,"reason":"unmapped_source_change"}`.
  - After: `src/Honua.Server/Features/Protocols/Scene/*` → `{"run_all":false,"shards":["Raster & Scene Analysis"],"reason":"targeted"}`; same for `Protocols/Elevation` and both test dirs.
  - Controls (unchanged, correct): Core Raster / Core Scene change → `run_all` / `unmapped_source_change`; an `src/Honua.Server/Features/Infrastructure/` change → `run_all` / `infrastructure_change`.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

> Note: this is a CI-config-only change (`.github/ci-shards.json`). Per the validation-gate analysis above, the meaningful pre-PR validation is the shard JSON validity check + the targeting-script routing simulation (not the full `dotnet` shard run, which `pre-pr-check.sh` drives for code changes); those gates were run and all passed, so the pre-PR box is checked on that basis.
