### PR TITLE
feat: add analysis content list + cost-estimate endpoints (#1237)

### DIFF
--- a/src/Honua.Ai/Features/AnalysisContent/AnalysisContentApiModels.cs
+++ b/src/Honua.Ai/Features/AnalysisContent/AnalysisContentApiModels.cs
@@ -65,6 +65,28 @@ internal sealed record AnalysisContentItemResponse
     public required AnalysisContentVersion Version { get; init; }
 }
 
+internal sealed record AnalysisContentItemListResponse
+{
+    public IReadOnlyList<AnalysisContentItem> Items { get; init; } = [];
+
+    public required long TotalCount { get; init; }
+
+    public required int Limit { get; init; }
+
+    public required int Offset { get; init; }
+}
+
+internal sealed record AnalysisContentEstimateResponse
+{
+    public required string ItemId { get; init; }
+
+    public required int Version { get; init; }
+
+    public required string VersionId { get; init; }
+
+    public required AnalysisContentEstimate Estimate { get; init; }
+}
+
 internal sealed record AnalysisContentVersionResponse
 {
     public required AnalysisContentItem Item { get; init; }
@@ -98,6 +120,8 @@ internal sealed record AnalysisArtifactResponse
 [JsonSerializable(typeof(RunAnalysisContentVersionRequest))]
 [JsonSerializable(typeof(RerunAnalysisContentVersionRequest))]
 [JsonSerializable(typeof(AnalysisContentItemResponse))]
+[JsonSerializable(typeof(AnalysisContentItemListResponse))]
+[JsonSerializable(typeof(AnalysisContentEstimateResponse))]
 [JsonSerializable(typeof(AnalysisContentVersionResponse))]
 [JsonSerializable(typeof(AnalysisContentJobResponse))]
 [JsonSerializable(typeof(AnalysisArtifactResponse))]
@@ -107,6 +131,8 @@ internal sealed record AnalysisArtifactResponse
 [JsonSerializable(typeof(ProblemDetailsResponse))]
 [JsonSerializable(typeof(AnalysisContentItem))]
 [JsonSerializable(typeof(AnalysisContentVersion))]
+[JsonSerializable(typeof(AnalysisContentEstimate))]
+[JsonSerializable(typeof(AnalysisContentLayerEstimate))]
 [JsonSerializable(typeof(SavedQueryContent))]
 [JsonSerializable(typeof(AnalysisPackageContent))]
 [JsonSerializable(typeof(ResultArtifactRecord))]

--- a/src/Honua.Ai/Features/AnalysisContent/AnalysisContentEndpoints.cs
+++ b/src/Honua.Ai/Features/AnalysisContent/AnalysisContentEndpoints.cs
@@ -27,6 +27,10 @@ internal static partial class AnalysisContentEndpoints
             .WithName("CreateAnalysisContentItem")
             .WithSummary("Create a saved-query or analysis-package content item.");
 
+        _ = content.MapGet("/items", HandleListItemsAsync)
+            .WithName("ListAnalysisContentItems")
+            .WithSummary("List analysis content items in a stable, paged, filterable order.");
+
         _ = content.MapGet("/items/{itemId}", HandleGetItemAsync)
             .WithName("GetAnalysisContentItem")
             .WithSummary("Open an analysis content item at its latest version.");
@@ -42,6 +46,10 @@ internal static partial class AnalysisContentEndpoints
         _ = content.MapPost("/items/{itemId}/versions", HandleCreateVersionAsync)
             .WithName("CreateAnalysisContentVersion")
             .WithSummary("Create a new immutable analysis content version.");
+
+        _ = content.MapPost("/items/{itemId}/versions/{contentVersion:int}/estimate", HandleEstimateAsync)
+            .WithName("EstimateAnalysisPackageVersion")
+            .WithSummary("Compute a server-side runtime and cost estimate for an analysis-package version.");
 
         _ = content.MapPost("/items/{itemId}/versions/{contentVersion:int}/preview", HandlePreviewAsync)
             .WithName("PreviewSavedQueryVersion")
@@ -133,6 +141,93 @@ internal static partial class AnalysisContentEndpoints
         catch (Exception ex)
         {
             LogEndpointFailed(context, "analysis-content.get", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static async Task<IResult> HandleListItemsAsync(
+        [FromQuery] string? kind,
+        [FromQuery] string? lifecycle,
+        [FromQuery] int? limit,
+        [FromQuery] int? offset,
+        [FromServices] IAnalysisContentService service,
+        HttpContext context)
+    {
+        try
+        {
+            if (!TryParseKind(kind, out var parsedKind))
+            {
+                return ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status400BadRequest,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+                    $"Unknown analysis content kind '{kind}'.");
+            }
+
+            if (!TryParseLifecycle(lifecycle, out var parsedLifecycle))
+            {
+                return ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status400BadRequest,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+                    $"Unknown analysis content lifecycle '{lifecycle}'.");
+            }
+
+            var result = await service.ListItemsAsync(
+                new ListAnalysisContentItemsQuery(parsedKind, parsedLifecycle, limit, offset),
+                context.RequestAborted).ConfigureAwait(false);
+
+            return Results.Json(
+                new AnalysisContentItemListResponse
+                {
+                    Items = result.Items,
+                    TotalCount = result.TotalCount,
+                    Limit = result.Limit,
+                    Offset = result.Offset
+                },
+                AnalysisContentApiJsonContext.Default.AnalysisContentItemListResponse);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "analysis-content.list", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static async Task<IResult> HandleEstimateAsync(
+        string itemId,
+        int contentVersion,
+        [FromServices] IAnalysisContentService service,
+        HttpContext context)
+    {
+        try
+        {
+            var result = await service.EstimateVersionAsync(
+                itemId,
+                contentVersion,
+                context.RequestAborted).ConfigureAwait(false);
+
+            return Results.Json(
+                new AnalysisContentEstimateResponse
+                {
+                    ItemId = result.ItemId,
+                    Version = result.Version,
+                    VersionId = result.VersionId,
+                    Estimate = result.Estimate
+                },
+                AnalysisContentApiJsonContext.Default.AnalysisContentEstimateResponse);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "analysis-content.estimate", ex);
             return CreateGenericProblem(context);
         }
     }
@@ -376,6 +471,54 @@ internal static partial class AnalysisContentEndpoints
             LogEndpointFailed(context, "analysis-content.job.failure", ex);
             return CreateGenericProblem(context);
         }
+    }
+
+    // Query-string enums use the JSON wire names (camelCase, e.g. "savedQuery"). Minimal-API's
+    // built-in enum binding only matches the CLR member name, so parse leniently here against both.
+    private static bool TryParseKind(string? value, out AnalysisContentKind? kind)
+    {
+        kind = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        if (string.Equals(value, "savedQuery", StringComparison.OrdinalIgnoreCase))
+        {
+            kind = AnalysisContentKind.SavedQuery;
+            return true;
+        }
+
+        if (string.Equals(value, "analysisPackage", StringComparison.OrdinalIgnoreCase))
+        {
+            kind = AnalysisContentKind.AnalysisPackage;
+            return true;
+        }
+
+        if (Enum.TryParse(value, ignoreCase: true, out AnalysisContentKind parsed))
+        {
+            kind = parsed;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryParseLifecycle(string? value, out AnalysisContentLifecycle? lifecycle)
+    {
+        lifecycle = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        if (Enum.TryParse(value, ignoreCase: true, out AnalysisContentLifecycle parsed))
+        {
+            lifecycle = parsed;
+            return true;
+        }
+
+        return false;
     }
 
     private static AnalysisContentItemResponse ToItemResponse(AnalysisContentItemResult result)

--- a/src/Honua.Ai/Features/AnalysisContent/AnalysisContentService.cs
+++ b/src/Honua.Ai/Features/AnalysisContent/AnalysisContentService.cs
@@ -36,6 +36,21 @@ internal sealed partial class AnalysisContentService(
 {
     private const int DefaultPreviewLimit = 25;
     private const int MaxPreviewLimit = 200;
+    private const int DefaultListLimit = 50;
+    private const int MaxListLimit = 200;
+
+    // Backend-neutral compute-unit projection. A query step costs a base unit plus a unit per
+    // estimated million input features it reads; a geoprocessing step costs a fixed compute unit;
+    // any other step costs a small fixed overhead. These coefficients are deliberate, documented
+    // constants so the estimate is deterministic and reproducible for a given plan + statistics.
+    private const double ComputeUnitsPerStepOverhead = 0.25d;
+    private const double ComputeUnitsPerQueryStep = 1.0d;
+    private const double ComputeUnitsPerGeoprocessStep = 2.0d;
+    private const double ComputeUnitsPerMillionInputFeatures = 1.5d;
+    private const decimal CostUsdPerComputeUnit = 0.02m;
+    private const double RuntimeSecondsPerComputeUnit = 4.0d;
+
+    private static readonly string[] LayerInputKeys = ["layerId", "layer", "storageLayerId", "sourceLayerId"];
     private const int DefaultLogLimit = 100;
     private const int MaxLogLimit = 200;
     private const int MaxDiagnosticLength = 512;
@@ -108,6 +123,161 @@ internal sealed partial class AnalysisContentService(
                 AnalysisContentTelemetry.SetContentTags(activity, item.ItemId, item.Kind, version.Version, version.VersionId);
                 return new AnalysisContentItemResult(item, version);
             }).ConfigureAwait(false);
+
+    public async Task<AnalysisContentListResult> ListItemsAsync(
+        ListAnalysisContentItemsQuery query,
+        CancellationToken cancellationToken)
+        => await AnalysisContentTelemetry.TrackAsync(
+            AnalysisContentTelemetry.OperationsNames.ListItems,
+            async activity =>
+            {
+                ArgumentNullException.ThrowIfNull(query);
+
+                var limit = ResolveLimit(query.Limit, DefaultListLimit, MaxListLimit);
+                var offset = query.Offset.GetValueOrDefault();
+                if (offset < 0)
+                {
+                    throw new AnalysisContentValidationException("Offset must be zero or greater.");
+                }
+
+                var page = await store.ListItemsAsync(
+                    new AnalysisContentItemQuery
+                    {
+                        Kind = query.Kind,
+                        Lifecycle = query.Lifecycle,
+                        Limit = limit,
+                        Offset = offset
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                activity?.SetTag("honua.analysis_content.list_count", page.Items.Count);
+                activity?.SetTag("honua.analysis_content.list_total", page.TotalCount);
+                return new AnalysisContentListResult(page.Items, page.TotalCount, limit, offset);
+            }).ConfigureAwait(false);
+
+    public async Task<AnalysisContentEstimateResult> EstimateVersionAsync(
+        string itemId,
+        int version,
+        CancellationToken cancellationToken)
+        => await AnalysisContentTelemetry.TrackAsync(
+            AnalysisContentTelemetry.OperationsNames.EstimateVersion,
+            async activity =>
+            {
+                var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
+                var package = contentVersion.AnalysisPackage
+                    ?? throw new AnalysisContentValidationException("The requested version is not an analysis package.");
+                AnalysisContentTelemetry.SetContentTags(
+                    activity,
+                    contentVersion.ItemId,
+                    contentVersion.Kind,
+                    contentVersion.Version,
+                    contentVersion.VersionId);
+
+                var estimate = await ComputePackageEstimateAsync(package, cancellationToken).ConfigureAwait(false);
+                activity?.SetTag("honua.analysis_content.estimated_compute_units", estimate.EstimatedComputeUnits);
+                return new AnalysisContentEstimateResult(
+                    contentVersion.ItemId,
+                    contentVersion.Version,
+                    contentVersion.VersionId,
+                    estimate);
+            }).ConfigureAwait(false);
+
+    private async Task<AnalysisContentEstimate> ComputePackageEstimateAsync(
+        AnalysisPackageContent package,
+        CancellationToken cancellationToken)
+    {
+        var steps = package.Plan.Steps;
+        var queryStepCount = 0;
+        var geoprocessStepCount = 0;
+        var inputs = new List<AnalysisContentLayerEstimate>();
+        long? estimatedInputFeatures = null;
+        var isLowerBound = false;
+
+        foreach (var step in steps)
+        {
+            switch (step.Kind)
+            {
+                case AnalysisPlanStepKind.QueryFeatures:
+                    queryStepCount++;
+                    break;
+                case AnalysisPlanStepKind.Geoprocess:
+                    geoprocessStepCount++;
+                    break;
+            }
+
+            if (!TryResolveLayerInput(step, out var layerId))
+            {
+                continue;
+            }
+
+            long? layerCount = null;
+            var unresolved = false;
+            try
+            {
+                var layerEstimate = await featureReader.GetEstimatesAsync(layerId, cancellationToken).ConfigureAwait(false);
+                layerCount = layerEstimate.EstimatedCount;
+                estimatedInputFeatures = (estimatedInputFeatures ?? 0) + layerEstimate.EstimatedCount;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // A missing or unreadable layer must not fail the estimate; record it as an
+                // unresolved input so the projection is reported as a lower bound instead.
+                unresolved = true;
+                isLowerBound = true;
+                Log.EstimateLayerUnresolved(logger, layerId, ex);
+            }
+
+            inputs.Add(new AnalysisContentLayerEstimate
+            {
+                StepId = step.StepId,
+                LayerId = layerId,
+                EstimatedFeatureCount = layerCount,
+                Unresolved = unresolved
+            });
+        }
+
+        var featureUnits = estimatedInputFeatures.HasValue
+            ? estimatedInputFeatures.Value / 1_000_000d * ComputeUnitsPerMillionInputFeatures
+            : 0d;
+        var computeUnits =
+            steps.Count * ComputeUnitsPerStepOverhead
+            + queryStepCount * ComputeUnitsPerQueryStep
+            + geoprocessStepCount * ComputeUnitsPerGeoprocessStep
+            + featureUnits;
+        computeUnits = Math.Round(computeUnits, 4, MidpointRounding.AwayFromZero);
+
+        var costUsd = Math.Round((decimal)computeUnits * CostUsdPerComputeUnit, 4, MidpointRounding.AwayFromZero);
+        var runtimeSeconds = Math.Round(computeUnits * RuntimeSecondsPerComputeUnit, 2, MidpointRounding.AwayFromZero);
+
+        return new AnalysisContentEstimate
+        {
+            StepCount = steps.Count,
+            QueryStepCount = queryStepCount,
+            GeoprocessStepCount = geoprocessStepCount,
+            EstimatedInputFeatureCount = estimatedInputFeatures,
+            EstimatedComputeUnits = computeUnits,
+            EstimatedCostUsd = costUsd,
+            EstimatedRuntimeSeconds = runtimeSeconds,
+            IsLowerBound = isLowerBound,
+            Inputs = inputs
+        };
+    }
+
+    private static bool TryResolveLayerInput(AnalysisPlanStep step, out int layerId)
+    {
+        foreach (var key in LayerInputKeys)
+        {
+            if (step.Inputs.TryGetValue(key, out var raw)
+                && int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out layerId)
+                && layerId >= 0)
+            {
+                return true;
+            }
+        }
+
+        layerId = 0;
+        return false;
+    }
 
     public async Task<AnalysisContentVersionResult> GetVersionAsync(
         string itemId,
@@ -987,5 +1157,8 @@ internal sealed partial class AnalysisContentService(
 
         [LoggerMessage(12006, LogLevel.Debug, "Retrying analysis content version creation for {ItemId} after conflict on attempt {Attempt}")]
         public static partial void ContentVersionConflictRetry(ILogger logger, string itemId, int attempt);
+
+        [LoggerMessage(12007, LogLevel.Debug, "Analysis content estimate could not resolve statistics for layer {LayerId}; reporting a lower bound")]
+        public static partial void EstimateLayerUnresolved(ILogger logger, int layerId, Exception exception);
     }
 }

--- a/src/Honua.Ai/Features/AnalysisContent/AnalysisContentTelemetry.cs
+++ b/src/Honua.Ai/Features/AnalysisContent/AnalysisContentTelemetry.cs
@@ -22,6 +22,8 @@ internal static class AnalysisContentTelemetry
     {
         public const string CreateItem = "create_item";
         public const string GetItem = "get_item";
+        public const string ListItems = "list_items";
+        public const string EstimateVersion = "estimate_version";
         public const string GetVersion = "get_version";
         public const string AddVersion = "add_version";
         public const string PreviewSavedQuery = "preview_saved_query";

--- a/src/Honua.Ai/Features/AnalysisContent/IAnalysisContentService.cs
+++ b/src/Honua.Ai/Features/AnalysisContent/IAnalysisContentService.cs
@@ -18,6 +18,15 @@ internal interface IAnalysisContentService
         string itemId,
         CancellationToken cancellationToken);
 
+    Task<AnalysisContentListResult> ListItemsAsync(
+        ListAnalysisContentItemsQuery query,
+        CancellationToken cancellationToken);
+
+    Task<AnalysisContentEstimateResult> EstimateVersionAsync(
+        string itemId,
+        int version,
+        CancellationToken cancellationToken);
+
     Task<AnalysisContentVersionResult> GetVersionAsync(
         string itemId,
         int? version,
@@ -68,6 +77,24 @@ internal interface IAnalysisContentService
 internal sealed record AnalysisContentItemResult(
     AnalysisContentItem Item,
     AnalysisContentVersion Version);
+
+internal sealed record ListAnalysisContentItemsQuery(
+    AnalysisContentKind? Kind,
+    AnalysisContentLifecycle? Lifecycle,
+    int? Limit,
+    int? Offset);
+
+internal sealed record AnalysisContentListResult(
+    IReadOnlyList<AnalysisContentItem> Items,
+    long TotalCount,
+    int Limit,
+    int Offset);
+
+internal sealed record AnalysisContentEstimateResult(
+    string ItemId,
+    int Version,
+    string VersionId,
+    AnalysisContentEstimate Estimate);
 
 internal sealed record AnalysisContentVersionResult(
     AnalysisContentItem Item,

--- a/src/Honua.Ai/Features/AnalysisContent/InMemoryAnalysisContentStore.cs
+++ b/src/Honua.Ai/Features/AnalysisContent/InMemoryAnalysisContentStore.cs
@@ -124,6 +124,38 @@ internal sealed class InMemoryAnalysisContentStore : IAnalysisContentStore
         return Task.FromResult<IReadOnlyList<AnalysisContentVersion>>(snapshot);
     }
 
+    public Task<AnalysisContentItemPage> ListItemsAsync(
+        AnalysisContentItemQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        AnalysisContentItem[] snapshot;
+        lock (_gate)
+        {
+            snapshot = _items.Values.ToArray();
+        }
+
+        var lifecycle = query.Lifecycle ?? AnalysisContentLifecycle.Active;
+        var filtered = snapshot
+            .Where(item => item.Lifecycle == lifecycle)
+            .Where(item => query.Kind is null || item.Kind == query.Kind.Value)
+            .OrderByDescending(item => item.UpdatedAt)
+            .ThenBy(item => item.ItemId, StringComparer.Ordinal)
+            .ToArray();
+
+        var page = filtered
+            .Skip(query.Offset)
+            .Take(query.Limit)
+            .ToArray();
+
+        return Task.FromResult(new AnalysisContentItemPage
+        {
+            Items = page,
+            TotalCount = filtered.Length
+        });
+    }
+
     public Task<ResultArtifactRecord> UpsertArtifactAsync(
         ResultArtifactRecord artifact,
         CancellationToken cancellationToken = default)

--- a/src/Honua.Core/Features/AnalysisContent/Abstractions/IAnalysisContentStore.cs
+++ b/src/Honua.Core/Features/AnalysisContent/Abstractions/IAnalysisContentStore.cs
@@ -122,6 +122,17 @@ public interface IAnalysisContentStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Lists content item roots in a stable, paged order (most recently updated first,
+    /// then by item identifier). Supports optional filtering by kind and lifecycle.
+    /// </summary>
+    /// <param name="query">Paging and filter query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The requested page of items and the total count matching the filter.</returns>
+    Task<AnalysisContentItemPage> ListItemsAsync(
+        AnalysisContentItemQuery query,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Inserts or updates durable result artifact metadata.
     /// </summary>
     /// <param name="artifact">Artifact metadata record.</param>

--- a/src/Honua.Core/Features/AnalysisContent/AnalysisContentJsonContext.cs
+++ b/src/Honua.Core/Features/AnalysisContent/AnalysisContentJsonContext.cs
@@ -19,6 +19,8 @@ namespace Honua.Core.Features.AnalysisContent;
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     UseStringEnumConverter = true)]
 [JsonSerializable(typeof(AnalysisContentItem))]
+[JsonSerializable(typeof(AnalysisContentItem[]))]
+[JsonSerializable(typeof(AnalysisContentItemPage))]
 [JsonSerializable(typeof(AnalysisContentVersion))]
 [JsonSerializable(typeof(AnalysisContentVersion[]))]
 [JsonSerializable(typeof(SavedQueryContent))]
@@ -27,6 +29,9 @@ namespace Honua.Core.Features.AnalysisContent;
 [JsonSerializable(typeof(ArtifactBindingRef[]))]
 [JsonSerializable(typeof(ResultArtifactRecord))]
 [JsonSerializable(typeof(ResultArtifactRecord[]))]
+[JsonSerializable(typeof(AnalysisContentEstimate))]
+[JsonSerializable(typeof(AnalysisContentLayerEstimate))]
+[JsonSerializable(typeof(AnalysisContentLayerEstimate[]))]
 [JsonSerializable(typeof(SavedQueryPreviewResult))]
 [JsonSerializable(typeof(SavedQueryPreviewFeature))]
 [JsonSerializable(typeof(SavedQueryPreviewFeature[]))]

--- a/src/Honua.Core/Features/AnalysisContent/Domain/AnalysisContentContracts.cs
+++ b/src/Honua.Core/Features/AnalysisContent/Domain/AnalysisContentContracts.cs
@@ -226,6 +226,49 @@ public sealed record AnalysisContentItem
 }
 
 /// <summary>
+/// Paged, filterable query over durable analysis content item roots.
+/// </summary>
+public sealed record AnalysisContentItemQuery
+{
+    /// <summary>
+    /// Optional kind filter. When null, items of every kind are returned.
+    /// </summary>
+    public AnalysisContentKind? Kind { get; init; }
+
+    /// <summary>
+    /// Optional lifecycle filter. When null, only <see cref="AnalysisContentLifecycle.Active"/>
+    /// items are returned so archived and soft-deleted content stays out of primary lists.
+    /// </summary>
+    public AnalysisContentLifecycle? Lifecycle { get; init; }
+
+    /// <summary>
+    /// Maximum number of items to return.
+    /// </summary>
+    public required int Limit { get; init; }
+
+    /// <summary>
+    /// Number of items to skip from the start of the stable order.
+    /// </summary>
+    public required int Offset { get; init; }
+}
+
+/// <summary>
+/// A page of analysis content item roots plus the total count matching the query filter.
+/// </summary>
+public sealed record AnalysisContentItemPage
+{
+    /// <summary>
+    /// Items in this page, ordered most-recently-updated first then by item identifier.
+    /// </summary>
+    public IReadOnlyList<AnalysisContentItem> Items { get; init; } = [];
+
+    /// <summary>
+    /// Total number of items matching the query filter across all pages.
+    /// </summary>
+    public required long TotalCount { get; init; }
+}
+
+/// <summary>
 /// Immutable analysis content version payload.
 /// </summary>
 public sealed record AnalysisContentVersion
@@ -523,6 +566,88 @@ public sealed record ResultArtifactRecord
     /// Optional UTC expiry timestamp.
     /// </summary>
     public DateTimeOffset? ExpiresAt { get; init; }
+}
+
+/// <summary>
+/// Server-computed runtime and cost estimate for an analysis-package version. The projection is
+/// derived from the plan (step count and category) and from catalog statistics for any input layers
+/// the plan reads, so the pre-submit gate can use an authoritative value instead of a local guess.
+/// </summary>
+public sealed record AnalysisContentEstimate
+{
+    /// <summary>
+    /// Number of executable steps in the plan.
+    /// </summary>
+    public required int StepCount { get; init; }
+
+    /// <summary>
+    /// Number of steps that read features from a data source.
+    /// </summary>
+    public required int QueryStepCount { get; init; }
+
+    /// <summary>
+    /// Number of steps that run a geoprocessing operation.
+    /// </summary>
+    public required int GeoprocessStepCount { get; init; }
+
+    /// <summary>
+    /// Approximate total input feature count summed across the plan's resolved input layers, using
+    /// catalog statistics. Null when the plan reads no resolvable layer.
+    /// </summary>
+    public long? EstimatedInputFeatureCount { get; init; }
+
+    /// <summary>
+    /// Approximate compute units the plan is expected to consume. A compute unit is a normalized,
+    /// backend-neutral measure derived from step categories and estimated input volume.
+    /// </summary>
+    public required double EstimatedComputeUnits { get; init; }
+
+    /// <summary>
+    /// Approximate monetary cost in USD for the estimated compute units, at the published unit rate.
+    /// </summary>
+    public required decimal EstimatedCostUsd { get; init; }
+
+    /// <summary>
+    /// Approximate wall-clock runtime, in seconds, the plan is expected to take.
+    /// </summary>
+    public required double EstimatedRuntimeSeconds { get; init; }
+
+    /// <summary>
+    /// True when the estimate could not resolve input statistics for one or more layers and is
+    /// therefore a lower bound rather than a full projection.
+    /// </summary>
+    public required bool IsLowerBound { get; init; }
+
+    /// <summary>
+    /// Per-input-layer estimate breakdown.
+    /// </summary>
+    public IReadOnlyList<AnalysisContentLayerEstimate> Inputs { get; init; } = [];
+}
+
+/// <summary>
+/// Per-layer input statistics contributing to an analysis-package estimate.
+/// </summary>
+public sealed record AnalysisContentLayerEstimate
+{
+    /// <summary>
+    /// Plan step identifier that reads this layer.
+    /// </summary>
+    public required string StepId { get; init; }
+
+    /// <summary>
+    /// Storage layer identifier read by the step.
+    /// </summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>
+    /// Approximate feature count from catalog statistics, when resolvable.
+    /// </summary>
+    public long? EstimatedFeatureCount { get; init; }
+
+    /// <summary>
+    /// True when catalog statistics for this layer could not be resolved.
+    /// </summary>
+    public required bool Unresolved { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Postgres/Features/AnalysisContent/PostgresAnalysisContentStore.cs
+++ b/src/Honua.Postgres/Features/AnalysisContent/PostgresAnalysisContentStore.cs
@@ -187,6 +187,58 @@ internal sealed class PostgresAnalysisContentStore : IAnalysisContentStore
             return versions;
         });
 
+    public Task<AnalysisContentItemPage> ListItemsAsync(
+        AnalysisContentItemQuery query,
+        CancellationToken cancellationToken = default)
+        => TranslateStoreFailuresAsync(async () =>
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            var lifecycle = (query.Lifecycle ?? AnalysisContentLifecycle.Active).ToString();
+            var kindFilter = query.Kind.HasValue ? " AND kind = @kind" : string.Empty;
+            var kind = query.Kind?.ToString();
+
+            // Stable order: most-recently-updated first, then by item_id. Backed by
+            // idx_analysis_content_items_kind_updated (kind, updated_at DESC, item_id) when a
+            // kind filter is supplied. The total count lets callers compute remaining pages.
+            var sql = $"""
+                SELECT item_id, kind, name, title, owner_id, visibility, current_version,
+                       current_version_id, lifecycle, created_at, updated_at, created_by,
+                       COUNT(*) OVER () AS total_count
+                FROM {_itemsTable}
+                WHERE lifecycle = @lifecycle{kindFilter}
+                ORDER BY updated_at DESC, item_id ASC
+                LIMIT @limit OFFSET @offset
+                """;
+
+            await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken)
+                .ConfigureAwait(false);
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.Parameters.AddWithValue("@lifecycle", lifecycle);
+            if (kind is not null)
+            {
+                command.Parameters.AddWithValue("@kind", kind);
+            }
+
+            command.Parameters.AddWithValue("@limit", query.Limit);
+            command.Parameters.AddWithValue("@offset", query.Offset);
+
+            var items = new List<AnalysisContentItem>();
+            long totalCount = 0;
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                items.Add(ReadItem(reader));
+                totalCount = reader.GetInt64(12);
+            }
+
+            return new AnalysisContentItemPage
+            {
+                Items = items,
+                TotalCount = totalCount
+            };
+        });
+
     public Task<ResultArtifactRecord> UpsertArtifactAsync(
         ResultArtifactRecord artifact,
         CancellationToken cancellationToken = default)

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -895,12 +895,14 @@ public static class EndpointRegistry
         new("POST", "/v1/spec/cancel"),
         new("GET", "/v1/spec/artifact/{hash}"),
 
-        // Analysis content HTTP surface (#1182).
+        // Analysis content HTTP surface (#1182, #1237).
         new("POST", "/api/v1/analysis/content/items"),
+        new("GET", "/api/v1/analysis/content/items"),
         new("GET", "/api/v1/analysis/content/items/{itemId}"),
         new("GET", "/api/v1/analysis/content/items/{itemId}/versions/latest"),
         new("GET", "/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}"),
         new("POST", "/api/v1/analysis/content/items/{itemId}/versions"),
+        new("POST", "/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/estimate"),
         new("POST", "/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/preview"),
         new("POST", "/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/runs"),
         new("POST", "/api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/reruns"),

--- a/tests/dotnet/Honua.Postgres.Tests/Features/AnalysisContent/PostgresAnalysisContentStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/AnalysisContent/PostgresAnalysisContentStoreTests.cs
@@ -54,6 +54,32 @@ public sealed class PostgresAnalysisContentStoreTests
     }
 
     [Fact]
+    public async Task ListItemsAsync_WhenConnectionFails_ThrowsStoreUnavailable()
+    {
+        var store = CreateStoreWithUnavailableConnection();
+
+        var act = () => store.ListItemsAsync(new AnalysisContentItemQuery { Limit = 50, Offset = 0 });
+
+        await act.Should().ThrowAsync<AnalysisContentStoreUnavailableException>();
+    }
+
+    [Fact]
+    public async Task ListItemsAsync_WhenConnectionProviderReportsServiceUnavailable_ThrowsStoreUnavailable()
+    {
+        var store = CreateStoreWithServiceUnavailableConnection();
+
+        var act = () => store.ListItemsAsync(
+            new AnalysisContentItemQuery
+            {
+                Kind = AnalysisContentKind.AnalysisPackage,
+                Limit = 25,
+                Offset = 0
+            });
+
+        await act.Should().ThrowAsync<AnalysisContentStoreUnavailableException>();
+    }
+
+    [Fact]
     public async Task GetArtifactAsync_WhenConnectionFails_ThrowsStoreUnavailable()
     {
         var store = CreateStoreWithUnavailableConnection();

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
@@ -154,6 +154,176 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /api/v1/analysis/content/items")]
+    [Endpoint("GET /api/v1/analysis/content/items")]
+    public async Task ListItems_IsPagedFilterableAndStable()
+    {
+        // Empty list before any item of this kind exists in a fresh slice: assert the paged
+        // envelope shape (the shared database may carry items from sibling tests, so assert on the
+        // envelope contract, not on a global empty set).
+        var emptyResponse = await _client.GetAsync(
+            "/api/v1/analysis/content/items?kind=analysisPackage&limit=1&offset=1000000");
+        var empty = await ReadJsonAsync<AnalysisContentItemListResponse>(emptyResponse, HttpStatusCode.OK);
+        Assert.NotNull(empty);
+        Assert.Empty(empty!.Items);
+        Assert.Equal(1, empty.Limit);
+        Assert.Equal(1000000, empty.Offset);
+
+        var marker = $"list-marker-{Guid.NewGuid():N}";
+        var createdIds = new List<string>();
+        for (var index = 0; index < 3; index++)
+        {
+            var create = new CreateAnalysisContentItemRequest
+            {
+                Kind = AnalysisContentKind.SavedQuery,
+                Name = $"{marker}-{index}",
+                Title = $"List Marker {index}",
+                SavedQuery = new SavedQueryContent
+                {
+                    LayerId = WebAppFixture.TestLayerId,
+                    ServiceName = WebAppFixture.TestServiceId,
+                    NaturalLanguageQuery = "show incidents"
+                }
+            };
+
+            var response = await _client.PostAsJsonAsync("/api/v1/analysis/content/items", create, JsonOptions);
+            var created = await ReadJsonAsync<AnalysisContentItemResponse>(response, HttpStatusCode.Created);
+            createdIds.Add(created!.Item.ItemId);
+        }
+
+        // Kind filter: every returned item must be the requested kind, and our three markers
+        // must be present in the total.
+        var savedQueryResponse = await _client.GetAsync(
+            "/api/v1/analysis/content/items?kind=savedQuery&limit=200");
+        var savedQueryPage = await ReadJsonAsync<AnalysisContentItemListResponse>(savedQueryResponse, HttpStatusCode.OK);
+        Assert.NotNull(savedQueryPage);
+        Assert.All(savedQueryPage!.Items, item => Assert.Equal(AnalysisContentKind.SavedQuery, item.Kind));
+        var markerItems = savedQueryPage.Items.Where(item => item.Name.StartsWith(marker, StringComparison.Ordinal)).ToArray();
+        Assert.Equal(3, markerItems.Length);
+        Assert.True(savedQueryPage.TotalCount >= 3);
+
+        // Stable order: most-recently-updated first, then by item id. Our three markers were
+        // created in order, so they must appear newest-first among themselves.
+        var orderedMarkers = markerItems.Select(item => item.ItemId).ToArray();
+        var expectedOrder = createdIds.AsEnumerable().Reverse().ToArray();
+        Assert.Equal(expectedOrder, orderedMarkers);
+
+        // Paging: limit 2 returns at most 2 and reports the limit/offset back; the second page
+        // continues the same stable order without overlap.
+        var firstPageResponse = await _client.GetAsync(
+            "/api/v1/analysis/content/items?kind=savedQuery&limit=2&offset=0");
+        var firstPage = await ReadJsonAsync<AnalysisContentItemListResponse>(firstPageResponse, HttpStatusCode.OK);
+        Assert.Equal(2, firstPage!.Limit);
+        Assert.Equal(0, firstPage.Offset);
+        Assert.True(firstPage.Items.Count <= 2);
+
+        var secondPageResponse = await _client.GetAsync(
+            "/api/v1/analysis/content/items?kind=savedQuery&limit=2&offset=2");
+        var secondPage = await ReadJsonAsync<AnalysisContentItemListResponse>(secondPageResponse, HttpStatusCode.OK);
+        Assert.Equal(2, secondPage!.Offset);
+        var firstIds = firstPage.Items.Select(item => item.ItemId).ToHashSet(StringComparer.Ordinal);
+        Assert.DoesNotContain(secondPage.Items, item => firstIds.Contains(item.ItemId));
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetEstimates)]
+    [Endpoint("POST /api/v1/analysis/content/items")]
+    [Endpoint("POST /api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/estimate")]
+    public async Task EstimateVersion_ReturnsServerComputedRuntimeAndCostProjection()
+    {
+        var create = new CreateAnalysisContentItemRequest
+        {
+            Kind = AnalysisContentKind.AnalysisPackage,
+            Name = $"estimate-package-{Guid.NewGuid():N}",
+            AnalysisPackage = new AnalysisPackageContent
+            {
+                Intent = new AnalysisIntent
+                {
+                    IntentId = "intent-estimate",
+                    Goal = "buffer incidents",
+                    RequestedOutputs = [ArtifactKind.FeatureLayer]
+                },
+                Plan = new AnalysisPlan
+                {
+                    PlanId = "plan-estimate",
+                    IntentId = "intent-estimate",
+                    Steps =
+                    [
+                        new AnalysisPlanStep
+                        {
+                            StepId = "query-1",
+                            Kind = AnalysisPlanStepKind.QueryFeatures,
+                            Inputs = new Dictionary<string, string>
+                            {
+                                ["layerId"] = WebAppFixture.TestLayerId.ToString(CultureInfo.InvariantCulture)
+                            }
+                        },
+                        new AnalysisPlanStep
+                        {
+                            StepId = "buffer-1",
+                            Kind = AnalysisPlanStepKind.Geoprocess,
+                            ProcessId = "geometry.buffer",
+                            Inputs = new Dictionary<string, string> { ["distance"] = "10" },
+                            DependsOn = ["query-1"]
+                        }
+                    ],
+                    Outputs = [ArtifactKind.FeatureLayer]
+                },
+                RequestedArtifacts = [ArtifactKind.FeatureLayer]
+            }
+        };
+
+        var createResponse = await _client.PostAsJsonAsync("/api/v1/analysis/content/items", create, JsonOptions);
+        var created = await ReadJsonAsync<AnalysisContentItemResponse>(createResponse, HttpStatusCode.Created);
+
+        var estimateResponse = await _client.PostAsync(
+            $"/api/v1/analysis/content/items/{created!.Item.ItemId}/versions/1/estimate",
+            content: null);
+        var estimate = await ReadJsonAsync<AnalysisContentEstimateResponse>(estimateResponse, HttpStatusCode.OK);
+
+        Assert.NotNull(estimate);
+        Assert.Equal(created.Item.ItemId, estimate!.ItemId);
+        Assert.Equal(1, estimate.Version);
+        Assert.Equal(created.Version.VersionId, estimate.VersionId);
+        Assert.Equal(2, estimate.Estimate.StepCount);
+        Assert.Equal(1, estimate.Estimate.QueryStepCount);
+        Assert.Equal(1, estimate.Estimate.GeoprocessStepCount);
+        // The projection is deterministic and strictly positive for a non-empty plan.
+        Assert.True(estimate.Estimate.EstimatedComputeUnits > 0);
+        Assert.True(estimate.Estimate.EstimatedCostUsd >= 0m);
+        Assert.True(estimate.Estimate.EstimatedRuntimeSeconds >= 0);
+        // The query step resolved an input layer, so the breakdown carries that layer.
+        Assert.Contains(estimate.Estimate.Inputs, input => input.LayerId == WebAppFixture.TestLayerId);
+
+        // A saved-query version has no analysis package and must be rejected as a bad request.
+        var savedQueryCreate = new CreateAnalysisContentItemRequest
+        {
+            Kind = AnalysisContentKind.SavedQuery,
+            Name = $"estimate-savedquery-{Guid.NewGuid():N}",
+            SavedQuery = new SavedQueryContent
+            {
+                LayerId = WebAppFixture.TestLayerId,
+                ServiceName = WebAppFixture.TestServiceId,
+                NaturalLanguageQuery = "show incidents"
+            }
+        };
+        var savedQueryResponse = await _client.PostAsJsonAsync("/api/v1/analysis/content/items", savedQueryCreate, JsonOptions);
+        var savedQuery = await ReadJsonAsync<AnalysisContentItemResponse>(savedQueryResponse, HttpStatusCode.Created);
+
+        var rejected = await _client.PostAsync(
+            $"/api/v1/analysis/content/items/{savedQuery!.Item.ItemId}/versions/1/estimate",
+            content: null);
+        Assert.Equal(HttpStatusCode.BadRequest, rejected.StatusCode);
+
+        // An unknown item is a 404.
+        var missing = await _client.PostAsync(
+            "/api/v1/analysis/content/items/does-not-exist/versions/1/estimate",
+            content: null);
+        Assert.Equal(HttpStatusCode.NotFound, missing.StatusCode);
+    }
+
+    [IntegrationTest]
     [Operation(Operations.ProcessExecution)]
     [Endpoint("POST /api/v1/analysis/content/items")]
     [Endpoint("POST /api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/runs")]

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentServiceTests.cs
@@ -387,6 +387,11 @@ public sealed class AnalysisContentServiceTests
             CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<AnalysisContentVersion>>(_versions.Values.ToArray());
 
+        public Task<AnalysisContentItemPage> ListItemsAsync(
+            AnalysisContentItemQuery query,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new AnalysisContentItemPage { Items = [_item], TotalCount = 1 });
+
         public Task<ResultArtifactRecord> UpsertArtifactAsync(
             ResultArtifactRecord artifact,
             CancellationToken cancellationToken = default)

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/GeoprocessingArtifactPersistenceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/GeoprocessingArtifactPersistenceTests.cs
@@ -188,6 +188,11 @@ public sealed class GeoprocessingArtifactPersistenceTests
             CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
+        public Task<AnalysisContentItemPage> ListItemsAsync(
+            AnalysisContentItemQuery query,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
         public Task<ResultArtifactRecord> UpsertArtifactAsync(
             ResultArtifactRecord artifact,
             CancellationToken cancellationToken = default)


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1237

## Summary
Adds the two incremental REST routes the Console analysis builder needs on the existing
`/api/v{version}/analysis/content` surface (delivered by #1182): a paged/filterable **list** of
content items, and a server-computed **runtime/cost estimate** for an analysis-package version so
the pre-submit gate can use an authoritative value instead of a local projection. REST-only — no
proto/SDK change (analysis content has zero proto presence and is not in the conformance fixtures).

## Changes Made
- `GET /api/v1/analysis/content/items` — paged (`limit`/`offset`), filterable by `kind` and
  `lifecycle`, stable order (most-recently-updated first, then by item id). Returns items plus
  `totalCount`/`limit`/`offset`.
- `POST /api/v1/analysis/content/items/{itemId}/versions/{contentVersion}/estimate` — returns a
  structured, deterministic `AnalysisContentEstimate` (step counts, estimated input feature count,
  compute units, USD cost, runtime seconds, per-input-layer breakdown, lower-bound flag). Input
  feature counts use `IFeatureReader.GetEstimatesAsync` (same catalog-statistics path as the
  FeatureServer `getEstimates` handler); an unresolved layer degrades to a lower-bound estimate
  rather than failing.
- Store: added `IAnalysisContentStore.ListItemsAsync` (paged) implemented in both the Postgres and
  in-memory stores. The Postgres query reuses the existing
  `idx_analysis_content_items_kind_updated (kind, updated_at DESC, item_id)` index for stable
  ordering — no migration required.
- DTOs/domain registered in both source-gen JSON contexts (`AnalysisContentApiJsonContext` and the
  Core `AnalysisContentJsonContext`) so AOT serialization works.
- Registered both routes in `EndpointRegistry` (architecture drift gate).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Local results: Postgres store tests 9/9 pass (incl. 2 new list store-unavailable cases); the
AnalysisContent endpoint + EndpointRegistry drift tests 12/12 pass (incl. new list paging/empty/
stable/filter and estimate cost/runtime/validation/404 cases); full `Tier=Fast` suite 1708/1708
pass; `dotnet format --verify-no-changes` clean; Release build clean.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact (analysis/content is not part of the curated OGC OpenAPI
      specs and has no proto presence; the OpenAPI drift gate only covers `/ogc/*`).

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow (reuses an existing index for stable paging)

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
