### PR TITLE
fix: read JSONB-backed attributes for shared-features storage layout (#1238)

### DIFF
--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.MetadataV2Graph.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.MetadataV2Graph.cs
@@ -269,6 +269,27 @@ internal sealed partial class PostgreSqlLayerPublishingService
         DateTimeOffset now)
     {
         var connectionId = request.ConnectionId?.ToString("D");
+        var options = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+        {
+            [FeatureStorageMapping.SourceBackedOption] = JsonSerializer.SerializeToElement(true),
+            ["schemaName"] = JsonSerializer.SerializeToElement(schema),
+            ["tableName"] = JsonSerializer.SerializeToElement(table),
+            ["primaryKeyColumn"] = JsonSerializer.SerializeToElement(primaryKeyColumn),
+            ["geometryColumn"] = JsonSerializer.SerializeToElement(geometryColumn),
+            ["storageSrid"] = JsonSerializer.SerializeToElement(storageSrid)
+        };
+
+        // Layers published onto the shared 'features' table store their non-key
+        // attributes as keys inside the 'features.attributes' JSONB column rather than
+        // as physical columns. Declare the JSONB accessor so the storage-mapped reader
+        // projects attributes->>'field' instead of bare columns (Postgres 42703). Gate
+        // strictly on the shared features table; dedicated per-layer tables keep their
+        // column-per-field projection. (See honua-server#1238.)
+        if (string.Equals(table, DatabaseSchema.FeaturesTable, StringComparison.OrdinalIgnoreCase))
+        {
+            options["attributesColumn"] = JsonSerializer.SerializeToElement("attributes");
+        }
+
         return new MetadataV2StorageBinding
         {
             Metadata = new MetadataV2ObjectMetadata
@@ -291,15 +312,7 @@ internal sealed partial class PostgreSqlLayerPublishingService
                 MetadataV2StorageBindingCapability.Sort,
                 MetadataV2StorageBindingCapability.Aggregate
             ],
-            Options = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
-            {
-                [FeatureStorageMapping.SourceBackedOption] = JsonSerializer.SerializeToElement(true),
-                ["schemaName"] = JsonSerializer.SerializeToElement(schema),
-                ["tableName"] = JsonSerializer.SerializeToElement(table),
-                ["primaryKeyColumn"] = JsonSerializer.SerializeToElement(primaryKeyColumn),
-                ["geometryColumn"] = JsonSerializer.SerializeToElement(geometryColumn),
-                ["storageSrid"] = JsonSerializer.SerializeToElement(storageSrid)
-            },
+            Options = options,
             Status = ActiveReadyStatus(now)
         };
     }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MobileOfflineDemoFixtureReplicationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MobileOfflineDemoFixtureReplicationTests.cs
@@ -61,7 +61,10 @@ public sealed class MobileOfflineDemoFixtureReplicationTests : IAsyncLifetime
 
     public Task DisposeAsync() => _fixture.DisposeAsync();
 
-    private async Task PublishMobileOfflineMetadataV2Async()
+    private Task PublishMobileOfflineMetadataV2Async()
+        => PublishMobileOfflineMetadataV2Async(includeAttributesAccessor: true);
+
+    private async Task PublishMobileOfflineMetadataV2Async(bool includeAttributesAccessor)
     {
         var provider = _fixture.GetService<IMetadataV2GraphProvider>() as TestMetadataV2GraphProvider
             ?? throw new InvalidOperationException(
@@ -142,8 +145,8 @@ public sealed class MobileOfflineDemoFixtureReplicationTests : IAsyncLifetime
 
         var storageBindings = new[]
         {
-            CreateMobileOfflineStorageBinding(OfflineSitesLayerId),
-            CreateMobileOfflineStorageBinding(68920)
+            CreateMobileOfflineStorageBinding(OfflineSitesLayerId, includeAttributesAccessor),
+            CreateMobileOfflineStorageBinding(68920, includeAttributesAccessor)
         };
         var publications = new[]
         {
@@ -215,8 +218,32 @@ public sealed class MobileOfflineDemoFixtureReplicationTests : IAsyncLifetime
         };
     }
 
-    private static MetadataV2StorageBinding CreateMobileOfflineStorageBinding(int layerId)
-        => new()
+    private static MetadataV2StorageBinding CreateMobileOfflineStorageBinding(
+        int layerId,
+        bool includeAttributesAccessor = true)
+    {
+        // The seed's shared 'features' table holds rows for every test layer keyed by a
+        // 'layer_id' discriminator; the geometry lives in the 'geometry' column and the
+        // mobile-offline schema fields are persisted in the 'attributes' JSONB column.
+        // FeatureStorageMapping.ParseRelationalLocator rejects any locator that
+        // contains ':' so use the table name directly and expose the layer/geometry/
+        // attributes columns via Options (matching WebAppFixtureMetadataV2Mixin.BuildDefaultTestGraph).
+        var options = new Dictionary<string, JsonElement>
+        {
+            ["geometryColumn"] = JsonSerializer.SerializeToElement("geometry")
+        };
+
+        // When omitted (includeAttributesAccessor: false) the binding reproduces the
+        // honua-server#1238 drift: the seed left storage_options empty so the reader
+        // projects bare columns ('globalid', ...) against the shared features table,
+        // which has no such columns => Postgres 42703. The seed/bridge fix supplies
+        // this accessor so declared fields resolve as attributes->>'field'.
+        if (includeAttributesAccessor)
+        {
+            options["attributesColumn"] = JsonSerializer.SerializeToElement("attributes");
+        }
+
+        return new()
         {
             Metadata = new MetadataV2ObjectMetadata
             {
@@ -225,19 +252,9 @@ public sealed class MobileOfflineDemoFixtureReplicationTests : IAsyncLifetime
             },
             ResourceId = $"res-layer-{layerId.ToString(System.Globalization.CultureInfo.InvariantCulture)}",
             StorageType = MetadataV2StorageType.RelationalTable,
-            // The seed's shared 'features' table holds rows for every test layer keyed by a
-            // 'layer_id' discriminator; the geometry lives in the 'geometry' column and the
-            // mobile-offline schema fields are persisted in the 'attributes' JSONB column.
-            // FeatureStorageMapping.ParseRelationalLocator rejects any locator that
-            // contains ':' so use the table name directly and expose the layer/geometry/
-            // attributes columns via Options (matching WebAppFixtureMetadataV2Mixin.BuildDefaultTestGraph).
             Locator = "features",
             StorageLayerId = layerId,
-            Options = new Dictionary<string, JsonElement>
-            {
-                ["geometryColumn"] = JsonSerializer.SerializeToElement("geometry"),
-                ["attributesColumn"] = JsonSerializer.SerializeToElement("attributes")
-            },
+            Options = options,
             Capabilities =
             [
                 MetadataV2StorageBindingCapability.Query,
@@ -248,6 +265,7 @@ public sealed class MobileOfflineDemoFixtureReplicationTests : IAsyncLifetime
                 MetadataV2StorageBindingCapability.Transactions
             ]
         };
+    }
 
     private static MetadataV2Publication CreateMobileOfflinePublication(int layerId)
         => new()
@@ -316,6 +334,45 @@ public sealed class MobileOfflineDemoFixtureReplicationTests : IAsyncLifetime
         var features = root.GetProperty("features");
         features.GetArrayLength().Should().BeGreaterThanOrEqualTo(3,
             "the v1 seed inserts three deterministic offline-site features");
+    }
+
+    // Regression for honua-server#1238: the JSONB-attribute layer must be queryable
+    // ONLY because the binding declares attributesColumn=attributes. This test republishes
+    // the graph WITHOUT that accessor to prove the bug reproduces (bare columns =>
+    // Postgres 42703 => GeoServices 400 "Invalid query syntax."), then republishes WITH
+    // the accessor (what the seed/bridge fix now supplies) to prove 200 with features.
+    // This guards against the TestKit attributesColumn shortcut silently masking the drift.
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/mobile_offline_demo/FeatureServer/68910/query")]
+    public async Task MobileOfflineFixture_JsonbAttributes_RequireStorageAccessorForQuery()
+    {
+        var requestUri =
+            $"/rest/services/{ServiceId}/FeatureServer/{OfflineSitesLayerId}/query"
+            + "?where=1%3D1&outFields=*&returnGeometry=true&f=json";
+
+        // Reproduce the drift: no attributesColumn => bare-column projection => 42703.
+        await PublishMobileOfflineMetadataV2Async(includeAttributesAccessor: false);
+
+        var brokenResponse = await _fixture.Client.GetAsync(requestUri);
+        using (var brokenDocument = await ReadJsonDocumentAsync(brokenResponse))
+        {
+            brokenDocument.RootElement.TryGetProperty("error", out _).Should().BeTrue(
+                "without the JSONB accessor the reader projects bare columns and Postgres "
+                + "rejects the query with 42703 (the honua-server#1238 failure)");
+        }
+
+        // The fix: with the accessor, declared fields resolve as attributes->>'field'.
+        await PublishMobileOfflineMetadataV2Async(includeAttributesAccessor: true);
+
+        var fixedResponse = await _fixture.Client.GetAsync(requestUri);
+        fixedResponse.Be200Ok();
+
+        using var fixedDocument = await ReadJsonDocumentAsync(fixedResponse);
+        var root = fixedDocument.RootElement;
+        root.TryGetProperty("error", out _).Should().BeFalse(
+            "with attributesColumn=attributes the JSONB-backed layer is queryable");
+        root.GetProperty("features").GetArrayLength().Should().BeGreaterThanOrEqualTo(3);
     }
 
     private async Task<string> CreateReplicaAsync()

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesJsonbAttributeLayerTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesJsonbAttributeLayerTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Infrastructure;
+
+namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features;
+
+/// <summary>
+/// Regression for honua-server#1238: querying a JSONB-attribute-backed layer (mobile
+/// offline demo layer 68910) via OGC API Features <c>/items</c> must succeed only because
+/// the storage binding declares <c>attributesColumn=attributes</c>. Without that accessor
+/// the storage-mapped reader projects bare columns against the shared <c>features</c> table
+/// (which has none) and Postgres raises 42703 — surfacing as an OGC 500. This test
+/// reproduces the broken drift, then proves the seed/bridge fix resolves it.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.OgcApiFeatures)]
+[Operation(Operations.Query)]
+public sealed class OgcFeaturesJsonbAttributeLayerTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+
+        var schema = _fixture.CurrentSchema
+            ?? throw new InvalidOperationException("WebAppFixture did not initialize an isolated schema.");
+
+        var seedPath = RepositoryPaths.Resolve("tests", "seed", "mobile-offline-demo-v1.sql");
+        var seedSql = await File.ReadAllTextAsync(seedPath);
+
+        await using var connection = await _fixture.Postgres.GetConnectionAsync(schema);
+        await using var command = connection.CreateCommand();
+        command.CommandText = seedSql;
+        await command.ExecuteNonQueryAsync();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    private TestMetadataV2GraphProvider Provider
+        => _fixture.GetService<TestMetadataV2GraphProvider>()
+            ?? throw new InvalidOperationException(
+                "Test V2 graph provider not registered as TestMetadataV2GraphProvider.");
+
+    [IntegrationTest]
+    [Endpoint("GET /ogc/features/collections/68910/items")]
+    public async Task GetItems_JsonbAttributes_RequireStorageAccessor()
+    {
+        var requestUri =
+            $"/ogc/features/collections/{MobileOfflineDemoGraphPublisher.OfflineSitesLayerId}/items";
+
+        // Reproduce the drift: no attributesColumn => bare-column projection => 42703 => 500.
+        MobileOfflineDemoGraphPublisher.Publish(Provider, includeAttributesAccessor: false);
+
+        var brokenResponse = await _fixture.Client.GetAsync(requestUri);
+        brokenResponse.StatusCode.Should().NotBe(HttpStatusCode.OK,
+            "without the JSONB accessor the reader projects bare columns and Postgres "
+            + "rejects the query with 42703 (the honua-server#1238 failure)");
+
+        // The fix: with the accessor, declared fields resolve as attributes->>'field'.
+        MobileOfflineDemoGraphPublisher.Publish(Provider, includeAttributesAccessor: true);
+
+        var fixedResponse = await _fixture.Client.GetAsync(requestUri);
+        fixedResponse.StatusCode.Should().Be(HttpStatusCode.OK,
+            "with attributesColumn=attributes the JSONB-backed layer is queryable via OGC items");
+
+        var json = JsonDocument.Parse(await fixedResponse.Content.ReadAsStringAsync());
+        json.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        json.RootElement.GetProperty("features").GetArrayLength().Should().BeGreaterThanOrEqualTo(3,
+            "the v1 seed inserts three deterministic offline-site features");
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Infrastructure/MobileOfflineDemoGraphPublisher.cs
+++ b/tests/dotnet/Honua.TestKit/Infrastructure/MobileOfflineDemoGraphPublisher.cs
@@ -1,0 +1,319 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Security.Domain;
+using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
+
+namespace Honua.TestKit.Infrastructure;
+
+/// <summary>
+/// Shared builder/publisher for the canonical <c>mobile_offline_demo</c> Metadata v2 graph
+/// (layers 68910/68920) used by both the FeatureServer and OGC API Features regression
+/// suites for honua-server#1238.
+/// <para>
+/// The seeded layers store every non-key field as a key inside the shared
+/// <c>features.attributes</c> JSONB column. The storage binding must therefore declare
+/// <c>attributesColumn=attributes</c> so the storage-mapped reader projects
+/// <c>attributes-&gt;&gt;'field'</c> instead of bare columns (which produce Postgres 42703).
+/// The <c>includeAttributesAccessor</c> flag lets a test reproduce the broken drift
+/// (no accessor =&gt; bare columns =&gt; 42703) and then prove the fix.
+/// </para>
+/// </summary>
+public static class MobileOfflineDemoGraphPublisher
+{
+    public const string ServiceName = "mobile_offline_demo";
+    public const int OfflineSitesLayerId = 68910;
+    public const int OfflineZonesLayerId = 68920;
+
+    private static readonly string[] Capabilities =
+        ["Query", "Extract", "Create", "Update", "Delete", "Editing", "Sync"];
+    private static readonly string[] SupportedFormats = ["JSON", "GeoJSON"];
+
+    /// <summary>
+    /// Replaces the mobile-offline service/resources/bindings/publications in the supplied
+    /// graph with FeatureServer and OGC API Features projections of layers 68910/68920.
+    /// </summary>
+    public static void Publish(
+        TestMetadataV2GraphProvider provider,
+        bool includeAttributesAccessor = true)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+
+        var snapshot = provider.GetCurrentAsync().AsTask().GetAwaiter().GetResult();
+        var graph = snapshot.Graph;
+
+        var accessPolicy = new AccessPolicy
+        {
+            AllowAnonymous = true,
+            AllowAnonymousWrite = true
+        };
+
+        var featureService = new MetadataV2Service
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "svc-mobile-offline-demo-feature",
+                Name = ServiceName,
+                Title = ServiceName,
+                Description = "Deterministic SDK-backed mobile offline field operations fixture"
+            },
+            ServiceType = MetadataV2ServiceType.EsriFeatureService,
+            Route = $"/rest/services/{ServiceName}/FeatureServer",
+            Protocols = [MetadataV2ServiceProtocols.FeatureServer],
+            AccessPolicy = accessPolicy,
+            SpatialReference = MetadataV2SpatialReference.Wgs84,
+            Options = new Dictionary<string, JsonElement>
+            {
+                ["capabilities"] = JsonSerializer.SerializeToElement(Capabilities),
+                ["supportedFormats"] = JsonSerializer.SerializeToElement(SupportedFormats)
+            }
+        };
+
+        var ogcService = new MetadataV2Service
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = "svc-mobile-offline-demo-ogc",
+                Name = ServiceName,
+                Title = ServiceName,
+                Description = "OGC API Features projection of the mobile offline fixture"
+            },
+            ServiceType = MetadataV2ServiceType.OgcApiFeatures,
+            Route = "/ogc/features",
+            Protocols = [MetadataV2ServiceProtocols.OgcFeatures],
+            AccessPolicy = accessPolicy,
+            SpatialReference = MetadataV2SpatialReference.Wgs84
+        };
+
+        var siteResource = CreateResource(
+            layerId: OfflineSitesLayerId,
+            name: "Offline Field Sites",
+            description: "Mobile-editable point layer for SDK offline create, update, delete, and conflict scenarios.",
+            geometryType: MetadataV2GeometryType.Point,
+            bbox: new MetadataV2Bbox { West = -158.1250, South = 21.2600, East = -157.8500, North = 21.4300 },
+            displayField: "site_name",
+            temporalField: "inspection_date",
+            fields:
+            [
+                Field("objectid", MetadataV2FieldType.Integer, nullable: false, "Object ID", ["id.primary"]),
+                Field("globalid", MetadataV2FieldType.String, nullable: false, "Stable mobile client/global identifier", length: 64),
+                Field("site_name", MetadataV2FieldType.String, nullable: false, "Field site name", length: 128),
+                Field("status", MetadataV2FieldType.String, nullable: false, "Workflow status", length: 32),
+                Field("priority", MetadataV2FieldType.String, nullable: false, "Dispatch priority", length: 32),
+                Field("assigned_to", MetadataV2FieldType.String, nullable: true, "Assigned mobile user", length: 64),
+                Field("inspection_date", MetadataV2FieldType.DateTime, nullable: false, "Inspection timestamp"),
+                Field("sync_version", MetadataV2FieldType.Integer, nullable: false, "Deterministic offline conflict token"),
+                Field("offline_action", MetadataV2FieldType.String, nullable: false, "Fixture role for offline harness", length: 32),
+                Field("notes", MetadataV2FieldType.String, nullable: true, "Operator notes", length: 1024),
+                Field("shape", MetadataV2FieldType.Geometry, nullable: true, "Geometry", ["geometry.primary"])
+            ],
+            accessPolicy);
+
+        var zoneResource = CreateResource(
+            layerId: OfflineZonesLayerId,
+            name: "Offline Work Zones",
+            description: "Polygon context layer included in the offline package as readonly operational context.",
+            geometryType: MetadataV2GeometryType.Polygon,
+            bbox: new MetadataV2Bbox { West = -158.1250, South = 21.2600, East = -157.7000, North = 21.5200 },
+            displayField: "zone_name",
+            temporalField: null,
+            fields:
+            [
+                Field("objectid", MetadataV2FieldType.Integer, nullable: false, "Object ID", ["id.primary"]),
+                Field("globalid", MetadataV2FieldType.String, nullable: false, "Stable zone identifier", length: 64),
+                Field("zone_name", MetadataV2FieldType.String, nullable: false, "Work zone name", length: 128),
+                Field("zone_status", MetadataV2FieldType.String, nullable: false, "Zone status", length: 32),
+                Field("sync_version", MetadataV2FieldType.Integer, nullable: false, "Readonly context generation token"),
+                Field("notes", MetadataV2FieldType.String, nullable: true, "Zone notes", length: 1024),
+                Field("shape", MetadataV2FieldType.Geometry, nullable: true, "Geometry", ["geometry.primary"])
+            ],
+            accessPolicy);
+
+        var storageBindings = new[]
+        {
+            CreateStorageBinding(OfflineSitesLayerId, includeAttributesAccessor),
+            CreateStorageBinding(OfflineZonesLayerId, includeAttributesAccessor)
+        };
+
+        var publications = new[]
+        {
+            CreateFeaturePublication(OfflineSitesLayerId),
+            CreateFeaturePublication(OfflineZonesLayerId),
+            CreateOgcPublication(OfflineSitesLayerId),
+            CreateOgcPublication(OfflineZonesLayerId)
+        };
+
+        var ownedServiceIds = new[] { "svc-mobile-offline-demo-feature", "svc-mobile-offline-demo-ogc" };
+        var ownedResourceIds = new[] { ResourceId(OfflineSitesLayerId), ResourceId(OfflineZonesLayerId) };
+        var ownedBindingIds = new[] { BindingId(OfflineSitesLayerId), BindingId(OfflineZonesLayerId) };
+        var ownedPublicationIds = publications.Select(p => p.Metadata.Id).ToHashSet(StringComparer.Ordinal);
+
+        provider.SetGraph(graph with
+        {
+            Revision = graph.Revision + 1,
+            Services = graph.Services
+                .Where(existing => !ownedServiceIds.Contains(existing.Metadata.Id))
+                .Append(featureService)
+                .Append(ogcService)
+                .ToArray(),
+            Resources = graph.Resources
+                .Where(existing => !ownedResourceIds.Contains(existing.Metadata.Id))
+                .Append(siteResource)
+                .Append(zoneResource)
+                .ToArray(),
+            StorageBindings = graph.StorageBindings
+                .Where(existing => !ownedBindingIds.Contains(existing.Metadata.Id))
+                .Concat(storageBindings)
+                .ToArray(),
+            Publications = graph.Publications
+                .Where(existing => !ownedPublicationIds.Contains(existing.Metadata.Id))
+                .Concat(publications)
+                .ToArray()
+        });
+    }
+
+    private static string ResourceId(int layerId)
+        => $"res-layer-{layerId.ToString(CultureInfo.InvariantCulture)}";
+
+    private static string BindingId(int layerId)
+        => $"binding-layer-{layerId.ToString(CultureInfo.InvariantCulture)}";
+
+    private static MetadataV2Resource CreateResource(
+        int layerId,
+        string name,
+        string description,
+        MetadataV2GeometryType geometryType,
+        MetadataV2Bbox bbox,
+        string displayField,
+        string? temporalField,
+        IReadOnlyList<MetadataV2Field> fields,
+        AccessPolicy accessPolicy)
+    {
+        var bindingId = BindingId(layerId);
+        return new MetadataV2Resource
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = ResourceId(layerId),
+                Name = name,
+                Title = name,
+                Description = description
+            },
+            Type = MetadataV2ResourceType.FeatureDataset,
+            StorageBindingIds = [bindingId],
+            PrimaryStorageBindingId = bindingId,
+            AccessPolicy = accessPolicy,
+            SchemaFields = fields,
+            Spatial = new MetadataV2ResourceSpatial
+            {
+                SpatialReference = MetadataV2SpatialReference.Wgs84,
+                GeometryType = geometryType,
+                Bbox = bbox,
+                PrimaryGeometryField = "shape"
+            },
+            Temporal = temporalField is null
+                ? null
+                : new MetadataV2ResourceTemporal { StartTimeField = temporalField },
+            Display = new MetadataV2ResourceDisplay { DisplayField = displayField },
+            Editing = new MetadataV2ResourceEditing { CanModify = true }
+        };
+    }
+
+    private static MetadataV2StorageBinding CreateStorageBinding(int layerId, bool includeAttributesAccessor)
+    {
+        // The seed's shared 'features' table holds rows for every layer keyed by a 'layer_id'
+        // discriminator; geometry lives in the 'geometry' column and the declared fields are
+        // persisted in the 'attributes' JSONB column. Expose geometry/attributes columns via
+        // Options (ParseRelationalLocator rejects locators containing ':').
+        var options = new Dictionary<string, JsonElement>
+        {
+            ["geometryColumn"] = JsonSerializer.SerializeToElement("geometry")
+        };
+
+        if (includeAttributesAccessor)
+        {
+            options["attributesColumn"] = JsonSerializer.SerializeToElement("attributes");
+        }
+
+        return new MetadataV2StorageBinding
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = BindingId(layerId),
+                Name = BindingId(layerId)
+            },
+            ResourceId = ResourceId(layerId),
+            StorageType = MetadataV2StorageType.RelationalTable,
+            Locator = "features",
+            StorageLayerId = layerId,
+            Options = options,
+            Capabilities =
+            [
+                MetadataV2StorageBindingCapability.Query,
+                MetadataV2StorageBindingCapability.Filter,
+                MetadataV2StorageBindingCapability.Sort,
+                MetadataV2StorageBindingCapability.Aggregate,
+                MetadataV2StorageBindingCapability.Edit,
+                MetadataV2StorageBindingCapability.Transactions
+            ]
+        };
+    }
+
+    private static MetadataV2Publication CreateFeaturePublication(int layerId)
+        => new()
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = $"pub-mobile-offline-feature-{layerId.ToString(CultureInfo.InvariantCulture)}",
+                Name = layerId.ToString(CultureInfo.InvariantCulture)
+            },
+            ServiceId = "svc-mobile-offline-demo-feature",
+            ResourceId = ResourceId(layerId),
+            StorageBindingId = BindingId(layerId),
+            Identifier = new MetadataV2PublicationIdentifier
+            {
+                Value = layerId.ToString(CultureInfo.InvariantCulture),
+                IsNumeric = true
+            },
+            PublicationType = MetadataV2PublicationType.EsriFeatureLayer
+        };
+
+    private static MetadataV2Publication CreateOgcPublication(int layerId)
+        => new()
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = $"pub-mobile-offline-ogc-{layerId.ToString(CultureInfo.InvariantCulture)}",
+                Name = layerId.ToString(CultureInfo.InvariantCulture)
+            },
+            ServiceId = "svc-mobile-offline-demo-ogc",
+            ResourceId = ResourceId(layerId),
+            StorageBindingId = BindingId(layerId),
+            Identifier = new MetadataV2PublicationIdentifier
+            {
+                Value = layerId.ToString(CultureInfo.InvariantCulture),
+                IsNumeric = true
+            },
+            PublicationType = MetadataV2PublicationType.OgcCollection
+        };
+
+    private static MetadataV2Field Field(
+        string name,
+        MetadataV2FieldType type,
+        bool nullable,
+        string description,
+        IReadOnlyList<string>? semanticRoles = null,
+        int? length = null)
+        => new()
+        {
+            Name = name,
+            Type = type,
+            Nullable = nullable,
+            Description = description,
+            SemanticRoles = semanticRoles ?? [],
+            Length = length
+        };
+}

--- a/tests/seed/mobile-offline-demo-v1.sql
+++ b/tests/seed/mobile-offline-demo-v1.sql
@@ -127,6 +127,7 @@ INSERT INTO honua.layers (
     table_name,
     primary_key_column,
     geometry_column,
+    storage_options,
     storage_srid,
     temporal_column,
     geometry_type,
@@ -145,6 +146,11 @@ VALUES
         'features',
         'objectid',
         'geometry',
+        -- Non-key fields (globalid, site_name, status, ...) live as keys in the shared
+        -- honua.features.attributes JSONB column, not as physical columns. Declare the
+        -- accessor so the storage-mapped reader projects attributes->>'field' instead of
+        -- bare columns (which produce Postgres 42703 "column ... does not exist").
+        jsonb_build_object('attributesColumn', 'attributes'),
         4326,
         'inspection_date',
         'Point',
@@ -186,6 +192,8 @@ VALUES
         'features',
         'objectid',
         'geometry',
+        -- See 68910: shared features.attributes JSONB column holds the declared fields.
+        jsonb_build_object('attributesColumn', 'attributes'),
         4326,
         NULL,
         'Polygon',


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1238

## Summary
The vendored `mobile-offline-demo-v1.sql` seed registers FeatureServer/OGC layers `68910`/`68920` with all non-key fields (`globalid`, `site_name`, `status`, ...) stored as keys inside the shared `honua.features.attributes` JSONB column, but left `storage_options` empty. The Metadata-v2 storage-mapped reader (`PostgresStorageMappedFeatureReader`) projects a declared field as a **bare SQL column** when the binding has no `attributesColumn`, so the live server emitted `SELECT ... globalid ...` against a table with no such column — Postgres `42703 column "globalid" does not exist`. This broke FeatureServer `/query` (400) and OGC API Features `/items` (500) for the seeded layer (root cause of the red `Live Server Integration` suite on honua-mobile trunk).

In-process tests passed only because the TestKit injected `attributesColumn=attributes` into the binding, masking the drift.

## Changes Made
- **Seed (canonical fix):** declare `attributesColumn: "attributes"` in `storage_options` for layers `68910`/`68920` in `tests/seed/mobile-offline-demo-v1.sql`, so the runtime storage mapping resolves declared fields as `attributes->>'field'`.
- **Defense-in-depth:** `PostgreSqlLayerPublishingService.MetadataV2Graph.BuildPublishedStorageBinding` now sets `attributesColumn=attributes` whenever a layer is published onto the shared `features` table (gated strictly on the shared features-table name), so any layer on that table reads correctly. Dedicated per-layer tables keep their column-per-field projection.
- **Regression tests (guard the drift):** added a shared TestKit publisher (`MobileOfflineDemoGraphPublisher`) and tests that publish the JSONB-attribute layer **without** the `attributesColumn` accessor (reproducing the 42703 failure) and then **with** it (proving the fix), covering both FeatureServer `/query` and OGC API Features `/items`.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Both regression tests pass; with the accessor temporarily removed, the OGC `/items` request returns 500 (the 42703 failure) and the FeatureServer `/query` returns a GeoServices error — confirming fail-before/pass-after. `dotnet format Honua.sln --verify-no-changes` and Release builds are clean.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
