### PR TITLE
feat: catalog discovery-endpoint registry read API (#1279)

### DIFF
--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -213,6 +213,10 @@ public static class EndpointRegistry
         new("GET", "/api/v1/console/share/content/{id}"),
         new("GET", "/api/v1/console/share/link/{token}"),
         new("POST", "/api/v1/console/share/embed/{token}/redeem"),
+        // v1 Console catalog discovery-endpoints registry read API (#1279)
+        new("GET", "/api/v1/console/catalog-endpoints/{workspaceId}"),
+        new("GET", "/api/v1/console/catalog-endpoints/{workspaceId}/{endpointKey}"),
+        new("GET", "/api/v1/console/catalog-endpoints/{workspaceId}/{endpointKey}/items/{itemId}"),
         new("POST", "/api/v1/admin/packages/validate"),
         new("POST", "/api/v1/admin/packages/preview"),
         new("GET", "/api/v1/console/workflow-node-registry"),

--- a/src/Honua.Server/Features/Console/CatalogDiscoveryEndpoints.cs
+++ b/src/Honua.Server/Features/Console/CatalogDiscoveryEndpoints.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Server.Features.Console.Models;
+using Honua.Server.Features.Console.Services;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Models;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Console;
+
+/// <summary>
+/// Console catalog discovery-endpoints registry read API (honua-server#1279).
+/// Workspace-scoped admin reads describing which discovery dialects (Esri
+/// catalog, OGC API Records, OData, STAC, DCAT) the server publishes to
+/// consumers, each endpoint's on/off and auto-default-vs-opt-in state, its
+/// feeders, and the per-endpoint/per-item drill-down. Distinct from the
+/// singular content catalog (<c>/api/v1/console/content</c>, #1162).
+/// </summary>
+internal static class CatalogDiscoveryEndpoints
+{
+    /// <summary>Log category for catalog discovery endpoints.</summary>
+    internal sealed class CatalogDiscoveryEndpointsLog;
+
+    /// <summary>Maps the catalog discovery-endpoints registry read endpoints.</summary>
+    public static void MapCatalogDiscoveryEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/console/catalog-endpoints")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Console")
+            .RequireAdminAuthorization();
+
+        group.MapGet("/{workspaceId}", HandleGetRegistry)
+            .WithDisplayName("Get Catalog Discovery Registry")
+            .WithSummary("Returns the workspace's catalog discovery-endpoints registry: the set of discovery dialects the server publishes, each endpoint's on/off and auto-default-vs-opt-in state, feeders, and aggregate counts.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        group.MapGet("/{workspaceId}/{endpointKey}", HandleGetEndpoint)
+            .WithDisplayName("Get Catalog Discovery Endpoint Detail")
+            .WithSummary("Returns one discovery endpoint with its header facts and mirrored items table.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        group.MapGet("/{workspaceId}/{endpointKey}/items/{itemId}", HandleGetItem)
+            .WithDisplayName("Get Catalog Discovery Item")
+            .WithSummary("Returns one catalog item with its identity, catalog-presentation, service-binding, and standards-mapping field groups.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+    }
+
+    private static async Task<Results<Ok<ApiResponse<CatalogDiscoveryRegistry>>, NotFound<ApiResponse<object>>, ProblemHttpResult>> HandleGetRegistry(
+        string workspaceId,
+        [FromServices] ICatalogDiscoveryRegistryStore store,
+        [FromServices] ILogger<CatalogDiscoveryEndpointsLog> logger,
+        HttpContext context)
+    {
+        try
+        {
+            var registry = await store.GetRegistryAsync(workspaceId, context.RequestAborted).ConfigureAwait(false);
+            if (registry is null)
+            {
+                return TypedResults.NotFound(ApiResponse<object>.Failure("Catalog discovery registry not found for workspace."));
+            }
+
+            return TypedResults.Ok(ApiResponse<CatalogDiscoveryRegistry>.CreateSuccess(registry));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            ConsoleEndpointsLog.EndpointFailed(logger, "catalog-endpoints.registry", ex);
+            return TypedResults.Problem(
+                title: "Catalog discovery registry lookup failed",
+                detail: "An internal error occurred while reading the catalog discovery registry.",
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+
+    private static async Task<Results<Ok<ApiResponse<CatalogEndpointDetail>>, NotFound<ApiResponse<object>>, ProblemHttpResult>> HandleGetEndpoint(
+        string workspaceId,
+        string endpointKey,
+        [FromServices] ICatalogDiscoveryRegistryStore store,
+        [FromServices] ILogger<CatalogDiscoveryEndpointsLog> logger,
+        HttpContext context)
+    {
+        try
+        {
+            var detail = await store.GetEndpointAsync(workspaceId, endpointKey, context.RequestAborted).ConfigureAwait(false);
+            if (detail is null)
+            {
+                return TypedResults.NotFound(ApiResponse<object>.Failure("Catalog discovery endpoint not found."));
+            }
+
+            return TypedResults.Ok(ApiResponse<CatalogEndpointDetail>.CreateSuccess(detail));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            ConsoleEndpointsLog.EndpointFailed(logger, "catalog-endpoints.detail", ex);
+            return TypedResults.Problem(
+                title: "Catalog discovery endpoint lookup failed",
+                detail: "An internal error occurred while reading the catalog discovery endpoint.",
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+
+    private static async Task<Results<Ok<ApiResponse<CatalogItem>>, NotFound<ApiResponse<object>>, ProblemHttpResult>> HandleGetItem(
+        string workspaceId,
+        string endpointKey,
+        string itemId,
+        [FromServices] ICatalogDiscoveryRegistryStore store,
+        [FromServices] ILogger<CatalogDiscoveryEndpointsLog> logger,
+        HttpContext context)
+    {
+        try
+        {
+            var item = await store.GetItemAsync(workspaceId, endpointKey, itemId, context.RequestAborted).ConfigureAwait(false);
+            if (item is null)
+            {
+                return TypedResults.NotFound(ApiResponse<object>.Failure("Catalog discovery item not found."));
+            }
+
+            return TypedResults.Ok(ApiResponse<CatalogItem>.CreateSuccess(item));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            ConsoleEndpointsLog.EndpointFailed(logger, "catalog-endpoints.item", ex);
+            return TypedResults.Problem(
+                title: "Catalog discovery item lookup failed",
+                detail: "An internal error occurred while reading the catalog discovery item.",
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+}

--- a/src/Honua.Server/Features/Console/Models/CatalogDiscoveryModels.cs
+++ b/src/Honua.Server/Features/Console/Models/CatalogDiscoveryModels.cs
@@ -1,0 +1,277 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Console.Models;
+
+// Wire DTOs for the Console catalog discovery-endpoints registry read API
+// (honua-server#1279). These shapes mirror the consumer contract defined in
+// honua-console's Honua.Console.Contracts/CatalogDiscoveryShims.cs
+// (IHonuaCatalogDiscoveryClient) so the live binding activates the moment this
+// API publishes. This surface is DISTINCT from the singular content catalog
+// (/api/v1/console/content, #1162): it describes *which discovery dialects the
+// server publishes to consumers* (Esri catalog, OGC API Records, OData, STAC,
+// DCAT), not the content items themselves.
+
+/// <summary>
+/// The catalog discovery dialects the registry can expose. Mirrors the
+/// honua-console <c>HonuaCatalogDialects</c> string set.
+/// </summary>
+public static class CatalogDialects
+{
+    /// <summary>Esri catalog / portal item discovery.</summary>
+    public const string Esri = "esri";
+
+    /// <summary>OGC API Records discovery.</summary>
+    public const string Ogc = "ogc";
+
+    /// <summary>OData v4 service document discovery.</summary>
+    public const string ODataV4 = "odata";
+
+    /// <summary>STAC catalog discovery.</summary>
+    public const string Stac = "stac";
+
+    /// <summary>DCAT data-catalog discovery.</summary>
+    public const string Dcat = "dcat";
+}
+
+/// <summary>
+/// How a single catalog-item field is sourced: derived from the backing
+/// service/resource, system-managed, or catalog-only operator input.
+/// </summary>
+public static class CatalogFieldStates
+{
+    /// <summary>Field is system-managed (identity, immutable).</summary>
+    public const string System = "system";
+
+    /// <summary>Field is calculated/derived from a backing resource.</summary>
+    public const string Calculated = "calculated";
+
+    /// <summary>Field is catalog-only operator input.</summary>
+    public const string Input = "input";
+}
+
+/// <summary>One feeder that populates a discovery endpoint (e.g. a FeatureServer or an OGC API collection).</summary>
+public sealed record CatalogFeeder
+{
+    /// <summary>Feeder kind (e.g. <c>feature-server</c>, <c>ogc-features</c>, <c>odata-entity-set</c>).</summary>
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    /// <summary>Human-readable feeder label.</summary>
+    [JsonPropertyName("label")]
+    public required string Label { get; init; }
+}
+
+/// <summary>One discovery endpoint card in the registry: dialect, on/off, auto-default vs opt-in, feeders, issues.</summary>
+public sealed record CatalogEndpoint
+{
+    /// <summary>Stable endpoint key used in drill-down routes.</summary>
+    [JsonPropertyName("key")]
+    public required string Key { get; init; }
+
+    /// <summary>Display title.</summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    /// <summary>Optional description.</summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>Discovery dialect (see <see cref="CatalogDialects"/>).</summary>
+    [JsonPropertyName("dialect")]
+    public required string Dialect { get; init; }
+
+    /// <summary>Server-wide on/off state.</summary>
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; init; }
+
+    /// <summary>True when the endpoint auto-mirrors publications (auto-default-on); false when resources opt in.</summary>
+    [JsonPropertyName("autoDefault")]
+    public bool AutoDefault { get; init; }
+
+    /// <summary>Public discovery URL, when published.</summary>
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+
+    /// <summary>Number of catalog entries currently exposed by the endpoint.</summary>
+    [JsonPropertyName("entries")]
+    public int Entries { get; init; }
+
+    /// <summary>Short summary of what feeds the endpoint.</summary>
+    [JsonPropertyName("fedBy")]
+    public string? FedBy { get; init; }
+
+    /// <summary>The feeders that populate the endpoint.</summary>
+    [JsonPropertyName("feeders")]
+    public IReadOnlyList<CatalogFeeder> Feeders { get; init; } = Array.Empty<CatalogFeeder>();
+
+    /// <summary>Count of per-endpoint validation issues.</summary>
+    [JsonPropertyName("issueCount")]
+    public int IssueCount { get; init; }
+}
+
+/// <summary>The discovery-endpoints registry projection: the endpoint cards plus auto/opt-in aggregate counts.</summary>
+public sealed record CatalogDiscoveryRegistry
+{
+    /// <summary>The workspace this registry belongs to.</summary>
+    [JsonPropertyName("workspaceId")]
+    public required string WorkspaceId { get; init; }
+
+    /// <summary>Display name of the workspace.</summary>
+    [JsonPropertyName("workspaceName")]
+    public string? WorkspaceName { get; init; }
+
+    /// <summary>Public host that serves the discovery endpoints.</summary>
+    [JsonPropertyName("publicHost")]
+    public string? PublicHost { get; init; }
+
+    /// <summary>The discovery endpoint cards.</summary>
+    [JsonPropertyName("endpoints")]
+    public IReadOnlyList<CatalogEndpoint> Endpoints { get; init; } = Array.Empty<CatalogEndpoint>();
+
+    /// <summary>Count of endpoints that auto-default-on.</summary>
+    [JsonPropertyName("autoDefaultCount")]
+    public int AutoDefaultCount { get; init; }
+
+    /// <summary>Count of endpoints that require resources to opt in.</summary>
+    [JsonPropertyName("optInCount")]
+    public int OptInCount { get; init; }
+}
+
+/// <summary>One row in the endpoint-detail items table: a mirrored publication item.</summary>
+public sealed record CatalogEndpointItem
+{
+    /// <summary>Stable item id used in the item drill-down route.</summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>Item title.</summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    /// <summary>Backing service the item is mirrored from.</summary>
+    [JsonPropertyName("fromService")]
+    public string? FromService { get; init; }
+
+    /// <summary>Backing resource reference.</summary>
+    [JsonPropertyName("resource")]
+    public string? Resource { get; init; }
+
+    /// <summary>Catalog tags.</summary>
+    [JsonPropertyName("tags")]
+    public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();
+
+    /// <summary>True when the item carries a thumbnail.</summary>
+    [JsonPropertyName("hasThumbnail")]
+    public bool HasThumbnail { get; init; }
+
+    /// <summary>Catalog-presentation license string.</summary>
+    [JsonPropertyName("license")]
+    public string? License { get; init; }
+
+    /// <summary>Count of per-item validation issues.</summary>
+    [JsonPropertyName("issueCount")]
+    public int IssueCount { get; init; }
+
+    /// <summary>Last-updated timestamp (ISO-8601), when known.</summary>
+    [JsonPropertyName("updated")]
+    public string? Updated { get; init; }
+}
+
+/// <summary>The endpoint-detail projection: the endpoint header facts plus the mirrored items table.</summary>
+public sealed record CatalogEndpointDetail
+{
+    /// <summary>The endpoint card.</summary>
+    [JsonPropertyName("endpoint")]
+    public required CatalogEndpoint Endpoint { get; init; }
+
+    /// <summary>Last rebuild timestamp (ISO-8601), when known.</summary>
+    [JsonPropertyName("lastRebuild")]
+    public string? LastRebuild { get; init; }
+
+    /// <summary>True when the endpoint auto-mirrors publications.</summary>
+    [JsonPropertyName("autoMirror")]
+    public bool AutoMirror { get; init; }
+
+    /// <summary>The mirrored items.</summary>
+    [JsonPropertyName("items")]
+    public IReadOnlyList<CatalogEndpointItem> Items { get; init; } = Array.Empty<CatalogEndpointItem>();
+}
+
+/// <summary>One field in the catalog item editor with its source state and (for derived fields) its origin.</summary>
+public sealed record CatalogItemField
+{
+    /// <summary>Field label.</summary>
+    [JsonPropertyName("label")]
+    public required string Label { get; init; }
+
+    /// <summary>Field source state (see <see cref="CatalogFieldStates"/>).</summary>
+    [JsonPropertyName("state")]
+    public required string State { get; init; }
+
+    /// <summary>Field value.</summary>
+    [JsonPropertyName("value")]
+    public string? Value { get; init; }
+
+    /// <summary>For derived fields, the resource/service the value is derived from.</summary>
+    [JsonPropertyName("derivedFrom")]
+    public string? DerivedFrom { get; init; }
+}
+
+/// <summary>A field group in the catalog item editor (Identity, Catalog presentation, Service bindings, Standards mapping).</summary>
+public sealed record CatalogItemFieldGroup
+{
+    /// <summary>Group title.</summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    /// <summary>Optional group subtitle.</summary>
+    [JsonPropertyName("subtitle")]
+    public string? Subtitle { get; init; }
+
+    /// <summary>Optional scope hint (e.g. <c>resource-derived</c>, <c>catalog-only</c>).</summary>
+    [JsonPropertyName("scope")]
+    public string? Scope { get; init; }
+
+    /// <summary>The fields in this group.</summary>
+    [JsonPropertyName("fields")]
+    public IReadOnlyList<CatalogItemField> Fields { get; init; } = Array.Empty<CatalogItemField>();
+}
+
+/// <summary>The catalog item editor projection: an auto-mirrored item with its derived/catalog/binding/standards groups.</summary>
+public sealed record CatalogItem
+{
+    /// <summary>Stable item id.</summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>Item title.</summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    /// <summary>True when the item is auto-mirrored from its backing service.</summary>
+    [JsonPropertyName("autoMirror")]
+    public bool AutoMirror { get; init; }
+
+    /// <summary>True when the item is live/published.</summary>
+    [JsonPropertyName("live")]
+    public bool Live { get; init; }
+
+    /// <summary>Number of backing services.</summary>
+    [JsonPropertyName("backingServiceCount")]
+    public int BackingServiceCount { get; init; }
+
+    /// <summary>Number of catalog tags.</summary>
+    [JsonPropertyName("tagCount")]
+    public int TagCount { get; init; }
+
+    /// <summary>Count of per-item validation issues.</summary>
+    [JsonPropertyName("issueCount")]
+    public int IssueCount { get; init; }
+
+    /// <summary>The field groups.</summary>
+    [JsonPropertyName("groups")]
+    public IReadOnlyList<CatalogItemFieldGroup> Groups { get; init; } = Array.Empty<CatalogItemFieldGroup>();
+}

--- a/src/Honua.Server/Features/Console/Models/ConsoleJsonContext.cs
+++ b/src/Honua.Server/Features/Console/Models/ConsoleJsonContext.cs
@@ -29,6 +29,13 @@ namespace Honua.Server.Features.Console.Models;
 [JsonSerializable(typeof(ApiResponse<ConsoleEmbedToken>))]
 [JsonSerializable(typeof(ApiResponse<ConsoleEmbedRedeemResponse>))]
 [JsonSerializable(typeof(ApiResponse<ConsoleShareDependencyClosureResponse>))]
+// Catalog discovery-endpoints registry read API (#1279).
+[JsonSerializable(typeof(ApiResponse<CatalogDiscoveryRegistry>))]
+[JsonSerializable(typeof(ApiResponse<CatalogEndpointDetail>))]
+[JsonSerializable(typeof(ApiResponse<CatalogItem>))]
+[JsonSerializable(typeof(CatalogDiscoveryRegistry))]
+[JsonSerializable(typeof(CatalogEndpointDetail))]
+[JsonSerializable(typeof(CatalogItem))]
 [JsonSerializable(typeof(CreateConsoleContentItemRequest))]
 [JsonSerializable(typeof(UpdateConsoleContentItemRequest))]
 [JsonSerializable(typeof(PatchConsoleContentItemRequest))]

--- a/src/Honua.Server/Features/Console/Services/ConfigCatalogDiscoveryRegistryStore.cs
+++ b/src/Honua.Server/Features/Console/Services/ConfigCatalogDiscoveryRegistryStore.cs
@@ -1,0 +1,367 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using Honua.Server.Features.Console.Models;
+
+namespace Honua.Server.Features.Console.Services;
+
+/// <summary>
+/// Configuration-backed read model for the Console catalog discovery-endpoints
+/// registry (honua-server#1279). The discovery dialects a server publishes are
+/// a server-wide concern owned by config/metadata; this store materialises that
+/// configuration into the Console projection. The default seed mirrors the five
+/// supported dialects so the Console Catalogs surface binds immediately, while
+/// the per-workspace map can be replaced/extended by configuration without
+/// touching the endpoints.
+/// </summary>
+public sealed class ConfigCatalogDiscoveryRegistryStore : ICatalogDiscoveryRegistryStore
+{
+    private readonly ConcurrentDictionary<string, CatalogDiscoveryRegistry> _registriesByWorkspace;
+    private readonly ConcurrentDictionary<(string Workspace, string Endpoint), CatalogEndpointDetail> _details;
+    private readonly ConcurrentDictionary<(string Workspace, string Endpoint, string Item), CatalogItem> _items;
+
+    /// <summary>
+    /// Creates a store seeded with the supplied per-workspace registries. When
+    /// no seed is supplied a single default workspace is materialised.
+    /// </summary>
+    public ConfigCatalogDiscoveryRegistryStore(IEnumerable<CatalogDiscoveryWorkspaceSeed>? seeds = null)
+    {
+        _registriesByWorkspace = new ConcurrentDictionary<string, CatalogDiscoveryRegistry>(StringComparer.OrdinalIgnoreCase);
+        _details = new ConcurrentDictionary<(string, string), CatalogEndpointDetail>(WorkspaceEndpointComparer.Instance);
+        _items = new ConcurrentDictionary<(string, string, string), CatalogItem>(WorkspaceEndpointItemComparer.Instance);
+
+        var materialised = (seeds ?? DefaultSeeds()).ToList();
+        foreach (var seed in materialised)
+        {
+            Ingest(seed);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<CatalogDiscoveryRegistry?> GetRegistryAsync(string workspaceId, CancellationToken cancellationToken = default)
+    {
+        _registriesByWorkspace.TryGetValue(workspaceId, out var registry);
+        return Task.FromResult(registry);
+    }
+
+    /// <inheritdoc />
+    public Task<CatalogEndpointDetail?> GetEndpointAsync(string workspaceId, string endpointKey, CancellationToken cancellationToken = default)
+    {
+        if (!_registriesByWorkspace.ContainsKey(workspaceId))
+        {
+            return Task.FromResult<CatalogEndpointDetail?>(null);
+        }
+
+        _details.TryGetValue((workspaceId, endpointKey), out var detail);
+        return Task.FromResult(detail);
+    }
+
+    /// <inheritdoc />
+    public Task<CatalogItem?> GetItemAsync(string workspaceId, string endpointKey, string itemId, CancellationToken cancellationToken = default)
+    {
+        if (!_details.ContainsKey((workspaceId, endpointKey)))
+        {
+            return Task.FromResult<CatalogItem?>(null);
+        }
+
+        _items.TryGetValue((workspaceId, endpointKey, itemId), out var item);
+        return Task.FromResult(item);
+    }
+
+    private void Ingest(CatalogDiscoveryWorkspaceSeed seed)
+    {
+        var endpoints = seed.Endpoints.Select(e => e.Endpoint).ToList();
+        var registry = new CatalogDiscoveryRegistry
+        {
+            WorkspaceId = seed.WorkspaceId,
+            WorkspaceName = seed.WorkspaceName,
+            PublicHost = seed.PublicHost,
+            Endpoints = endpoints,
+            AutoDefaultCount = endpoints.Count(e => e.AutoDefault),
+            OptInCount = endpoints.Count(e => !e.AutoDefault),
+        };
+        _registriesByWorkspace[seed.WorkspaceId] = registry;
+
+        foreach (var endpoint in seed.Endpoints)
+        {
+            _details[(seed.WorkspaceId, endpoint.Endpoint.Key)] = new CatalogEndpointDetail
+            {
+                Endpoint = endpoint.Endpoint,
+                LastRebuild = endpoint.LastRebuild,
+                AutoMirror = endpoint.Endpoint.AutoDefault,
+                Items = endpoint.Items.Select(i => i.Row).ToList(),
+            };
+
+            foreach (var item in endpoint.Items)
+            {
+                _items[(seed.WorkspaceId, endpoint.Endpoint.Key, item.Row.Id)] = item.Detail;
+            }
+        }
+    }
+
+    private static IEnumerable<CatalogDiscoveryWorkspaceSeed> DefaultSeeds()
+    {
+        yield return new CatalogDiscoveryWorkspaceSeed
+        {
+            WorkspaceId = "default",
+            WorkspaceName = "Default workspace",
+            PublicHost = "https://localhost:8080",
+            Endpoints =
+            [
+                BuildEsriEndpoint(),
+                BuildOgcEndpoint(),
+                BuildODataEndpoint(),
+                BuildStacEndpoint(),
+                BuildDcatEndpoint(),
+            ],
+        };
+    }
+
+    private static CatalogEndpointSeed BuildEsriEndpoint()
+    {
+        var itemDetail = new CatalogItem
+        {
+            Id = "parcels",
+            Title = "Parcels",
+            AutoMirror = true,
+            Live = true,
+            BackingServiceCount = 1,
+            TagCount = 2,
+            IssueCount = 0,
+            Groups =
+            [
+                new CatalogItemFieldGroup
+                {
+                    Title = "Identity",
+                    Subtitle = "Resource-derived",
+                    Scope = "resource-derived",
+                    Fields =
+                    [
+                        new CatalogItemField { Label = "Item id", State = CatalogFieldStates.System, Value = "parcels" },
+                        new CatalogItemField { Label = "Type", State = CatalogFieldStates.Calculated, Value = "Feature Layer", DerivedFrom = "Parcels FeatureServer" },
+                    ],
+                },
+                new CatalogItemFieldGroup
+                {
+                    Title = "Catalog presentation",
+                    Subtitle = "Catalog-only input",
+                    Scope = "catalog-only",
+                    Fields =
+                    [
+                        new CatalogItemField { Label = "Title", State = CatalogFieldStates.Input, Value = "Parcels" },
+                        new CatalogItemField { Label = "Tags", State = CatalogFieldStates.Input, Value = "parcels, cadastre" },
+                    ],
+                },
+                new CatalogItemFieldGroup
+                {
+                    Title = "Service bindings",
+                    Scope = "resource-derived",
+                    Fields =
+                    [
+                        new CatalogItemField { Label = "FeatureServer", State = CatalogFieldStates.Calculated, Value = "/rest/services/Parcels/FeatureServer", DerivedFrom = "Parcels FeatureServer" },
+                    ],
+                },
+                new CatalogItemFieldGroup
+                {
+                    Title = "Standards mapping",
+                    Scope = "resource-derived",
+                    Fields =
+                    [
+                        new CatalogItemField { Label = "ISO 19115", State = CatalogFieldStates.Calculated, Value = "dataset", DerivedFrom = "Parcels FeatureServer" },
+                    ],
+                },
+            ],
+        };
+
+        return new CatalogEndpointSeed
+        {
+            Endpoint = new CatalogEndpoint
+            {
+                Key = "esri",
+                Title = "Esri catalog",
+                Description = "ArcGIS-compatible portal item discovery.",
+                Dialect = CatalogDialects.Esri,
+                Enabled = true,
+                AutoDefault = true,
+                Url = "/rest/portal",
+                Entries = 1,
+                FedBy = "FeatureServer, MapServer, ImageServer",
+                Feeders =
+                [
+                    new CatalogFeeder { Kind = "feature-server", Label = "Parcels FeatureServer" },
+                ],
+                IssueCount = 0,
+            },
+            LastRebuild = "2026-05-01T00:00:00Z",
+            Items =
+            [
+                new CatalogItemSeed
+                {
+                    Row = new CatalogEndpointItem
+                    {
+                        Id = "parcels",
+                        Title = "Parcels",
+                        FromService = "Parcels FeatureServer",
+                        Resource = "/rest/services/Parcels/FeatureServer",
+                        Tags = ["parcels", "cadastre"],
+                        HasThumbnail = false,
+                        License = "CC-BY-4.0",
+                        IssueCount = 0,
+                        Updated = "2026-05-01T00:00:00Z",
+                    },
+                    Detail = itemDetail,
+                },
+            ],
+        };
+    }
+
+    private static CatalogEndpointSeed BuildOgcEndpoint() => new()
+    {
+        Endpoint = new CatalogEndpoint
+        {
+            Key = "ogc",
+            Title = "OGC API Records",
+            Description = "OGC API - Records catalogue of published collections.",
+            Dialect = CatalogDialects.Ogc,
+            Enabled = true,
+            AutoDefault = true,
+            Url = "/ogc/features/collections",
+            Entries = 0,
+            FedBy = "OGC API Features collections",
+            Feeders = [new CatalogFeeder { Kind = "ogc-features", Label = "OGC API Features" }],
+            IssueCount = 0,
+        },
+        LastRebuild = "2026-05-01T00:00:00Z",
+        Items = [],
+    };
+
+    private static CatalogEndpointSeed BuildODataEndpoint() => new()
+    {
+        Endpoint = new CatalogEndpoint
+        {
+            Key = "odata",
+            Title = "OData v4",
+            Description = "OData v4 service document of exposed entity sets.",
+            Dialect = CatalogDialects.ODataV4,
+            Enabled = false,
+            AutoDefault = false,
+            Url = "/odata",
+            Entries = 0,
+            FedBy = "OData entity sets",
+            Feeders = [new CatalogFeeder { Kind = "odata-entity-set", Label = "OData entity sets" }],
+            IssueCount = 0,
+        },
+        LastRebuild = null,
+        Items = [],
+    };
+
+    private static CatalogEndpointSeed BuildStacEndpoint() => new()
+    {
+        Endpoint = new CatalogEndpoint
+        {
+            Key = "stac",
+            Title = "STAC",
+            Description = "SpatioTemporal Asset Catalog of raster/coverage assets.",
+            Dialect = CatalogDialects.Stac,
+            Enabled = true,
+            AutoDefault = false,
+            Url = "/stac",
+            Entries = 0,
+            FedBy = "ImageServer, coverages",
+            Feeders = [new CatalogFeeder { Kind = "image-server", Label = "ImageServer" }],
+            IssueCount = 0,
+        },
+        LastRebuild = "2026-05-01T00:00:00Z",
+        Items = [],
+    };
+
+    private static CatalogEndpointSeed BuildDcatEndpoint() => new()
+    {
+        Endpoint = new CatalogEndpoint
+        {
+            Key = "dcat",
+            Title = "DCAT",
+            Description = "DCAT data-catalog feed for open-data portals.",
+            Dialect = CatalogDialects.Dcat,
+            Enabled = false,
+            AutoDefault = false,
+            Url = "/dcat/catalog.json",
+            Entries = 0,
+            FedBy = "Published open-data items",
+            Feeders = [new CatalogFeeder { Kind = "open-data", Label = "Open-data items" }],
+            IssueCount = 0,
+        },
+        LastRebuild = null,
+        Items = [],
+    };
+
+    private sealed class WorkspaceEndpointComparer : IEqualityComparer<(string Workspace, string Endpoint)>
+    {
+        public static readonly WorkspaceEndpointComparer Instance = new();
+
+        public bool Equals((string Workspace, string Endpoint) x, (string Workspace, string Endpoint) y)
+            => string.Equals(x.Workspace, y.Workspace, StringComparison.OrdinalIgnoreCase)
+               && string.Equals(x.Endpoint, y.Endpoint, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode((string Workspace, string Endpoint) obj)
+            => HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Workspace),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Endpoint));
+    }
+
+    private sealed class WorkspaceEndpointItemComparer : IEqualityComparer<(string Workspace, string Endpoint, string Item)>
+    {
+        public static readonly WorkspaceEndpointItemComparer Instance = new();
+
+        public bool Equals((string Workspace, string Endpoint, string Item) x, (string Workspace, string Endpoint, string Item) y)
+            => string.Equals(x.Workspace, y.Workspace, StringComparison.OrdinalIgnoreCase)
+               && string.Equals(x.Endpoint, y.Endpoint, StringComparison.OrdinalIgnoreCase)
+               && string.Equals(x.Item, y.Item, StringComparison.Ordinal);
+
+        public int GetHashCode((string Workspace, string Endpoint, string Item) obj)
+            => HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Workspace),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Endpoint),
+                StringComparer.Ordinal.GetHashCode(obj.Item));
+    }
+}
+
+/// <summary>Configuration seed for one workspace's discovery-endpoints registry.</summary>
+public sealed record CatalogDiscoveryWorkspaceSeed
+{
+    /// <summary>Workspace id.</summary>
+    public required string WorkspaceId { get; init; }
+
+    /// <summary>Workspace display name.</summary>
+    public string? WorkspaceName { get; init; }
+
+    /// <summary>Public host that serves the discovery endpoints.</summary>
+    public string? PublicHost { get; init; }
+
+    /// <summary>The endpoint seeds.</summary>
+    public IReadOnlyList<CatalogEndpointSeed> Endpoints { get; init; } = Array.Empty<CatalogEndpointSeed>();
+}
+
+/// <summary>Configuration seed for one discovery endpoint, including its detail and items.</summary>
+public sealed record CatalogEndpointSeed
+{
+    /// <summary>The endpoint card.</summary>
+    public required CatalogEndpoint Endpoint { get; init; }
+
+    /// <summary>Last rebuild timestamp (ISO-8601), when known.</summary>
+    public string? LastRebuild { get; init; }
+
+    /// <summary>The endpoint's items.</summary>
+    public IReadOnlyList<CatalogItemSeed> Items { get; init; } = Array.Empty<CatalogItemSeed>();
+}
+
+/// <summary>Configuration seed for one catalog item: its table row plus its editor detail.</summary>
+public sealed record CatalogItemSeed
+{
+    /// <summary>The item row shown in the endpoint-detail items table.</summary>
+    public required CatalogEndpointItem Row { get; init; }
+
+    /// <summary>The item editor detail (field groups).</summary>
+    public required CatalogItem Detail { get; init; }
+}

--- a/src/Honua.Server/Features/Console/Services/ICatalogDiscoveryRegistryStore.cs
+++ b/src/Honua.Server/Features/Console/Services/ICatalogDiscoveryRegistryStore.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Server.Features.Console.Models;
+
+namespace Honua.Server.Features.Console.Services;
+
+/// <summary>
+/// Read-model store for the Console catalog discovery-endpoints registry
+/// (honua-server#1279). Describes which discovery dialects (Esri catalog, OGC
+/// API Records, OData, STAC, DCAT) a workspace publishes to consumers, each
+/// endpoint's on/off and auto-default-vs-opt-in state, its feeders, and the
+/// per-endpoint/per-item drill-down. This is a read-only projection: the
+/// authoritative endpoint configuration is owned by server config/metadata, so
+/// implementations are not expected to support writes.
+/// </summary>
+public interface ICatalogDiscoveryRegistryStore
+{
+    /// <summary>
+    /// Returns the discovery-endpoints registry for a workspace, or <c>null</c>
+    /// when the workspace is unknown. A known workspace with no published
+    /// dialects returns a registry with an empty endpoint list.
+    /// </summary>
+    Task<CatalogDiscoveryRegistry?> GetRegistryAsync(string workspaceId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns one discovery endpoint with its mirrored items, or <c>null</c>
+    /// when the workspace or endpoint key is unknown.
+    /// </summary>
+    Task<CatalogEndpointDetail?> GetEndpointAsync(string workspaceId, string endpointKey, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns one catalog item with its field groups, or <c>null</c> when the
+    /// workspace, endpoint key, or item id is unknown.
+    /// </summary>
+    Task<CatalogItem?> GetItemAsync(string workspaceId, string endpointKey, string itemId, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -448,6 +448,12 @@ builder.Services.AddSingleton<Honua.Core.Features.Console.Abstractions.IConsoleS
         sp.GetService<TimeProvider>() ?? TimeProvider.System));
 builder.Services.AddScoped<Honua.Core.Features.Console.Abstractions.IConsoleDependencyClosureValidator,
     Honua.Server.Features.Console.Services.ConsoleDependencyClosureValidator>();
+// Console catalog discovery-endpoints registry read model (#1279). The discovery
+// dialects a server publishes are a server-wide config/metadata concern; this
+// config-backed read model materialises them into the Console projection. A
+// durable/metadata-v2-backed source can replace this registration later.
+builder.Services.AddSingleton<Honua.Server.Features.Console.Services.ICatalogDiscoveryRegistryStore>(
+    _ => new Honua.Server.Features.Console.Services.ConfigCatalogDiscoveryRegistryStore());
 
 // Content publication registry for Studio-generated maps/dashboards/reports/apps (#1183).
 // In-memory store is the default; Postgres registration (AddPostgreSqlServices) overrides
@@ -1046,6 +1052,7 @@ app.MapConsoleContentEndpoints();
 app.MapConsoleActionEndpoints();
 // Console Share access public-link + embed API (#1215)
 app.MapConsoleShareEndpoints();
+app.MapCatalogDiscoveryEndpoints();
 app.MapConsoleSharePublicEndpoints();
 app.MapStudioPackageEndpoints();
 app.MapWorkflowPackageEndpoints();

--- a/tests/dotnet/Honua.Server.Tests/Features/Console/CatalogDiscoveryEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Console/CatalogDiscoveryEndpointsTests.cs
@@ -1,0 +1,276 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Server.Features.Console.Models;
+using Honua.Server.Features.Console.Services;
+using Honua.Infrastructure.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests.Features.Console;
+
+/// <summary>
+/// Integration tests for the Console catalog discovery-endpoints registry read
+/// API (honua-server#1279): registry list (incl. empty workspace and
+/// opt-in-vs-default-on aggregates), endpoint detail (incl. not-found), item
+/// drill-down (incl. not-found), and admin permission enforcement.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.RoleManagement)]
+public sealed class CatalogDiscoveryEndpointsTests : IAsyncLifetime
+{
+    private const string AdminPassword = "catalog-discovery-admin-key";
+    private const string WorkspaceId = "default";
+    private const string EmptyWorkspaceId = "empty-ws";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.KebabCaseLower, allowIntegerValues: true) },
+    };
+
+    private readonly WebAppFixture _fixture;
+    private HttpClient _adminClient = null!;
+    private HttpClient _anonymousClient = null!;
+
+    public CatalogDiscoveryEndpointsTests()
+    {
+        // Seed two workspaces: the canonical "default" (five dialects, mixed
+        // auto-default/opt-in), and an "empty-ws" with no published dialects so
+        // the empty-registry contract is exercised.
+        var seeds = new[]
+        {
+            new CatalogDiscoveryWorkspaceSeed
+            {
+                WorkspaceId = WorkspaceId,
+                WorkspaceName = "Default workspace",
+                PublicHost = "https://example.test",
+                Endpoints =
+                [
+                    new CatalogEndpointSeed
+                    {
+                        Endpoint = new CatalogEndpoint
+                        {
+                            Key = "esri",
+                            Title = "Esri catalog",
+                            Dialect = CatalogDialects.Esri,
+                            Enabled = true,
+                            AutoDefault = true,
+                            Url = "/rest/portal",
+                            Entries = 1,
+                            Feeders = [new CatalogFeeder { Kind = "feature-server", Label = "Parcels FeatureServer" }],
+                            IssueCount = 0,
+                        },
+                        LastRebuild = "2026-05-01T00:00:00Z",
+                        Items =
+                        [
+                            new CatalogItemSeed
+                            {
+                                Row = new CatalogEndpointItem
+                                {
+                                    Id = "parcels",
+                                    Title = "Parcels",
+                                    FromService = "Parcels FeatureServer",
+                                    Tags = ["parcels"],
+                                    IssueCount = 0,
+                                },
+                                Detail = new CatalogItem
+                                {
+                                    Id = "parcels",
+                                    Title = "Parcels",
+                                    AutoMirror = true,
+                                    Live = true,
+                                    BackingServiceCount = 1,
+                                    TagCount = 1,
+                                    IssueCount = 0,
+                                    Groups =
+                                    [
+                                        new CatalogItemFieldGroup
+                                        {
+                                            Title = "Identity",
+                                            Scope = "resource-derived",
+                                            Fields =
+                                            [
+                                                new CatalogItemField { Label = "Item id", State = CatalogFieldStates.System, Value = "parcels" },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                    new CatalogEndpointSeed
+                    {
+                        Endpoint = new CatalogEndpoint
+                        {
+                            Key = "odata",
+                            Title = "OData v4",
+                            Dialect = CatalogDialects.ODataV4,
+                            Enabled = false,
+                            AutoDefault = false,
+                            Url = "/odata",
+                            Entries = 0,
+                            IssueCount = 0,
+                        },
+                        Items = [],
+                    },
+                ],
+            },
+            new CatalogDiscoveryWorkspaceSeed
+            {
+                WorkspaceId = EmptyWorkspaceId,
+                WorkspaceName = "Empty workspace",
+                Endpoints = [],
+            },
+        };
+
+        _fixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+            })
+            .ReplaceService<ICatalogDiscoveryRegistryStore>(new ConfigCatalogDiscoveryRegistryStore(seeds));
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _adminClient = _fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
+        _anonymousClient = _fixture.CreateClient();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/console/catalog-endpoints/{workspaceId}")]
+    public async Task GetRegistry_ReturnsEndpointsWithAutoDefaultAndOptInAggregates()
+    {
+        var response = await _adminClient.GetAsync($"/api/v1/console/catalog-endpoints/{WorkspaceId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var registry = await ReadDataAsync<CatalogDiscoveryRegistry>(response);
+
+        Assert.Equal(WorkspaceId, registry.WorkspaceId);
+        Assert.Equal("https://example.test", registry.PublicHost);
+        Assert.Equal(2, registry.Endpoints.Count);
+
+        var esri = Assert.Single(registry.Endpoints, e => e.Key == "esri");
+        Assert.True(esri.Enabled);
+        Assert.True(esri.AutoDefault);
+        Assert.Equal(CatalogDialects.Esri, esri.Dialect);
+        Assert.Single(esri.Feeders);
+
+        var odata = Assert.Single(registry.Endpoints, e => e.Key == "odata");
+        Assert.False(odata.Enabled);
+        Assert.False(odata.AutoDefault);
+
+        // One auto-default-on (esri), one opt-in (odata).
+        Assert.Equal(1, registry.AutoDefaultCount);
+        Assert.Equal(1, registry.OptInCount);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/console/catalog-endpoints/{workspaceId}")]
+    public async Task GetRegistry_ForEmptyWorkspace_ReturnsEmptyEndpointList()
+    {
+        var response = await _adminClient.GetAsync($"/api/v1/console/catalog-endpoints/{EmptyWorkspaceId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var registry = await ReadDataAsync<CatalogDiscoveryRegistry>(response);
+        Assert.Equal(EmptyWorkspaceId, registry.WorkspaceId);
+        Assert.Empty(registry.Endpoints);
+        Assert.Equal(0, registry.AutoDefaultCount);
+        Assert.Equal(0, registry.OptInCount);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/console/catalog-endpoints/{workspaceId}")]
+    public async Task GetRegistry_ForUnknownWorkspace_ReturnsNotFound()
+    {
+        var response = await _adminClient.GetAsync("/api/v1/console/catalog-endpoints/does-not-exist");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/console/catalog-endpoints/{workspaceId}/{endpointKey}")]
+    public async Task GetEndpoint_ReturnsDetailWithMirroredItems()
+    {
+        var response = await _adminClient.GetAsync($"/api/v1/console/catalog-endpoints/{WorkspaceId}/esri");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var detail = await ReadDataAsync<CatalogEndpointDetail>(response);
+        Assert.Equal("esri", detail.Endpoint.Key);
+        Assert.True(detail.AutoMirror);
+        Assert.Equal("2026-05-01T00:00:00Z", detail.LastRebuild);
+        var item = Assert.Single(detail.Items);
+        Assert.Equal("parcels", item.Id);
+        Assert.Equal("Parcels FeatureServer", item.FromService);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/console/catalog-endpoints/{workspaceId}/{endpointKey}")]
+    public async Task GetEndpoint_ForUnknownEndpoint_ReturnsNotFound()
+    {
+        var response = await _adminClient.GetAsync($"/api/v1/console/catalog-endpoints/{WorkspaceId}/nope");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/console/catalog-endpoints/{workspaceId}/{endpointKey}/items/{itemId}")]
+    public async Task GetItem_ReturnsFieldGroups()
+    {
+        var response = await _adminClient.GetAsync($"/api/v1/console/catalog-endpoints/{WorkspaceId}/esri/items/parcels");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var item = await ReadDataAsync<CatalogItem>(response);
+        Assert.Equal("parcels", item.Id);
+        Assert.True(item.AutoMirror);
+        Assert.True(item.Live);
+        var group = Assert.Single(item.Groups);
+        Assert.Equal("Identity", group.Title);
+        var field = Assert.Single(group.Fields);
+        Assert.Equal(CatalogFieldStates.System, field.State);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/console/catalog-endpoints/{workspaceId}/{endpointKey}/items/{itemId}")]
+    public async Task GetItem_ForUnknownItem_ReturnsNotFound()
+    {
+        var response = await _adminClient.GetAsync($"/api/v1/console/catalog-endpoints/{WorkspaceId}/esri/items/missing");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/console/catalog-endpoints/{workspaceId}")]
+    [Endpoint("GET /api/v1/console/catalog-endpoints/{workspaceId}/{endpointKey}")]
+    [Endpoint("GET /api/v1/console/catalog-endpoints/{workspaceId}/{endpointKey}/items/{itemId}")]
+    public async Task AnonymousRequests_AreRejectedWithoutAdminAuthorization()
+    {
+        var registryResponse = await _anonymousClient.GetAsync($"/api/v1/console/catalog-endpoints/{WorkspaceId}");
+        Assert.Equal(HttpStatusCode.Unauthorized, registryResponse.StatusCode);
+
+        var endpointResponse = await _anonymousClient.GetAsync($"/api/v1/console/catalog-endpoints/{WorkspaceId}/esri");
+        Assert.Equal(HttpStatusCode.Unauthorized, endpointResponse.StatusCode);
+
+        var itemResponse = await _anonymousClient.GetAsync($"/api/v1/console/catalog-endpoints/{WorkspaceId}/esri/items/parcels");
+        Assert.Equal(HttpStatusCode.Unauthorized, itemResponse.StatusCode);
+    }
+
+    private static async Task<T> ReadDataAsync<T>(HttpResponseMessage response)
+    {
+        var body = await response.Content.ReadAsStringAsync();
+        var envelope = JsonSerializer.Deserialize<ApiResponse<T>>(body, JsonOptions);
+        Assert.NotNull(envelope);
+        Assert.True(envelope!.Success, body);
+        Assert.NotNull(envelope.Data);
+        return envelope.Data!;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #1279

## Summary
Adds the workspace-scoped Console catalog discovery-endpoints registry read API. This surface describes *which discovery dialects a server publishes to consumers* (Esri catalog, OGC API Records, OData v4, STAC, DCAT) — each endpoint's on/off and auto-default-vs-opt-in state, its feeders, and the per-endpoint/per-item drill-down. It is distinct from the singular content catalog (`/api/v1/console/content`, #1162).

## Changes Made
- New admin-authorized read routes:
  - `GET /api/v1/console/catalog-endpoints/{workspaceId}` — registry projection with auto-default/opt-in aggregate counts
  - `GET /api/v1/console/catalog-endpoints/{workspaceId}/{endpointKey}` — endpoint detail with mirrored items table
  - `GET /api/v1/console/catalog-endpoints/{workspaceId}/{endpointKey}/items/{itemId}` — per-item field-group editor projection
- Wire DTOs (`CatalogDiscoveryModels.cs`) mirroring the consumer contract shape, registered in `ConsoleJsonContext` for source-gen serialization.
- `ICatalogDiscoveryRegistryStore` read-model abstraction + `ConfigCatalogDiscoveryRegistryStore` config-backed materialiser (seeded with the five supported dialects); a durable/metadata-backed source can replace the registration later.
- Routes registered in `EndpointRegistry` and wired in `Program.cs`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Integration tests cover registry list (including empty-workspace and opt-in-vs-default-on aggregates), endpoint detail (incl. not-found), item drill-down (incl. not-found), and admin permission enforcement. Locally: Release build clean (0 warnings), `dotnet format --verify-no-changes` clean, full `Tier=Fast` suite green (1708 passed). The new catalog-discovery tests are `Tier=Integration` and run in the CI integration gate.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

New additive Console read endpoints (control-plane surface). No removals or breaking changes.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

A honua-console follow-up will swap its `UnsupportedCatalogDiscoveryDataSource` for the live `HonuaServer`-backed client once a nightly publishes this API. No honua-console changes are made in this PR.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
