### PR TITLE
feat: temporal history capability discovery + as-of read (#1166)

### DIFF
--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -2686,7 +2686,7 @@
         },
         {
           "proofClass": "scenario-depth",
-          "proofMechanism": "Deterministic tileset.json/GLB byte-equality across runs, ECEF projection of WGS-84 vertices, EXT_structural_metadata attribute round-trip (Integer→INT32 with clamping warnings, BigInteger→INT64 with 8-byte bufferView alignment and coercion warnings, all-null STRING column emits a >=1-byte values bufferView), fan triangulation of polygon outer rings, polygon extrusion bounding-region uses BaseHeightField/extrusionHeight (not vertex Z), layer-not-found / unsupported-geometry / feature-cap / scene-id-conflict / options-invalid problem-detail mapping, staging-then-promote concurrency contract (loser's 409 leaves winner's final-path bytes byte-identical), Postgres feature-source cancellation throws between batches, and scene-registry registration after a successful generation are exercised by core and server tests",
+          "proofMechanism": "Deterministic tileset.json/GLB byte-equality across runs, ECEF projection of WGS-84 vertices, EXT_structural_metadata attribute round-trip (Integer\u2192INT32 with clamping warnings, BigInteger\u2192INT64 with 8-byte bufferView alignment and coercion warnings, all-null STRING column emits a >=1-byte values bufferView), fan triangulation of polygon outer rings, polygon extrusion bounding-region uses BaseHeightField/extrusionHeight (not vertex Z), layer-not-found / unsupported-geometry / feature-cap / scene-id-conflict / options-invalid problem-detail mapping, staging-then-promote concurrency contract (loser's 409 leaves winner's final-path bytes byte-identical), Postgres feature-source cancellation throws between batches, and scene-registry registration after a successful generation are exercised by core and server tests",
           "executionLane": "ci:test-all",
           "evidenceLocations": [
             "tests/dotnet/Honua.Core.Tests/Features/Scene/Generation/EcefCoordinateTransformTests.cs",
@@ -2882,7 +2882,7 @@
       "displayName": "MCP operator surface (server-owned)",
       "surfaceKind": "http-route-family",
       "protocol": "MCP",
-      "canonicalIdentifier": "POST /mcp — JSON-RPC 2.0 operator surface",
+      "canonicalIdentifier": "POST /mcp \u2014 JSON-RPC 2.0 operator surface",
       "parentSurfaceId": null,
       "endpointPrefixes": [],
       "endpointExactMatches": [
@@ -3121,6 +3121,48 @@
           "ownerRepo": "honua-server",
           "status": "implemented",
           "linkedTicket": "#1182",
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
+      "surfaceId": "temporal-data-history",
+      "displayName": "Temporal data history HTTP surface (capability discovery + as-of read)",
+      "surfaceKind": "http-route-family",
+      "protocol": "Temporal",
+      "canonicalIdentifier": "/api/v1/temporal/services/{serviceId}/layers/{layerId}/*",
+      "parentSurfaceId": null,
+      "endpointPrefixes": [
+        "/api/v1/temporal/"
+      ],
+      "endpointExactMatches": [],
+      "endpointContains": [],
+      "operationKeys": [],
+      "proofs": [
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "EndpointRegistry coverage plus temporal capability-discovery and as-of read integration tests (supported/unsupported/empty/unknown-layer cases)",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/EndpointRegistry.cs",
+            "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/Temporal/TemporalHistoryEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#1166",
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "scenario-depth",
+          "proofMechanism": "Slice 1 of #1166 ships capability discovery and as-of read on the existing change tracker + temporal column; diff, timeline, attribution, and governed rollback are deferred and tracked in the follow-up ticket",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "tests/dotnet/Honua.Server.Tests/Features/Temporal/TemporalHistoryEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "bounded-child-ticket",
+          "linkedTicket": "#1285",
           "versionCaptureRule": null
         }
       ]

--- a/src/Honua.Core.Abstractions/Features/Temporal/Abstractions/ITemporalHistoryService.cs
+++ b/src/Honua.Core.Abstractions/Features/Temporal/Abstractions/ITemporalHistoryService.cs
@@ -37,16 +37,17 @@ public interface ITemporalHistoryService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Reads the layer's collapsed feature changes as-of a generation/timestamp cursor.
+    /// Reads the layer's collapsed feature changes as-of a generation cursor. A timestamp cursor is
+    /// rejected in slice 1 (timestamp-to-generation resolution is a deferred #1166 follow-up).
     /// </summary>
     /// <param name="serviceId">Metadata v2 service id.</param>
     /// <param name="layerId">Service-local layer index.</param>
-    /// <param name="request">Normalized as-of request (generation or timestamp cursor).</param>
+    /// <param name="request">Normalized as-of request (slice 1: generation cursor only).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The deterministic as-of result for the resolved cursor.</returns>
     /// <exception cref="TemporalLayerNotFoundException">Thrown when the service/layer does not resolve.</exception>
     /// <exception cref="TemporalNotSupportedException">Thrown when the layer does not support history reads.</exception>
-    /// <exception cref="TemporalValidationException">Thrown when the request is malformed.</exception>
+    /// <exception cref="TemporalValidationException">Thrown when the request is malformed or supplies a timestamp cursor.</exception>
     Task<TemporalAsOfResult> ReadAsOfAsync(
         string serviceId,
         int layerId,

--- a/src/Honua.Core.Abstractions/Features/Temporal/Abstractions/ITemporalHistoryService.cs
+++ b/src/Honua.Core.Abstractions/Features/Temporal/Abstractions/ITemporalHistoryService.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Temporal.Domain;
+
+namespace Honua.Core.Features.Temporal.Abstractions;
+
+/// <summary>
+/// Slice-1 temporal history surface for honua-server#1166: capability discovery and as-of reads.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This service is intentionally read-only and built on the existing change-tracker primitive
+/// (<c>IChangeTracker</c>) plus the storage mapping's temporal column. It does not introduce a parallel
+/// history store, and it interoperates with — but does not depend on — named-version editing
+/// (honua-server#371): a layer can expose temporal history without participating in version branches.
+/// </para>
+/// <para>
+/// Diff, per-feature timeline, attribution, and governed rollback are deferred to later slices and are
+/// not part of this contract. Rollback, when added, must execute through the job runner
+/// (Honua.Jobs / Honua.Geoprocessing) rather than a parallel lifecycle.
+/// </para>
+/// </remarks>
+public interface ITemporalHistoryService
+{
+    /// <summary>
+    /// Reports whether the addressed layer supports temporal history reads and which primitives back it.
+    /// </summary>
+    /// <param name="serviceId">Metadata v2 service id.</param>
+    /// <param name="layerId">Service-local layer index.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The capability descriptor for the layer.</returns>
+    /// <exception cref="TemporalLayerNotFoundException">Thrown when the service/layer does not resolve.</exception>
+    Task<TemporalCapability> GetCapabilityAsync(
+        string serviceId,
+        int layerId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads the layer's collapsed feature changes as-of a generation/timestamp cursor.
+    /// </summary>
+    /// <param name="serviceId">Metadata v2 service id.</param>
+    /// <param name="layerId">Service-local layer index.</param>
+    /// <param name="request">Normalized as-of request (generation or timestamp cursor).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The deterministic as-of result for the resolved cursor.</returns>
+    /// <exception cref="TemporalLayerNotFoundException">Thrown when the service/layer does not resolve.</exception>
+    /// <exception cref="TemporalNotSupportedException">Thrown when the layer does not support history reads.</exception>
+    /// <exception cref="TemporalValidationException">Thrown when the request is malformed.</exception>
+    Task<TemporalAsOfResult> ReadAsOfAsync(
+        string serviceId,
+        int layerId,
+        TemporalAsOfRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core.Abstractions/Features/Temporal/Abstractions/TemporalExceptions.cs
+++ b/src/Honua.Core.Abstractions/Features/Temporal/Abstractions/TemporalExceptions.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Temporal.Abstractions;
+
+/// <summary>
+/// Thrown when a service/layer addressed by a temporal request cannot be resolved.
+/// </summary>
+public sealed class TemporalLayerNotFoundException : Exception
+{
+    /// <summary>Creates the exception with the given message.</summary>
+    public TemporalLayerNotFoundException(string message) : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Thrown when a layer exists but does not support the requested temporal capability.
+/// </summary>
+public sealed class TemporalNotSupportedException : Exception
+{
+    /// <summary>Creates the exception with the given message.</summary>
+    public TemporalNotSupportedException(string message) : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Thrown when a temporal request is malformed (e.g. conflicting cursors or negative generation).
+/// </summary>
+public sealed class TemporalValidationException : Exception
+{
+    /// <summary>Creates the exception with the given message.</summary>
+    public TemporalValidationException(string message) : base(message)
+    {
+    }
+}

--- a/src/Honua.Core.Abstractions/Features/Temporal/Domain/TemporalContracts.cs
+++ b/src/Honua.Core.Abstractions/Features/Temporal/Domain/TemporalContracts.cs
@@ -56,14 +56,18 @@ public sealed record TemporalDeferredCapabilities(
 
 /// <summary>
 /// Identifies the kind of temporal cursor a client supplied or that the server resolved.
-/// Slice 1 supports <see cref="Generation"/>; <see cref="Timestamp"/> is resolved to a generation.
+/// Slice 1 supports <see cref="Generation"/> only; a <see cref="Timestamp"/> cursor is rejected with a
+/// 400 (timestamp-to-generation resolution is a deferred #1166 follow-up).
 /// </summary>
 public enum TemporalCursorKind
 {
     /// <summary>Monotonic change-tracker generation (the slice-1 canonical cursor).</summary>
     Generation = 0,
 
-    /// <summary>Wall-clock timestamp, resolved against the temporal column / change log.</summary>
+    /// <summary>
+    /// Wall-clock timestamp. Reserved for a later slice; rejected in slice 1 because the change tracker
+    /// exposes no timestamp -> generation index.
+    /// </summary>
     Timestamp = 1
 }
 
@@ -120,11 +124,12 @@ public sealed record TemporalAsOfResult(
     ImmutableArray<TemporalFeatureState> Features);
 
 /// <summary>
-/// A normalized as-of read request. Exactly one of <see cref="Generation"/> or <see cref="Timestamp"/>
-/// should be supplied by the client; the service resolves either to a generation cursor.
+/// A normalized as-of read request. Slice 1 accepts a <see cref="Generation"/> cursor; a
+/// <see cref="Timestamp"/> cursor is rejected with a 400 (timestamp-to-generation resolution is a
+/// deferred #1166 follow-up). The two cursors are mutually exclusive.
 /// </summary>
 /// <param name="Generation">Generation cursor (changes since this generation, exclusive).</param>
-/// <param name="Timestamp">Timestamp cursor, resolved to a generation by the service.</param>
+/// <param name="Timestamp">Timestamp cursor. Rejected in slice 1; reserved for a later slice.</param>
 /// <param name="Limit">Optional cap on returned feature states.</param>
 public sealed record TemporalAsOfRequest(
     long? Generation = null,

--- a/src/Honua.Core.Abstractions/Features/Temporal/Domain/TemporalContracts.cs
+++ b/src/Honua.Core.Abstractions/Features/Temporal/Domain/TemporalContracts.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+
+namespace Honua.Core.Features.Temporal.Domain;
+
+/// <summary>
+/// Describes whether a published layer/resource supports temporal history reads and which
+/// temporal primitives back that support. This is the slice-1 capability contract: it reports
+/// discovery only (as-of read availability) and explicitly defers diff/timeline/attribution/rollback
+/// to later slices so clients can negotiate capability without depending on those endpoints existing.
+/// </summary>
+/// <param name="ServiceId">Owning Metadata v2 service id.</param>
+/// <param name="LayerId">Service-local layer index addressed by the request.</param>
+/// <param name="LayerName">Human-readable resource name when available.</param>
+/// <param name="SupportsHistory">
+/// True when the layer can answer history reads. Requires both a configured temporal column on the
+/// storage mapping and a non-no-op change tracker for the backing provider.
+/// </param>
+/// <param name="SupportsAsOf">True when an as-of read can be served for this layer (slice 1).</param>
+/// <param name="TemporalColumn">
+/// The temporal column declared on the storage mapping, when present. Surfaced for diagnostics only;
+/// the physical column name is not load-bearing for clients.
+/// </param>
+/// <param name="CursorKind">The temporal cursor kind clients may use for as-of reads (slice 1: generation).</param>
+/// <param name="CurrentGeneration">Current change-tracker generation, when history is supported.</param>
+/// <param name="DeferredCapabilities">
+/// Capabilities recognized by the contract but not yet implemented in this slice (diff, timeline,
+/// attribution, rollback). Reported as <c>false</c> so clients negotiate forward-compatibly.
+/// </param>
+public sealed record TemporalCapability(
+    string ServiceId,
+    int LayerId,
+    string? LayerName,
+    bool SupportsHistory,
+    bool SupportsAsOf,
+    string? TemporalColumn,
+    TemporalCursorKind CursorKind,
+    long? CurrentGeneration,
+    TemporalDeferredCapabilities DeferredCapabilities);
+
+/// <summary>
+/// Capabilities recognized by the temporal contract but deferred to later slices of honua-server#1166.
+/// All values are <c>false</c> in slice 1; clients must not assume these endpoints exist yet.
+/// </summary>
+/// <param name="SupportsDiff">Diff between two checkpoints (deferred).</param>
+/// <param name="SupportsTimeline">Per-feature timeline reads (deferred).</param>
+/// <param name="SupportsAttribution">Actor/source/operation attribution (deferred).</param>
+/// <param name="SupportsRollback">Governed rollback via the job runner (deferred).</param>
+public sealed record TemporalDeferredCapabilities(
+    bool SupportsDiff = false,
+    bool SupportsTimeline = false,
+    bool SupportsAttribution = false,
+    bool SupportsRollback = false);
+
+/// <summary>
+/// Identifies the kind of temporal cursor a client supplied or that the server resolved.
+/// Slice 1 supports <see cref="Generation"/>; <see cref="Timestamp"/> is resolved to a generation.
+/// </summary>
+public enum TemporalCursorKind
+{
+    /// <summary>Monotonic change-tracker generation (the slice-1 canonical cursor).</summary>
+    Generation = 0,
+
+    /// <summary>Wall-clock timestamp, resolved against the temporal column / change log.</summary>
+    Timestamp = 1
+}
+
+/// <summary>
+/// A single feature's state in an as-of read, expressed as the net change since the requested cursor.
+/// Geometry is intentionally omitted in slice 1: the as-of read reports identity, net operation, and
+/// the feature's current attribute snapshot for surviving features, built on the existing change tracker.
+/// </summary>
+/// <param name="ObjectId">Stable object id of the feature.</param>
+/// <param name="NetOperation">Collapsed net operation since the requested cursor (insert/update/delete).</param>
+/// <param name="ChangedAtUtc">Timestamp of the most recent change, in UTC.</param>
+/// <param name="Attributes">
+/// Current attribute snapshot for surviving features (insert/update). Null for deleted features, since
+/// the change tracker does not retain pre-delete attribute state in this slice.
+/// </param>
+public sealed record TemporalFeatureState(
+    long ObjectId,
+    TemporalChangeKind NetOperation,
+    DateTimeOffset ChangedAtUtc,
+    IReadOnlyDictionary<string, object?>? Attributes);
+
+/// <summary>
+/// Net change kind reported by an as-of read. Mirrors the change tracker's collapsed operation set.
+/// </summary>
+public enum TemporalChangeKind
+{
+    /// <summary>Feature was inserted (net) since the cursor.</summary>
+    Insert = 1,
+
+    /// <summary>Feature was updated (net) since the cursor.</summary>
+    Update = 2,
+
+    /// <summary>Feature was deleted (net) since the cursor.</summary>
+    Delete = 3
+}
+
+/// <summary>
+/// Result of an as-of read: the resolved cursor, the current generation, and the collapsed set of
+/// features changed since the requested cursor. An empty <see cref="Features"/> set with a resolved
+/// cursor means the layer is unchanged as-of that point (a deterministic, valid result).
+/// </summary>
+/// <param name="ServiceId">Owning service id.</param>
+/// <param name="LayerId">Service-local layer index.</param>
+/// <param name="RequestedCursorKind">Cursor kind the client requested.</param>
+/// <param name="ResolvedGeneration">Generation the cursor resolved to.</param>
+/// <param name="CurrentGeneration">Current change-tracker generation at read time.</param>
+/// <param name="Features">Collapsed net changes since the resolved cursor.</param>
+public sealed record TemporalAsOfResult(
+    string ServiceId,
+    int LayerId,
+    TemporalCursorKind RequestedCursorKind,
+    long ResolvedGeneration,
+    long CurrentGeneration,
+    ImmutableArray<TemporalFeatureState> Features);
+
+/// <summary>
+/// A normalized as-of read request. Exactly one of <see cref="Generation"/> or <see cref="Timestamp"/>
+/// should be supplied by the client; the service resolves either to a generation cursor.
+/// </summary>
+/// <param name="Generation">Generation cursor (changes since this generation, exclusive).</param>
+/// <param name="Timestamp">Timestamp cursor, resolved to a generation by the service.</param>
+/// <param name="Limit">Optional cap on returned feature states.</param>
+public sealed record TemporalAsOfRequest(
+    long? Generation = null,
+    DateTimeOffset? Timestamp = null,
+    int? Limit = null);

--- a/src/Honua.Core/Features/Temporal/Services/TemporalHistoryService.cs
+++ b/src/Honua.Core/Features/Temporal/Services/TemporalHistoryService.cs
@@ -1,0 +1,243 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Temporal.Abstractions;
+using Honua.Core.Features.Temporal.Domain;
+
+namespace Honua.Core.Features.Temporal.Services;
+
+/// <summary>
+/// Slice-1 temporal history service for honua-server#1166.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Capability discovery rides the Metadata v2 graph and the existing temporal hint
+/// (<see cref="FeatureStorageMapping.TemporalColumn"/>). As-of reads are served from the existing
+/// change-tracking primitive (<see cref="IChangeTracker"/>) — the closest existing history primitive —
+/// rather than a parallel history store.
+/// </para>
+/// <para>
+/// History is considered supported only when the storage mapping declares a temporal column AND the
+/// resolved change tracker actually records changes (read-only providers register a no-op tracker, so
+/// they report history as unsupported). This interoperates with named-version editing (honua-server#371)
+/// without depending on it: a layer can expose temporal history with or without version branches.
+/// </para>
+/// </remarks>
+public sealed class TemporalHistoryService : ITemporalHistoryService
+{
+    private const int DefaultLimit = 1000;
+    private const int MaxLimit = 10000;
+
+    private readonly IMetadataV2GraphProvider _graphProvider;
+    private readonly IChangeTracker _changeTracker;
+    private readonly IFeatureReader _featureReader;
+
+    /// <summary>Creates the temporal history service.</summary>
+    public TemporalHistoryService(
+        IMetadataV2GraphProvider graphProvider,
+        IChangeTracker changeTracker,
+        IFeatureReader featureReader)
+    {
+        _graphProvider = graphProvider ?? throw new ArgumentNullException(nameof(graphProvider));
+        _changeTracker = changeTracker ?? throw new ArgumentNullException(nameof(changeTracker));
+        _featureReader = featureReader ?? throw new ArgumentNullException(nameof(featureReader));
+    }
+
+    /// <inheritdoc />
+    public async Task<TemporalCapability> GetCapabilityAsync(
+        string serviceId,
+        int layerId,
+        CancellationToken cancellationToken = default)
+    {
+        var resolved = await ResolveLayerAsync(serviceId, layerId, cancellationToken).ConfigureAwait(false);
+
+        var temporalColumn = resolved.StorageMapping?.TemporalColumn;
+        var historyCapable = !string.IsNullOrWhiteSpace(temporalColumn)
+            && resolved.StorageLayerId is not null
+            && IsHistoryTrackingTracker(_changeTracker);
+
+        long? currentGeneration = null;
+        if (historyCapable)
+        {
+            currentGeneration = await _changeTracker
+                .GetCurrentGenerationAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return new TemporalCapability(
+            ServiceId: serviceId,
+            LayerId: layerId,
+            LayerName: resolved.Resource.Metadata.Name,
+            SupportsHistory: historyCapable,
+            SupportsAsOf: historyCapable,
+            TemporalColumn: temporalColumn,
+            CursorKind: TemporalCursorKind.Generation,
+            CurrentGeneration: currentGeneration,
+            DeferredCapabilities: new TemporalDeferredCapabilities());
+    }
+
+    /// <inheritdoc />
+    public async Task<TemporalAsOfResult> ReadAsOfAsync(
+        string serviceId,
+        int layerId,
+        TemporalAsOfRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.Generation is not null && request.Timestamp is not null)
+        {
+            throw new TemporalValidationException(
+                "Specify either a generation cursor or a timestamp cursor, not both.");
+        }
+
+        if (request.Generation is < 0)
+        {
+            throw new TemporalValidationException("Generation cursor must be non-negative.");
+        }
+
+        if (request.Limit is <= 0)
+        {
+            throw new TemporalValidationException("Limit must be greater than zero when provided.");
+        }
+
+        var resolved = await ResolveLayerAsync(serviceId, layerId, cancellationToken).ConfigureAwait(false);
+
+        var temporalColumn = resolved.StorageMapping?.TemporalColumn;
+        if (string.IsNullOrWhiteSpace(temporalColumn)
+            || resolved.StorageLayerId is null
+            || !IsHistoryTrackingTracker(_changeTracker))
+        {
+            throw new TemporalNotSupportedException(
+                $"Layer '{resolved.Resource.Metadata.Name ?? layerId.ToString(CultureInfo.InvariantCulture)}' "
+                + "does not support temporal history reads.");
+        }
+
+        var storageLayerId = resolved.StorageLayerId.Value;
+        var requestedKind = request.Timestamp is not null
+            ? TemporalCursorKind.Timestamp
+            : TemporalCursorKind.Generation;
+
+        var currentGeneration = await _changeTracker
+            .GetCurrentGenerationAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Slice 1 resolves any cursor to a generation. A timestamp cursor before any recorded change
+        // resolves to generation 0 (full state); the change tracker stores per-change timestamps but
+        // the slice-1 primitive keys on generation, so a timestamp clamps to "since the beginning".
+        var resolvedGeneration = request.Generation ?? 0L;
+        if (resolvedGeneration > currentGeneration)
+        {
+            resolvedGeneration = currentGeneration;
+        }
+
+        var changes = await _changeTracker
+            .GetChangesSinceAsync(resolvedGeneration, [storageLayerId], cancellationToken)
+            .ConfigureAwait(false);
+
+        var limit = request.Limit ?? DefaultLimit;
+        limit = Math.Min(limit, MaxLimit);
+
+        var states = ImmutableArray.CreateBuilder<TemporalFeatureState>();
+        foreach (var change in changes)
+        {
+            if (states.Count >= limit)
+            {
+                break;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var kind = (TemporalChangeKind)(short)change.Operation;
+            IReadOnlyDictionary<string, object?>? attributes = null;
+
+            // Surviving features (insert/update) expose their current attribute snapshot; deleted
+            // features have no retained attribute state in this slice.
+            if (kind != TemporalChangeKind.Delete)
+            {
+                var feature = await _featureReader
+                    .GetAsync(storageLayerId, change.ObjectId, cancellationToken)
+                    .ConfigureAwait(false);
+                if (feature is { } present)
+                {
+                    attributes = present.Attributes;
+                }
+            }
+
+            states.Add(new TemporalFeatureState(
+                ObjectId: change.ObjectId,
+                NetOperation: kind,
+                ChangedAtUtc: change.ChangedAt.ToUniversalTime(),
+                Attributes: attributes));
+        }
+
+        return new TemporalAsOfResult(
+            ServiceId: serviceId,
+            LayerId: layerId,
+            RequestedCursorKind: requestedKind,
+            ResolvedGeneration: resolvedGeneration,
+            CurrentGeneration: currentGeneration,
+            Features: states.ToImmutable());
+    }
+
+    private async Task<ResolvedLayer> ResolveLayerAsync(
+        string serviceId,
+        int layerId,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(serviceId))
+        {
+            throw new TemporalLayerNotFoundException("Service id is required.");
+        }
+
+        var snapshot = await _graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+
+        var service = snapshot.Index.ServicesById.TryGetValue(serviceId, out var byId)
+            ? byId
+            : snapshot.FindService(serviceId);
+        if (service is null)
+        {
+            throw new TemporalLayerNotFoundException($"Service '{serviceId}' was not found.");
+        }
+
+        var publication = snapshot.FindPublicationByLayerIndex(service.Metadata.Id, layerId);
+        if (publication is null)
+        {
+            throw new TemporalLayerNotFoundException(
+                $"Layer '{layerId}' was not found on service '{serviceId}'.");
+        }
+
+        var resource = snapshot.ResolveResource(publication)
+            ?? throw new TemporalLayerNotFoundException(
+                $"Layer '{layerId}' on service '{serviceId}' does not resolve to a resource.");
+
+        var storageBinding = snapshot.ResolveStorageBinding(publication);
+        FeatureStorageMapping? storageMapping = null;
+        int? storageLayerId = null;
+        if (storageBinding is { StorageType: MetadataV2StorageType.RelationalTable })
+        {
+            storageMapping = FeatureStorageMapping.FromMetadata(resource, storageBinding);
+            storageLayerId = storageBinding.StorageLayerId;
+        }
+
+        return new ResolvedLayer(service, publication, resource, storageMapping, storageLayerId);
+    }
+
+    // Read-only providers (DuckDB, MySQL/MariaDB) register a no-op change tracker so DI activation
+    // succeeds; those layers cannot answer history reads even if a temporal column is configured.
+    private static bool IsHistoryTrackingTracker(IChangeTracker tracker)
+        => tracker is not Honua.Core.Features.FeatureStore.ReadOnlyProviders.NoOpChangeTracker;
+
+    private sealed record ResolvedLayer(
+        MetadataV2Service Service,
+        MetadataV2Publication Publication,
+        MetadataV2Resource Resource,
+        FeatureStorageMapping? StorageMapping,
+        int? StorageLayerId);
+}

--- a/src/Honua.Core/Features/Temporal/Services/TemporalHistoryService.cs
+++ b/src/Honua.Core/Features/Temporal/Services/TemporalHistoryService.cs
@@ -97,6 +97,19 @@ public sealed class TemporalHistoryService : ITemporalHistoryService
                 "Specify either a generation cursor or a timestamp cursor, not both.");
         }
 
+        // Slice 1 keys exclusively on the change-tracker generation sequence (IChangeTracker exposes
+        // GetCurrentGenerationAsync/GetChangesSinceAsync(generation, ...) only — there is no
+        // timestamp -> generation index). Rather than silently treating a timestamp as generation 0
+        // (which would return the full change feed for any timestamp, including future ones), reject
+        // timestamp cursors with a clear 400. Resolving a timestamp to the generation in effect at
+        // that point is tracked as a #1166 follow-up.
+        if (request.Timestamp is not null)
+        {
+            throw new TemporalValidationException(
+                "Timestamp cursors are not yet supported in this slice; use a generation cursor. "
+                + "Timestamp-to-generation resolution is a #1166 follow-up.");
+        }
+
         if (request.Generation is < 0)
         {
             throw new TemporalValidationException("Generation cursor must be non-negative.");
@@ -120,17 +133,16 @@ public sealed class TemporalHistoryService : ITemporalHistoryService
         }
 
         var storageLayerId = resolved.StorageLayerId.Value;
-        var requestedKind = request.Timestamp is not null
-            ? TemporalCursorKind.Timestamp
-            : TemporalCursorKind.Generation;
+
+        // Timestamp cursors are rejected above; slice 1 only resolves generation cursors.
+        const TemporalCursorKind requestedKind = TemporalCursorKind.Generation;
 
         var currentGeneration = await _changeTracker
             .GetCurrentGenerationAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        // Slice 1 resolves any cursor to a generation. A timestamp cursor before any recorded change
-        // resolves to generation 0 (full state); the change tracker stores per-change timestamps but
-        // the slice-1 primitive keys on generation, so a timestamp clamps to "since the beginning".
+        // The cursor is a generation (changes since this generation, exclusive). A cursor at or beyond
+        // the current generation resolves to the current generation, yielding an empty delta.
         var resolvedGeneration = request.Generation ?? 0L;
         if (resolvedGeneration > currentGeneration)
         {

--- a/src/Honua.Core/Features/Temporal/TemporalServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Temporal/TemporalServiceCollectionExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Temporal.Abstractions;
+using Honua.Core.Features.Temporal.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Core.Features.Temporal;
+
+/// <summary>
+/// Service registration for the slice-1 temporal history feature (honua-server#1166).
+/// </summary>
+public static class TemporalServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the temporal history service. Scoped to match the lifetime of the change tracker
+    /// and feature reader it composes.
+    /// </summary>
+    public static IServiceCollection AddTemporalHistory(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.TryAddScoped<ITemporalHistoryService, TemporalHistoryService>();
+        return services;
+    }
+}

--- a/src/Honua.Hosting/Features/Authentication/AuthenticationExtensions.cs
+++ b/src/Honua.Hosting/Features/Authentication/AuthenticationExtensions.cs
@@ -27,6 +27,14 @@ public static class AuthenticationExtensions
     public const string AdminPolicyAlias = "AdminPolicy";
 
     /// <summary>
+    /// Authorization policy name for temporal-history read access (honua-server#1166).
+    /// Distinct from the current-read and admin surfaces so it can be tightened to a
+    /// dedicated permission grant in a later slice without touching endpoint code. In
+    /// this slice it requires the admin role, matching the admin baseline.
+    /// </summary>
+    public const string TemporalHistoryReadPolicy = "TemporalHistoryRead";
+
+    /// <summary>
     /// Adds API key authentication and authorization services
     /// </summary>
     public static IServiceCollection AddApiKeyAuthentication(this IServiceCollection services)
@@ -58,6 +66,14 @@ public static class AuthenticationExtensions
                 policy.AuthenticationSchemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
             });
 
+            options.AddPolicy(TemporalHistoryReadPolicy, policy =>
+            {
+                _ = policy.RequireAuthenticatedUser();
+                _ = policy.RequireRole("admin");
+                policy.AuthenticationSchemes.Add(ApiKeyScheme);
+                policy.AuthenticationSchemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
+            });
+
         });
 
         return services;
@@ -77,4 +93,11 @@ public static class AuthenticationExtensions
     /// </summary>
     public static TBuilder RequireAdminAuthorization<TBuilder>(this TBuilder builder)
         where TBuilder : IEndpointConventionBuilder => builder.RequireAuthorization(AdminPolicy);
+
+    /// <summary>
+    /// Requires the distinct temporal-history read authorization for an endpoint or group
+    /// (honua-server#1166).
+    /// </summary>
+    public static TBuilder RequireTemporalHistoryRead<TBuilder>(this TBuilder builder)
+        where TBuilder : IEndpointConventionBuilder => builder.RequireAuthorization(TemporalHistoryReadPolicy);
 }

--- a/src/Honua.Hosting/Features/Authentication/OidcAuthenticationExtensions.cs
+++ b/src/Honua.Hosting/Features/Authentication/OidcAuthenticationExtensions.cs
@@ -218,6 +218,12 @@ public static class OidcAuthenticationExtensions
                 AuthenticationExtensions.AdminPolicyAlias,
                 adminRoles,
                 schemes);
+
+            UpdateRolePolicy(
+                authzOptions,
+                AuthenticationExtensions.TemporalHistoryReadPolicy,
+                adminRoles,
+                schemes);
         });
 
         return services;

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -261,6 +261,11 @@ public static class EndpointRegistry
         new("POST", "/api/v1/console/publications/{publicationId}/republish"),
         new("POST", "/api/v1/console/publications/{publicationId}/rollback"),
         new("PATCH", "/api/v1/console/publications/{publicationId}/policy"),
+
+        // Temporal data history (slice 1 of #1166): capability discovery + as-of read.
+        new("GET", "/api/v1/temporal/services/{serviceId}/layers/{layerId}/capabilities"),
+        new("GET", "/api/v1/temporal/services/{serviceId}/layers/{layerId}/as-of"),
+
         new("GET", "/api/v1/published/{*routeSlug}"),
 
         // v1 admin metadata resource CRUD endpoints removed in #1035 cutover.

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -3,6 +3,8 @@
 
 using Honua.Core.Features.Compliance;
 using Honua.Core.Features.Metadata;
+using Honua.Core.Features.Temporal;
+using Honua.Server.Features.Temporal;
 using Honua.Postgres.Features.Scene;
 using Honua.Server.Features.Admin;
 using Honua.ControlPlane;
@@ -106,6 +108,7 @@ internal static class FeatureRegistrationExtensions
         // carved Honua.Geoprocessing assembly.
         services.AddJobOrchestration();
         services.AddAnalysisContent(configuration);
+        services.AddTemporalHistory();
         services.AddAnalysisReporting(configuration);
         services.AddCapabilityManifest();
         services.AddPackageReview();
@@ -177,6 +180,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapSpatialAnalyticsOgcEndpoints();
         endpoints.MapGPServerEndpoints();
         endpoints.MapAnalysisContentEndpoints();
+        endpoints.MapTemporalHistoryEndpoints();
         endpoints.MapAnalysisReporting();
         endpoints.MapCapabilityManifestEndpoints();
         endpoints.MapMcpOperatorSurface();

--- a/src/Honua.Server/Features/Temporal/TemporalHistoryApiModels.cs
+++ b/src/Honua.Server/Features/Temporal/TemporalHistoryApiModels.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Infrastructure.Models;
+
+namespace Honua.Server.Features.Temporal;
+
+/// <summary>
+/// Capability descriptor returned by the temporal capability-discovery endpoint (slice 1 of #1166).
+/// </summary>
+public sealed class TemporalCapabilityResponse
+{
+    /// <summary>Owning service id.</summary>
+    public required string ServiceId { get; init; }
+
+    /// <summary>Service-local layer index.</summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>Human-readable layer name when available.</summary>
+    public string? LayerName { get; init; }
+
+    /// <summary>True when the layer can answer temporal history reads.</summary>
+    public required bool SupportsHistory { get; init; }
+
+    /// <summary>True when an as-of read can be served (slice 1).</summary>
+    public required bool SupportsAsOf { get; init; }
+
+    /// <summary>The temporal column on the storage mapping, when present (diagnostics only).</summary>
+    public string? TemporalColumn { get; init; }
+
+    /// <summary>The cursor kind clients should use for as-of reads.</summary>
+    public required string CursorKind { get; init; }
+
+    /// <summary>Current change-tracker generation when history is supported.</summary>
+    public long? CurrentGeneration { get; init; }
+
+    /// <summary>Capabilities recognized by the contract but deferred to later slices.</summary>
+    public required TemporalDeferredCapabilitiesResponse Deferred { get; init; }
+}
+
+/// <summary>
+/// Capabilities deferred to later slices of #1166. All values are <c>false</c> in slice 1.
+/// </summary>
+public sealed class TemporalDeferredCapabilitiesResponse
+{
+    /// <summary>Diff between two checkpoints (deferred).</summary>
+    public required bool SupportsDiff { get; init; }
+
+    /// <summary>Per-feature timeline reads (deferred).</summary>
+    public required bool SupportsTimeline { get; init; }
+
+    /// <summary>Actor/source/operation attribution (deferred).</summary>
+    public required bool SupportsAttribution { get; init; }
+
+    /// <summary>Governed rollback via the job runner (deferred).</summary>
+    public required bool SupportsRollback { get; init; }
+}
+
+/// <summary>
+/// As-of read result returned by the temporal as-of endpoint (slice 1 of #1166).
+/// </summary>
+public sealed class TemporalAsOfResponse
+{
+    /// <summary>Owning service id.</summary>
+    public required string ServiceId { get; init; }
+
+    /// <summary>Service-local layer index.</summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>Cursor kind the client requested.</summary>
+    public required string RequestedCursorKind { get; init; }
+
+    /// <summary>Generation the cursor resolved to.</summary>
+    public required long ResolvedGeneration { get; init; }
+
+    /// <summary>Current change-tracker generation at read time.</summary>
+    public required long CurrentGeneration { get; init; }
+
+    /// <summary>Collapsed net feature changes since the resolved cursor.</summary>
+    public required IReadOnlyList<TemporalFeatureStateResponse> Features { get; init; }
+}
+
+/// <summary>
+/// A single feature's net state in an as-of read.
+/// </summary>
+public sealed class TemporalFeatureStateResponse
+{
+    /// <summary>Stable object id.</summary>
+    public required long ObjectId { get; init; }
+
+    /// <summary>Net operation since the cursor: insert, update, or delete.</summary>
+    public required string Operation { get; init; }
+
+    /// <summary>Timestamp of the most recent change, in UTC ISO-8601.</summary>
+    public required string ChangedAt { get; init; }
+
+    /// <summary>Current attribute snapshot for surviving features; null for deletes.</summary>
+    public IReadOnlyDictionary<string, object?>? Attributes { get; init; }
+}
+
+/// <summary>
+/// Source-generated JSON context for the temporal history admin API (AOT).
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(TemporalCapabilityResponse))]
+[JsonSerializable(typeof(TemporalDeferredCapabilitiesResponse))]
+[JsonSerializable(typeof(TemporalAsOfResponse))]
+[JsonSerializable(typeof(TemporalFeatureStateResponse))]
+[JsonSerializable(typeof(ProblemDetailsResponse))]
+// The feature attribute bag flows through as IReadOnlyDictionary<string, object?>; register the
+// concrete dictionary plus the primitive value types so the polymorphic serializer can emit them
+// under AOT (mirrors SpatialAnalyticsJsonContext).
+[JsonSerializable(typeof(IReadOnlyDictionary<string, object?>))]
+[JsonSerializable(typeof(Dictionary<string, object?>))]
+[JsonSerializable(typeof(object))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(short))]
+[JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(float))]
+[JsonSerializable(typeof(decimal))]
+[JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(DateTime))]
+[JsonSerializable(typeof(DateTimeOffset))]
+[JsonSerializable(typeof(Guid))]
+[JsonSerializable(typeof(byte[]))]
+internal sealed partial class TemporalHistoryApiJsonContext : System.Text.Json.Serialization.JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Temporal/TemporalHistoryEndpoints.cs
+++ b/src/Honua.Server/Features/Temporal/TemporalHistoryEndpoints.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Temporal.Abstractions;
+using Honua.Core.Features.Temporal.Domain;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Models;
+using Honua.ServiceDefaults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Features.Temporal;
+
+/// <summary>
+/// Admin endpoint group for slice 1 of the temporal data history API (honua-server#1166):
+/// capability discovery and as-of reads. These are thin adapters — they parse, authorize
+/// (temporal-history read), delegate to <see cref="ITemporalHistoryService"/>, and format results.
+/// </summary>
+/// <remarks>
+/// Diff, per-feature timeline, attribution, and governed rollback are deferred to later slices.
+/// The group uses a distinct <see cref="AuthenticationExtensions.TemporalHistoryReadPolicy"/> so the
+/// history-read surface is authorized separately from current reads and admin mutations.
+/// </remarks>
+internal static partial class TemporalHistoryEndpoints
+{
+    /// <summary>Log category for temporal history endpoints.</summary>
+    internal sealed class TemporalHistoryEndpointsLog;
+
+    /// <summary>Maps the temporal history admin endpoints.</summary>
+    public static IEndpointRouteBuilder MapTemporalHistoryEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/temporal/services/{serviceId}/layers/{layerId:int}")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Temporal")
+            .WithDescription("Read-only temporal data history: capability discovery and as-of reads (slice 1 of #1166).")
+            .RequireTemporalHistoryRead();
+
+        _ = group.MapGet("/capabilities", HandleGetCapabilityAsync)
+            .WithName("GetTemporalCapability")
+            .WithSummary("Report whether a layer supports temporal history and which primitives back it.");
+
+        _ = group.MapGet("/as-of", HandleReadAsOfAsync)
+            .WithName("ReadTemporalAsOf")
+            .WithSummary("Read a layer's collapsed feature changes as-of a generation/timestamp cursor.");
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleGetCapabilityAsync(
+        string serviceId,
+        int layerId,
+        [FromServices] ITemporalHistoryService service,
+        HttpContext context)
+    {
+        try
+        {
+            var capability = await service.GetCapabilityAsync(serviceId, layerId, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(ToResponse(capability), TemporalHistoryApiJsonContext.Default.TemporalCapabilityResponse);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "temporal.capabilities", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static async Task<IResult> HandleReadAsOfAsync(
+        string serviceId,
+        int layerId,
+        [FromQuery] long? generation,
+        [FromQuery] string? timestamp,
+        [FromQuery] int? limit,
+        [FromServices] ITemporalHistoryService service,
+        HttpContext context)
+    {
+        try
+        {
+            DateTimeOffset? parsedTimestamp = null;
+            if (!string.IsNullOrWhiteSpace(timestamp))
+            {
+                if (!DateTimeOffset.TryParse(
+                        timestamp,
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                        out var ts))
+                {
+                    return ProblemDetailsHelpers.CreateAdminProblem(
+                        context,
+                        StatusCodes.Status400BadRequest,
+                        ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+                        "Query parameter 'timestamp' must be a valid ISO-8601 date-time.");
+                }
+
+                parsedTimestamp = ts;
+            }
+
+            var request = new TemporalAsOfRequest(generation, parsedTimestamp, limit);
+            var result = await service.ReadAsOfAsync(serviceId, layerId, request, context.RequestAborted).ConfigureAwait(false);
+            return Results.Json(ToResponse(result), TemporalHistoryApiJsonContext.Default.TemporalAsOfResponse);
+        }
+        catch (Exception ex) when (TryMapException(ex, context, out var problem))
+        {
+            return problem;
+        }
+        catch (Exception ex)
+        {
+            LogEndpointFailed(context, "temporal.as-of", ex);
+            return CreateGenericProblem(context);
+        }
+    }
+
+    private static TemporalCapabilityResponse ToResponse(TemporalCapability capability)
+        => new()
+        {
+            ServiceId = capability.ServiceId,
+            LayerId = capability.LayerId,
+            LayerName = capability.LayerName,
+            SupportsHistory = capability.SupportsHistory,
+            SupportsAsOf = capability.SupportsAsOf,
+            TemporalColumn = capability.TemporalColumn,
+            CursorKind = capability.CursorKind.ToString(),
+            CurrentGeneration = capability.CurrentGeneration,
+            Deferred = new TemporalDeferredCapabilitiesResponse
+            {
+                SupportsDiff = capability.DeferredCapabilities.SupportsDiff,
+                SupportsTimeline = capability.DeferredCapabilities.SupportsTimeline,
+                SupportsAttribution = capability.DeferredCapabilities.SupportsAttribution,
+                SupportsRollback = capability.DeferredCapabilities.SupportsRollback
+            }
+        };
+
+    private static TemporalAsOfResponse ToResponse(TemporalAsOfResult result)
+        => new()
+        {
+            ServiceId = result.ServiceId,
+            LayerId = result.LayerId,
+            RequestedCursorKind = result.RequestedCursorKind.ToString(),
+            ResolvedGeneration = result.ResolvedGeneration,
+            CurrentGeneration = result.CurrentGeneration,
+            Features = result.Features
+                .Select(static feature => new TemporalFeatureStateResponse
+                {
+                    ObjectId = feature.ObjectId,
+                    Operation = feature.NetOperation.ToString(),
+                    ChangedAt = feature.ChangedAtUtc.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture),
+                    Attributes = feature.Attributes
+                })
+                .ToArray()
+        };
+
+    private static bool TryMapException(Exception ex, HttpContext context, out IResult problem)
+    {
+        switch (ex)
+        {
+            case TemporalValidationException validationEx:
+                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status400BadRequest,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+                    validationEx.Message);
+                return true;
+            case TemporalLayerNotFoundException notFoundEx:
+                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status404NotFound,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status404NotFound),
+                    notFoundEx.Message);
+                return true;
+            case TemporalNotSupportedException notSupportedEx:
+                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status409Conflict,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status409Conflict),
+                    notSupportedEx.Message);
+                return true;
+            default:
+                problem = Results.Empty;
+                return false;
+        }
+    }
+
+    private static IResult CreateGenericProblem(HttpContext context)
+        => ProblemDetailsHelpers.CreateAdminProblem(
+            context,
+            StatusCodes.Status500InternalServerError,
+            ProblemDetailsHelpers.GetTitle(StatusCodes.Status500InternalServerError),
+            "An internal error occurred while processing the temporal history request.");
+
+    private static void LogEndpointFailed(HttpContext context, string operation, Exception exception)
+    {
+        var logger = context.RequestServices.GetRequiredService<ILogger<TemporalHistoryEndpointsLog>>();
+        Log.EndpointFailed(logger, operation, exception);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(12120, LogLevel.Error, "Temporal history endpoint {Operation} failed")]
+        public static partial void EndpointFailed(
+            ILogger logger,
+            string operation,
+            Exception exception);
+    }
+}

--- a/src/Honua.Server/Features/Temporal/TemporalHistoryEndpoints.cs
+++ b/src/Honua.Server/Features/Temporal/TemporalHistoryEndpoints.cs
@@ -45,7 +45,7 @@ internal static partial class TemporalHistoryEndpoints
 
         _ = group.MapGet("/as-of", HandleReadAsOfAsync)
             .WithName("ReadTemporalAsOf")
-            .WithSummary("Read a layer's collapsed feature changes as-of a generation/timestamp cursor.");
+            .WithSummary("Read a layer's collapsed feature changes as-of a generation cursor (timestamp cursors are a deferred #1166 follow-up).");
 
         return endpoints;
     }

--- a/src/Honua.Server/Startup/JsonContextRegistration.cs
+++ b/src/Honua.Server/Startup/JsonContextRegistration.cs
@@ -31,6 +31,7 @@ internal static class JsonContextRegistration
                 Honua.Core.Features.Metadata.Domain.V2.MetadataReleaseJsonContext.Default,
                 Honua.Server.Features.Admin.Models.MetadataPrevalidationJsonContext.Default,
                 Honua.Core.Features.Publishing.Content.Domain.ContentPublicationJsonContext.Default,
+                Honua.Server.Features.Temporal.TemporalHistoryApiJsonContext.Default,
                 Honua.Server.Features.Admin.Models.DeployControlJsonContext.Default,
                 Honua.Infrastructure.Monitoring.MetricsJsonContext.Default,
                 Honua.Import.FileImport.ImportJsonContext.Default,

--- a/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
@@ -52,7 +52,8 @@ public sealed class VerticalSliceIsolationTests
         "Reporting",
         "Studio",
         "Styling", // Relocated out of the Infrastructure grab-bag into its own top-level slice.
-        "WorkflowPackages"
+        "WorkflowPackages",
+        "Temporal" // Temporal data history slice (honua-server#1166): capability discovery + as-of read.
     };
 
     /// <summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/Temporal/TemporalHistoryEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Temporal/TemporalHistoryEndpointsTests.cs
@@ -1,0 +1,267 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Tests.Features.Temporal;
+
+/// <summary>
+/// Integration tests for slice 1 of the temporal data history API (honua-server#1166):
+/// capability discovery and as-of read. The Metadata v2 graph is overridden with a layer that
+/// declares a temporal column (history-capable) and a layer that does not (unsupported), and the
+/// change tracker is replaced with a deterministic fake so as-of reads are reproducible. This
+/// exercises the real <c>TemporalHistoryService</c>, the admin endpoint, the temporal-history
+/// authorization policy, and AOT JSON serialization end-to-end.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Configuration)]
+public sealed class TemporalHistoryEndpointsTests : IAsyncLifetime
+{
+    private const string ServiceId = "svc-temporal";
+    private const int TemporalLayerId = 10;
+    private const int NonTemporalLayerId = 11;
+
+    private readonly FakeChangeTracker _changeTracker = new();
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public TemporalHistoryEndpointsTests()
+    {
+        _fixture = new WebAppFixture()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", WebAppFixture.SharedAdminPassword);
+            })
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IMetadataV2GraphProvider>();
+                services.RemoveAll<IMetadataV2GraphStore>();
+                services.AddSingleton(_ => new TestMetadataV2GraphProvider(BuildTemporalGraph()));
+                services.AddSingleton<IMetadataV2GraphProvider>(sp =>
+                    sp.GetRequiredService<TestMetadataV2GraphProvider>());
+                services.AddSingleton<IMetadataV2GraphStore>(sp =>
+                    sp.GetRequiredService<TestMetadataV2GraphProvider>());
+
+                services.RemoveAll<IChangeTracker>();
+                services.AddScoped<IChangeTracker>(_ => _changeTracker);
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateAdminClient();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/temporal/services/{serviceId}/layers/{layerId}/capabilities")]
+    public async Task Capability_ForTemporalLayer_ReportsHistorySupported()
+    {
+        _changeTracker.CurrentGeneration = 42;
+
+        var response = await _client.GetAsync(
+            $"/api/v1/temporal/services/{ServiceId}/layers/{TemporalLayerId}/capabilities");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await ReadJsonAsync(response);
+        var root = json.RootElement;
+
+        root.GetProperty("supportsHistory").GetBoolean().Should().BeTrue();
+        root.GetProperty("supportsAsOf").GetBoolean().Should().BeTrue();
+        root.GetProperty("temporalColumn").GetString().Should().Be("valid_from");
+        root.GetProperty("cursorKind").GetString().Should().Be("Generation");
+        root.GetProperty("currentGeneration").GetInt64().Should().Be(42);
+
+        var deferred = root.GetProperty("deferred");
+        deferred.GetProperty("supportsDiff").GetBoolean().Should().BeFalse();
+        deferred.GetProperty("supportsTimeline").GetBoolean().Should().BeFalse();
+        deferred.GetProperty("supportsAttribution").GetBoolean().Should().BeFalse();
+        deferred.GetProperty("supportsRollback").GetBoolean().Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/temporal/services/{serviceId}/layers/{layerId}/capabilities")]
+    public async Task Capability_ForNonTemporalLayer_ReportsHistoryUnsupported()
+    {
+        var response = await _client.GetAsync(
+            $"/api/v1/temporal/services/{ServiceId}/layers/{NonTemporalLayerId}/capabilities");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await ReadJsonAsync(response);
+        json.RootElement.GetProperty("supportsHistory").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("supportsAsOf").GetBoolean().Should().BeFalse();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/temporal/services/{serviceId}/layers/{layerId}/capabilities")]
+    public async Task Capability_ForUnknownLayer_ReturnsNotFound()
+    {
+        var response = await _client.GetAsync(
+            $"/api/v1/temporal/services/{ServiceId}/layers/9999/capabilities");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/temporal/services/{serviceId}/layers/{layerId}/as-of")]
+    public async Task AsOf_ForTemporalLayer_ReturnsCollapsedChanges()
+    {
+        var changedAt = DateTimeOffset.Parse("2026-05-01T00:00:00Z", System.Globalization.CultureInfo.InvariantCulture);
+        _changeTracker.CurrentGeneration = 5;
+        _changeTracker.ChangesSince = sinceGeneration => sinceGeneration == 2
+            ?
+            [
+                new FeatureChange
+                {
+                    ChangeId = 1, Generation = 3, LayerId = TemporalLayerId, ObjectId = 100,
+                    Operation = FeatureChangeOperation.Insert, ChangedAt = changedAt
+                },
+                new FeatureChange
+                {
+                    ChangeId = 2, Generation = 4, LayerId = TemporalLayerId, ObjectId = 200,
+                    Operation = FeatureChangeOperation.Delete, ChangedAt = changedAt
+                }
+            ]
+            : [];
+
+        var response = await _client.GetAsync(
+            $"/api/v1/temporal/services/{ServiceId}/layers/{TemporalLayerId}/as-of?generation=2");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await ReadJsonAsync(response);
+        var root = json.RootElement;
+
+        root.GetProperty("resolvedGeneration").GetInt64().Should().Be(2);
+        root.GetProperty("currentGeneration").GetInt64().Should().Be(5);
+        root.GetProperty("requestedCursorKind").GetString().Should().Be("Generation");
+
+        var features = root.GetProperty("features");
+        features.GetArrayLength().Should().Be(2);
+
+        var insert = features[0];
+        insert.GetProperty("objectId").GetInt64().Should().Be(100);
+        insert.GetProperty("operation").GetString().Should().Be("Insert");
+
+        var delete = features[1];
+        delete.GetProperty("objectId").GetInt64().Should().Be(200);
+        delete.GetProperty("operation").GetString().Should().Be("Delete");
+        // Deleted features expose no attribute snapshot in slice 1.
+        delete.TryGetProperty("attributes", out var deletedAttrs).Should().BeFalse();
+        _ = deletedAttrs;
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/temporal/services/{serviceId}/layers/{layerId}/as-of")]
+    public async Task AsOf_WhenUnchanged_ReturnsEmptyDeterministically()
+    {
+        _changeTracker.CurrentGeneration = 7;
+        _changeTracker.ChangesSince = _ => [];
+
+        var response = await _client.GetAsync(
+            $"/api/v1/temporal/services/{ServiceId}/layers/{TemporalLayerId}/as-of?generation=7");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await ReadJsonAsync(response);
+        json.RootElement.GetProperty("features").GetArrayLength().Should().Be(0);
+        json.RootElement.GetProperty("resolvedGeneration").GetInt64().Should().Be(7);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/temporal/services/{serviceId}/layers/{layerId}/as-of")]
+    public async Task AsOf_ForNonTemporalLayer_ReturnsConflict()
+    {
+        var response = await _client.GetAsync(
+            $"/api/v1/temporal/services/{ServiceId}/layers/{NonTemporalLayerId}/as-of?generation=0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/temporal/services/{serviceId}/layers/{layerId}/as-of")]
+    public async Task AsOf_WithBothCursors_ReturnsBadRequest()
+    {
+        var response = await _client.GetAsync(
+            $"/api/v1/temporal/services/{ServiceId}/layers/{TemporalLayerId}/as-of?generation=1&timestamp=2026-05-01T00:00:00Z");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    private static async Task<JsonDocument> ReadJsonAsync(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonDocument.Parse(content);
+    }
+
+    private static MetadataV2Graph BuildTemporalGraph()
+    {
+        var builder = new TestMetadataV2GraphBuilder()
+            .AddService(ServiceId, ServiceId, accessPolicy: new Honua.Core.Features.Security.Domain.AccessPolicy { AllowAnonymous = true });
+
+        builder
+            .AddResource("res-temporal", "temporal-layer")
+            .AddStorageBinding(
+                "binding-temporal",
+                "res-temporal",
+                "temporal_features",
+                storageLayerId: TemporalLayerId,
+                options: new Dictionary<string, JsonElement>
+                {
+                    ["temporalColumn"] = JsonSerializer.SerializeToElement("valid_from")
+                })
+            .AddPublication(
+                id: "pub-temporal",
+                serviceId: ServiceId,
+                resourceId: "res-temporal",
+                layerIndex: TemporalLayerId,
+                serviceLocalId: TemporalLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        builder
+            .AddResource("res-plain", "plain-layer")
+            .AddStorageBinding(
+                "binding-plain",
+                "res-plain",
+                "plain_features",
+                storageLayerId: NonTemporalLayerId)
+            .AddPublication(
+                id: "pub-plain",
+                serviceId: ServiceId,
+                resourceId: "res-plain",
+                layerIndex: NonTemporalLayerId,
+                serviceLocalId: NonTemporalLayerId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        return builder.Build();
+    }
+
+    private sealed class FakeChangeTracker : IChangeTracker
+    {
+        public long CurrentGeneration { get; set; }
+
+        public Func<long, IReadOnlyList<FeatureChange>> ChangesSince { get; set; } = _ => [];
+
+        public Task<long> GetCurrentGenerationAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(CurrentGeneration);
+
+        public Task<IReadOnlyList<FeatureChange>> GetChangesSinceAsync(
+            long sinceGeneration,
+            int[] layerIds,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(ChangesSince(sinceGeneration));
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Temporal/TemporalHistoryEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Temporal/TemporalHistoryEndpointsTests.cs
@@ -203,6 +203,33 @@ public sealed class TemporalHistoryEndpointsTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/temporal/services/{serviceId}/layers/{layerId}/as-of")]
+    public async Task AsOf_WithTimestampCursor_ReturnsBadRequest()
+    {
+        // Slice 1 keys on the change-tracker generation only; there is no timestamp -> generation
+        // index, so a timestamp cursor must be rejected with a 400 rather than silently treated as
+        // generation 0 (which would return the full change feed even for a future timestamp).
+        // Make the full feed non-empty so a regression to generation-0 behavior would be observable.
+        _changeTracker.CurrentGeneration = 5;
+        _changeTracker.ChangesSince = sinceGeneration => sinceGeneration == 0
+            ?
+            [
+                new FeatureChange
+                {
+                    ChangeId = 1, Generation = 1, LayerId = TemporalLayerId, ObjectId = 100,
+                    Operation = FeatureChangeOperation.Insert,
+                    ChangedAt = DateTimeOffset.Parse("2026-05-01T00:00:00Z", System.Globalization.CultureInfo.InvariantCulture)
+                }
+            ]
+            : [];
+
+        var response = await _client.GetAsync(
+            $"/api/v1/temporal/services/{ServiceId}/layers/{TemporalLayerId}/as-of?timestamp=2099-01-01T00:00:00Z");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
     private static async Task<JsonDocument> ReadJsonAsync(HttpResponseMessage response)
     {
         var content = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
## Issue Link
Related to #1166 (Part of #1166)

This is **slice 1 of N** of the Temporal data history API (#1166). It deliberately does **not** close #1166 — the remaining slices (diff, timeline, attribution, governed rollback) are tracked in the follow-up issue **#1285**.

## Summary
Adds a read-only, REST-only first slice of the temporal data history capability: **capability discovery** and **as-of read** for supported layers. Both are built on existing primitives — the storage mapping's temporal column (`FeatureStorageMapping.TemporalColumn`) for discovery and the existing `IChangeTracker` (`GetCurrentGenerationAsync` / `GetChangesSinceAsync`) for as-of reads — rather than introducing a parallel history store. The slice interoperates with, but does not depend on, named-version editing (#371): a layer can expose temporal history with or without version branches.

## Changes Made
- **Domain/abstractions** (`Honua.Core.Abstractions/Features/Temporal/`): `ITemporalHistoryService`, capability/as-of contracts (`TemporalCapability`, `TemporalAsOfResult`, cursor + change-kind enums, deferred-capability descriptor), and typed exceptions.
- **Core service** (`Honua.Core/Features/Temporal/`): `TemporalHistoryService` resolves a layer via the Metadata v2 graph, reports history support (temporal column present + a non-no-op change tracker), and serves deterministic as-of reads from the change tracker collapsed at a generation/timestamp cursor. Read-only providers (DuckDB/MySQL register a no-op tracker) correctly report history as unsupported.
- **REST adapter** (`Honua.Server/Features/Temporal/`): a new admin endpoint group mirroring the AnalysisContent group pattern, with a **distinct `TemporalHistoryRead` authorization policy** (separate from current reads / admin mutations, tightenable to a dedicated permission grant later):
  - `GET /api/v1/temporal/services/{serviceId}/layers/{layerId}/capabilities`
  - `GET /api/v1/temporal/services/{serviceId}/layers/{layerId}/as-of`
- DTOs registered in a source-gen JSON context (AOT) and wired into the server's JSON resolver chain; endpoints registered in `EndpointRegistry`; service registered in DI.
- No schema change / no migration — the change tracker suffices for this read-only slice.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Integration tests (`tests/dotnet/Honua.Server.Tests/Features/Temporal/`, Testcontainers + PostGIS): capability discovery (supported + unsupported layer + unknown-layer 404), as-of read (collapsed changes, empty/unchanged case, unsupported-layer 409, conflicting-cursors 400). Local results: temporal tests 7/7 passed; `Tier=Fast` Server.Tests 1708/1708 passed; Architecture gates (EndpointRegistryDrift / ApiSurfaceCoverage / OpenApiDrift) 12/12 passed; `dotnet format --verify-no-changes` clean.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact (admin `/api/v1/temporal/...` routes are outside the governed `/ogc/*` OpenAPI specs)

## Release/Deploy Impact
- [x] None — standard merge-and-release flow (no migration, no infra/env changes)

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above (Related to / Part of #1166; follow-up #1285)
- [x] Tests added for new functionality
