### PR TITLE
feat: named replica list + detail management API (#1167)

### DIFF
--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -118,6 +118,10 @@ public static class EndpointRegistry
         new("PUT", "/api/v1/admin/services/{serviceName}/timeinfo"),
         new("PUT", "/api/v1/admin/services/{serviceName}/layers/{layerId}/metadata"),
 
+        // v1 admin named-replica management endpoints (#1167, slice 1)
+        new("GET", "/api/v1/admin/services/{serviceId}/replicas"),
+        new("GET", "/api/v1/admin/services/{serviceId}/replicas/{replicaId}"),
+
         // v1 admin secure connection endpoints
         new("GET", "/api/v1/admin/connections"),
         new("GET", "/api/v1/admin/connections/{id}"),

--- a/src/Honua.Server/Features/Admin/Models/ReplicaManagementJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/ReplicaManagementJsonContext.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Infrastructure.Models;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// JSON source-generation context for the admin replica-management APIs (AOT-safe).
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(ReplicaManagementSummary))]
+[JsonSerializable(typeof(ReplicaManagementSummary[]))]
+[JsonSerializable(typeof(ReplicaManagementDetail))]
+[JsonSerializable(typeof(ReplicaManagementListResponse))]
+[JsonSerializable(typeof(ApiResponse<ReplicaManagementListResponse>))]
+[JsonSerializable(typeof(ApiResponse<ReplicaManagementDetail>))]
+public sealed partial class ReplicaManagementJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Admin/Models/ReplicaManagementModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/ReplicaManagementModels.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Operator-facing summary of a named replica registered against a feature service.
+/// Surfaced by the admin replica-management list endpoint so Console and operators
+/// can review active disconnected replicas (#1167, slice 1).
+/// </summary>
+public sealed class ReplicaManagementSummary
+{
+    /// <summary>
+    /// Unique replica identifier (GUID hex).
+    /// </summary>
+    public required string ReplicaId { get; init; }
+
+    /// <summary>
+    /// Human-readable replica name supplied at creation time.
+    /// </summary>
+    public required string ReplicaName { get; init; }
+
+    /// <summary>
+    /// Identifier of the feature service the replica belongs to.
+    /// </summary>
+    public required string ServiceId { get; init; }
+
+    /// <summary>
+    /// Sync model: none, perLayer, or perReplica.
+    /// </summary>
+    public required string SyncModel { get; init; }
+
+    /// <summary>
+    /// Service-local layer identifiers included in the replica.
+    /// </summary>
+    public required int[] LayerIds { get; init; }
+
+    /// <summary>
+    /// Timestamp (UTC) when the replica was created.
+    /// </summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>
+    /// Timestamp (UTC) of the last successful synchronization.
+    /// </summary>
+    public required DateTimeOffset LastSyncTime { get; init; }
+}
+
+/// <summary>
+/// Operator-facing detail view of a single named replica, including the server
+/// generation cursor captured at the last successful sync (#1167, slice 1).
+/// </summary>
+public sealed class ReplicaManagementDetail
+{
+    /// <summary>
+    /// Unique replica identifier (GUID hex).
+    /// </summary>
+    public required string ReplicaId { get; init; }
+
+    /// <summary>
+    /// Human-readable replica name supplied at creation time.
+    /// </summary>
+    public required string ReplicaName { get; init; }
+
+    /// <summary>
+    /// Identifier of the feature service the replica belongs to.
+    /// </summary>
+    public required string ServiceId { get; init; }
+
+    /// <summary>
+    /// Sync model: none, perLayer, or perReplica.
+    /// </summary>
+    public required string SyncModel { get; init; }
+
+    /// <summary>
+    /// Service-local layer identifiers included in the replica.
+    /// </summary>
+    public required int[] LayerIds { get; init; }
+
+    /// <summary>
+    /// Timestamp (UTC) when the replica was created.
+    /// </summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>
+    /// Timestamp (UTC) of the last successful synchronization.
+    /// </summary>
+    public required DateTimeOffset LastSyncTime { get; init; }
+
+    /// <summary>
+    /// Server generation cursor recorded at the last successful synchronization.
+    /// </summary>
+    public required long LastSyncGeneration { get; init; }
+}
+
+/// <summary>
+/// Envelope returned by the replica-management list endpoint.
+/// </summary>
+public sealed class ReplicaManagementListResponse
+{
+    /// <summary>
+    /// Identifier of the feature service whose replicas are listed.
+    /// </summary>
+    public required string ServiceId { get; init; }
+
+    /// <summary>
+    /// Replica summaries registered against the service. May be empty.
+    /// </summary>
+    public required ReplicaManagementSummary[] Replicas { get; init; }
+}

--- a/src/Honua.Server/Features/Admin/ReplicaManagementEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/ReplicaManagementEndpoints.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Validation.Abstractions;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Models;
+using Honua.Server.Features.Admin.Models;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Admin/operator endpoints for inspecting named disconnected-sync replicas (#1167, slice 1).
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the operator-facing management surface that mirrors the Esri offline/disconnected
+/// editing shape: clients create named replicas via the GeoServices FeatureServer
+/// <c>createReplica</c>/<c>synchronizeReplica</c> REST endpoints, and operators review the
+/// active replicas (name, owner-supplied metadata, layers, sync model, last sync time, and the
+/// server generation cursor) here. It reads durable replica state from
+/// <see cref="IReplicaRepository"/>; it does not create, mutate, or synchronize replicas.
+/// </para>
+/// <para>
+/// The group is gated by <c>RequireAdminAuthorization</c> (replica/conflict-review entitlement),
+/// which is the distinct authorization surface separate from the per-layer data-editor checks
+/// used by the protocol replication endpoints. The durable conflict-record review and resolution
+/// APIs are deferred to a follow-up slice.
+/// </para>
+/// </remarks>
+internal static class ReplicaManagementEndpoints
+{
+    /// <summary>
+    /// Maps the admin replica-management endpoints onto the admin services API group.
+    /// </summary>
+    public static void MapReplicaManagementEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/services/{serviceId}/replicas")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Replicas")
+            .RequireAdminAuthorization();
+
+        _ = group.MapGet("/", HandleListReplicas)
+            .WithName("ListAdminReplicas")
+            .WithSummary("List named replicas registered against a feature service")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        _ = group.MapGet("/{replicaId}", HandleGetReplica)
+            .WithName("GetAdminReplica")
+            .WithSummary("Get detail for a single named replica")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+    }
+
+    private static async Task<IResult> HandleListReplicas(
+        string serviceId,
+        HttpContext context,
+        [FromServices] IResourceValidator resourceValidator,
+        [FromServices] IReplicaRepository replicaRepository,
+        CancellationToken cancellationToken)
+    {
+        var serviceProblem = await ValidateServiceAsync(serviceId, context, resourceValidator, cancellationToken)
+            .ConfigureAwait(false);
+        if (serviceProblem != null)
+        {
+            return serviceProblem;
+        }
+
+        var records = await replicaRepository.ListByServiceAsync(serviceId, cancellationToken).ConfigureAwait(false);
+
+        var response = new ReplicaManagementListResponse
+        {
+            ServiceId = serviceId,
+            Replicas = records.Select(ToSummary).ToArray(),
+        };
+
+        return Results.Json(
+            ApiResponse<ReplicaManagementListResponse>.CreateSuccess(response),
+            ReplicaManagementJsonContext.Default.ApiResponseReplicaManagementListResponse);
+    }
+
+    private static async Task<IResult> HandleGetReplica(
+        string serviceId,
+        string replicaId,
+        HttpContext context,
+        [FromServices] IResourceValidator resourceValidator,
+        [FromServices] IReplicaRepository replicaRepository,
+        CancellationToken cancellationToken)
+    {
+        var serviceProblem = await ValidateServiceAsync(serviceId, context, resourceValidator, cancellationToken)
+            .ConfigureAwait(false);
+        if (serviceProblem != null)
+        {
+            return serviceProblem;
+        }
+
+        var record = await replicaRepository.GetAsync(replicaId, cancellationToken).ConfigureAwait(false);
+        if (record is null ||
+            !string.Equals(record.Value.ServiceId, serviceId, StringComparison.OrdinalIgnoreCase))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status404NotFound,
+                $"Replica '{replicaId}' not found for service '{serviceId}'.");
+        }
+
+        var detail = ToDetail(record.Value);
+        return Results.Json(
+            ApiResponse<ReplicaManagementDetail>.CreateSuccess(detail),
+            ReplicaManagementJsonContext.Default.ApiResponseReplicaManagementDetail);
+    }
+
+    private static async Task<IResult?> ValidateServiceAsync(
+        string serviceId,
+        HttpContext context,
+        IResourceValidator resourceValidator,
+        CancellationToken cancellationToken)
+    {
+        var serviceResult = await resourceValidator.ValidateServiceV2Async(serviceId, cancellationToken)
+            .ConfigureAwait(false);
+        if (serviceResult.IsValid && serviceResult.Resource != null)
+        {
+            return null;
+        }
+
+        var statusCode = serviceResult.ErrorCode == ResourceValidationError.InvalidIdentifier
+            ? StatusCodes.Status400BadRequest
+            : StatusCodes.Status404NotFound;
+        var message = serviceResult.ErrorMessage ?? $"Service '{serviceId}' not found.";
+        return ProblemDetailsHelpers.CreateAdminProblem(context, statusCode, message);
+    }
+
+    private static ReplicaManagementSummary ToSummary(ReplicaRecord record) => new()
+    {
+        ReplicaId = record.ReplicaId,
+        ReplicaName = record.ReplicaName,
+        ServiceId = record.ServiceId,
+        SyncModel = record.SyncModel,
+        LayerIds = record.LayerIds,
+        CreatedAt = record.CreatedAt,
+        LastSyncTime = record.LastSyncTime,
+    };
+
+    private static ReplicaManagementDetail ToDetail(ReplicaRecord record) => new()
+    {
+        ReplicaId = record.ReplicaId,
+        ReplicaName = record.ReplicaName,
+        ServiceId = record.ServiceId,
+        SyncModel = record.SyncModel,
+        LayerIds = record.LayerIds,
+        CreatedAt = record.CreatedAt,
+        LastSyncTime = record.LastSyncTime,
+        LastSyncGeneration = record.LastSyncGeneration,
+    };
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -1005,6 +1005,7 @@ app.MapDeployControlEndpoints();
 app.MapAdminLayerStyleEndpoints();
 app.MapAdminLayerFieldConfigurationEndpoints();
 app.MapAdminLayerFilterConfigurationEndpoints();
+app.MapReplicaManagementEndpoints();
 app.MapAdminLayerValidationEndpoints();
 app.MapAdminStyleSuggestionEndpoints();
 app.MapAdminSldStyleEndpoints();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicaManagementEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicaManagementEndpointTests.cs
@@ -1,0 +1,216 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Infrastructure.Models;
+using Honua.Server.Features.Admin.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
+
+/// <summary>
+/// Integration tests for the admin/operator named-replica management API (#1167, slice 1):
+/// list + detail of durable named replicas behind <c>RequireAdminAuthorization</c>.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+public sealed class ReplicaManagementEndpointTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    private static string ListPath(string serviceId) =>
+        $"/api/v1/admin/services/{serviceId}/replicas";
+
+    private static string DetailPath(string serviceId, string replicaId) =>
+        $"/api/v1/admin/services/{serviceId}/replicas/{replicaId}";
+
+    private async Task<string> CreateReplicaAsync(string replicaName)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            replicaName,
+            layers = "0",
+            syncModel = "perReplica",
+            f = "json"
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/createReplica",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(content);
+        return document.RootElement.GetProperty("replicaID").GetString()!;
+    }
+
+    private static async Task<ApiResponse<ReplicaManagementListResponse>?> ReadListAsync(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize(
+            content,
+            ReplicaManagementJsonContext.Default.ApiResponseReplicaManagementListResponse);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ListReplicas)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas")]
+    public async Task ListReplicas_WhenNoneRegistered_ReturnsEmptyCollection()
+    {
+        var response = await _fixture.Client.GetAsync(ListPath(WebAppFixture.TestServiceId));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await ReadListAsync(response);
+        body.Should().NotBeNull();
+        body!.Success.Should().BeTrue();
+        body.Data.Should().NotBeNull();
+        body.Data!.ServiceId.Should().Be(WebAppFixture.TestServiceId);
+        body.Data.Replicas.Should().BeEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ListReplicas)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas")]
+    public async Task ListReplicas_AfterCreate_ReturnsRegisteredReplica()
+    {
+        var replicaId = await CreateReplicaAsync("OperatorReviewReplica");
+
+        var response = await _fixture.Client.GetAsync(ListPath(WebAppFixture.TestServiceId));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await ReadListAsync(response);
+        body.Should().NotBeNull();
+        body!.Data.Should().NotBeNull();
+
+        var match = body.Data!.Replicas.Should().ContainSingle(r => r.ReplicaId == replicaId).Subject;
+        match.ReplicaName.Should().Be("OperatorReviewReplica");
+        match.ServiceId.Should().Be(WebAppFixture.TestServiceId);
+        match.SyncModel.Should().Be("perReplica");
+        match.LayerIds.Should().Contain(0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ListReplicas)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas")]
+    public async Task ListReplicas_ForUnknownService_ReturnsNotFound()
+    {
+        var response = await _fixture.Client.GetAsync(ListPath("does-not-exist"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ListReplicas)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas")]
+    public async Task ListReplicas_WithoutAdminAuthorization_IsRejected()
+    {
+        // The admin replica-management group is gated by RequireAdminAuthorization.
+        // Disable the dev-auth bypass (which the default shared fixture enables) so the
+        // authorization requirement is actually enforced, while staying in the Test
+        // environment so configuration validation still passes.
+        var fixture = new WebAppFixture().ConfigureWebHost(builder =>
+        {
+            builder.UseSetting("HONUA_DEV_AUTH_ALLOW_BYPASS", "false");
+            builder.UseSetting("HONUA_ADMIN_PASSWORD", WebAppFixture.SharedAdminPassword);
+        });
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var anonymousClient = fixture.CreateClient();
+
+            var response = await anonymousClient.GetAsync(ListPath(WebAppFixture.TestServiceId));
+
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+            // A correctly authenticated admin is not rejected by the authorization gate.
+            var adminResponse = await fixture.CreateAdminClient().GetAsync(ListPath(WebAppFixture.TestServiceId));
+            adminResponse.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+            adminResponse.StatusCode.Should().NotBe(HttpStatusCode.Forbidden);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ReplicaInfo)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}")]
+    public async Task GetReplica_ForRegisteredReplica_ReturnsDetail()
+    {
+        var replicaId = await CreateReplicaAsync("DetailReplica");
+
+        var response = await _fixture.Client.GetAsync(DetailPath(WebAppFixture.TestServiceId, replicaId));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        var body = JsonSerializer.Deserialize(
+            content,
+            ReplicaManagementJsonContext.Default.ApiResponseReplicaManagementDetail);
+
+        body.Should().NotBeNull();
+        body!.Success.Should().BeTrue();
+        body.Data.Should().NotBeNull();
+        body.Data!.ReplicaId.Should().Be(replicaId);
+        body.Data.ReplicaName.Should().Be("DetailReplica");
+        body.Data.ServiceId.Should().Be(WebAppFixture.TestServiceId);
+        body.Data.SyncModel.Should().Be("perReplica");
+        body.Data.LayerIds.Should().Contain(0);
+        body.Data.LastSyncGeneration.Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ReplicaInfo)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}")]
+    public async Task GetReplica_ForUnknownReplica_ReturnsNotFound()
+    {
+        var response = await _fixture.Client.GetAsync(
+            DetailPath(WebAppFixture.TestServiceId, "00000000000000000000000000000000"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ReplicaInfo)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}")]
+    public async Task GetReplica_WithoutAdminAuthorization_IsRejected()
+    {
+        var fixture = new WebAppFixture().ConfigureWebHost(builder =>
+        {
+            builder.UseSetting("HONUA_DEV_AUTH_ALLOW_BYPASS", "false");
+            builder.UseSetting("HONUA_ADMIN_PASSWORD", WebAppFixture.SharedAdminPassword);
+        });
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var anonymousClient = fixture.CreateClient();
+
+            var response = await anonymousClient.GetAsync(
+                DetailPath(WebAppFixture.TestServiceId, "00000000000000000000000000000000"));
+
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+            var adminResponse = await fixture.CreateAdminClient().GetAsync(
+                DetailPath(WebAppFixture.TestServiceId, "00000000000000000000000000000000"));
+            adminResponse.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+            adminResponse.StatusCode.Should().NotBe(HttpStatusCode.Forbidden);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Part of #1167 (slice 1 of N — partial). Follow-up for deferred conflict-review slices: #1287

## Summary
Adds the first vertical slice of the disconnected-replica work in #1167: an operator/Console-facing admin endpoint group for inspecting **named replicas**. Clients still create/synchronize replicas through the existing Esri GeoServices FeatureServer `createReplica`/`synchronizeReplica` REST endpoints; this PR adds the management surface to **list and inspect** the durable named replicas behind admin authorization. This slice does not depend on #1166.

## Changes Made
- Add `ReplicaManagementEndpoints` (Minimal APIs) under `src/Honua.Server/Features/Admin`, mirroring the existing admin endpoint groups and gated by `RequireAdminAuthorization` (replica/conflict-review entitlement):
  - `GET /api/v1/admin/services/{serviceId}/replicas` — list named replicas for a service (returns an empty collection when none are registered).
  - `GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}` — replica detail (404 when the replica is unknown or belongs to another service).
- Endpoints are read-only: they resolve durable state from `IReplicaRepository` and do not create, mutate, or synchronize replicas. Existing last-write-wins / client-wins / server-wins sync strategies are unchanged.
- Add `ReplicaManagementModels` (summary/detail/list DTOs) and an AOT-safe source-generated `ReplicaManagementJsonContext`.
- Register both routes in `EndpointRegistry.All` so the API-surface coverage and endpoint-registry drift gates stay green.
- Add integration tests alongside the GeoServices FeatureServer replication tests covering list (empty + populated), detail (found + not-found), unknown-service handling, and admin-authorization permission checks (anonymous rejected with dev bypass disabled; admin not rejected).

Deferred to follow-up #1287 (not built here): durable conflict records (new table), conflict creation on conflicting upload, conflict classification/detail (base/client/server states), and conflict-resolution actions. The conflict↔temporal change-set linkage is to be coordinated with #1166; conflict interop with versioned editing (#371) is interop-only and not a dependency.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Local results:
- `dotnet format Honua.sln --verify-no-changes` — clean.
- `dotnet build` (Release, `TreatWarningsAsErrors=true`) — `Honua.Server` and affected test projects build with 0 warnings / 0 errors.
- `Honua.Protocols.GeoServices.Tests` → `ReplicaManagementEndpointTests` — 7/7 passed.
- `Honua.Architecture.Tests` → EndpointRegistryDrift + ApiSurfaceCoverage + OpenApiDrift gates — 12/12 passed.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

New endpoints live under the admin `/api/v1/admin/...` surface (REST-only, server-only; replica/sync are not part of proto/conformance). The OGC OpenAPI governance gate does not cover the admin surface; no OGC spec changes are required.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract (n/a — additive admin endpoints)
- [ ] If breaking admin/control-plane API changes: updated migration guide (n/a — additive)
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review (n/a)