### PR TITLE
feat: studio map collaboration comments + activity API (#1278)

### DIFF
--- a/src/Honua.Core/Features/Console/Collaboration/Abstractions/IStudioMapCollaborationStore.cs
+++ b/src/Honua.Core/Features/Console/Collaboration/Abstractions/IStudioMapCollaborationStore.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Console.Collaboration.Domain;
+
+namespace Honua.Core.Features.Console.Collaboration.Abstractions;
+
+/// <summary>
+/// Persistence contract for durable Studio map collaboration data (honua-server#1278,
+/// slice 1): feature-pinned comment threads and the collaboration activity feed for a
+/// map draft/package. The real-time presence/cursor/markup transport is a separate
+/// slice and is intentionally not part of this contract.
+/// </summary>
+/// <remarks>
+/// Recording a comment-thread mutation (open/reply/resolve/reopen) also appends a
+/// corresponding <see cref="StudioMapActivityEvent"/> so the activity feed stays a
+/// faithful, ordered projection of collaboration history.
+/// </remarks>
+public interface IStudioMapCollaborationStore
+{
+    /// <summary>Lists comment threads for a map, newest activity first.</summary>
+    Task<IReadOnlyList<StudioMapCommentThread>> ListThreadsAsync(
+        string mapId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Returns a single thread by id, or <see langword="null"/> when not found.</summary>
+    Task<StudioMapCommentThread?> GetThreadAsync(
+        string mapId,
+        Guid threadId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Opens a new comment thread with its first message and anchor metadata.
+    /// Returns the created thread.
+    /// </summary>
+    Task<StudioMapCommentThread> CreateThreadAsync(
+        string mapId,
+        string featureLabel,
+        string layerRef,
+        double anchorX,
+        double anchorY,
+        string authorName,
+        string? authorId,
+        string body,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Appends a reply to an existing thread. Returns the updated thread, or
+    /// <see langword="null"/> when the thread does not exist for the map.
+    /// </summary>
+    Task<StudioMapCommentThread?> AddReplyAsync(
+        string mapId,
+        Guid threadId,
+        string authorName,
+        string? authorId,
+        string body,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the resolved flag for a thread. Returns the updated thread, or
+    /// <see langword="null"/> when the thread does not exist for the map.
+    /// </summary>
+    Task<StudioMapCommentThread?> SetResolvedAsync(
+        string mapId,
+        Guid threadId,
+        bool resolved,
+        string actorName,
+        string? actorId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Lists collaboration activity events for a map, newest first.</summary>
+    Task<IReadOnlyList<StudioMapActivityEvent>> ListActivityAsync(
+        string mapId,
+        int limit,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Console/Collaboration/Domain/StudioMapCollaborationModels.cs
+++ b/src/Honua.Core/Features/Console/Collaboration/Domain/StudioMapCollaborationModels.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Console.Collaboration.Domain;
+
+/// <summary>
+/// A feature-pinned comment thread anchored to a feature/layer on a Studio map
+/// draft or package (honua-server#1278, slice 1). The anchor metadata
+/// (<see cref="FeatureLabel"/>, <see cref="LayerRef"/>, <see cref="AnchorX"/>,
+/// <see cref="AnchorY"/>) lets the Console comment drawer re-render the pin over
+/// the map canvas. Threads are durable and survive map edits.
+/// </summary>
+public sealed record StudioMapCommentThread
+{
+    /// <summary>Stable thread identifier.</summary>
+    public required Guid ThreadId { get; init; }
+
+    /// <summary>Map draft/package the thread belongs to.</summary>
+    public required string MapId { get; init; }
+
+    /// <summary>Human-readable label of the anchored feature (e.g. "Parcel 1042").</summary>
+    public required string FeatureLabel { get; init; }
+
+    /// <summary>Layer reference the anchored feature belongs to.</summary>
+    public required string LayerRef { get; init; }
+
+    /// <summary>Normalized horizontal anchor position over the map canvas (0..1).</summary>
+    public required double AnchorX { get; init; }
+
+    /// <summary>Normalized vertical anchor position over the map canvas (0..1).</summary>
+    public required double AnchorY { get; init; }
+
+    /// <summary>Whether the thread has been resolved.</summary>
+    public bool Resolved { get; init; }
+
+    /// <summary>Messages in the thread, oldest first.</summary>
+    public required IReadOnlyList<StudioMapCommentMessage> Messages { get; init; }
+
+    /// <summary>Actor that opened the thread.</summary>
+    public string? CreatedBy { get; init; }
+
+    /// <summary>When the thread was opened.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>When the thread last changed (new reply or resolve toggle).</summary>
+    public required DateTimeOffset UpdatedAt { get; init; }
+}
+
+/// <summary>A single message within a <see cref="StudioMapCommentThread"/>.</summary>
+public sealed record StudioMapCommentMessage
+{
+    /// <summary>Stable message identifier.</summary>
+    public required Guid MessageId { get; init; }
+
+    /// <summary>Display name of the author.</summary>
+    public required string AuthorName { get; init; }
+
+    /// <summary>Stable author identifier (audit actor), when known.</summary>
+    public string? AuthorId { get; init; }
+
+    /// <summary>Message body text.</summary>
+    public required string Body { get; init; }
+
+    /// <summary>When the message was posted.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+}
+
+/// <summary>
+/// A durable collaboration activity event for a Studio map draft/package: who did
+/// what and when. Slice 1 records the comment-thread lifecycle (thread opened,
+/// reply posted, thread resolved/reopened); the real-time markup/presence stream
+/// is deferred to slice 2.
+/// </summary>
+public sealed record StudioMapActivityEvent
+{
+    /// <summary>Stable activity event identifier.</summary>
+    public required Guid EventId { get; init; }
+
+    /// <summary>Map draft/package the event belongs to.</summary>
+    public required string MapId { get; init; }
+
+    /// <summary>Kind of collaboration event.</summary>
+    public required StudioMapActivityKind Kind { get; init; }
+
+    /// <summary>Display name of the actor that produced the event.</summary>
+    public required string ActorName { get; init; }
+
+    /// <summary>Stable actor identifier (audit actor), when known.</summary>
+    public string? ActorId { get; init; }
+
+    /// <summary>Human-readable action summary (e.g. "commented on Parcel 1042").</summary>
+    public required string Action { get; init; }
+
+    /// <summary>Related thread, when the event is comment-scoped.</summary>
+    public Guid? ThreadId { get; init; }
+
+    /// <summary>When the event occurred.</summary>
+    public required DateTimeOffset OccurredAt { get; init; }
+}
+
+/// <summary>Category of a <see cref="StudioMapActivityEvent"/>.</summary>
+public enum StudioMapActivityKind
+{
+    /// <summary>A comment thread was opened.</summary>
+    ThreadOpened,
+
+    /// <summary>A reply was posted to a thread.</summary>
+    CommentPosted,
+
+    /// <summary>A thread was resolved.</summary>
+    ThreadResolved,
+
+    /// <summary>A resolved thread was reopened.</summary>
+    ThreadReopened,
+}

--- a/src/Honua.Core/Features/Console/Collaboration/Services/InMemoryStudioMapCollaborationStore.cs
+++ b/src/Honua.Core/Features/Console/Collaboration/Services/InMemoryStudioMapCollaborationStore.cs
@@ -1,0 +1,213 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Console.Collaboration.Abstractions;
+using Honua.Core.Features.Console.Collaboration.Domain;
+
+namespace Honua.Core.Features.Console.Collaboration.Services;
+
+/// <summary>
+/// In-memory Studio map collaboration store for tests and local fallback when no
+/// durable Postgres backing is configured. Thread-safe via a coarse lock.
+/// </summary>
+public sealed class InMemoryStudioMapCollaborationStore : IStudioMapCollaborationStore
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<Guid, StudioMapCommentThread> _threads = new();
+    private readonly List<StudioMapActivityEvent> _activity = new();
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Creates the store with the supplied clock.</summary>
+    public InMemoryStudioMapCollaborationStore(TimeProvider? timeProvider = null)
+        => _timeProvider = timeProvider ?? TimeProvider.System;
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StudioMapCommentThread>> ListThreadsAsync(
+        string mapId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            IReadOnlyList<StudioMapCommentThread> threads = _threads.Values
+                .Where(t => string.Equals(t.MapId, mapId, StringComparison.Ordinal))
+                .OrderByDescending(t => t.UpdatedAt)
+                .ToList();
+            return Task.FromResult(threads);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<StudioMapCommentThread?> GetThreadAsync(
+        string mapId,
+        Guid threadId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            return Task.FromResult(FindThread(mapId, threadId));
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<StudioMapCommentThread> CreateThreadAsync(
+        string mapId,
+        string featureLabel,
+        string layerRef,
+        double anchorX,
+        double anchorY,
+        string authorName,
+        string? authorId,
+        string body,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var now = _timeProvider.GetUtcNow();
+        var thread = new StudioMapCommentThread
+        {
+            ThreadId = Guid.NewGuid(),
+            MapId = mapId,
+            FeatureLabel = featureLabel,
+            LayerRef = layerRef,
+            AnchorX = anchorX,
+            AnchorY = anchorY,
+            Resolved = false,
+            Messages =
+            [
+                new StudioMapCommentMessage
+                {
+                    MessageId = Guid.NewGuid(),
+                    AuthorName = authorName,
+                    AuthorId = authorId,
+                    Body = body,
+                    CreatedAt = now,
+                },
+            ],
+            CreatedBy = authorId,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        lock (_gate)
+        {
+            _threads[thread.ThreadId] = thread;
+            RecordActivity(mapId, StudioMapActivityKind.ThreadOpened, authorName, authorId,
+                $"opened a comment on {featureLabel}", thread.ThreadId, now);
+        }
+
+        return Task.FromResult(thread);
+    }
+
+    /// <inheritdoc />
+    public Task<StudioMapCommentThread?> AddReplyAsync(
+        string mapId,
+        Guid threadId,
+        string authorName,
+        string? authorId,
+        string body,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var now = _timeProvider.GetUtcNow();
+        lock (_gate)
+        {
+            var existing = FindThread(mapId, threadId);
+            if (existing is null)
+            {
+                return Task.FromResult<StudioMapCommentThread?>(null);
+            }
+
+            var messages = existing.Messages.ToList();
+            messages.Add(new StudioMapCommentMessage
+            {
+                MessageId = Guid.NewGuid(),
+                AuthorName = authorName,
+                AuthorId = authorId,
+                Body = body,
+                CreatedAt = now,
+            });
+
+            var updated = existing with { Messages = messages, UpdatedAt = now };
+            _threads[threadId] = updated;
+            RecordActivity(mapId, StudioMapActivityKind.CommentPosted, authorName, authorId,
+                $"replied on {existing.FeatureLabel}", threadId, now);
+            return Task.FromResult<StudioMapCommentThread?>(updated);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<StudioMapCommentThread?> SetResolvedAsync(
+        string mapId,
+        Guid threadId,
+        bool resolved,
+        string actorName,
+        string? actorId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var now = _timeProvider.GetUtcNow();
+        lock (_gate)
+        {
+            var existing = FindThread(mapId, threadId);
+            if (existing is null)
+            {
+                return Task.FromResult<StudioMapCommentThread?>(null);
+            }
+
+            var updated = existing with { Resolved = resolved, UpdatedAt = now };
+            _threads[threadId] = updated;
+            var kind = resolved ? StudioMapActivityKind.ThreadResolved : StudioMapActivityKind.ThreadReopened;
+            var verb = resolved ? "resolved" : "reopened";
+            RecordActivity(mapId, kind, actorName, actorId,
+                $"{verb} the comment on {existing.FeatureLabel}", threadId, now);
+            return Task.FromResult<StudioMapCommentThread?>(updated);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StudioMapActivityEvent>> ListActivityAsync(
+        string mapId,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            IReadOnlyList<StudioMapActivityEvent> events = _activity
+                .Where(e => string.Equals(e.MapId, mapId, StringComparison.Ordinal))
+                .OrderByDescending(e => e.OccurredAt)
+                .Take(limit)
+                .ToList();
+            return Task.FromResult(events);
+        }
+    }
+
+    private StudioMapCommentThread? FindThread(string mapId, Guid threadId)
+        => _threads.TryGetValue(threadId, out var thread)
+            && string.Equals(thread.MapId, mapId, StringComparison.Ordinal)
+            ? thread
+            : null;
+
+    private void RecordActivity(
+        string mapId,
+        StudioMapActivityKind kind,
+        string actorName,
+        string? actorId,
+        string action,
+        Guid threadId,
+        DateTimeOffset occurredAt)
+    {
+        _activity.Add(new StudioMapActivityEvent
+        {
+            EventId = Guid.NewGuid(),
+            MapId = mapId,
+            Kind = kind,
+            ActorName = actorName,
+            ActorId = actorId,
+            Action = action,
+            ThreadId = threadId,
+            OccurredAt = occurredAt,
+        });
+    }
+}

--- a/src/Honua.Core/Features/Console/Collaboration/StudioMapCollaborationServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Console/Collaboration/StudioMapCollaborationServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Console.Collaboration.Abstractions;
+using Honua.Core.Features.Console.Collaboration.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Core.Features.Console.Collaboration;
+
+/// <summary>
+/// Dependency injection helpers for the durable Studio map collaboration slice
+/// (honua-server#1278): comment threads + activity feed.
+/// </summary>
+public static class StudioMapCollaborationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the in-memory collaboration store as the default. A Postgres-backed
+    /// store overrides it when Postgres persistence is active.
+    /// </summary>
+    public static IServiceCollection AddStudioMapCollaboration(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(TimeProvider.System);
+        services.TryAddSingleton<IStudioMapCollaborationStore>(sp =>
+            new InMemoryStudioMapCollaborationStore(sp.GetService<TimeProvider>()));
+        return services;
+    }
+}

--- a/src/Honua.Postgres/Features/Console/Collaboration/PostgresStudioMapCollaborationStore.cs
+++ b/src/Honua.Postgres/Features/Console/Collaboration/PostgresStudioMapCollaborationStore.cs
@@ -1,0 +1,449 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using Honua.Core.Features.Console.Collaboration.Abstractions;
+using Honua.Core.Features.Console.Collaboration.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Infrastructure;
+using Npgsql;
+
+namespace Honua.Postgres.Features.Console.Collaboration;
+
+/// <summary>
+/// Durable Postgres-backed Studio map collaboration store (#1278, slice 1):
+/// feature-pinned comment threads + activity feed. Thread mutations append a
+/// matching activity event in the same transaction so the feed stays a faithful
+/// projection of collaboration history.
+/// </summary>
+internal sealed class PostgresStudioMapCollaborationStore : IStudioMapCollaborationStore
+{
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly TimeProvider _timeProvider;
+    private readonly string _threadsTable;
+    private readonly string _messagesTable;
+    private readonly string _activityTable;
+
+    public PostgresStudioMapCollaborationStore(
+        IDatabaseConnectionProvider connectionProvider,
+        TimeProvider? timeProvider = null,
+        string? schemaName = null)
+    {
+        ArgumentNullException.ThrowIfNull(connectionProvider);
+        _connectionProvider = connectionProvider;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _threadsTable = SchemaSearchPath.QualifyTable("studio_map_comment_threads", schemaName);
+        _messagesTable = SchemaSearchPath.QualifyTable("studio_map_comment_messages", schemaName);
+        _activityTable = SchemaSearchPath.QualifyTable("studio_map_activity_events", schemaName);
+    }
+
+    public async Task<IReadOnlyList<StudioMapCommentThread>> ListThreadsAsync(
+        string mapId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        var sql = $"""
+            SELECT thread_id, map_id, feature_label, layer_ref, anchor_x, anchor_y,
+                   resolved, created_by, created_at, updated_at
+            FROM {_threadsTable}
+            WHERE map_id = @map_id
+            ORDER BY updated_at DESC
+            """;
+        var threads = new List<(StudioMapCommentThread Thread, Guid Id)>();
+        await using (var command = new NpgsqlCommand(sql, lease.Connection))
+        {
+            command.Parameters.AddWithValue("@map_id", mapId);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                threads.Add((ReadThread(reader, []), reader.GetGuid(0)));
+            }
+        }
+
+        var result = new List<StudioMapCommentThread>(threads.Count);
+        foreach (var (thread, id) in threads)
+        {
+            var messages = await LoadMessagesAsync(lease.Connection, transaction: null, id, cancellationToken).ConfigureAwait(false);
+            result.Add(thread with { Messages = messages });
+        }
+
+        return result;
+    }
+
+    public async Task<StudioMapCommentThread?> GetThreadAsync(
+        string mapId,
+        Guid threadId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        return await LoadThreadAsync(lease.Connection, transaction: null, mapId, threadId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<StudioMapCommentThread> CreateThreadAsync(
+        string mapId,
+        string featureLabel,
+        string layerRef,
+        double anchorX,
+        double anchorY,
+        string authorName,
+        string? authorId,
+        string body,
+        CancellationToken cancellationToken = default)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var threadId = Guid.NewGuid();
+        var messageId = Guid.NewGuid();
+
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        var connection = lease.Connection;
+        await using var transaction = await connection.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken).ConfigureAwait(false);
+        var committed = false;
+        try
+        {
+            var insertThread = $"""
+                INSERT INTO {_threadsTable}
+                    (thread_id, map_id, feature_label, layer_ref, anchor_x, anchor_y, resolved, created_by, created_at, updated_at)
+                VALUES
+                    (@thread_id, @map_id, @feature_label, @layer_ref, @anchor_x, @anchor_y, FALSE, @created_by, @created_at, @updated_at)
+                """;
+            await using (var command = new NpgsqlCommand(insertThread, connection, transaction))
+            {
+                command.Parameters.AddWithValue("@thread_id", threadId);
+                command.Parameters.AddWithValue("@map_id", mapId);
+                command.Parameters.AddWithValue("@feature_label", featureLabel);
+                command.Parameters.AddWithValue("@layer_ref", layerRef);
+                command.Parameters.AddWithValue("@anchor_x", anchorX);
+                command.Parameters.AddWithValue("@anchor_y", anchorY);
+                command.Parameters.AddWithValue("@created_by", (object?)authorId ?? DBNull.Value);
+                command.Parameters.AddWithValue("@created_at", now);
+                command.Parameters.AddWithValue("@updated_at", now);
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await InsertMessageAsync(connection, transaction, messageId, threadId, authorName, authorId, body, now, cancellationToken).ConfigureAwait(false);
+            await InsertActivityAsync(connection, transaction, mapId, "thread-opened", authorName, authorId,
+                $"opened a comment on {featureLabel}", threadId, now, cancellationToken).ConfigureAwait(false);
+
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            committed = true;
+        }
+        catch
+        {
+            if (!committed)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            throw;
+        }
+
+        return (await GetThreadAsync(mapId, threadId, cancellationToken).ConfigureAwait(false))!;
+    }
+
+    public async Task<StudioMapCommentThread?> AddReplyAsync(
+        string mapId,
+        Guid threadId,
+        string authorName,
+        string? authorId,
+        string body,
+        CancellationToken cancellationToken = default)
+    {
+        var now = _timeProvider.GetUtcNow();
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        var connection = lease.Connection;
+        await using var transaction = await connection.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken).ConfigureAwait(false);
+        var committed = false;
+        try
+        {
+            var featureLabel = await TouchThreadAsync(connection, transaction, mapId, threadId, now, cancellationToken).ConfigureAwait(false);
+            if (featureLabel is null)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                committed = true;
+                return null;
+            }
+
+            await InsertMessageAsync(connection, transaction, Guid.NewGuid(), threadId, authorName, authorId, body, now, cancellationToken).ConfigureAwait(false);
+            await InsertActivityAsync(connection, transaction, mapId, "comment-posted", authorName, authorId,
+                $"replied on {featureLabel}", threadId, now, cancellationToken).ConfigureAwait(false);
+
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            committed = true;
+        }
+        catch
+        {
+            if (!committed)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            throw;
+        }
+
+        return await GetThreadAsync(mapId, threadId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<StudioMapCommentThread?> SetResolvedAsync(
+        string mapId,
+        Guid threadId,
+        bool resolved,
+        string actorName,
+        string? actorId,
+        CancellationToken cancellationToken = default)
+    {
+        var now = _timeProvider.GetUtcNow();
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        var connection = lease.Connection;
+        await using var transaction = await connection.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken).ConfigureAwait(false);
+        var committed = false;
+        try
+        {
+            string? featureLabel;
+            var updateSql = $"""
+                UPDATE {_threadsTable}
+                SET resolved = @resolved, updated_at = @updated_at
+                WHERE thread_id = @thread_id AND map_id = @map_id
+                RETURNING feature_label
+                """;
+            await using (var command = new NpgsqlCommand(updateSql, connection, transaction))
+            {
+                command.Parameters.AddWithValue("@resolved", resolved);
+                command.Parameters.AddWithValue("@updated_at", now);
+                command.Parameters.AddWithValue("@thread_id", threadId);
+                command.Parameters.AddWithValue("@map_id", mapId);
+                var scalar = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+                featureLabel = scalar as string;
+            }
+
+            if (featureLabel is null)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                committed = true;
+                return null;
+            }
+
+            var kind = resolved ? "thread-resolved" : "thread-reopened";
+            var verb = resolved ? "resolved" : "reopened";
+            await InsertActivityAsync(connection, transaction, mapId, kind, actorName, actorId,
+                $"{verb} the comment on {featureLabel}", threadId, now, cancellationToken).ConfigureAwait(false);
+
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            committed = true;
+        }
+        catch
+        {
+            if (!committed)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            throw;
+        }
+
+        return await GetThreadAsync(mapId, threadId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<StudioMapActivityEvent>> ListActivityAsync(
+        string mapId,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        await using var lease = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        var sql = $"""
+            SELECT event_id, map_id, kind, actor_name, actor_id, action, thread_id, occurred_at
+            FROM {_activityTable}
+            WHERE map_id = @map_id
+            ORDER BY occurred_at DESC
+            LIMIT @limit
+            """;
+        await using var command = new NpgsqlCommand(sql, lease.Connection);
+        command.Parameters.AddWithValue("@map_id", mapId);
+        command.Parameters.AddWithValue("@limit", limit);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var events = new List<StudioMapActivityEvent>();
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            events.Add(new StudioMapActivityEvent
+            {
+                EventId = reader.GetGuid(0),
+                MapId = reader.GetString(1),
+                Kind = FromDbKind(reader.GetString(2)),
+                ActorName = reader.GetString(3),
+                ActorId = reader.IsDBNull(4) ? null : reader.GetString(4),
+                Action = reader.GetString(5),
+                ThreadId = reader.IsDBNull(6) ? null : reader.GetGuid(6),
+                OccurredAt = reader.GetFieldValue<DateTimeOffset>(7),
+            });
+        }
+
+        return events;
+    }
+
+    private async Task<StudioMapCommentThread?> LoadThreadAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        string mapId,
+        Guid threadId,
+        CancellationToken cancellationToken)
+    {
+        var sql = $"""
+            SELECT thread_id, map_id, feature_label, layer_ref, anchor_x, anchor_y,
+                   resolved, created_by, created_at, updated_at
+            FROM {_threadsTable}
+            WHERE thread_id = @thread_id AND map_id = @map_id
+            """;
+        StudioMapCommentThread? header = null;
+        await using (var command = new NpgsqlCommand(sql, connection, transaction))
+        {
+            command.Parameters.AddWithValue("@thread_id", threadId);
+            command.Parameters.AddWithValue("@map_id", mapId);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                header = ReadThread(reader, []);
+            }
+        }
+
+        if (header is null)
+        {
+            return null;
+        }
+
+        var messages = await LoadMessagesAsync(connection, transaction, threadId, cancellationToken).ConfigureAwait(false);
+        return header with { Messages = messages };
+    }
+
+    private async Task<IReadOnlyList<StudioMapCommentMessage>> LoadMessagesAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        Guid threadId,
+        CancellationToken cancellationToken)
+    {
+        var sql = $"""
+            SELECT message_id, author_name, author_id, body, created_at
+            FROM {_messagesTable}
+            WHERE thread_id = @thread_id
+            ORDER BY created_at
+            """;
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("@thread_id", threadId);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var messages = new List<StudioMapCommentMessage>();
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            messages.Add(new StudioMapCommentMessage
+            {
+                MessageId = reader.GetGuid(0),
+                AuthorName = reader.GetString(1),
+                AuthorId = reader.IsDBNull(2) ? null : reader.GetString(2),
+                Body = reader.GetString(3),
+                CreatedAt = reader.GetFieldValue<DateTimeOffset>(4),
+            });
+        }
+
+        return messages;
+    }
+
+    private async Task<string?> TouchThreadAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string mapId,
+        Guid threadId,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        var sql = $"""
+            UPDATE {_threadsTable}
+            SET updated_at = @updated_at
+            WHERE thread_id = @thread_id AND map_id = @map_id
+            RETURNING feature_label
+            """;
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("@updated_at", now);
+        command.Parameters.AddWithValue("@thread_id", threadId);
+        command.Parameters.AddWithValue("@map_id", mapId);
+        return await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) as string;
+    }
+
+    private async Task InsertMessageAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        Guid messageId,
+        Guid threadId,
+        string authorName,
+        string? authorId,
+        string body,
+        DateTimeOffset createdAt,
+        CancellationToken cancellationToken)
+    {
+        var sql = $"""
+            INSERT INTO {_messagesTable}
+                (message_id, thread_id, author_name, author_id, body, created_at)
+            VALUES
+                (@message_id, @thread_id, @author_name, @author_id, @body, @created_at)
+            """;
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("@message_id", messageId);
+        command.Parameters.AddWithValue("@thread_id", threadId);
+        command.Parameters.AddWithValue("@author_name", authorName);
+        command.Parameters.AddWithValue("@author_id", (object?)authorId ?? DBNull.Value);
+        command.Parameters.AddWithValue("@body", body);
+        command.Parameters.AddWithValue("@created_at", createdAt);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task InsertActivityAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        string mapId,
+        string kind,
+        string actorName,
+        string? actorId,
+        string action,
+        Guid threadId,
+        DateTimeOffset occurredAt,
+        CancellationToken cancellationToken)
+    {
+        var sql = $"""
+            INSERT INTO {_activityTable}
+                (event_id, map_id, kind, actor_name, actor_id, action, thread_id, occurred_at)
+            VALUES
+                (@event_id, @map_id, @kind, @actor_name, @actor_id, @action, @thread_id, @occurred_at)
+            """;
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("@event_id", Guid.NewGuid());
+        command.Parameters.AddWithValue("@map_id", mapId);
+        command.Parameters.AddWithValue("@kind", kind);
+        command.Parameters.AddWithValue("@actor_name", actorName);
+        command.Parameters.AddWithValue("@actor_id", (object?)actorId ?? DBNull.Value);
+        command.Parameters.AddWithValue("@action", action);
+        command.Parameters.AddWithValue("@thread_id", threadId);
+        command.Parameters.AddWithValue("@occurred_at", occurredAt);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static StudioMapCommentThread ReadThread(NpgsqlDataReader reader, IReadOnlyList<StudioMapCommentMessage> messages)
+        => new()
+        {
+            ThreadId = reader.GetGuid(0),
+            MapId = reader.GetString(1),
+            FeatureLabel = reader.GetString(2),
+            LayerRef = reader.GetString(3),
+            AnchorX = reader.GetDouble(4),
+            AnchorY = reader.GetDouble(5),
+            Resolved = reader.GetBoolean(6),
+            CreatedBy = reader.IsDBNull(7) ? null : reader.GetString(7),
+            Messages = messages,
+            CreatedAt = reader.GetFieldValue<DateTimeOffset>(8),
+            UpdatedAt = reader.GetFieldValue<DateTimeOffset>(9),
+        };
+
+    private static StudioMapActivityKind FromDbKind(string kind) => kind switch
+    {
+        "thread-opened" => StudioMapActivityKind.ThreadOpened,
+        "comment-posted" => StudioMapActivityKind.CommentPosted,
+        "thread-resolved" => StudioMapActivityKind.ThreadResolved,
+        "thread-reopened" => StudioMapActivityKind.ThreadReopened,
+        _ => throw new InvalidDataException($"Unsupported Studio map activity kind '{kind}' in storage."),
+    };
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -183,6 +183,13 @@ internal static class ServiceCollectionExtensions
             new PostgresStudioPackageStore(
                 serviceProvider.GetRequiredService<IDatabaseConnectionProvider>(),
                 configuration["Database:Schema"]));
+        // Durable Studio map collaboration store (#1278). Overrides the in-memory
+        // default registered by AddStudioMapCollaboration when Postgres is active.
+        services.AddScoped<Honua.Core.Features.Console.Collaboration.Abstractions.IStudioMapCollaborationStore>(serviceProvider =>
+            new Features.Console.Collaboration.PostgresStudioMapCollaborationStore(
+                serviceProvider.GetRequiredService<IDatabaseConnectionProvider>(),
+                serviceProvider.GetService<TimeProvider>(),
+                configuration["Database:Schema"]));
         services.AddScoped<IAnalysisContentStore>(serviceProvider =>
             new PostgresAnalysisContentStore(
                 serviceProvider.GetRequiredService<IDatabaseConnectionProvider>(),

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -250,6 +250,13 @@ public static class EndpointRegistry
         new("POST", "/api/v1/studio/content-items/{itemId}/versions/{versionId}/reopen"),
         new("POST", "/api/v1/studio/content-items/{itemId}/rollback-requests"),
 
+        // v1 Studio map collaboration: comment threads + activity feed (#1278, slice 1)
+        new("GET", "/api/v1/console/maps/{mapId}/collab/comments"),
+        new("POST", "/api/v1/console/maps/{mapId}/collab/comments"),
+        new("POST", "/api/v1/console/maps/{mapId}/collab/comments/{threadId}/replies"),
+        new("POST", "/api/v1/console/maps/{mapId}/collab/comments/{threadId}/resolve"),
+        new("GET", "/api/v1/console/maps/{mapId}/collab/activity"),
+
         // v1 content publication registry for Studio-generated artifacts (#1183)
         new("POST", "/api/v1/console/publications"),
         new("GET", "/api/v1/console/publications/{publicationId}"),

--- a/src/Honua.Server/Features/Console/Collaboration/Models/StudioMapCollaborationApiModels.cs
+++ b/src/Honua.Server/Features/Console/Collaboration/Models/StudioMapCollaborationApiModels.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Console.Collaboration.Models;
+
+/// <summary>
+/// Wire DTO for a feature-pinned comment thread. JSON shape matches the Console
+/// <c>StudioMapCommentPin</c> view model (honua-console#124) so the comment drawer
+/// binds directly: <c>threadId, featureLabel, layerRef, commentCount, resolved,
+/// xFraction, yFraction, messages[]</c>.
+/// </summary>
+public sealed class StudioMapCommentThreadDto
+{
+    /// <summary>Stable thread identifier.</summary>
+    [JsonPropertyName("threadId")]
+    public required string ThreadId { get; init; }
+
+    /// <summary>Human-readable label of the anchored feature.</summary>
+    [JsonPropertyName("featureLabel")]
+    public required string FeatureLabel { get; init; }
+
+    /// <summary>Layer reference the anchored feature belongs to.</summary>
+    [JsonPropertyName("layerRef")]
+    public required string LayerRef { get; init; }
+
+    /// <summary>Number of messages in the thread.</summary>
+    [JsonPropertyName("commentCount")]
+    public required int CommentCount { get; init; }
+
+    /// <summary>Whether the thread is resolved.</summary>
+    [JsonPropertyName("resolved")]
+    public required bool Resolved { get; init; }
+
+    /// <summary>Normalized horizontal anchor position over the map canvas (0..1).</summary>
+    [JsonPropertyName("xFraction")]
+    public required double XFraction { get; init; }
+
+    /// <summary>Normalized vertical anchor position over the map canvas (0..1).</summary>
+    [JsonPropertyName("yFraction")]
+    public required double YFraction { get; init; }
+
+    /// <summary>Messages in the thread, oldest first.</summary>
+    [JsonPropertyName("messages")]
+    public required IReadOnlyList<StudioMapCommentMessageDto> Messages { get; init; }
+}
+
+/// <summary>
+/// Wire DTO for a single comment message. JSON shape matches the Console
+/// <c>StudioMapCommentMessage</c> view model.
+/// </summary>
+public sealed class StudioMapCommentMessageDto
+{
+    /// <summary>Stable message identifier.</summary>
+    [JsonPropertyName("messageId")]
+    public required string MessageId { get; init; }
+
+    /// <summary>Display name of the author.</summary>
+    [JsonPropertyName("authorName")]
+    public required string AuthorName { get; init; }
+
+    /// <summary>Author initials for the avatar badge.</summary>
+    [JsonPropertyName("authorInitials")]
+    public required string AuthorInitials { get; init; }
+
+    /// <summary>Deterministic author avatar color.</summary>
+    [JsonPropertyName("authorColor")]
+    public required string AuthorColor { get; init; }
+
+    /// <summary>Relative time label (e.g. "2m ago").</summary>
+    [JsonPropertyName("relativeTime")]
+    public required string RelativeTime { get; init; }
+
+    /// <summary>Message body text.</summary>
+    [JsonPropertyName("body")]
+    public required string Body { get; init; }
+}
+
+/// <summary>List response wrapper for comment threads on a map.</summary>
+public sealed class StudioMapCommentThreadListResponse
+{
+    /// <summary>Map draft/package identifier.</summary>
+    [JsonPropertyName("mapId")]
+    public required string MapId { get; init; }
+
+    /// <summary>Threads, newest activity first.</summary>
+    [JsonPropertyName("threads")]
+    public required IReadOnlyList<StudioMapCommentThreadDto> Threads { get; init; }
+}
+
+/// <summary>
+/// Wire DTO for a collaboration activity-feed entry. JSON shape matches the Console
+/// <c>StudioMapActivityEntry</c> view model: <c>participantName, initials, color,
+/// relativeTime, action</c>.
+/// </summary>
+public sealed class StudioMapActivityEntryDto
+{
+    /// <summary>Display name of the participant.</summary>
+    [JsonPropertyName("participantName")]
+    public required string ParticipantName { get; init; }
+
+    /// <summary>Participant initials for the avatar badge.</summary>
+    [JsonPropertyName("initials")]
+    public required string Initials { get; init; }
+
+    /// <summary>Deterministic participant avatar color.</summary>
+    [JsonPropertyName("color")]
+    public required string Color { get; init; }
+
+    /// <summary>Relative time label (e.g. "5m ago").</summary>
+    [JsonPropertyName("relativeTime")]
+    public required string RelativeTime { get; init; }
+
+    /// <summary>Human-readable action summary.</summary>
+    [JsonPropertyName("action")]
+    public required string Action { get; init; }
+}
+
+/// <summary>List response wrapper for the activity feed on a map.</summary>
+public sealed class StudioMapActivityListResponse
+{
+    /// <summary>Map draft/package identifier.</summary>
+    [JsonPropertyName("mapId")]
+    public required string MapId { get; init; }
+
+    /// <summary>Activity entries, newest first.</summary>
+    [JsonPropertyName("activity")]
+    public required IReadOnlyList<StudioMapActivityEntryDto> Activity { get; init; }
+}
+
+/// <summary>Request body for opening a feature-pinned comment thread.</summary>
+public sealed class CreateStudioMapCommentThreadRequest
+{
+    /// <summary>Human-readable label of the anchored feature.</summary>
+    [Required]
+    [JsonPropertyName("featureLabel")]
+    public required string FeatureLabel { get; init; }
+
+    /// <summary>Layer reference the anchored feature belongs to.</summary>
+    [Required]
+    [JsonPropertyName("layerRef")]
+    public required string LayerRef { get; init; }
+
+    /// <summary>Normalized horizontal anchor position over the map canvas (0..1).</summary>
+    [Range(0d, 1d)]
+    [JsonPropertyName("xFraction")]
+    public required double XFraction { get; init; }
+
+    /// <summary>Normalized vertical anchor position over the map canvas (0..1).</summary>
+    [Range(0d, 1d)]
+    [JsonPropertyName("yFraction")]
+    public required double YFraction { get; init; }
+
+    /// <summary>First message body.</summary>
+    [Required]
+    [JsonPropertyName("body")]
+    public required string Body { get; init; }
+}
+
+/// <summary>Request body for replying to a comment thread.</summary>
+public sealed class CreateStudioMapCommentReplyRequest
+{
+    /// <summary>Reply body text.</summary>
+    [Required]
+    [JsonPropertyName("body")]
+    public required string Body { get; init; }
+}
+
+/// <summary>Request body for resolving or reopening a comment thread.</summary>
+public sealed class ResolveStudioMapCommentThreadRequest
+{
+    /// <summary>Target resolved state. True resolves, false reopens.</summary>
+    [JsonPropertyName("resolved")]
+    public bool Resolved { get; init; } = true;
+}

--- a/src/Honua.Server/Features/Console/Collaboration/Models/StudioMapCollaborationJsonContext.cs
+++ b/src/Honua.Server/Features/Console/Collaboration/Models/StudioMapCollaborationJsonContext.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Infrastructure.Models;
+
+namespace Honua.Server.Features.Console.Collaboration.Models;
+
+/// <summary>
+/// Source-generated JSON context for the durable Studio map collaboration API
+/// (honua-server#1278, slice 1): comment threads + activity feed.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(ApiResponse<StudioMapCommentThreadDto>))]
+[JsonSerializable(typeof(ApiResponse<StudioMapCommentThreadListResponse>))]
+[JsonSerializable(typeof(ApiResponse<StudioMapActivityListResponse>))]
+[JsonSerializable(typeof(ApiResponse<object>))]
+[JsonSerializable(typeof(CreateStudioMapCommentThreadRequest))]
+[JsonSerializable(typeof(CreateStudioMapCommentReplyRequest))]
+[JsonSerializable(typeof(ResolveStudioMapCommentThreadRequest))]
+[JsonSerializable(typeof(StudioMapCommentThreadDto))]
+[JsonSerializable(typeof(StudioMapCommentThreadListResponse))]
+[JsonSerializable(typeof(StudioMapActivityListResponse))]
+[JsonSerializable(typeof(StudioMapActivityEntryDto))]
+[JsonSerializable(typeof(StudioMapCommentMessageDto))]
+internal sealed partial class StudioMapCollaborationJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Console/Collaboration/StudioMapCollaborationEndpoints.cs
+++ b/src/Honua.Server/Features/Console/Collaboration/StudioMapCollaborationEndpoints.cs
@@ -1,0 +1,285 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+using Honua.Core.Features.Console.Collaboration.Abstractions;
+using Honua.Core.Features.Console.Collaboration.Domain;
+using Honua.Server.Features.Console.Collaboration.Models;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Models;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Console.Collaboration;
+
+/// <summary>
+/// Durable Studio map collaboration endpoints (honua-server#1278, slice 1):
+/// feature-pinned comment threads (list/create/reply/resolve) and the collaboration
+/// activity feed for a map draft/package. The real-time presence/cursor/markup
+/// transport is deferred to a follow-up slice; the Console collaboration surface
+/// (#124) keeps rendering its missing-binding state for those live slots until then.
+/// All routes require admin authorization (Console management surface).
+/// </summary>
+internal static class StudioMapCollaborationEndpoints
+{
+    private const int DefaultActivityLimit = 50;
+    private const int MaxActivityLimit = 200;
+
+    /// <summary>Log category for the collaboration endpoints.</summary>
+    internal sealed class StudioMapCollaborationLogCategory;
+
+    /// <summary>Maps the durable Studio map collaboration endpoints.</summary>
+    public static void MapStudioMapCollaborationEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/console/maps/{mapId}/collab")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Console")
+            .RequireAdminAuthorization();
+
+        group.MapGet("/comments", HandleListThreads)
+            .WithDisplayName("List Studio Map Comment Threads")
+            .WithSummary("Lists feature-pinned comment threads for a Studio map draft/package, newest activity first.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        group.MapPost("/comments", HandleCreateThread)
+            .WithDisplayName("Open Studio Map Comment Thread")
+            .WithSummary("Opens a feature-pinned comment thread with its first message and anchor metadata.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+
+        group.MapPost("/comments/{threadId}/replies", HandleAddReply)
+            .WithDisplayName("Reply To Studio Map Comment Thread")
+            .WithSummary("Appends a reply to an existing comment thread.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+
+        group.MapPost("/comments/{threadId}/resolve", HandleResolveThread)
+            .WithDisplayName("Resolve Studio Map Comment Thread")
+            .WithSummary("Resolves or reopens a comment thread.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
+
+        group.MapGet("/activity", HandleListActivity)
+            .WithDisplayName("List Studio Map Activity Feed")
+            .WithSummary("Lists durable collaboration activity events (comment lifecycle) for a Studio map draft/package, newest first.")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+    }
+
+    private static async Task<Results<Ok<ApiResponse<StudioMapCommentThreadListResponse>>, ProblemHttpResult>> HandleListThreads(
+        string mapId,
+        [FromServices] IStudioMapCollaborationStore store,
+        [FromServices] TimeProvider timeProvider,
+        [FromServices] ILogger<StudioMapCollaborationLogCategory> logger,
+        HttpContext context)
+    {
+        try
+        {
+            var threads = await store.ListThreadsAsync(mapId, context.RequestAborted).ConfigureAwait(false);
+            var now = timeProvider.GetUtcNow();
+            var response = new StudioMapCommentThreadListResponse
+            {
+                MapId = mapId,
+                Threads = threads.Select(t => StudioMapCollaborationMapper.ToThreadDto(t, now)).ToList(),
+            };
+            return TypedResults.Ok(ApiResponse<StudioMapCommentThreadListResponse>.CreateSuccess(response));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            ConsoleEndpointsLog.EndpointFailed(logger, "collab.comments.list", ex);
+            return Failure("Failed to list comment threads.");
+        }
+    }
+
+    private static async Task<Results<Ok<ApiResponse<StudioMapCommentThreadDto>>, BadRequest<ApiResponse<object>>, ProblemHttpResult>> HandleCreateThread(
+        string mapId,
+        CreateStudioMapCommentThreadRequest request,
+        [FromServices] IStudioMapCollaborationStore store,
+        [FromServices] TimeProvider timeProvider,
+        [FromServices] ILogger<StudioMapCollaborationLogCategory> logger,
+        HttpContext context)
+    {
+        try
+        {
+            if (!TryValidate(request, out var validationError))
+            {
+                return TypedResults.BadRequest(ApiResponse<object>.Failure(validationError));
+            }
+
+            var (actorName, actorId) = ResolveActor(context);
+            var thread = await store.CreateThreadAsync(
+                mapId,
+                request.FeatureLabel,
+                request.LayerRef,
+                request.XFraction,
+                request.YFraction,
+                actorName,
+                actorId,
+                request.Body,
+                context.RequestAborted).ConfigureAwait(false);
+
+            var now = timeProvider.GetUtcNow();
+            return TypedResults.Ok(ApiResponse<StudioMapCommentThreadDto>.CreateSuccess(
+                StudioMapCollaborationMapper.ToThreadDto(thread, now)));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            ConsoleEndpointsLog.EndpointFailed(logger, "collab.comments.create", ex);
+            return Failure("Failed to open comment thread.");
+        }
+    }
+
+    private static async Task<Results<Ok<ApiResponse<StudioMapCommentThreadDto>>, NotFound<ApiResponse<object>>, BadRequest<ApiResponse<object>>, ProblemHttpResult>> HandleAddReply(
+        string mapId,
+        string threadId,
+        CreateStudioMapCommentReplyRequest request,
+        [FromServices] IStudioMapCollaborationStore store,
+        [FromServices] TimeProvider timeProvider,
+        [FromServices] ILogger<StudioMapCollaborationLogCategory> logger,
+        HttpContext context)
+    {
+        try
+        {
+            if (!Guid.TryParse(threadId, out var threadGuid))
+            {
+                return TypedResults.NotFound(ApiResponse<object>.Failure("Comment thread not found."));
+            }
+            if (!TryValidate(request, out var validationError))
+            {
+                return TypedResults.BadRequest(ApiResponse<object>.Failure(validationError));
+            }
+
+            var (actorName, actorId) = ResolveActor(context);
+            var thread = await store.AddReplyAsync(
+                mapId, threadGuid, actorName, actorId, request.Body, context.RequestAborted).ConfigureAwait(false);
+            if (thread is null)
+            {
+                return TypedResults.NotFound(ApiResponse<object>.Failure("Comment thread not found."));
+            }
+
+            var now = timeProvider.GetUtcNow();
+            return TypedResults.Ok(ApiResponse<StudioMapCommentThreadDto>.CreateSuccess(
+                StudioMapCollaborationMapper.ToThreadDto(thread, now)));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            ConsoleEndpointsLog.EndpointFailed(logger, "collab.comments.reply", ex);
+            return Failure("Failed to add reply.");
+        }
+    }
+
+    private static async Task<Results<Ok<ApiResponse<StudioMapCommentThreadDto>>, NotFound<ApiResponse<object>>, ProblemHttpResult>> HandleResolveThread(
+        string mapId,
+        string threadId,
+        ResolveStudioMapCommentThreadRequest request,
+        [FromServices] IStudioMapCollaborationStore store,
+        [FromServices] TimeProvider timeProvider,
+        [FromServices] ILogger<StudioMapCollaborationLogCategory> logger,
+        HttpContext context)
+    {
+        try
+        {
+            if (!Guid.TryParse(threadId, out var threadGuid))
+            {
+                return TypedResults.NotFound(ApiResponse<object>.Failure("Comment thread not found."));
+            }
+
+            var (actorName, actorId) = ResolveActor(context);
+            var thread = await store.SetResolvedAsync(
+                mapId, threadGuid, request.Resolved, actorName, actorId, context.RequestAborted).ConfigureAwait(false);
+            if (thread is null)
+            {
+                return TypedResults.NotFound(ApiResponse<object>.Failure("Comment thread not found."));
+            }
+
+            var now = timeProvider.GetUtcNow();
+            return TypedResults.Ok(ApiResponse<StudioMapCommentThreadDto>.CreateSuccess(
+                StudioMapCollaborationMapper.ToThreadDto(thread, now)));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            ConsoleEndpointsLog.EndpointFailed(logger, "collab.comments.resolve", ex);
+            return Failure("Failed to update comment thread.");
+        }
+    }
+
+    private static async Task<Results<Ok<ApiResponse<StudioMapActivityListResponse>>, ProblemHttpResult>> HandleListActivity(
+        string mapId,
+        [FromServices] IStudioMapCollaborationStore store,
+        [FromServices] TimeProvider timeProvider,
+        [FromServices] ILogger<StudioMapCollaborationLogCategory> logger,
+        HttpContext context,
+        [FromQuery] int? limit = null)
+    {
+        try
+        {
+            var effectiveLimit = Math.Clamp(limit ?? DefaultActivityLimit, 1, MaxActivityLimit);
+            var events = await store.ListActivityAsync(mapId, effectiveLimit, context.RequestAborted).ConfigureAwait(false);
+            var now = timeProvider.GetUtcNow();
+            var response = new StudioMapActivityListResponse
+            {
+                MapId = mapId,
+                Activity = events.Select(e => StudioMapCollaborationMapper.ToActivityDto(e, now)).ToList(),
+            };
+            return TypedResults.Ok(ApiResponse<StudioMapActivityListResponse>.CreateSuccess(response));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            ConsoleEndpointsLog.EndpointFailed(logger, "collab.activity.list", ex);
+            return Failure("Failed to list activity feed.");
+        }
+    }
+
+    private static (string Name, string? Id) ResolveActor(HttpContext context)
+    {
+        var actorId = ConsolePrincipal.ResolveActorId(context.User);
+        var name = context.User.Identity?.Name;
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            name = actorId;
+        }
+
+        return (string.IsNullOrWhiteSpace(name) ? "Unknown" : name, actorId);
+    }
+
+    private static ProblemHttpResult Failure(string detail)
+        => TypedResults.Problem(
+            title: "Studio map collaboration request failed",
+            detail: detail,
+            statusCode: StatusCodes.Status500InternalServerError);
+
+    private static bool TryValidate<TRequest>(TRequest request, out string error) where TRequest : notnull
+    {
+        var validationResults = new List<ValidationResult>();
+        if (Validator.TryValidateObject(request, new ValidationContext(request), validationResults, validateAllProperties: true))
+        {
+            error = string.Empty;
+            return true;
+        }
+
+        error = string.Join(", ", validationResults.Select(r => r.ErrorMessage));
+        if (string.IsNullOrEmpty(error))
+        {
+            error = "Request validation failed.";
+        }
+
+        return false;
+    }
+}

--- a/src/Honua.Server/Features/Console/Collaboration/StudioMapCollaborationMapper.cs
+++ b/src/Honua.Server/Features/Console/Collaboration/StudioMapCollaborationMapper.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Console.Collaboration.Domain;
+using Honua.Server.Features.Console.Collaboration.Models;
+
+namespace Honua.Server.Features.Console.Collaboration;
+
+/// <summary>
+/// Projects durable collaboration domain records onto the Console-facing wire DTOs,
+/// deriving presentation-only fields (avatar initials/color, relative time) that the
+/// Console comment drawer and activity sidebar render.
+/// </summary>
+internal static class StudioMapCollaborationMapper
+{
+    // Deterministic palette mirrored from the Console collaboration mockup so the
+    // same author keeps the same avatar color across server-rendered surfaces.
+    private static readonly string[] _palette =
+    [
+        "#2563eb", "#7c3aed", "#db2777", "#ea580c",
+        "#16a34a", "#0891b2", "#ca8a04", "#dc2626",
+    ];
+
+    public static StudioMapCommentThreadDto ToThreadDto(StudioMapCommentThread thread, DateTimeOffset now)
+        => new()
+        {
+            ThreadId = thread.ThreadId.ToString("D", CultureInfo.InvariantCulture),
+            FeatureLabel = thread.FeatureLabel,
+            LayerRef = thread.LayerRef,
+            CommentCount = thread.Messages.Count,
+            Resolved = thread.Resolved,
+            XFraction = thread.AnchorX,
+            YFraction = thread.AnchorY,
+            Messages = thread.Messages.Select(m => ToMessageDto(m, now)).ToList(),
+        };
+
+    public static StudioMapCommentMessageDto ToMessageDto(StudioMapCommentMessage message, DateTimeOffset now)
+        => new()
+        {
+            MessageId = message.MessageId.ToString("D", CultureInfo.InvariantCulture),
+            AuthorName = message.AuthorName,
+            AuthorInitials = Initials(message.AuthorName),
+            AuthorColor = Color(message.AuthorName),
+            RelativeTime = RelativeTime(message.CreatedAt, now),
+            Body = message.Body,
+        };
+
+    public static StudioMapActivityEntryDto ToActivityDto(StudioMapActivityEvent activity, DateTimeOffset now)
+        => new()
+        {
+            ParticipantName = activity.ActorName,
+            Initials = Initials(activity.ActorName),
+            Color = Color(activity.ActorName),
+            RelativeTime = RelativeTime(activity.OccurredAt, now),
+            Action = activity.Action,
+        };
+
+    internal static string Initials(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return "?";
+        }
+
+        var parts = name.Split([' ', '\t', '-', '_', '.'], StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+        {
+            return "?";
+        }
+
+        if (parts.Length == 1)
+        {
+            return parts[0].Length == 1
+                ? parts[0].ToUpperInvariant()
+                : parts[0][..2].ToUpperInvariant();
+        }
+
+        return string.Concat(
+            char.ToUpperInvariant(parts[0][0]),
+            char.ToUpperInvariant(parts[^1][0]));
+    }
+
+    internal static string Color(string name)
+    {
+        var key = name ?? string.Empty;
+        var hash = 0;
+        foreach (var ch in key)
+        {
+            hash = unchecked((hash * 31) + ch);
+        }
+
+        var index = (int)((uint)hash % (uint)_palette.Length);
+        return _palette[index];
+    }
+
+    internal static string RelativeTime(DateTimeOffset at, DateTimeOffset now)
+    {
+        var delta = now - at;
+        if (delta < TimeSpan.Zero)
+        {
+            delta = TimeSpan.Zero;
+        }
+
+        if (delta.TotalSeconds < 60)
+        {
+            return "just now";
+        }
+
+        if (delta.TotalMinutes < 60)
+        {
+            var minutes = (int)delta.TotalMinutes;
+            return $"{minutes}m ago";
+        }
+
+        if (delta.TotalHours < 24)
+        {
+            var hours = (int)delta.TotalHours;
+            return $"{hours}h ago";
+        }
+
+        var days = (int)delta.TotalDays;
+        return $"{days}d ago";
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -116,6 +116,10 @@ internal static class FeatureRegistrationExtensions
         services.AddEnhancedAdminServices();
         services.AddMetadataReleaseServices();
         services.AddStudioPackageLifecycle();
+        // Durable Studio map collaboration: comment threads + activity feed (#1278, slice 1).
+        // In-memory store is the default; AddPostgreSqlServices overrides it with durable storage.
+        Honua.Core.Features.Console.Collaboration.StudioMapCollaborationServiceCollectionExtensions
+            .AddStudioMapCollaboration(services);
         services.AddCompliance(configuration);
         services.AddOrchestration();
         services.AddPMTilesProxy();

--- a/src/Honua.Server/Migrations/039_CreateStudioMapCollaboration.sql
+++ b/src/Honua.Server/Migrations/039_CreateStudioMapCollaboration.sql
@@ -1,0 +1,59 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Durable Studio map collaboration: feature-pinned comment threads and the
+-- collaboration activity feed for a map draft/package (#1278, slice 1).
+-- The real-time presence/cursor/markup transport is a separate slice and is
+-- intentionally not modelled here.
+
+CREATE TABLE IF NOT EXISTS honua.studio_map_comment_threads (
+    thread_id     UUID        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    map_id        TEXT        NOT NULL,
+    feature_label TEXT        NOT NULL,
+    layer_ref     TEXT        NOT NULL,
+    anchor_x      DOUBLE PRECISION NOT NULL,
+    anchor_y      DOUBLE PRECISION NOT NULL,
+    resolved      BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_by    TEXT        NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Dominant access path: "list threads for this map, newest activity first."
+CREATE INDEX IF NOT EXISTS idx_studio_map_comment_threads_map
+    ON honua.studio_map_comment_threads (map_id, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS honua.studio_map_comment_messages (
+    message_id  UUID        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    thread_id   UUID        NOT NULL REFERENCES honua.studio_map_comment_threads(thread_id) ON DELETE CASCADE,
+    author_name TEXT        NOT NULL,
+    author_id   TEXT        NULL,
+    body        TEXT        NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Messages are always read in thread order, oldest first.
+CREATE INDEX IF NOT EXISTS idx_studio_map_comment_messages_thread
+    ON honua.studio_map_comment_messages (thread_id, created_at);
+
+CREATE TABLE IF NOT EXISTS honua.studio_map_activity_events (
+    event_id   UUID        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    map_id     TEXT        NOT NULL,
+    kind       TEXT        NOT NULL,
+    actor_name TEXT        NOT NULL,
+    actor_id   TEXT        NULL,
+    action     TEXT        NOT NULL,
+    thread_id  UUID        NULL,
+    occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_studio_map_activity_kind CHECK (kind IN (
+        'thread-opened','comment-posted','thread-resolved','thread-reopened'))
+);
+
+-- Activity feed is read newest-first per map.
+CREATE INDEX IF NOT EXISTS idx_studio_map_activity_events_map
+    ON honua.studio_map_activity_events (map_id, occurred_at DESC);
+
+COMMENT ON TABLE honua.studio_map_comment_threads IS
+    'Feature-pinned comment threads on a Studio map draft/package (#1278, slice 1).';
+COMMENT ON TABLE honua.studio_map_activity_events IS
+    'Durable collaboration activity feed for a Studio map draft/package (#1278, slice 1).';

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -32,6 +32,7 @@ using Honua.Server.Features.Admin.TileOperations;
 using Honua.Server.Features.CloudDemo;
 using Honua.Server.Features.Collaboration;
 using Honua.Server.Features.Console;
+using Honua.Server.Features.Console.Collaboration;
 using Honua.Server.Features.Collaboration.Sessions;
 using Honua.Io.Export;
 using Honua.Server.Features.PrintingTools;
@@ -603,6 +604,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.Admin.Models.UserManagementJsonContext.Default,
         Honua.Server.Features.Admin.Models.RoleJsonContext.Default,
         Honua.Server.Features.Console.Models.ConsoleJsonContext.Default,
+        Honua.Server.Features.Console.Collaboration.Models.StudioMapCollaborationJsonContext.Default,
         Honua.Server.Features.Studio.Models.StudioApiJsonContext.Default,
         Honua.Core.Features.Studio.Domain.StudioJsonContext.Default,
         Honua.Ai.AnalysisContent.AnalysisContentApiJsonContext.Default,
@@ -1049,6 +1051,7 @@ app.MapConsoleActionEndpoints();
 app.MapConsoleShareEndpoints();
 app.MapConsoleSharePublicEndpoints();
 app.MapStudioPackageEndpoints();
+app.MapStudioMapCollaborationEndpoints();
 app.MapWorkflowPackageEndpoints();
 Honua.Server.Features.Console.Publications.ContentPublicationEndpoints.MapContentPublicationEndpoints(app);
 Honua.Server.Features.Console.Publications.PublishedRouteEndpoints.MapPublishedRouteEndpoints(app);

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminReplicaManagementDriftBackingTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/AdminReplicaManagementDriftBackingTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+/// <summary>
+/// Endpoint-level backing coverage for the admin named-replica inspection routes
+/// (#1167). The GeoServices-side suite already exercises these routes, but it builds
+/// the request path through a helper, which the EndpointRegistry drift source-scanner
+/// (<see cref="Honua.Server.Tests.Features.API.EndpointRegistryDriftTests"/>) cannot
+/// associate with the route. These tests issue the same-method HTTP request with the
+/// literal path inline so the admin replica registry entries are recognized as backed.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.ReplicaInfo)]
+public sealed class AdminReplicaManagementDriftBackingTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public AdminReplicaManagementDriftBackingTests()
+    {
+        _fixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", WebAppFixture.SharedAdminPassword);
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateAdminClient();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas")]
+    public async Task ListReplicas_ForSeededService_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/services/test/replicas");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}")]
+    public async Task GetReplica_UnknownReplica_ReturnsNotFound()
+    {
+        var response = await _client.GetAsync(
+            "/api/v1/admin/services/test/replicas/00000000-0000-0000-0000-000000000000");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Console/Collaboration/InMemoryStudioMapCollaborationStoreTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Console/Collaboration/InMemoryStudioMapCollaborationStoreTests.cs
@@ -6,7 +6,6 @@ using Honua.Core.Features.Console.Collaboration.Domain;
 using Honua.Core.Features.Console.Collaboration.Services;
 using Honua.Server.Features.Console.Collaboration;
 using Honua.TestKit.Attributes;
-using Microsoft.Extensions.Time.Testing;
 
 namespace Honua.Server.Tests.Features.Console.Collaboration;
 
@@ -194,5 +193,19 @@ public sealed class InMemoryStudioMapCollaborationStoreTests
         dto.Messages.Should().ContainSingle();
         dto.Messages[0].AuthorInitials.Should().Be("KT");
         dto.Messages[0].RelativeTime.Should().Be("just now");
+    }
+
+    /// <summary>
+    /// Minimal controllable clock for deterministic store tests. Mirrors the local
+    /// <c>FakeTimeProvider</c> convention used elsewhere in the test suite (no
+    /// external test-time package dependency) while supporting <see cref="Advance"/>.
+    /// </summary>
+    private sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan delta) => _utcNow = _utcNow.Add(delta);
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Console/Collaboration/InMemoryStudioMapCollaborationStoreTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Console/Collaboration/InMemoryStudioMapCollaborationStoreTests.cs
@@ -1,0 +1,198 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Console.Collaboration.Domain;
+using Honua.Core.Features.Console.Collaboration.Services;
+using Honua.Server.Features.Console.Collaboration;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Honua.Server.Tests.Features.Console.Collaboration;
+
+/// <summary>
+/// Fast unit coverage for the durable Studio map collaboration store (#1278, slice 1):
+/// comment thread create/list/reply/resolve with anchor metadata and not-found
+/// handling, plus the activity-feed projection and presentation mapper.
+/// </summary>
+public sealed class InMemoryStudioMapCollaborationStoreTests
+{
+    private const string MapId = "map-draft-1";
+
+    private static (InMemoryStudioMapCollaborationStore Store, FakeTimeProvider Clock) NewStore()
+    {
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 5, 30, 12, 0, 0, TimeSpan.Zero));
+        return (new InMemoryStudioMapCollaborationStore(clock), clock);
+    }
+
+    [UnitTest]
+    public async Task CreateThread_PersistsAnchorMetadataAndFirstMessage()
+    {
+        var (store, _) = NewStore();
+
+        var thread = await store.CreateThreadAsync(
+            MapId, "Parcel 1042", "layer:parcels", 0.42, 0.73, "Kira Tan", "kira", "Boundary looks off here.");
+
+        thread.MapId.Should().Be(MapId);
+        thread.FeatureLabel.Should().Be("Parcel 1042");
+        thread.LayerRef.Should().Be("layer:parcels");
+        thread.AnchorX.Should().Be(0.42);
+        thread.AnchorY.Should().Be(0.73);
+        thread.Resolved.Should().BeFalse();
+        thread.Messages.Should().ContainSingle();
+        thread.Messages[0].Body.Should().Be("Boundary looks off here.");
+        thread.Messages[0].AuthorName.Should().Be("Kira Tan");
+
+        var fetched = await store.GetThreadAsync(MapId, thread.ThreadId);
+        fetched.Should().NotBeNull();
+        fetched!.ThreadId.Should().Be(thread.ThreadId);
+    }
+
+    [UnitTest]
+    public async Task ListThreads_IsScopedToMap_AndOrderedByRecentActivity()
+    {
+        var (store, clock) = NewStore();
+        var first = await store.CreateThreadAsync(MapId, "A", "layer:a", 0.1, 0.1, "User One", "u1", "first");
+        clock.Advance(TimeSpan.FromMinutes(5));
+        var second = await store.CreateThreadAsync(MapId, "B", "layer:b", 0.2, 0.2, "User Two", "u2", "second");
+        await store.CreateThreadAsync("other-map", "C", "layer:c", 0.3, 0.3, "User Three", "u3", "third");
+
+        // Reply on the older thread to bump it to the top.
+        clock.Advance(TimeSpan.FromMinutes(5));
+        await store.AddReplyAsync(MapId, first.ThreadId, "User One", "u1", "follow up");
+
+        var threads = await store.ListThreadsAsync(MapId);
+
+        threads.Should().HaveCount(2);
+        threads[0].ThreadId.Should().Be(first.ThreadId, "most recent activity sorts first");
+        threads[1].ThreadId.Should().Be(second.ThreadId);
+    }
+
+    [UnitTest]
+    public async Task AddReply_AppendsMessage_AndBumpsUpdatedAt()
+    {
+        var (store, clock) = NewStore();
+        var thread = await store.CreateThreadAsync(MapId, "Parcel", "layer:p", 0.5, 0.5, "Kira", "kira", "hi");
+        clock.Advance(TimeSpan.FromMinutes(3));
+
+        var updated = await store.AddReplyAsync(MapId, thread.ThreadId, "Lee", "lee", "agreed");
+
+        updated.Should().NotBeNull();
+        updated!.Messages.Should().HaveCount(2);
+        updated.Messages[1].AuthorName.Should().Be("Lee");
+        updated.UpdatedAt.Should().BeAfter(thread.UpdatedAt);
+    }
+
+    [UnitTest]
+    public async Task AddReply_UnknownThread_ReturnsNull()
+    {
+        var (store, _) = NewStore();
+
+        var result = await store.AddReplyAsync(MapId, Guid.NewGuid(), "Lee", "lee", "ghost reply");
+
+        result.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task AddReply_WrongMap_ReturnsNull()
+    {
+        var (store, _) = NewStore();
+        var thread = await store.CreateThreadAsync(MapId, "Parcel", "layer:p", 0.5, 0.5, "Kira", "kira", "hi");
+
+        var result = await store.AddReplyAsync("different-map", thread.ThreadId, "Lee", "lee", "wrong map");
+
+        result.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task SetResolved_TogglesFlag_AndUnknownThreadReturnsNull()
+    {
+        var (store, _) = NewStore();
+        var thread = await store.CreateThreadAsync(MapId, "Parcel", "layer:p", 0.5, 0.5, "Kira", "kira", "hi");
+
+        var resolved = await store.SetResolvedAsync(MapId, thread.ThreadId, true, "Kira", "kira");
+        resolved.Should().NotBeNull();
+        resolved!.Resolved.Should().BeTrue();
+
+        var reopened = await store.SetResolvedAsync(MapId, thread.ThreadId, false, "Kira", "kira");
+        reopened!.Resolved.Should().BeFalse();
+
+        var missing = await store.SetResolvedAsync(MapId, Guid.NewGuid(), true, "Kira", "kira");
+        missing.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task ActivityFeed_RecordsLifecycleEvents_NewestFirst()
+    {
+        var (store, clock) = NewStore();
+        var thread = await store.CreateThreadAsync(MapId, "Parcel 7", "layer:p", 0.5, 0.5, "Kira Tan", "kira", "open");
+        clock.Advance(TimeSpan.FromMinutes(1));
+        await store.AddReplyAsync(MapId, thread.ThreadId, "Lee Ng", "lee", "reply");
+        clock.Advance(TimeSpan.FromMinutes(1));
+        await store.SetResolvedAsync(MapId, thread.ThreadId, true, "Kira Tan", "kira");
+
+        var activity = await store.ListActivityAsync(MapId, 50);
+
+        activity.Should().HaveCount(3);
+        activity[0].Kind.Should().Be(StudioMapActivityKind.ThreadResolved);
+        activity[1].Kind.Should().Be(StudioMapActivityKind.CommentPosted);
+        activity[2].Kind.Should().Be(StudioMapActivityKind.ThreadOpened);
+        activity[0].Action.Should().Contain("Parcel 7");
+        activity.Should().OnlyContain(e => e.ThreadId == thread.ThreadId);
+    }
+
+    [UnitTest]
+    public async Task ActivityFeed_RespectsLimit_AndMapScope()
+    {
+        var (store, clock) = NewStore();
+        for (var i = 0; i < 5; i++)
+        {
+            await store.CreateThreadAsync(MapId, $"Feature {i}", "layer:p", 0.1, 0.1, "User", "u", "note");
+            clock.Advance(TimeSpan.FromSeconds(30));
+        }
+
+        await store.CreateThreadAsync("other-map", "Other", "layer:o", 0.1, 0.1, "User", "u", "note");
+
+        var limited = await store.ListActivityAsync(MapId, 3);
+        limited.Should().HaveCount(3);
+        limited.Should().OnlyContain(e => e.MapId == MapId);
+    }
+
+    [UnitTest]
+    public void Mapper_DerivesInitials_Color_AndRelativeTime()
+    {
+        StudioMapCollaborationMapper.Initials("Kira Tan").Should().Be("KT");
+        StudioMapCollaborationMapper.Initials("madison").Should().Be("MA");
+        StudioMapCollaborationMapper.Initials("").Should().Be("?");
+
+        // Deterministic per name.
+        StudioMapCollaborationMapper.Color("Kira Tan").Should().Be(StudioMapCollaborationMapper.Color("Kira Tan"));
+        StudioMapCollaborationMapper.Color("Kira Tan").Should().StartWith("#");
+
+        var now = new DateTimeOffset(2026, 5, 30, 12, 0, 0, TimeSpan.Zero);
+        StudioMapCollaborationMapper.RelativeTime(now.AddSeconds(-10), now).Should().Be("just now");
+        StudioMapCollaborationMapper.RelativeTime(now.AddMinutes(-5), now).Should().Be("5m ago");
+        StudioMapCollaborationMapper.RelativeTime(now.AddHours(-3), now).Should().Be("3h ago");
+        StudioMapCollaborationMapper.RelativeTime(now.AddDays(-2), now).Should().Be("2d ago");
+    }
+
+    [UnitTest]
+    public async Task Mapper_ThreadDto_MatchesConsoleShape()
+    {
+        var (store, _) = NewStore();
+        var thread = await store.CreateThreadAsync(MapId, "Parcel 1042", "layer:parcels", 0.42, 0.73, "Kira Tan", "kira", "note");
+
+        var dto = StudioMapCollaborationMapper.ToThreadDto(thread, thread.CreatedAt);
+
+        dto.ThreadId.Should().Be(thread.ThreadId.ToString("D"));
+        dto.FeatureLabel.Should().Be("Parcel 1042");
+        dto.LayerRef.Should().Be("layer:parcels");
+        dto.XFraction.Should().Be(0.42);
+        dto.YFraction.Should().Be(0.73);
+        dto.CommentCount.Should().Be(1);
+        dto.Resolved.Should().BeFalse();
+        dto.Messages.Should().ContainSingle();
+        dto.Messages[0].AuthorInitials.Should().Be("KT");
+        dto.Messages[0].RelativeTime.Should().Be("just now");
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Console/Collaboration/StudioMapCollaborationEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Console/Collaboration/StudioMapCollaborationEndpointsTests.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using FluentAssertions;
+using Honua.Core.Features.Console.Collaboration.Abstractions;
+using Honua.Core.Features.Console.Collaboration.Services;
+using Honua.Infrastructure.Models;
+using Honua.Server.Features.Console.Collaboration.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Tests.Features.Console.Collaboration;
+
+/// <summary>
+/// Integration coverage for the durable Studio map collaboration endpoints
+/// (#1278, slice 1): comment thread create/list/reply/resolve and the activity
+/// feed, including anchor metadata, not-found, and admin permission gating.
+/// </summary>
+[Collection("Database")]
+public sealed class StudioMapCollaborationEndpointsTests : IAsyncLifetime
+{
+    private const string MapId = "map-draft-collab";
+
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public StudioMapCollaborationEndpointsTests()
+    {
+        _fixture = new WebAppFixture()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", WebAppFixture.SharedAdminPassword);
+            })
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IStudioMapCollaborationStore>();
+                services.AddSingleton<IStudioMapCollaborationStore>(
+                    new InMemoryStudioMapCollaborationStore(TimeProvider.System));
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateAdminClient();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/console/maps/{mapId}/collab/comments")]
+    [Endpoint("POST /api/v1/console/maps/{mapId}/collab/comments")]
+    [Endpoint("POST /api/v1/console/maps/{mapId}/collab/comments/{threadId}/replies")]
+    [Endpoint("POST /api/v1/console/maps/{mapId}/collab/comments/{threadId}/resolve")]
+    [Endpoint("GET /api/v1/console/maps/{mapId}/collab/activity")]
+    public async Task CommentLifecycle_CreateListReplyResolve_AndActivityFeed()
+    {
+        var createResponse = await PostAsync(
+            $"/api/v1/console/maps/{MapId}/collab/comments",
+            new CreateStudioMapCommentThreadRequest
+            {
+                FeatureLabel = "Parcel 1042",
+                LayerRef = "layer:parcels",
+                XFraction = 0.42,
+                YFraction = 0.73,
+                Body = "Boundary looks off here.",
+            },
+            StudioMapCollaborationJsonContext.Default.CreateStudioMapCommentThreadRequest);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var thread = await ReadAsync(
+            createResponse,
+            StudioMapCollaborationJsonContext.Default.ApiResponseStudioMapCommentThreadDto);
+        thread.FeatureLabel.Should().Be("Parcel 1042");
+        thread.LayerRef.Should().Be("layer:parcels");
+        thread.XFraction.Should().Be(0.42);
+        thread.YFraction.Should().Be(0.73);
+        thread.CommentCount.Should().Be(1);
+        thread.Resolved.Should().BeFalse();
+
+        var listResponse = await _client.GetAsync($"/api/v1/console/maps/{MapId}/collab/comments");
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var list = await ReadAsync(
+            listResponse,
+            StudioMapCollaborationJsonContext.Default.ApiResponseStudioMapCommentThreadListResponse);
+        list.MapId.Should().Be(MapId);
+        list.Threads.Should().ContainSingle(t => t.ThreadId == thread.ThreadId);
+
+        var replyResponse = await PostAsync(
+            $"/api/v1/console/maps/{MapId}/collab/comments/{thread.ThreadId}/replies",
+            new CreateStudioMapCommentReplyRequest { Body = "Agreed, re-survey needed." },
+            StudioMapCollaborationJsonContext.Default.CreateStudioMapCommentReplyRequest);
+        replyResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var replied = await ReadAsync(
+            replyResponse,
+            StudioMapCollaborationJsonContext.Default.ApiResponseStudioMapCommentThreadDto);
+        replied.CommentCount.Should().Be(2);
+
+        var resolveResponse = await PostAsync(
+            $"/api/v1/console/maps/{MapId}/collab/comments/{thread.ThreadId}/resolve",
+            new ResolveStudioMapCommentThreadRequest { Resolved = true },
+            StudioMapCollaborationJsonContext.Default.ResolveStudioMapCommentThreadRequest);
+        resolveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var resolved = await ReadAsync(
+            resolveResponse,
+            StudioMapCollaborationJsonContext.Default.ApiResponseStudioMapCommentThreadDto);
+        resolved.Resolved.Should().BeTrue();
+
+        var activityResponse = await _client.GetAsync($"/api/v1/console/maps/{MapId}/collab/activity");
+        activityResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var activity = await ReadAsync(
+            activityResponse,
+            StudioMapCollaborationJsonContext.Default.ApiResponseStudioMapActivityListResponse);
+        activity.MapId.Should().Be(MapId);
+        activity.Activity.Should().HaveCount(3);
+        activity.Activity[0].Action.Should().Contain("Parcel 1042");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/console/maps/{mapId}/collab/comments/{threadId}/replies")]
+    public async Task Reply_ToUnknownThread_ReturnsNotFound()
+    {
+        var response = await PostAsync(
+            $"/api/v1/console/maps/{MapId}/collab/comments/{Guid.NewGuid()}/replies",
+            new CreateStudioMapCommentReplyRequest { Body = "ghost" },
+            StudioMapCollaborationJsonContext.Default.CreateStudioMapCommentReplyRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/console/maps/{mapId}/collab/comments/{threadId}/resolve")]
+    public async Task Resolve_UnknownThread_ReturnsNotFound()
+    {
+        var response = await PostAsync(
+            $"/api/v1/console/maps/{MapId}/collab/comments/{Guid.NewGuid()}/resolve",
+            new ResolveStudioMapCommentThreadRequest { Resolved = true },
+            StudioMapCollaborationJsonContext.Default.ResolveStudioMapCommentThreadRequest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/console/maps/{mapId}/collab/comments")]
+    public async Task CreateThread_MissingBody_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsync(
+            $"/api/v1/console/maps/{MapId}/collab/comments",
+            new StringContent(
+                "{\"featureLabel\":\"P\",\"layerRef\":\"l\",\"xFraction\":0.1,\"yFraction\":0.1,\"body\":\"\"}",
+                Encoding.UTF8,
+                "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/console/maps/{mapId}/collab/comments")]
+    public async Task Comments_WithoutAdmin_ReturnsUnauthorized()
+    {
+        using var unauthenticated = _fixture.CreateClient();
+
+        var response = await unauthenticated.GetAsync($"/api/v1/console/maps/{MapId}/collab/comments");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task<HttpResponseMessage> PostAsync<T>(string path, T body, JsonTypeInfo<T> typeInfo)
+        => await _client.PostAsync(path, new StringContent(JsonSerializer.Serialize(body, typeInfo), Encoding.UTF8, "application/json"));
+
+    private static async Task<TData> ReadAsync<TData>(HttpResponseMessage response, JsonTypeInfo<ApiResponse<TData>> typeInfo)
+    {
+        var payload = await response.Content.ReadAsStringAsync();
+        var envelope = JsonSerializer.Deserialize(payload, typeInfo);
+        envelope.Should().NotBeNull();
+        envelope!.Success.Should().BeTrue();
+        envelope.Data.Should().NotBeNull();
+        return envelope.Data!;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Console/Collaboration/StudioMapCollaborationEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Console/Collaboration/StudioMapCollaborationEndpointsTests.cs
@@ -24,6 +24,8 @@ namespace Honua.Server.Tests.Features.Console.Collaboration;
 /// feed, including anchor metadata, not-found, and admin permission gating.
 /// </summary>
 [Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Configuration)]
 public sealed class StudioMapCollaborationEndpointsTests : IAsyncLifetime
 {
     private const string MapId = "map-draft-collab";


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1278 (slice 1 of N — see "Part of #1278" below; the umbrella issue stays open for slice 2 / #1290)

## Summary
Slice 1 of N for the Studio Map multiplayer collaboration API (#1278): the **durable** collaboration data that feeds the Console comment drawer + activity sidebar (honua-console#124). This is the tractable, request/response part — feature-pinned comment threads and an activity feed over REST. The real-time presence/cursors/markup/follow-mode surfaces require a separate real-time transport and are deferred to slice 2 (follow-up issue linked below); the Console collaboration surface keeps rendering its `MissingBinding` state for those live slots until then.

## Changes Made
- New vertical slice `Console.Collaboration`: domain + `IStudioMapCollaborationStore` abstraction in `Honua.Core`, in-memory store (default) + DI extension.
- Durable Postgres-backed store (`PostgresStudioMapCollaborationStore`) and migration `039_CreateStudioMapCollaboration.sql` (comment threads, messages, activity events). A thread mutation appends a matching activity event in the same transaction so the feed is a faithful projection.
- Minimal-API endpoints under the Console group (`RequireAdminAuthorization`), DTOs whose JSON shapes match the console-side `StudioMapCommentPin` / `StudioMapCommentMessage` / `StudioMapActivityEntry` contracts, registered in a source-gen JSON context (AOT) and added to `EndpointRegistry`.
- Tests: fast unit coverage for the in-memory store + presentation mapper (create/list/reply/resolve, anchor metadata, not-found, activity ordering/limit/scope) and integration coverage for the endpoints (lifecycle, not-found, validation, admin permission gating).

### Endpoints added
- `GET  /api/v1/console/maps/{mapId}/collab/comments`
- `POST /api/v1/console/maps/{mapId}/collab/comments`
- `POST /api/v1/console/maps/{mapId}/collab/comments/{threadId}/replies`
- `POST /api/v1/console/maps/{mapId}/collab/comments/{threadId}/resolve`
- `GET  /api/v1/console/maps/{mapId}/collab/activity`

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

(New routes carry OpenAPI metadata via `.WithSummary`/`.WithDisplayName`; the runtime `/openapi` document stays in sync. The committed OGC `openapi.json` is unaffected — these are admin/Console routes.)

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [x] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

## Deferred (slice 2)
Real-time presence / live cursors / collaborative markup-layer sync / follow-mode — tracked in #1290 (real-time SignalR/WebSocket transport). The Console surface (honua-console#124) keeps rendering missing-binding for those live slots until slice 2 lands. A console follow-up will bind the comments + activity surfaces once a nightly publishes; honua-console is not modified by this PR.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
