### PR TITLE
fix(metadata-v2): compat-compile must propagate layer storage_options (JSONB attrs -> query 400)

### DIFF
--- a/tests/seed/base-schema.sql
+++ b/tests/seed/base-schema.sql
@@ -373,6 +373,7 @@ BEGIN
                 COALESCE(NULLIF(l.table_schema, ''), 'public') AS table_schema,
                 l.table_name,
                 l.geometry_type,
+                COALESCE(l.storage_options, '{}'::jsonb) AS storage_options,
                 l.srid,
                 ST_XMin(l.extent)::double precision AS west,
                 ST_YMin(l.extent)::double precision AS south,
@@ -558,7 +559,7 @@ BEGIN
                     'locator', table_schema || '.' || table_name,
                     'storageLayerId', layer_id,
                     'capabilities', to_jsonb(ARRAY['query', 'filter', 'sort', 'aggregate', 'edit', 'transactions', 'render', 'tile', 'search']::text[]),
-                    'options', '{}'::jsonb,
+                    'options', storage_options,
                     'status', (SELECT value FROM status_doc),
                     'extensions', '{}'::jsonb
                 ) AS value,


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1238

## Summary
`seed_metadata_v2_compat_snapshot()` (the v1->v2 compat compile in `tests/seed/base-schema.sql`) builds the compiled **feature storage binding** with its `options` hardcoded to `'{}'` — it drops each layer's `honua.layers.storage_options`. For a layer whose non-key fields live in the shared `honua.features.attributes` JSONB column (`storage_options = {attributesColumn: attributes}`), the compiled graph's storage binding therefore has no `attributesColumn`. The Metadata-v2 storage-mapped reader (`PostgresStorageMappedFeatureReader`) then projects each declared field as a **bare SQL column**:

```
GET .../FeatureServer/{layer}/query?f=json  -> 400 "Invalid query parameters"
  inner: Npgsql 42703: column "name" does not exist
```

This is the compat-compile analogue of #1238/#1282 (which declared `attributesColumn` on the *seed layers* but didn't make the compat-compile carry it into the graph). Any shared-features JSONB layer registered via the compat snapshot is unqueryable — and `outFields=*` is exactly what ArcGIS Pro and other Esri clients always send.

## Changes Made
- Carry `honua.layers.storage_options` through the compile's `layer_rows` CTE.
- Emit it as the feature storage binding's `options` (was hardcoded `'{}'`).

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Manual (end-to-end), fresh trunk image + a shared-`features` JSONB layer:
```
# before:  query -> 400 (42703 column "name" does not exist)
# after recompile with the fix:
GET .../FeatureServer/2000/query?where=1=1&outFields=*&f=json -> 200
  {"geometryType":"esriGeometryPoint","fields":[{...objectid...},{...name...}],"features":[...]}
```
Verified by the `honua-io/honua-esri-compat` harness: the FeatureServer lane drops from 19 query failures to 0 once the compiled snapshot carries `attributesColumn`.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None — the compat-compile is test/seed infrastructure; output is additive (storage binding `options` gains `attributesColumn` where the layer declares it).

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] If protocol/auth behavior changed: updated compatibility contract

Follow-up: a compat-compile assertion (compiled storage binding carries `attributesColumn` for a shared-features JSONB layer) is worth adding; this PR is the minimal 2-line seed fix, verified end-to-end by the harness.

> **Validation note:** SQL-only change to the compat-compile (`tests/seed/base-schema.sql`); no `.cs` projects affected. Verified end-to-end against a live from-source trunk target via the honua-esri-compat harness: FeatureServer `/query` with `outFields=*` goes 400 -> 200 and the FeatureServer lane drops from 19 query failures to 0. Full server shards run in CI.
