### PR TITLE
fix(geoservices): accept POST on MapServer legend (#1295)

### DIFF
--- a/src/Honua.Protocols.GeoServices/MapServer/MapServerEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/MapServerEndpoints.cs
@@ -98,6 +98,15 @@ internal static partial class MapServerEndpoints
             .WithTags("MapServer")
             .CacheOutput("MapServerLegend");
 
+        endpoints.MapPost("/rest/services/{serviceId}/MapServer/legend",
+                static (HttpContext context, CancellationToken cancellationToken) => HandleLegend(context))
+            .WithDisplayName("Get Map Legend (POST)")
+            .WithName("MapServerLegendPost")
+            .WithSummary("Get map legend using POST")
+            .WithDescription("Returns legend information with swatch images for all visible layers")
+            .WithTags("MapServer")
+            .AllowAnonymous();
+
         endpoints.MapGet("/rest/services/{serviceId}/MapServer/find",
                 static (HttpContext context, CancellationToken cancellationToken) => HandleFind(context))
             .WithDisplayName("Find Features")

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -654,6 +654,7 @@ public static class EndpointRegistry
         new("GET", "/rest/services/{serviceId}/MapServer/identify"),
         new("POST", "/rest/services/{serviceId}/MapServer/identify"),
         new("GET", "/rest/services/{serviceId}/MapServer/legend"),
+        new("POST", "/rest/services/{serviceId}/MapServer/legend"),
         new("GET", "/rest/services/{serviceId}/MapServer/find"),
         new("POST", "/rest/services/{serviceId}/MapServer/find"),
         new("GET", "/rest/services/{serviceId}/MapServer/{layerId}/query"),

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
@@ -762,6 +762,29 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.Metadata)]
+    [Endpoint("POST /rest/services/{serviceId}/MapServer/legend")]
+    public async Task MapServer_Legend_Post_ReturnsLegendLayers()
+    {
+        var payload = new FormUrlEncodedContent(
+        [
+            new KeyValuePair<string, string>("f", "json")
+        ]);
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/legend",
+            payload);
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        var legend = JsonSerializer.Deserialize(content, MapServerJsonContext.Default.LegendResponse);
+
+        legend.Should().NotBeNull();
+        legend!.Layers.Should().NotBeNullOrEmpty();
+        legend.Layers!.First().Legend.Should().NotBeNullOrEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
     [Endpoint("GET /rest/services/{serviceId}/MapServer/legend")]
     public async Task MapServer_Legend_WithUnsupportedFormat_ReturnsBadRequest()
     {


### PR DESCRIPTION
## Issue Link
Fixes #1295

## Summary
ArcGIS clients issue the MapServer `legend` operation over POST, but the route was only registered for GET, so POST requests returned HTTP 405. Esri MapServer accepts both GET and POST for `legend`. This PR adds a POST companion that delegates to the same legend handler, restoring client compatibility.

## Changes Made
- Registered a `MapPost` companion for `/rest/services/{serviceId}/MapServer/legend` calling the existing `HandleLegend` handler, mirroring the `identify`/`find` POST companions (`.AllowAnonymous()`, no `CacheOutput`).
- Added the `POST /rest/services/{serviceId}/MapServer/legend` entry to `EndpointRegistry` immediately after the existing GET legend entry.
- Added an integration test `MapServer_Legend_Post_ReturnsLegendLayers` asserting POST legend returns 200 with legend layers.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

> **Validation note:** build (warnings-as-errors) and the new integration test pass locally; the full Core server-test shard exceeds the 35-min cap on this shared box and runs in CI.
