### PR TITLE
fix(geoservices): type the ObjectID field as esriFieldTypeOID (#1299)

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.TopFeatures.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.TopFeatures.cs
@@ -144,13 +144,15 @@ internal static partial class FeatureServerEndpoints
         var geometryType = resource.Spatial?.GeometryType ?? MetadataV2GeometryType.None;
         var hasGeometry = geometryType is not MetadataV2GeometryType.None;
         var srid = resource.ReadSrid() ?? SpatialReference.WGS84.Wkid;
+        var objectIdField = GeoServicesObjectIdFieldResolver.ResolveObjectIdFieldName(resource);
         var response = new QueryResponse
         {
             GeometryType = hasGeometry ? MapGeometryTypeV2(geometryType) : null,
             SpatialReference = hasGeometry
                 ? new GeoServicesSpatialReference { Wkid = srid, LatestWkid = srid }
                 : null,
-            Fields = [.. ResolveVisibleFieldsV2(resource).Select(MapFieldInfoV2)],
+            ObjectIdFieldName = objectIdField,
+            Fields = [.. ResolveVisibleFieldsV2(resource).Select(field => MapFieldInfoV2(field, objectIdField))],
             Features = responseFeatures,
             ExceededTransferLimit = result.HasMoreResults
         };

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
@@ -64,7 +64,7 @@ internal static partial class FeatureServerEndpoints
 
         var visibleFields = publications
             .SelectMany(pair => ResolveVisibleFieldsV2(pair.Resource))
-            .Select(MapFieldInfoV2)
+            .Select(field => MapFieldInfoV2(field, objectIdField))
             .ToArray();
 
         var supportedFormats = ReadServiceSupportedFormatsV2(service);
@@ -151,7 +151,7 @@ internal static partial class FeatureServerEndpoints
             Extent = extent,
             TimeInfo = timeInfo,
             ExtrusionInfo = extrusionInfo,
-            Fields = [.. ResolveVisibleFieldsV2(resource).Select(MapFieldInfoV2)],
+            Fields = [.. ResolveVisibleFieldsV2(resource).Select(field => MapFieldInfoV2(field, objectIdField))],
             MaxRecordCount = queryLimits.MaxRecordCount,
             ObjectIdField = objectIdField,
             DisplayField = displayField,
@@ -210,13 +210,16 @@ internal static partial class FeatureServerEndpoints
 
     /// <summary>
     /// Maps a canonical <see cref="MetadataV2Field"/> to the Esri-style GeoServices
-    /// field info shape.
+    /// field info shape. The layer's object-id field is forced to
+    /// <c>esriFieldTypeOID</c> regardless of its SQL type so that Esri clients can
+    /// locate the OID field by type (see issue #1299).
     /// </summary>
-    private static GeoServicesFieldInfo MapFieldInfoV2(MetadataV2Field field)
+    private static GeoServicesFieldInfo MapFieldInfoV2(MetadataV2Field field, string objectIdFieldName)
     {
         ArgumentNullException.ThrowIfNull(field);
 
-        var geoServicesType = MapFieldTypeToGeoServicesV2(field.Type);
+        var isObjectId = field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase);
+        var geoServicesType = isObjectId ? "esriFieldTypeOID" : MapFieldTypeToGeoServicesV2(field.Type);
         var sqlType = MapFieldTypeToSqlV2(field.Type);
         var isGeometry = field.Type is MetadataV2FieldType.Geometry or MetadataV2FieldType.Geography;
 
@@ -229,8 +232,8 @@ internal static partial class FeatureServerEndpoints
             // V2 has no length slot on the canonical field model (length lives in the
             // storage binding when needed). Pass null so the response omits the key.
             Length = null,
-            Nullable = field.Nullable,
-            Editable = !isGeometry,
+            Nullable = field.Nullable && !isObjectId,
+            Editable = !isGeometry && !isObjectId,
             // V2 has no default-value slot on the canonical field; the catalog/admin layer
             // owns insertion defaults.
             DefaultValue = null,

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/QueryFormatters.cs
@@ -436,7 +436,7 @@ internal sealed class QueryFormatter : IQueryFormatter
             .Where(static field => !IsGeometryField(field))
             .Where(static field => !field.Hidden)
             .Where(field => includeAllFields || requestedFields!.Contains(field.Name))
-            .Select(MapFieldInfo)
+            .Select(field => MapFieldInfo(field, objectIdFieldName))
             .ToList();
 
         if (!mappedFields.Any(field => field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase)))
@@ -563,18 +563,21 @@ internal sealed class QueryFormatter : IQueryFormatter
         return firstStringField?.Name ?? objectIdFieldName;
     }
 
-    internal static GeoServicesFieldInfo MapFieldInfo(MetadataV2Field field)
+    internal static GeoServicesFieldInfo MapFieldInfo(MetadataV2Field field, string objectIdFieldName)
     {
         var isGeometry = IsGeometryField(field);
+        // The layer's object-id field must be typed esriFieldTypeOID regardless of its
+        // SQL type so Esri clients can locate the OID field by type (see issue #1299).
+        var isObjectId = field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase);
         return new GeoServicesFieldInfo
         {
             Name = field.Name,
-            Type = MapFieldTypeToGeoServices(field.Type),
+            Type = isObjectId ? "esriFieldTypeOID" : MapFieldTypeToGeoServices(field.Type),
             SqlType = field.SqlType ?? MapFieldTypeToSql(field.Type),
             Alias = field.Alias ?? field.Title ?? field.Name,
             Length = field.Length,
-            Nullable = field.Nullable,
-            Editable = field.Editable && !isGeometry,
+            Nullable = field.Nullable && !isObjectId,
+            Editable = field.Editable && !isGeometry && !isObjectId,
             DefaultValue = field.DefaultValue.HasValue ? ConvertJsonElement(field.DefaultValue.Value) : null,
             Domain = GeoServicesFieldDomainMapper.Map(field.Domain),
             Visible = !field.Hidden

--- a/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Metadata.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Metadata.cs
@@ -356,7 +356,7 @@ internal static partial class MapServerEndpoints
             Extent = ResolveLayerExtent(resource, serviceExtent),
             DisplayField = displayField,
             ObjectIdField = objectIdField,
-            Fields = [.. resource.SchemaFields.Select(MapFieldInfoV2)],
+            Fields = [.. resource.SchemaFields.Select(field => MapFieldInfoV2(field, objectIdField))],
             Capabilities = layerCapabilities,
             SupportsAdvancedQueries = true,
             HasAttachments = resource.Editing?.SupportsAttachments ?? false,
@@ -538,17 +538,23 @@ internal static partial class MapServerEndpoints
                resource.FindPrimaryGeometryField() is not null;
     }
 
-    private static MapServerFieldInfo MapFieldInfoV2(MetadataV2Field field)
-        => new()
+    private static MapServerFieldInfo MapFieldInfoV2(MetadataV2Field field, string objectIdFieldName)
+    {
+        // The layer's object-id field must be typed esriFieldTypeOID regardless of its
+        // SQL type so Esri clients can locate the OID field by type (see issue #1299).
+        var isObjectId = field.Name.Equals(objectIdFieldName, StringComparison.OrdinalIgnoreCase);
+        return new()
         {
             Name = field.Name,
-            Type = MapFieldTypeToGeoServicesV2(field.Type),
+            Type = isObjectId ? "esriFieldTypeOID" : MapFieldTypeToGeoServicesV2(field.Type),
             Alias = field.Alias ?? field.Title ?? field.Name,
             Length = field.Length,
-            Nullable = field.Nullable,
-            Editable = field.Editable && field.Type is not MetadataV2FieldType.Geometry and not MetadataV2FieldType.Geography,
+            Nullable = field.Nullable && !isObjectId,
+            Editable = field.Editable && !isObjectId
+                && field.Type is not MetadataV2FieldType.Geometry and not MetadataV2FieldType.Geography,
             DefaultValue = field.DefaultValue.HasValue ? field.DefaultValue.Value : null
         };
+    }
 
     private static string MapFieldTypeToGeoServicesV2(MetadataV2FieldType type)
         => type switch

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/QueryFormatterTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/QueryFormatterTests.cs
@@ -458,7 +458,7 @@ public sealed class QueryFormatterTests
         queryResponse.Fields.Should().Contain(field =>
             field.Name == "id" && field.Type == "esriFieldTypeString");
         queryResponse.Fields.Should().Contain(field =>
-            field.Name == FieldNames.ObjectId && field.Type == "esriFieldTypeInteger");
+            field.Name == FieldNames.ObjectId && field.Type == "esriFieldTypeOID");
 
         var attributes = queryResponse.Features.Should().ContainSingle().Subject.Attributes;
         attributes.Should().Contain("id", "alpha-1");

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerObjectIdFieldTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerObjectIdFieldTests.cs
@@ -46,7 +46,7 @@ public sealed class MapServerObjectIdFieldTests
         layer.Should().NotBeNull();
         layer!.ObjectIdField.Should().Be(FieldNames.ObjectId);
         layer.Fields.Should().Contain(field => field.Name == "id" && field.Type == "esriFieldTypeString");
-        layer.Fields.Should().Contain(field => field.Name == FieldNames.ObjectId && field.Type == "esriFieldTypeInteger");
+        layer.Fields.Should().Contain(field => field.Name == FieldNames.ObjectId && field.Type == "esriFieldTypeOID");
     }
 
     [IntegrationTest]
@@ -67,7 +67,7 @@ public sealed class MapServerObjectIdFieldTests
         query.Should().NotBeNull();
         query!.ObjectIdFieldName.Should().Be(FieldNames.ObjectId);
         query.Fields.Should().Contain(field => field.Name == "id" && field.Type == "esriFieldTypeString");
-        query.Fields.Should().Contain(field => field.Name == FieldNames.ObjectId && field.Type == "esriFieldTypeInteger");
+        query.Fields.Should().Contain(field => field.Name == FieldNames.ObjectId && field.Type == "esriFieldTypeOID");
 
         var attributes = query.Features.Should().ContainSingle().Subject.Attributes;
         ReadStringAttribute(attributes, "id").Should().Be("alpha-1");

--- a/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -389,6 +389,75 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.GetMetadata)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
+    public async Task GetLayerMetadata_ObjectIdField_IsTypedEsriFieldTypeOid()
+    {
+        // Regression for #1299: Esri clients (including the ArcGIS Python SDK) locate the
+        // object-id field by filtering fields for type == "esriFieldTypeOID". The field that
+        // matches objectIdField must therefore be typed esriFieldTypeOID, and there must be
+        // exactly one such field per layer.
+
+        // Act
+        var layerResponse = await GetLayerMetadataAsync();
+
+        // Assert
+        layerResponse.ObjectIdField.Should().NotBeNullOrEmpty();
+
+        var oidFields = layerResponse.Fields
+            .Where(f => f.Type.Equals("esriFieldTypeOID", StringComparison.Ordinal))
+            .ToList();
+
+        oidFields.Should().ContainSingle("there must be exactly one esriFieldTypeOID field per layer");
+        oidFields[0].Name.Should().Be(layerResponse.ObjectIdField);
+
+        // No field named like the object-id field should leak a non-OID Esri type.
+        layerResponse.Fields
+            .Where(f => f.Name.Equals(layerResponse.ObjectIdField, StringComparison.OrdinalIgnoreCase))
+            .Should().OnlyContain(f => f.Type == "esriFieldTypeOID");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task QueryFeatures_ObjectIdField_IsTypedEsriFieldTypeOid()
+    {
+        // Regression for #1299: the query response fields[] array must also type the
+        // object-id field as esriFieldTypeOID so feature-returning queries resolve the OID.
+
+        // Act
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=1%3D1&f=json");
+
+        // Assert
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var queryResponse = JsonSerializer.Deserialize<QueryResponse>(
+            content, FeatureServerJsonContext.Default.QueryResponse);
+        queryResponse.Should().NotBeNull();
+        queryResponse!.ObjectIdFieldName.Should().NotBeNullOrEmpty();
+        queryResponse.Fields.Should().NotBeNullOrEmpty();
+
+        var oidFields = queryResponse.Fields!
+            .Where(f => f.Type.Equals("esriFieldTypeOID", StringComparison.Ordinal))
+            .ToList();
+
+        oidFields.Should().ContainSingle("the query response must expose exactly one esriFieldTypeOID field");
+        oidFields[0].Name.Should().Be(queryResponse.ObjectIdFieldName);
+    }
+
+    private async Task<LayerResponse> GetLayerMetadataAsync()
+    {
+        var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}");
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var layerResponse = JsonSerializer.Deserialize<LayerResponse>(
+            content, FeatureServerJsonContext.Default.LayerResponse);
+        layerResponse.Should().NotBeNull();
+        return layerResponse!;
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}")]
     public async Task GetLayerMetadata_WithUnsupportedFormat_Returns400()
     {
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}?f=html");


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1299

## Summary
FeatureServer/MapServer field metadata and query-response `fields` typed the ObjectID field as `esriFieldTypeInteger` instead of `esriFieldTypeOID` — no field was `esriFieldTypeOID`. The ArcGIS API for Python locates the OID field by filtering for `type == "esriFieldTypeOID"`, so it threw `IndexError` and **every feature-returning query failed**. This types the object-id field as `esriFieldTypeOID` in both metadata and query responses, matching Esri conformance.

## Changes Made
- Type the layer's object-id/primary-key field as `esriFieldTypeOID` in FeatureServer layer metadata, query-response field sets, top-features, and MapServer layer metadata.
- Add integration tests asserting exactly one `esriFieldTypeOID` field matching `objectIdField` in metadata and query responses.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Verified with the `honua-esri-compat` arcgis 2.4.3 SDK matrix: feature-returning queries (`query`, `as df`, `to_geojson`, pagination) succeed once the OID field is typed correctly.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None — corrects the OID field's `type` to the Esri-conformant `esriFieldTypeOID`; the field name/`objectIdField` are unchanged.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] Issue number linked above

> **Validation note:** authored with integration tests asserting the OID field type in metadata + query; build + full server-test shards run in CI on dedicated runners (the local `pre-pr-check.sh` Core shard exceeds the 35-min cap under this shared box's build-lock contention).
