### PR TITLE
feat(geoservices): implement GeometryServer distance, relation, densify, convexHull, generalize, labelPoints (#1301)

### DIFF
--- a/src/Honua.Protocols.GeoServices/GeometryService/GeometryServiceEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/GeometryService/GeometryServiceEndpoints.cs
@@ -132,6 +132,72 @@ internal static class GeometryServiceEndpoints
             .WithTags("GeometryService")
             .AllowAnonymous();
 
+        endpoints.MapGet($"{GeometryRoutePrefix}/distance", (Delegate)HandleDistance)
+            .WithDisplayName("Geometry Service Distance (GET)")
+            .WithName("GeometryServiceDistanceGet")
+            .WithTags("GeometryService");
+
+        endpoints.MapPost($"{GeometryRoutePrefix}/distance", (Delegate)HandleDistance)
+            .WithDisplayName("Geometry Service Distance (POST)")
+            .WithName("GeometryServiceDistancePost")
+            .WithTags("GeometryService")
+            .AllowAnonymous();
+
+        endpoints.MapGet($"{GeometryRoutePrefix}/relation", (Delegate)HandleRelation)
+            .WithDisplayName("Geometry Service Relation (GET)")
+            .WithName("GeometryServiceRelationGet")
+            .WithTags("GeometryService");
+
+        endpoints.MapPost($"{GeometryRoutePrefix}/relation", (Delegate)HandleRelation)
+            .WithDisplayName("Geometry Service Relation (POST)")
+            .WithName("GeometryServiceRelationPost")
+            .WithTags("GeometryService")
+            .AllowAnonymous();
+
+        endpoints.MapGet($"{GeometryRoutePrefix}/densify", (Delegate)HandleDensify)
+            .WithDisplayName("Geometry Service Densify (GET)")
+            .WithName("GeometryServiceDensifyGet")
+            .WithTags("GeometryService");
+
+        endpoints.MapPost($"{GeometryRoutePrefix}/densify", (Delegate)HandleDensify)
+            .WithDisplayName("Geometry Service Densify (POST)")
+            .WithName("GeometryServiceDensifyPost")
+            .WithTags("GeometryService")
+            .AllowAnonymous();
+
+        endpoints.MapGet($"{GeometryRoutePrefix}/convexHull", (Delegate)HandleConvexHull)
+            .WithDisplayName("Geometry Service Convex Hull (GET)")
+            .WithName("GeometryServiceConvexHullGet")
+            .WithTags("GeometryService");
+
+        endpoints.MapPost($"{GeometryRoutePrefix}/convexHull", (Delegate)HandleConvexHull)
+            .WithDisplayName("Geometry Service Convex Hull (POST)")
+            .WithName("GeometryServiceConvexHullPost")
+            .WithTags("GeometryService")
+            .AllowAnonymous();
+
+        endpoints.MapGet($"{GeometryRoutePrefix}/generalize", (Delegate)HandleGeneralize)
+            .WithDisplayName("Geometry Service Generalize (GET)")
+            .WithName("GeometryServiceGeneralizeGet")
+            .WithTags("GeometryService");
+
+        endpoints.MapPost($"{GeometryRoutePrefix}/generalize", (Delegate)HandleGeneralize)
+            .WithDisplayName("Geometry Service Generalize (POST)")
+            .WithName("GeometryServiceGeneralizePost")
+            .WithTags("GeometryService")
+            .AllowAnonymous();
+
+        endpoints.MapGet($"{GeometryRoutePrefix}/labelPoints", (Delegate)HandleLabelPoints)
+            .WithDisplayName("Geometry Service Label Points (GET)")
+            .WithName("GeometryServiceLabelPointsGet")
+            .WithTags("GeometryService");
+
+        endpoints.MapPost($"{GeometryRoutePrefix}/labelPoints", (Delegate)HandleLabelPoints)
+            .WithDisplayName("Geometry Service Label Points (POST)")
+            .WithName("GeometryServiceLabelPointsPost")
+            .WithTags("GeometryService")
+            .AllowAnonymous();
+
         return endpoints;
     }
 
@@ -140,7 +206,7 @@ internal static class GeometryServiceEndpoints
     // their discovery handshake before invoking buffer/simplify/etc.
     private const string GeometryServerInfoJson =
         "{\"currentVersion\":11.1,"
-        + "\"serviceDescription\":\"Honua Geometry Service — buffer, simplify, project, intersect, union, clip, difference, areasAndLengths, lengths.\","
+        + "\"serviceDescription\":\"Honua Geometry Service — buffer, simplify, project, intersect, union, clip, difference, areasAndLengths, lengths, distance, relation, densify, convexHull, generalize, labelPoints.\","
         + "\"maxBufferCount\":1000,"
         + "\"maxSimplifyCount\":1000,"
         + "\"resampled\":true}";
@@ -218,5 +284,53 @@ internal static class GeometryServiceEndpoints
     {
         var ct = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
         return await handler.HandleLengthAsync(context, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<IResult> HandleDistance(
+        HttpContext context,
+        GeometryServiceHandler handler)
+    {
+        var ct = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+        return await handler.HandleDistanceAsync(context, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<IResult> HandleRelation(
+        HttpContext context,
+        GeometryServiceHandler handler)
+    {
+        var ct = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+        return await handler.HandleRelationAsync(context, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<IResult> HandleDensify(
+        HttpContext context,
+        GeometryServiceHandler handler)
+    {
+        var ct = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+        return await handler.HandleDensifyAsync(context, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<IResult> HandleConvexHull(
+        HttpContext context,
+        GeometryServiceHandler handler)
+    {
+        var ct = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+        return await handler.HandleConvexHullAsync(context, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<IResult> HandleGeneralize(
+        HttpContext context,
+        GeometryServiceHandler handler)
+    {
+        var ct = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+        return await handler.HandleGeneralizeAsync(context, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<IResult> HandleLabelPoints(
+        HttpContext context,
+        GeometryServiceHandler handler)
+    {
+        var ct = TimeoutTokenHelper.GetTimeoutAwareCancellationToken(context);
+        return await handler.HandleLabelPointsAsync(context, ct).ConfigureAwait(false);
     }
 }

--- a/src/Honua.Protocols.GeoServices/GeometryService/Models/GeometryServiceJsonContext.cs
+++ b/src/Honua.Protocols.GeoServices/GeometryService/Models/GeometryServiceJsonContext.cs
@@ -16,6 +16,9 @@ namespace Honua.Protocols.GeoServices.GeometryService.Models;
 [JsonSerializable(typeof(GeometryServiceSpatialReference))]
 [JsonSerializable(typeof(GeometryServiceAreasAndLengthsResponse))]
 [JsonSerializable(typeof(GeometryServiceLengthResponse))]
+[JsonSerializable(typeof(GeometryServiceDistanceResponse))]
+[JsonSerializable(typeof(GeometryServiceRelationResponse))]
+[JsonSerializable(typeof(GeometryServiceGeometryResponse))]
 [JsonSerializable(typeof(GeometryServiceErrorResponse))]
 [JsonSerializable(typeof(JsonElement))]
 internal sealed partial class GeometryServiceJsonContext : JsonSerializerContext;

--- a/src/Honua.Protocols.GeoServices/GeometryService/Models/GeometryServiceRequests.cs
+++ b/src/Honua.Protocols.GeoServices/GeometryService/Models/GeometryServiceRequests.cs
@@ -65,6 +65,71 @@ internal sealed class UnionParameters
 }
 
 /// <summary>
+/// Parsed parameters for the distance operation (closest distance between two geometries).
+/// </summary>
+internal sealed class DistanceParameters
+{
+    public required string Geometry1Json { get; init; }
+    public required string Geometry2Json { get; init; }
+    public int SR { get; init; }
+    public string? DistanceUnit { get; init; }
+    public bool Geodesic { get; init; }
+}
+
+/// <summary>
+/// Parsed parameters for the relation operation (pairwise spatial relation testing).
+/// </summary>
+internal sealed class RelationParameters
+{
+    public required string[] Geometries1Json { get; init; }
+    public required string[] Geometries2Json { get; init; }
+    public int SR { get; init; }
+    public required string Relation { get; init; }
+    public string? RelationParam { get; init; }
+}
+
+/// <summary>
+/// Parsed parameters for the densify operation (insert vertices along segments).
+/// </summary>
+internal sealed class DensifyParameters
+{
+    public required string[] GeometryJsonStrings { get; init; }
+    public string? GeometryType { get; init; }
+    public int SR { get; init; }
+    public double MaxSegmentLength { get; init; }
+}
+
+/// <summary>
+/// Parsed parameters for the convexHull operation.
+/// </summary>
+internal sealed class ConvexHullParameters
+{
+    public required string[] GeometryJsonStrings { get; init; }
+    public string? GeometryType { get; init; }
+    public int SR { get; init; }
+}
+
+/// <summary>
+/// Parsed parameters for the generalize operation (Douglas-Peucker simplification).
+/// </summary>
+internal sealed class GeneralizeParameters
+{
+    public required string[] GeometryJsonStrings { get; init; }
+    public string? GeometryType { get; init; }
+    public int SR { get; init; }
+    public double MaxDeviation { get; init; }
+}
+
+/// <summary>
+/// Parsed parameters for the labelPoints operation (interior point of each polygon).
+/// </summary>
+internal sealed class LabelPointsParameters
+{
+    public required string[] GeometryJsonStrings { get; init; }
+    public int SR { get; init; }
+}
+
+/// <summary>
 /// Parsed parameters for area and length operations.
 /// </summary>
 internal enum MeasurementCalculationType

--- a/src/Honua.Protocols.GeoServices/GeometryService/Models/GeometryServiceResponses.cs
+++ b/src/Honua.Protocols.GeoServices/GeometryService/Models/GeometryServiceResponses.cs
@@ -61,6 +61,60 @@ public sealed class GeometryServiceLengthResponse
 }
 
 /// <summary>
+/// Response payload for the <c>distance</c> operation.
+/// </summary>
+public sealed class GeometryServiceDistanceResponse
+{
+    /// <summary>
+    /// Distance between the two input geometries, expressed in the requested distance unit.
+    /// </summary>
+    [JsonPropertyName("distance")]
+    public double Distance { get; init; }
+}
+
+/// <summary>
+/// Response payload for the <c>relation</c> operation.
+/// </summary>
+public sealed class GeometryServiceRelationResponse
+{
+    /// <summary>
+    /// Index pairs identifying which input geometries satisfy the requested spatial relation.
+    /// </summary>
+    [JsonPropertyName("relations")]
+    public GeometryServiceRelationPair[]? Relations { get; init; }
+}
+
+/// <summary>
+/// A single relation match identifying a geometry from each input set.
+/// </summary>
+public sealed class GeometryServiceRelationPair
+{
+    /// <summary>
+    /// Zero-based index of the matching geometry in the first input set (<c>geometries1</c>).
+    /// </summary>
+    [JsonPropertyName("geometry1Index")]
+    public int Geometry1Index { get; init; }
+
+    /// <summary>
+    /// Zero-based index of the matching geometry in the second input set (<c>geometries2</c>).
+    /// </summary>
+    [JsonPropertyName("geometry2Index")]
+    public int Geometry2Index { get; init; }
+}
+
+/// <summary>
+/// Response payload for operations that return a single geometry (for example <c>convexHull</c>).
+/// </summary>
+public sealed class GeometryServiceGeometryResponse
+{
+    /// <summary>
+    /// Result geometry in GeoServices JSON format.
+    /// </summary>
+    [JsonPropertyName("geometry")]
+    public JsonElement Geometry { get; init; }
+}
+
+/// <summary>
 /// Error response for geometry service operations.
 /// </summary>
 public sealed class GeometryServiceErrorResponse

--- a/src/Honua.Protocols.GeoServices/GeometryService/Services/GeometryServiceHandler.cs
+++ b/src/Honua.Protocols.GeoServices/GeometryService/Services/GeometryServiceHandler.cs
@@ -641,6 +641,724 @@ internal sealed class GeometryServiceHandler(
         }
     }
 
+    public async Task<IResult> HandleDistanceAsync(HttpContext context, CancellationToken ct)
+    {
+        using var scope = HonuaTelemetryScope.StartFeature(
+            "distance", HonuaTelemetry.Protocols.GeometryService, "geometry");
+
+        try
+        {
+            var (values, parseError) = await GeometryServiceRequestParser.TryReadRequestValuesAsync(context.Request, ct);
+            var requestLimits = ResolveRequestLimits(context);
+            if (values is null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "distance", parseError ?? "No parameters");
+                return CreateRequestParameterError(context, parseError);
+            }
+
+            var formatError = GeometryServiceRequestParser.ValidateFormat(
+                GeometryServiceRequestParser.GetValue(values, "f"));
+            if (formatError is not null)
+            {
+                return CreateError(context, 400, formatError);
+            }
+
+            var (geometry1, geom1Error) = GeometryServiceRequestParser.ParseSingleGeometry(
+                GeometryServiceRequestParser.GetValue(values, "geometry1"),
+                "geometry1",
+                requestLimits.MaxGeometryJsonLength);
+            if (geom1Error is not null || string.IsNullOrWhiteSpace(geometry1))
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "distance", geom1Error ?? "Missing geometry1");
+                return CreateError(context, 400, geom1Error ?? "Parameter 'geometry1' is required.");
+            }
+
+            var (geometry2, geom2Error) = GeometryServiceRequestParser.ParseSingleGeometry(
+                GeometryServiceRequestParser.GetValue(values, "geometry2"),
+                "geometry2",
+                requestLimits.MaxGeometryJsonLength);
+            if (geom2Error is not null || string.IsNullOrWhiteSpace(geometry2))
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "distance", geom2Error ?? "Missing geometry2");
+                return CreateError(context, 400, geom2Error ?? "Parameter 'geometry2' is required.");
+            }
+
+            var (sr, srError) = await ResolveRequiredSpatialReferenceAsync(values, "sr", ct);
+            if (srError is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "distance", srError);
+                return CreateError(context, 400, srError);
+            }
+
+            var parameters = new DistanceParameters
+            {
+                Geometry1Json = geometry1,
+                Geometry2Json = geometry2,
+                SR = sr!.Value,
+                DistanceUnit = GeometryServiceRequestParser.GetValue(values, "distanceUnit"),
+                Geodesic = GeometryServiceRequestParser.ParseBool(
+                    GeometryServiceRequestParser.GetValue(values, "geodesic"))
+            };
+
+            var spatialContext = await ResolveMeasurementSpatialContextAsync(
+                context.RequestServices,
+                parameters.SR,
+                ct).ConfigureAwait(false);
+
+            return await ExecuteDistanceAsync(parameters, spatialContext, scope, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            GeometryServiceLog.InvalidGeometryInput(_logger, "distance", ex.Message);
+            scope.RecordException(ex);
+            return CreateError(context, 400, InvalidGeometryInputMessage);
+        }
+        catch (Exception ex)
+        {
+            GeometryServiceLog.GeometryOperationFailed(_logger, "distance", ex.Message, ex);
+            scope.RecordException(ex);
+            return CreateError(context, 500, "An internal error occurred during the distance operation.");
+        }
+    }
+
+    public async Task<IResult> HandleRelationAsync(HttpContext context, CancellationToken ct)
+    {
+        using var scope = HonuaTelemetryScope.StartFeature(
+            "relation", HonuaTelemetry.Protocols.GeometryService, "geometry");
+
+        try
+        {
+            var (values, parseError) = await GeometryServiceRequestParser.TryReadRequestValuesAsync(context.Request, ct);
+            var requestLimits = ResolveRequestLimits(context);
+            if (values is null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "relation", parseError ?? "No parameters");
+                return CreateRequestParameterError(context, parseError);
+            }
+
+            var formatError = GeometryServiceRequestParser.ValidateFormat(
+                GeometryServiceRequestParser.GetValue(values, "f"));
+            if (formatError is not null)
+            {
+                return CreateError(context, 400, formatError);
+            }
+
+            var (geometries1, _, geom1Error) = GeometryServiceRequestParser.ParseGeometries(
+                GeometryServiceRequestParser.GetValue(values, "geometries1"),
+                requestLimits.MaxGeometriesPerRequest,
+                requestLimits.MaxGeometryJsonLength);
+            if (geom1Error is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "relation", geom1Error);
+                return CreateError(context, 400, geom1Error.Replace("'geometries'", "'geometries1'", StringComparison.Ordinal));
+            }
+
+            var (geometries2, _, geom2Error) = GeometryServiceRequestParser.ParseGeometries(
+                GeometryServiceRequestParser.GetValue(values, "geometries2"),
+                requestLimits.MaxGeometriesPerRequest,
+                requestLimits.MaxGeometryJsonLength);
+            if (geom2Error is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "relation", geom2Error);
+                return CreateError(context, 400, geom2Error.Replace("'geometries'", "'geometries2'", StringComparison.Ordinal));
+            }
+
+            if (geometries1.Length == 0 || geometries2.Length == 0)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "relation", "No geometries provided");
+                return CreateError(context, 400, "Parameters 'geometries1' and 'geometries2' must each contain at least one geometry.");
+            }
+
+            var (sr, srError) = await ResolveRequiredSpatialReferenceAsync(values, "sr", ct);
+            if (srError is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "relation", srError);
+                return CreateError(context, 400, srError);
+            }
+
+            var relation = GeometryServiceRequestParser.GetValue(values, "relation");
+            if (string.IsNullOrWhiteSpace(relation))
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "relation", "Missing relation");
+                return CreateError(context, 400, "Parameter 'relation' is required.");
+            }
+
+            var relationParam = GeometryServiceRequestParser.GetValue(values, "relationParam");
+            if (RelationRequiresRelationParam(relation) && string.IsNullOrWhiteSpace(relationParam))
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "relation", "Missing relationParam");
+                return CreateError(
+                    context,
+                    400,
+                    "Parameter 'relationParam' (a DE-9IM pattern) is required when 'relation' is 'esriGeometryRelationRelation'.");
+            }
+
+            if (!IsSupportedRelation(relation))
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "relation", $"Unsupported relation '{relation}'");
+                return CreateError(
+                    context,
+                    400,
+                    $"Parameter 'relation' value '{relation}' is not supported.");
+            }
+
+            var parameters = new RelationParameters
+            {
+                Geometries1Json = geometries1,
+                Geometries2Json = geometries2,
+                SR = sr!.Value,
+                Relation = relation,
+                RelationParam = relationParam
+            };
+
+            return ExecuteRelation(parameters, scope);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            GeometryServiceLog.InvalidGeometryInput(_logger, "relation", ex.Message);
+            scope.RecordException(ex);
+            return CreateError(context, 400, InvalidGeometryInputMessage);
+        }
+        catch (Exception ex)
+        {
+            GeometryServiceLog.GeometryOperationFailed(_logger, "relation", ex.Message, ex);
+            scope.RecordException(ex);
+            return CreateError(context, 500, "An internal error occurred during the relation operation.");
+        }
+    }
+
+    public async Task<IResult> HandleDensifyAsync(HttpContext context, CancellationToken ct)
+    {
+        using var scope = HonuaTelemetryScope.StartFeature(
+            "densify", HonuaTelemetry.Protocols.GeometryService, "geometry");
+
+        try
+        {
+            var (values, parseError) = await GeometryServiceRequestParser.TryReadRequestValuesAsync(context.Request, ct);
+            var requestLimits = ResolveRequestLimits(context);
+            if (values is null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "densify", parseError ?? "No parameters");
+                return CreateRequestParameterError(context, parseError);
+            }
+
+            var formatError = GeometryServiceRequestParser.ValidateFormat(
+                GeometryServiceRequestParser.GetValue(values, "f"));
+            if (formatError is not null)
+            {
+                return CreateError(context, 400, formatError);
+            }
+
+            var (geomStrings, geomType, geomError) = GeometryServiceRequestParser.ParseGeometries(
+                GeometryServiceRequestParser.GetValue(values, "geometries"),
+                requestLimits.MaxGeometriesPerRequest,
+                requestLimits.MaxGeometryJsonLength);
+            if (geomError is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "densify", geomError);
+                return CreateError(context, 400, geomError);
+            }
+
+            if (geomStrings.Length == 0)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "densify", "No geometries provided");
+                return CreateError(context, 400, "Parameter 'geometries' must contain at least one geometry.");
+            }
+
+            var (sr, srError) = await ResolveRequiredSpatialReferenceAsync(values, "sr", ct);
+            if (srError is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "densify", srError);
+                return CreateError(context, 400, srError);
+            }
+
+            var (maxSegmentLength, segmentError) = ParseRequiredPositiveDouble(
+                GeometryServiceRequestParser.GetValue(values, "maxSegmentLength"),
+                "maxSegmentLength");
+            if (segmentError is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "densify", segmentError);
+                return CreateError(context, 400, segmentError);
+            }
+
+            var parameters = new DensifyParameters
+            {
+                GeometryJsonStrings = geomStrings,
+                GeometryType = geomType,
+                SR = sr!.Value,
+                MaxSegmentLength = maxSegmentLength
+            };
+
+            GeometryServiceLog.RequestParsed(_logger, "densify", parameters.GeometryJsonStrings.Length, parameters.GeometryType);
+            return ExecuteDensify(parameters, scope);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            GeometryServiceLog.InvalidGeometryInput(_logger, "densify", ex.Message);
+            scope.RecordException(ex);
+            return CreateError(context, 400, InvalidGeometryInputMessage);
+        }
+        catch (Exception ex)
+        {
+            GeometryServiceLog.GeometryOperationFailed(_logger, "densify", ex.Message, ex);
+            scope.RecordException(ex);
+            return CreateError(context, 500, "An internal error occurred during the densify operation.");
+        }
+    }
+
+    public async Task<IResult> HandleConvexHullAsync(HttpContext context, CancellationToken ct)
+    {
+        using var scope = HonuaTelemetryScope.StartFeature(
+            "convexHull", HonuaTelemetry.Protocols.GeometryService, "geometry");
+
+        try
+        {
+            var (values, parseError) = await GeometryServiceRequestParser.TryReadRequestValuesAsync(context.Request, ct);
+            var requestLimits = ResolveRequestLimits(context);
+            if (values is null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "convexHull", parseError ?? "No parameters");
+                return CreateRequestParameterError(context, parseError);
+            }
+
+            var formatError = GeometryServiceRequestParser.ValidateFormat(
+                GeometryServiceRequestParser.GetValue(values, "f"));
+            if (formatError is not null)
+            {
+                return CreateError(context, 400, formatError);
+            }
+
+            var (geomStrings, geomType, geomError) = GeometryServiceRequestParser.ParseGeometries(
+                GeometryServiceRequestParser.GetValue(values, "geometries"),
+                requestLimits.MaxGeometriesPerRequest,
+                requestLimits.MaxGeometryJsonLength);
+            if (geomError is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "convexHull", geomError);
+                return CreateError(context, 400, geomError);
+            }
+
+            if (geomStrings.Length == 0)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "convexHull", "No geometries provided");
+                return CreateError(context, 400, "Parameter 'geometries' must contain at least one geometry.");
+            }
+
+            var (sr, srError) = await ResolveRequiredSpatialReferenceAsync(values, "sr", ct);
+            if (srError is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "convexHull", srError);
+                return CreateError(context, 400, srError);
+            }
+
+            var parameters = new ConvexHullParameters
+            {
+                GeometryJsonStrings = geomStrings,
+                GeometryType = geomType,
+                SR = sr!.Value
+            };
+
+            GeometryServiceLog.RequestParsed(_logger, "convexHull", parameters.GeometryJsonStrings.Length, parameters.GeometryType);
+            return ExecuteConvexHull(parameters, scope);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            GeometryServiceLog.InvalidGeometryInput(_logger, "convexHull", ex.Message);
+            scope.RecordException(ex);
+            return CreateError(context, 400, InvalidGeometryInputMessage);
+        }
+        catch (Exception ex)
+        {
+            GeometryServiceLog.GeometryOperationFailed(_logger, "convexHull", ex.Message, ex);
+            scope.RecordException(ex);
+            return CreateError(context, 500, "An internal error occurred during the convexHull operation.");
+        }
+    }
+
+    public async Task<IResult> HandleGeneralizeAsync(HttpContext context, CancellationToken ct)
+    {
+        using var scope = HonuaTelemetryScope.StartFeature(
+            "generalize", HonuaTelemetry.Protocols.GeometryService, "geometry");
+
+        try
+        {
+            var (values, parseError) = await GeometryServiceRequestParser.TryReadRequestValuesAsync(context.Request, ct);
+            var requestLimits = ResolveRequestLimits(context);
+            if (values is null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "generalize", parseError ?? "No parameters");
+                return CreateRequestParameterError(context, parseError);
+            }
+
+            var formatError = GeometryServiceRequestParser.ValidateFormat(
+                GeometryServiceRequestParser.GetValue(values, "f"));
+            if (formatError is not null)
+            {
+                return CreateError(context, 400, formatError);
+            }
+
+            var (geomStrings, geomType, geomError) = GeometryServiceRequestParser.ParseGeometries(
+                GeometryServiceRequestParser.GetValue(values, "geometries"),
+                requestLimits.MaxGeometriesPerRequest,
+                requestLimits.MaxGeometryJsonLength);
+            if (geomError is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "generalize", geomError);
+                return CreateError(context, 400, geomError);
+            }
+
+            if (geomStrings.Length == 0)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "generalize", "No geometries provided");
+                return CreateError(context, 400, "Parameter 'geometries' must contain at least one geometry.");
+            }
+
+            var (sr, srError) = await ResolveRequiredSpatialReferenceAsync(values, "sr", ct);
+            if (srError is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "generalize", srError);
+                return CreateError(context, 400, srError);
+            }
+
+            var (maxDeviation, deviationError) = ParseRequiredPositiveDouble(
+                GeometryServiceRequestParser.GetValue(values, "maxDeviation"),
+                "maxDeviation");
+            if (deviationError is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "generalize", deviationError);
+                return CreateError(context, 400, deviationError);
+            }
+
+            var parameters = new GeneralizeParameters
+            {
+                GeometryJsonStrings = geomStrings,
+                GeometryType = geomType,
+                SR = sr!.Value,
+                MaxDeviation = maxDeviation
+            };
+
+            GeometryServiceLog.RequestParsed(_logger, "generalize", parameters.GeometryJsonStrings.Length, parameters.GeometryType);
+            return ExecuteGeneralize(parameters, scope);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            GeometryServiceLog.InvalidGeometryInput(_logger, "generalize", ex.Message);
+            scope.RecordException(ex);
+            return CreateError(context, 400, InvalidGeometryInputMessage);
+        }
+        catch (Exception ex)
+        {
+            GeometryServiceLog.GeometryOperationFailed(_logger, "generalize", ex.Message, ex);
+            scope.RecordException(ex);
+            return CreateError(context, 500, "An internal error occurred during the generalize operation.");
+        }
+    }
+
+    public async Task<IResult> HandleLabelPointsAsync(HttpContext context, CancellationToken ct)
+    {
+        using var scope = HonuaTelemetryScope.StartFeature(
+            "labelPoints", HonuaTelemetry.Protocols.GeometryService, "geometry");
+
+        try
+        {
+            var (values, parseError) = await GeometryServiceRequestParser.TryReadRequestValuesAsync(context.Request, ct);
+            var requestLimits = ResolveRequestLimits(context);
+            if (values is null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "labelPoints", parseError ?? "No parameters");
+                return CreateRequestParameterError(context, parseError);
+            }
+
+            var formatError = GeometryServiceRequestParser.ValidateFormat(
+                GeometryServiceRequestParser.GetValue(values, "f"));
+            if (formatError is not null)
+            {
+                return CreateError(context, 400, formatError);
+            }
+
+            var polygons = GetPreferredValue(values, "polygons", "geometries");
+            if (string.IsNullOrWhiteSpace(polygons))
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "labelPoints", "Missing polygons");
+                return CreateError(context, 400, "Parameter 'polygons' is required.");
+            }
+
+            var (geomStrings, _, geomError) = GeometryServiceRequestParser.ParseGeometries(
+                polygons,
+                requestLimits.MaxGeometriesPerRequest,
+                requestLimits.MaxGeometryJsonLength);
+            if (geomError is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "labelPoints", geomError);
+                return CreateError(context, 400, geomError.Replace("'geometries'", "'polygons'", StringComparison.Ordinal));
+            }
+
+            if (geomStrings.Length == 0)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "labelPoints", "No geometries provided");
+                return CreateError(context, 400, "Parameter 'polygons' must contain at least one geometry.");
+            }
+
+            var (sr, srError) = await ResolveRequiredSpatialReferenceAsync(values, "sr", ct);
+            if (srError is not null)
+            {
+                GeometryServiceLog.InvalidGeometryInput(_logger, "labelPoints", srError);
+                return CreateError(context, 400, srError);
+            }
+
+            var parameters = new LabelPointsParameters
+            {
+                GeometryJsonStrings = geomStrings,
+                SR = sr!.Value
+            };
+
+            GeometryServiceLog.RequestParsed(_logger, "labelPoints", parameters.GeometryJsonStrings.Length, "esriGeometryPolygon");
+            return ExecuteLabelPoints(parameters, scope);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            GeometryServiceLog.InvalidGeometryInput(_logger, "labelPoints", ex.Message);
+            scope.RecordException(ex);
+            return CreateError(context, 400, InvalidGeometryInputMessage);
+        }
+        catch (Exception ex)
+        {
+            GeometryServiceLog.GeometryOperationFailed(_logger, "labelPoints", ex.Message, ex);
+            scope.RecordException(ex);
+            return CreateError(context, 500, "An internal error occurred during the labelPoints operation.");
+        }
+    }
+
+    private async Task<IResult> ExecuteDistanceAsync(
+        DistanceParameters parameters,
+        MeasurementSpatialContext spatialContext,
+        HonuaTelemetryScope scope,
+        CancellationToken ct)
+    {
+        var geometry1 = ReadGeometry(parameters.Geometry1Json);
+        var geometry2 = ReadGeometry(parameters.Geometry2Json);
+
+        double distanceMeters;
+        if (parameters.Geodesic)
+        {
+            // Build a polyline between the closest points of the two geometries and
+            // measure it geodesically through the shared measurement pipeline (projects
+            // to EPSG:4326 and uses ST_Length on geography). This reuses the same
+            // geodesic path that 'lengths' relies on.
+            var nearest = NetTopologySuite.Operation.Distance.DistanceOp.NearestPoints(geometry1, geometry2);
+            var lineWkb = new WKBWriter().Write(
+                geometry1.Factory.CreateLineString([nearest[0], nearest[1]]));
+            var measurementGeometry = await ProjectForGeodeticMeasurementAsync(lineWkb, parameters.SR, ct).ConfigureAwait(false);
+            distanceMeters = await _operationService.LengthAsync(measurementGeometry, 4326, ct).ConfigureAwait(false);
+        }
+        else
+        {
+            distanceMeters = geometry1.Distance(geometry2) * spatialContext.MetersPerNativeUnit;
+        }
+
+        var distance = string.IsNullOrWhiteSpace(parameters.DistanceUnit)
+            ? (parameters.Geodesic
+                ? distanceMeters
+                : geometry1.Distance(geometry2))
+            : ConvertLengthFromMeters(distanceMeters, parameters.DistanceUnit);
+
+        var response = new GeometryServiceDistanceResponse { Distance = distance };
+        GeometryServiceLog.MeasurementOperationCompleted(_logger, "distance", 1);
+        scope.SetSuccess(1);
+        return Results.Json(response, GeometryServiceJsonContext.Default.GeometryServiceDistanceResponse, contentType: "application/json");
+    }
+
+    private IResult ExecuteRelation(RelationParameters parameters, HonuaTelemetryScope scope)
+    {
+        var geometries1 = new Geometry[parameters.Geometries1Json.Length];
+        for (var i = 0; i < geometries1.Length; i++)
+        {
+            geometries1[i] = ReadGeometry(parameters.Geometries1Json[i]);
+        }
+
+        var geometries2 = new Geometry[parameters.Geometries2Json.Length];
+        for (var j = 0; j < geometries2.Length; j++)
+        {
+            geometries2[j] = ReadGeometry(parameters.Geometries2Json[j]);
+        }
+
+        var matches = new List<GeometryServiceRelationPair>();
+        for (var i = 0; i < geometries1.Length; i++)
+        {
+            for (var j = 0; j < geometries2.Length; j++)
+            {
+                if (EvaluateRelation(parameters.Relation, parameters.RelationParam, geometries1[i], geometries2[j]))
+                {
+                    matches.Add(new GeometryServiceRelationPair { Geometry1Index = i, Geometry2Index = j });
+                }
+            }
+        }
+
+        var response = new GeometryServiceRelationResponse { Relations = matches.ToArray() };
+        GeometryServiceLog.BinaryOperationCompleted(_logger, "relation", matches.Count);
+        scope.SetSuccess(matches.Count);
+        return Results.Json(response, GeometryServiceJsonContext.Default.GeometryServiceRelationResponse, contentType: "application/json");
+    }
+
+    private IResult ExecuteDensify(DensifyParameters parameters, HonuaTelemetryScope scope)
+    {
+        var densified = new List<byte[]>(parameters.GeometryJsonStrings.Length);
+        var writer = new WKBWriter();
+        foreach (var geomJson in parameters.GeometryJsonStrings)
+        {
+            var geometry = ReadGeometry(geomJson);
+            var result = NetTopologySuite.Densify.Densifier.Densify(geometry, parameters.MaxSegmentLength);
+            densified.Add(writer.Write(result));
+        }
+
+        var response = ConvertToResponse(densified, parameters.SR, parameters.GeometryType);
+        GeometryServiceLog.SimplifyOperationCompleted(_logger, parameters.GeometryJsonStrings.Length);
+        scope.SetSuccess(densified.Count);
+        return Results.Json(response, GeometryServiceJsonContext.Default.GeometryServiceResponse, contentType: "application/json");
+    }
+
+    private IResult ExecuteConvexHull(ConvexHullParameters parameters, HonuaTelemetryScope scope)
+    {
+        var factory = NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory();
+        var geometries = new Geometry[parameters.GeometryJsonStrings.Length];
+        for (var i = 0; i < geometries.Length; i++)
+        {
+            geometries[i] = ReadGeometry(parameters.GeometryJsonStrings[i]);
+        }
+
+        // convexHull computes a single hull over the union of all input geometries.
+        var combined = geometries.Length == 1
+            ? geometries[0]
+            : factory.CreateGeometryCollection(geometries);
+        var hull = combined.ConvexHull();
+        var hullWkb = new WKBWriter().Write(hull);
+        var hullElement = _geometryConverter.ConvertWkbToGeoServicesGeometry(hullWkb, parameters.SR);
+
+        var response = new GeometryServiceGeometryResponse { Geometry = hullElement };
+        GeometryServiceLog.BinaryOperationCompleted(_logger, "convexHull", parameters.GeometryJsonStrings.Length);
+        scope.SetSuccess(1);
+        return Results.Json(response, GeometryServiceJsonContext.Default.GeometryServiceGeometryResponse, contentType: "application/json");
+    }
+
+    private IResult ExecuteGeneralize(GeneralizeParameters parameters, HonuaTelemetryScope scope)
+    {
+        var generalized = new List<byte[]>(parameters.GeometryJsonStrings.Length);
+        var writer = new WKBWriter();
+        foreach (var geomJson in parameters.GeometryJsonStrings)
+        {
+            var geometry = ReadGeometry(geomJson);
+            var result = NetTopologySuite.Simplify.DouglasPeuckerSimplifier.Simplify(geometry, parameters.MaxDeviation);
+            generalized.Add(writer.Write(result));
+        }
+
+        var response = ConvertToResponse(generalized, parameters.SR, parameters.GeometryType);
+        GeometryServiceLog.SimplifyOperationCompleted(_logger, parameters.GeometryJsonStrings.Length);
+        scope.SetSuccess(generalized.Count);
+        return Results.Json(response, GeometryServiceJsonContext.Default.GeometryServiceResponse, contentType: "application/json");
+    }
+
+    private IResult ExecuteLabelPoints(LabelPointsParameters parameters, HonuaTelemetryScope scope)
+    {
+        var points = new List<byte[]>(parameters.GeometryJsonStrings.Length);
+        var writer = new WKBWriter();
+        foreach (var geomJson in parameters.GeometryJsonStrings)
+        {
+            var geometry = ReadGeometry(geomJson);
+            // InteriorPoint is guaranteed to lie inside the polygon, matching the
+            // semantics ArcGIS uses for label placement points.
+            var labelPoint = geometry.InteriorPoint;
+            points.Add(writer.Write(labelPoint));
+        }
+
+        var response = ConvertToResponse(points, parameters.SR, "esriGeometryPoint");
+        GeometryServiceLog.BinaryOperationCompleted(_logger, "labelPoints", points.Count);
+        scope.SetSuccess(points.Count);
+        return Results.Json(response, GeometryServiceJsonContext.Default.GeometryServiceResponse, contentType: "application/json");
+    }
+
+    private Geometry ReadGeometry(string geometryJson)
+    {
+        var wkb = _geometryConverter.ConvertGeoServicesJsonToWkb(geometryJson);
+        return new WKBReader().Read(wkb);
+    }
+
+    private static (double Value, string? Error) ParseRequiredPositiveDouble(string? raw, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return (0, $"Parameter '{parameterName}' is required.");
+        }
+
+        if (!double.TryParse(raw.Trim(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var value)
+            || double.IsNaN(value) || double.IsInfinity(value) || value <= 0)
+        {
+            return (0, $"Parameter '{parameterName}' must be a positive number.");
+        }
+
+        return (value, null);
+    }
+
+    private static bool RelationRequiresRelationParam(string relation)
+        => string.Equals(relation, "esriGeometryRelationRelation", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsSupportedRelation(string relation)
+        => relation.ToLowerInvariant() switch
+        {
+            "esrigeometryrelationcross" => true,
+            "esrigeometryrelationdisjoint" => true,
+            "esrigeometryrelationin" => true,
+            "esrigeometryrelationinteriorintersection" => true,
+            "esrigeometryrelationintersection" => true,
+            "esrigeometryrelationlinetouch" => true,
+            "esrigeometryrelationoverlap" => true,
+            "esrigeometryrelationpointtouch" => true,
+            "esrigeometryrelationtouch" => true,
+            "esrigeometryrelationwithin" => true,
+            "esrigeometryrelationrelation" => true,
+            _ => false
+        };
+
+    private static bool EvaluateRelation(string relation, string? relationParam, Geometry geometry1, Geometry geometry2)
+        => relation.ToLowerInvariant() switch
+        {
+            "esrigeometryrelationcross" => geometry1.Crosses(geometry2),
+            "esrigeometryrelationdisjoint" => geometry1.Disjoint(geometry2),
+            "esrigeometryrelationin" => geometry1.Within(geometry2),
+            "esrigeometryrelationwithin" => geometry1.Within(geometry2),
+            "esrigeometryrelationinteriorintersection" => geometry1.Relate(geometry2, "T********"),
+            "esrigeometryrelationintersection" => geometry1.Intersects(geometry2),
+            "esrigeometryrelationoverlap" => geometry1.Overlaps(geometry2),
+            "esrigeometryrelationtouch" => geometry1.Touches(geometry2),
+            "esrigeometryrelationlinetouch" => geometry1.Relate(geometry2, "F***T****"),
+            "esrigeometryrelationpointtouch" => geometry1.Relate(geometry2, "FT*******"),
+            "esrigeometryrelationrelation" => geometry1.Relate(geometry2, relationParam!),
+            _ => false
+        };
+
     private async Task<IResult> ExecuteBufferAsync(BufferParameters parameters, HonuaTelemetryScope scope, CancellationToken ct)
     {
         // bufferSR cascade: buffer in bufferSR ?? outSR ?? inSR, then project to outSR ?? inSR

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -812,6 +812,18 @@ public static class EndpointRegistry
         new("POST", "/rest/services/Utilities/Geometry/GeometryServer/areasAndLengths"),
         new("GET", "/rest/services/Utilities/Geometry/GeometryServer/lengths"),
         new("POST", "/rest/services/Utilities/Geometry/GeometryServer/lengths"),
+        new("GET", "/rest/services/Utilities/Geometry/GeometryServer/distance"),
+        new("POST", "/rest/services/Utilities/Geometry/GeometryServer/distance"),
+        new("GET", "/rest/services/Utilities/Geometry/GeometryServer/relation"),
+        new("POST", "/rest/services/Utilities/Geometry/GeometryServer/relation"),
+        new("GET", "/rest/services/Utilities/Geometry/GeometryServer/densify"),
+        new("POST", "/rest/services/Utilities/Geometry/GeometryServer/densify"),
+        new("GET", "/rest/services/Utilities/Geometry/GeometryServer/convexHull"),
+        new("POST", "/rest/services/Utilities/Geometry/GeometryServer/convexHull"),
+        new("GET", "/rest/services/Utilities/Geometry/GeometryServer/generalize"),
+        new("POST", "/rest/services/Utilities/Geometry/GeometryServer/generalize"),
+        new("GET", "/rest/services/Utilities/Geometry/GeometryServer/labelPoints"),
+        new("POST", "/rest/services/Utilities/Geometry/GeometryServer/labelPoints"),
 
         // NAServer minimal mobile routing compatibility (#366)
         new("POST", "/rest/services/{serviceId}/NAServer/Route/solve"),

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceMeasureAnalysisTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceMeasureAnalysisTests.cs
@@ -1,0 +1,357 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Protocols.GeoServices.GeometryService.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService;
+
+/// <summary>
+/// Integration coverage for the measure/edit/analysis GeometryServer operations
+/// (#1301): distance, relation, densify, convexHull, generalize, labelPoints.
+/// These are the operations ArcGIS Pro and the ArcGIS API for Python invoke most
+/// frequently and which previously returned 404.
+/// </summary>
+[Protocol(TestProtocols.GeometryService)]
+[Collection("Database")]
+public sealed class GeometryServiceMeasureAnalysisTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    // --- distance ---
+
+    [IntegrationTest]
+    [Operation(Operations.Distance)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/distance")]
+    public async Task Distance_PostPlanarPoints_ReturnsClosestDistance()
+    {
+        var body = """
+        {
+            "geometry1": {"x": 0, "y": 0},
+            "geometry2": {"x": 3, "y": 4},
+            "sr": "3857",
+            "distanceUnit": "esriMeters"
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/distance",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceDistanceResponse);
+        result.Should().NotBeNull();
+        result!.Distance.Should().BeApproximately(5.0, 0.001);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Distance)]
+    [Endpoint("GET /rest/services/Utilities/Geometry/GeometryServer/distance")]
+    public async Task Distance_GetWithValidParameters_ReturnsDistance()
+    {
+        var geometry1 = Uri.EscapeDataString("""{"x":0,"y":0}""");
+        var geometry2 = Uri.EscapeDataString("""{"x":0,"y":1}""");
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/Utilities/Geometry/GeometryServer/distance?geometry1={geometry1}&geometry2={geometry2}&sr=4326&geodesic=true&distanceUnit=esriMeters");
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceDistanceResponse);
+        result.Should().NotBeNull();
+        // One degree of latitude is roughly 110-112 km.
+        result!.Distance.Should().BeGreaterThan(110_000d).And.BeLessThan(112_000d);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Distance)]
+    [Endpoint("GET /rest/services/Utilities/Geometry/GeometryServer/distance")]
+    public async Task Distance_GetMissingParameters_Returns400()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/distance?sr=4326");
+        response.Be400BadRequest();
+    }
+
+    // --- relation ---
+
+    [IntegrationTest]
+    [Operation(Operations.Relation)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/relation")]
+    public async Task Relation_PostIntersection_ReturnsMatchingPairs()
+    {
+        var body = """
+        {
+            "geometries1": {
+                "geometryType": "esriGeometryPolygon",
+                "geometries": [
+                    {"rings": [[[0,0],[2,0],[2,2],[0,2],[0,0]]]}
+                ]
+            },
+            "geometries2": {
+                "geometryType": "esriGeometryPolygon",
+                "geometries": [
+                    {"rings": [[[1,1],[3,1],[3,3],[1,3],[1,1]]]},
+                    {"rings": [[[10,10],[11,10],[11,11],[10,11],[10,10]]]}
+                ]
+            },
+            "sr": "4326",
+            "relation": "esriGeometryRelationIntersection"
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/relation",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceRelationResponse);
+        result.Should().NotBeNull();
+        result!.Relations.Should().ContainSingle();
+        result.Relations![0].Geometry1Index.Should().Be(0);
+        result.Relations[0].Geometry2Index.Should().Be(0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Relation)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/relation")]
+    public async Task Relation_PostRelationPattern_UsesDe9imParam()
+    {
+        var body = """
+        {
+            "geometries1": {
+                "geometryType": "esriGeometryPolygon",
+                "geometries": [
+                    {"rings": [[[0,0],[2,0],[2,2],[0,2],[0,0]]]}
+                ]
+            },
+            "geometries2": {
+                "geometryType": "esriGeometryPolygon",
+                "geometries": [
+                    {"rings": [[[1,1],[3,1],[3,3],[1,3],[1,1]]]}
+                ]
+            },
+            "sr": "4326",
+            "relation": "esriGeometryRelationRelation",
+            "relationParam": "T********"
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/relation",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceRelationResponse);
+        result.Should().NotBeNull();
+        result!.Relations.Should().ContainSingle();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Relation)]
+    [Endpoint("GET /rest/services/Utilities/Geometry/GeometryServer/relation")]
+    public async Task Relation_GetMissingRelation_Returns400()
+    {
+        var geometries1 = Uri.EscapeDataString("""{"geometryType":"esriGeometryPolygon","geometries":[{"rings":[[[0,0],[2,0],[2,2],[0,2],[0,0]]]}]}""");
+        var geometries2 = Uri.EscapeDataString("""{"geometryType":"esriGeometryPolygon","geometries":[{"rings":[[[1,1],[3,1],[3,3],[1,3],[1,1]]]}]}""");
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/Utilities/Geometry/GeometryServer/relation?geometries1={geometries1}&geometries2={geometries2}&sr=4326");
+
+        response.Be400BadRequest();
+    }
+
+    // --- densify ---
+
+    [IntegrationTest]
+    [Operation(Operations.Densify)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/densify")]
+    public async Task Densify_PostPolyline_AddsVertices()
+    {
+        var body = """
+        {
+            "geometries": {
+                "geometryType": "esriGeometryPolyline",
+                "geometries": [
+                    {"paths": [[[0,0],[10,0]]]}
+                ]
+            },
+            "sr": "3857",
+            "maxSegmentLength": 2.0
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/densify",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceResponse);
+        result.Should().NotBeNull();
+        result!.Geometries.Should().HaveCount(1);
+        // The 10-unit segment split at maxSegmentLength=2 must add interior vertices.
+        var paths = result.Geometries![0];
+        paths.TryGetProperty("paths", out var pathsElement).Should().BeTrue();
+        pathsElement[0].GetArrayLength().Should().BeGreaterThan(2);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Densify)]
+    [Endpoint("GET /rest/services/Utilities/Geometry/GeometryServer/densify")]
+    public async Task Densify_GetMissingMaxSegmentLength_Returns400()
+    {
+        var geometries = Uri.EscapeDataString("""{"geometryType":"esriGeometryPolyline","geometries":[{"paths":[[[0,0],[10,0]]]}]}""");
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/Utilities/Geometry/GeometryServer/densify?geometries={geometries}&sr=3857");
+
+        response.Be400BadRequest();
+    }
+
+    // --- convexHull ---
+
+    [IntegrationTest]
+    [Operation(Operations.ConvexHull)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/convexHull")]
+    public async Task ConvexHull_PostMultiplePoints_ReturnsHullPolygon()
+    {
+        var body = """
+        {
+            "geometries": {
+                "geometryType": "esriGeometryPoint",
+                "geometries": [
+                    {"x": 0, "y": 0},
+                    {"x": 4, "y": 0},
+                    {"x": 4, "y": 4},
+                    {"x": 0, "y": 4},
+                    {"x": 2, "y": 2}
+                ]
+            },
+            "sr": "4326"
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/convexHull",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceGeometryResponse);
+        result.Should().NotBeNull();
+        // The hull of the five points is a rectangle (rings present).
+        result!.Geometry.TryGetProperty("rings", out var rings).Should().BeTrue();
+        rings.GetArrayLength().Should().Be(1);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ConvexHull)]
+    [Endpoint("GET /rest/services/Utilities/Geometry/GeometryServer/convexHull")]
+    public async Task ConvexHull_GetMissingParameters_Returns400()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/convexHull?sr=4326");
+        response.Be400BadRequest();
+    }
+
+    // --- generalize ---
+
+    [IntegrationTest]
+    [Operation(Operations.Generalize)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/generalize")]
+    public async Task Generalize_PostPolyline_RemovesNearCollinearVertices()
+    {
+        var body = """
+        {
+            "geometries": {
+                "geometryType": "esriGeometryPolyline",
+                "geometries": [
+                    {"paths": [[[0,0],[5,0.01],[10,0]]]}
+                ]
+            },
+            "sr": "3857",
+            "maxDeviation": 1.0
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/generalize",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceResponse);
+        result.Should().NotBeNull();
+        result!.Geometries.Should().HaveCount(1);
+        var paths = result.Geometries![0];
+        paths.TryGetProperty("paths", out var pathsElement).Should().BeTrue();
+        // The near-collinear middle vertex should be dropped, leaving 2 points.
+        pathsElement[0].GetArrayLength().Should().Be(2);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Generalize)]
+    [Endpoint("GET /rest/services/Utilities/Geometry/GeometryServer/generalize")]
+    public async Task Generalize_GetMissingMaxDeviation_Returns400()
+    {
+        var geometries = Uri.EscapeDataString("""{"geometryType":"esriGeometryPolyline","geometries":[{"paths":[[[0,0],[10,0]]]}]}""");
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/Utilities/Geometry/GeometryServer/generalize?geometries={geometries}&sr=3857");
+
+        response.Be400BadRequest();
+    }
+
+    // --- labelPoints ---
+
+    [IntegrationTest]
+    [Operation(Operations.LabelPoints)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/labelPoints")]
+    public async Task LabelPoints_PostPolygons_ReturnsInteriorPoints()
+    {
+        var body = """
+        {
+            "polygons": [
+                {"rings": [[[0,0],[10,0],[10,10],[0,10],[0,0]]]}
+            ],
+            "sr": "4326"
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/labelPoints",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceResponse);
+        result.Should().NotBeNull();
+        result!.Geometries.Should().HaveCount(1);
+        result.Geometries![0].TryGetProperty("x", out _).Should().BeTrue();
+        result.Geometries[0].TryGetProperty("y", out _).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.LabelPoints)]
+    [Endpoint("GET /rest/services/Utilities/Geometry/GeometryServer/labelPoints")]
+    public async Task LabelPoints_GetMissingParameters_Returns400()
+    {
+        var response = await _fixture.Client.GetAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/labelPoints?sr=4326");
+        response.Be400BadRequest();
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Constants/Operations.cs
+++ b/tests/dotnet/Honua.TestKit/Constants/Operations.cs
@@ -41,6 +41,12 @@ public static class Operations
     public const string Difference = "Difference";
     public const string Area = "Area";
     public const string Length = "Length";
+    public const string Distance = "Distance";
+    public const string Relation = "Relation";
+    public const string Densify = "Densify";
+    public const string ConvexHull = "ConvexHull";
+    public const string Generalize = "Generalize";
+    public const string LabelPoints = "LabelPoints";
 
     // Metadata Operations
     public const string GetMetadata = "GetMetadata";


### PR DESCRIPTION
## Issue Link
Fixes #1301

## Summary
Adds six previously-404 GeometryServer operations that ArcGIS Pro and the ArcGIS API for Python use for measure, edit, and analysis workflows: `distance`, `relation`, `densify`, `convexHull`, `generalize`, and `labelPoints`. Each is a thin protocol adapter that parses the Esri request shape, reuses the existing geometry/CRS helpers (`IGeometryConverter`, `SpatialReferenceResolver`, `IGeometryOperationService`, and the shared measurement pipeline), and formats the documented Esri response shape. No parallel geometry path is introduced.

## Changes Made
- Implemented `distance` (closest distance; planar in SR units or geodesic via the shared measurement/projection pipeline), `relation` (pairwise spatial relation testing including DE-9IM `relationParam`), `densify`, `convexHull`, `generalize`, and `labelPoints` handlers in `GeometryServiceHandler`.
- Registered GET+POST routes for all six operations in `GeometryServiceEndpoints` (POST marked `AllowAnonymous`, matching the existing stateless-geometry pattern) and added them to `EndpointRegistry`.
- Added request-parameter and response DTOs (`GeometryServiceDistanceResponse`, `GeometryServiceRelationResponse`/`GeometryServiceRelationPair`, `GeometryServiceGeometryResponse`) and registered them in the source-generated `GeometryServiceJsonContext`.
- Updated the GeometryServer service descriptor to advertise the new operations.
- Added `Distance`/`Relation`/`Densify`/`ConvexHull`/`Generalize`/`LabelPoints` test operation constants.
- Added 14 integration tests in `GeometryServiceMeasureAnalysisTests` exercising each operation (GET+POST, happy path and 400 validation) with realistic geometry input.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None — purely additive. The remaining GeometryServer operations (`cut`, `trimExtend`, `offset`, `autoComplete`, `reshape`, `findTransformations`, `toGeoCoordinateString`, `fromGeoCoordinateString`) stay 404 and are tracked as follow-up in #1301.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

> **Validation note:** build (warnings-as-errors) and the new integration tests pass locally; the full Core server-test shard exceeds the 35-min cap on this shared box and runs in CI.
