### PR TITLE
feat: shared field-level validation error contract (Wave 0)

### DIFF
--- a/src/Honua.Core/Features/Validation/Contracts/FieldValidationError.cs
+++ b/src/Honua.Core/Features/Validation/Contracts/FieldValidationError.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Validation.Contracts;
+
+/// <summary>
+/// Shared field-level validation error contract returned by validate and
+/// publish endpoints. This is the single wire shape all field-addressable
+/// validators converge on; it is modeled on the canonical Studio package
+/// diagnostic (<c>{code,severity,path,message}</c>) and adds an optional
+/// <see cref="FieldId"/> alias for shapes that address fields by id rather
+/// than by JSON Pointer path.
+/// </summary>
+public sealed record FieldValidationError
+{
+    /// <summary>Machine-friendly, stable error code.</summary>
+    [JsonPropertyName("code")]
+    public required string Code { get; init; }
+
+    /// <summary>Severity of the error (info/warning/error/blocker).</summary>
+    [JsonPropertyName("severity")]
+    public required ValidationSeverity Severity { get; init; }
+
+    /// <summary>
+    /// JSON Pointer (RFC 6901) or dotted field path identifying the location
+    /// of the error within the validated document. Null when the error is not
+    /// addressable to a specific location.
+    /// </summary>
+    [JsonPropertyName("path")]
+    public string? Path { get; init; }
+
+    /// <summary>Human-readable error message.</summary>
+    [JsonPropertyName("message")]
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// Optional field identifier alias. Some validators address fields by a
+    /// logical field id rather than a document path; consumers may use this to
+    /// bind errors to inputs when <see cref="Path"/> is absent or coarse.
+    /// </summary>
+    [JsonPropertyName("fieldId")]
+    public string? FieldId { get; init; }
+
+    /// <summary>
+    /// Creates a field-level error.
+    /// </summary>
+    /// <param name="code">Stable machine-readable code.</param>
+    /// <param name="message">Human-readable message.</param>
+    /// <param name="severity">Severity; defaults to <see cref="ValidationSeverity.Error"/>.</param>
+    /// <param name="path">Optional JSON Pointer or dotted path.</param>
+    /// <param name="fieldId">Optional field id alias.</param>
+    /// <returns>A populated <see cref="FieldValidationError"/>.</returns>
+    public static FieldValidationError Create(
+        string code,
+        string message,
+        ValidationSeverity severity = ValidationSeverity.Error,
+        string? path = null,
+        string? fieldId = null)
+        => new()
+        {
+            Code = code,
+            Message = message,
+            Severity = severity,
+            Path = path,
+            FieldId = fieldId,
+        };
+}

--- a/src/Honua.Core/Features/Validation/Contracts/FieldValidationErrorConverters.cs
+++ b/src/Honua.Core/Features/Validation/Contracts/FieldValidationErrorConverters.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Forms.Packages;
+using Honua.Core.Features.Studio.Domain;
+using Honua.Core.Features.WorkflowPackages.Domain;
+
+namespace Honua.Core.Features.Validation.Contracts;
+
+/// <summary>
+/// Normalizes the existing field-addressable validation shapes onto the shared
+/// <see cref="FieldValidationError"/> contract without changing what is
+/// validated. Covers the three already-structured shapes:
+/// Studio package diagnostics (<see cref="StudioValidationDiagnostic"/>),
+/// Form package issues (<see cref="FormValidationIssue"/>), and Workflow
+/// package failures (<see cref="WorkflowPackageValidationFailure"/>). The flat
+/// throwers (Analysis content, Content publication) are intentionally not
+/// handled here.
+/// </summary>
+public static class FieldValidationErrorConverters
+{
+    /// <summary>
+    /// Converts a Studio package diagnostic to the shared contract. The Studio
+    /// shape is the canonical template, so this is a structural rename only.
+    /// </summary>
+    /// <param name="diagnostic">Studio diagnostic.</param>
+    /// <returns>The normalized <see cref="FieldValidationError"/>.</returns>
+    public static FieldValidationError ToFieldValidationError(this StudioValidationDiagnostic diagnostic)
+    {
+        ArgumentNullException.ThrowIfNull(diagnostic);
+
+        return new FieldValidationError
+        {
+            Code = diagnostic.Code,
+            Severity = MapSeverity(diagnostic.Severity),
+            Path = diagnostic.Path,
+            Message = diagnostic.Message,
+        };
+    }
+
+    /// <summary>
+    /// Converts a Form package validation issue to the shared contract,
+    /// preserving the field id alias alongside the path.
+    /// </summary>
+    /// <param name="issue">Form validation issue.</param>
+    /// <returns>The normalized <see cref="FieldValidationError"/>.</returns>
+    public static FieldValidationError ToFieldValidationError(this FormValidationIssue issue)
+    {
+        ArgumentNullException.ThrowIfNull(issue);
+
+        return new FieldValidationError
+        {
+            Code = issue.Code,
+            Severity = ParseSeverity(issue.Severity),
+            Path = issue.Path,
+            Message = issue.Message,
+            FieldId = issue.FieldId,
+        };
+    }
+
+    /// <summary>
+    /// Converts a Workflow package validation failure to the shared contract.
+    /// Failures are always blocking, and the workflow-specific <c>fieldPath</c>
+    /// is normalized onto <see cref="FieldValidationError.Path"/>.
+    /// </summary>
+    /// <param name="failure">Workflow validation failure.</param>
+    /// <returns>The normalized <see cref="FieldValidationError"/>.</returns>
+    public static FieldValidationError ToFieldValidationError(this WorkflowPackageValidationFailure failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+
+        return new FieldValidationError
+        {
+            Code = failure.Code,
+            Severity = ValidationSeverity.Error,
+            Path = failure.FieldPath,
+            Message = failure.Message,
+        };
+    }
+
+    /// <summary>
+    /// Normalizes a Studio validation summary's diagnostics onto the shared
+    /// contract. Non-error diagnostics are preserved with their severity.
+    /// </summary>
+    /// <param name="summary">Studio validation summary.</param>
+    /// <returns>A <see cref="FieldValidationResult"/> mirroring the diagnostics.</returns>
+    public static FieldValidationResult ToFieldValidationResult(this StudioValidationSummary summary)
+    {
+        ArgumentNullException.ThrowIfNull(summary);
+
+        var errors = new List<FieldValidationError>(summary.Diagnostics.Count);
+        foreach (var diagnostic in summary.Diagnostics)
+        {
+            errors.Add(diagnostic.ToFieldValidationError());
+        }
+
+        return new FieldValidationResult { Errors = errors };
+    }
+
+    /// <summary>
+    /// Normalizes a Form package validation result onto the shared contract.
+    /// </summary>
+    /// <param name="result">Form validation result.</param>
+    /// <returns>A <see cref="FieldValidationResult"/> mirroring the issues.</returns>
+    public static FieldValidationResult ToFieldValidationResult(this FormPackageValidationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        var errors = new List<FieldValidationError>(result.Issues.Length);
+        foreach (var issue in result.Issues)
+        {
+            errors.Add(issue.ToFieldValidationError());
+        }
+
+        return new FieldValidationResult { Errors = errors };
+    }
+
+    /// <summary>
+    /// Normalizes a Workflow package validation result onto the shared
+    /// contract. Both blocking failures and non-fatal warnings are surfaced;
+    /// warnings carry the <c>workflow.validation.warning</c> code.
+    /// </summary>
+    /// <param name="result">Workflow validation result.</param>
+    /// <returns>A <see cref="FieldValidationResult"/> mirroring failures and warnings.</returns>
+    public static FieldValidationResult ToFieldValidationResult(this WorkflowPackageValidationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        var errors = new List<FieldValidationError>(result.Failures.Count + result.Warnings.Count);
+        foreach (var failure in result.Failures)
+        {
+            errors.Add(failure.ToFieldValidationError());
+        }
+
+        foreach (var warning in result.Warnings)
+        {
+            errors.Add(new FieldValidationError
+            {
+                Code = "workflow.validation.warning",
+                Severity = ValidationSeverity.Warning,
+                Message = warning,
+            });
+        }
+
+        return new FieldValidationResult { Errors = errors };
+    }
+
+    private static ValidationSeverity MapSeverity(StudioPackageDiagnosticSeverity severity) => severity switch
+    {
+        StudioPackageDiagnosticSeverity.Info => ValidationSeverity.Info,
+        StudioPackageDiagnosticSeverity.Warning => ValidationSeverity.Warning,
+        StudioPackageDiagnosticSeverity.Error => ValidationSeverity.Error,
+        StudioPackageDiagnosticSeverity.Blocker => ValidationSeverity.Blocker,
+        _ => ValidationSeverity.Error,
+    };
+
+    private static ValidationSeverity ParseSeverity(string? severity)
+        => severity?.ToLower(CultureInfo.InvariantCulture) switch
+        {
+            "info" => ValidationSeverity.Info,
+            "warning" => ValidationSeverity.Warning,
+            "blocker" => ValidationSeverity.Blocker,
+            _ => ValidationSeverity.Error,
+        };
+}

--- a/src/Honua.Core/Features/Validation/Contracts/FieldValidationResult.cs
+++ b/src/Honua.Core/Features/Validation/Contracts/FieldValidationResult.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Validation.Contracts;
+
+/// <summary>
+/// Wrapper around a collection of <see cref="FieldValidationError"/> items, the
+/// shared field-level validation result used across validate and publish
+/// endpoints. Named <c>FieldValidationResult</c> to avoid collision with the
+/// pre-existing query <c>ValidationResult</c> in
+/// <c>Honua.Core.Features.Validation</c>; it is the "ValidationResult wrapper"
+/// the form-validation contract refers to.
+/// </summary>
+public sealed record FieldValidationResult
+{
+    /// <summary>Shared empty (valid) result.</summary>
+    public static FieldValidationResult Valid { get; } = new();
+
+    /// <summary>The field-level errors.</summary>
+    [JsonPropertyName("errors")]
+    public IReadOnlyList<FieldValidationError> Errors { get; init; } = Array.Empty<FieldValidationError>();
+
+    /// <summary>
+    /// True when there are no error- or blocker-severity entries. Info and
+    /// warning entries do not invalidate the result.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsValid
+    {
+        get
+        {
+            foreach (var error in Errors)
+            {
+                if (error.Severity is ValidationSeverity.Error or ValidationSeverity.Blocker)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Creates a result from the supplied errors.
+    /// </summary>
+    /// <param name="errors">Field-level errors; null is treated as empty.</param>
+    /// <returns>A populated <see cref="FieldValidationResult"/>.</returns>
+    public static FieldValidationResult FromErrors(IEnumerable<FieldValidationError>? errors)
+        => errors is null
+            ? Valid
+            : new FieldValidationResult { Errors = errors as IReadOnlyList<FieldValidationError> ?? errors.ToList() };
+}

--- a/src/Honua.Core/Features/Validation/Contracts/ValidationContractJsonContext.cs
+++ b/src/Honua.Core/Features/Validation/Contracts/ValidationContractJsonContext.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Validation.Contracts;
+
+/// <summary>
+/// Source-generated JSON context for the shared field-level validation contract
+/// (<see cref="FieldValidationError"/> / <see cref="FieldValidationResult"/>).
+/// Keeps the contract AOT-serializable wherever it is emitted.
+/// </summary>
+[JsonSourceGenerationOptions(
+    JsonSerializerDefaults.General,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(FieldValidationError))]
+[JsonSerializable(typeof(FieldValidationError[]))]
+[JsonSerializable(typeof(IReadOnlyList<FieldValidationError>))]
+[JsonSerializable(typeof(FieldValidationResult))]
+public sealed partial class ValidationContractJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Core/Features/Validation/Contracts/ValidationSeverity.cs
+++ b/src/Honua.Core/Features/Validation/Contracts/ValidationSeverity.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Validation.Contracts;
+
+/// <summary>
+/// Severity of a single field-level validation error. Modeled on the Studio
+/// package diagnostic severity (the canonical, AOT/JSON-wired shape) so the
+/// shared <see cref="FieldValidationError"/> contract serializes identically.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<ValidationSeverity>))]
+public enum ValidationSeverity
+{
+    /// <summary>Informational diagnostic; does not block.</summary>
+    [JsonStringEnumMemberName("info")]
+    Info,
+
+    /// <summary>Warning diagnostic; does not block but should be surfaced.</summary>
+    [JsonStringEnumMemberName("warning")]
+    Warning,
+
+    /// <summary>Error diagnostic; blocks the validated subject.</summary>
+    [JsonStringEnumMemberName("error")]
+    Error,
+
+    /// <summary>Blocking diagnostic; hard stop.</summary>
+    [JsonStringEnumMemberName("blocker")]
+    Blocker,
+}

--- a/src/Honua.Hosting/Features/Models/ProblemDetailsHelpers.cs
+++ b/src/Honua.Hosting/Features/Models/ProblemDetailsHelpers.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Globalization;
+using Honua.Core.Features.Validation.Contracts;
 
 namespace Honua.Infrastructure.Models;
 
@@ -11,6 +12,7 @@ internal static class ProblemDetailsHelpers
     private const string OgcType = "about:blank";
     private const string AdminType = "https://honua.io/problems/admin";
     private const string SecurityType = "https://honua.io/problems/security";
+    private const string ValidationType = "https://honua.io/problems/validation";
 
     public static IResult CreateOgcProblem(HttpContext context, int statusCode, string detail)
         => CreateProblem(context, OgcType, statusCode, GetTitle(statusCode), detail);
@@ -38,6 +40,48 @@ internal static class ProblemDetailsHelpers
 
     public static IResult CreateSecurityProblem(HttpContext context, int statusCode, string title, string detail)
         => CreateProblem(context, SecurityType, statusCode, title, detail);
+
+    /// <summary>
+    /// Creates an RFC 7807 problem response carrying the shared field-level
+    /// validation contract as an <c>errors[]</c> extension member.
+    /// </summary>
+    /// <param name="context">Current request context.</param>
+    /// <param name="statusCode">HTTP status code (typically 400).</param>
+    /// <param name="errors">Field-level validation errors to surface.</param>
+    /// <param name="detail">Optional detail; a count-based default is used when omitted.</param>
+    /// <returns>A problem result with the <c>errors[]</c> extension.</returns>
+    public static IResult CreateValidationProblem(
+        HttpContext context,
+        int statusCode,
+        IReadOnlyList<FieldValidationError> errors,
+        string? detail = null)
+    {
+        ArgumentNullException.ThrowIfNull(errors);
+
+        var instance = BuildInstance(context);
+        var resolvedDetail = detail ?? BuildValidationDetail(errors.Count);
+        var problemDetails = CreateProblemDetails(
+            ValidationType,
+            statusCode,
+            GetTitle(statusCode),
+            resolvedDetail,
+            instance,
+            context) with
+        {
+            Errors = errors,
+        };
+
+        return Results.Json(
+            problemDetails,
+            ProblemJsonContext.Default.ProblemDetailsResponse,
+            statusCode: statusCode,
+            contentType: ContentType);
+    }
+
+    private static string BuildValidationDetail(int errorCount)
+        => errorCount == 1
+            ? "1 validation error occurred."
+            : string.Create(CultureInfo.InvariantCulture, $"{errorCount} validation errors occurred.");
 
     public static IResult CreateProblem(HttpContext context, string type, int statusCode, string title, string detail)
     {

--- a/src/Honua.Hosting/Features/Models/ProblemDetailsResponse.cs
+++ b/src/Honua.Hosting/Features/Models/ProblemDetailsResponse.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Validation.Contracts;
+
 namespace Honua.Infrastructure.Models;
 
 /// <summary>
@@ -42,4 +44,10 @@ internal sealed record ProblemDetailsResponse
     /// Timestamp for when the error occurred (UTC, ISO 8601).
     /// </summary>
     public string? Timestamp { get; init; }
+
+    /// <summary>
+    /// Field-level validation errors (RFC 7807 extension member). Emitted only
+    /// by validation problems; null/omitted for all other problem responses.
+    /// </summary>
+    public IReadOnlyList<FieldValidationError>? Errors { get; init; }
 }

--- a/src/Honua.Hosting/Features/Models/ProblemJsonContext.cs
+++ b/src/Honua.Hosting/Features/Models/ProblemJsonContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Text.Json.Serialization;
+using Honua.Core.Features.Validation.Contracts;
 
 namespace Honua.Infrastructure.Models;
 
@@ -9,6 +10,8 @@ namespace Honua.Infrastructure.Models;
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(ProblemDetailsResponse))]
+[JsonSerializable(typeof(FieldValidationError))]
+[JsonSerializable(typeof(IReadOnlyList<FieldValidationError>))]
 internal sealed partial class ProblemJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -639,6 +639,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
         Honua.Server.Features.CloudDemo.CloudDemoJsonContext.Default,
         Honua.Server.Features.HealthCheck.HealthJsonContext.Default,
         Honua.Infrastructure.Models.ProblemJsonContext.Default,
+        Honua.Core.Features.Validation.Contracts.ValidationContractJsonContext.Default,
         Honua.Infrastructure.Authentication.ClientCertificates.ClientCertificateInfrastructureJsonContext.Default,
         Honua.Infrastructure.Middleware.LimitsEnforcementJsonContext.Default,
         Honua.Infrastructure.Security.CspViolationJsonContext.Default,

--- a/src/Honua.Server/Startup/JsonContextRegistration.cs
+++ b/src/Honua.Server/Startup/JsonContextRegistration.cs
@@ -86,6 +86,7 @@ internal static class JsonContextRegistration
                 Honua.PackageReview.PackageReviewJsonContext.Default,
                 Honua.Server.Features.CloudDemo.CloudDemoJsonContext.Default,
                 Honua.Server.Features.HealthCheck.HealthJsonContext.Default,
+                Honua.Core.Features.Validation.Contracts.ValidationContractJsonContext.Default,
                 Honua.Infrastructure.Models.ProblemJsonContext.Default,
                 Honua.Infrastructure.Middleware.LimitsEnforcementJsonContext.Default,
                 Honua.Infrastructure.Security.CspViolationJsonContext.Default,

--- a/tests/dotnet/Honua.Core.Tests/Features/Validation/FieldValidationContractTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Validation/FieldValidationContractTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Forms.Packages;
+using Honua.Core.Features.Studio.Domain;
+using Honua.Core.Features.Validation.Contracts;
+using Honua.Core.Features.WorkflowPackages.Domain;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Core.Tests.Features.Validation;
+
+[Protocol(ProtocolNames.Admin)]
+public sealed class FieldValidationContractTests
+{
+    [UnitTest]
+    public void FieldValidationError_SerializesToCanonicalShape()
+    {
+        var error = FieldValidationError.Create(
+            code: "studio.map.initial-view.bbox.order",
+            message: "minX must be <= maxX.",
+            severity: ValidationSeverity.Blocker,
+            path: "/map/initialView/bbox",
+            fieldId: "InitialExtent");
+
+        var json = JsonSerializer.Serialize(error, ValidationContractJsonContext.Default.FieldValidationError);
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        root.GetProperty("code").GetString().Should().Be("studio.map.initial-view.bbox.order");
+        root.GetProperty("severity").GetString().Should().Be("blocker");
+        root.GetProperty("path").GetString().Should().Be("/map/initialView/bbox");
+        root.GetProperty("message").GetString().Should().Be("minX must be <= maxX.");
+        root.GetProperty("fieldId").GetString().Should().Be("InitialExtent");
+    }
+
+    [UnitTest]
+    public void FieldValidationError_OmitsNullPathAndFieldId()
+    {
+        var error = FieldValidationError.Create("generic.code", "message");
+
+        var json = JsonSerializer.Serialize(error, ValidationContractJsonContext.Default.FieldValidationError);
+
+        json.Should().NotContain("path");
+        json.Should().NotContain("fieldId");
+        json.Should().Contain("\"severity\":\"error\"");
+    }
+
+    [UnitTest]
+    public void FieldValidationResult_IsValid_TrueWhenOnlyInfoOrWarning()
+    {
+        var result = FieldValidationResult.FromErrors(new[]
+        {
+            FieldValidationError.Create("a", "info", ValidationSeverity.Info),
+            FieldValidationError.Create("b", "warn", ValidationSeverity.Warning),
+        });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void FieldValidationResult_IsValid_FalseWhenErrorOrBlocker()
+    {
+        FieldValidationResult.FromErrors(new[] { FieldValidationError.Create("a", "err", ValidationSeverity.Error) })
+            .IsValid.Should().BeFalse();
+        FieldValidationResult.FromErrors(new[] { FieldValidationError.Create("a", "block", ValidationSeverity.Blocker) })
+            .IsValid.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void FieldValidationResult_FromNull_IsValidEmpty()
+    {
+        var result = FieldValidationResult.FromErrors(null);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public void StudioDiagnostic_NormalizesPreservingAllFields()
+    {
+        var diagnostic = new StudioValidationDiagnostic
+        {
+            Code = "studio.binding.key.duplicate",
+            Severity = StudioPackageDiagnosticSeverity.Blocker,
+            Path = "/bindings/0/key",
+            Message = "Duplicate key.",
+        };
+
+        var error = diagnostic.ToFieldValidationError();
+
+        error.Code.Should().Be("studio.binding.key.duplicate");
+        error.Severity.Should().Be(ValidationSeverity.Blocker);
+        error.Path.Should().Be("/bindings/0/key");
+        error.Message.Should().Be("Duplicate key.");
+        error.FieldId.Should().BeNull();
+    }
+
+    [UnitTest]
+    public void FormIssue_NormalizesPreservingCodeSeverityFieldMessagePath()
+    {
+        var issue = new FormValidationIssue
+        {
+            Code = "fieldIdDuplicate",
+            Severity = "warning",
+            FieldId = "status",
+            Path = "fields.status",
+            Message = "Field id 'status' is duplicated.",
+        };
+
+        var error = issue.ToFieldValidationError();
+
+        error.Code.Should().Be("fieldIdDuplicate");
+        error.Severity.Should().Be(ValidationSeverity.Warning);
+        error.FieldId.Should().Be("status");
+        error.Path.Should().Be("fields.status");
+        error.Message.Should().Be("Field id 'status' is duplicated.");
+    }
+
+    [UnitTest]
+    public void FormIssue_UnknownSeverity_DefaultsToError()
+    {
+        var issue = new FormValidationIssue { Code = "c", Severity = "weird", Message = "m" };
+
+        issue.ToFieldValidationError().Severity.Should().Be(ValidationSeverity.Error);
+    }
+
+    [UnitTest]
+    public void WorkflowFailure_NormalizesFieldPathOntoPathAsError()
+    {
+        var failure = new WorkflowPackageValidationFailure
+        {
+            Code = "workflow.graph.cycle",
+            Message = "Graph has a cycle.",
+            FieldPath = "nodes[2]",
+        };
+
+        var error = failure.ToFieldValidationError();
+
+        error.Code.Should().Be("workflow.graph.cycle");
+        error.Severity.Should().Be(ValidationSeverity.Error);
+        error.Path.Should().Be("nodes[2]");
+        error.Message.Should().Be("Graph has a cycle.");
+    }
+
+    [UnitTest]
+    public void FormResult_RoundTripsAllIssues()
+    {
+        var formResult = new FormPackageValidationResult
+        {
+            IsValid = false,
+            Issues =
+            [
+                new FormValidationIssue { Code = "a", Severity = "error", FieldId = "f1", Path = "p1", Message = "m1" },
+                new FormValidationIssue { Code = "b", Severity = "warning", FieldId = "f2", Path = "p2", Message = "m2" },
+            ],
+        };
+
+        var normalized = formResult.ToFieldValidationResult();
+
+        normalized.Errors.Should().HaveCount(2);
+        normalized.Errors[0].Code.Should().Be("a");
+        normalized.Errors[0].FieldId.Should().Be("f1");
+        normalized.Errors[1].Severity.Should().Be(ValidationSeverity.Warning);
+        normalized.IsValid.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void StudioSummary_RoundTripsDiagnostics()
+    {
+        var summary = new StudioValidationSummary
+        {
+            Status = StudioPackageValidationStatus.Invalid,
+            Diagnostics =
+            [
+                new StudioValidationDiagnostic
+                {
+                    Code = "studio.visibility.enum",
+                    Severity = StudioPackageDiagnosticSeverity.Error,
+                    Path = "/publicationIntent/visibility",
+                    Message = "Unsupported visibility.",
+                },
+            ],
+        };
+
+        var normalized = summary.ToFieldValidationResult();
+
+        normalized.Errors.Should().ContainSingle();
+        normalized.Errors[0].Code.Should().Be("studio.visibility.enum");
+        normalized.Errors[0].Path.Should().Be("/publicationIntent/visibility");
+    }
+
+    [UnitTest]
+    public void WorkflowResult_SurfacesFailuresAndWarnings()
+    {
+        var result = WorkflowPackageValidationResult.Failed(
+            failures: [new WorkflowPackageValidationFailure { Code = "c", Message = "m", FieldPath = "fp" }],
+            warnings: ["deprecated node kind"]);
+
+        var normalized = result.ToFieldValidationResult();
+
+        normalized.Errors.Should().HaveCount(2);
+        normalized.Errors[0].Severity.Should().Be(ValidationSeverity.Error);
+        normalized.Errors[1].Code.Should().Be("workflow.validation.warning");
+        normalized.Errors[1].Severity.Should().Be(ValidationSeverity.Warning);
+        normalized.Errors[1].Message.Should().Be("deprecated node kind");
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Hosting/ValidationProblemDetailsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Hosting/ValidationProblemDetailsTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Validation.Contracts;
+using Honua.Infrastructure.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Server.Tests.Infrastructure.Hosting;
+
+/// <summary>
+/// Pins the wire shape emitted by
+/// <see cref="ProblemDetailsHelpers.CreateValidationProblem"/>: an RFC 7807
+/// problem document carrying the shared field-level validation contract as an
+/// <c>errors[]</c> extension member.
+/// </summary>
+public sealed class ValidationProblemDetailsTests
+{
+    [Fact]
+    public async Task CreateValidationProblem_EmitsErrorsExtensionAndProblemShape()
+    {
+        var errors = new List<FieldValidationError>
+        {
+            FieldValidationError.Create(
+                code: "fieldIdDuplicate",
+                message: "Field id 'status' is duplicated.",
+                severity: ValidationSeverity.Blocker,
+                path: "fields.status",
+                fieldId: "status"),
+            FieldValidationError.Create(
+                code: "rangeIncomplete",
+                message: "Range max is missing.",
+                severity: ValidationSeverity.Warning),
+        };
+
+        var (status, json) = await ExecuteAsync(
+            ProblemDetailsHelpers.CreateValidationProblem(BuildContext(), StatusCodes.Status400BadRequest, errors));
+
+        status.Should().Be(StatusCodes.Status400BadRequest);
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        root.GetProperty("type").GetString().Should().Be("https://honua.io/problems/validation");
+        root.GetProperty("title").GetString().Should().Be("Bad Request");
+        root.GetProperty("status").GetInt32().Should().Be(400);
+        root.GetProperty("detail").GetString().Should().Be("2 validation errors occurred.");
+
+        var emitted = root.GetProperty("errors");
+        emitted.GetArrayLength().Should().Be(2);
+
+        var first = emitted[0];
+        first.GetProperty("code").GetString().Should().Be("fieldIdDuplicate");
+        first.GetProperty("severity").GetString().Should().Be("blocker");
+        first.GetProperty("path").GetString().Should().Be("fields.status");
+        first.GetProperty("fieldId").GetString().Should().Be("status");
+        first.GetProperty("message").GetString().Should().Be("Field id 'status' is duplicated.");
+
+        var second = emitted[1];
+        second.GetProperty("severity").GetString().Should().Be("warning");
+        second.TryGetProperty("path", out _).Should().BeFalse("null path is omitted");
+        second.TryGetProperty("fieldId", out _).Should().BeFalse("null fieldId is omitted");
+    }
+
+    [Fact]
+    public async Task CreateValidationProblem_SingleError_UsesSingularDetail()
+    {
+        var errors = new List<FieldValidationError>
+        {
+            FieldValidationError.Create("c", "m"),
+        };
+
+        var (_, json) = await ExecuteAsync(
+            ProblemDetailsHelpers.CreateValidationProblem(BuildContext(), StatusCodes.Status400BadRequest, errors));
+
+        using var document = JsonDocument.Parse(json);
+        document.RootElement.GetProperty("detail").GetString().Should().Be("1 validation error occurred.");
+    }
+
+    [Fact]
+    public async Task CreateValidationProblem_HonorsExplicitDetail()
+    {
+        var (_, json) = await ExecuteAsync(
+            ProblemDetailsHelpers.CreateValidationProblem(
+                BuildContext(),
+                StatusCodes.Status400BadRequest,
+                [FieldValidationError.Create("c", "m")],
+                detail: "Form package is invalid."));
+
+        using var document = JsonDocument.Parse(json);
+        document.RootElement.GetProperty("detail").GetString().Should().Be("Form package is invalid.");
+    }
+
+    private static DefaultHttpContext BuildContext()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        return new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+            Request = { Path = "/api/v1/forms/packages/p1/validate" },
+            Response = { Body = new MemoryStream() },
+        };
+    }
+
+    private static async Task<(int Status, string Json)> ExecuteAsync(IResult result)
+    {
+        var context = BuildContext();
+        await result.ExecuteAsync(context);
+        context.Response.Body.Position = 0;
+        using var reader = new StreamReader(context.Response.Body, Encoding.UTF8);
+        var json = await reader.ReadToEndAsync();
+        return (context.Response.StatusCode, json);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #418

## Summary
Wave 0 (server side) of the form-validation initiative: a single field-level validation-error contract that all validate/publish endpoints can converge on. This wave establishes the contract, the RFC 7807 emission helper, and normalization of the already-structured field-addressable shapes onto the contract. It does not change what is validated.

## Changes Made
- Add `FieldValidationError {code, severity, path, message, fieldId?}` and a `FieldValidationResult` wrapper in `Honua.Core.Features.Validation.Contracts`, with a `ValidationSeverity` enum (info/warning/error/blocker). Modeled on the canonical `StudioValidationDiagnostic` (the existing AOT/JSON-wired template). Named `FieldValidationResult` to avoid collision with the pre-existing query `ValidationResult` in `Honua.Core.Features.Validation`.
- Add `ProblemDetailsHelpers.CreateValidationProblem(context, status, errors)` emitting RFC 7807 ProblemDetails with an `errors[]` extension member of `FieldValidationError` (new `https://honua.io/problems/validation` type).
- Add normalization converters mapping the existing field-addressable shapes onto the shared contract without behavior change: Studio diagnostics, Form `FormValidationIssue` (preserves `fieldId`+`path`), and Workflow `WorkflowPackageValidationFailure` (`fieldPath` -> `path`); plus summary/result-level converters. Studio `/validate` summary is left as-is (the template).
- Register the new types in the relevant AOT source-gen JSON contexts (`ValidationContractJsonContext` in Core, `FieldValidationError` added to `ProblemJsonContext`, and the new Core context wired into `JsonContextRegistration`).

The flat throwers (AnalysisContent, ContentPublication) are intentionally untouched — deferred to Waves 3/4.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Local results (Release):
- `dotnet format Honua.sln --verify-no-changes`: clean
- `Honua.Core.Tests` (contract primitive + Form/Workflow/Studio normalization round-trip + existing Form/Workflow validators): 37 passed, 0 failed
- `Honua.Server.Tests` `ValidationProblemDetailsTests` (errors[] emission shape): 3 passed; `EndpointRegistryDriftTests`/`OpenApiDriftTests`/`ApiSurfaceCoverageTests`: passed
- `Honua.Architecture.Tests`: 101 passed, 1 skipped

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact

(New additive shared contract type; no existing wire shape changed, no OpenAPI/endpoint change.)

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
