### PR TITLE
test(geoservices): cover returnDistinctValues with paramless where (#1280)

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -608,6 +608,100 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         queryResponse.HasM.Should().BeFalse();
     }
 
+    // Regression: returnDistinctValues=true with a paramless WHERE clause (the canonical
+    // ArcGIS "where=1=1" select-all) plus a named outFields previously returned HTTP 500
+    // ("Parameter '' cannot be null") because the unlimited count path mis-bound parameters.
+    // See issue #1280 — ArcGIS Pro's Unique Values renderer relies on this exact request.
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task QueryFeatures_ReturnDistinctValuesWithTautologicalWhere_Returns200WithDistinctValues()
+    {
+        // Act: where=1=1 produces no bound parameters; category has duplicate values across rows.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=1%3D1&outFields=category&returnDistinctValues=true&returnGeometry=false&f=json");
+
+        // Assert
+        response.Be200Ok();
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        var content = await response.Content.ReadAsStringAsync();
+        var queryResponse = JsonSerializer.Deserialize<QueryResponse>(
+            content, FeatureServerJsonContext.Default.QueryResponse);
+        queryResponse.Should().NotBeNull();
+        queryResponse!.Features.Should().NotBeNull();
+
+        // Seed layer 0 has categories test/sample/test/sample/test -> two distinct values.
+        var distinctCategories = queryResponse.Features!
+            .Select(feature => feature.Attributes.TryGetValue("category", out var value) ? value?.ToString() : null)
+            .Where(value => value is not null)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        queryResponse.Features!.Length.Should().Be(distinctCategories.Length);
+        distinctCategories.Should().HaveCount(2);
+        distinctCategories.Should().Contain("test");
+        distinctCategories.Should().Contain("sample");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task QueryFeatures_ReturnDistinctValuesWithContradictoryWhere_Returns200Empty()
+    {
+        // Act: where=1=2 is also paramless and matches nothing.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=1%3D2&outFields=category&returnDistinctValues=true&returnGeometry=false&f=json");
+
+        // Assert
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var queryResponse = JsonSerializer.Deserialize<QueryResponse>(
+            content, FeatureServerJsonContext.Default.QueryResponse);
+        queryResponse.Should().NotBeNull();
+        queryResponse!.Features.Should().NotBeNull();
+        queryResponse.Features!.Should().BeEmpty();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task QueryFeatures_ReturnDistinctValuesWithRealPredicate_Returns200WithDistinctValues()
+    {
+        // Act: a real bound predicate exercises the parameterized path alongside distinct.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=category='test'&outFields=category&returnDistinctValues=true&returnGeometry=false&f=json");
+
+        // Assert
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var queryResponse = JsonSerializer.Deserialize<QueryResponse>(
+            content, FeatureServerJsonContext.Default.QueryResponse);
+        queryResponse.Should().NotBeNull();
+        queryResponse!.Features.Should().NotBeNull();
+        queryResponse.Features!.Length.Should().Be(1);
+        queryResponse.Features![0].Attributes.TryGetValue("category", out var category).Should().BeTrue();
+        category?.ToString().Should().Be("test");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task QueryFeatures_ReturnDistinctValuesWithAllFields_Returns200()
+    {
+        // Act: outFields=* does not apply distinct, but must still succeed with where=1=1.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=1%3D1&outFields=*&returnDistinctValues=true&returnGeometry=false&f=json");
+
+        // Assert
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var queryResponse = JsonSerializer.Deserialize<QueryResponse>(
+            content, FeatureServerJsonContext.Default.QueryResponse);
+        queryResponse.Should().NotBeNull();
+        queryResponse!.Features.Should().NotBeNull();
+        queryResponse.Features!.Should().NotBeEmpty();
+    }
+
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/query")]


### PR DESCRIPTION
## Issue Link
Fixes #1280

## Summary
Issue #1280 reported that a FeatureServer `/query` with `returnDistinctValues=true` plus a parameter-less WHERE clause (the canonical ArcGIS `where=1=1` select-all, or `1=2`) and a named `outFields` returned HTTP 500 (`Parameter '' cannot be null` in the unlimited distinct count path). On current `trunk` this is no longer reproducible — the distinct/aggregation count and select paths bind parameters consistently for paramless predicates. This PR adds the missing integration coverage so the scenario stays green and the regression cannot silently return.

## Changes Made
- Added FeatureServer `/query` integration test for `returnDistinctValues=true&where=1=1&outFields=category` asserting HTTP 200 and correct distinct values.
- Added a `where=1=2` (contradictory, paramless) distinct case asserting HTTP 200 with an empty result set.
- Added a `where=category='test'` (real bound predicate) distinct case and an `outFields=*` distinct case, matching the acceptance criteria in the issue.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

> **Validation note:** build (warnings-as-errors) and the new integration test pass locally; the full Core server-test shard exceeds the 35-min cap on this shared box and runs in CI.
