### PR TITLE
feat: field-addressable content publication validation errors (Wave 3)

### DIFF
--- a/src/Honua.Core/Features/Publishing/Content/ContentPublicationExceptions.cs
+++ b/src/Honua.Core/Features/Publishing/Content/ContentPublicationExceptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Validation.Contracts;
+
 namespace Honua.Core.Features.Publishing.Content;
 
 /// <summary>
@@ -21,9 +23,56 @@ public abstract class ContentPublicationException : Exception
     public int StatusCode { get; }
 }
 
-/// <summary>A client request failed validation (HTTP 400).</summary>
-public sealed class ContentPublicationValidationException(string message)
-    : ContentPublicationException(400, message);
+/// <summary>
+/// A client request failed validation (HTTP 400). Carries one or more
+/// field-addressable <see cref="FieldValidationError"/>s so endpoints can return an
+/// RFC-7807 ProblemDetails with an <c>errors[]</c> extension that the console binds
+/// onto the offending report/dashboard inputs. The exception <see cref="System.Exception.Message"/>
+/// remains the first error's message for log/back-compat surfaces.
+/// </summary>
+public sealed class ContentPublicationValidationException : ContentPublicationException
+{
+    /// <summary>
+    /// Creates a single-field validation error. The <paramref name="code"/> and
+    /// <paramref name="path"/> make the failure field-addressable; both default to
+    /// safe values so legacy call sites that pass only a message still produce a
+    /// well-formed (form-level) <see cref="FieldValidationError"/>.
+    /// </summary>
+    public ContentPublicationValidationException(
+        string message,
+        string code = "publication.invalid",
+        string? path = null)
+        : base(400, message)
+    {
+        Errors =
+        [
+            FieldValidationError.Create(code, message, ValidationSeverity.Error, path),
+        ];
+    }
+
+    /// <summary>
+    /// Creates a validation error carrying a pre-built set of field-addressable
+    /// errors (for body validation that collects multiple findings in one pass).
+    /// The exception message is the first error's message.
+    /// </summary>
+    public ContentPublicationValidationException(IReadOnlyList<FieldValidationError> errors)
+        : base(400, ResolveMessage(errors))
+    {
+        ArgumentNullException.ThrowIfNull(errors);
+        if (errors.Count == 0)
+        {
+            throw new ArgumentException("At least one field validation error is required.", nameof(errors));
+        }
+
+        Errors = errors;
+    }
+
+    /// <summary>The field-addressable validation errors carried by this rejection (never empty).</summary>
+    public IReadOnlyList<FieldValidationError> Errors { get; }
+
+    private static string ResolveMessage(IReadOnlyList<FieldValidationError> errors)
+        => errors is { Count: > 0 } ? errors[0].Message : "The content publication request failed validation.";
+}
 
 /// <summary>The referenced publication does not exist (HTTP 404).</summary>
 public sealed class ContentPublicationNotFoundException(string message)

--- a/src/Honua.Core/Features/Publishing/Content/Services/ContentPublicationBodyValidator.cs
+++ b/src/Honua.Core/Features/Publishing/Content/Services/ContentPublicationBodyValidator.cs
@@ -1,0 +1,220 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Publishing.Content.Domain;
+using Honua.Core.Features.Validation.Contracts;
+
+namespace Honua.Core.Features.Publishing.Content.Services;
+
+/// <summary>
+/// Field-addressable body validation for report and dashboard content payloads published through the
+/// content publication registry. The console serializes the authored report/dashboard document into the
+/// request <c>contentPayload</c> (a <c>bindings[]</c> + <c>panels[]</c> graph with embedded Vega-Lite
+/// chart specs); this validator parses that document and surfaces the same business rules the console
+/// enforces client-side — required bindings (alias + contentRef), unique binding aliases, every panel's
+/// <c>bindingAlias</c> referencing a declared binding, and every chart panel declaring a parseable
+/// Vega-Lite spec (a JSON object with a vega-lite <c>$schema</c>) — as
+/// <see cref="FieldValidationError"/>s keyed by JSON Pointer so they bind back onto the offending input.
+/// <para>
+/// It is intentionally tolerant: a payload that is absent, not JSON, or not a recognised
+/// report/dashboard document is accepted opaquely (the server still hashes the blob), so this never
+/// rejects map/generated-app payloads or third-party documents — it only enforces the rules when the
+/// document clearly carries the bindings/panels graph.
+/// </para>
+/// </summary>
+internal static class ContentPublicationBodyValidator
+{
+    /// <summary>
+    /// Validates <paramref name="contentPayload"/> for a report/dashboard publish/republish and throws a
+    /// <see cref="ContentPublicationValidationException"/> carrying every field-addressable finding when
+    /// the document violates a binding/panel/vega-lite rule. No-ops for non-report/dashboard kinds, an
+    /// absent payload, or a payload that does not parse as a recognised document.
+    /// </summary>
+    public static void Validate(ContentPublicationKind kind, string? contentPayload)
+    {
+        if (kind is not (ContentPublicationKind.Report or ContentPublicationKind.Dashboard))
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(contentPayload))
+        {
+            return;
+        }
+
+        JsonElement root;
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(contentPayload);
+        }
+        catch (JsonException)
+        {
+            // An unparseable payload is left to the opaque-blob path; the console gates malformed JSON
+            // client-side and the server still records the content hash.
+            return;
+        }
+
+        using (document)
+        {
+            root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return;
+            }
+
+            var hasBindings = root.TryGetProperty("bindings", out var bindings) && bindings.ValueKind == JsonValueKind.Array;
+            var hasPanels = root.TryGetProperty("panels", out var panels) && panels.ValueKind == JsonValueKind.Array;
+            if (!hasBindings && !hasPanels)
+            {
+                // Not a recognised bindings/panels document; accept opaquely.
+                return;
+            }
+
+            var errors = new List<FieldValidationError>();
+            var aliases = ValidateBindings(hasBindings ? bindings : default, errors);
+            if (hasPanels)
+            {
+                ValidatePanels(panels, aliases, errors);
+            }
+
+            if (errors.Count > 0)
+            {
+                throw new ContentPublicationValidationException(errors);
+            }
+        }
+    }
+
+    private static HashSet<string> ValidateBindings(JsonElement bindings, List<FieldValidationError> errors)
+    {
+        var aliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (bindings.ValueKind != JsonValueKind.Array)
+        {
+            return aliases;
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var index = 0;
+        foreach (var binding in bindings.EnumerateArray())
+        {
+            var path = $"/bindings/{index}";
+            var alias = GetString(binding, "alias");
+            var contentRef = GetString(binding, "contentRef");
+
+            if (string.IsNullOrWhiteSpace(alias))
+            {
+                errors.Add(FieldValidationError.Create(
+                    "publication.binding.alias.required",
+                    "Give every data binding an alias.",
+                    path: path + "/alias"));
+            }
+            else
+            {
+                aliases.Add(alias.Trim());
+                if (!seen.Add(alias.Trim()))
+                {
+                    errors.Add(FieldValidationError.Create(
+                        "publication.binding.alias.duplicate",
+                        $"Binding alias '{alias.Trim()}' is already used. Binding aliases must be unique.",
+                        path: path + "/alias"));
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(contentRef))
+            {
+                errors.Add(FieldValidationError.Create(
+                    "publication.binding.contentRef.required",
+                    "Give every data binding a content reference.",
+                    path: path + "/contentRef"));
+            }
+
+            index++;
+        }
+
+        return aliases;
+    }
+
+    private static void ValidatePanels(JsonElement panels, HashSet<string> aliases, List<FieldValidationError> errors)
+    {
+        if (panels.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        var index = 0;
+        foreach (var panel in panels.EnumerateArray())
+        {
+            var path = $"/panels/{index}";
+            var bindingAlias = GetString(panel, "bindingAlias");
+
+            // Every panel must reference a declared binding alias (referential integrity).
+            if (string.IsNullOrWhiteSpace(bindingAlias) || !aliases.Contains(bindingAlias.Trim()))
+            {
+                errors.Add(FieldValidationError.Create(
+                    "publication.panel.bindingAlias.unresolved",
+                    string.IsNullOrWhiteSpace(bindingAlias)
+                        ? "Bind this panel to a declared data binding."
+                        : $"Panel binding alias '{bindingAlias.Trim()}' does not reference a declared data binding.",
+                    path: path + "/bindingAlias"));
+            }
+
+            if (IsChartPanel(panel) && !DeclaresVegaLiteSchema(panel))
+            {
+                errors.Add(FieldValidationError.Create(
+                    "publication.panel.chartSpec.vegaLite",
+                    "Chart panels must declare a Vega-Lite spec: a JSON object with a vega-lite \"$schema\".",
+                    path: path + "/chartSpec"));
+            }
+
+            index++;
+        }
+    }
+
+    private static bool IsChartPanel(JsonElement panel)
+    {
+        var kind = GetString(panel, "kind");
+        return string.Equals(kind, "chart", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// True when the panel's chart spec is a JSON object declaring a vega-lite <c>$schema</c>. Mirrors the
+    /// console's <c>DeclaresVegaLiteSchema</c> helper. The chart spec is embedded either as a structured
+    /// object (the console parses valid JSON before publishing) or as a raw string (round-tripped when it
+    /// did not parse) — only a structured object with a vega-lite schema URL passes.
+    /// </summary>
+    private static bool DeclaresVegaLiteSchema(JsonElement panel)
+    {
+        if (!panel.TryGetProperty("chartSpec", out var spec))
+        {
+            return false;
+        }
+
+        // A raw (unparsed) chart spec round-trips as a JSON string; that is not a declared Vega-Lite object.
+        if (spec.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (!spec.TryGetProperty("$schema", out var schema) || schema.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        var schemaUrl = schema.GetString();
+        return !string.IsNullOrEmpty(schemaUrl)
+            && schemaUrl.Contains("vega-lite", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? GetString(JsonElement element, string property)
+    {
+        if (element.ValueKind == JsonValueKind.Object
+            && element.TryGetProperty(property, out var value)
+            && value.ValueKind == JsonValueKind.String)
+        {
+            return value.GetString();
+        }
+
+        return null;
+    }
+}

--- a/src/Honua.Core/Features/Publishing/Content/Services/ContentPublicationBodyValidator.cs
+++ b/src/Honua.Core/Features/Publishing/Content/Services/ContentPublicationBodyValidator.cs
@@ -64,17 +64,40 @@ internal static class ContentPublicationBodyValidator
                 return;
             }
 
-            var hasBindings = root.TryGetProperty("bindings", out var bindings) && bindings.ValueKind == JsonValueKind.Array;
-            var hasPanels = root.TryGetProperty("panels", out var panels) && panels.ValueKind == JsonValueKind.Array;
-            if (!hasBindings && !hasPanels)
+            var bindingsPresent = root.TryGetProperty("bindings", out var bindings);
+            var panelsPresent = root.TryGetProperty("panels", out var panels);
+            if (!bindingsPresent && !panelsPresent)
             {
                 // Not a recognised bindings/panels document; accept opaquely.
                 return;
             }
 
+            // The document IS a report/dashboard bindings/panels graph, so enforce it. A present-but-wrong-type
+            // bindings/panels member is itself a violation (it would otherwise silently bypass validation).
             var errors = new List<FieldValidationError>();
-            var aliases = ValidateBindings(hasBindings ? bindings : default, errors);
-            if (hasPanels)
+
+            HashSet<string> aliases;
+            if (bindingsPresent && bindings.ValueKind != JsonValueKind.Array)
+            {
+                errors.Add(FieldValidationError.Create(
+                    "publication.bindings.invalid",
+                    "The report/dashboard document's bindings must be an array.",
+                    path: "/bindings"));
+                aliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+            else
+            {
+                aliases = ValidateBindings(bindingsPresent ? bindings : default, errors);
+            }
+
+            if (panelsPresent && panels.ValueKind != JsonValueKind.Array)
+            {
+                errors.Add(FieldValidationError.Create(
+                    "publication.panels.invalid",
+                    "The report/dashboard document's panels must be an array.",
+                    path: "/panels"));
+            }
+            else if (panelsPresent)
             {
                 ValidatePanels(panels, aliases, errors);
             }

--- a/src/Honua.Core/Features/Publishing/Content/Services/ContentPublicationService.cs
+++ b/src/Honua.Core/Features/Publishing/Content/Services/ContentPublicationService.cs
@@ -72,6 +72,7 @@ public sealed class ContentPublicationService : IContentPublicationService
         ValidateKind(request.Kind);
         ValidateBbox(request.DefaultViewBbox);
         ValidatePolicyShape(request.Policy);
+        ContentPublicationBodyValidator.Validate(request.Kind, request.ContentPayload);
 
         var slug = ContentPublicationSlug.Normalize(request.RouteSlug, request.Title);
 
@@ -166,7 +167,10 @@ public sealed class ContentPublicationService : IContentPublicationService
 
         if (string.IsNullOrWhiteSpace(versionSelector))
         {
-            throw new ContentPublicationValidationException("A version selector is required.");
+            throw new ContentPublicationValidationException(
+                "A version selector is required.",
+                code: "publication.versionSelector.required",
+                path: "/versionSelector");
         }
 
         if (TryParseRevision(versionSelector, out var revision))
@@ -179,7 +183,10 @@ public sealed class ContentPublicationService : IContentPublicationService
             return await _store.GetVersionByIdAsync(publicationId, versionSelector, cancellationToken).ConfigureAwait(false);
         }
 
-        throw new ContentPublicationValidationException("Version selector must be a revision number, 'v{n}', or a version id.");
+        throw new ContentPublicationValidationException(
+            "Version selector must be a revision number, 'v{n}', or a version id.",
+            code: "publication.versionSelector.invalid",
+            path: "/versionSelector");
     }
 
     /// <inheritdoc />
@@ -197,6 +204,8 @@ public sealed class ContentPublicationService : IContentPublicationService
         var route = await _store.GetRouteByPublicationIdAsync(publicationId, cancellationToken).ConfigureAwait(false)
             ?? throw new ContentPublicationNotFoundException("Publication not found.");
         EnsureEtagMatches(route, request.ExpectedEtag);
+
+        ContentPublicationBodyValidator.Validate(route.Kind, request.ContentPayload);
 
         await ValidateDependenciesAsync(request.Dependencies, cancellationToken).ConfigureAwait(false);
 
@@ -280,17 +289,26 @@ public sealed class ContentPublicationService : IContentPublicationService
         }
         else
         {
-            throw new ContentPublicationValidationException("A rollback target (targetVersionId or targetRevision) is required.");
+            throw new ContentPublicationValidationException(
+                "A rollback target (targetVersionId or targetRevision) is required.",
+                code: "publication.rollback.target.required",
+                path: "/targetVersionId");
         }
 
         if (target is null)
         {
-            throw new ContentPublicationValidationException("The rollback target version was not found.");
+            throw new ContentPublicationValidationException(
+                "The rollback target version was not found.",
+                code: "publication.rollback.target.notFound",
+                path: "/targetVersionId");
         }
 
         if (string.Equals(target.VersionId, route.ActiveVersionId, StringComparison.Ordinal))
         {
-            throw new ContentPublicationValidationException("The rollback target is already the active version.");
+            throw new ContentPublicationValidationException(
+                "The rollback target is already the active version.",
+                code: "publication.rollback.target.active",
+                path: "/targetVersionId");
         }
 
         var now = _timeProvider.GetUtcNow();
@@ -361,7 +379,10 @@ public sealed class ContentPublicationService : IContentPublicationService
             var index = links.FindIndex(l => string.Equals(l.LinkId, revokeId, StringComparison.Ordinal));
             if (index < 0)
             {
-                throw new ContentPublicationValidationException("The public link to revoke was not found.");
+                throw new ContentPublicationValidationException(
+                    "The public link to revoke was not found.",
+                    code: "publication.publicLink.revoke.notFound",
+                    path: "/revokePublicLinkId");
             }
 
             links[index] = links[index] with { Revoked = true, RevokedAt = now };
@@ -451,7 +472,10 @@ public sealed class ContentPublicationService : IContentPublicationService
     {
         if (!Guid.TryParse(publicationId, out _))
         {
-            throw new ContentPublicationValidationException("publicationId must be a valid GUID.");
+            throw new ContentPublicationValidationException(
+                "publicationId must be a valid GUID.",
+                code: "publication.publicationId.invalid",
+                path: "/publicationId");
         }
     }
 
@@ -469,7 +493,10 @@ public sealed class ContentPublicationService : IContentPublicationService
     {
         if (!IsDefinedKind(kind))
         {
-            throw new ContentPublicationValidationException("kind is not a defined content publication kind.");
+            throw new ContentPublicationValidationException(
+                "kind is not a defined content publication kind.",
+                code: "publication.kind.invalid",
+                path: "/kind");
         }
     }
 
@@ -492,7 +519,10 @@ public sealed class ContentPublicationService : IContentPublicationService
     {
         if (!IsDefinedVisibility(visibility))
         {
-            throw new ContentPublicationValidationException("visibility is not a defined content publication visibility scope.");
+            throw new ContentPublicationValidationException(
+                "visibility is not a defined content publication visibility scope.",
+                code: "publication.visibility.invalid",
+                path: "/policy/visibility");
         }
     }
 
@@ -525,7 +555,9 @@ public sealed class ContentPublicationService : IContentPublicationService
             if (string.IsNullOrWhiteSpace(token) || ContainsWhitespaceOrControl(token))
             {
                 throw new ContentPublicationValidationException(
-                    $"{field} entries must be non-empty values without whitespace or control characters.");
+                    $"{field} entries must be non-empty values without whitespace or control characters.",
+                    code: "publication.embed.token.invalid",
+                    path: "/policy/" + field.Replace('.', '/'));
             }
         }
     }
@@ -552,18 +584,27 @@ public sealed class ContentPublicationService : IContentPublicationService
 
         if (string.IsNullOrWhiteSpace(bbox.Crs))
         {
-            throw new ContentPublicationValidationException("defaultViewBbox.crs must be declared.");
+            throw new ContentPublicationValidationException(
+                "defaultViewBbox.crs must be declared.",
+                code: "publication.bbox.crs.required",
+                path: "/defaultViewBbox/crs");
         }
 
         if (bbox.MinX > bbox.MaxX || bbox.MinY > bbox.MaxY)
         {
-            throw new ContentPublicationValidationException("defaultViewBbox minimum must not exceed maximum.");
+            throw new ContentPublicationValidationException(
+                "defaultViewBbox minimum must not exceed maximum.",
+                code: "publication.bbox.order",
+                path: "/defaultViewBbox");
         }
 
         if (IsWgs84(bbox.Crs)
             && (bbox.MinX < -180 || bbox.MaxX > 180 || bbox.MinY < -90 || bbox.MaxY > 90))
         {
-            throw new ContentPublicationValidationException("defaultViewBbox is out of range for EPSG:4326 lon/lat.");
+            throw new ContentPublicationValidationException(
+                "defaultViewBbox is out of range for EPSG:4326 lon/lat.",
+                code: "publication.bbox.range",
+                path: "/defaultViewBbox");
         }
     }
 
@@ -596,7 +637,10 @@ public sealed class ContentPublicationService : IContentPublicationService
 
             if (string.IsNullOrWhiteSpace(dependency.RefId))
             {
-                throw new ContentPublicationValidationException("Each dependency must carry a non-empty refId.");
+                throw new ContentPublicationValidationException(
+                    "Each dependency must carry a non-empty refId.",
+                    code: "publication.dependency.refId.required",
+                    path: "/dependencies");
             }
 
             switch (dependency.Kind)
@@ -648,7 +692,10 @@ public sealed class ContentPublicationService : IContentPublicationService
     {
         if (!IsDefinedDependencyKind(kind))
         {
-            throw new ContentPublicationValidationException("dependency.kind is not a defined content publication dependency kind.");
+            throw new ContentPublicationValidationException(
+                "dependency.kind is not a defined content publication dependency kind.",
+                code: "publication.dependency.kind.invalid",
+                path: "/dependencies");
         }
     }
 

--- a/src/Honua.Server/Features/Console/Publications/ContentPublicationEndpoints.cs
+++ b/src/Honua.Server/Features/Console/Publications/ContentPublicationEndpoints.cs
@@ -95,7 +95,7 @@ internal static class ContentPublicationEndpoints
         }
         catch (ContentPublicationException ex)
         {
-            return ProblemDetailsHelpers.CreateAdminProblem(context, ex.StatusCode, ex.Message);
+            return ToProblem(context, ex);
         }
         catch (OperationCanceledException)
         {
@@ -123,7 +123,7 @@ internal static class ContentPublicationEndpoints
         }
         catch (ContentPublicationException ex)
         {
-            return ProblemDetailsHelpers.CreateAdminProblem(context, ex.StatusCode, ex.Message);
+            return ToProblem(context, ex);
         }
         catch (OperationCanceledException)
         {
@@ -158,7 +158,7 @@ internal static class ContentPublicationEndpoints
         }
         catch (ContentPublicationException ex)
         {
-            return ProblemDetailsHelpers.CreateAdminProblem(context, ex.StatusCode, ex.Message);
+            return ToProblem(context, ex);
         }
         catch (OperationCanceledException)
         {
@@ -199,7 +199,7 @@ internal static class ContentPublicationEndpoints
         }
         catch (ContentPublicationException ex)
         {
-            return ProblemDetailsHelpers.CreateAdminProblem(context, ex.StatusCode, ex.Message);
+            return ToProblem(context, ex);
         }
         catch (OperationCanceledException)
         {
@@ -240,7 +240,7 @@ internal static class ContentPublicationEndpoints
         }
         catch (ContentPublicationException ex)
         {
-            return ProblemDetailsHelpers.CreateAdminProblem(context, ex.StatusCode, ex.Message);
+            return ToProblem(context, ex);
         }
         catch (OperationCanceledException)
         {
@@ -293,7 +293,7 @@ internal static class ContentPublicationEndpoints
         }
         catch (ContentPublicationException ex)
         {
-            return ProblemDetailsHelpers.CreateAdminProblem(context, ex.StatusCode, ex.Message);
+            return ToProblem(context, ex);
         }
         catch (OperationCanceledException)
         {
@@ -305,6 +305,18 @@ internal static class ContentPublicationEndpoints
             return ProblemDetailsHelpers.CreateAdminProblem(context, StatusCodes.Status500InternalServerError, "An internal error occurred while updating the policy.");
         }
     }
+
+    /// <summary>
+    /// Maps a <see cref="ContentPublicationException"/> to an RFC-7807 problem result. Validation
+    /// failures (a <see cref="ContentPublicationValidationException"/>) are field-addressable, so they
+    /// flow through <see cref="ProblemDetailsHelpers.CreateValidationProblem"/> with the shared
+    /// <c>errors[]</c> extension the console binds onto report/dashboard inputs; all other publication
+    /// errors (404/409/503) keep the flat admin problem shape.
+    /// </summary>
+    private static IResult ToProblem(HttpContext context, ContentPublicationException exception)
+        => exception is ContentPublicationValidationException validation
+            ? ProblemDetailsHelpers.CreateValidationProblem(context, validation.StatusCode, validation.Errors, validation.Message)
+            : ProblemDetailsHelpers.CreateAdminProblem(context, exception.StatusCode, exception.Message);
 
     private static async Task InvalidateAsync(HttpContext context, string publicationId, string routeSlug)
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Console/Publications/ContentPublicationEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Console/Publications/ContentPublicationEndpointsTests.cs
@@ -219,6 +219,157 @@ public sealed class ContentPublicationEndpointsTests : IAsyncLifetime
         AssertNoSensitiveLeak(payload);
     }
 
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/console/publications")]
+    public async Task Publish_ReportWithUnresolvedPanelAlias_ReturnsFieldAddressableErrors()
+    {
+        // A report document whose only panel references a binding alias that is not declared, plus a chart
+        // panel with no Vega-Lite spec, must be rejected with field-level errors[] addressed by JSON Pointer.
+        const string payload = """
+            {
+              "format": "honua.report-document.v1",
+              "title": "Bad Report",
+              "bindings": [ { "alias": "incidents", "contentRef": "content:incidents" } ],
+              "panels": [ { "title": "Chart", "kind": "chart", "bindingAlias": "missing", "chartSpec": null } ]
+            }
+            """;
+
+        var body = SerializePublish(new PublishContentRequest
+        {
+            Kind = ContentPublicationKind.Report,
+            RouteSlug = "bad-report",
+            Title = "Bad Report",
+            ContentPayload = payload,
+        });
+
+        var response = await _client.PostAsync("/api/v1/console/publications", JsonContent(body));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        AssertNoSensitiveLeak(responseBody);
+
+        using var document = JsonDocument.Parse(responseBody);
+        var root = document.RootElement;
+        root.TryGetProperty("errors", out var errors).Should().BeTrue("the rejection must carry the field-level errors[] extension");
+        errors.ValueKind.Should().Be(JsonValueKind.Array);
+
+        var items = errors.EnumerateArray().ToList();
+        items.Should().NotBeEmpty();
+
+        // Every item carries the shared FieldValidationError shape: code, severity, message, and an
+        // addressable JSON Pointer path.
+        foreach (var item in items)
+        {
+            item.GetProperty("code").GetString().Should().NotBeNullOrEmpty();
+            item.GetProperty("severity").GetString().Should().NotBeNullOrEmpty();
+            item.GetProperty("message").GetString().Should().NotBeNullOrEmpty();
+            item.GetProperty("path").GetString().Should().NotBeNullOrEmpty();
+        }
+
+        var paths = items.Select(i => i.GetProperty("path").GetString()).ToList();
+        paths.Should().Contain("/panels/0/bindingAlias");
+        paths.Should().Contain("/panels/0/chartSpec");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/console/publications")]
+    public async Task Publish_ReportWithDuplicateBindingAlias_ReturnsDuplicateError()
+    {
+        const string payload = """
+            {
+              "format": "honua.report-document.v1",
+              "title": "Dup Report",
+              "bindings": [
+                { "alias": "incidents", "contentRef": "content:a" },
+                { "alias": "incidents", "contentRef": "content:b" }
+              ],
+              "panels": [
+                {
+                  "title": "Chart",
+                  "kind": "chart",
+                  "bindingAlias": "incidents",
+                  "chartSpec": { "$schema": "https://vega.github.io/schema/vega-lite/v5.json", "mark": "bar" }
+                }
+              ]
+            }
+            """;
+
+        var body = SerializePublish(new PublishContentRequest
+        {
+            Kind = ContentPublicationKind.Report,
+            RouteSlug = "dup-report",
+            Title = "Dup Report",
+            ContentPayload = payload,
+        });
+
+        var response = await _client.PostAsync("/api/v1/console/publications", JsonContent(body));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var codes = document.RootElement.GetProperty("errors").EnumerateArray()
+            .Select(i => i.GetProperty("code").GetString())
+            .ToList();
+        codes.Should().Contain("publication.binding.alias.duplicate");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/console/publications")]
+    public async Task Publish_ValidReportDocument_Succeeds()
+    {
+        // A well-formed report document (declared binding, referencing chart panel, valid Vega-Lite) passes
+        // body validation and publishes — proving the validator is not over-eager.
+        const string payload = """
+            {
+              "format": "honua.report-document.v1",
+              "title": "Good Report",
+              "bindings": [ { "alias": "incidents", "contentRef": "content:incidents" } ],
+              "panels": [
+                {
+                  "title": "Chart",
+                  "kind": "chart",
+                  "bindingAlias": "incidents",
+                  "chartSpec": { "$schema": "https://vega.github.io/schema/vega-lite/v5.json", "mark": "bar" }
+                }
+              ]
+            }
+            """;
+
+        var body = SerializePublish(new PublishContentRequest
+        {
+            Kind = ContentPublicationKind.Report,
+            RouteSlug = "good-report",
+            Title = "Good Report",
+            ContentPayload = payload,
+        });
+
+        var response = await _client.PostAsync("/api/v1/console/publications", JsonContent(body));
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/console/publications")]
+    public async Task Publish_MapWithBindingsLikePayload_IsNotBodyValidated()
+    {
+        // Map/non-report-dashboard kinds carry opaque payloads; the body validator must not reject them even
+        // if they happen to look like a bindings/panels document.
+        const string payload = """
+            { "bindings": [ { "alias": "", "contentRef": "" } ], "panels": [ { "kind": "chart", "bindingAlias": "x" } ] }
+            """;
+
+        var body = SerializePublish(new PublishContentRequest
+        {
+            Kind = ContentPublicationKind.Map,
+            RouteSlug = "opaque-map",
+            Title = "Opaque Map",
+            ContentPayload = payload,
+        });
+
+        var response = await _client.PostAsync("/api/v1/console/publications", JsonContent(body));
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
     private async Task<ContentPublicationDetail> PublishAsync(string slug, ContentPublicationKind kind, string? payload = null)
     {
         var body = SerializePublish(new PublishContentRequest { Kind = kind, RouteSlug = slug, Title = slug, ContentPayload = payload });

--- a/tests/dotnet/Honua.Server.Tests/Features/Console/Publications/ContentPublicationEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Console/Publications/ContentPublicationEndpointsTests.cs
@@ -370,6 +370,33 @@ public sealed class ContentPublicationEndpointsTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.Created);
     }
 
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/console/publications")]
+    public async Task Publish_ReportWithWrongTypedBindingsAndPanels_IsRejected()
+    {
+        // A report document whose bindings/panels members are present but the wrong JSON type must be
+        // rejected (not silently treated as opaque), since the document declares the bindings/panels graph.
+        const string payload = """{ "format": "honua.report-document.v1", "bindings": {}, "panels": "nope" }""";
+
+        var body = SerializePublish(new PublishContentRequest
+        {
+            Kind = ContentPublicationKind.Report,
+            RouteSlug = "wrong-typed-report",
+            Title = "Wrong Typed Report",
+            ContentPayload = payload,
+        });
+
+        var response = await _client.PostAsync("/api/v1/console/publications", JsonContent(body));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var codes = document.RootElement.GetProperty("errors").EnumerateArray()
+            .Select(i => i.GetProperty("code").GetString())
+            .ToList();
+        codes.Should().Contain("publication.bindings.invalid");
+        codes.Should().Contain("publication.panels.invalid");
+    }
+
     private async Task<ContentPublicationDetail> PublishAsync(string slug, ContentPublicationKind kind, string? payload = null)
     {
         var body = SerializePublish(new PublishContentRequest { Kind = kind, RouteSlug = slug, Title = slug, ContentPayload = payload });


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #418

## Summary
Wave 3 (server side) of the form-validation initiative: make the content publication registry return field-addressable validation errors so report/dashboard publish responds with RFC 7807 ProblemDetails carrying an `errors[]` of the shared `FieldValidationError` contract instead of a flat message. This is the server half the console report builder (Wave 3 console) binds onto its inputs.

## Changes Made
- `ContentPublicationValidationException` now carries one or more `FieldValidationError`s. Existing single-message throw sites gain stable codes + JSON Pointer paths (versionSelector, rollback target, publicationId, kind, visibility, embed tokens, bbox, dependencies); a new constructor accepts a pre-built list for multi-error body validation.
- New `ContentPublicationBodyValidator` validates report/dashboard `contentPayload` documents: each binding's alias + contentRef required, binding aliases unique, every panel's `bindingAlias` references a declared binding (referential), and chart panels declare a parseable Vega-Lite spec (a JSON object with a vega-lite `$schema`). It is tolerant — an absent/unparseable payload, or a non-report/dashboard kind, is accepted opaquely so map/generated-app payloads are never body-validated.
- `ContentPublicationEndpoints` route `ContentPublicationException` through a `ToProblem` helper: validation failures (400) flow through `ProblemDetailsHelpers.CreateValidationProblem` (the merged Wave-0 `errors[]` emission); other statuses (404/409/503) keep the flat admin problem shape.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Local results (Release, build lock):
- `dotnet format Honua.sln --verify-no-changes`: clean
- Release build (`TreatWarningsAsErrors=true`): succeeded
- `Honua.Server.Tests` `ContentPublicationEndpointsTests` (incl. new field-error-shape, duplicate-alias, valid-report-publishes, opaque-map cases): 13 passed
- `Honua.Server.Tests --filter Tier=Fast`: 1721 passed, 0 failed
- `Honua.Architecture.Tests` (drift/OpenApi/ApiSurfaceCoverage incl.): 101 passed, 1 skipped

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

(The 400 rejection body for report/dashboard publish gains the additive `errors[]` extension already defined by Wave 0; no endpoint, route, or OpenAPI operation shape changes.)

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
