### PR TITLE
feat: field-addressable analysis-content validation errors (Wave 4)

### DIFF
--- a/src/Honua.Ai/Features/AnalysisContent/AnalysisContentEndpoints.cs
+++ b/src/Honua.Ai/Features/AnalysisContent/AnalysisContentEndpoints.cs
@@ -543,16 +543,15 @@ internal static partial class AnalysisContentEndpoints
             case AnalysisContentValidationException validationEx:
                 // Surface the field-addressable RFC-7807 ProblemDetails errors[] of FieldValidationError so
                 // console clients can bind the finding onto the offending input rather than a flat message.
+                var validationError = FieldValidationError.Create(
+                    validationEx.Code,
+                    validationEx.Message,
+                    ValidationSeverity.Error,
+                    validationEx.Path);
                 problem = ProblemDetailsHelpers.CreateValidationProblem(
                     context,
                     StatusCodes.Status400BadRequest,
-                    [
-                        FieldValidationError.Create(
-                            validationEx.Code,
-                            validationEx.Message,
-                            ValidationSeverity.Error,
-                            validationEx.Path),
-                    ],
+                    [validationError],
                     validationEx.Message);
                 return true;
             case AnalysisContentNotFoundException notFoundEx:

--- a/src/Honua.Ai/Features/AnalysisContent/AnalysisContentEndpoints.cs
+++ b/src/Honua.Ai/Features/AnalysisContent/AnalysisContentEndpoints.cs
@@ -3,6 +3,7 @@
 
 using Honua.Core.Features.AnalysisContent.Abstractions;
 using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.Validation.Contracts;
 using Honua.Geoprocessing;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Models;
@@ -540,10 +541,18 @@ internal static partial class AnalysisContentEndpoints
         switch (ex)
         {
             case AnalysisContentValidationException validationEx:
-                problem = ProblemDetailsHelpers.CreateAdminProblem(
+                // Surface the field-addressable RFC-7807 ProblemDetails errors[] of FieldValidationError so
+                // console clients can bind the finding onto the offending input rather than a flat message.
+                problem = ProblemDetailsHelpers.CreateValidationProblem(
                     context,
                     StatusCodes.Status400BadRequest,
-                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+                    [
+                        FieldValidationError.Create(
+                            validationEx.Code,
+                            validationEx.Message,
+                            ValidationSeverity.Error,
+                            validationEx.Path),
+                    ],
                     validationEx.Message);
                 return true;
             case AnalysisContentNotFoundException notFoundEx:

--- a/src/Honua.Ai/Features/AnalysisContent/AnalysisContentExceptions.cs
+++ b/src/Honua.Ai/Features/AnalysisContent/AnalysisContentExceptions.cs
@@ -3,7 +3,26 @@
 
 namespace Honua.Ai.AnalysisContent;
 
-internal sealed class AnalysisContentValidationException(string message) : Exception(message);
+/// <summary>
+/// Thrown when an analysis content request body fails validation. Carries a stable machine-readable
+/// <see cref="Code"/> and an optional <see cref="Path"/> (JSON Pointer / dotted field path) so the endpoint
+/// can surface a field-addressable RFC-7807 ProblemDetails <c>errors[]</c> rather than a flat message.
+/// </summary>
+internal sealed class AnalysisContentValidationException : Exception
+{
+    public AnalysisContentValidationException(string message, string code, string? path = null)
+        : base(message)
+    {
+        Code = code;
+        Path = path;
+    }
+
+    /// <summary>Stable machine-readable error code (e.g. <c>analysis.content.name.required</c>).</summary>
+    public string Code { get; }
+
+    /// <summary>Optional JSON Pointer / dotted field path of the offending value (e.g. <c>/inputs/0/layerId</c>).</summary>
+    public string? Path { get; }
+}
 
 internal sealed class AnalysisContentNotFoundException(string message) : Exception(message);
 

--- a/src/Honua.Ai/Features/AnalysisContent/AnalysisContentService.cs
+++ b/src/Honua.Ai/Features/AnalysisContent/AnalysisContentService.cs
@@ -137,7 +137,7 @@ internal sealed partial class AnalysisContentService(
                 var offset = query.Offset.GetValueOrDefault();
                 if (offset < 0)
                 {
-                    throw new AnalysisContentValidationException("Offset must be zero or greater.");
+                    throw new AnalysisContentValidationException("Offset must be zero or greater.", "analysis.content.offset.range", "/offset");
                 }
 
                 var page = await store.ListItemsAsync(
@@ -165,7 +165,7 @@ internal sealed partial class AnalysisContentService(
             {
                 var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
                 var package = contentVersion.AnalysisPackage
-                    ?? throw new AnalysisContentValidationException("The requested version is not an analysis package.");
+                    ?? throw new AnalysisContentValidationException("The requested version is not an analysis package.", "analysis.content.kind.mismatch", "/kind");
                 AnalysisContentTelemetry.SetContentTags(
                     activity,
                     contentVersion.ItemId,
@@ -373,7 +373,7 @@ internal sealed partial class AnalysisContentService(
             {
                 var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
                 var savedQuery = contentVersion.SavedQuery
-                    ?? throw new AnalysisContentValidationException("The requested version is not a saved query.");
+                    ?? throw new AnalysisContentValidationException("The requested version is not a saved query.", "analysis.content.kind.mismatch", "/kind");
                 AnalysisContentTelemetry.SetContentTags(
                     activity,
                     contentVersion.ItemId,
@@ -395,7 +395,9 @@ internal sealed partial class AnalysisContentService(
                     if (!compiled.IsSuccess || compiled.Expression is null)
                     {
                         throw new AnalysisContentValidationException(
-                            compiled.ErrorMessage ?? "Saved query filter plan could not be compiled.");
+                            compiled.ErrorMessage ?? "Saved query filter plan could not be compiled.",
+                            "analysis.content.savedQuery.filter.invalid",
+                            "/savedQuery/filter");
                     }
 
                     filter = QueryFilter.FromExpression(
@@ -419,7 +421,9 @@ internal sealed partial class AnalysisContentService(
                 if (!validation.IsValid)
                 {
                     throw new AnalysisContentValidationException(
-                        validation.ErrorMessage ?? "Saved query preview request is invalid.");
+                        validation.ErrorMessage ?? "Saved query preview request is invalid.",
+                        "analysis.content.savedQuery.preview.invalid",
+                        "/savedQuery");
                 }
 
                 var optimized = queryProcessor.OptimizeQuery(query, resource);
@@ -489,7 +493,7 @@ internal sealed partial class AnalysisContentService(
             {
                 var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
                 var package = contentVersion.AnalysisPackage
-                    ?? throw new AnalysisContentValidationException("The requested version is not an analysis package.");
+                    ?? throw new AnalysisContentValidationException("The requested version is not an analysis package.", "analysis.content.kind.mismatch", "/kind");
                 AnalysisContentTelemetry.SetContentTags(
                     activity,
                     contentVersion.ItemId,
@@ -522,7 +526,7 @@ internal sealed partial class AnalysisContentService(
             {
                 var contentVersion = await GetRequiredVersionAsync(itemId, version, cancellationToken).ConfigureAwait(false);
                 var package = contentVersion.AnalysisPackage
-                    ?? throw new AnalysisContentValidationException("The requested version is not an analysis package.");
+                    ?? throw new AnalysisContentValidationException("The requested version is not an analysis package.", "analysis.content.kind.mismatch", "/kind");
                 AnalysisContentTelemetry.SetContentTags(
                     activity,
                     contentVersion.ItemId,
@@ -737,7 +741,7 @@ internal sealed partial class AnalysisContentService(
     {
         if (string.IsNullOrWhiteSpace(command.Name))
         {
-            throw new AnalysisContentValidationException("Analysis content name is required.");
+            throw new AnalysisContentValidationException("Analysis content name is required.", "analysis.content.name.required", "/name");
         }
 
         ValidatePayload(command.Kind, command.SavedQuery, command.AnalysisPackage);
@@ -753,29 +757,29 @@ internal sealed partial class AnalysisContentService(
             case AnalysisContentKind.SavedQuery:
                 if (savedQuery is null || analysisPackage is not null)
                 {
-                    throw new AnalysisContentValidationException("Saved-query content requires a savedQuery payload only.");
+                    throw new AnalysisContentValidationException("Saved-query content requires a savedQuery payload only.", "analysis.content.savedQuery.exclusive", "/savedQuery");
                 }
 
                 if (savedQuery.LayerId < 0)
                 {
-                    throw new AnalysisContentValidationException("Saved-query layerId must be non-negative.");
+                    throw new AnalysisContentValidationException("Saved-query layerId must be non-negative.", "analysis.content.savedQuery.layerId.range", "/savedQuery/layerId");
                 }
 
                 break;
             case AnalysisContentKind.AnalysisPackage:
                 if (analysisPackage is null || savedQuery is not null)
                 {
-                    throw new AnalysisContentValidationException("Analysis-package content requires an analysisPackage payload only.");
+                    throw new AnalysisContentValidationException("Analysis-package content requires an analysisPackage payload only.", "analysis.content.analysisPackage.exclusive", "/analysisPackage");
                 }
 
                 if (analysisPackage.Plan.Steps.Count == 0)
                 {
-                    throw new AnalysisContentValidationException("Analysis package plan must contain at least one step.");
+                    throw new AnalysisContentValidationException("Analysis package plan must contain at least one step.", "analysis.content.analysisPackage.plan.required", "/analysisPackage/plan/steps");
                 }
 
                 break;
             default:
-                throw new AnalysisContentValidationException("Unsupported analysis content kind.");
+                throw new AnalysisContentValidationException("Unsupported analysis content kind.", "analysis.content.kind.unsupported", "/kind");
         }
     }
 
@@ -788,7 +792,7 @@ internal sealed partial class AnalysisContentService(
         {
             if (string.IsNullOrWhiteSpace(pair.Key))
             {
-                throw new AnalysisContentValidationException("Parameter override keys are required.");
+                throw new AnalysisContentValidationException("Parameter override keys are required.", "analysis.content.parameterOverrides.key.required", "/parameterOverrides");
             }
 
             normalizedOverrides[pair.Key.Trim()] = pair.Value;
@@ -828,7 +832,9 @@ internal sealed partial class AnalysisContentService(
             if (!matchedKeys.Contains(pair.Key))
             {
                 throw new AnalysisContentValidationException(
-                    $"Parameter override '{pair.Key}' does not match an executable analysis plan input.");
+                    $"Parameter override '{pair.Key}' does not match an executable analysis plan input.",
+                    "analysis.content.parameterOverrides.unmatched",
+                    "/parameterOverrides");
             }
         }
 
@@ -965,7 +971,7 @@ internal sealed partial class AnalysisContentService(
         var resolved = limit.GetValueOrDefault(defaultLimit);
         if (resolved <= 0)
         {
-            throw new AnalysisContentValidationException("Limit must be greater than zero.");
+            throw new AnalysisContentValidationException("Limit must be greater than zero.", "analysis.content.limit.range", "/limit");
         }
 
         return Math.Min(resolved, maxLimit);

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMultidimensionalInfoHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMultidimensionalInfoHandlerTests.cs
@@ -154,19 +154,19 @@ public class ImageServerMultidimensionalInfoHandlerTests
 
     private static MultidimensionalCoverageRegistration CreateRegistration(
         MultidimensionalCoverageMetadata? metadata) => new()
-    {
-        Id = 7,
-        LayerId = 1,
-        Name = "cube",
-        Format = MultidimensionalCoverageFormat.NetCdf4,
-        Provider = CloudStorageProvider.AwsS3,
-        Bucket = "bucket",
-        ObjectKey = "cube.nc",
-        Variables = Array.Empty<string>(),
-        Metadata = metadata,
-        MetadataScannedAt = metadata is null ? null : DateTimeOffset.UtcNow,
-        CreatedAt = DateTimeOffset.UtcNow
-    };
+        {
+            Id = 7,
+            LayerId = 1,
+            Name = "cube",
+            Format = MultidimensionalCoverageFormat.NetCdf4,
+            Provider = CloudStorageProvider.AwsS3,
+            Bucket = "bucket",
+            ObjectKey = "cube.nc",
+            Variables = Array.Empty<string>(),
+            Metadata = metadata,
+            MetadataScannedAt = metadata is null ? null : DateTimeOffset.UtcNow,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
 
     private static DefaultHttpContext CreateImageServerContext()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentEndpointsTests.cs
@@ -462,6 +462,73 @@ public sealed class AnalysisContentEndpointsTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
     }
 
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /api/v1/analysis/content/items")]
+    public async Task CreateItem_MissingName_ReturnsFieldAddressableValidationProblem()
+    {
+        // A blank name must be rejected with the shared field-addressable validation contract: an
+        // RFC-7807 ProblemDetails carrying errors[] of FieldValidationError, not a flat admin problem.
+        var create = new CreateAnalysisContentItemRequest
+        {
+            Kind = AnalysisContentKind.SavedQuery,
+            Name = "   ",
+            SavedQuery = new SavedQueryContent
+            {
+                LayerId = WebAppFixture.TestLayerId,
+                ServiceName = WebAppFixture.TestServiceId,
+                NaturalLanguageQuery = "show incidents"
+            }
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/v1/analysis/content/items", create, JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = document.RootElement;
+
+        // The validation problem type and a non-empty errors[] extension.
+        Assert.Equal("https://honua.io/problems/validation", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("errors", out var errors));
+        Assert.Equal(JsonValueKind.Array, errors.ValueKind);
+        Assert.NotEmpty(errors.EnumerateArray());
+
+        var first = errors.EnumerateArray().First();
+        Assert.Equal("analysis.content.name.required", first.GetProperty("code").GetString());
+        Assert.Equal("/name", first.GetProperty("path").GetString());
+        Assert.Equal("error", first.GetProperty("severity").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(first.GetProperty("message").GetString()));
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /api/v1/analysis/content/items")]
+    public async Task CreateItem_NegativeSavedQueryLayerId_ReturnsPathScopedValidationError()
+    {
+        // A negative layerId must be addressed to the offending field path so the console can bind the
+        // finding inline next to the layer-id input.
+        var create = new CreateAnalysisContentItemRequest
+        {
+            Kind = AnalysisContentKind.SavedQuery,
+            Name = $"neg-layer-{Guid.NewGuid():N}",
+            SavedQuery = new SavedQueryContent
+            {
+                LayerId = -5,
+                ServiceName = WebAppFixture.TestServiceId,
+                NaturalLanguageQuery = "show incidents"
+            }
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/v1/analysis/content/items", create, JsonOptions);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var first = document.RootElement.GetProperty("errors").EnumerateArray().First();
+        Assert.Equal("analysis.content.savedQuery.layerId.range", first.GetProperty("code").GetString());
+        Assert.Equal("/savedQuery/layerId", first.GetProperty("path").GetString());
+    }
+
     private static async Task<T?> ReadJsonAsync<T>(HttpResponseMessage response, HttpStatusCode expectedStatus)
     {
         var body = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #418 (Wave 4 of the console form-validation initiative — server half).

## Summary
Makes the analysis-content validation surface field-addressable. `AnalysisContentValidationException` now carries a stable machine-readable `Code` and an optional `Path`, and its 400 responses route through `ProblemDetailsHelpers.CreateValidationProblem` so the analysis-content endpoints return an RFC-7807 ProblemDetails with an `errors[]` extension of `FieldValidationError` (the shared field-level contract from #1309) instead of a flat admin problem. This lets the Console bind each finding onto the offending plan input (Wave-4 console PR).

## Changes Made
- `AnalysisContentValidationException` gains `Code` + optional `Path`; every throw site in `AnalysisContentService` supplies a stable code and a JSON-Pointer/dotted field path (e.g. `/name`, `/savedQuery/layerId`, `/analysisPackage/plan/steps`, `/parameterOverrides`).
- `AnalysisContentEndpoints.TryMapException` routes the validation exception through `ProblemDetailsHelpers.CreateValidationProblem` (validation problem type + `errors[]`).
- Integration tests asserting the field-level shape (code/path/severity, `application/problem+json`, validation problem type) for a missing name and a negative saved-query layerId.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [x] None — no docs or contract impact (error body now uses the already-merged shared validation contract; no new endpoints/shapes)

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
The analysis-content 400 body changes from a flat admin ProblemDetails to a validation ProblemDetails carrying `errors[]`. It remains RFC-7807 `application/problem+json`; consumers reading only `status`/`detail` are unaffected.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
