### PR TITLE
fix(geoservices): honor Esri JSON bboxSR/imageSR on exportImage and return Esri keyProperties shape (#1302)

### DIFF
--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerKeyPropertiesHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerKeyPropertiesHandler.cs
@@ -74,9 +74,16 @@ internal sealed class ImageServerKeyPropertiesHandler
                 };
             }
 
+            var (lowCellSize, highCellSize) = ComputeCellSizes(raster.GeoTransform);
+
             var response = new KeyPropertiesResponse
             {
                 BandProperties = bandProperties,
+                LowCellSize = lowCellSize,
+                HighCellSize = highCellSize,
+                MaxCellSize = highCellSize,
+                ConfigKeyword = string.Empty,
+                BandDefinitionKeyword = string.Empty,
                 DataType = MapPixelType(raster.PixelType),
                 BandCount = raster.BandCount,
                 NoDataValue = raster.NoDataValue,
@@ -97,6 +104,40 @@ internal sealed class ImageServerKeyPropertiesHandler
             scope.RecordException(ex);
             return StandardErrorHelpers.CreateInternalServerError(context, "An error occurred while retrieving key properties.");
         }
+    }
+
+    /// <summary>
+    /// Derives the finest/coarsest cell size from the raster geotransform.
+    /// GeoTransform layout: [upperLeftX, scaleX, skewX, upperLeftY, skewY, scaleY];
+    /// pixel width is <c>|scaleX|</c> (index 1) and pixel height is <c>|scaleY|</c> (index 5).
+    /// Returns <c>(null, null)</c> when no geotransform is available.
+    /// </summary>
+    private static (double? Low, double? High) ComputeCellSizes(double[]? geoTransform)
+    {
+        if (geoTransform is not { Length: >= 6 })
+        {
+            return (null, null);
+        }
+
+        var pixelWidth = Math.Abs(geoTransform[1]);
+        var pixelHeight = Math.Abs(geoTransform[5]);
+
+        if (pixelWidth <= 0 && pixelHeight <= 0)
+        {
+            return (null, null);
+        }
+
+        if (pixelWidth <= 0)
+        {
+            return (pixelHeight, pixelHeight);
+        }
+
+        if (pixelHeight <= 0)
+        {
+            return (pixelWidth, pixelWidth);
+        }
+
+        return (Math.Min(pixelWidth, pixelHeight), Math.Max(pixelWidth, pixelHeight));
     }
 
     private static string MapPixelType(string postgisPixelType)

--- a/src/Honua.Protocols.GeoServices/ImageServer/Models/ComputeOpsModels.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Models/ComputeOpsModels.cs
@@ -91,6 +91,9 @@ public sealed class SampleLocation
 
 /// <summary>
 /// Esri-conformant response for the Image Server <c>keyProperties</c> endpoint.
+/// Mirrors the ArcGIS REST "Key Properties" document so the ArcGIS API for Python
+/// <c>ImageryLayer.key_properties()</c> receives the flat raster key-property dictionary
+/// it expects: a <c>BandProperties</c> array plus cell-size and configuration keywords.
 /// </summary>
 public sealed class KeyPropertiesResponse
 {
@@ -101,7 +104,39 @@ public sealed class KeyPropertiesResponse
     public BandProperty[] BandProperties { get; init; } = [];
 
     /// <summary>
+    /// Coarsest (largest) cell size of the raster, in source spatial-reference units.
+    /// </summary>
+    [JsonPropertyName("HighCellSize")]
+    public double? HighCellSize { get; init; }
+
+    /// <summary>
+    /// Finest (smallest) cell size of the raster, in source spatial-reference units.
+    /// </summary>
+    [JsonPropertyName("LowCellSize")]
+    public double? LowCellSize { get; init; }
+
+    /// <summary>
+    /// Maximum cell size of the raster, in source spatial-reference units.
+    /// </summary>
+    [JsonPropertyName("MaxCellSize")]
+    public double? MaxCellSize { get; init; }
+
+    /// <summary>
+    /// Raster storage configuration keyword. Empty when the source does not declare one.
+    /// </summary>
+    [JsonPropertyName("ConfigKeyword")]
+    public string ConfigKeyword { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Band definition keyword identifying the sensor/product band layout.
+    /// Empty when the source does not declare one.
+    /// </summary>
+    [JsonPropertyName("BandDefinitionKeyword")]
+    public string BandDefinitionKeyword { get; init; } = string.Empty;
+
+    /// <summary>
     /// Esri pixel data type of the raster (e.g. <c>U8</c>, <c>F32</c>).
+    /// Retained alongside the canonical keys for callers that read it directly.
     /// </summary>
     [JsonPropertyName("DataType")]
     public string? DataType { get; init; }
@@ -125,7 +160,7 @@ public sealed class KeyPropertiesResponse
 public sealed class BandProperty
 {
     /// <summary>
-    /// 1-based band index.
+    /// Human-readable band name (e.g. <c>Band_1</c>).
     /// </summary>
     [JsonPropertyName("BandName")]
     public required string BandName { get; init; }

--- a/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerModels.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerModels.cs
@@ -584,10 +584,15 @@ public sealed class ExportImageRequest
     [StringLength(11, ErrorMessage = "Size is too long")]
     public string? Size { get; init; }
 
-    [RegularExpression(@"^\d{1,6}$", ErrorMessage = "ImageSr must be a valid SRID")]
+    // No RegularExpression constraint: the handler parses imageSR/bboxSR through
+    // SpatialReferenceHelpers, which accepts bare SRIDs, EPSG:/URN/OGC URI forms,
+    // CRS84, and the Esri JSON spatial-reference form ({"wkid":N}/{"latestWkid":N})
+    // that ArcGIS SDK clients (ArcGIS API for Python export_image) send. A digits-only
+    // regex would advertise an incorrect contract and reject those valid SDK forms.
+    [StringLength(512, ErrorMessage = "ImageSr is too long")]
     public string? ImageSr { get; init; }
 
-    [RegularExpression(@"^\d{1,6}$", ErrorMessage = "BboxSr must be a valid SRID")]
+    [StringLength(512, ErrorMessage = "BboxSr is too long")]
     public string? BboxSr { get; init; }
 
     [RegularExpression(@"^(png|jpg|jpeg|tiff|tif)$",

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
@@ -436,6 +436,47 @@ public class ImageServerEndpointsTests
     [IntegrationTest]
     [Endpoint("GET /rest/services/{id}/ImageServer/keyProperties")]
     [Operation(Operations.Metadata)]
+    public async Task KeyProperties_Get_ReturnsEsriConformantKeyPropertyShape()
+    {
+        // The ArcGIS API for Python ImageryLayer.key_properties() expects the
+        // canonical Esri raster key-properties document: a flat object whose
+        // BandProperties entries carry a BandName, plus cell-size and config
+        // keyword properties. See ArcGIS REST "Key Properties" reference.
+        var fixture = await CreateFixtureAsync(CreateRasterStoreSubstitute(bandCount: 2));
+        try
+        {
+            var response = await fixture.Client.GetAsync(
+                $"/rest/services/{TestLayerId}/ImageServer/keyProperties?f=json");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var root = json.RootElement;
+
+            // Canonical Esri keyProperties keys must be present.
+            root.TryGetProperty("BandProperties", out var bands).Should().BeTrue();
+            root.TryGetProperty("HighCellSize", out _).Should().BeTrue();
+            root.TryGetProperty("LowCellSize", out _).Should().BeTrue();
+            root.TryGetProperty("MaxCellSize", out _).Should().BeTrue();
+            root.TryGetProperty("ConfigKeyword", out _).Should().BeTrue();
+            root.TryGetProperty("BandDefinitionKeyword", out _).Should().BeTrue();
+
+            bands.ValueKind.Should().Be(JsonValueKind.Array);
+            bands.GetArrayLength().Should().Be(2);
+            bands[0].GetProperty("BandName").GetString().Should().Be("Band_1");
+
+            // GeoTransform [-180, 1.40625, 0, 90, 0, -0.703125] -> cell sizes 1.40625 / 0.703125.
+            root.GetProperty("MaxCellSize").GetDouble().Should().BeApproximately(1.40625, 1e-6);
+            root.GetProperty("LowCellSize").GetDouble().Should().BeApproximately(0.703125, 1e-6);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /rest/services/{id}/ImageServer/keyProperties")]
+    [Operation(Operations.Metadata)]
     public async Task KeyProperties_NonExistentLayer_ReturnsNotFound()
     {
         var fixture = await CreateFixtureAsync(CreateRasterStoreSubstitute());

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerExportHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerExportHandlerTests.cs
@@ -487,6 +487,40 @@ public class ImageServerExportHandlerTests
 
     [UnitTest]
     [Operation(Operations.Export)]
+    public async Task ExportImageAsync_WithEsriJsonBboxSr_PassesParsedSridToRasterStore()
+    {
+        // ArcGIS API for Python sends spatial references as Esri JSON ({"wkid":N}).
+        SetupSuccessfulExport();
+        RasterQuery? capturedQuery = null;
+        _rasterStore.ExportImageAsync(1, 100, Arg.Any<RasterQuery>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedQuery = callInfo.ArgAt<RasterQuery>(2);
+                return CreateTestRasterResult();
+            });
+
+        var context = CreateImageServerContext();
+        var request = CreateRequest(
+            bbox: "-20037508,-20037508,20037508,20037508",
+            bboxSr: "{\"wkid\":3857}",
+            imageSr: "{\"latestWkid\":4326}");
+        var result = await _handler.ExportImageAsync(context, 1, request);
+
+        result.Should().BeOfType<JsonHttpResult<ExportImageResponse>>();
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.Value.OutputSrid.Should().Be(4326);
+        var clipRegion = capturedQuery.Value.ClipRegion;
+        clipRegion.HasValue.Should().BeTrue();
+        if (!clipRegion.HasValue)
+        {
+            throw new InvalidOperationException("Clip region should be set when bbox is provided.");
+        }
+
+        clipRegion.Value.Srid.Should().Be(3857);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
     public async Task ExportImageAsync_NullExtent_FallsBackToSelectedRasterExtent()
     {
         SetupLayerAndRasters();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerParameterValidationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerParameterValidationTests.cs
@@ -206,6 +206,52 @@ public class ImageServerParameterValidationTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.Export)]
+    [Endpoint("POST /rest/services/{id}/ImageServer/exportImage")]
+    public async Task ExportImage_PostFormBody_WithEsriJsonSpatialReferences_DoesNotReturnBadRequest()
+    {
+        // The ArcGIS API for Python ImageryLayer.export_image POSTs a form body
+        // carrying the spatial references in Esri JSON form (bboxSR={"wkid":4326}).
+        using var content = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("f", "json"),
+            new KeyValuePair<string, string>("bbox", "-180,-90,180,90"),
+            new KeyValuePair<string, string>("size", "256,256"),
+            new KeyValuePair<string, string>("format", "png"),
+            new KeyValuePair<string, string>("bboxSR", "{\"wkid\":4326}"),
+            new KeyValuePair<string, string>("imageSR", "{\"wkid\":4326}"),
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{TestLayerId}/ImageServer/exportImage",
+            content);
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotFound);
+        response.StatusCode.Should().NotBe(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Export)]
+    [Endpoint("POST /rest/services/{id}/ImageServer/exportImage")]
+    public async Task ExportImage_PostJsonBody_WithEsriJsonSpatialReferences_DoesNotReturnBadRequest()
+    {
+        // ArcGIS clients may also POST a JSON body where bboxSR/imageSR are nested
+        // JSON objects ({"wkid":4326}) rather than strings.
+        using var content = new StringContent(
+            "{\"f\":\"json\",\"bbox\":\"-180,-90,180,90\",\"size\":\"256,256\"," +
+            "\"format\":\"png\",\"bboxSR\":{\"wkid\":4326},\"imageSR\":{\"latestWkid\":3857}}",
+            System.Text.Encoding.UTF8,
+            "application/json");
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{TestLayerId}/ImageServer/exportImage",
+            content);
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NotFound);
+        response.StatusCode.Should().NotBe(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Export)]
     [Endpoint("GET /rest/services/{id}/ImageServer/exportImage")]
     public async Task ExportImage_MinimumSize_ReturnsSuccessOrNotFound()
     {


### PR DESCRIPTION
## Issue Link
Related to #1302

## Summary
Closes two ImageServer gaps flagged by the Esri SDK certification matrix so the ArcGIS API for Python `ImageryLayer` works against Honua:
1. `exportImage` now honors the Esri JSON spatial-reference form (`bboxSR={"wkid":4326}` / `imageSR={"latestWkid":N}`) that `ImageryLayer.export_image` sends, on the POST surface as well as GET.
2. `keyProperties` now returns the canonical Esri raster key-properties document that `ImageryLayer.key_properties()` expects.

**Root cause (bboxSR):** The handler already routes `bboxSR`/`imageSR` through `SpatialReferenceHelpers.TryParseSrid`, which #1321 extended to accept `{"wkid":N}`/`{"latestWkid":N}`. The remaining gap was twofold: (a) the `ExportImageRequest.ImageSr`/`BboxSr` properties carried a digits-only `[RegularExpression(@"^\d{1,6}$")]` that advertised an incorrect contract (it would reject every non-numeric SDK form — EPSG:/URN/CRS84/Esri-JSON — the moment any validation filter were wired, and misrepresented the contract in OpenAPI); and (b) there was no test proving the POST path (form-encoded and JSON body) carries the Esri JSON SR through to the handler. The live all-fixes stack at https://localhost:8443 could not be used for before/after reproduction because it is `Not Ready` — its data backend host "does not resolve", so every raster endpoint (including base ImageServer metadata) returns 500; reproduction was done through the Testcontainers integration harness instead.

**Root cause (keyProperties):** The response was a non-canonical shape (`{BandProperties, DataType, BandCount, NoDataValue}`) missing the Esri key-properties keys. Per the ArcGIS REST "Key Properties" reference, the document is a flat object with `BandProperties` plus `HighCellSize`/`LowCellSize`/`MaxCellSize` and `ConfigKeyword`/`BandDefinitionKeyword`.

## Changes Made
- Removed the misleading digits-only `RegularExpression` on `ExportImageRequest.ImageSr`/`BboxSr`; replaced with a length bound and a comment documenting that the handler accepts bare SRID, EPSG/URN/OGC-URI, CRS84, and Esri JSON SR forms.
- Extended `KeyPropertiesResponse` with the canonical Esri keys (`HighCellSize`, `LowCellSize`, `MaxCellSize`, `ConfigKeyword`, `BandDefinitionKeyword`) while retaining the existing `DataType`/`BandCount`/`NoDataValue` fields.
- `ImageServerKeyPropertiesHandler` now derives cell sizes from the raster geotransform (`|scaleX|`, `|scaleY|`) and emits the config/band-definition keywords.
- Tests: POST form-body and JSON-body `exportImage` with Esri JSON `bboxSR`/`imageSR` return non-400; handler-level unit test asserting parsed JSON SRIDs reach the raster store; `keyProperties` Esri-conformant shape assertion.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

Targeted ImageServer tests pass (11/11 in a clean run): new POST/JSON-SR exportImage tests, the JSON-SR handler unit test, and the keyProperties shape test. `dotnet build src/Honua.Protocols.GeoServices/Honua.Protocols.GeoServices.csproj -c Release /p:TreatWarningsAsErrors=true` is green (0 warnings, 0 errors). `dotnet format --verify-no-changes` on the changed source files is clean. The only test failures observed were intermittent `Testcontainers MatchImage RegexMatchTimeoutException` during PostgreSQL fixture startup on the shared, heavily-loaded host — unrelated to these changes.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] OpenAPI spec changed

The `imageSR`/`bboxSR` parameter constraints and the `keyProperties` response schema change in the generated GeoServices OpenAPI surface.

## Breaking Changes
None. The `keyProperties` change is additive (new keys alongside the existing ones); the `exportImage` SR change only widens accepted input.

> **Validation note:** Live before/after reproduction against https://localhost:8443 was not possible — that stack is `Not Ready` (data backend "Name does not resolve"; all raster endpoints 500, base metadata included). Reproduction and verification were done through the Testcontainers integration harness, which exercises the real routes, binding, and JSON serialization end to end.

---

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] Tests added for new functionality
