### PR TITLE
fix: restore OData-Version header in GlobalExceptionMiddleware test host

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/GlobalExceptionMiddlewareTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/GlobalExceptionMiddlewareTests.cs
@@ -8,6 +8,7 @@ using Honua.Core.Configuration;
 using Honua.Core.Exceptions;
 using Honua.Infrastructure.Middleware;
 using Honua.Infrastructure.Models;
+using Honua.Protocols.OData;
 using Honua.Protocols.OData.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -30,6 +31,14 @@ public class GlobalExceptionMiddlewareTests : IDisposable
 
     public GlobalExceptionMiddlewareTests()
     {
+        // The OData-formatted error path (OData-Version header + ODataError JSON
+        // envelope) is dispatched through StandardErrorResponseFormatter's
+        // ODataErrorFormatterOverride delegate, which production installs in
+        // ODataServiceCollectionExtensions.AddOData(). This minimal test host
+        // does not call AddOData(), so install just the error-formatter override
+        // it relies on (idempotent — production assigns the same delegate).
+        StandardErrorResponseFormatter.ODataErrorFormatterOverride = ODataErrorFormatter.Format;
+
         var builder = new HostBuilder()
             .ConfigureWebHost(webHost =>
             {


### PR DESCRIPTION
## Issue Link

Fixes #1337

## Summary

PR #1236 (modularization) moved the OData error contract — the `OData-Version` header and the `ODataError` JSON envelope — out of `StandardErrorResponseFormatter` and into an `ODataErrorFormatterOverride` delegate that `ODataServiceCollectionExtensions.AddOData()` installs at startup. Production wiring is intact (`FeatureRegistrationExtensions` calls `AddOData()`), and the full-app fixture tests (`StandardErrorResponseFormatterTests`, `ErrorHandlingConsistencyTests` via `WebAppFixture`) still pass.

`GlobalExceptionMiddlewareTests` builds a bare minimal host that never calls `AddOData()`, so after #1236 the override stayed `null` and `GlobalExceptionMiddleware_ODataPath_ReturnsODataErrorFormat` fell through to generic ProblemDetails with no `OData-Version` header.

## Changes Made

- Install just the OData error-formatter override the minimal test host relies on, mirroring `AddOData()` (idempotent — the same delegate production assigns). Both `StandardErrorResponseFormatter.ODataErrorFormatterOverride` and `ODataErrorFormatter.Format` are `internal` and visible to the test project via `InternalsVisibleTo Honua.Server.Tests`.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/ci/pre-pr-check.sh`)

Verified locally: `Honua.Server.Tests` builds with 0 errors and the previously-failing test passes (`Passed! - Failed: 0, Passed: 1`).

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [x] None — standard merge-and-release flow

## Breaking Changes

None. Test-only change; production behavior is unchanged.

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Issue number linked above
