### PR TITLE
fix: align integration-test geometry field name with physical column (geometry)

### DIFF
--- a/tests/python/ogc_features/test_crs_datetime.py
+++ b/tests/python/ogc_features/test_crs_datetime.py
@@ -84,7 +84,7 @@ class TestCrsAndDatetime:
         response = http_client.get(
             f"/ogc/features/collections/{test_collection_id}/items",
             params={
-                "filter": "S_INTERSECTS(shape, POINT(37.7749 -122.4194))",
+                "filter": "S_INTERSECTS(geometry, POINT(37.7749 -122.4194))",
                 "filter-crs": EPSG4326,
             },
         )

--- a/tests/python/ogc_features/test_geometry_matrix.py
+++ b/tests/python/ogc_features/test_geometry_matrix.py
@@ -40,6 +40,6 @@ class TestGeometryMatrix:
         geom = getattr(geometry_generator, geometry_method)()
         response = http_client.get(
             f"/ogc/features/collections/{test_collection_id}/items",
-            params={"filter": f"S_INTERSECTS(shape, {geom.wkt})"},
+            params={"filter": f"S_INTERSECTS(geometry, {geom.wkt})"},
         )
         assert response.status_code == 200

--- a/tests/python/ogc_features/test_spatial.py
+++ b/tests/python/ogc_features/test_spatial.py
@@ -131,7 +131,7 @@ class TestSpatialPredicates:
         """S_INTERSECTS spatial predicate."""
         polygon = geometry_generator.polygon_simple()
         # CQL2 spatial function syntax
-        filter_expr = f"S_INTERSECTS(shape, {polygon.wkt})"
+        filter_expr = f"S_INTERSECTS(geometry, {polygon.wkt})"
 
         response = http_client.get(
             f"/ogc/features/collections/{test_collection_id}/items",

--- a/tests/python/shared/cql2_cases.py
+++ b/tests/python/shared/cql2_cases.py
@@ -25,9 +25,9 @@ CQL2_TEXT_CASES: list[tuple[str, str]] = [
     ("function_upper", "UPPER(name) = 'ALPHA'"),
     ("function_concat", "CONCAT(name, 'x') LIKE 'alphax'"),
     ("function_mod", "MOD(count, 2) = 0"),
-    ("spatial_intersects", "S_INTERSECTS(shape, POINT(-122.4194 37.7749))"),
-    ("spatial_dwithin", "S_DWITHIN(shape, POINT(-122.4194 37.7749), 1000)"),
-    ("spatial_bbox", "S_INTERSECTS(shape, BBOX(-122.5, 37.7, -122.4, 37.8))"),
+    ("spatial_intersects", "S_INTERSECTS(geometry, POINT(-122.4194 37.7749))"),
+    ("spatial_dwithin", "S_DWITHIN(geometry, POINT(-122.4194 37.7749), 1000)"),
+    ("spatial_bbox", "S_INTERSECTS(geometry, BBOX(-122.5, 37.7, -122.4, 37.8))"),
     ("temporal_after", "T_AFTER(created_at, TIMESTAMP('2024-01-01T00:00:00Z'))"),
     ("temporal_during", "T_DURING(created_at, INTERVAL('2024-01-01T00:00:00Z', '2024-01-31T23:59:59Z'))"),
     ("array_contains", "A_CONTAINS(tags, ('red', 'blue'))"),
@@ -70,7 +70,7 @@ CQL2_JSON_CASES: list[tuple[str, dict]] = [
         {
             "op": "s_intersects",
             "args": [
-                {"property": "shape"},
+                {"property": "geometry"},
                 {"type": "Point", "coordinates": [-122.4194, 37.7749]},
             ],
         },
@@ -80,7 +80,7 @@ CQL2_JSON_CASES: list[tuple[str, dict]] = [
         {
             "op": "s_dwithin",
             "args": [
-                {"property": "shape"},
+                {"property": "geometry"},
                 {"type": "Point", "coordinates": [-122.4194, 37.7749]},
                 1000,
             ],

--- a/tests/python/shared/postgis.py
+++ b/tests/python/shared/postgis.py
@@ -644,7 +644,7 @@ class PostGISFixture:
                         (%s, 'objectid', 'Integer', 0, NULL, false, NULL, 'Object ID'),
                         (%s, 'name', 'String', 1, 255, true, NULL, 'Name'),
                         (%s, 'description', 'String', 2, 1024, true, NULL, 'Description'),
-                        (%s, 'shape', 'Geometry', 3, NULL, true, NULL, 'Geometry')
+                        (%s, 'geometry', 'Geometry', 3, NULL, true, NULL, 'Geometry')
                     ON CONFLICT (layer_id, field_name) DO NOTHING;
                     """,
                     (layer_id, layer_id, layer_id, layer_id),
@@ -974,7 +974,7 @@ class PostGISFixture:
                     "isGeographic": srid == 4326,
                 },
                 "geometryType": geometry_type_token,
-                "primaryGeometryField": "shape",
+                "primaryGeometryField": "geometry",
                 "bbox": {
                     "west": west,
                     "south": south,


### PR DESCRIPTION
## Issue Link

Fixes #1337

## Summary

The Python integration test seed (`tests/python/shared/postgis.py`) creates the `features` table with a physical geometry column named **`geometry`** (table DDL, GIST index, and `layers.geometry_column` default are all `geometry`), but registered the geometry **field's name** as `shape` in `layer_fields` and set the metadata-v2 snapshot's `primaryGeometryField` to `shape`.

The metadata-v2 snapshot path resolves the geometry SQL column from the metadata field name (`FindPrimaryGeometryField` → `SchemaFields[].Name`; `MetadataV2Field` has no separate storage-column property). So queries emitted `ST_AsBinary("shape"::geometry)` against a table whose column is `geometry`, producing PostgreSQL `column "shape" does not exist` → HTTP 500/400 on every feature query against the test layer.

This was masked before the v2 snapshot existed because the legacy reader uses the hardcoded `FeatureQueryEncoding.GeometryColumn = "geometry"` constant.

## Changes Made

- `postgis.py`: geometry field name in `layer_fields` and metadata-v2 `primaryGeometryField` → `geometry`.
- `cql2_cases.py`, `test_spatial.py`, `test_geometry_matrix.py`, `test_crs_datetime.py`: CQL2 `S_INTERSECTS`/`S_DWITHIN` geometry property → `geometry`.

Standardizes on `geometry` (the physical column name) for the geometry field everywhere it is referenced in the canonical test path.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/ci/pre-pr-check.sh`)

Verified the mechanism directly against PostGIS: `ST_AsBinary("shape"::geometry)` fails with the exact CI error (`column "shape" does not exist`) while `ST_AsBinary("geometry"::geometry)` succeeds and returns rows. Full end-to-end validation runs in this PR's Python/JavaScript Integration shards.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [x] None — standard merge-and-release flow

## Breaking Changes

None. Test-fixture-only change; no production code touched.

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Issue number linked above
