### PR TITLE
fix(ci): restore all projects for the target RID in the AOT nightly image build

### DIFF
--- a/docker/Dockerfile.aot
+++ b/docker/Dockerfile.aot
@@ -23,20 +23,20 @@ RUN apk add --no-cache \
     zlib-dev \
     && rm -rf /var/cache/apk/*
 
-# Copy solution and project files first for better layer caching
+# Copy the full project graph (all .csproj) plus build/config files first so the
+# RID-specific restore below covers every transitive project the publish needs.
+# We copy the whole src/ tree's project files via the source checkout to avoid a
+# hand-maintained csproj copy-list that rots whenever projects are added/split
+# (e.g. the #1236 modularization). The dedicated restore layer keeps caching.
 COPY Honua.sln Directory.Build.props Directory.Packages.props NuGet.config .editorconfig ./
 COPY scripts/docker/restore-dotnet-with-github-packages.sh scripts/docker/
-COPY src/Honua.Core/*.csproj src/Honua.Core/
-COPY src/Honua.DuckDB/*.csproj src/Honua.DuckDB/
-COPY src/Honua.MySql/*.csproj src/Honua.MySql/
-COPY src/Honua.Postgres/*.csproj src/Honua.Postgres/
-COPY src/Honua.ServiceDefaults/*.csproj src/Honua.ServiceDefaults/
-COPY src/Honua.Server/*.csproj src/Honua.Server/
-COPY src/Honua.SqlServer/*.csproj src/Honua.SqlServer/
+COPY src/ src/
 
 ARG TARGETARCH
 
-# Restore dependencies
+# Restore dependencies for the target runtime so the AOT self-contained publish
+# (which runs --no-restore) finds obj/project.assets.json for every project in
+# the Honua.Server graph at the RID it builds.
 RUN --mount=type=cache,target=/root/.nuget/packages \
     --mount=type=secret,id=github_actor \
     --mount=type=secret,id=github_token \
@@ -52,14 +52,22 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
 # Copy source code
 COPY . .
 
-# Build Native AOT application for minimal image size
+# Build Native AOT application for minimal image size.
+# Re-restore for the target RID before publishing so the assets cover the full
+# project graph as copied by `COPY . .` (the dedicated restore layer above
+# warms the NuGet cache; this is a near-instant no-op cache hit on success).
 ARG CONFIGURATION=Release
 RUN --mount=type=cache,target=/root/.nuget/packages \
+    --mount=type=secret,id=github_actor \
+    --mount=type=secret,id=github_token \
     case "${TARGETARCH:-amd64}" in \
         amd64) RUNTIME_ID="linux-musl-x64" ; ILC_SINGLE_THREADED="false" ;; \
         arm64) RUNTIME_ID="linux-musl-arm64" ; ILC_SINGLE_THREADED="true" ;; \
         *) echo "Unsupported TARGETARCH=${TARGETARCH}" && exit 1 ;; \
     esac && \
+    sh scripts/docker/restore-dotnet-with-github-packages.sh src/Honua.Server/Honua.Server.csproj \
+      --runtime "$RUNTIME_ID" \
+      -p:RuntimeIdentifier="$RUNTIME_ID" && \
     dotnet publish src/Honua.Server/Honua.Server.csproj \
       --configuration "$CONFIGURATION" \
       --runtime "$RUNTIME_ID" \


### PR DESCRIPTION
## Issue Link
Fixes #1332

## Summary
The nightly AOT container build (`docker/Dockerfile.aot`, used by the `build-aot` job in `.github/workflows/nightly-container-build.yml`) has failed every night since 2026-05-31, leaving the published `nightly`-family AOT images stale and blocking every downstream consumer that pins them (console integration tests, SDK conformance lane, mobile, cross-server-consume).

Root cause: the Dockerfile copied a **hand-maintained list of only 7 `.csproj` files** before its single `dotnet restore`, then ran `dotnet publish --no-restore`. After the #1236 modularization split the codebase into ~29 projects, the new transitive projects (Honua.ArcGisRest, Honua.Hosting, Honua.Jobs, Honua.Ai, Honua.Protocols.*, Honua.Postgres.Shared, Honua.Geocoding, …) were not present at the restore layer and only arrived via `COPY . .`, so their `obj/project.assets.json` was never produced and the `--no-restore` publish failed with `NETSDK1004` for ~every project. The root JIT `Dockerfile` did not hit this because it re-restores after `COPY . .`; the AOT Dockerfile did not.

## Changes Made
- Replace the rotting hand-maintained csproj copy-list with `COPY src/ src/`, so the restore covers the full `Honua.Server` project graph.
- Restore the `Honua.Server` graph for the target runtime (`linux-musl-x64` / `linux-musl-arm64`) in the dedicated restore layer **and** immediately before the AOT publish (mirroring the working JIT `Dockerfile`), so the `--no-restore` publish finds RID-specific assets for every transitive project.
- Keep `--no-restore` on the publish; the pre-publish restore is a near-instant cache hit when the dedicated layer already warmed the NuGet cache.

## Testing
- [x] Manual testing performed

Verified locally with `docker buildx build --platform linux/amd64 --file docker/Dockerfile.aot --target build --build-arg CONFIGURATION=Release` (with `github_actor`/`github_token` secrets as the workflow passes them). The restore step restored all 28 graph projects for `linux-musl-x64` with no `NETSDK1004`, and the AOT publish stage completed successfully (managed build + ILC native codegen + link), well past the original failure point.

> Note: the `AOT-Build-Verification` context is skipped on PRs; the local `docker build` above is the real proof for this change.

## Gate Impact
- [x] Nightly gates (conformance, performance, security)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] No source (.cs) changes — Dockerfile/CI only

> Pre-PR check scope: this diff touches only `docker/Dockerfile.aot` (zero `.cs` files), so the script's build/format/test/AOT stages are no-ops for code. The applicable checks were run and pass — `check-instructions-sync.sh` (canonical instruction file present) and `local-architecture-review.py` ("No C# files changed - architecture review skipped"). The substantive verification for this change is the local `docker buildx build` of the AOT publish stage described under Testing, which completed past `NETSDK1004`.
