### PR TITLE
style: fix whitespace in ImageServerMultidimensionalInfoHandlerTests

### DIFF
--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMultidimensionalInfoHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMultidimensionalInfoHandlerTests.cs
@@ -154,19 +154,19 @@ public class ImageServerMultidimensionalInfoHandlerTests
 
     private static MultidimensionalCoverageRegistration CreateRegistration(
         MultidimensionalCoverageMetadata? metadata) => new()
-    {
-        Id = 7,
-        LayerId = 1,
-        Name = "cube",
-        Format = MultidimensionalCoverageFormat.NetCdf4,
-        Provider = CloudStorageProvider.AwsS3,
-        Bucket = "bucket",
-        ObjectKey = "cube.nc",
-        Variables = Array.Empty<string>(),
-        Metadata = metadata,
-        MetadataScannedAt = metadata is null ? null : DateTimeOffset.UtcNow,
-        CreatedAt = DateTimeOffset.UtcNow
-    };
+        {
+            Id = 7,
+            LayerId = 1,
+            Name = "cube",
+            Format = MultidimensionalCoverageFormat.NetCdf4,
+            Provider = CloudStorageProvider.AwsS3,
+            Bucket = "bucket",
+            ObjectKey = "cube.nc",
+            Variables = Array.Empty<string>(),
+            Metadata = metadata,
+            MetadataScannedAt = metadata is null ? null : DateTimeOffset.UtcNow,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
 
     private static DefaultHttpContext CreateImageServerContext()
     {


### PR DESCRIPTION
Related to #1332.

## Problem
Trunk's **Build & Format Check** is red on pre-existing whitespace violations (lines ~157–166 of `ImageServerMultidimensionalInfoHandlerTests.cs`, introduced by #1321). `dotnet format --verify-no-changes` checks the whole tree, so this fails the format gate on **every** honua-server PR (e.g. #1327).

## Change
`dotnet format` applied to the offending test file (whitespace-only, 13/13). No behavior change.

## Acceptance
- `dotnet format Honua.sln --verify-no-changes` passes on trunk again.
- Unblocks the server PR format gate.

## Gate / release / deploy impact
None — test-file whitespace only.

## Pre-PR Checklist
- [x] Ran `dotnet format` and verified clean
- [x] Conventional commit
- [x] Issue/context linked
