### PR TITLE
fix: seed honua.data_connections for the v2 provider router (unblock integration tests)

### DIFF
--- a/tests/python/shared/postgis.py
+++ b/tests/python/shared/postgis.py
@@ -1069,7 +1069,18 @@ class PostGISFixture:
                     "tile",
                     "search",
                 ],
-                "options": {},
+                # Physical storage columns for the shared `features` table. Without these,
+                # FeatureStorageMapping.FromStorageBinding falls back to field-name/default
+                # heuristics (geometryColumn -> the geometry field's name, no layer filter),
+                # which breaks v2 feature reads against this fixture. The features table is
+                # shared across layers and keyed by layer_id, so the layer discriminator is
+                # required to constrain queries to the bound layer's rows.
+                "options": {
+                    "geometryColumn": "geometry",
+                    "primaryKeyColumn": "objectid",
+                    "attributesColumn": "attributes",
+                    "layerDiscriminatorColumn": "layer_id",
+                },
                 "status": status,
             })
             storage_by_id.setdefault(image_storage_id, {

--- a/tests/python/shared/postgis.py
+++ b/tests/python/shared/postgis.py
@@ -464,6 +464,39 @@ class PostGISFixture:
                     """
                 )
 
+                # Secure connection registry (server migration 006). The Metadata-v2
+                # provider router (FeatureServerQueryExecutor.V2 -> FeatureProviderQueryRouter)
+                # looks up the storage binding's connection here. The table can be empty:
+                # GetConnectionAsync returns null on no matching row, and the router falls
+                # back to the v2 snapshot connection's declared provider ('postgres'). If the
+                # table is absent the lookup throws 42P01 and every feature query 500s.
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS honua.data_connections (
+                        connection_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                        name VARCHAR(64) NOT NULL UNIQUE,
+                        description TEXT,
+                        host VARCHAR(255) NOT NULL,
+                        port INT NOT NULL DEFAULT 5432,
+                        database_name VARCHAR(64) NOT NULL,
+                        username VARCHAR(64) NOT NULL,
+                        provider_name TEXT NOT NULL DEFAULT 'postgis',
+                        ssl_required BOOLEAN NOT NULL DEFAULT TRUE,
+                        ssl_mode VARCHAR(16) NOT NULL DEFAULT 'require',
+                        connection_string_encrypted BYTEA,
+                        encryption_key_version INT NOT NULL DEFAULT 1,
+                        secret_ref VARCHAR(255),
+                        secret_type VARCHAR(32),
+                        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                        created_by VARCHAR(64) NOT NULL DEFAULT 'system',
+                        is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                        last_health_check TIMESTAMPTZ,
+                        health_status VARCHAR(16) DEFAULT 'unknown'
+                    );
+                    """
+                )
+
                 conn.execute(
                     """
                     CREATE TABLE IF NOT EXISTS honua.feature_change_outbox (

--- a/tests/python/shared/postgis.py
+++ b/tests/python/shared/postgis.py
@@ -1069,18 +1069,7 @@ class PostGISFixture:
                     "tile",
                     "search",
                 ],
-                # Physical storage columns for the shared `features` table. Without these,
-                # FeatureStorageMapping.FromStorageBinding falls back to field-name/default
-                # heuristics (geometryColumn -> the geometry field's name, no layer filter),
-                # which breaks v2 feature reads against this fixture. The features table is
-                # shared across layers and keyed by layer_id, so the layer discriminator is
-                # required to constrain queries to the bound layer's rows.
-                "options": {
-                    "geometryColumn": "geometry",
-                    "primaryKeyColumn": "objectid",
-                    "attributesColumn": "attributes",
-                    "layerDiscriminatorColumn": "layer_id",
-                },
+                "options": {},
                 "status": status,
             })
             storage_by_id.setdefault(image_storage_id, {


### PR DESCRIPTION
## Issue Link

Related to #1337 (trunk integration shards still red after #1333). Complements #1346.

## Summary

The Metadata-v2 feature read path (`FeatureServerQueryExecutor.V2` → `FeatureProviderQueryRouter`, introduced by #1236) resolves a publication's storage binding to a connection and looks it up via `PostgresSecureConnectionRegistry`, which queries `honua.data_connections` (created by server migration `006_CreateSecureConnectionRegistry.sql`).

The Python integration seed (`tests/python/shared/postgis.py`) hand-rolls its own `honua.*` schema and never created that table, so every feature query against the seeded layer threw PostgreSQL `42P01` (`relation "honua.data_connections" does not exist`) → HTTP 500. This regressed the `Python Integration` and `JavaScript Integration` shards once the v2 read path became the active router.

This is a **different gap** from the one #1346 closed. #1346 populated the v2 snapshot's feature storage-binding `options` (geometryColumn/attributesColumn/layerDiscriminatorColumn/primaryKeyColumn). This PR adds the missing `honua.data_connections` registry table so the binding→connection lookup in the v2 provider router does not throw. Both are required for the v2 read path to resolve end-to-end.

The seed's v2 snapshot already declares the connection resource with `provider: "postgres"` (`connectionId: "conn-postgres"`), and the router falls back to that provider when the registry returns null. So an **empty** `data_connections` table is sufficient: `GetConnectionAsync` returns null on no matching row (vs. throwing on a missing table), and routing proceeds via the snapshot-declared provider.

## Changes Made

- Add `CREATE TABLE IF NOT EXISTS honua.data_connections (...)` to `seed_test_catalog`, mirroring server migration 006 (the columns the registry SELECTs). Idempotent and additive — coexists with the #1346 binding-options seed (verified non-duplicated after merging trunk).

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/ci/pre-pr-check.sh`)

This is a test-seed change, so PR CI skips the integration shards (affected-projects router). A `workflow_dispatch` trunk validation run is the authoritative check — the `Python Integration` and `JavaScript Integration` shards must be green there. The SQL mechanism (missing table throws `42P01`; present-but-empty table returns null → provider fallback) is confirmed against the v2 router code path.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact

- [x] None — no docs or contract impact

## Release/Deploy Impact

- [x] None — standard merge-and-release flow

## Breaking Changes

None. Test-fixture-only change; no production code touched.

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above

> **Validation note:** rebased on trunk (merged `origin/trunk`, clean auto-merge in `tests/python/shared/postgis.py`); confirmed the `honua.data_connections` table seed and the #1346 binding `options` each appear exactly once (no duplication). Python seed parses cleanly. The authoritative `Python Integration` / `JavaScript Integration` shard greens come from a `workflow_dispatch` trunk validation run.
