### PR TITLE
feat(geoservices): emit syncEnabled + supportsTopFeaturesQuery in FeatureServer metadata (#1293)

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
@@ -91,7 +91,8 @@ internal static partial class FeatureServerEndpoints
             SupportsAdvancedQueries = supportsAdvancedQueries,
             SupportsStatistics = supportsStatistics,
             HasGeometryProperties = hasGeometry,
-            AllowGeometryUpdates = supportsEditing
+            AllowGeometryUpdates = supportsEditing,
+            SyncEnabled = ServiceSupportsSyncV2(service)
         };
     }
 
@@ -807,6 +808,17 @@ internal static partial class FeatureServerEndpoints
     private static bool ServiceSupportsAdvancedQueriesV2(MetadataV2Service service)
         => ReadServiceCapabilitiesV2(service)
             .Any(capability => capability.Equals("Query", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Whether the service opts into the sync/replica surface (createReplica /
+    /// synchronizeReplica / extractChanges), driven by a declared <c>Sync</c>
+    /// capability in <c>service.Options["capabilities"]</c>. The replica handlers
+    /// are served unconditionally; this flag only advertises the surface so Esri
+    /// clients enable their offline/replica workflows against the service.
+    /// </summary>
+    private static bool ServiceSupportsSyncV2(MetadataV2Service service)
+        => ReadServiceCapabilitiesV2(service)
+            .Any(capability => capability.Equals("Sync", StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// V2 equivalent of <c>layer.SupportsAttachments</c>. V2 doesn't model attachments on the

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.cs
@@ -247,6 +247,10 @@ internal static partial class FeatureServerEndpoints
             SupportsReturningQueryExtent = supportsAdvancedQueries,
             SupportsQueryWithDistance = supportsAdvancedQueries,
             SupportsSqlExpression = supportsAdvancedQueries,
+            // queryTopFeatures is served unconditionally by HandleQueryTopFeatures;
+            // advertise it whenever the layer supports advanced queries so Esri
+            // clients (arcgis query_top_features) discover the operation.
+            SupportsTopFeaturesQuery = supportsAdvancedQueries,
             SupportsBatchEditing = supportsAdvancedQueries
         };
     }

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Models/FeatureServerResponse.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Models/FeatureServerResponse.cs
@@ -117,4 +117,12 @@ public sealed class FeatureServerResponse
     /// Whether the service allows geometry updates on features
     /// </summary>
     public bool AllowGeometryUpdates { get; init; } = true;
+
+    /// <summary>
+    /// Whether the service is sync-enabled (supports offline replicas:
+    /// createReplica / synchronizeReplica / extractChanges). Emitted so Esri
+    /// clients (ArcGIS API for Python <c>FeatureLayerCollection</c>, ArcGIS Pro
+    /// offline workflows) discover the replication surface the server exposes.
+    /// </summary>
+    public bool SyncEnabled { get; init; }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MobileOfflineDemoFixtureReplicationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MobileOfflineDemoFixtureReplicationTests.cs
@@ -340,6 +340,47 @@ public sealed class MobileOfflineDemoFixtureReplicationTests : IAsyncLifetime
             "the v1 seed inserts three deterministic offline-site features");
     }
 
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/mobile_offline_demo/FeatureServer")]
+    public async Task MobileOfflineFixture_ServiceMetadata_AdvertisesSyncEnabled()
+    {
+        // The fixture declares a "Sync" capability, so the FeatureServer service
+        // metadata must advertise syncEnabled=true (the replica/extractChanges
+        // surface Esri offline clients discover). Without the Sync capability the
+        // flag stays false.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{ServiceId}/FeatureServer?f=json");
+
+        response.Be200Ok();
+
+        using var document = await ReadJsonDocumentAsync(response);
+        var root = document.RootElement;
+        root.TryGetProperty("error", out _).Should().BeFalse();
+        root.GetProperty("syncEnabled").GetBoolean().Should().BeTrue(
+            "the fixture declares a 'Sync' capability so the service is sync-enabled");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/mobile_offline_demo/FeatureServer/68910")]
+    public async Task MobileOfflineFixture_LayerMetadata_AdvertisesSupportsTopFeaturesQuery()
+    {
+        // queryTopFeatures is served unconditionally, so advanced-query layers must
+        // advertise advancedQueryCapabilities.supportsTopFeaturesQuery=true.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{ServiceId}/FeatureServer/{OfflineSitesLayerId}?f=json");
+
+        response.Be200Ok();
+
+        using var document = await ReadJsonDocumentAsync(response);
+        var root = document.RootElement;
+        root.TryGetProperty("error", out _).Should().BeFalse();
+        root.GetProperty("advancedQueryCapabilities")
+            .GetProperty("supportsTopFeaturesQuery").GetBoolean().Should().BeTrue(
+            "queryTopFeatures is served unconditionally for advanced-query layers");
+    }
+
     // Regression for honua-server#1238: the JSONB-attribute layer must be queryable
     // ONLY because the binding declares attributesColumn=attributes. This test republishes
     // the graph WITHOUT that accessor to prove the bug reproduces (bare columns =>


### PR DESCRIPTION
## Issue Link
Related to #1293

## Summary
The FeatureServer `queryTopFeatures` and replica handlers (`createReplica` /
`synchronizeReplica` / `extractChanges`) are served, but the service/layer
metadata never advertised the matching capability flags. Esri clients gate on
those flags, so the ArcGIS API for Python `query_top_features` and
`FeatureLayerCollection` offline/replica workflows skipped operations the
server already supports. This emits the flags so the operations are
discoverable. Surfaced by the honua-esri-compat SDK-matrix editing lane, whose
sync/topFeatures knobs were stuck on `skip` despite the handlers working live.

## Changes Made
- `AdvancedQueryCapabilities` now sets `SupportsTopFeaturesQuery` whenever the
  layer supports advanced queries — `HandleQueryTopFeatures` serves the
  operation unconditionally, so the flag was the only missing piece.
- `FeatureServerResponse` gains a `SyncEnabled` flag (`syncEnabled` in JSON);
  `MapServiceToResponseV2` emits it when the service declares a `Sync`
  capability in `Options["capabilities"]` — opt-in, mirroring the existing
  `Extract` capability pattern, so non-sync services stay `syncEnabled=false`.
- New `ServiceSupportsSyncV2` reads the `Sync` capability token.
- `MobileOfflineDemoFixtureReplicationTests` gains two assertions over the
  existing sync-capable `mobile_offline_demo` fixture (literal routes
  `GET /rest/services/mobile_offline_demo/FeatureServer` and `.../68910`):
  service `syncEnabled=true` and layer
  `advancedQueryCapabilities.supportsTopFeaturesQuery=true`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Release-build run of `Honua.Protocols.GeoServices.Tests` filtered to
`MobileOfflineDemoFixtureReplicationTests`: 5/5 pass (Testcontainers + PostGIS).
`dotnet build src/Honua.Server -c Release /p:TreatWarningsAsErrors=true`: 0
warnings / 0 errors. `dotnet format --verify-no-changes` on the changed files:
clean. Verified live against `honua-allfixes:cert`: both `queryTopFeatures` and
`createReplica` already return valid payloads; only the metadata flags were
absent.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

(The change only adds two metadata flags that reflect already-served operations;
no OpenAPI/proto surface changes.)

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. `syncEnabled` defaults to `false` and only flips when a service opts in
via a `Sync` capability; `supportsTopFeaturesQuery` reflects an operation that
was already served. No existing service metadata changes unless it declares
`Sync`.

---

> **Validation note:** `queryTopFeatures` and `createReplica`/`extractChanges`/
> `synchronizeReplica` were confirmed working live (valid payloads) before this
> change; this PR only advertises them in metadata, verified by the two new
> assertions in `MobileOfflineDemoFixtureReplicationTests` (5/5 pass on a Release
> Testcontainers run).

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh
