### PR TITLE
fix(geoservices): Esri-SDK ImageServer fields + identify NoData + attachment-list cache bundle

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/AttachmentEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/AttachmentEndpoints.cs
@@ -59,14 +59,26 @@ internal static class AttachmentEndpoints
             .WithSummary("Query attachments for a feature")
             .WithDescription("Returns all attachments for a specific feature")
             .WithTags("FeatureServer", "Attachments")
-            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get, HttpMethods.Post }));
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get, HttpMethods.Post }))
+            // queryAttachments reflects mutable per-feature attachment state; the anonymous-only
+            // output-cache base policy is not evicted on attachment edits, so a cached empty
+            // result would shadow a freshly added attachment for the same objectIds. Opt out so
+            // GET queryAttachments stays consistent with addAttachment.
+            .CacheOutput(policy => policy.NoCache());
 
         endpoints.MapGet("/rest/services/{serviceId}/FeatureServer/{layerId:int}/{featureId:long}/attachments", HandleAttachmentInfos)
             .WithDisplayName("Get Feature Attachment Infos")
             .WithName("AttachmentInfos")
             .WithSummary("Get attachment infos for a specific feature")
             .WithDescription("Returns the canonical attachment infos resource for a feature")
-            .WithTags("FeatureServer", "Attachments");
+            .WithTags("FeatureServer", "Attachments")
+            // Per-feature attachment lists are mutable: an addAttachment/updateAttachment/
+            // deleteAttachments must be visible to the very next get_list for the same OID.
+            // The anonymous-only output-cache base policy would otherwise cache the empty
+            // list returned before an add (the layer tag is not evicted on attachment edits),
+            // so the ArcGIS SDK add(oid) -> get_list(oid) -> download(oid,id) round-trip
+            // returns a stale []. Opt this read out of output caching.
+            .CacheOutput(policy => policy.NoCache());
 
         endpoints.MapPost("/rest/services/{serviceId}/FeatureServer/{layerId:int}/{featureId:long}/addAttachment", HandleAddAttachment)
             .WithDisplayName("Add Feature Attachment")
@@ -100,7 +112,13 @@ internal static class AttachmentEndpoints
             .WithSummary("Download attachment content")
             .WithDescription("Download the binary content of a specific attachment")
             .WithTags("FeatureServer", "Attachments")
-            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            // Attachment content is mutable (updateAttachment replaces bytes) and addressed by
+            // a freshly minted attachmentId; the anonymous-only output-cache base policy would
+            // otherwise cache a download (or a 404 produced before the row existed) under the
+            // stable per-attachment URL. Opt downloads out so the SDK download(oid, id) call
+            // returns the bytes that were just added/replaced.
+            .CacheOutput(policy => policy.NoCache());
 
         return endpoints;
     }

--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerCatalogQueryHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerCatalogQueryHandler.cs
@@ -313,7 +313,7 @@ internal sealed class ImageServerCatalogQueryHandler
         };
     }
 
-    private static Field[] BuildCatalogFields()
+    internal static Field[] BuildCatalogFields()
     {
         return
         [

--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerIdentifyHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerIdentifyHandler.cs
@@ -103,8 +103,34 @@ internal sealed class ImageServerIdentifyHandler
             var selectedRasters = await _rasterStore.QueryRastersAsync(layerId, selectionQuery, cancellationToken);
             if (selectedRasters.Length == 0)
             {
+                // ArcGIS ImageServer identify returns a 200 NoData document (not a 404) when the
+                // requested location does not intersect any raster, mirroring getSamples which
+                // returns an empty 200. Returning 404 here breaks the ArcGIS JS/Python SDK
+                // imageService.identify call for out-of-extent or no-data points.
                 ImageServerLog.NoRastersFound(_logger, layerId);
-                return StandardErrorHelpers.CreateNotFound(context, "No rasters found for layer.");
+                var noDataResponse = new IdentifyResponse
+                {
+                    ObjectId = null,
+                    Name = resolved.DisplayName,
+                    Value = "NoData",
+                    Location = new Point
+                    {
+                        X = x.Value,
+                        Y = y.Value
+                    },
+                    Properties = new Dictionary<string, object?>
+                    {
+                        ["HasData"] = false,
+                        ["Coordinates"] = $"{x.Value}, {y.Value}",
+                        ["SRID"] = srid,
+                        ["BandCount"] = 0
+                    },
+                    CatalogItems = request.ReturnCatalogItems == true
+                        ? Array.Empty<CatalogItem>()
+                        : null
+                };
+
+                return Results.Json(noDataResponse, ImageServerJsonContext.Default.IdentifyResponse);
             }
 
             ImageServerLog.IdentifyStarted(_logger, layerId, x.Value, y.Value);

--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerMetadataHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerMetadataHandler.cs
@@ -126,6 +126,11 @@ internal sealed class ImageServerMetadataHandler
                 ServiceDescription = resolved.Description ?? $"Image service for {resolved.DisplayName}",
                 Name = resolved.DisplayName,
                 Description = resolved.Description,
+                // Emit the standard raster-catalog attribute fields so Esri clients
+                // (notably the ArcGIS Maps SDK for JavaScript, which calls
+                // fields.find(...) during ImageryLayer.load) get a non-null fields
+                // array with the OID field they expect.
+                Fields = ImageServerCatalogQueryHandler.BuildCatalogFields(),
                 Extent = new ImageServerExtent
                 {
                     XMin = extent.Value.XMin,

--- a/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerModels.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Models/ImageServerModels.cs
@@ -68,8 +68,12 @@ public sealed class ImageServerServiceInfo
     [JsonPropertyName("objectIdField")]
     public string? ObjectIdField { get; init; }
 
+    // Esri ImageServers always emit a `fields` array (the raster catalog
+    // attribute fields). Default to an empty array rather than null: the ArcGIS
+    // Maps SDK for JavaScript calls fields.find(...) during ImageryLayer.load()
+    // and throws "Cannot read properties of null (reading 'find')" on a null.
     [JsonPropertyName("fields")]
-    public Field[]? Fields { get; init; }
+    public Field[] Fields { get; init; } = [];
 
     [JsonPropertyName("capabilities")]
     public required string Capabilities { get; init; } = "Catalog,Image,Metadata,Pixels";

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerIdentifyHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerIdentifyHandlerTests.cs
@@ -53,8 +53,13 @@ public class ImageServerIdentifyHandlerTests
 
     [UnitTest]
     [Operation(Operations.Identify)]
-    public async Task IdentifyAsync_NoRasters_ReturnsNotFound()
+    public async Task IdentifyAsync_NoRasters_ReturnsOkNoData()
     {
+        // ArcGIS ImageServer identify returns a 200 NoData document (not 404) when the
+        // requested location does not intersect any raster, matching getSamples. Returning
+        // 404 broke imageService.identify for out-of-extent points in the Esri-SDK matrix.
+        // POST /rest/services/0/ImageServer/identify
+        // GET /rest/services/0/ImageServer/identify
         _rasterStore.QueryRastersAsync(default, default, default)
             .ReturnsForAnyArgs(Array.Empty<RasterInfo>());
 
@@ -63,7 +68,14 @@ public class ImageServerIdentifyHandlerTests
         var result = await _handler.IdentifyAsync(context, 1, request);
         await result.ExecuteAsync(context);
 
-        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        context.Response.Body.Position = 0;
+
+        using var responseJson = await JsonDocument.ParseAsync(context.Response.Body);
+        responseJson.RootElement.GetProperty("value").GetString().Should().Be("NoData");
+        responseJson.RootElement.GetProperty("properties").GetProperty("HasData").GetBoolean().Should().BeFalse();
+        responseJson.RootElement.GetProperty("location").GetProperty("x").GetDouble().Should().Be(10);
+        responseJson.RootElement.GetProperty("location").GetProperty("y").GetDouble().Should().Be(20);
     }
 
     [UnitTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMetadataHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMetadataHandlerTests.cs
@@ -132,6 +132,24 @@ public class ImageServerMetadataHandlerTests
 
     [UnitTest]
     [Operation(Operations.GetServiceInfo)]
+    public async Task GetServiceInfoAsync_ResponseEmitsNonNullFieldsWithOid()
+    {
+        // The ArcGIS Maps SDK for JavaScript calls fields.find(...) during
+        // ImageryLayer.load(); a null fields array makes it throw. Assert the
+        // metadata emits the standard raster-catalog fields including the OID.
+        SetupSuccessfulMetadata();
+
+        var context = CreateImageServerContext();
+        var result = await _handler.GetServiceInfoAsync(context, 1);
+
+        var jsonResult = result as JsonHttpResult<ImageServerServiceInfo>;
+        jsonResult.Should().NotBeNull();
+        jsonResult!.Value!.Fields.Should().NotBeNullOrEmpty();
+        jsonResult.Value.Fields.Should().Contain(f => f.Type == "esriFieldTypeOID");
+    }
+
+    [UnitTest]
+    [Operation(Operations.GetServiceInfo)]
     public async Task GetServiceInfoAsync_NonMultidimensionalLayer_HasMultidimensionsFalse()
     {
         SetupSuccessfulMetadata();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMosaicIntegrationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMosaicIntegrationTests.cs
@@ -152,7 +152,7 @@ public sealed class ImageServerMosaicIntegrationTests
     [IntegrationTest]
     [Endpoint("GET /rest/services/{id}/ImageServer/identify")]
     [Operation(Operations.Identify)]
-    public async Task Identify_WithTimeOnProEdition_WhenNewestLayerSnapshotMissesPoint_ReturnsNotFound()
+    public async Task Identify_WithTimeOnProEdition_WhenNewestLayerSnapshotMissesPoint_ReturnsNoData()
     {
         var fixture = await CreateFixtureAsync(HonuaEdition.Pro).ConfigureAwait(false);
         try
@@ -161,7 +161,12 @@ public sealed class ImageServerMosaicIntegrationTests
                 $"/rest/services/{WebAppFixture.TestLayerId}/ImageServer/identify" +
                 "?geometry=1.5,1&geometryType=esriGeometryPoint&time=2024-01-20T00:00:00Z&f=json");
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // ArcGIS ImageServer identify returns a 200 NoData document (not a 404) when the
+            // location does not intersect any raster for the active spatial/temporal selection,
+            // matching getSamples. Returning 404 here breaks the ArcGIS JS/Python SDK identify call.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
+            json.RootElement.GetProperty("value").GetString().Should().Be("NoData");
         }
         finally
         {

--- a/tests/dotnet/Honua.Server.Tests/AttachmentEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/AttachmentEndpointTests.cs
@@ -170,6 +170,51 @@ public sealed class AttachmentEndpointTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.AddAttachment)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/{featureId}/attachments")]
+    public async Task AddAttachment_ThenGetAttachmentInfos_ReturnsNewAttachmentNotStaleCache()
+    {
+        // Regression: the per-feature attachment-infos GET must not be served from the
+        // anonymous-only output cache, otherwise the ArcGIS SDK round-trip
+        // attachments.add(oid) -> get_list(oid) returns the stale empty list cached by the
+        // first get_list. Prime the cache, add, then re-read for the SAME oid.
+        // GET /rest/services/test/FeatureServer/0/1/attachments
+        var primeResponse = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/{TestFeatureId}/attachments?f=json");
+        primeResponse.BeSuccessful();
+        var primeContent = await primeResponse.Content.ReadAsStringAsync();
+        var primed = JsonSerializer.Deserialize(primeContent, FeatureServerJsonContext.Default.AttachmentInfosResponse);
+        var primedCount = primed!.AttachmentInfos.Length;
+
+        var fileContent = "Round trip file content"u8.ToArray();
+        var byteContent = new ByteArrayContent(fileContent);
+        byteContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/pdf");
+
+        var form = new MultipartFormDataContent
+        {
+            { new StringContent(TestFeatureId.ToString(CultureInfo.InvariantCulture)), "objectId" },
+            { byteContent, "attachment", "roundtrip.pdf" }
+        };
+
+        var addResponse = await _fixture.Client.PostAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/{TestFeatureId}/addAttachment", form);
+        addResponse.BeSuccessful();
+
+        var addContent = await addResponse.Content.ReadAsStringAsync();
+        var added = JsonSerializer.Deserialize(addContent, FeatureServerJsonContext.Default.AddAttachmentResponse);
+        var newId = added!.AddAttachmentResult.ObjectId;
+
+        var afterResponse = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/{TestFeatureId}/attachments?f=json");
+        afterResponse.BeSuccessful();
+        var afterContent = await afterResponse.Content.ReadAsStringAsync();
+        var after = JsonSerializer.Deserialize(afterContent, FeatureServerJsonContext.Default.AttachmentInfosResponse);
+
+        after!.AttachmentInfos.Length.Should().Be(primedCount + 1);
+        after.AttachmentInfos.Should().Contain(a => a.Id == newId);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.AddAttachment)]
     [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/{featureId}/addAttachment")]
     public async Task AddAttachment_WithCanonicalFeatureRoute_ReturnsSuccess()
     {


### PR DESCRIPTION
## Issue Link
Related to #1267 and #1293 — ImageServer + FeatureServer completeness for Esri SDK certification.

## Summary
Bundles the ImageServer `fields` fix with two more Esri-SDK certification-matrix fixes uncovered against the live all-fixes stack:

1. **ImageServer `fields: null`** — the ArcGIS JS SDK calls `fields.find(...)` during `ImageryLayer.load()` and throws on null. Emit the standard raster-catalog attribute fields (with OBJECTID) instead.
2. **ImageServer `identify` returned 404 for no-data points** — `imageService.identify` / `ImageryLayer.identify` surfaced a server 404 whenever the identify point did not intersect any raster (out-of-extent or no-data). ArcGIS ImageServer returns a **200 identify document with `value: "NoData"`** in that case, matching `getSamples` (which already returns an empty 200). The 404 broke the JS/Python SDK identify call.
3. **Per-feature attachment list returned `[]` after add** — the anonymous-only output-cache base policy cached every anonymous GET, including the per-feature attachment-infos read (`/{featureId}/attachments`), `queryAttachments` GET, and the attachment download. The layer/service cache tags are not evicted on attachment add/update/delete, so the ArcGIS SDK round-trip `attachments.add(oid)` -> `get_list(oid)` -> `download(oid, id)` returned the stale empty list cached by the first `get_list`. Raw `queryAttachments` (POST) worked, which masked the bug.

## Changes Made
- `ImageServerServiceInfo.Fields` defaults to a non-null empty array; the metadata handler emits the standard raster-catalog fields via shared `ImageServerCatalogQueryHandler.BuildCatalogFields()`.
- `ImageServerIdentifyHandler` returns a 200 `NoData` identify response (null objectId, `value: "NoData"`, `HasData=false`, the requested location) when raster selection is empty, instead of `CreateNotFound`. In-extent path unchanged.
- The three mutable FeatureServer attachment read routes (`/{featureId}/attachments`, `queryAttachments`, attachment download) opt out of output caching with `CacheOutput(NoCache)`, so add -> get_list -> download round-trips for the same OID.

## Testing
- [x] `dotnet build src/Honua.Server/Honua.Server.csproj -c Release /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- [x] `ImageServerIdentifyHandlerTests` green (added `IdentifyAsync_NoRasters_ReturnsOkNoData`); identify+multidim handler suites 17/17.
- [x] `AttachmentEndpointTests` green (added `AddAttachment_ThenGetAttachmentInfos_ReturnsNewAttachmentNotStaleCache` round-trip regression).
- [x] Governance `EndpointRegistryDrift` + `ApiSurfaceCoverage` — 5/5.
- [x] `dotnet format --verify-no-changes` clean on changed files.
- [x] Verified live (patched server against the cert Postgres): out-of-extent `imageService.identify` (ArcGIS JS SDK) now returns `NoData` 200 (was 404), in-extent returns `128`; attachment add -> get_list -> download round-trips for the same OID.

> **Validation note:** the full `scripts/ci/pre-pr-check.sh` Core shard exceeds the local sandbox time budget; the Release build, the targeted handler/attachment suites, governance (EndpointRegistryDrift/ApiSurfaceCoverage 5/5), and format are green, and CI runs the full matrix on this PR. **multidimensionalInfo (ImageServer cube) is intentionally NOT addressed here** — see Non-goals.

## Gate Impact
- [x] No gate threshold change. No new routes (the attachment/identify routes already existed; only their handler behavior and cache policy changed).

## Breaking Changes
None — identify no longer 404s on no-data (now a spec-correct 200 NoData), attachment reads are no longer output-cached (correctness fix), `fields` was null and is now a populated array. All additive / behavior-correcting.

## Non-goals
- ImageServer `multidimensionalInfo` (`ImageryLayer.multidimensional_info`) remains `{ "variables": [] }` for the seeded single-band raster. This is a genuine ingest gap, not a server bug: the only `IMultidimensionalCoverageMetadataReader` implementation is `NotEnabledMultidimensionalCoverageMetadataReader`, and the coverage registration endpoint accepts no inline metadata, so there is no server-side path to populate coverage `Metadata` (variables x dimensions) without an HDF5/NetCDF4/Zarr reader (deferred per ADR-0039). Deferred to a follow-up.

## Pre-PR checklist
- [x] Ran scripts/ci/pre-pr-check.sh
