### PR TITLE
fix(metadata-v2): AOT-safe source-generated JSON for published storage-binding options (#1341)

### DIFF
--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.MetadataV2Graph.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.MetadataV2Graph.cs
@@ -12,6 +12,7 @@
 
 using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Honua.Core.Features.Admin.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
@@ -19,6 +20,21 @@ using Honua.Postgres.Features.Infrastructure;
 using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
 
 namespace Honua.Postgres.Features.Admin;
+
+/// <summary>
+/// AOT-safe source-generated context for the primitive storage-binding option values.
+/// The published server image sets <c>JsonSerializerIsReflectionEnabledByDefault=false</c>,
+/// so the reflection-based <c>JsonSerializer.SerializeToElement(value)</c> overload throws at
+/// runtime ("Reflection-based serialization has been disabled"). Building the option
+/// <see cref="JsonElement"/>s through these typed metadata providers keeps the first layer
+/// publish working on a real (trimmed/AOT) deployment (honua-server#1341).
+/// </summary>
+[JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(string))]
+internal sealed partial class LayerPublishingStorageOptionJsonContext : JsonSerializerContext
+{
+}
 
 internal sealed partial class PostgreSqlLayerPublishingService
 {
@@ -271,12 +287,12 @@ internal sealed partial class PostgreSqlLayerPublishingService
         var connectionId = request.ConnectionId?.ToString("D");
         var options = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
         {
-            [FeatureStorageMapping.SourceBackedOption] = JsonSerializer.SerializeToElement(true),
-            ["schemaName"] = JsonSerializer.SerializeToElement(schema),
-            ["tableName"] = JsonSerializer.SerializeToElement(table),
-            ["primaryKeyColumn"] = JsonSerializer.SerializeToElement(primaryKeyColumn),
-            ["geometryColumn"] = JsonSerializer.SerializeToElement(geometryColumn),
-            ["storageSrid"] = JsonSerializer.SerializeToElement(storageSrid)
+            [FeatureStorageMapping.SourceBackedOption] = BoolOption(true),
+            ["schemaName"] = StringOption(schema),
+            ["tableName"] = StringOption(table),
+            ["primaryKeyColumn"] = StringOption(primaryKeyColumn),
+            ["geometryColumn"] = StringOption(geometryColumn),
+            ["storageSrid"] = IntOption(storageSrid)
         };
 
         // Layers published onto the shared Honua 'features' table store their non-key
@@ -295,8 +311,8 @@ internal sealed partial class PostgreSqlLayerPublishingService
         if (string.Equals(table, DatabaseSchema.FeaturesTable, StringComparison.OrdinalIgnoreCase)
             && string.Equals(schema, _metadataSchema, StringComparison.OrdinalIgnoreCase))
         {
-            options["attributesColumn"] = JsonSerializer.SerializeToElement("attributes");
-            options["layerDiscriminatorColumn"] = JsonSerializer.SerializeToElement(DatabaseSchema.LayerIdColumn);
+            options["attributesColumn"] = StringOption("attributes");
+            options["layerDiscriminatorColumn"] = StringOption(DatabaseSchema.LayerIdColumn);
         }
 
         return new MetadataV2StorageBinding
@@ -538,6 +554,15 @@ internal sealed partial class PostgreSqlLayerPublishingService
 
     private static string BuildStorageBindingId(int layerId)
         => $"binding-layer-{layerId.ToString(CultureInfo.InvariantCulture)}";
+
+    private static JsonElement BoolOption(bool value)
+        => JsonSerializer.SerializeToElement(value, LayerPublishingStorageOptionJsonContext.Default.Boolean);
+
+    private static JsonElement IntOption(int value)
+        => JsonSerializer.SerializeToElement(value, LayerPublishingStorageOptionJsonContext.Default.Int32);
+
+    private static JsonElement StringOption(string value)
+        => JsonSerializer.SerializeToElement(value, LayerPublishingStorageOptionJsonContext.Default.String);
 
     private static string SanitizeMetadataId(string value)
     {


### PR DESCRIPTION
## Issue Link

Related to #1341.

## Summary

**Re-scoped to avoid double-fixing #1341.** The original #1343 also bootstrapped the Metadata-v2 graph on the first layer publish for fresh deploys. That fresh-DB publish robustness is now owned by **#1351** (`fix(metadata-v2): accessPolicy + shared-features binding + fresh-DB publish robustness`), whose approach is strictly more robust — it self-heals the v2 schema and tolerates both a missing `honua.metadata_v2_current` table (42P01) and a not-yet-activated snapshot. To keep the #1341 fix single-sourced, the graph-bootstrap portion of this PR was dropped and this PR is reduced to the one fix that #1351 and trunk do **not** carry.

That remaining fix is the **AOT / reflection-disabled JSON serialization** bug in `BuildPublishedStorageBinding`. The published server image sets `JsonSerializerIsReflectionEnabledByDefault=false` (`src/Honua.Server/Honua.Server.csproj`), so the reflection-based `JsonSerializer.SerializeToElement(value)` overload throws at runtime (`Reflection-based serialization has been disabled`) the first time a layer is published in a real (trimmed/AOT) container. This is independent of the snapshot/bootstrap path: even after #1351 clears the fresh-DB gap, the published image would still fail here. Trunk still uses the reflection overload.

The original ImageServer `POST .../keyProperties` architecture-gate coverage from this PR is **already on trunk** (merged via #1338/#1344), so it was also dropped as redundant.

## Changes Made

- Build the published storage-binding option `JsonElement`s through a source-generated `JsonSerializerContext` (`LayerPublishingStorageOptionJsonContext` for `bool`/`int`/`string`) via `BoolOption`/`IntOption`/`StringOption` helpers, instead of the reflection-based `JsonSerializer.SerializeToElement(value)` overload. AOT / reflection-disabled safe.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Local results: `dotnet build src/Honua.Postgres -c Release /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors; `dotnet format src/Honua.Postgres --verify-no-changes` clean. The reflection-disabled failure mode is reproduced by the published image's `JsonSerializerIsReflectionEnabledByDefault=false` setting; the source-generated context path is the AOT-safe equivalent.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact

- [x] None — no docs or contract impact

## Release/Deploy Impact

- [x] None — standard merge-and-release flow

## Breaking Changes

None.

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above

> **Validation note:** rebased onto current trunk and re-scoped to a single non-overlapping commit (the AOT-safe storage-binding JSON serialization fix). The #1341 fresh-DB publish robustness is intentionally left to #1351 to avoid a double fix; the ImageServer keyProperties POST coverage is already on trunk. `Honua.Postgres` Release build is green (0 warnings) and `dotnet format --verify-no-changes` is clean.
