### PR TITLE
test: cover service-level POST ImageServer/keyProperties (unblock trunk arch test)

### DIFF
--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerBasicTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerBasicTests.cs
@@ -283,6 +283,7 @@ public class ImageServerBasicTests : IAsyncLifetime
     [Endpoint("GET /rest/services/{serviceId}/ImageServer/getSamples")]
     [Endpoint("POST /rest/services/{serviceId}/ImageServer/getSamples")]
     [Endpoint("GET /rest/services/{serviceId}/ImageServer/keyProperties")]
+    [Endpoint("POST /rest/services/{serviceId}/ImageServer/keyProperties")]
     [Endpoint("GET /rest/services/{serviceId}/ImageServer/legend")]
     [Endpoint("GET /rest/services/{serviceId}/ImageServer/computeClassStatistics")]
     [Endpoint("POST /rest/services/{serviceId}/ImageServer/computeClassStatistics")]
@@ -339,6 +340,10 @@ public class ImageServerBasicTests : IAsyncLifetime
                 new("f", "json")
             ]),
             ($"/rest/services/{serviceId}/ImageServer/query",
+            [
+                new("f", "json")
+            ]),
+            ($"/rest/services/{serviceId}/ImageServer/keyProperties",
             [
                 new("f", "json")
             ]),


### PR DESCRIPTION
## Issue Link

Fixes #1344

## Summary

`Honua.Architecture.Tests` → `ApiSurfaceCoverageTests.AllRegisteredEndpoints_HaveIntegrationTests` has been failing on trunk:

```
found at least one item {"POST /rest/services/{serviceId}/ImageServer/keyProperties"}
```

The service-level POST keyProperties route (`serviceGroup.MapPost("/keyProperties", KeyPropertiesPostByService)`, added by #1338) had no integration test tagged with a matching `[Endpoint]` attribute. The existing POST keyProperties test only covers the layer-level route (`{id:int}`).

This is a **blanket blocker**: the failing architecture test fails every PR's full CI (`.NET Foundation Tests` shard) and every ticket's local-checks, regardless of the ticket's own code. It is currently blocking the migration backlog (#1252/PR #1324, #1257) from validating/merging.

## Changes Made

- Add the service-level POST keyProperties case to the existing `ServiceNameRoutes_DispatchToImageServerSurface` coverage test in `ImageServerBasicTests.cs`: the `[Endpoint("POST /rest/services/{serviceId}/ImageServer/keyProperties")]` attribute plus a form-POST request exercising the route, mirroring the adjacent service-level POST cases (exportImage/identify/query/...).

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/ci/pre-pr-check.sh`)

Verified locally: `Honua.Protocols.GeoServices.Tests` builds clean and `AllRegisteredEndpoints_HaveIntegrationTests` now passes (`Failed: 0, Passed: 1`).

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [x] None — no docs or contract impact

## Release/Deploy Impact

- [x] None — standard merge-and-release flow

## Breaking Changes

None. Test-only change adding coverage for an existing endpoint.

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Issue number linked above