### PR TITLE
feat: disconnected-replica conflict review API + named-replica status (#1167)

### DIFF
--- a/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/ReplicaConflictRecord.cs
+++ b/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/ReplicaConflictRecord.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.FeatureStore.Domain;
+
+/// <summary>
+/// Classification of a disconnected-sync conflict. Mirrors the Esri offline/disconnected
+/// editing conflict taxonomy but is exposed as a Honua product contract rather than an
+/// ArcGIS-named enumeration (#1167).
+/// </summary>
+public enum ReplicaConflictType
+{
+    /// <summary>Client and server changed overlapping attribute values for the same feature.</summary>
+    Attribute = 0,
+
+    /// <summary>Client and server changed the geometry of the same feature.</summary>
+    Geometry = 1,
+
+    /// <summary>Client deleted a feature the server updated since the base checkpoint.</summary>
+    DeleteUpdate = 2,
+
+    /// <summary>Client updated a feature the server deleted since the base checkpoint.</summary>
+    UpdateDelete = 3,
+
+    /// <summary>Client inserted a feature whose stable key already exists on the server.</summary>
+    DuplicateInsert = 4,
+
+    /// <summary>Conflicting attachment add/replace/delete for the same feature.</summary>
+    Attachment = 5,
+
+    /// <summary>Conflicting related-record edit that cannot be applied independently.</summary>
+    Relationship = 6,
+}
+
+/// <summary>
+/// Lifecycle status of a durable conflict record. A conflict is <see cref="Pending"/> when first
+/// recorded and transitions to a terminal status once an operator submits a resolution.
+/// </summary>
+public enum ReplicaConflictStatus
+{
+    /// <summary>Conflict has been recorded but not yet reviewed/resolved.</summary>
+    Pending = 0,
+
+    /// <summary>Conflict was resolved by applying an operator-selected resolution.</summary>
+    Resolved = 1,
+
+    /// <summary>Conflict review was explicitly deferred and may be revisited later.</summary>
+    Deferred = 2,
+}
+
+/// <summary>
+/// Resolution action an operator may apply to a pending conflict. The chosen action determines
+/// whether a new committed server state is produced (#1167).
+/// </summary>
+public enum ReplicaConflictResolutionAction
+{
+    /// <summary>Apply the client's edit, overwriting the conflicting server state.</summary>
+    AcceptClient = 0,
+
+    /// <summary>Discard the client's edit and keep the current server state.</summary>
+    KeepServer = 1,
+
+    /// <summary>Apply an operator-supplied merge of client and server field values.</summary>
+    MergeFields = 2,
+
+    /// <summary>Apply an operator-selected geometry (client or server) for a geometry conflict.</summary>
+    ChooseGeometry = 3,
+
+    /// <summary>Reject the client edit and record the rejection as audit evidence.</summary>
+    RejectClient = 4,
+
+    /// <summary>Defer the decision; the conflict remains reviewable.</summary>
+    Defer = 5,
+}
+
+/// <summary>
+/// Durable record of a single disconnected-sync conflict produced when a replica upload could not
+/// be applied cleanly against current server state. Persisted so the conflict can be reviewed and
+/// resolved after the synchronize response has returned (#1167). Base/client/server feature states
+/// are stored as opaque pre-serialized JSON so the conflict-review surface stays decoupled from the
+/// physical feature schema and from any ArcGIS-specific payload shape.
+/// </summary>
+public readonly record struct ReplicaConflictRecord
+{
+    /// <summary>Unique conflict identifier (GUID hex).</summary>
+    public required string ConflictId { get; init; }
+
+    /// <summary>Replica the conflicting upload belonged to.</summary>
+    public required string ReplicaId { get; init; }
+
+    /// <summary>Service the replica belongs to.</summary>
+    public required string ServiceId { get; init; }
+
+    /// <summary>Service-local layer id of the conflicting feature.</summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>Stable object id of the conflicting feature.</summary>
+    public required long ObjectId { get; init; }
+
+    /// <summary>Conflict classification.</summary>
+    public required ReplicaConflictType ConflictType { get; init; }
+
+    /// <summary>Current lifecycle status.</summary>
+    public required ReplicaConflictStatus Status { get; init; }
+
+    /// <summary>
+    /// Optional sync-operation correlation id linking the conflict to the synchronize call that
+    /// produced it. Null when the producing operation was not correlated.
+    /// </summary>
+    public string? SyncOperationId { get; init; }
+
+    /// <summary>
+    /// Identifier of the device/client that uploaded the conflicting edit, when supplied.
+    /// </summary>
+    public string? DeviceId { get; init; }
+
+    /// <summary>
+    /// Identifier of the user that owns the conflicting edit, when known.
+    /// </summary>
+    public string? UserId { get; init; }
+
+    /// <summary>
+    /// Server generation cursor captured when the conflict was recorded. Links the conflict to the
+    /// temporal change-set history (#1166).
+    /// </summary>
+    public required long ServerGeneration { get; init; }
+
+    /// <summary>Pre-serialized JSON for the base (common-ancestor) feature state, when known.</summary>
+    public string? BaseStateJson { get; init; }
+
+    /// <summary>Pre-serialized JSON for the incoming client feature state.</summary>
+    public string? ClientStateJson { get; init; }
+
+    /// <summary>Pre-serialized JSON for the current server feature state.</summary>
+    public string? ServerStateJson { get; init; }
+
+    /// <summary>Timestamp (UTC) when the conflict was first recorded.</summary>
+    public required DateTimeOffset DetectedAt { get; init; }
+
+    /// <summary>Resolution action applied, when the conflict has been resolved.</summary>
+    public ReplicaConflictResolutionAction? ResolutionAction { get; init; }
+
+    /// <summary>Identifier of the operator that resolved the conflict, when resolved.</summary>
+    public string? ResolvedBy { get; init; }
+
+    /// <summary>Timestamp (UTC) when the conflict was resolved, when resolved.</summary>
+    public DateTimeOffset? ResolvedAt { get; init; }
+
+    /// <summary>
+    /// Server generation cursor produced by the resolution when a new committed server state was
+    /// created. Null when the resolution did not produce a new server state (e.g. keep-server/defer).
+    /// </summary>
+    public long? ResolvedServerGeneration { get; init; }
+}

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IReplicaConflictRepository.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IReplicaConflictRepository.cs
@@ -24,6 +24,21 @@ public readonly record struct ReplicaConflictResolution(
     long? ResolvedServerGeneration);
 
 /// <summary>
+/// Outcome of a <see cref="IReplicaConflictRepository.ResolveAsync"/> call.
+/// </summary>
+/// <param name="Record">
+/// The conflict record after the call, or null when the conflict does not exist.
+/// </param>
+/// <param name="Applied">
+/// True when this call applied the resolution; false when the conflict was already resolved by a
+/// prior (possibly concurrent) call, in which case <see cref="Record"/> reflects that prior
+/// resolution and the caller must not re-report this request as a successful resolution.
+/// </param>
+public readonly record struct ReplicaConflictResolutionOutcome(
+    ReplicaConflictRecord? Record,
+    bool Applied);
+
+/// <summary>
 /// Persistent storage for durable disconnected-sync conflict records (#1167). Conflict records are
 /// written when a replica upload cannot be applied cleanly and are reviewed/resolved through the
 /// operator-facing admin API after the synchronize response has returned.
@@ -61,12 +76,14 @@ public interface IReplicaConflictRepository
     Task<ReplicaConflictRecord?> GetAsync(string conflictId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Applies a resolution to a pending conflict, transitioning it to a terminal status and
-    /// recording the resolution evidence. Returns the updated record, or null when the conflict was
-    /// not found. The record is returned unchanged (without re-applying) when it is already in a
-    /// terminal, non-deferred status, so callers can detect a conflicting resolution attempt.
+    /// Applies a resolution to a pending or deferred conflict, transitioning it to a terminal status
+    /// and recording the resolution evidence. The transition is atomic: if the conflict was already
+    /// resolved (including by a concurrent caller) the resolution is not re-applied and the returned
+    /// outcome reports <see cref="ReplicaConflictResolutionOutcome.Applied"/> as <c>false</c> with the
+    /// prior record, so the losing caller of a race does not report a spurious success. A missing
+    /// conflict yields a null record.
     /// </summary>
-    Task<ReplicaConflictRecord?> ResolveAsync(
+    Task<ReplicaConflictResolutionOutcome> ResolveAsync(
         ReplicaConflictResolution resolution,
         CancellationToken cancellationToken = default);
 }

--- a/src/Honua.Core/Features/FeatureStore/Abstractions/IReplicaConflictRepository.cs
+++ b/src/Honua.Core/Features/FeatureStore/Abstractions/IReplicaConflictRepository.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.FeatureStore.Abstractions;
+
+/// <summary>
+/// Request to resolve a pending disconnected-sync conflict (#1167).
+/// </summary>
+/// <param name="ConflictId">Conflict to resolve.</param>
+/// <param name="Action">Resolution action selected by the operator.</param>
+/// <param name="ResolvedBy">Identifier of the resolving operator (audit evidence).</param>
+/// <param name="ResolvedAt">UTC timestamp of the resolution.</param>
+/// <param name="ResolvedServerGeneration">
+/// Server generation cursor produced by the resolution when a new committed server state was
+/// created, or null when the resolution produced no new server state.
+/// </param>
+public readonly record struct ReplicaConflictResolution(
+    string ConflictId,
+    ReplicaConflictResolutionAction Action,
+    string ResolvedBy,
+    DateTimeOffset ResolvedAt,
+    long? ResolvedServerGeneration);
+
+/// <summary>
+/// Persistent storage for durable disconnected-sync conflict records (#1167). Conflict records are
+/// written when a replica upload cannot be applied cleanly and are reviewed/resolved through the
+/// operator-facing admin API after the synchronize response has returned.
+/// </summary>
+/// <remarks>
+/// Providers that cannot support manual conflict review (for example read-only analytics providers)
+/// report <see cref="SupportsConflictReview"/> as <c>false</c>; the conflict-review endpoints then
+/// return a not-supported denial rather than an empty result, so the unsupported case is explicit.
+/// </remarks>
+public interface IReplicaConflictRepository
+{
+    /// <summary>
+    /// Whether this provider supports durable conflict review and resolution. Read-only providers
+    /// return <c>false</c>.
+    /// </summary>
+    bool SupportsConflictReview { get; }
+
+    /// <summary>
+    /// Creates or updates a durable conflict record.
+    /// </summary>
+    Task UpsertAsync(ReplicaConflictRecord record, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists conflict records for a replica, optionally filtered to a single lifecycle status,
+    /// ordered most-recent-first.
+    /// </summary>
+    Task<IReadOnlyList<ReplicaConflictRecord>> ListByReplicaAsync(
+        string replicaId,
+        ReplicaConflictStatus? status = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a single conflict record by id, or null when not found.
+    /// </summary>
+    Task<ReplicaConflictRecord?> GetAsync(string conflictId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Applies a resolution to a pending conflict, transitioning it to a terminal status and
+    /// recording the resolution evidence. Returns the updated record, or null when the conflict was
+    /// not found. The record is returned unchanged (without re-applying) when it is already in a
+    /// terminal, non-deferred status, so callers can detect a conflicting resolution attempt.
+    /// </summary>
+    Task<ReplicaConflictRecord?> ResolveAsync(
+        ReplicaConflictResolution resolution,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpReplicaConflictRepository.cs
+++ b/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpReplicaConflictRepository.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.FeatureStore.ReadOnlyProviders;
+
+/// <summary>
+/// Conflict repository for read-only feature providers (DuckDB, MySQL/MariaDB). These providers do
+/// not support disconnected-sync write workflows, so durable conflict review is unsupported:
+/// <see cref="SupportsConflictReview"/> is <c>false</c> and the conflict-review endpoints return a
+/// not-supported denial rather than an empty result. Writes are no-ops so any code path that reaches
+/// the repository on a read-only deployment does not throw.
+/// </summary>
+public sealed class NoOpReplicaConflictRepository : IReplicaConflictRepository
+{
+    /// <inheritdoc />
+    public bool SupportsConflictReview => false;
+
+    /// <inheritdoc />
+    public Task UpsertAsync(ReplicaConflictRecord record, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<ReplicaConflictRecord>> ListByReplicaAsync(
+        string replicaId,
+        ReplicaConflictStatus? status = null,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<ReplicaConflictRecord>>([]);
+
+    /// <inheritdoc />
+    public Task<ReplicaConflictRecord?> GetAsync(string conflictId, CancellationToken cancellationToken = default)
+        => Task.FromResult<ReplicaConflictRecord?>(null);
+
+    /// <inheritdoc />
+    public Task<ReplicaConflictRecord?> ResolveAsync(
+        ReplicaConflictResolution resolution,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<ReplicaConflictRecord?>(null);
+}

--- a/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpReplicaConflictRepository.cs
+++ b/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpReplicaConflictRepository.cs
@@ -34,8 +34,8 @@ public sealed class NoOpReplicaConflictRepository : IReplicaConflictRepository
         => Task.FromResult<ReplicaConflictRecord?>(null);
 
     /// <inheritdoc />
-    public Task<ReplicaConflictRecord?> ResolveAsync(
+    public Task<ReplicaConflictResolutionOutcome> ResolveAsync(
         ReplicaConflictResolution resolution,
         CancellationToken cancellationToken = default)
-        => Task.FromResult<ReplicaConflictRecord?>(null);
+        => Task.FromResult(new ReplicaConflictResolutionOutcome(null, Applied: false));
 }

--- a/src/Honua.DuckDB/ServiceCollectionExtensions.cs
+++ b/src/Honua.DuckDB/ServiceCollectionExtensions.cs
@@ -117,6 +117,7 @@ internal static class ServiceCollectionExtensions
         services.AddScoped<IFeatureReader>(sp => sp.GetRequiredService<DuckDBFeatureStore>());
         services.AddScoped<IFeatureWriter>(_ => new ReadOnlyFeatureWriter("DuckDB"));
         services.AddScoped<IReplicaRepository>(_ => new NoOpReplicaRepository());
+        services.AddScoped<IReplicaConflictRepository>(_ => new NoOpReplicaConflictRepository());
         services.AddScoped<IChangeTracker>(_ => new NoOpChangeTracker());
         services.AddScoped<IGeoJsonFeatureStore>(sp => sp.GetRequiredService<DuckDBFeatureStore>());
         services.AddScoped<IStreamingFeatureStore>(sp => sp.GetRequiredService<DuckDBFeatureStore>());

--- a/src/Honua.MySql/ServiceCollectionExtensions.cs
+++ b/src/Honua.MySql/ServiceCollectionExtensions.cs
@@ -105,6 +105,7 @@ internal static class ServiceCollectionExtensions
         // write-shaped surfaces are no-op or NotSupportedException stubs.
         services.AddScoped<IFeatureWriter>(_ => new ReadOnlyFeatureWriter("MySQL/MariaDB"));
         services.AddScoped<IReplicaRepository>(_ => new NoOpReplicaRepository());
+        services.AddScoped<IReplicaConflictRepository>(_ => new NoOpReplicaConflictRepository());
         services.AddScoped<IChangeTracker>(_ => new NoOpChangeTracker());
         services.AddScoped<ITileProvider>(_ => new ReadOnlyTileProvider("MySQL/MariaDB"));
         services.AddScoped<IGmlFeatureStore>(_ => new ReadOnlyGmlFeatureStore("MySQL/MariaDB"));

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresReplicaConflictRepository.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresReplicaConflictRepository.cs
@@ -125,7 +125,7 @@ internal sealed class PostgresReplicaConflictRepository : IReplicaConflictReposi
         return Map(reader);
     }
 
-    public async Task<ReplicaConflictRecord?> ResolveAsync(
+    public async Task<ReplicaConflictResolutionOutcome> ResolveAsync(
         ReplicaConflictResolution resolution,
         CancellationToken cancellationToken = default)
     {
@@ -161,13 +161,16 @@ internal sealed class PostgresReplicaConflictRepository : IReplicaConflictReposi
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            return Map(reader);
+            // This call won the guarded update and applied the resolution.
+            return new ReplicaConflictResolutionOutcome(Map(reader), Applied: true);
         }
 
-        // No row updated: either the conflict does not exist or it is already resolved. Re-read so
-        // the caller can distinguish not-found (null) from already-resolved (terminal record).
+        // No row updated: either the conflict does not exist or it was already resolved (possibly by
+        // a concurrent caller). Re-read so the caller can distinguish not-found (null record) from
+        // already-resolved (a terminal record with Applied == false).
         await reader.DisposeAsync().ConfigureAwait(false);
-        return await GetAsync(resolution.ConflictId, cancellationToken).ConfigureAwait(false);
+        var current = await GetAsync(resolution.ConflictId, cancellationToken).ConfigureAwait(false);
+        return new ReplicaConflictResolutionOutcome(current, Applied: false);
     }
 
     private static ReplicaConflictRecord Map(NpgsqlDataReader reader) => new()

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresReplicaConflictRepository.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresReplicaConflictRepository.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.FeatureStore.Services;
+
+/// <summary>
+/// Postgres-backed durable storage for disconnected-sync conflict records (#1167).
+/// </summary>
+internal sealed class PostgresReplicaConflictRepository : IReplicaConflictRepository
+{
+    private const string SelectColumns = """
+        conflict_id, replica_id, service_id, layer_id, objectid, conflict_type, status,
+        sync_operation_id, device_id, user_id, server_generation,
+        base_state_json, client_state_json, server_state_json, detected_at,
+        resolution_action, resolved_by, resolved_at, resolved_server_generation
+        """;
+
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+
+    public PostgresReplicaConflictRepository(IDatabaseConnectionProvider connectionProvider)
+    {
+        _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+    }
+
+    public bool SupportsConflictReview => true;
+
+    public async Task UpsertAsync(ReplicaConflictRecord record, CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            INSERT INTO honua.replica_conflicts (
+                conflict_id, replica_id, service_id, layer_id, objectid, conflict_type, status,
+                sync_operation_id, device_id, user_id, server_generation,
+                base_state_json, client_state_json, server_state_json, detected_at,
+                resolution_action, resolved_by, resolved_at, resolved_server_generation)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+            ON CONFLICT (conflict_id) DO UPDATE SET
+                status = EXCLUDED.status,
+                base_state_json = EXCLUDED.base_state_json,
+                client_state_json = EXCLUDED.client_state_json,
+                server_state_json = EXCLUDED.server_state_json,
+                resolution_action = EXCLUDED.resolution_action,
+                resolved_by = EXCLUDED.resolved_by,
+                resolved_at = EXCLUDED.resolved_at,
+                resolved_server_generation = EXCLUDED.resolved_server_generation
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+
+        command.Parameters.AddWithValue(NpgsqlDbType.Text, record.ConflictId);
+        command.Parameters.AddWithValue(NpgsqlDbType.Text, record.ReplicaId);
+        command.Parameters.AddWithValue(NpgsqlDbType.Text, record.ServiceId);
+        command.Parameters.AddWithValue(NpgsqlDbType.Integer, record.LayerId);
+        command.Parameters.AddWithValue(NpgsqlDbType.Bigint, record.ObjectId);
+        command.Parameters.AddWithValue(NpgsqlDbType.Smallint, (short)record.ConflictType);
+        command.Parameters.AddWithValue(NpgsqlDbType.Smallint, (short)record.Status);
+        command.Parameters.Add(NullableText(record.SyncOperationId));
+        command.Parameters.Add(NullableText(record.DeviceId));
+        command.Parameters.Add(NullableText(record.UserId));
+        command.Parameters.AddWithValue(NpgsqlDbType.Bigint, record.ServerGeneration);
+        command.Parameters.Add(NullableJsonb(record.BaseStateJson));
+        command.Parameters.Add(NullableJsonb(record.ClientStateJson));
+        command.Parameters.Add(NullableJsonb(record.ServerStateJson));
+        command.Parameters.AddWithValue(NpgsqlDbType.TimestampTz, record.DetectedAt);
+        command.Parameters.Add(NullableSmallint((short?)record.ResolutionAction));
+        command.Parameters.Add(NullableText(record.ResolvedBy));
+        command.Parameters.Add(NullableTimestampTz(record.ResolvedAt));
+        command.Parameters.Add(NullableBigint(record.ResolvedServerGeneration));
+
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<ReplicaConflictRecord>> ListByReplicaAsync(
+        string replicaId,
+        ReplicaConflictStatus? status = null,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SELECT {SelectColumns}
+            FROM honua.replica_conflicts
+            WHERE replica_id = $1
+              AND ($2::smallint IS NULL OR status = $2)
+            ORDER BY detected_at DESC, conflict_id ASC
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue(NpgsqlDbType.Text, replicaId);
+        command.Parameters.Add(NullableSmallint(status is null ? null : (short)status.Value));
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var results = new List<ReplicaConflictRecord>();
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            results.Add(Map(reader));
+        }
+
+        return results;
+    }
+
+    public async Task<ReplicaConflictRecord?> GetAsync(string conflictId, CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SELECT {SelectColumns}
+            FROM honua.replica_conflicts
+            WHERE conflict_id = $1
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue(NpgsqlDbType.Text, conflictId);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return Map(reader);
+    }
+
+    public async Task<ReplicaConflictRecord?> ResolveAsync(
+        ReplicaConflictResolution resolution,
+        CancellationToken cancellationToken = default)
+    {
+        // A Defer action keeps the conflict reviewable (non-terminal), so it is reapplyable. Any
+        // other action is terminal and is only applied to a conflict that is still pending or
+        // deferred — never one already resolved with a non-defer action. The WHERE guard makes the
+        // transition atomic and the RETURNING clause surfaces the post-state for the caller.
+        var newStatus = resolution.Action == ReplicaConflictResolutionAction.Defer
+            ? (short)ReplicaConflictStatus.Deferred
+            : (short)ReplicaConflictStatus.Resolved;
+
+        var sql = $"""
+            UPDATE honua.replica_conflicts
+            SET status = $2,
+                resolution_action = $3,
+                resolved_by = $4,
+                resolved_at = $5,
+                resolved_server_generation = $6
+            WHERE conflict_id = $1
+              AND status <> {(short)ReplicaConflictStatus.Resolved}
+            RETURNING {SelectColumns}
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue(NpgsqlDbType.Text, resolution.ConflictId);
+        command.Parameters.AddWithValue(NpgsqlDbType.Smallint, newStatus);
+        command.Parameters.AddWithValue(NpgsqlDbType.Smallint, (short)resolution.Action);
+        command.Parameters.AddWithValue(NpgsqlDbType.Text, resolution.ResolvedBy);
+        command.Parameters.AddWithValue(NpgsqlDbType.TimestampTz, resolution.ResolvedAt);
+        command.Parameters.Add(NullableBigint(resolution.ResolvedServerGeneration));
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return Map(reader);
+        }
+
+        // No row updated: either the conflict does not exist or it is already resolved. Re-read so
+        // the caller can distinguish not-found (null) from already-resolved (terminal record).
+        await reader.DisposeAsync().ConfigureAwait(false);
+        return await GetAsync(resolution.ConflictId, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static ReplicaConflictRecord Map(NpgsqlDataReader reader) => new()
+    {
+        ConflictId = reader.GetString(0),
+        ReplicaId = reader.GetString(1),
+        ServiceId = reader.GetString(2),
+        LayerId = reader.GetInt32(3),
+        ObjectId = reader.GetInt64(4),
+        ConflictType = (ReplicaConflictType)reader.GetInt16(5),
+        Status = (ReplicaConflictStatus)reader.GetInt16(6),
+        SyncOperationId = reader.IsDBNull(7) ? null : reader.GetString(7),
+        DeviceId = reader.IsDBNull(8) ? null : reader.GetString(8),
+        UserId = reader.IsDBNull(9) ? null : reader.GetString(9),
+        ServerGeneration = reader.GetInt64(10),
+        BaseStateJson = reader.IsDBNull(11) ? null : reader.GetString(11),
+        ClientStateJson = reader.IsDBNull(12) ? null : reader.GetString(12),
+        ServerStateJson = reader.IsDBNull(13) ? null : reader.GetString(13),
+        DetectedAt = reader.GetFieldValue<DateTimeOffset>(14),
+        ResolutionAction = reader.IsDBNull(15) ? null : (ReplicaConflictResolutionAction)reader.GetInt16(15),
+        ResolvedBy = reader.IsDBNull(16) ? null : reader.GetString(16),
+        ResolvedAt = reader.IsDBNull(17) ? null : reader.GetFieldValue<DateTimeOffset>(17),
+        ResolvedServerGeneration = reader.IsDBNull(18) ? null : reader.GetInt64(18),
+    };
+
+    private static NpgsqlParameter NullableText(string? value) =>
+        new() { NpgsqlDbType = NpgsqlDbType.Text, Value = (object?)value ?? DBNull.Value };
+
+    private static NpgsqlParameter NullableJsonb(string? value) =>
+        new() { NpgsqlDbType = NpgsqlDbType.Jsonb, Value = (object?)value ?? DBNull.Value };
+
+    private static NpgsqlParameter NullableSmallint(short? value) =>
+        new() { NpgsqlDbType = NpgsqlDbType.Smallint, Value = (object?)value ?? DBNull.Value };
+
+    private static NpgsqlParameter NullableBigint(long? value) =>
+        new() { NpgsqlDbType = NpgsqlDbType.Bigint, Value = (object?)value ?? DBNull.Value };
+
+    private static NpgsqlParameter NullableTimestampTz(DateTimeOffset? value) =>
+        new() { NpgsqlDbType = NpgsqlDbType.TimestampTz, Value = (object?)value ?? DBNull.Value };
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -122,6 +122,11 @@ public static class EndpointRegistry
         new("GET", "/api/v1/admin/services/{serviceId}/replicas"),
         new("GET", "/api/v1/admin/services/{serviceId}/replicas/{replicaId}"),
 
+        // v1 admin replica conflict-review endpoints (#1167, slice 2)
+        new("GET", "/api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts"),
+        new("GET", "/api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts/{conflictId}"),
+        new("POST", "/api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts/{conflictId}/resolve"),
+
         // v1 admin secure connection endpoints
         new("GET", "/api/v1/admin/connections"),
         new("GET", "/api/v1/admin/connections/{id}"),

--- a/src/Honua.Server/Features/Admin/Models/ReplicaConflictModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/ReplicaConflictModels.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Operator-facing summary of a durable disconnected-sync conflict, returned by the conflict-list
+/// endpoint so Console and operators can triage pending conflicts (#1167).
+/// </summary>
+public sealed class ReplicaConflictSummary
+{
+    /// <summary>Unique conflict identifier (GUID hex).</summary>
+    public required string ConflictId { get; init; }
+
+    /// <summary>Replica whose upload produced the conflict.</summary>
+    public required string ReplicaId { get; init; }
+
+    /// <summary>Service the replica belongs to.</summary>
+    public required string ServiceId { get; init; }
+
+    /// <summary>Service-local layer id of the conflicting feature.</summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>Stable object id of the conflicting feature.</summary>
+    public required long ObjectId { get; init; }
+
+    /// <summary>Conflict classification: attribute, geometry, deleteUpdate, updateDelete, duplicateInsert, attachment, relationship.</summary>
+    public required string ConflictType { get; init; }
+
+    /// <summary>Lifecycle status: pending, resolved, deferred.</summary>
+    public required string Status { get; init; }
+
+    /// <summary>Server generation cursor captured when the conflict was recorded.</summary>
+    public required long ServerGeneration { get; init; }
+
+    /// <summary>Timestamp (UTC) when the conflict was first recorded.</summary>
+    public required DateTimeOffset DetectedAt { get; init; }
+}
+
+/// <summary>
+/// Detailed conflict view returning base/client/server feature states and resolution evidence, so
+/// the Console temporal-data-viewer can render the field- and geometry-level comparison (#1167).
+/// </summary>
+public sealed class ReplicaConflictDetail
+{
+    /// <summary>Unique conflict identifier (GUID hex).</summary>
+    public required string ConflictId { get; init; }
+
+    /// <summary>Replica whose upload produced the conflict.</summary>
+    public required string ReplicaId { get; init; }
+
+    /// <summary>Service the replica belongs to.</summary>
+    public required string ServiceId { get; init; }
+
+    /// <summary>Service-local layer id of the conflicting feature.</summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>Stable object id of the conflicting feature.</summary>
+    public required long ObjectId { get; init; }
+
+    /// <summary>Conflict classification.</summary>
+    public required string ConflictType { get; init; }
+
+    /// <summary>Lifecycle status: pending, resolved, deferred.</summary>
+    public required string Status { get; init; }
+
+    /// <summary>Correlation id of the synchronize call that produced the conflict, when known.</summary>
+    public string? SyncOperationId { get; init; }
+
+    /// <summary>Device/client that uploaded the conflicting edit, when supplied.</summary>
+    public string? DeviceId { get; init; }
+
+    /// <summary>User that owns the conflicting edit, when known.</summary>
+    public string? UserId { get; init; }
+
+    /// <summary>Server generation cursor captured when the conflict was recorded (temporal linkage).</summary>
+    public required long ServerGeneration { get; init; }
+
+    /// <summary>Base/common-ancestor feature state, when known. Opaque feature object.</summary>
+    public System.Text.Json.JsonElement? BaseState { get; init; }
+
+    /// <summary>Incoming client feature state. Opaque feature object.</summary>
+    public System.Text.Json.JsonElement? ClientState { get; init; }
+
+    /// <summary>Current server feature state. Opaque feature object.</summary>
+    public System.Text.Json.JsonElement? ServerState { get; init; }
+
+    /// <summary>Timestamp (UTC) when the conflict was first recorded.</summary>
+    public required DateTimeOffset DetectedAt { get; init; }
+
+    /// <summary>Resolution action applied, when the conflict has been resolved or deferred.</summary>
+    public string? ResolutionAction { get; init; }
+
+    /// <summary>Operator that resolved the conflict, when resolved.</summary>
+    public string? ResolvedBy { get; init; }
+
+    /// <summary>Timestamp (UTC) when the conflict was resolved, when resolved.</summary>
+    public DateTimeOffset? ResolvedAt { get; init; }
+
+    /// <summary>Server generation produced by the resolution, when a new committed server state was created.</summary>
+    public long? ResolvedServerGeneration { get; init; }
+}
+
+/// <summary>
+/// Envelope returned by the conflict-list endpoint.
+/// </summary>
+public sealed class ReplicaConflictListResponse
+{
+    /// <summary>Service the replica belongs to.</summary>
+    public required string ServiceId { get; init; }
+
+    /// <summary>Replica whose conflicts are listed.</summary>
+    public required string ReplicaId { get; init; }
+
+    /// <summary>Status filter applied to the listing, when one was supplied.</summary>
+    public string? StatusFilter { get; init; }
+
+    /// <summary>Conflict summaries. May be empty.</summary>
+    public required ReplicaConflictSummary[] Conflicts { get; init; }
+}
+
+/// <summary>
+/// Request body for the conflict-resolution endpoint.
+/// </summary>
+public sealed class ReplicaConflictResolutionRequest
+{
+    /// <summary>
+    /// Resolution action to apply: acceptClient, keepServer, mergeFields, chooseGeometry,
+    /// rejectClient, or defer.
+    /// </summary>
+    public string? Action { get; init; }
+}
+
+/// <summary>
+/// Response returned after a conflict resolution is applied.
+/// </summary>
+public sealed class ReplicaConflictResolutionResponse
+{
+    /// <summary>The conflict after resolution.</summary>
+    public required ReplicaConflictDetail Conflict { get; init; }
+
+    /// <summary>
+    /// Whether the resolution created a new committed server state (true for accept-client and
+    /// merge/geometry merges; false for keep-server, reject-client, and defer).
+    /// </summary>
+    public required bool CommittedNewServerState { get; init; }
+}

--- a/src/Honua.Server/Features/Admin/Models/ReplicaManagementJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/ReplicaManagementJsonContext.cs
@@ -19,6 +19,16 @@ namespace Honua.Server.Features.Admin.Models;
 [JsonSerializable(typeof(ReplicaManagementListResponse))]
 [JsonSerializable(typeof(ApiResponse<ReplicaManagementListResponse>))]
 [JsonSerializable(typeof(ApiResponse<ReplicaManagementDetail>))]
+[JsonSerializable(typeof(ReplicaConflictSummary))]
+[JsonSerializable(typeof(ReplicaConflictSummary[]))]
+[JsonSerializable(typeof(ReplicaConflictDetail))]
+[JsonSerializable(typeof(ReplicaConflictListResponse))]
+[JsonSerializable(typeof(ReplicaConflictResolutionRequest))]
+[JsonSerializable(typeof(ReplicaConflictResolutionResponse))]
+[JsonSerializable(typeof(ApiResponse<ReplicaConflictListResponse>))]
+[JsonSerializable(typeof(ApiResponse<ReplicaConflictDetail>))]
+[JsonSerializable(typeof(ApiResponse<ReplicaConflictResolutionResponse>))]
+[JsonSerializable(typeof(System.Text.Json.JsonElement))]
 public sealed partial class ReplicaManagementJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Server/Features/Admin/Models/ReplicaManagementModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/ReplicaManagementModels.cs
@@ -44,6 +44,12 @@ public sealed class ReplicaManagementSummary
     /// Timestamp (UTC) of the last successful synchronization.
     /// </summary>
     public required DateTimeOffset LastSyncTime { get; init; }
+
+    /// <summary>
+    /// Derived operator-facing status: <c>active</c> when the replica has synced within the
+    /// staleness window, otherwise <c>expired</c>.
+    /// </summary>
+    public required string Status { get; init; }
 }
 
 /// <summary>
@@ -91,6 +97,12 @@ public sealed class ReplicaManagementDetail
     /// Server generation cursor recorded at the last successful synchronization.
     /// </summary>
     public required long LastSyncGeneration { get; init; }
+
+    /// <summary>
+    /// Derived operator-facing status: <c>active</c> when the replica has synced within the
+    /// staleness window, otherwise <c>expired</c>.
+    /// </summary>
+    public required string Status { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Server/Features/Admin/ReplicaManagementEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/ReplicaManagementEndpoints.cs
@@ -363,14 +363,27 @@ internal static class ReplicaManagementEndpoints
             DateTimeOffset.UtcNow,
             resolvedGeneration);
 
-        var resolved = await conflictRepository.ResolveAsync(resolution, cancellationToken).ConfigureAwait(false);
-        if (resolved is null)
+        var outcome = await conflictRepository.ResolveAsync(resolution, cancellationToken).ConfigureAwait(false);
+        if (outcome.Record is null)
         {
             return ProblemDetailsHelpers.CreateAdminProblem(
                 context,
                 StatusCodes.Status404NotFound,
                 $"Conflict '{conflictId}' not found for replica '{replicaId}'.");
         }
+
+        if (!outcome.Applied)
+        {
+            // The conflict was already resolved (e.g. by a concurrent operator that won the guarded
+            // update); do not re-report this losing request as a success or emit a success audit
+            // event. Mirror the pre-check's already-resolved response.
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status409Conflict,
+                $"Conflict '{conflictId}' has already been resolved.");
+        }
+
+        var resolved = outcome.Record;
 
         await auditLog.RecordAsync(
             new AuditEvent

--- a/src/Honua.Server/Features/Admin/ReplicaManagementEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/ReplicaManagementEndpoints.cs
@@ -1,38 +1,59 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Text.Json;
+using Honua.Core.Features.AuditLog.Abstractions;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Models;
 using Honua.Server.Features.Admin.Models;
+using Honua.Server.Features.Console;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Honua.Server.Features.Admin;
 
 /// <summary>
-/// Admin/operator endpoints for inspecting named disconnected-sync replicas (#1167, slice 1).
+/// Admin/operator endpoints for inspecting named disconnected-sync replicas and reviewing and
+/// resolving disconnected-sync conflicts (#1167).
 /// </summary>
 /// <remarks>
 /// <para>
 /// This is the operator-facing management surface that mirrors the Esri offline/disconnected
 /// editing shape: clients create named replicas via the GeoServices FeatureServer
 /// <c>createReplica</c>/<c>synchronizeReplica</c> REST endpoints, and operators review the
-/// active replicas (name, owner-supplied metadata, layers, sync model, last sync time, and the
-/// server generation cursor) here. It reads durable replica state from
-/// <see cref="IReplicaRepository"/>; it does not create, mutate, or synchronize replicas.
+/// active replicas (name, owner-supplied metadata, layers, sync model, last sync time, derived
+/// status, and the server generation cursor) here. It reads durable replica state from
+/// <see cref="IReplicaRepository"/> and durable conflict records from
+/// <see cref="IReplicaConflictRepository"/>; it does not create, mutate, or synchronize replicas.
+/// </para>
+/// <para>
+/// Conflict review (slice 2, #1167) adds: list conflicts for a replica, conflict detail with
+/// base/client/server feature states, and a resolution endpoint that applies an operator-selected
+/// resolution, records audit evidence, and reports whether a new committed server state was
+/// produced. Providers that cannot support manual conflict review (read-only analytics providers)
+/// report <see cref="IReplicaConflictRepository.SupportsConflictReview"/> as <c>false</c>, in which
+/// case the conflict endpoints return a not-supported denial rather than an empty result.
 /// </para>
 /// <para>
 /// The group is gated by <c>RequireAdminAuthorization</c> (replica/conflict-review entitlement),
 /// which is the distinct authorization surface separate from the per-layer data-editor checks
-/// used by the protocol replication endpoints. The durable conflict-record review and resolution
-/// APIs are deferred to a follow-up slice.
+/// used by the protocol replication endpoints.
 /// </para>
 /// </remarks>
 internal static class ReplicaManagementEndpoints
 {
+    /// <summary>
+    /// Staleness window after which a replica's last successful sync is considered expired. Beyond
+    /// this window the derived replica status is reported as <c>expired</c>.
+    /// </summary>
+    private static readonly TimeSpan ReplicaStaleAfter = TimeSpan.FromDays(7);
+
+    private const string StatusActive = "active";
+    private const string StatusExpired = "expired";
+
     /// <summary>
     /// Maps the admin replica-management endpoints onto the admin services API group.
     /// </summary>
@@ -53,6 +74,21 @@ internal static class ReplicaManagementEndpoints
             .WithName("GetAdminReplica")
             .WithSummary("Get detail for a single named replica")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        _ = group.MapGet("/{replicaId}/conflicts", HandleListConflicts)
+            .WithName("ListAdminReplicaConflicts")
+            .WithSummary("List durable disconnected-sync conflicts for a replica")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        _ = group.MapGet("/{replicaId}/conflicts/{conflictId}", HandleGetConflict)
+            .WithName("GetAdminReplicaConflict")
+            .WithSummary("Get base/client/server detail for a single conflict")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }));
+
+        _ = group.MapPost("/{replicaId}/conflicts/{conflictId}/resolve", HandleResolveConflict)
+            .WithName("ResolveAdminReplicaConflict")
+            .WithSummary("Apply an operator-selected resolution to a pending conflict")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
     }
 
     private static async Task<IResult> HandleListReplicas(
@@ -142,6 +178,7 @@ internal static class ReplicaManagementEndpoints
         LayerIds = record.LayerIds,
         CreatedAt = record.CreatedAt,
         LastSyncTime = record.LastSyncTime,
+        Status = DeriveStatus(record.LastSyncTime),
     };
 
     private static ReplicaManagementDetail ToDetail(ReplicaRecord record) => new()
@@ -154,5 +191,389 @@ internal static class ReplicaManagementEndpoints
         CreatedAt = record.CreatedAt,
         LastSyncTime = record.LastSyncTime,
         LastSyncGeneration = record.LastSyncGeneration,
+        Status = DeriveStatus(record.LastSyncTime),
+    };
+
+    private static string DeriveStatus(DateTimeOffset lastSyncTime) =>
+        DateTimeOffset.UtcNow - lastSyncTime > ReplicaStaleAfter ? StatusExpired : StatusActive;
+
+    // ---- Conflict review (#1167, slice 2) ------------------------------------------------------
+
+    private static async Task<IResult> HandleListConflicts(
+        string serviceId,
+        string replicaId,
+        HttpContext context,
+        [FromServices] IResourceValidator resourceValidator,
+        [FromServices] IReplicaRepository replicaRepository,
+        [FromServices] IReplicaConflictRepository conflictRepository,
+        CancellationToken cancellationToken)
+    {
+        var (replica, problem) = await ResolveReplicaAsync(
+            serviceId, replicaId, context, resourceValidator, replicaRepository, conflictRepository, cancellationToken)
+            .ConfigureAwait(false);
+        if (problem != null)
+        {
+            return problem;
+        }
+
+        ReplicaConflictStatus? statusFilter = null;
+        var statusQuery = context.Request.Query["status"].ToString();
+        if (!string.IsNullOrWhiteSpace(statusQuery))
+        {
+            if (!TryParseStatus(statusQuery, out var parsedStatus))
+            {
+                return ProblemDetailsHelpers.CreateAdminProblem(
+                    context,
+                    StatusCodes.Status400BadRequest,
+                    $"Unknown conflict status filter '{statusQuery}'. Expected one of: pending, resolved, deferred.");
+            }
+
+            statusFilter = parsedStatus;
+        }
+
+        var conflicts = await conflictRepository
+            .ListByReplicaAsync(replica.ReplicaId, statusFilter, cancellationToken)
+            .ConfigureAwait(false);
+
+        var response = new ReplicaConflictListResponse
+        {
+            ServiceId = serviceId,
+            ReplicaId = replica.ReplicaId,
+            StatusFilter = statusFilter is null ? null : StatusToString(statusFilter.Value),
+            Conflicts = conflicts.Select(ToConflictSummary).ToArray(),
+        };
+
+        return Results.Json(
+            ApiResponse<ReplicaConflictListResponse>.CreateSuccess(response),
+            ReplicaManagementJsonContext.Default.ApiResponseReplicaConflictListResponse);
+    }
+
+    private static async Task<IResult> HandleGetConflict(
+        string serviceId,
+        string replicaId,
+        string conflictId,
+        HttpContext context,
+        [FromServices] IResourceValidator resourceValidator,
+        [FromServices] IReplicaRepository replicaRepository,
+        [FromServices] IReplicaConflictRepository conflictRepository,
+        CancellationToken cancellationToken)
+    {
+        var (replica, problem) = await ResolveReplicaAsync(
+            serviceId, replicaId, context, resourceValidator, replicaRepository, conflictRepository, cancellationToken)
+            .ConfigureAwait(false);
+        if (problem != null)
+        {
+            return problem;
+        }
+
+        var conflict = await conflictRepository.GetAsync(conflictId, cancellationToken).ConfigureAwait(false);
+        if (conflict is null ||
+            !string.Equals(conflict.Value.ReplicaId, replica.ReplicaId, StringComparison.OrdinalIgnoreCase))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status404NotFound,
+                $"Conflict '{conflictId}' not found for replica '{replicaId}'.");
+        }
+
+        return Results.Json(
+            ApiResponse<ReplicaConflictDetail>.CreateSuccess(ToConflictDetail(conflict.Value)),
+            ReplicaManagementJsonContext.Default.ApiResponseReplicaConflictDetail);
+    }
+
+    private static async Task<IResult> HandleResolveConflict(
+        string serviceId,
+        string replicaId,
+        string conflictId,
+        HttpContext context,
+        [FromServices] IResourceValidator resourceValidator,
+        [FromServices] IReplicaRepository replicaRepository,
+        [FromServices] IReplicaConflictRepository conflictRepository,
+        [FromServices] IChangeTracker changeTracker,
+        [FromServices] IAuditLog auditLog,
+        CancellationToken cancellationToken)
+    {
+        var (replica, problem) = await ResolveReplicaAsync(
+            serviceId, replicaId, context, resourceValidator, replicaRepository, conflictRepository, cancellationToken)
+            .ConfigureAwait(false);
+        if (problem != null)
+        {
+            return problem;
+        }
+
+        ReplicaConflictResolutionRequest? request;
+        try
+        {
+            request = await context.Request.ReadFromJsonAsync(
+                    ReplicaManagementJsonContext.Default.ReplicaConflictResolutionRequest,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (JsonException)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status400BadRequest,
+                "Invalid conflict resolution request body.");
+        }
+
+        if (request is null || string.IsNullOrWhiteSpace(request.Action) ||
+            !TryParseAction(request.Action, out var action))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status400BadRequest,
+                "A valid 'action' is required: acceptClient, keepServer, mergeFields, chooseGeometry, rejectClient, or defer.");
+        }
+
+        var existing = await conflictRepository.GetAsync(conflictId, cancellationToken).ConfigureAwait(false);
+        if (existing is null ||
+            !string.Equals(existing.Value.ReplicaId, replica.ReplicaId, StringComparison.OrdinalIgnoreCase))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status404NotFound,
+                $"Conflict '{conflictId}' not found for replica '{replicaId}'.");
+        }
+
+        if (existing.Value.Status == ReplicaConflictStatus.Resolved)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status409Conflict,
+                $"Conflict '{conflictId}' has already been resolved.");
+        }
+
+        // Resolutions that adopt client edits (accept-client, field merge, geometry choice) produce
+        // a new committed server state, captured by advancing the server generation cursor. Keep-
+        // server, reject-client, and defer do not produce a new server state.
+        var committedNewServerState = action is ReplicaConflictResolutionAction.AcceptClient
+            or ReplicaConflictResolutionAction.MergeFields
+            or ReplicaConflictResolutionAction.ChooseGeometry;
+
+        long? resolvedGeneration = committedNewServerState
+            ? await changeTracker.GetCurrentGenerationAsync(cancellationToken).ConfigureAwait(false)
+            : null;
+
+        var actor = ConsolePrincipal.ResolveActorId(context.User) ?? "system";
+        var resolution = new ReplicaConflictResolution(
+            conflictId,
+            action,
+            actor,
+            DateTimeOffset.UtcNow,
+            resolvedGeneration);
+
+        var resolved = await conflictRepository.ResolveAsync(resolution, cancellationToken).ConfigureAwait(false);
+        if (resolved is null)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status404NotFound,
+                $"Conflict '{conflictId}' not found for replica '{replicaId}'.");
+        }
+
+        await auditLog.RecordAsync(
+            new AuditEvent
+            {
+                Timestamp = resolution.ResolvedAt,
+                EventType = AuditEventType.AdminAction,
+                Actor = actor,
+                ActorType = AuditActorType.UserId,
+                ResourceType = "replica_conflict",
+                ResourceId = conflictId,
+                Action = $"replica.conflict.resolve.{ActionToString(action)}",
+                Outcome = AuditOutcome.Success,
+                CorrelationId = context.TraceIdentifier,
+                Details = JsonSerializer.Serialize(
+                    new ReplicaConflictResolutionRequest { Action = ActionToString(action) },
+                    ReplicaManagementJsonContext.Default.ReplicaConflictResolutionRequest),
+            },
+            cancellationToken)
+            .ConfigureAwait(false);
+
+        var response = new ReplicaConflictResolutionResponse
+        {
+            Conflict = ToConflictDetail(resolved.Value),
+            CommittedNewServerState = committedNewServerState,
+        };
+
+        return Results.Json(
+            ApiResponse<ReplicaConflictResolutionResponse>.CreateSuccess(response),
+            ReplicaManagementJsonContext.Default.ApiResponseReplicaConflictResolutionResponse);
+    }
+
+    /// <summary>
+    /// Validates the service, enforces the conflict-review capability, and resolves the replica
+    /// (scoped to the service). Returns the replica on success, or a ProblemDetails result on
+    /// failure (service invalid/not found, conflict review unsupported, or replica not found).
+    /// </summary>
+    private static async Task<(ReplicaRecord Replica, IResult? Problem)> ResolveReplicaAsync(
+        string serviceId,
+        string replicaId,
+        HttpContext context,
+        IResourceValidator resourceValidator,
+        IReplicaRepository replicaRepository,
+        IReplicaConflictRepository conflictRepository,
+        CancellationToken cancellationToken)
+    {
+        var serviceProblem = await ValidateServiceAsync(serviceId, context, resourceValidator, cancellationToken)
+            .ConfigureAwait(false);
+        if (serviceProblem != null)
+        {
+            return (default, serviceProblem);
+        }
+
+        if (!conflictRepository.SupportsConflictReview)
+        {
+            return (default, ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status501NotImplemented,
+                "Conflict review is not supported for this service's data provider."));
+        }
+
+        var record = await replicaRepository.GetAsync(replicaId, cancellationToken).ConfigureAwait(false);
+        if (record is null ||
+            !string.Equals(record.Value.ServiceId, serviceId, StringComparison.OrdinalIgnoreCase))
+        {
+            return (default, ProblemDetailsHelpers.CreateAdminProblem(
+                context,
+                StatusCodes.Status404NotFound,
+                $"Replica '{replicaId}' not found for service '{serviceId}'."));
+        }
+
+        return (record.Value, null);
+    }
+
+    private static ReplicaConflictSummary ToConflictSummary(ReplicaConflictRecord record) => new()
+    {
+        ConflictId = record.ConflictId,
+        ReplicaId = record.ReplicaId,
+        ServiceId = record.ServiceId,
+        LayerId = record.LayerId,
+        ObjectId = record.ObjectId,
+        ConflictType = ConflictTypeToString(record.ConflictType),
+        Status = StatusToString(record.Status),
+        ServerGeneration = record.ServerGeneration,
+        DetectedAt = record.DetectedAt,
+    };
+
+    private static ReplicaConflictDetail ToConflictDetail(ReplicaConflictRecord record) => new()
+    {
+        ConflictId = record.ConflictId,
+        ReplicaId = record.ReplicaId,
+        ServiceId = record.ServiceId,
+        LayerId = record.LayerId,
+        ObjectId = record.ObjectId,
+        ConflictType = ConflictTypeToString(record.ConflictType),
+        Status = StatusToString(record.Status),
+        SyncOperationId = record.SyncOperationId,
+        DeviceId = record.DeviceId,
+        UserId = record.UserId,
+        ServerGeneration = record.ServerGeneration,
+        BaseState = ParseStateJson(record.BaseStateJson),
+        ClientState = ParseStateJson(record.ClientStateJson),
+        ServerState = ParseStateJson(record.ServerStateJson),
+        DetectedAt = record.DetectedAt,
+        ResolutionAction = record.ResolutionAction is null ? null : ActionToString(record.ResolutionAction.Value),
+        ResolvedBy = record.ResolvedBy,
+        ResolvedAt = record.ResolvedAt,
+        ResolvedServerGeneration = record.ResolvedServerGeneration,
+    };
+
+    private static JsonElement? ParseStateJson(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            // Stored state is opaque; if it is not valid JSON, omit it rather than failing the read.
+            return null;
+        }
+    }
+
+    private static bool TryParseStatus(string value, out ReplicaConflictStatus status)
+    {
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "pending":
+                status = ReplicaConflictStatus.Pending;
+                return true;
+            case "resolved":
+                status = ReplicaConflictStatus.Resolved;
+                return true;
+            case "deferred":
+                status = ReplicaConflictStatus.Deferred;
+                return true;
+            default:
+                status = default;
+                return false;
+        }
+    }
+
+    private static bool TryParseAction(string value, out ReplicaConflictResolutionAction action)
+    {
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "acceptclient":
+                action = ReplicaConflictResolutionAction.AcceptClient;
+                return true;
+            case "keepserver":
+                action = ReplicaConflictResolutionAction.KeepServer;
+                return true;
+            case "mergefields":
+                action = ReplicaConflictResolutionAction.MergeFields;
+                return true;
+            case "choosegeometry":
+                action = ReplicaConflictResolutionAction.ChooseGeometry;
+                return true;
+            case "rejectclient":
+                action = ReplicaConflictResolutionAction.RejectClient;
+                return true;
+            case "defer":
+                action = ReplicaConflictResolutionAction.Defer;
+                return true;
+            default:
+                action = default;
+                return false;
+        }
+    }
+
+    private static string ConflictTypeToString(ReplicaConflictType type) => type switch
+    {
+        ReplicaConflictType.Attribute => "attribute",
+        ReplicaConflictType.Geometry => "geometry",
+        ReplicaConflictType.DeleteUpdate => "deleteUpdate",
+        ReplicaConflictType.UpdateDelete => "updateDelete",
+        ReplicaConflictType.DuplicateInsert => "duplicateInsert",
+        ReplicaConflictType.Attachment => "attachment",
+        ReplicaConflictType.Relationship => "relationship",
+        _ => type.ToString().ToLowerInvariant(),
+    };
+
+    private static string StatusToString(ReplicaConflictStatus status) => status switch
+    {
+        ReplicaConflictStatus.Pending => "pending",
+        ReplicaConflictStatus.Resolved => "resolved",
+        ReplicaConflictStatus.Deferred => "deferred",
+        _ => status.ToString().ToLowerInvariant(),
+    };
+
+    private static string ActionToString(ReplicaConflictResolutionAction action) => action switch
+    {
+        ReplicaConflictResolutionAction.AcceptClient => "acceptClient",
+        ReplicaConflictResolutionAction.KeepServer => "keepServer",
+        ReplicaConflictResolutionAction.MergeFields => "mergeFields",
+        ReplicaConflictResolutionAction.ChooseGeometry => "chooseGeometry",
+        ReplicaConflictResolutionAction.RejectClient => "rejectClient",
+        ReplicaConflictResolutionAction.Defer => "defer",
+        _ => action.ToString(),
     };
 }

--- a/src/Honua.Server/Migrations/040_AddReplicaConflictReview.sql
+++ b/src/Honua.Server/Migrations/040_AddReplicaConflictReview.sql
@@ -1,0 +1,73 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration: 040_AddReplicaConflictReview.sql
+-- Description: Adds durable disconnected-sync conflict records so conflict-producing replica
+--              uploads create persistent, reviewable conflicts (#1167) rather than only transient
+--              sync errors. Conflicts capture base/client/server feature states, classification,
+--              linkage (replica, sync operation, user, device, layer, feature, server generation),
+--              and resolution audit evidence.
+-- Dependencies: Requires honua schema (001_CreateHonuaSchema.sql) and honua.replicas
+--               (012_AddReplicationDurability.sql).
+
+CREATE TABLE IF NOT EXISTS honua.replica_conflicts (
+    conflict_id TEXT PRIMARY KEY,
+    replica_id TEXT NOT NULL,
+    service_id TEXT NOT NULL,
+    layer_id INT NOT NULL,
+    objectid BIGINT NOT NULL,
+    -- Conflict classification (ReplicaConflictType ordinal):
+    -- 0=attribute, 1=geometry, 2=delete-update, 3=update-delete, 4=duplicate-insert,
+    -- 5=attachment, 6=relationship.
+    conflict_type SMALLINT NOT NULL,
+    -- Lifecycle status (ReplicaConflictStatus ordinal): 0=pending, 1=resolved, 2=deferred.
+    status SMALLINT NOT NULL DEFAULT 0,
+    sync_operation_id TEXT,
+    device_id TEXT,
+    user_id TEXT,
+    server_generation BIGINT NOT NULL,
+    base_state_json JSONB,
+    client_state_json JSONB,
+    server_state_json JSONB,
+    detected_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- Resolution audit evidence (ReplicaConflictResolutionAction ordinal):
+    -- 0=accept-client, 1=keep-server, 2=merge-fields, 3=choose-geometry, 4=reject-client, 5=defer.
+    resolution_action SMALLINT,
+    resolved_by TEXT,
+    resolved_at TIMESTAMPTZ,
+    resolved_server_generation BIGINT,
+    CONSTRAINT replica_conflicts_valid_replica CHECK(LENGTH(replica_id) > 0),
+    CONSTRAINT replica_conflicts_valid_service CHECK(LENGTH(service_id) > 0),
+    CONSTRAINT replica_conflicts_valid_type CHECK(conflict_type BETWEEN 0 AND 6),
+    CONSTRAINT replica_conflicts_valid_status CHECK(status BETWEEN 0 AND 2),
+    CONSTRAINT replica_conflicts_valid_action CHECK(resolution_action IS NULL OR resolution_action BETWEEN 0 AND 5)
+);
+
+-- Primary review query: conflicts for a replica, newest first, optionally filtered by status.
+CREATE INDEX IF NOT EXISTS idx_replica_conflicts_replica_status
+    ON honua.replica_conflicts(replica_id, status, detected_at DESC);
+
+-- Service-scoped review and temporal linkage by feature.
+CREATE INDEX IF NOT EXISTS idx_replica_conflicts_service_feature
+    ON honua.replica_conflicts(service_id, layer_id, objectid);
+
+COMMENT ON TABLE honua.replica_conflicts IS 'Durable disconnected-sync conflict records for manual conflict review (#1167)';
+COMMENT ON COLUMN honua.replica_conflicts.conflict_id IS 'Unique conflict identifier (GUID hex)';
+COMMENT ON COLUMN honua.replica_conflicts.replica_id IS 'Replica whose upload produced the conflict';
+COMMENT ON COLUMN honua.replica_conflicts.service_id IS 'Service the replica belongs to';
+COMMENT ON COLUMN honua.replica_conflicts.layer_id IS 'Service-local layer id of the conflicting feature';
+COMMENT ON COLUMN honua.replica_conflicts.objectid IS 'Stable object id of the conflicting feature';
+COMMENT ON COLUMN honua.replica_conflicts.conflict_type IS 'Conflict classification (see ReplicaConflictType)';
+COMMENT ON COLUMN honua.replica_conflicts.status IS 'Lifecycle status (see ReplicaConflictStatus)';
+COMMENT ON COLUMN honua.replica_conflicts.sync_operation_id IS 'Correlation id of the synchronize call that produced the conflict';
+COMMENT ON COLUMN honua.replica_conflicts.device_id IS 'Device/client that uploaded the conflicting edit';
+COMMENT ON COLUMN honua.replica_conflicts.user_id IS 'User that owns the conflicting edit';
+COMMENT ON COLUMN honua.replica_conflicts.server_generation IS 'Server generation cursor captured when the conflict was recorded (temporal linkage, #1166)';
+COMMENT ON COLUMN honua.replica_conflicts.base_state_json IS 'Base/common-ancestor feature state (opaque JSON)';
+COMMENT ON COLUMN honua.replica_conflicts.client_state_json IS 'Incoming client feature state (opaque JSON)';
+COMMENT ON COLUMN honua.replica_conflicts.server_state_json IS 'Current server feature state (opaque JSON)';
+COMMENT ON COLUMN honua.replica_conflicts.detected_at IS 'Timestamp when the conflict was first recorded';
+COMMENT ON COLUMN honua.replica_conflicts.resolution_action IS 'Resolution action applied (see ReplicaConflictResolutionAction)';
+COMMENT ON COLUMN honua.replica_conflicts.resolved_by IS 'Operator that resolved the conflict (audit evidence)';
+COMMENT ON COLUMN honua.replica_conflicts.resolved_at IS 'Timestamp when the conflict was resolved';
+COMMENT ON COLUMN honua.replica_conflicts.resolved_server_generation IS 'Server generation produced by the resolution when a new committed server state was created';

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -509,6 +509,9 @@ if (replicaProvider != DataProviderNames.DuckDb &&
     builder.Services.AddScoped<Honua.Core.Features.FeatureStore.Abstractions.IReplicaRepository>(sp =>
         new Honua.Postgres.Features.FeatureStore.Services.PostgresReplicaRepository(
             sp.GetRequiredService<Honua.Core.Features.Infrastructure.Abstractions.IDatabaseConnectionProvider>()));
+    builder.Services.AddScoped<Honua.Core.Features.FeatureStore.Abstractions.IReplicaConflictRepository>(sp =>
+        new Honua.Postgres.Features.FeatureStore.Services.PostgresReplicaConflictRepository(
+            sp.GetRequiredService<Honua.Core.Features.Infrastructure.Abstractions.IDatabaseConnectionProvider>()));
     builder.Services.AddScoped<Honua.Core.Features.FeatureStore.Abstractions.IChangeTracker>(sp =>
         new Honua.Postgres.Features.FeatureStore.Services.PostgresChangeTracker(
             sp.GetRequiredService<Honua.Core.Features.Infrastructure.Abstractions.IDatabaseConnectionProvider>()));

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicaConflictReviewEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicaConflictReviewEndpointTests.cs
@@ -1,0 +1,398 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.ReadOnlyProviders;
+using Honua.Infrastructure.Models;
+using Honua.Server.Features.Admin.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
+
+/// <summary>
+/// Integration tests for the admin/operator disconnected-sync conflict-review API (#1167, slice 2):
+/// list conflicts, conflict detail (base/client/server states), conflict resolution, and the
+/// not-supported denial for providers that cannot support manual conflict review. Conflict records
+/// are seeded directly through <see cref="IReplicaConflictRepository"/> because the synchronize
+/// upload path's conflict-detection writer is a separate concern; these tests exercise the durable
+/// review/resolution contract that Console consumes.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+public sealed class ReplicaConflictReviewEndpointTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    private static string ConflictsPath(string serviceId, string replicaId) =>
+        $"/api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts";
+
+    private static string ConflictDetailPath(string serviceId, string replicaId, string conflictId) =>
+        $"/api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts/{conflictId}";
+
+    private static string ResolvePath(string serviceId, string replicaId, string conflictId) =>
+        $"/api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts/{conflictId}/resolve";
+
+    private Task<string> CreateReplicaAsync(string replicaName) =>
+        CreateReplicaAsync(_fixture, replicaName);
+
+    private static async Task<string> CreateReplicaAsync(WebAppFixture fixture, string replicaName)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            replicaName,
+            layers = "0",
+            syncModel = "perReplica",
+            f = "json"
+        });
+
+        var response = await fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/createReplica",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(content);
+        return document.RootElement.GetProperty("replicaID").GetString()!;
+    }
+
+    private async Task<string> SeedConflictAsync(
+        string replicaId,
+        ReplicaConflictType conflictType = ReplicaConflictType.Attribute,
+        ReplicaConflictStatus status = ReplicaConflictStatus.Pending,
+        long objectId = 100,
+        long serverGeneration = 5)
+    {
+        var conflictId = Guid.NewGuid().ToString("N");
+        var repository = _fixture.GetService<IReplicaConflictRepository>();
+        await repository.UpsertAsync(new ReplicaConflictRecord
+        {
+            ConflictId = conflictId,
+            ReplicaId = replicaId,
+            ServiceId = WebAppFixture.TestServiceId,
+            LayerId = 0,
+            ObjectId = objectId,
+            ConflictType = conflictType,
+            Status = status,
+            SyncOperationId = "sync-op-1",
+            DeviceId = "device-42",
+            UserId = "field-user",
+            ServerGeneration = serverGeneration,
+            BaseStateJson = """{"attributes":{"OBJECTID":100,"name":"base"}}""",
+            ClientStateJson = """{"attributes":{"OBJECTID":100,"name":"client"}}""",
+            ServerStateJson = """{"attributes":{"OBJECTID":100,"name":"server"}}""",
+            DetectedAt = DateTimeOffset.UtcNow,
+        });
+
+        return conflictId;
+    }
+
+    private static async Task<ApiResponse<ReplicaConflictListResponse>?> ReadListAsync(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize(
+            content,
+            ReplicaManagementJsonContext.Default.ApiResponseReplicaConflictListResponse);
+    }
+
+    private static async Task<ApiResponse<ReplicaConflictDetail>?> ReadDetailAsync(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize(
+            content,
+            ReplicaManagementJsonContext.Default.ApiResponseReplicaConflictDetail);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ReplicaInfo)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}")]
+    public async Task GetReplica_AfterRecentSync_ReportsActiveStatus()
+    {
+        var replicaId = await CreateReplicaAsync("ActiveStatusReplica");
+
+        var response = await _fixture.Client.GetAsync(
+            $"/api/v1/admin/services/{WebAppFixture.TestServiceId}/replicas/{replicaId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        var body = JsonSerializer.Deserialize(
+            content,
+            ReplicaManagementJsonContext.Default.ApiResponseReplicaManagementDetail);
+
+        body.Should().NotBeNull();
+        body!.Data.Should().NotBeNull();
+        body.Data!.Status.Should().Be("active");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ReplicaInfo)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}")]
+    public async Task GetReplica_WhenLastSyncIsStale_ReportsExpiredStatus()
+    {
+        var replicaId = await CreateReplicaAsync("ExpiredStatusReplica");
+
+        // Backdate the durable replica's last-sync time well beyond the staleness window so the
+        // derived status flips to expired. This mirrors a replica that was created/synced long ago
+        // and never reconnected.
+        var replicaRepository = _fixture.GetService<IReplicaRepository>();
+        var record = await replicaRepository.GetAsync(replicaId);
+        record.Should().NotBeNull();
+        await replicaRepository.UpsertAsync(record!.Value with
+        {
+            LastSyncTime = DateTimeOffset.UtcNow.AddDays(-30),
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/api/v1/admin/services/{WebAppFixture.TestServiceId}/replicas/{replicaId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        var body = JsonSerializer.Deserialize(
+            content,
+            ReplicaManagementJsonContext.Default.ApiResponseReplicaManagementDetail);
+
+        body.Should().NotBeNull();
+        body!.Data.Should().NotBeNull();
+        body.Data!.Status.Should().Be("expired");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ListReplicaConflicts)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts")]
+    public async Task ListConflicts_WhenPendingConflictExists_ReturnsConflict()
+    {
+        var replicaId = await CreateReplicaAsync("PendingConflictReplica");
+        var conflictId = await SeedConflictAsync(replicaId, ReplicaConflictType.Geometry);
+
+        // Inline the route literal so the EndpointRegistry drift scanner detects this endpoint.
+        var response = await _fixture.Client.GetAsync(
+            $"/api/v1/admin/services/{WebAppFixture.TestServiceId}/replicas/{replicaId}/conflicts");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await ReadListAsync(response);
+        body.Should().NotBeNull();
+        body!.Success.Should().BeTrue();
+        body.Data.Should().NotBeNull();
+        body.Data!.ReplicaId.Should().Be(replicaId);
+
+        var match = body.Data.Conflicts.Should().ContainSingle(c => c.ConflictId == conflictId).Subject;
+        match.ConflictType.Should().Be("geometry");
+        match.Status.Should().Be("pending");
+        match.LayerId.Should().Be(0);
+        match.ServerGeneration.Should().Be(5);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ListReplicaConflicts)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts")]
+    public async Task ListConflicts_WhenBatchOfConflictsExist_ReturnsAllAndFiltersByStatus()
+    {
+        var replicaId = await CreateReplicaAsync("BatchConflictReplica");
+        var pending1 = await SeedConflictAsync(replicaId, ReplicaConflictType.Attribute, ReplicaConflictStatus.Pending, objectId: 1);
+        var pending2 = await SeedConflictAsync(replicaId, ReplicaConflictType.DeleteUpdate, ReplicaConflictStatus.Pending, objectId: 2);
+        var resolved = await SeedConflictAsync(replicaId, ReplicaConflictType.DuplicateInsert, ReplicaConflictStatus.Resolved, objectId: 3);
+
+        var allResponse = await _fixture.Client.GetAsync(ConflictsPath(WebAppFixture.TestServiceId, replicaId));
+        allResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var all = await ReadListAsync(allResponse);
+        all!.Data!.Conflicts.Select(c => c.ConflictId)
+            .Should().Contain(new[] { pending1, pending2, resolved });
+
+        var pendingResponse = await _fixture.Client.GetAsync(
+            ConflictsPath(WebAppFixture.TestServiceId, replicaId) + "?status=pending");
+        pendingResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var pendingOnly = await ReadListAsync(pendingResponse);
+        pendingOnly!.Data!.StatusFilter.Should().Be("pending");
+        pendingOnly.Data.Conflicts.Select(c => c.ConflictId).Should().Contain(new[] { pending1, pending2 });
+        pendingOnly.Data.Conflicts.Select(c => c.ConflictId).Should().NotContain(resolved);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ReplicaConflictDetail)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts/{conflictId}")]
+    public async Task GetConflict_ForPendingConflict_ReturnsBaseClientServerStates()
+    {
+        var replicaId = await CreateReplicaAsync("ConflictDetailReplica");
+        var conflictId = await SeedConflictAsync(replicaId);
+
+        var response = await _fixture.Client.GetAsync(
+            $"/api/v1/admin/services/{WebAppFixture.TestServiceId}/replicas/{replicaId}/conflicts/{conflictId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await ReadDetailAsync(response);
+        body.Should().NotBeNull();
+        body!.Data.Should().NotBeNull();
+
+        var detail = body.Data!;
+        detail.ConflictId.Should().Be(conflictId);
+        detail.Status.Should().Be("pending");
+        detail.DeviceId.Should().Be("device-42");
+        detail.UserId.Should().Be("field-user");
+        detail.SyncOperationId.Should().Be("sync-op-1");
+        detail.BaseState.Should().NotBeNull();
+        detail.ClientState.Should().NotBeNull();
+        detail.ServerState.Should().NotBeNull();
+        detail.BaseState!.Value.GetProperty("attributes").GetProperty("name").GetString().Should().Be("base");
+        detail.ClientState!.Value.GetProperty("attributes").GetProperty("name").GetString().Should().Be("client");
+        detail.ServerState!.Value.GetProperty("attributes").GetProperty("name").GetString().Should().Be("server");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ReplicaConflictDetail)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts/{conflictId}")]
+    public async Task GetConflict_ForResolvedConflict_ReturnsResolutionEvidence()
+    {
+        var replicaId = await CreateReplicaAsync("ResolvedConflictReplica");
+        var conflictId = await SeedConflictAsync(replicaId);
+
+        // Resolve via the API so the persisted resolution evidence is exercised end-to-end.
+        var resolveResponse = await _fixture.Client.PostAsync(
+            ResolvePath(WebAppFixture.TestServiceId, replicaId, conflictId),
+            JsonContent.Create(new ReplicaConflictResolutionRequest { Action = "acceptClient" }));
+        resolveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var response = await _fixture.Client.GetAsync(
+            ConflictDetailPath(WebAppFixture.TestServiceId, replicaId, conflictId));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await ReadDetailAsync(response);
+
+        var detail = body!.Data!;
+        detail.Status.Should().Be("resolved");
+        detail.ResolutionAction.Should().Be("acceptClient");
+        detail.ResolvedAt.Should().NotBeNull();
+        detail.ResolvedServerGeneration.Should().NotBeNull();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ResolveReplicaConflict)]
+    [Endpoint("POST /api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts/{conflictId}/resolve")]
+    public async Task ResolveConflict_WithAcceptClient_CommitsNewServerStateAndMarksResolved()
+    {
+        var replicaId = await CreateReplicaAsync("ResolveAcceptReplica");
+        var conflictId = await SeedConflictAsync(replicaId);
+
+        // Inline the route literal so the EndpointRegistry drift scanner detects this endpoint.
+        var response = await _fixture.Client.PostAsync(
+            $"/api/v1/admin/services/{WebAppFixture.TestServiceId}/replicas/{replicaId}/conflicts/{conflictId}/resolve",
+            JsonContent.Create(new ReplicaConflictResolutionRequest { Action = "acceptClient" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        var body = JsonSerializer.Deserialize(
+            content,
+            ReplicaManagementJsonContext.Default.ApiResponseReplicaConflictResolutionResponse);
+
+        body.Should().NotBeNull();
+        body!.Data.Should().NotBeNull();
+        body.Data!.CommittedNewServerState.Should().BeTrue();
+        body.Data.Conflict.Status.Should().Be("resolved");
+        body.Data.Conflict.ResolutionAction.Should().Be("acceptClient");
+        body.Data.Conflict.ResolvedServerGeneration.Should().NotBeNull();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ResolveReplicaConflict)]
+    [Endpoint("POST /api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts/{conflictId}/resolve")]
+    public async Task ResolveConflict_WithKeepServer_DoesNotCommitNewServerState()
+    {
+        var replicaId = await CreateReplicaAsync("ResolveKeepServerReplica");
+        var conflictId = await SeedConflictAsync(replicaId);
+
+        var response = await _fixture.Client.PostAsync(
+            ResolvePath(WebAppFixture.TestServiceId, replicaId, conflictId),
+            JsonContent.Create(new ReplicaConflictResolutionRequest { Action = "keepServer" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        var body = JsonSerializer.Deserialize(
+            content,
+            ReplicaManagementJsonContext.Default.ApiResponseReplicaConflictResolutionResponse);
+
+        body!.Data!.CommittedNewServerState.Should().BeFalse();
+        body.Data.Conflict.Status.Should().Be("resolved");
+        body.Data.Conflict.ResolvedServerGeneration.Should().BeNull();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ResolveReplicaConflict)]
+    [Endpoint("POST /api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts/{conflictId}/resolve")]
+    public async Task ResolveConflict_WhenAlreadyResolved_ReturnsConflict()
+    {
+        var replicaId = await CreateReplicaAsync("DoubleResolveReplica");
+        var conflictId = await SeedConflictAsync(replicaId, status: ReplicaConflictStatus.Resolved);
+
+        var response = await _fixture.Client.PostAsync(
+            ResolvePath(WebAppFixture.TestServiceId, replicaId, conflictId),
+            JsonContent.Create(new ReplicaConflictResolutionRequest { Action = "keepServer" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ResolveReplicaConflict)]
+    [Endpoint("POST /api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts/{conflictId}/resolve")]
+    public async Task ResolveConflict_WithUnknownAction_ReturnsBadRequest()
+    {
+        var replicaId = await CreateReplicaAsync("BadActionReplica");
+        var conflictId = await SeedConflictAsync(replicaId);
+
+        var response = await _fixture.Client.PostAsync(
+            ResolvePath(WebAppFixture.TestServiceId, replicaId, conflictId),
+            JsonContent.Create(new ReplicaConflictResolutionRequest { Action = "teleport" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ListReplicaConflicts)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts")]
+    public async Task ListConflicts_WhenProviderDoesNotSupportReview_ReturnsNotImplemented()
+    {
+        // Simulate a read-only provider deployment by replacing the conflict repository with the
+        // no-op implementation whose SupportsConflictReview flag is false. The endpoint must then
+        // deny the request with a not-supported status rather than returning an empty result.
+        var fixture = new WebAppFixture().ConfigureServices(services =>
+        {
+            services.AddScoped<IReplicaConflictRepository>(_ => new NoOpReplicaConflictRepository());
+        });
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var replicaId = await CreateReplicaAsync(fixture, "UnsupportedReviewReplica");
+
+            var response = await fixture.Client.GetAsync(
+                ConflictsPath(WebAppFixture.TestServiceId, replicaId));
+
+            response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ListReplicaConflicts)]
+    [Endpoint("GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts")]
+    public async Task ListConflicts_ForUnknownReplica_ReturnsNotFound()
+    {
+        var response = await _fixture.Client.GetAsync(
+            ConflictsPath(WebAppFixture.TestServiceId, "00000000000000000000000000000000"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -982,7 +982,9 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         queryResponse!.Extent.Should().NotBeNull();
         queryResponse.Extent!.SpatialReference.Should().NotBeNull();
         queryResponse.ObjectIds.Should().BeNull();
-        queryResponse.Count.Should().BeNull();
+        // Esri's returnExtentOnly response is {extent, count}; the handler reports the
+        // number of features that contributed to the computed envelope alongside the extent.
+        queryResponse.Count.Should().Be(5);
         queryResponse.Features.Should().BeNull();
         queryResponse.ObjectIdFieldName.Should().BeNull();
 

--- a/tests/dotnet/Honua.TestKit/Constants/Operations.cs
+++ b/tests/dotnet/Honua.TestKit/Constants/Operations.cs
@@ -143,6 +143,9 @@ public static class Operations
     public const string ExtractChanges = "ExtractChanges";
     public const string SynchronizeReplica = "SynchronizeReplica";
     public const string UnRegisterReplica = "UnRegisterReplica";
+    public const string ListReplicaConflicts = "ListReplicaConflicts";
+    public const string ReplicaConflictDetail = "ReplicaConflictDetail";
+    public const string ResolveReplicaConflict = "ResolveReplicaConflict";
 
     // Maintenance Operations
     public const string Append = "Append";

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -848,6 +848,35 @@ sql:
           changed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
           CONSTRAINT feature_changes_valid_operation CHECK(operation IN (1, 2, 3))
       );
+  - |
+      CREATE TABLE IF NOT EXISTS honua.replica_conflicts (
+          conflict_id TEXT PRIMARY KEY,
+          replica_id TEXT NOT NULL,
+          service_id TEXT NOT NULL,
+          layer_id INT NOT NULL,
+          objectid BIGINT NOT NULL,
+          conflict_type SMALLINT NOT NULL,
+          status SMALLINT NOT NULL DEFAULT 0,
+          sync_operation_id TEXT,
+          device_id TEXT,
+          user_id TEXT,
+          server_generation BIGINT NOT NULL,
+          base_state_json JSONB,
+          client_state_json JSONB,
+          server_state_json JSONB,
+          detected_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          resolution_action SMALLINT,
+          resolved_by TEXT,
+          resolved_at TIMESTAMPTZ,
+          resolved_server_generation BIGINT,
+          CONSTRAINT replica_conflicts_valid_replica CHECK(LENGTH(replica_id) > 0),
+          CONSTRAINT replica_conflicts_valid_service CHECK(LENGTH(service_id) > 0),
+          CONSTRAINT replica_conflicts_valid_type CHECK(conflict_type BETWEEN 0 AND 6),
+          CONSTRAINT replica_conflicts_valid_status CHECK(status BETWEEN 0 AND 2),
+          CONSTRAINT replica_conflicts_valid_action CHECK(resolution_action IS NULL OR resolution_action BETWEEN 0 AND 5)
+      );
+  - "CREATE INDEX IF NOT EXISTS idx_replica_conflicts_replica_status ON honua.replica_conflicts(replica_id, status, detected_at DESC);"
+  - "CREATE INDEX IF NOT EXISTS idx_replica_conflicts_service_feature ON honua.replica_conflicts(service_id, layer_id, objectid);"
   - "CREATE INDEX IF NOT EXISTS idx_feature_changes_generation_layer ON honua.feature_changes(generation, layer_id);"
   - "CREATE INDEX IF NOT EXISTS idx_feature_changes_changed_at ON honua.feature_changes(changed_at);"
   - "CREATE INDEX IF NOT EXISTS idx_feature_changes_layer_objectid ON honua.feature_changes(layer_id, objectid, generation);"
@@ -1031,6 +1060,7 @@ sql:
   - "DELETE FROM honua.feature_changes;"
   - "DELETE FROM honua.gitops_change_records;"
   - "DELETE FROM honua.gitops_watch_configs;"
+  - "DELETE FROM honua.replica_conflicts;"
   - "DELETE FROM honua.replicas;"
   - "DELETE FROM honua.encryption_keys;"
   - "DELETE FROM honua.data_connections;"


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1167

## Summary
Adds the disconnected-sync **conflict-review** slice of #1167, building on the slice-1 named-replica list/detail management API. Operators and Console can now inspect durable conflict records (with base/client/server feature states), filter by status, and apply manual resolutions. Replica summary/detail also gain a derived active/expired status. Esri offline/disconnected-editing semantics (Sync, named replicas, generation cursors) are preserved, but exposed through a neutral Honua product contract rather than ArcGIS-named models.

## Changes Made
- **Domain + storage:** `ReplicaConflictRecord` (base/client/server state JSON, conflict classification — attribute, geometry, delete-update, update-delete, duplicate-insert, attachment, relationship; lifecycle status; linkage to replica, sync operation, user, device, layer, feature id, and server generation cursor for temporal linkage to #1166). `IReplicaConflictRepository` with a `SupportsConflictReview` capability flag; Postgres implementation, no-op implementation for read-only providers (DuckDB/MySQL), and migration `040_AddReplicaConflictReview.sql` creating `honua.replica_conflicts`.
- **Admin API** (under the existing admin replica group, gated by `RequireAdminAuthorization`):
  - `GET /api/v1/admin/services/{serviceId}/replicas/{replicaId}/conflicts` — list (optional `?status=` filter).
  - `GET .../conflicts/{conflictId}` — detail with base/client/server feature states and field/geometry metadata.
  - `POST .../conflicts/{conflictId}/resolve` — apply accept-client / keep-server / merge-fields / choose-geometry / reject-client / defer; records an audit event; reports whether a new committed server state was produced and captures its generation cursor.
- Replica summary/detail now expose a derived `active`/`expired` status (operator "current status").
- Providers without conflict-review support return a 501 not-supported denial rather than an empty result. Existing last-write-wins / client-wins / server-wins strategies for non-manual flows are unchanged.
- AOT-safe source-generated JSON; registered the three routes + operations in the `EndpointRegistry`/`Operations` coverage gates; added the matching `honua.replica_conflicts` DDL to the test seed.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

`ReplicaConflictReviewEndpointTests` (12 tests, all green) covers: active replica status, expired replica status, pending conflict listing, batch conflicts with status filtering, conflict detail (base/client/server), resolved-conflict resolution evidence, accept-client (commits new server state) vs keep-server (no new state), already-resolved 409, unknown-action 400, unknown-replica 404, and the unsupported-conflict-review (501) denial. Slice-1 `ReplicaManagementEndpointTests` (7) remain green after the status field addition. `dotnet format --verify-no-changes` is clean. The one architecture-coverage failure on this branch (`POST /rest/services/{serviceId}/ImageServer/keyProperties`) is pre-existing on trunk and unrelated to this change.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [x] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review