### PR TITLE
test(geoservices): align returnExtentOnly expectation with {extent, count} (#1334)

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -982,7 +982,9 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         queryResponse!.Extent.Should().NotBeNull();
         queryResponse.Extent!.SpatialReference.Should().NotBeNull();
         queryResponse.ObjectIds.Should().BeNull();
-        queryResponse.Count.Should().BeNull();
+        // Esri's returnExtentOnly response shape is {extent, count}; the handler reports the
+        // matched-feature count alongside the extent, so count is populated (not null) here.
+        queryResponse.Count.Should().Be(5);
         queryResponse.Features.Should().BeNull();
         queryResponse.ObjectIdFieldName.Should().BeNull();
 


### PR DESCRIPTION
Related to #1334

## Summary
Trunk's full test suite is red because `FeatureServerEndpointTests.QueryFeatures_WithReturnExtentOnly_ReturnsExtent` asserts a null `count`, but PR #1334 ("Esri-SDK certification gap bundle") intentionally changed `FeatureServerQueryHandler` to emit `Count` alongside `Extent` for `returnExtentOnly=true` (Esri's response shape is `{extent, count}`). The test was never updated, so it fails on trunk and on every branch cut after #1334 — a merge of trunk alone does **not** clear it. This blocks all open PRs.

## Changes Made
- Updated the stale assertion in `QueryFeatures_WithReturnExtentOnly_ReturnsExtent` from `Count.Should().BeNull()` to `Count.Should().Be(5)`, matching the handler's established `{extent, count}` behavior, with an explanatory comment.

## Testing
- [x] Confirmed via CI logs (trunk Core job 78883058037) that the failure is the stale assertion, not a handler regression — the handler emits `count=5` by design (#1334).
- [x] The previously-failing test now asserts the actual server behavior.

## Gate Impact
- [x] Unblocks the `Server Tests (Core)` shard and `Test Suite Summary` / `CI Gate` on trunk and on all rebased PRs. No production code changed.

## Breaking Changes
None. Test-only change; no production behavior is altered.

- [x] Ran scripts/ci/pre-pr-check.sh

> **Validation note:** Test-only assertion alignment with the already-merged #1334 handler behavior; the diff is a single assertion line plus a comment, so a full local build was not re-run — CI's Core shard is the authoritative validation.
