### PR TITLE
ci: make container cache export non-fatal and bound nightly build jobs

### DIFF
--- a/.github/workflows/nightly-container-build.yml
+++ b/.github/workflows/nightly-container-build.yml
@@ -19,6 +19,7 @@ jobs:
   build-aot:
     name: Build & Push AOT (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -79,13 +80,18 @@ jobs:
             github_actor=${{ github.actor }}
             github_token=${{ github.token }}
           cache-from: type=gha,scope=nightly-aot-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=nightly-aot-${{ matrix.arch }}
+          # ignore-error: a failed/interrupted GHA cache export (common on the
+          # hosted arm64 runner fleet, which can be preempted mid-export) must
+          # not fail an otherwise-successful build+push. The cache is a build
+          # accelerator, not a release artifact.
+          cache-to: type=gha,mode=max,scope=nightly-aot-${{ matrix.arch }},ignore-error=true
           provenance: true
           sbom: true
 
   build-jit:
     name: Build & Push JIT (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -146,7 +152,11 @@ jobs:
             github_actor=${{ github.actor }}
             github_token=${{ github.token }}
           cache-from: type=gha,scope=nightly-jit-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=nightly-jit-${{ matrix.arch }}
+          # ignore-error: a failed/interrupted GHA cache export (common on the
+          # hosted arm64 runner fleet, which can be preempted mid-export) must
+          # not fail an otherwise-successful build+push. The cache is a build
+          # accelerator, not a release artifact.
+          cache-to: type=gha,mode=max,scope=nightly-jit-${{ matrix.arch }},ignore-error=true
           provenance: true
           sbom: true
 


### PR DESCRIPTION
## Root cause

The nightly arm64 JIT build (`build-jit` matrix, `linux/arm64`) failed in [run 26751029102](https://github.com/honua-io/honua-server/actions/runs/26751029102) because the **hosted arm64 runner (`ubuntu-24.04-arm`) received a shutdown signal during the GHA cache export**, *after* the image was already built and pushed.

Evidence from the failed job log (`Build & Push JIT (arm64)`):
- `#38 ... pushing manifest ... DONE 26.6s` — image build + registry push **succeeded** at 11:08:15.
- `#40 exporting to GitHub Actions Cache` — the slow `cache-to type=gha,mode=max` tail then ran, writing layers.
- It stalled ~53s on one layer, then: `##[error]The runner has received a shutdown signal...` at 11:10:54, killing the job at 6m19s.

This is **runner preemption during the cache-export tail**, not a build error, OOM, or step timeout:
- The matrix uses **native arm64 runners**, not QEMU emulation, so emulation OOM is ruled out.
- No `timeout-minutes` was configured and the job died at 6m19s — nowhere near any timeout.
- The amd64 JIT job and arm64 AOT job both spent ~2.5–3.2 min in the same cache-export step and passed; arm64 JIT just got unlucky and was preempted mid-export.

## Consistent vs intermittent

**Intermittent.** Recent failures of this workflow are spread across different jobs, not pinned to arm64 JIT: AOT amd64, AOT arm64, JIT amd64, and a manifest job have all failed on different nights. They fall into at least two classes — (1) cache-export preemption / runner shutdown (this run) and (2) NuGet restore races on AOT builds (`NETSDK1004` / `NETSDK1064`). This PR targets class (1).

## Fix

`.github/workflows/nightly-container-build.yml`:
- Add `ignore-error=true` to both `cache-to: type=gha,mode=max,...` backends (AOT + JIT). A failed or interrupted GHA cache export no longer fails an otherwise-successful build+push; the cache is a build accelerator, not a release artifact. This also unblocks the `manifest-jit` / `manifest-aot` publish jobs (gated on `build-*.result == 'success'`) when only the cache tail was flaky.
- Add `timeout-minutes: 90` to both build jobs to bound any genuinely hung step (arm64 AOT legitimately runs ~35m, so 90m is a generous ceiling) instead of relying on the implicit 6h default.

Before:
```yaml
cache-to: type=gha,mode=max,scope=nightly-jit-${{ matrix.arch }}
```
After:
```yaml
cache-to: type=gha,mode=max,scope=nightly-jit-${{ matrix.arch }},ignore-error=true
```
plus `timeout-minutes: 90` on `build-aot` and `build-jit`.

## Honest limitation / what I couldn't verify locally

`ignore-error=true` cannot save a job if the runner is killed *before* the build+push completes; it only prevents the cache-export tail from failing a job whose deliverable already succeeded. For pure runner preemption there is no YAML-only guarantee — the most robust further mitigation would be a scheduled auto-rerun of failed jobs or moving to a self-hosted/larger native arm64 runner; flagged here rather than forced into config. I could not reproduce a hosted-arm64 build on this WSL host, so the fix is based on the run logs, run history, and the documented `cache-to` `ignore-error` semantics rather than a local green run. YAML was validated locally.