### PR TITLE
ci: fix load-soak nightly server startup in production

### DIFF
--- a/.github/workflows/load-soak-nightly.yml
+++ b/.github/workflows/load-soak-nightly.yml
@@ -134,7 +134,9 @@ jobs:
         env:
           ASPNETCORE_URLS: ${{ env.BASE_URL }}
           ASPNETCORE_ENVIRONMENT: Production
-          HONUA_ADMIN_PASSWORD: "load-soak-admin-password"
+          HONUA_ADMIN_PASSWORD: "Load-Soak-Admin-Pass1!"
+          PUBLIC_BASE_URL: ${{ env.BASE_URL }}
+          HostValidation__AllowedHosts__0: "localhost"
           Security__DisableHttpsRedirection: "true"
           Security__ConnectionEncryption__MasterKey: "test-master-key-32-chars-long-000000"
           ConnectionStrings__DefaultConnection: Host=localhost;Port=5432;Database=${{ env.DB_NAME }};Username=${{ env.DB_USER }};Password=${{ env.DB_PASSWORD }};Maximum Pool Size=50
@@ -156,7 +158,7 @@ jobs:
 
       - name: Run load/soak tests
         env:
-          HONUA_API_KEY: "load-soak-admin-password"
+          HONUA_API_KEY: "Load-Soak-Admin-Pass1!"
         run: |
           PROFILE="${{ github.event.inputs.profile || 'nightly' }}"
           DURATION="${{ github.event.inputs.duration || '' }}"


### PR DESCRIPTION
## Problem

The `load-soak` job in `.github/workflows/load-soak-nightly.yml` (run [26743897559](https://github.com/honua-io/honua-server/actions/runs/26743897559)) failed to start the server:

```
Unhandled exception. System.InvalidOperationException: Admin password must contain uppercase, lowercase, digit, and special characters in production environment
```

The server runs with `ASPNETCORE_ENVIRONMENT=Production`. The workflow set `HONUA_ADMIN_PASSWORD: "load-soak-admin-password"`, which is all lowercase letters and a hyphen with no uppercase or digit. The production policy in `src/Honua.Server/Startup/AuthenticationOptionsRegistration.cs` requires min 16 chars plus uppercase, lowercase, digit, and special character, so config registration threw at startup.

A non-fatal warning was also logged: "Host validation is enabled, but no explicit host allowlist is configured."

## Change

CI input only — the production password policy is unchanged.

- `HONUA_ADMIN_PASSWORD`: `load-soak-admin-password` -> `Load-Soak-Admin-Pass1!` (22 chars; upper, lower, digit, special).
- `HONUA_API_KEY` (used by the load tests to authenticate) updated to the same value so auth still works.
- Added `PUBLIC_BASE_URL` and `HostValidation__AllowedHosts__0: localhost` to clear the host-validation warning.

## Verification

Built `src/Honua.Server` in Release and ran it locally with the new env (`ASPNETCORE_ENVIRONMENT=Production`, the new password, host-validation vars) against a throwaway PostGIS container. The server booted cleanly: no admin-password exception, no host-validation warning, CRS warmup completed, background services started, and the process stayed up.