### PR TITLE
fix(ci): repair PyQGIS client-compat nightly (geometry-column binding in seed)

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Seed/ClientCompatSeedSequenceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Seed/ClientCompatSeedSequenceTests.cs
@@ -56,6 +56,64 @@ public sealed class ClientCompatSeedSequenceTests
         }
     }
 
+    [IntegrationTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task ClientCompatSeed_LayerStorageBinding_DeclaresPhysicalFeaturesTableColumns()
+    {
+        // Regression for the PyQGIS nightly: the certification layer binds to the shared
+        // `features` table, whose physical layout stores attributes in the `attributes`
+        // JSONB column and geometry in the `geometry` column (keyed by `layer_id`). The
+        // resource's schema fields name the geometry field `shape` (the Esri-style client
+        // facing name) and tag it `geometry.primary`. Without explicit storage-binding
+        // options, FeatureStorageMapping.FromMetadata falls back to the `geometry.primary`
+        // field name (`shape`) and to bare per-field column projection, producing Postgres
+        // 42703 "column \"shape\" does not exist" on every OGC API Features items query.
+        await using var container = new PostgreSqlBuilder()
+            .WithImage(PostgisImage)
+            .WithDatabase("honua_seed_binding_regression")
+            .WithUsername("postgres")
+            .WithPassword("compat_password")
+            .WithEnvironment("POSTGIS_GDAL_ENABLED_DRIVERS", "ENABLE_ALL")
+            .WithLabel("honua.test.owner", "honua-server")
+            .WithLabel("honua.test.run_id", Environment.GetEnvironmentVariable(TestRunIdEnv) ?? "manual")
+            .Build();
+
+        await container.StartAsync();
+
+        var connectionString = new NpgsqlConnectionStringBuilder(container.GetConnectionString())
+        {
+            Timeout = 60,
+            CommandTimeout = 120
+        }.ToString();
+        await using var dataSource = NpgsqlDataSource.Create(connectionString);
+        await ExecuteSqlFileAsync(dataSource, RepositoryPaths.Resolve("tests", "seed", "client-compat-v1.sql"));
+
+        var snapshots = await ReadCurrentSnapshotsAsync(dataSource);
+
+        foreach (var snapshot in snapshots.Values)
+        {
+            using var document = JsonDocument.Parse(snapshot);
+
+            var binding = document.RootElement
+                .GetProperty("storageBindings")
+                .EnumerateArray()
+                .Single(b => b.GetProperty("metadata").GetProperty("id").GetString() == "storage-layer-0");
+
+            var options = binding.GetProperty("options");
+
+            options.GetProperty("geometryColumn").GetString().Should().Be(
+                "geometry",
+                "the physical features table stores geometry in the `geometry` column, not the `shape` schema field");
+            options.GetProperty("attributesColumn").GetString().Should().Be(
+                "attributes",
+                "declared schema fields live in the shared features.attributes JSONB document");
+            options.GetProperty("layerDiscriminatorColumn").GetString().Should().Be(
+                "layer_id",
+                "the features table is shared across layers and reads must be constrained by layer_id");
+            options.GetProperty("primaryKeyColumn").GetString().Should().Be("objectid");
+        }
+    }
+
     private static async Task ExecuteSqlFileAsync(NpgsqlDataSource dataSource, string path)
     {
         await ExecuteSqlAsync(dataSource, await File.ReadAllTextAsync(path));

--- a/tests/seed/client-compat-v1.sql
+++ b/tests/seed/client-compat-v1.sql
@@ -500,7 +500,23 @@ BEGIN
                     'locator', table_schema || '.' || table_name,
                     'storageLayerId', layer_id,
                     'capabilities', to_jsonb(ARRAY['query', 'filter', 'sort', 'aggregate', 'edit', 'transactions', 'render', 'tile', 'search']::text[]),
-                    'options', '{}'::jsonb,
+                    -- The certification layers all bind to the shared `features` table, whose
+                    -- physical layout is: pk `objectid`, geometry in the `geometry` column,
+                    -- declared schema fields stored as keys in the `attributes` JSONB document,
+                    -- and rows discriminated by `layer_id`. Declare those columns explicitly so
+                    -- the storage-mapped reader projects `attributes->>'field'` and selects the
+                    -- real geometry column. Without `geometryColumn`, FromMetadata() would fall
+                    -- back to the `geometry.primary` schema field name (`shape`), and without
+                    -- `attributesColumn` the reader would project bare per-field columns; both
+                    -- produce Postgres 42703 "column ... does not exist" at query time.
+                    'options', jsonb_build_object(
+                        'schemaName', table_schema,
+                        'tableName', table_name,
+                        'primaryKeyColumn', 'objectid',
+                        'geometryColumn', 'geometry',
+                        'attributesColumn', 'attributes',
+                        'layerDiscriminatorColumn', 'layer_id'
+                    ),
                     'status', (SELECT value FROM status_doc),
                     'extensions', '{}'::jsonb
                 ) AS value,


### PR DESCRIPTION
## Problem

The `pyqgis-client-compat-nightly` workflow (`PyQGIS OGC + WFS Compatibility`) failed every OGC API Features certification case. The Postgres logs showed, repeatedly:

```
ERROR:  column "shape" does not exist at character 59
STATEMENT:  SELECT "objectid"::bigint AS objectid,
       ST_AsBinary("shape"::geometry) AS geometry,
       (jsonb_build_object('objectid', ..., 'numbers', "numbers"))::text AS attributes
       FROM "honua"."features" ORDER BY "objectid" ASC LIMIT $1 OFFSET $2
```

The uploaded `server.log` confirms `Npgsql.PostgresException 42703: column "shape" does not exist` on `/ogc/features/collections/0/items`. The OAPIF cert suite failed all cases; the WFS cert suite passed all cases (it uses a different reader path).

## Root cause

The certification layer binds to the shared `features` table, whose physical layout is: pk `objectid`, geometry in the **`geometry`** column, declared schema fields stored as keys in the **`attributes`** JSONB document, rows discriminated by **`layer_id`**.

The hand-built metadata-v2 snapshot in `tests/seed/client-compat-v1.sql` left the layer storage binding `options` as `'{}'::jsonb`. As a result `FeatureStorageMapping.FromMetadata`:

- resolved the geometry column via `resource.FindPrimaryGeometryField()`, which returns the schema field carrying the `geometry.primary` role — the seed names that field **`shape`** (the Esri client-facing name), so the reader emitted `ST_AsBinary("shape"::geometry)`; and
- with no `attributesColumn`, projected each declared field as a bare physical column.

Neither `shape` nor the per-field columns exist on the physical `features` table, producing the `42703` error on every items query.

## Fix

Declare the physical columns on the layer's storage binding `options` (matching the proven `MobileOfflineDemoGraphPublisher` / `OgcFeaturesJsonbAttributeLayerTests` contract):

- `geometryColumn = geometry`
- `attributesColumn = attributes`
- `layerDiscriminatorColumn = layer_id`
- `primaryKeyColumn = objectid`, `schemaName`/`tableName`

`FromMetadata` reads `options.geometryColumn` before the `geometry.primary` fallback, so the explicit binding wins even though the resource still exposes a `shape` schema field.

Added `ClientCompatSeed_LayerStorageBinding_DeclaresPhysicalFeaturesTableColumns` to `ClientCompatSeedSequenceTests` to guard against future seed drift.

## On `database "honua" does not exist`

This `FATAL` is a benign teardown artifact. It appears **only** in the Postgres container log dump (single stray connection, PID 545, logged at `13:15:02` after the test step had already failed), never in the Honua.Server log. The server only ever uses the configured `honua_test` database (`ConnectionStrings__DefaultConnection=Host=localhost;Database=honua_test;...`), confirmed in `server.log` and the migration output. No app/config change is needed for it.

## Verification

- Reproduced locally with `postgis/postgis:18-3.6`: applied the seed, confirmed `features` lives in schema `honua` with columns `geometry`/`attributes`/`objectid`/`layer_id` and no `shape`. The old `ST_AsBinary("shape"::geometry)` query fails with `column "shape" does not exist`; the fixed `geometry` + `attributes->>'field'` query returns the seeded rows.
- Verified the generated snapshot's `storage-layer-0` binding now carries the correct options.
- `dotnet test` for the new regression test: **Passed (1/1)**.
- Full PyQGIS harness requires QGIS and was not run locally; the SQL-level reproduction + regression test cover the root cause.