### PR TITLE
test: fix geoservices-parity nightly timeout flake

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Import/GeoservicesParityIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/GeoservicesParityIntegrationTests.cs
@@ -32,6 +32,27 @@ public sealed class GeoservicesParityIntegrationTests : IAsyncLifetime, IDisposa
     private const int SampleFeatureCount = 15;
     private const int QueryMatrixPageSize = 50;
     private const double MaxSpatialParityEnvelopeSpanDegrees = 2d;
+
+    // Import budget tuning for the external parity suite.
+    //
+    // The candidate layers are tiny-to-modest (12-3557 features) and the public Esri
+    // sample servers normally answer a page in <2s, so a healthy import completes in
+    // well under a minute. The previous configuration paired a 90s per-request timeout
+    // with MaxRetries=1, which let a single transient upstream stall consume
+    // 90s + retry delay + 90s ~= 181s by itself. That already exceeded the 180s
+    // WaitForCompletionAsync budget, so one slow page on a free shared Esri endpoint
+    // tipped a multi-page import (e.g. usa_cities = 18 pages) over the deadline and
+    // produced the nightly TimeoutException flake.
+    //
+    // Cap a single request (incl. retry) far below the overall wait so no one page can
+    // exhaust the budget, and give the overall wait generous headroom for multi-page
+    // imports that hit a couple of slow pages, while staying well inside the workflow's
+    // 90-minute job timeout. A genuinely stuck import still fails at a bounded deadline
+    // rather than hanging the suite.
+    private const int ImportRequestTimeoutSeconds = 30;
+    private const int ImportMaxRetries = 2;
+    private static readonly TimeSpan _importCompletionTimeout = TimeSpan.FromMinutes(5);
+
     private static readonly JsonSerializerOptions _scorecardJsonOptions = new() { WriteIndented = true };
 
     private static readonly ParityServiceCase[] _serviceCases =
@@ -148,7 +169,7 @@ public sealed class GeoservicesParityIntegrationTests : IAsyncLifetime, IDisposa
             _importedTables.Add(tableName);
 
             var jobId = await StartImportAsync(serviceCase, tableName);
-            var progress = await WaitForCompletionAsync(jobId, TimeSpan.FromMinutes(3));
+            var progress = await WaitForCompletionAsync(jobId, _importCompletionTimeout);
 
             ReadStatus(progress.GetProperty("status")).Should().Be(
                 GeoservicesImportStatus.Completed,
@@ -253,7 +274,7 @@ public sealed class GeoservicesParityIntegrationTests : IAsyncLifetime, IDisposa
             _importedTables.Add(tableName);
 
             var jobId = await StartImportAsync(serviceCase, tableName);
-            var progress = await WaitForCompletionAsync(jobId, TimeSpan.FromMinutes(3));
+            var progress = await WaitForCompletionAsync(jobId, _importCompletionTimeout);
 
             ReadStatus(progress.GetProperty("status")).Should().Be(
                 GeoservicesImportStatus.Completed,
@@ -527,8 +548,8 @@ public sealed class GeoservicesParityIntegrationTests : IAsyncLifetime, IDisposa
             TargetSchema = _schema,
             OverwriteExisting = true,
             BatchSize = 200,
-            RequestTimeoutSeconds = 90,
-            MaxRetries = 1,
+            RequestTimeoutSeconds = ImportRequestTimeoutSeconds,
+            MaxRetries = ImportMaxRetries,
             AutoPublish = false
         };
 


### PR DESCRIPTION
## Problem

The `geoservices-parity-nightly` workflow (job *External GeoServices Parity*) failed:

```
ImportAndPublish_FromCandidateServices_PreservesFeatureServerQueryParity [FAIL]
System.TimeoutException : Geoservices import job 96beb4812348 did not complete within 180 seconds.
   at ...WaitForCompletionAsync(...) GeoservicesParityIntegrationTests.cs:line 579
```

## Root cause: flake amplified by an under-margined test budget (not a hang or genuine slowness)

The suite imports 10 candidate Esri layers from public sample servers and waited 180s per import job, while configuring each import with `RequestTimeoutSeconds=90` and `MaxRetries=1`.

Evidence:
- The candidate layers are small-to-modest (12-3557 features) and pages return in <2s; all 10 imports complete in ~52s locally (`Import_FromCandidateServices_PreservesImportedTableParity` passes).
- All layers advertise `supportsPagination=true` and the import pagination loop terminates correctly, so there is no infinite loop / hang.
- With `RequestTimeoutSeconds=90` and `MaxRetries=1`, a single transient upstream stall can consume `90s + retry delay + 90s ≈ 181s` for **one page** by itself — already over the 180s wait, with zero headroom. One slow page on a free shared Esri endpoint tips a multi-page import (e.g. `usa_cities` = 18 pages) past the deadline, producing the `TimeoutException`.

So this is a flaky external dependency, magnified by a wait budget that a single request-plus-retry could exhaust. The import is not legitimately slow and there is no deadlock/retry loop bug, so the fix is to right-size the test budget rather than blindly bump the timeout.

## Fix

In `GeoservicesParityIntegrationTests` only:
- `RequestTimeoutSeconds` 90 -> **30** (still generous vs observed <2s pages); worst-case single page incl. retries is now ~92s.
- `MaxRetries` 1 -> **2** (more resilience to transient blips, still bounded).
- Per-job completion wait 3min -> **5min**, comfortably above the largest expected multi-page import even with a few slow pages, and well inside the workflow's 90-minute job timeout.

A genuinely stuck import still fails at a bounded deadline rather than hanging the suite. Constants are named and documented so the budget relationship is explicit.

## Validation

- `Import_FromCandidateServices_PreservesImportedTableParity` passes locally (Testcontainers + PostGIS, `HONUA_TEST_ESRI_PARITY=1`) in ~52s, exercising the changed import config and `WaitForCompletionAsync` against all 10 live services.
- The import path in `ImportAndPublish_*` no longer times out locally (it now proceeds past `WaitForCompletionAsync`).

## Note / out of scope

`ImportAndPublish_*` has a separate, pre-existing metadata-parity assertion (`ValidatePublishedLayerMetadataParityAsync`) that is environment-dependent: locally Honua publishes the `objectid` column as `esriFieldTypeOID`, which the test's field extractor excludes, so `unexpectedHonuaFields` is empty and `OnlyContain("objectid")` fails. This is unrelated to the nightly's reported `TimeoutException` (the nightly got past metadata parity on its first service before timing out on a later one) and is left for a separate change.