### PR TITLE
ci: harden nightly AOT container build against ILC OOM kills and restore races

### DIFF
--- a/docker/Dockerfile.aot
+++ b/docker/Dockerfile.aot
@@ -56,32 +56,58 @@ COPY . .
 # Re-restore for the target RID before publishing so the assets cover the full
 # project graph as copied by `COPY . .` (the dedicated restore layer above
 # warms the NuGet cache; this is a near-instant no-op cache hit on success).
+# ILC (the native compiler) is single-threaded on BOTH arches. Parallel ILC on
+# amd64 (IlcSingleThreaded=false) pushed peak RSS over the hosted runner's
+# memory ceiling, and the kernel OOM-killer reaped ilc mid-link: it exits with
+# code -1 and no diagnostic, surfacing only as
+#   Microsoft.NETCore.Native.targets: error MSB3073: "...ilc..." exited with code -1.
+# Single-threaded linking trades wall-clock for a much lower memory peak and
+# fits comfortably inside the 90-minute job timeout. arm64 already used this.
+#
+# The restore+publish unit is retried with backoff so an intermittent
+# GitHub-Packages/nuget.org blip, a restore-assets hiccup, or a transient ILC
+# kill does not fail the nightly outright. Retries are cheap: a successful
+# restore is an "up-to-date" no-op and successful publish output is reused.
 ARG CONFIGURATION=Release
+ARG AOT_PUBLISH_MAX_ATTEMPTS=3
 RUN --mount=type=cache,target=/root/.nuget/packages \
     --mount=type=secret,id=github_actor \
     --mount=type=secret,id=github_token \
     case "${TARGETARCH:-amd64}" in \
-        amd64) RUNTIME_ID="linux-musl-x64" ; ILC_SINGLE_THREADED="false" ;; \
-        arm64) RUNTIME_ID="linux-musl-arm64" ; ILC_SINGLE_THREADED="true" ;; \
+        amd64) RUNTIME_ID="linux-musl-x64" ;; \
+        arm64) RUNTIME_ID="linux-musl-arm64" ;; \
         *) echo "Unsupported TARGETARCH=${TARGETARCH}" && exit 1 ;; \
     esac && \
-    sh scripts/docker/restore-dotnet-with-github-packages.sh src/Honua.Server/Honua.Server.csproj \
-      --runtime "$RUNTIME_ID" \
-      -p:RuntimeIdentifier="$RUNTIME_ID" && \
-    dotnet publish src/Honua.Server/Honua.Server.csproj \
-      --configuration "$CONFIGURATION" \
-      --runtime "$RUNTIME_ID" \
-      --no-restore \
-      --self-contained true \
-      --output /app \
-      -p:RuntimeIdentifier="$RUNTIME_ID" \
-      -p:PublishAot=true \
-      -p:DebugType=None \
-      -p:DebugSymbols=false \
-      -p:StripSymbols=true \
-      -p:OptimizationPreference=Speed \
-      -p:IlcOptimizationPreference=Speed \
-      -p:IlcSingleThreaded="$ILC_SINGLE_THREADED" && \
+    attempt=1 && \
+    max_attempts="${AOT_PUBLISH_MAX_ATTEMPTS:-3}" && \
+    until \
+        sh scripts/docker/restore-dotnet-with-github-packages.sh src/Honua.Server/Honua.Server.csproj \
+          --runtime "$RUNTIME_ID" \
+          -p:RuntimeIdentifier="$RUNTIME_ID" && \
+        dotnet publish src/Honua.Server/Honua.Server.csproj \
+          --configuration "$CONFIGURATION" \
+          --runtime "$RUNTIME_ID" \
+          --no-restore \
+          --self-contained true \
+          --output /app \
+          -p:RuntimeIdentifier="$RUNTIME_ID" \
+          -p:PublishAot=true \
+          -p:DebugType=None \
+          -p:DebugSymbols=false \
+          -p:StripSymbols=true \
+          -p:OptimizationPreference=Speed \
+          -p:IlcOptimizationPreference=Speed \
+          -p:IlcSingleThreaded=true ; \
+    do \
+        status=$? ; \
+        if [ "$attempt" -ge "$max_attempts" ]; then \
+            echo "AOT restore+publish failed after ${attempt} attempts (last exit ${status})" >&2 ; \
+            exit "$status" ; \
+        fi ; \
+        echo "AOT restore+publish attempt ${attempt} failed (exit ${status}); retrying after backoff..." >&2 ; \
+        sleep $((attempt * 15)) ; \
+        attempt=$((attempt + 1)) ; \
+    done && \
     rm -rf /app/BlazorDebugProxy /app/wwwroot && \
     find /app -type f \( -name '*.pdb' -o -name '*.dbg' \) -delete
 

--- a/scripts/docker/restore-dotnet-with-github-packages.sh
+++ b/scripts/docker/restore-dotnet-with-github-packages.sh
@@ -13,6 +13,12 @@ nuget_config="/tmp/honua-nuget.config"
 cp NuGet.config "$nuget_config"
 trap 'rm -f "$nuget_config"' EXIT
 
+# Make restore resilient to transient GitHub Packages / nuget.org blips. These
+# only affect network fetches; on a warm cache they are no-ops. Tune via env.
+export NUGET_ENABLE_ENHANCED_HTTP_RETRY="${NUGET_ENABLE_ENHANCED_HTTP_RETRY:-true}"
+export NUGET_ENHANCED_MAX_NETWORK_TRY_COUNT="${NUGET_ENHANCED_MAX_NETWORK_TRY_COUNT:-6}"
+export NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS="${NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS:-1000}"
+
 if [ -s /run/secrets/github_token ]; then
   github_actor="github-actions"
   if [ -s /run/secrets/github_actor ]; then
@@ -27,4 +33,9 @@ if [ -s /run/secrets/github_token ]; then
     --store-password-in-clear-text >/dev/null
 fi
 
-dotnet restore "$project" --configfile "$nuget_config" "$@"
+# --disable-parallel serializes per-project restore so the project graph's
+# obj/project.assets.json files are written deterministically. Parallel restore
+# of this wide graph intermittently raced and left a project without its assets
+# file, surfacing later as NETSDK1004 ("Assets file ... not found") in the
+# --no-restore publish that follows.
+dotnet restore "$project" --configfile "$nuget_config" --disable-parallel "$@"


### PR DESCRIPTION
## Problem

`nightly-container-build` AOT jobs fail intermittently. Investigating run [26794969364](https://github.com/honua-io/honua-server/actions/runs/26794969364) (the `Build & Push AOT (amd64)` failure), the AOT amd64 and arm64 jobs **always pass or fail together** — never one without the other — which points to a shared, non-arch-specific cause rather than an amd64-only restore race.

There are actually two distinct failure modes across recent AOT runs, both surfacing as `exit code: 1` at step #26 (the restore+publish `RUN`):

### Mode A — ILC killed (this run, 26794969364)
Restore succeeded cleanly (`#24 DONE 15.8s`, second restore `All projects are up-to-date`). The build then ran ILC for ~783s emitting only benign `IL3000` Oracle warnings, then:

```
#26 783.3 .../Microsoft.NETCore.Native.targets(330,5): error MSB3073:
  The command ".../ilc ... Honua.Server.ilc.rsp" exited with code -1.
```

`ilc` exiting with **code -1** and **no diagnostic** after a long compile is the signature of the kernel OOM-killer (SIGKILL). amd64 ran parallel ILC (`IlcSingleThreaded=false`, higher peak RSS); arm64 died the same way, just later (1938s, single-threaded under QEMU).

### Mode B — restore assets race (e.g. run 26733680813)
```
NETSDK1004: Assets file '/src/src/Honua.Core.Abstractions/obj/project.assets.json' not found.
```
The wide project graph's parallel `dotnet restore` intermittently left a project without its assets file, failing the subsequent `--no-restore` publish.

## Fix

`docker/Dockerfile.aot`:
- Build ILC single-threaded on **amd64 too** (arm64 already did) — `IlcSingleThreaded=true`. Trades wall-clock for a far lower memory peak to avoid the OOM kill; stays well inside the 90-minute job timeout.
- Retry the restore+publish unit with backoff (3 attempts) as a backstop for any remaining transient registry/ILC hiccup. Retries are cheap no-ops on a warm cache.

`scripts/docker/restore-dotnet-with-github-packages.sh`:
- `--disable-parallel` so every project's `obj/project.assets.json` is written deterministically (kills Mode B).
- NuGet enhanced HTTP retry env vars to absorb transient GitHub Packages / nuget.org blips.

## Verification

- Retry-loop logic unit-tested locally (succeeds on a passing retry; exits non-zero after exhausting attempts).
- `sh -n` syntax-checked the edited restore script and the reconstructed `RUN` body.
- Not verified locally: a full AOT musl-x64 build (infeasible on this WSL host; GitHub Packages auth would 401). Correctness rests on the failing log analysis plus the arm64/JIT comparison. Final confirmation is the next nightly run (or a `workflow_dispatch`).