### PR TITLE
test: fix geoservices-parity metadata-parity OID assertion

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Import/GeoservicesParityIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/GeoservicesParityIntegrationTests.cs
@@ -1711,6 +1711,17 @@ public sealed class GeoservicesParityIntegrationTests : IAsyncLifetime, IDisposa
             sourceSnapshot.ExpectedImportedFields,
             because: "published layer should expose imported source fields");
 
+        // ExtractComparableFieldMappings intentionally drops the esriFieldTypeOID
+        // primary-key field (it is not value-comparable across source/Honua), so add
+        // the published object id field back in before diffing. Honua publishes the
+        // import-created primary key as esriFieldTypeOID, which is the correct Esri
+        // behavior; this check verifies it is the only field added beyond the imported
+        // source attributes.
+        var honuaObjectIdField = ResolveObjectIdField(honuaLayerMetadata);
+        honuaObjectIdField.Should().NotBeNullOrWhiteSpace(
+            because: "published layer metadata should expose an object id field");
+        honuaFields.Add(honuaObjectIdField!.SanitizeFieldName());
+
         var unexpectedHonuaFields = honuaFields
             .Except(sourceSnapshot.ExpectedImportedFields, StringComparer.Ordinal)
             .ToArray();


### PR DESCRIPTION
## Problem

The geoservices-parity nightly (trunk run 26794966459) failed in `ImportAndPublish_FromCandidateServices_PreservesFeatureServerQueryParity` with:

> Expected collection to contain only items matching Equals(field, "objectid", Ordinal) because published metadata should only add the table primary key field beyond imported source fields, but the collection is empty.

(The earlier timeout flake was fixed in #1357; this was a separate, real assertion failure.)

## Root cause — test bug

`ValidatePublishedLayerMetadataParityAsync` builds the published-field set with `ExtractComparableFieldMappings`, whose `IsComparableFieldType` helper intentionally returns `false` for `esriFieldTypeOID` (OID values are not value-comparable across source vs. Honua). The check then diffs that set against the imported source fields and asserts the only added field is the table primary key `objectid`.

Because the OID field was already excluded from the published set, the "added beyond imported fields" diff came back empty, so `OnlyContain("objectid")` failed on an empty collection.

The server is correct: Honua publishes the import-created primary key (`objectid`) as `esriFieldTypeOID` (`FeatureServerUtilities.V2.MapFieldInfoV2`), which is the expected Esri behavior so clients recognize the OID field. The bug is purely in the test's field extractor/diff.

## Fix

Resolve the published object id field via the existing `ResolveObjectIdField` helper and add it back into the compared set before diffing, with a comment explaining why the comparable-field extractor omits it. The diff then correctly yields exactly `{objectid}`.

## Test result

Reproduced locally against PostGIS (Testcontainers) with live Esri sample servers reachable:

```
HONUA_TEST_ESRI_PARITY=1 dotnet test ... --filter "FullyQualifiedName~PreservesFeatureServerQueryParity"
Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1, Duration: 4 m 14 s
```