### PR TITLE
ci: fix load-soak nightly readiness gate (provide Redis for durable events)

### DIFF
--- a/.github/workflows/load-soak-nightly.yml
+++ b/.github/workflows/load-soak-nightly.yml
@@ -55,6 +55,15 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -108,7 +117,7 @@ jobs:
           dsn = f"host={host} port={port} dbname={dbname} user={user} password={password}"
 
           conn = None
-          for _ in range(30):
+          for _ in range(60):
               try:
                   conn = psycopg.connect(dsn)
                   break
@@ -139,6 +148,7 @@ jobs:
           HostValidation__AllowedHosts__0: "localhost"
           Security__DisableHttpsRedirection: "true"
           Security__ConnectionEncryption__MasterKey: "test-master-key-32-chars-long-000000"
+          ConnectionStrings__redis: "localhost:6379"
           ConnectionStrings__DefaultConnection: Host=localhost;Port=5432;Database=${{ env.DB_NAME }};Username=${{ env.DB_USER }};Password=${{ env.DB_PASSWORD }};Maximum Pool Size=50
         run: |
           dotnet run --project src/Honua.Server -c Release --no-build --no-launch-profile > server.log 2>&1 &
@@ -146,7 +156,10 @@ jobs:
 
       - name: Wait for readiness
         run: |
-          for i in {1..30}; do
+          # Production cold start runs the PostGIS preflight check, database
+          # migrations, and high-frequency query preparation before /healthz/ready
+          # reports 200, so budget generously (90 iterations x 2s = 180s).
+          for i in {1..90}; do
             if curl -sf "$BASE_URL/healthz/ready" >/dev/null; then
               exit 0
             fi


### PR DESCRIPTION
## Root cause

The admin-password fix (#1355) stopped the startup crash, but the load-soak nightly still failed the readiness gate (run 26794970294). Server logs showed the DB connected and warmup was in progress when the readiness loop expired — but the real cause is **not a too-short cold-start budget**.

In `ASPNETCORE_ENVIRONMENT=Production` the server requires *durable distributed* feature-change events (`requiresDurableDistributedEvents = true`). The workflow configures no Redis connection string, so:

- the Redis-connect block in `Program.cs` (gated on a connection string being present) is skipped, no `IConnectionMultiplexer` is registered;
- `InMemoryFeatureChangeEventStore` is constructed with `allowInMemoryFallback = false`;
- `CanPersistEvents` is therefore permanently `false`;
- `ReadinessCheckService` returns `Feature-change event storage unavailable` → `/healthz/ready` = **503 forever**.

The readiness loop (`{1..30}` × `sleep 2` ≈ 60s) then expired. The 02:44:03 query-prep log is a `BackgroundService` that only runs after `app.Run()`, confirming the server was already listening — readiness was failing the event-store check, not still warming up.

## Local verification

Built `Honua.Server` (Release) and ran it exactly like the workflow (Production, `--no-build`) against a PostGIS container:

| Scenario | `GET /healthz/ready` |
|---|---|
| No Redis | **503 for 120s+** (DatabaseHealth Healthy, CacheHealth Healthy, FeatureChangeEventStore Unhealthy) |
| Redis present (`ConnectionStrings__redis`) | **200 in ~5s** |

So readiness is a missing-dependency problem, and Production cold start is fast (~5s) once the dependency exists.

## Change

`.github/workflows/load-soak-nightly.yml`:
- Add a `redis:7-alpine` service container (health-checked) and set `ConnectionStrings__redis: "localhost:6379"` on the Start server step so the durable event store can persist → `/healthz/ready` returns 200.
- Widen the readiness wait budget **60s → 180s** (`{1..30}` → `{1..90}`) and the Postgres-wait python loop **60s → 120s** (`range(30)` → `range(60)`) to leave comfortable headroom on slower CI runners.

No application code changed; this aligns the CI environment with Production's durable-events requirement.