### PR TITLE
fix(metadata-v2): restore OGC API Maps GetMap for collections sharing a layer id with a raster sidecar

### DIFF
--- a/src/Honua.Core/Features/Validation/ResourceValidator.cs
+++ b/src/Honua.Core/Features/Validation/ResourceValidator.cs
@@ -32,19 +32,46 @@ public sealed class ResourceValidator : IResourceValidator
         CancellationToken cancellationToken = default)
     {
         var snapshot = await RequireV2SnapshotAsync(cancellationToken).ConfigureAwait(false);
-        var pub = snapshot.Graph.Publications.FirstOrDefault(p => p.LayerIndex == layerId);
-        if (pub is null)
+
+        // A single storage layer index can be published more than once (for
+        // example a feature dataset and a raster sidecar that share the same
+        // integer layer id, as the client-compat seed does for layer 2000).
+        // Prefer the publication whose backing resource resolves to a usable
+        // storage-layer handle so the integer-collection-id contract returns a
+        // storage-backed layer rather than an arbitrary first match (which may
+        // be a raster resource with no integer storage handle, leaving callers
+        // such as OGC API Maps unable to resolve the layer). Fall back to any
+        // matching publication's resource so existing single-publication and
+        // non-storage-backed cases keep their previous behaviour.
+        MetadataV2Resource? firstResource = null;
+        foreach (var candidate in snapshot.Graph.Publications)
+        {
+            if (candidate.LayerIndex != layerId)
+            {
+                continue;
+            }
+
+            var candidateResource = snapshot.ResolveResource(candidate);
+            if (candidateResource is null)
+            {
+                continue;
+            }
+
+            firstResource ??= candidateResource;
+
+            if (snapshot.ResolveStorageLayerId(candidate).HasValue)
+            {
+                return ResourceValidationResult.Success(candidateResource);
+            }
+        }
+
+        if (firstResource is null)
         {
             return ResourceValidationResult.NotFound<MetadataV2Resource>(
                 ErrorMessages.NotFound.FormatLayer(layerId));
         }
-        var resource = snapshot.ResolveResource(pub);
-        if (resource is null)
-        {
-            return ResourceValidationResult.NotFound<MetadataV2Resource>(
-                ErrorMessages.NotFound.FormatLayer(layerId));
-        }
-        return ResourceValidationResult.Success(resource);
+
+        return ResourceValidationResult.Success(firstResource);
     }
 
     /// <inheritdoc />

--- a/tests/dotnet/Honua.Core.Tests/Features/Validation/ResourceValidatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Validation/ResourceValidatorTests.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Validation;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Infrastructure;
+
+namespace Honua.Core.Tests.Features.Validation;
+
+/// <summary>
+/// Tests for <see cref="ResourceValidator"/> integer-collection-id resolution, in
+/// particular the case where one storage layer index is published more than once
+/// (a feature dataset and a raster sidecar that share the same layer id, as the
+/// client-compat seed does for layer 2000). The integer-collection-id contract must
+/// resolve to the storage-backed feature resource so callers such as OGC API Maps can
+/// resolve an integer storage-layer handle instead of 404-ing on the raster sidecar.
+/// </summary>
+[Protocol(ProtocolNames.TestQuality)]
+public sealed class ResourceValidatorTests
+{
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public async Task ValidateLayerV2Async_WhenLayerIndexSharedWithRasterSidecar_ResolvesStorageBackedResource()
+    {
+        var provider = new TestMetadataV2GraphProvider(SharedLayerIndexGraph());
+        var validator = new ResourceValidator(provider);
+
+        var result = await validator.ValidateLayerV2Async(2000);
+
+        result.IsValid.Should().BeTrue();
+        result.Resource.Should().NotBeNull();
+        // Must NOT resolve to the raster sidecar (res-image-layer-2000), whose primary
+        // storage binding has no integer StorageLayerId.
+        result.Resource!.Metadata.Id.Should().Be("res-layer-2000");
+
+        var snapshot = await provider.GetCurrentAsync();
+        snapshot.ResolveStorageLayerId(result.Resource).Should().Be(2000);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public async Task ValidateCollectionV2Async_WithIntegerId_ResolvesStorageBackedResource()
+    {
+        var provider = new TestMetadataV2GraphProvider(SharedLayerIndexGraph());
+        var validator = new ResourceValidator(provider);
+
+        var result = await validator.ValidateCollectionV2Async("2000");
+
+        result.IsValid.Should().BeTrue();
+        result.Resource!.Metadata.Id.Should().Be("res-layer-2000");
+    }
+
+    /// <summary>
+    /// Builds a graph where storage layer index 2000 is published twice: a raster
+    /// sidecar publication (ordered first, no integer StorageLayerId) and a
+    /// storage-backed feature publication. Mirrors the client-compat seed shape.
+    /// </summary>
+    private static MetadataV2Graph SharedLayerIndexGraph()
+    {
+        return new MetadataV2Graph
+        {
+            Revision = 1,
+            Environment = "Production",
+            GeneratedAt = DateTimeOffset.Parse("2026-06-01T00:00:00Z", System.Globalization.CultureInfo.InvariantCulture),
+            Resources =
+            [
+                new MetadataV2Resource
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "res-image-layer-2000", Name = "Browser Points imagery" },
+                    Type = MetadataV2ResourceType.RasterDataset,
+                    StorageBindingIds = ["storage-image-layer-2000"],
+                    PrimaryStorageBindingId = "storage-image-layer-2000",
+                },
+                new MetadataV2Resource
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "res-layer-2000", Name = "Browser Points" },
+                    Type = MetadataV2ResourceType.FeatureDataset,
+                    StorageBindingIds = ["storage-layer-2000"],
+                    PrimaryStorageBindingId = "storage-layer-2000",
+                },
+            ],
+            StorageBindings =
+            [
+                // Raster sidecar: no integer storage-layer handle.
+                new MetadataV2StorageBinding
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "storage-image-layer-2000", Name = "storage-image-layer-2000" },
+                    ResourceId = "res-image-layer-2000",
+                    StorageType = MetadataV2StorageType.RelationalTable,
+                    Locator = "honua.raster_data",
+                    StorageLayerId = null,
+                },
+                new MetadataV2StorageBinding
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "storage-layer-2000", Name = "storage-layer-2000" },
+                    ResourceId = "res-layer-2000",
+                    StorageType = MetadataV2StorageType.RelationalTable,
+                    Locator = "public.features",
+                    StorageLayerId = 2000,
+                },
+            ],
+            Services =
+            [
+                new MetadataV2Service
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "svc-browser-compat-image", Name = "browser_compat" },
+                    Protocols = [ServiceProtocols.ImageServer],
+                },
+                new MetadataV2Service
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "svc-browser-compat-map", Name = "browser_compat" },
+                    Protocols = [ServiceProtocols.OgcApiMaps],
+                },
+            ],
+            Publications =
+            [
+                // Raster sidecar publication ordered first — the previous
+                // FirstOrDefault(LayerIndex == 2000) match returned this resource,
+                // which has no integer StorageLayerId and caused OGC API Maps 404s.
+                new MetadataV2Publication
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "pub-browser-compat-image-2000", Name = "2000" },
+                    ResourceId = "res-image-layer-2000",
+                    ServiceId = "svc-browser-compat-image",
+                    StorageBindingId = "storage-image-layer-2000",
+                    PublicationType = MetadataV2PublicationType.EsriImageLayer,
+                    Identifier = new MetadataV2PublicationIdentifier { Value = "2000", IsNumeric = true },
+                },
+                new MetadataV2Publication
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "pub-browser-compat-map-2000", Name = "2000" },
+                    ResourceId = "res-layer-2000",
+                    ServiceId = "svc-browser-compat-map",
+                    StorageBindingId = "storage-layer-2000",
+                    PublicationType = MetadataV2PublicationType.EsriMapLayer,
+                    Identifier = new MetadataV2PublicationIdentifier { Value = "2000", IsNumeric = true },
+                },
+            ],
+        };
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #1364

## Summary
The client-interop nightly (trunk run 26794968358) flagged two `js/ogc-maps` regressions — `CERT-RNDR-01` (render) and `CERT-ERRH-01` (error handling), both hitting `GET /ogc/maps/collections/2000/map`. Collection `2000` is published twice (a feature dataset and a raster sidecar with no integer `StorageLayerId`); `ValidateLayerV2Async` picked the sidecar via `FirstOrDefault`, got a null storage handle, and 404'd before the renderer/format-check. This fixes the resolver to prefer the publication that resolves to a usable storage-layer handle.

## Changes Made
- `src/Honua.Core/Features/Validation/ResourceValidator.cs`: `ValidateLayerV2Async` now prefers the publication whose backing resource resolves to a usable integer storage-layer handle, falling back to the first matching resource (preserves single-publication / non-storage-backed behavior).
- Added `tests/dotnet/Honua.Core.Tests/Features/Validation/ResourceValidatorTests.cs` (2 tests for the shared-layer-index case; fail without the fix).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Built `Honua.Server` (Release), ran under `ASPNETCORE_ENVIRONMENT=Production` against PostGIS (`POSTGIS_GDAL_ENABLED_DRIVERS=ENABLE_ALL`) + the client-compat seed. After the fix: `f=png` → `200 image/png` (PNG magic, 580 bytes); `f=json` → `400 application/problem+json`. 204 metadata-v2 + validation Core.Tests pass; `dotnet format --verify-no-changes` clean.

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None
