### PR TITLE
fix(geoservices): emit exceededTransferLimit, advertise Sync, honor returnCountOnly on queryTopFeatures

### DIFF
--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.TopFeatures.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.TopFeatures.cs
@@ -112,6 +112,13 @@ internal static partial class FeatureServerEndpoints
                 [parseError ?? "topFilter must be valid JSON."]);
         }
 
+        if (!TryParseBoolValue(values, "returnCountOnly", false, out var returnCountOnly, out var countError))
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "Invalid returnCountOnly parameter",
+                [countError ?? "returnCountOnly must be a boolean."]);
+        }
+
         // Build query from common parameters
         var query = new FeatureQuery
         {
@@ -131,6 +138,18 @@ internal static partial class FeatureServerEndpoints
 
         var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
         var result = await featureReader.QueryTopFeaturesAsync(storageLayerId.Value, query, cancellationToken);
+
+        // returnCountOnly: Esri's queryTopFeatures honors this and returns the
+        // top-feature count, not a FeatureSet. The ArcGIS API for Python issues
+        // it as the first step of query_top_features paging; ignoring it left the
+        // SDK with a null total and a TypeError in its paginator.
+        if (returnCountOnly)
+        {
+            return Results.Json(
+                new QueryResponse { Count = result.Items.Length, Features = null },
+                FeatureServerJsonContext.Default.QueryResponse,
+                contentType: "application/json");
+        }
 
         var responseFeatures = result.Items.Select(feature => new GeoServicesFeature
         {

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.V2.cs
@@ -280,6 +280,15 @@ internal static partial class FeatureServerEndpoints
             capabilities.Add("Extract");
         }
 
+        // Advertise "Sync" when the service declares it (syncEnabled). The
+        // createReplica / synchronizeReplica endpoints are served, but Esri SDK
+        // clients only attempt the sync surface when the capabilities string
+        // includes "Sync"; omitting it left a working sync backend unreachable.
+        if (ServiceSupportsSyncV2(service))
+        {
+            capabilities.Add("Sync");
+        }
+
         if (supportsAttachmentUploads && publications.Any(pair => ResourceSupportsAttachmentsV2(pair.Resource)))
         {
             capabilities.Add("Uploads");
@@ -318,6 +327,15 @@ internal static partial class FeatureServerEndpoints
         if (declared.Any(capability => capability.Equals("Extract", StringComparison.OrdinalIgnoreCase)))
         {
             capabilities.Add("Extract");
+        }
+
+        // Advertise "Sync" when the service declares it (syncEnabled). The
+        // createReplica / synchronizeReplica endpoints are served, but Esri SDK
+        // clients only attempt the sync surface when the capabilities string
+        // includes "Sync"; omitting it left a working sync backend unreachable.
+        if (ServiceSupportsSyncV2(service))
+        {
+            capabilities.Add("Sync");
         }
 
         if (supportsAttachmentUploads && ResourceSupportsAttachmentsV2(resource))

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Models/QueryResponse.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Models/QueryResponse.cs
@@ -87,9 +87,13 @@ public sealed class QueryResponse : ICollectionResponse<GeoServicesFeature>
     public GeoServicesFeature[]? Features { get; init; }
 
     /// <summary>
-    /// Whether the transfer limit was exceeded
+    /// Whether the transfer limit was exceeded. Always emitted (including
+    /// <c>false</c>) to match the Esri GeoServices query contract — Esri always
+    /// returns this field. Omitting it on the <c>false</c> path made the ArcGIS
+    /// API for Python <c>query_top_features</c> paginator dereference a missing
+    /// value (<c>fetched &gt;= None</c> -&gt; TypeError), so a single-page
+    /// queryTopFeatures result could not be read.
     /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool ExceededTransferLimit { get; init; }
 
     ImmutableArray<GeoServicesFeature> ICollectionResponse<GeoServicesFeature>.Items =>

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureServerQueryExecutor.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/FeatureServerQueryExecutor.cs
@@ -195,10 +195,11 @@ internal sealed partial class FeatureServerQueryExecutor
         }
 
         writer.WriteEndArray();
-        if (result.HasMoreResults)
-        {
-            writer.WriteBoolean("exceededTransferLimit", true);
-        }
+
+        // Always emit exceededTransferLimit (including false). Esri's GeoServices query
+        // contract always returns this field; omitting the false case made the ArcGIS API
+        // for Python paginator dereference a missing value (fetched >= None -> TypeError).
+        writer.WriteBoolean("exceededTransferLimit", result.HasMoreResults);
 
         writer.WriteEndObject();
         writer.Flush();

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/QueryFormatters.cs
@@ -948,10 +948,10 @@ internal sealed class StreamingQueryFormatter
 
         writer.WriteEndArray();
 
-        if (hasMoreResults)
-        {
-            writer.WriteBoolean("exceededTransferLimit", true);
-        }
+        // Always emit exceededTransferLimit (including false). Esri's GeoServices query
+        // contract always returns this field; omitting the false case made the ArcGIS API
+        // for Python paginator dereference a missing value (fetched >= None -> TypeError).
+        writer.WriteBoolean("exceededTransferLimit", hasMoreResults);
 
         writer.WriteEndObject();
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryGapsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryGapsTests.cs
@@ -193,6 +193,32 @@ public sealed class FeatureServerQueryGapsTests : IAsyncLifetime
         content.Should().Contain("sqlFormat");
     }
 
+    // Gap 4: the Esri GeoServices query contract always returns exceededTransferLimit,
+    // including the false case. It was [JsonIgnore(WhenWritingDefault)], so a single-page
+    // (false) result omitted the field and the ArcGIS API for Python query paginator
+    // dereferenced a missing value (fetched >= None -> TypeError). It must be present in
+    // the raw JSON even when false.
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task Query_FalseCase_AlwaysEmitsExceededTransferLimit()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query?f=json&where=1%3D1");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        using var document = JsonDocument.Parse(content);
+        var root = document.RootElement;
+
+        // The seeded result fits in a single page, so exceededTransferLimit is false —
+        // but the field MUST still be present in the wire payload (Esri always returns it).
+        root.TryGetProperty("exceededTransferLimit", out var exceeded)
+            .Should().BeTrue("Esri's query contract always emits exceededTransferLimit, including the false case");
+        exceeded.ValueKind.Should().Be(JsonValueKind.False);
+    }
+
     private static long? GetObjectId(Dictionary<string, object?> attributes)
     {
         if (!attributes.TryGetValue("objectid", out var value) || value is null)

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryTopFeaturesTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryTopFeaturesTests.cs
@@ -49,6 +49,45 @@ public sealed class FeatureServerQueryTopFeaturesTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.QueryTopFeatures)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryTopFeatures")]
+    public async Task QueryTopFeatures_WithReturnCountOnly_ReturnsCountNotFeatures()
+    {
+        // The ArcGIS API for Python issues returnCountOnly=true as the first step of
+        // query_top_features paging and reads `count`. queryTopFeatures previously
+        // returned a FeatureSet regardless, leaving the paginator with a null total
+        // (fetched >= None -> TypeError). It must honor returnCountOnly: return the
+        // top-feature count and no `features`, with exceededTransferLimit always present.
+        var topFilter = JsonSerializer.Serialize(new
+        {
+            groupByFields = "category",
+            topCount = 2,
+            orderByFields = "objectid desc"
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryTopFeatures?topFilter={Uri.EscapeDataString(topFilter)}&returnCountOnly=true&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(content);
+        var root = document.RootElement;
+
+        root.TryGetProperty("count", out var count).Should().BeTrue(
+            "returnCountOnly=true must return a top-feature count for the arcgis paginator");
+        count.ValueKind.Should().Be(JsonValueKind.Number);
+        count.GetInt64().Should().BeGreaterThan(0);
+
+        root.TryGetProperty("features", out _).Should().BeFalse(
+            "returnCountOnly=true must not return a FeatureSet");
+
+        root.TryGetProperty("exceededTransferLimit", out var exceeded).Should().BeTrue(
+            "the count-only response must still carry exceededTransferLimit (Esri always emits it)");
+        exceeded.ValueKind.Should().Be(JsonValueKind.False);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryTopFeatures)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryTopFeatures")]
     public async Task QueryTopFeatures_MissingTopFilter_ReturnsBadRequest()
     {
         var response = await _fixture.Client.GetAsync(

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MobileOfflineDemoFixtureReplicationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MobileOfflineDemoFixtureReplicationTests.cs
@@ -363,6 +363,41 @@ public sealed class MobileOfflineDemoFixtureReplicationTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.GetMetadata)]
+    [Endpoint("GET /rest/services/mobile_offline_demo/FeatureServer")]
+    public async Task MobileOfflineFixture_ServiceMetadata_AdvertisesSyncCapability()
+    {
+        // syncEnabled=true is necessary but not sufficient: Esri SDK clients gate the
+        // sync/replica surface on the "Sync" token appearing in the capabilities STRING.
+        // The createReplica/synchronizeReplica handlers were served, but the capabilities
+        // string omitted "Sync", so a working sync backend was unreachable. Assert both
+        // the service and layer capabilities strings advertise Sync.
+        var serviceResponse = await _fixture.Client.GetAsync(
+            $"/rest/services/{ServiceId}/FeatureServer?f=json");
+        serviceResponse.Be200Ok();
+
+        using (var serviceDocument = await ReadJsonDocumentAsync(serviceResponse))
+        {
+            var serviceCapabilities = serviceDocument.RootElement.GetProperty("capabilities").GetString();
+            serviceCapabilities.Should().NotBeNull();
+            serviceCapabilities!.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                .Should().Contain("Sync",
+                    "Esri SDK clients only attempt the sync surface when 'Sync' is in the capabilities string");
+        }
+
+        var layerResponse = await _fixture.Client.GetAsync(
+            $"/rest/services/{ServiceId}/FeatureServer/{OfflineSitesLayerId}?f=json");
+        layerResponse.Be200Ok();
+
+        using var layerDocument = await ReadJsonDocumentAsync(layerResponse);
+        var layerCapabilities = layerDocument.RootElement.GetProperty("capabilities").GetString();
+        layerCapabilities.Should().NotBeNull();
+        layerCapabilities!.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .Should().Contain("Sync",
+                "the layer capabilities string must also advertise Sync for sync-enabled services");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
     [Endpoint("GET /rest/services/mobile_offline_demo/FeatureServer/68910")]
     public async Task MobileOfflineFixture_LayerMetadata_AdvertisesSupportsTopFeaturesQuery()
     {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/FeatureServerQueryExecutorTests.cs
@@ -405,7 +405,7 @@ public sealed class FeatureServerQueryExecutorTests
     }
 
     [Fact]
-    public async Task StreamQueryAsync_WithPagedQueryThatFits_DoesNotSetExceededTransferLimit()
+    public async Task StreamQueryAsync_WithPagedQueryThatFits_EmitsExceededTransferLimitFalse()
     {
         var featureReader = Substitute.For<IFeatureReader>();
         featureReader.CountAsync(Arg.Any<int>(), Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
@@ -441,7 +441,9 @@ public sealed class FeatureServerQueryExecutorTests
         var json = await ReadResponseAsync(context);
         using var document = JsonDocument.Parse(json);
         document.RootElement.GetProperty("features").GetArrayLength().Should().Be(2);
-        document.RootElement.TryGetProperty("exceededTransferLimit", out _).Should().BeFalse();
+        // Esri's query contract always emits exceededTransferLimit, including the false case.
+        document.RootElement.TryGetProperty("exceededTransferLimit", out var exceeded).Should().BeTrue();
+        exceeded.GetBoolean().Should().BeFalse();
     }
 
     [Fact]

--- a/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -912,7 +912,9 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
 
         using var jsonDoc = JsonDocument.Parse(content);
         jsonDoc.RootElement.TryGetProperty("features", out _).Should().BeFalse();
-        jsonDoc.RootElement.TryGetProperty("exceededTransferLimit", out _).Should().BeFalse();
+        // Esri's query contract always emits exceededTransferLimit (including false).
+        jsonDoc.RootElement.TryGetProperty("exceededTransferLimit", out var countExceeded).Should().BeTrue();
+        countExceeded.GetBoolean().Should().BeFalse();
     }
 
     [IntegrationTest]
@@ -938,6 +940,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
 
         using var jsonDoc = JsonDocument.Parse(content);
         jsonDoc.RootElement.TryGetProperty("features", out _).Should().BeFalse();
+        // returnIdsOnly returns the full id set (paged by offset), not a transfer-limited
+        // FeatureSet, so Esri does not emit exceededTransferLimit on this shape.
         jsonDoc.RootElement.TryGetProperty("exceededTransferLimit", out _).Should().BeFalse();
     }
 
@@ -961,6 +965,7 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
 
         using var jsonDoc = JsonDocument.Parse(content);
         jsonDoc.RootElement.TryGetProperty("features", out _).Should().BeFalse();
+        // returnIdsOnly is not a FeatureSet; exceededTransferLimit is not part of this shape.
         jsonDoc.RootElement.TryGetProperty("exceededTransferLimit", out _).Should().BeFalse();
     }
 
@@ -990,7 +995,9 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
 
         using var jsonDoc = JsonDocument.Parse(content);
         jsonDoc.RootElement.TryGetProperty("features", out _).Should().BeFalse();
-        jsonDoc.RootElement.TryGetProperty("exceededTransferLimit", out _).Should().BeFalse();
+        // Esri's query contract always emits exceededTransferLimit (including false).
+        jsonDoc.RootElement.TryGetProperty("exceededTransferLimit", out var extentExceeded).Should().BeTrue();
+        extentExceeded.GetBoolean().Should().BeFalse();
     }
 
     [IntegrationTest]
@@ -1777,7 +1784,11 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         queryResponse.ExceededTransferLimit.Should().BeFalse("because all available features were returned");
 
         using var jsonDoc = JsonDocument.Parse(content);
-        jsonDoc.RootElement.TryGetProperty("exceededTransferLimit", out _).Should().BeFalse();
+        // Esri's query contract always emits exceededTransferLimit; the false case must be
+        // present in the wire payload (the ArcGIS API for Python paginator reads it
+        // unconditionally — a missing value caused a fetched >= None TypeError).
+        jsonDoc.RootElement.TryGetProperty("exceededTransferLimit", out var allResultsExceeded).Should().BeTrue();
+        allResultsExceeded.GetBoolean().Should().BeFalse();
     }
 
     /// <summary>


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1365

## Summary
Closes the client-visible GeoServices FeatureServer gaps that #1365's Esri-SDK
certification (honua-esri-compat, ArcGIS API for Python) attributes to #1367,
each verified at the GeoServices HTTP/JSON level and now covered by tests:

1. `exceededTransferLimit` is always emitted (including the `false` case) on the
   FeatureServer `query` JSON path, matching Esri's query contract. Omitting it
   on the single-page path made the ArcGIS API for Python paginator dereference a
   missing value (`fetched >= None` → `TypeError`).
2. The service- and layer-level `capabilities` strings advertise `Sync` when the
   service declares it (`syncEnabled`). The `createReplica`/`synchronizeReplica`
   surface was already served, but Esri SDK clients gate the sync workflow on the
   `Sync` token in the capabilities string, so a working sync backend was
   unreachable.
3. `queryTopFeatures` honors `returnCountOnly`: it returns `{count,
   exceededTransferLimit}` instead of a FeatureSet, which is the first step the
   ArcGIS API for Python `query_top_features` paginator issues.

The original PR fixed `exceededTransferLimit` only on the buffered `QueryResponse`
model path; the primary streaming JSON `query` path (the path the SDK actually
hits) still omitted the field on the `false` case. This revision fixes the
streaming GeoServices-JSON writers as well and adds the missing test coverage for
all three fixes. The GeoJSON (`f=geojson`) output is intentionally left unchanged
— that is a separate Esri-extension contract and emits the flag only when true.

## Changes Made
- Always emit `exceededTransferLimit` on both streaming GeoServices-JSON query
  paths (`FeatureServerQueryExecutor` raw point fast-path and
  `StreamingQueryFormatter.StreamAsGeoServicesJsonAsync`); the buffered
  `QueryResponse` model already serializes it unconditionally.
- Advertise `Sync` in the V2 service- and layer-level capabilities strings when
  `ServiceSupportsSyncV2` (unchanged from prior revision).
- Honor `returnCountOnly` on `queryTopFeatures`, returning a count-only response
  (unchanged from prior revision).
- Tests: `exceededTransferLimit` always-present (false case) on `query`;
  `returnCountOnly` on `queryTopFeatures`; `Sync` in service/layer capabilities
  strings; updated existing assertions that encoded the old "omit when false"
  behavior on FeatureSet/count/extent responses (ids-only stays unchanged — it is
  not a FeatureSet, so Esri does not emit the flag there).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Targeted integration tests run green locally (Testcontainers + PostGIS):
`FeatureServerQueryGapsTests`, `FeatureServerQueryTopFeaturesTests`,
`MobileOfflineDemoFixtureReplicationTests`, `FeatureServerQueryExecutorTests`,
and the `FeatureServerEndpointTests` query suite (68/68).
`dotnet format Honua.sln --verify-no-changes` is clean on all touched files.
The honua-esri-compat ArcGIS harness is not runnable in this environment;
reproduced at the GeoServices HTTP/JSON level instead.

Ran `scripts/ci/pre-pr-check.sh`: build (warnings-as-errors), format, and all
affected unit/integration/architecture test shards passed (Server.Tests core
412/412, GeoServices FeatureServer/Replication/Services shards, Architecture
101/101). The script's final AOT publish step surfaces a pre-existing
`IL2075` trimming analysis error in `Honua.Core/.../ParameterBinder.cs:57`
(`GetType().GetProperties(...)`) — that line is byte-identical on `origin/trunk`
and is not touched by this PR, so it is not a regression from this change. AOT is
a Nightly gate, not a PR gate.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. `exceededTransferLimit` becomes always-present on the JSON `query` path
(previously omitted when false); this is additive and matches the Esri contract.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (build/format/tests green; only a pre-existing, unrelated `Honua.Core` AOT IL2075 trimming error remains — see Testing)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
