### PR TITLE
feat: persistent RBAC store + canonical permission resolver (#1374, #1375)

### DIFF
--- a/docs/contributor/adr/0048-single-auth-identity-token-foundation.md
+++ b/docs/contributor/adr/0048-single-auth-identity-token-foundation.md
@@ -1,0 +1,131 @@
+# ADR-0048: Single Auth/Identity/Token Foundation Shared by OIDC SSO and ArcGIS OAuth2
+
+## Status
+
+Accepted
+
+## Context
+
+Honua's enterprise-auth roadmap has three tracks landing in close succession:
+
+- **#348 — OIDC SSO.** The interactive single-sign-on track for
+  Entra ID / Okta / Auth0 / generic OIDC.
+- **#1242 — ArcGIS OAuth2 named-user.** `oauth2/authorize` + `oauth2/token`
+  so ArcGIS Pro "Add Portal" and Field Maps can log a *named user* in against
+  Honua's portal facade (#1240).
+- **#349 — RBAC.** Per-service/per-layer/per-operation access decisions, of
+  which the persistent store (#1374) and canonical resolver (#1375) are the
+  load-bearing half.
+
+The risk identified in the #348/#349 assessment is that #1242 and #348 each
+build their **own** auth/token system — a second user store, a second token
+store, and a second group→role mapping — and we rebuild authentication twice.
+
+A single foundation already exists in-tree and must be the basis for all three
+tracks rather than reinvented:
+
+- **Identity / login:** `OidcAuthenticationExtensions`
+  (`src/Honua.Hosting/Features/Authentication/OidcAuthenticationExtensions.cs`)
+  already wires JWT-bearer validation **and** interactive auth-code+PKCE for
+  Entra ID, Google, Okta, Auth0, and a generic OIDC provider, with per-provider
+  authority/issuer/audience config, `env:` secret resolution, token-replay
+  protection, and a composite policy scheme selecting between JWT,
+  admin-session cookie, client certificate, and API key. Provider quirks
+  (Okta `groups`, Auth0 namespaced `roles`/`permissions`) are already handled,
+  and claims→role mapping runs through `OidcClaimsTransformation`.
+- **ArcGIS-shaped tokens:** `IPortalTokenIssuer`
+  (`src/Honua.Core/Features/Authorization/Abstractions/IPortalTokenIssuer.cs`)
+  + `PortalTokenIssuer`
+  (`src/Honua.Hosting/Features/Authentication/PortalTokenIssuer.cs`) mint
+  distributed-cache-backed opaque bearer tokens that are URL-safe for the
+  `?token=` query parameter ArcGIS clients send, with referer/IP/host binding.
+  `PortalTokenAuthenticationHandler` validates them on the request path, and
+  `generateToken` is live at
+  `src/Honua.Protocols.GeoServices/Sharing/SharingRestEndpoints.cs`.
+- **Access decisions:** the RBAC resolver (#1375) over the persistent role
+  store (#1374) is the per-operation `(service, layer, operation) → allow/deny`
+  seam (see the scope section below), backed by `IRoleStore` and
+  `EffectivePermissions` in `Honua.Core`.
+
+If #1242 ships before the RBAC resolver exists, it will hardcode the access
+decision and we will rebuild it; therefore RBAC-resolver-first is an explicit
+cross-track ordering constraint.
+
+## Decision
+
+**There is exactly one auth/identity/token foundation. All three tracks
+compose it; none of them introduces a parallel one.**
+
+1. **Identity is OIDC.** Interactive login and bearer validation are owned by
+   the existing `OidcAuthenticationExtensions` middleware and its composite
+   policy scheme. New providers are configuration, not new code paths.
+
+2. **ArcGIS tokens are minted by `IPortalTokenIssuer`.** Any Esri-shaped token
+   (the `?token=` opaque bearer, the `generateToken` response, and the eventual
+   `oauth2/token` response) is produced and validated through the existing
+   issuer/handler pair. No second token store.
+
+3. **Authorization is the RBAC resolver.** Per-operation access decisions for
+   every protocol are made by the canonical permission resolver (#1375) over
+   the persistent role store (#1374). RBAC grants are the **source** of the
+   access policies the portal facade exports for item sharing (#1240) — the
+   facade reads grants, it does not own a separate policy model.
+
+4. **#1242 is a thin bridge, not a new system.**
+   - `oauth2/authorize` delegates to the configured per-provider OIDC
+     auth-code+PKCE flow already in `OidcAuthenticationExtensions`.
+   - On callback, `oauth2/token` returns the Esri-shaped
+     `{ access_token, expires_in, refresh_token }` minted via
+     `IPortalTokenIssuer`.
+   - #1242 and #1240 MUST NOT introduce a separate user store, a separate
+     token store, or a separate group→role mapping. Group→role mapping is
+     `OidcClaimsTransformation`; roles/grants live in the persistent role
+     store; access decisions are the resolver.
+
+5. **Ordering constraint.** The RBAC persistent store (#1374) and resolver
+   (#1375) land **before** #1242 hardcodes access decisions. Sequence:
+   RBAC persistent store + resolver → OIDC provider validate/test (#499) →
+   #1242 OAuth2 bridge → SCIM (#510) / SAML (#508) write into the same store.
+
+## Consequences
+
+**Easier:**
+
+- One place to reason about identity (OIDC), one place for Esri tokens
+  (`IPortalTokenIssuer`), one place for access decisions (the resolver). The
+  ArcGIS facade and SSO share the same role/grant truth.
+- #1242 becomes a small, testable adapter rather than an auth subsystem.
+- SCIM (#510) / SAML (#508) provision into a single durable role store.
+
+**Harder / explicit trade-offs:**
+
+- #1242 cannot proceed until #1374 + #1375 are merged (this ADR makes that an
+  accepted dependency, not an accident).
+- Any future "quick" parallel token path is now an ADR violation and should be
+  rejected in review.
+
+## Scope landed with this ADR
+
+This ADR is recorded alongside the first implementation slice that makes it
+real (#1374 + #1375):
+
+- **#1374** — Postgres-backed `IRoleStore` (`PostgresRoleStore`) with an
+  idempotent schema migration, replacing `InMemoryRoleStore` as the registered
+  implementation (in-memory retained for Community/no-DB mode and tests).
+- **#1375** — the canonical `IPermissionResolver`
+  (`(principal, service, layer, operation) → allow / deny / requires-auth`)
+  over `EffectivePermissions`, wired into the existing enforced read/write
+  seam (`AccessPolicyEvaluator`) so today's protocol paths consult
+  per-operation grants, **falling back to the coarse `AccessPolicy` when no
+  grant matches** (no behavior change for unconfigured services).
+
+Deferred to **#1376**: re-wiring every protocol adapter to call the resolver
+with the full per-operation taxonomy (the cross-protocol conformance matrix).
+Deferred to **#1242**: the OAuth2 bridge itself.
+
+## Cross-references
+
+- Complements ADR-0024 (Open-Core Edition Model) and the RBAC enforcement model.
+- Linked from #348 (OIDC SSO), #349 (RBAC tracking), #1240 (ArcGIS portal
+  facade), #1242 (ArcGIS OAuth2 named-user), #1374 (persistent store),
+  #1375 (resolver).

--- a/docs/contributor/adr/0049-single-auth-identity-token-foundation.md
+++ b/docs/contributor/adr/0049-single-auth-identity-token-foundation.md
@@ -1,4 +1,4 @@
-# ADR-0048: Single Auth/Identity/Token Foundation Shared by OIDC SSO and ArcGIS OAuth2
+# ADR-0049: Single Auth/Identity/Token Foundation Shared by OIDC SSO and ArcGIS OAuth2
 
 ## Status
 

--- a/docs/contributor/adr/README.md
+++ b/docs/contributor/adr/README.md
@@ -53,7 +53,7 @@ This folder contains Architecture Decision Records (ADRs) for the Honua greenfie
 | [0045](0045-defer-migration-sequence-collision-renumbering.md) | Defer Renumbering of Colliding Migration Sequence Numbers | Accepted | 2026-05 |
 | [0046](0046-audit-c3-database-session-progressive-migration.md) | Audit C3 — Progressive `IDatabaseSession` Migration With Coexistence | Accepted | 2026-05 |
 | [0047](0047-module-dependency-policy.md) | Module Dependency Policy | Accepted | 2026-05 |
-| [0048](0048-single-auth-identity-token-foundation.md) | Single Auth/Identity/Token Foundation Shared by OIDC SSO and ArcGIS OAuth2 | Accepted | 2026-06 |
+| [0049](0049-single-auth-identity-token-foundation.md) | Single Auth/Identity/Token Foundation Shared by OIDC SSO and ArcGIS OAuth2 | Accepted | 2026-06 |
 
 ## Template
 

--- a/docs/contributor/adr/README.md
+++ b/docs/contributor/adr/README.md
@@ -52,10 +52,8 @@ This folder contains Architecture Decision Records (ADRs) for the Honua greenfie
 | [0044](0044-server-infrastructure-decomposition.md) | Server.Features.Infrastructure Decomposition (Audit-A1 / Phase 1 Prerequisite) | Proposed | 2026-05 |
 | [0045](0045-defer-migration-sequence-collision-renumbering.md) | Defer Renumbering of Colliding Migration Sequence Numbers | Accepted | 2026-05 |
 | [0046](0046-audit-c3-database-session-progressive-migration.md) | Audit C3 — Progressive `IDatabaseSession` Migration With Coexistence | Accepted | 2026-05 |
-<<<<<<< HEAD
 | [0047](0047-module-dependency-policy.md) | Module Dependency Policy | Accepted | 2026-05 |
-=======
->>>>>>> c7f99d944... docs(adr): refresh stale ADR statuses
+| [0048](0048-single-auth-identity-token-foundation.md) | Single Auth/Identity/Token Foundation Shared by OIDC SSO and ArcGIS OAuth2 | Accepted | 2026-06 |
 
 ## Template
 

--- a/src/Honua.Core/Features/Authorization/Abstractions/IPermissionResolver.cs
+++ b/src/Honua.Core/Features/Authorization/Abstractions/IPermissionResolver.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Authorization.Domain;
+
+namespace Honua.Core.Features.Authorization.Abstractions;
+
+/// <summary>
+/// The canonical per-operation permission resolver — the single shared
+/// authorization seam (#1375). Maps a <c>(principal, service, layer, operation)</c>
+/// tuple to an allow / deny / requires-authentication decision by evaluating the
+/// principal's <see cref="EffectivePermissions"/> from <see cref="IRoleStore"/>.
+/// </summary>
+/// <remarks>
+/// This resolver is the source of per-operation access decisions for every
+/// protocol. The existing coarse seams (<c>AccessPolicyEvaluator</c> /
+/// <c>ServiceDataEditorAuthorization</c>) consult it first and fall back to the
+/// legacy <c>AccessPolicy</c> only when it reports
+/// <see cref="PermissionResult.NoMatchingGrant"/>, so unconfigured services keep
+/// their current behavior.
+/// </remarks>
+public interface IPermissionResolver
+{
+    /// <summary>
+    /// Resolves whether the supplied effective permissions authorize an
+    /// operation on a service/layer.
+    /// </summary>
+    /// <param name="effectivePermissions">
+    /// The principal's resolved permissions (from
+    /// <see cref="IRoleStore.GetEffectivePermissionsAsync"/>).
+    /// </param>
+    /// <param name="service">The service name being accessed.</param>
+    /// <param name="layer">
+    /// The layer identifier being accessed, or <see langword="null"/> for a
+    /// service-scoped check (treated as the wildcard layer).
+    /// </param>
+    /// <param name="operation">The operation being performed.</param>
+    /// <returns>
+    /// An <see cref="PermissionResult.Allow"/> decision (with the matched grant)
+    /// when a grant covers the tuple, otherwise
+    /// <see cref="PermissionResult.NoMatchingGrant"/>.
+    /// </returns>
+    PermissionDecision Authorize(
+        EffectivePermissions effectivePermissions,
+        string service,
+        string? layer,
+        AuthorizationOperation operation);
+
+    /// <summary>
+    /// Resolves a per-operation permission for a principal by first loading the
+    /// principal's effective permissions and then evaluating the
+    /// <c>(service, layer, operation)</c> tuple.
+    /// </summary>
+    /// <param name="userId">The principal's stable identifier.</param>
+    /// <param name="roles">The role names the principal is a member of.</param>
+    /// <param name="service">The service name being accessed.</param>
+    /// <param name="layer">
+    /// The layer identifier being accessed, or <see langword="null"/> for a
+    /// service-scoped check.
+    /// </param>
+    /// <param name="operation">The operation being performed.</param>
+    /// <param name="isAuthenticated">
+    /// Whether the principal is authenticated. When <see langword="false"/> and
+    /// no grant matches, the decision is
+    /// <see cref="PermissionResult.RequiresAuthentication"/>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resolved permission decision.</returns>
+    Task<PermissionDecision> AuthorizeAsync(
+        string userId,
+        IReadOnlyList<string> roles,
+        string service,
+        string? layer,
+        AuthorizationOperation operation,
+        bool isAuthenticated,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Authorization/Domain/AuthorizationOperation.cs
+++ b/src/Honua.Core/Features/Authorization/Domain/AuthorizationOperation.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Authorization.Domain;
+
+/// <summary>
+/// The canonical per-operation taxonomy for RBAC authorization decisions (#1375).
+/// A <see cref="PermissionGrant.Operation"/> string is matched against these
+/// values (case-insensitively) by <c>IPermissionResolver</c>. Grants are
+/// expressed with the wire string form
+/// (<see cref="AuthorizationOperationExtensions.ToWireName"/>); the
+/// wildcard <c>"*"</c> grant matches every operation.
+/// </summary>
+/// <remarks>
+/// The taxonomy intentionally goes beyond the coarse read-vs-write seam of
+/// <c>AccessPolicy</c>. <see cref="Query"/> is the canonical read operation and
+/// <see cref="Read"/> is retained as a synonym so legacy <c>"read"</c> grants
+/// (seeded by the original <c>InMemoryRoleStore</c>) keep working.
+/// </remarks>
+public enum AuthorizationOperation
+{
+    /// <summary>
+    /// Read a feature/record set (the canonical read operation; wire name <c>"query"</c>).
+    /// </summary>
+    Query = 0,
+
+    /// <summary>
+    /// Insert/create new features (wire name <c>"insert"</c>).
+    /// </summary>
+    Insert = 1,
+
+    /// <summary>
+    /// Update existing features (wire name <c>"update"</c>).
+    /// </summary>
+    Update = 2,
+
+    /// <summary>
+    /// Delete features (wire name <c>"delete"</c>).
+    /// </summary>
+    Delete = 3,
+
+    /// <summary>
+    /// Bulk/streaming export of data (wire name <c>"export"</c>).
+    /// </summary>
+    Export = 4,
+
+    /// <summary>
+    /// Read service/layer metadata and capabilities (wire name <c>"metadata"</c>).
+    /// </summary>
+    Metadata = 5,
+
+    /// <summary>
+    /// Administrative operations on the service/layer (wire name <c>"admin"</c>).
+    /// </summary>
+    Admin = 6,
+
+    /// <summary>
+    /// Synonym for <see cref="Query"/> retained for backward compatibility with
+    /// existing <c>"read"</c> grants (wire name <c>"read"</c>).
+    /// </summary>
+    Read = 7,
+}
+
+/// <summary>
+/// Wire-name helpers for <see cref="AuthorizationOperation"/>.
+/// </summary>
+public static class AuthorizationOperationExtensions
+{
+    /// <summary>
+    /// The wildcard operation string that matches every operation in a grant.
+    /// </summary>
+    public const string Wildcard = "*";
+
+    /// <summary>
+    /// Returns the canonical lowercase wire-name for an operation.
+    /// </summary>
+    /// <param name="operation">The operation.</param>
+    /// <returns>The lowercase wire name (e.g. <c>"query"</c>).</returns>
+    public static string ToWireName(this AuthorizationOperation operation) => operation switch
+    {
+        AuthorizationOperation.Query => "query",
+        AuthorizationOperation.Insert => "insert",
+        AuthorizationOperation.Update => "update",
+        AuthorizationOperation.Delete => "delete",
+        AuthorizationOperation.Export => "export",
+        AuthorizationOperation.Metadata => "metadata",
+        AuthorizationOperation.Admin => "admin",
+        AuthorizationOperation.Read => "read",
+        _ => operation.ToString().ToLowerInvariant(),
+    };
+
+    /// <summary>
+    /// Determines whether a grant operation string satisfies the requested
+    /// operation. A grant of <see cref="Wildcard"/> satisfies anything; a
+    /// <c>"read"</c> grant satisfies <see cref="AuthorizationOperation.Query"/>
+    /// (and vice-versa) so legacy read grants cover the canonical read op.
+    /// </summary>
+    /// <param name="grantOperation">The operation string stored on the grant.</param>
+    /// <param name="requested">The operation being authorized.</param>
+    /// <returns><see langword="true"/> when the grant covers the request.</returns>
+    public static bool Satisfies(string? grantOperation, AuthorizationOperation requested)
+    {
+        if (string.IsNullOrWhiteSpace(grantOperation))
+        {
+            return false;
+        }
+
+        var grant = grantOperation.Trim();
+        if (grant == Wildcard)
+        {
+            return true;
+        }
+
+        // Read/Query are synonyms: a "read" grant covers a Query request and a
+        // "query" grant covers a Read request.
+        if (IsReadSynonym(requested) && IsReadSynonymString(grant))
+        {
+            return true;
+        }
+
+        return string.Equals(grant, requested.ToWireName(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsReadSynonym(AuthorizationOperation operation)
+        => operation is AuthorizationOperation.Query or AuthorizationOperation.Read;
+
+    private static bool IsReadSynonymString(string operation)
+        => string.Equals(operation, "read", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(operation, "query", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Honua.Core/Features/Authorization/Domain/PermissionDecision.cs
+++ b/src/Honua.Core/Features/Authorization/Domain/PermissionDecision.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Authorization.Domain;
+
+/// <summary>
+/// The outcome of a per-operation permission resolution.
+/// </summary>
+public enum PermissionResult
+{
+    /// <summary>
+    /// No grant in the principal's effective permissions covers the requested
+    /// <c>(service, layer, operation)</c> tuple. Callers decide whether to fall
+    /// back to a coarser policy or treat this as a denial.
+    /// </summary>
+    NoMatchingGrant = 0,
+
+    /// <summary>
+    /// A grant explicitly authorizes the requested operation.
+    /// </summary>
+    Allow = 1,
+
+    /// <summary>
+    /// Authentication is required before a decision can be made (the principal
+    /// is anonymous and no anonymous grant applies).
+    /// </summary>
+    RequiresAuthentication = 2,
+}
+
+/// <summary>
+/// The result of resolving a per-operation permission for a principal against
+/// the <c>(service, layer, operation)</c> grant tuples in their
+/// <see cref="EffectivePermissions"/> (#1375).
+/// </summary>
+public readonly record struct PermissionDecision
+{
+    private PermissionDecision(PermissionResult result, PermissionGrant? matchedGrant)
+    {
+        Result = result;
+        MatchedGrant = matchedGrant;
+    }
+
+    /// <summary>
+    /// The resolution outcome.
+    /// </summary>
+    public PermissionResult Result { get; }
+
+    /// <summary>
+    /// The grant that satisfied the request, when <see cref="Result"/> is
+    /// <see cref="PermissionResult.Allow"/>; otherwise <see langword="null"/>.
+    /// </summary>
+    public PermissionGrant? MatchedGrant { get; }
+
+    /// <summary>
+    /// <see langword="true"/> when the operation is explicitly allowed.
+    /// </summary>
+    public bool IsAllowed => Result == PermissionResult.Allow;
+
+    /// <summary>
+    /// <see langword="true"/> when no grant matched, so the caller may fall back
+    /// to a coarser policy (e.g. the legacy <c>AccessPolicy</c>).
+    /// </summary>
+    public bool HasNoMatchingGrant => Result == PermissionResult.NoMatchingGrant;
+
+    /// <summary>
+    /// Creates an allow decision backed by the grant that matched.
+    /// </summary>
+    /// <param name="matchedGrant">The grant that satisfied the request.</param>
+    /// <returns>An allow decision.</returns>
+    public static PermissionDecision Allow(PermissionGrant matchedGrant)
+        => new(PermissionResult.Allow, matchedGrant);
+
+    /// <summary>
+    /// Creates a decision indicating no grant matched the request.
+    /// </summary>
+    /// <returns>A no-matching-grant decision.</returns>
+    public static PermissionDecision NoMatch()
+        => new(PermissionResult.NoMatchingGrant, null);
+
+    /// <summary>
+    /// Creates a decision indicating authentication is required.
+    /// </summary>
+    /// <returns>A requires-authentication decision.</returns>
+    public static PermissionDecision RequiresAuthentication()
+        => new(PermissionResult.RequiresAuthentication, null);
+}

--- a/src/Honua.Core/Features/Authorization/PermissionResolver.cs
+++ b/src/Honua.Core/Features/Authorization/PermissionResolver.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+
+namespace Honua.Core.Features.Authorization;
+
+/// <summary>
+/// Default <see cref="IPermissionResolver"/>: evaluates a principal's
+/// <see cref="EffectivePermissions"/> against a <c>(service, layer, operation)</c>
+/// tuple using wildcard-aware matching (#1375).
+/// </summary>
+/// <remarks>
+/// Matching rules:
+/// <list type="bullet">
+/// <item>A grant <see cref="PermissionGrant.Service"/> of <c>"*"</c> matches any
+/// service; otherwise the service name must match case-insensitively.</item>
+/// <item>A grant <see cref="PermissionGrant.Layer"/> of <c>"*"</c> matches any
+/// layer (so a service-level grant implies all layers); otherwise the layer must
+/// match case-insensitively. A <see langword="null"/> requested layer is treated
+/// as the wildcard layer (service-scoped check).</item>
+/// <item>The grant <see cref="PermissionGrant.Operation"/> is matched via
+/// <see cref="AuthorizationOperationExtensions.Satisfies"/> (wildcard and
+/// read/query synonym aware).</item>
+/// </list>
+/// The resolver never returns a hard "deny": when no grant matches it reports
+/// <see cref="PermissionResult.NoMatchingGrant"/> so the calling seam can fall
+/// back to the coarse <c>AccessPolicy</c> and preserve current behavior for
+/// services that have no per-operation grants configured.
+/// </remarks>
+public sealed class PermissionResolver : IPermissionResolver
+{
+    private readonly IRoleStore _roleStore;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PermissionResolver"/> class.
+    /// </summary>
+    /// <param name="roleStore">The role/permission store used to resolve
+    /// effective permissions for the async overload.</param>
+    public PermissionResolver(IRoleStore roleStore)
+    {
+        ArgumentNullException.ThrowIfNull(roleStore);
+        _roleStore = roleStore;
+    }
+
+    /// <inheritdoc />
+    public PermissionDecision Authorize(
+        EffectivePermissions effectivePermissions,
+        string service,
+        string? layer,
+        AuthorizationOperation operation)
+    {
+        ArgumentNullException.ThrowIfNull(effectivePermissions);
+        ArgumentException.ThrowIfNullOrWhiteSpace(service);
+
+        var requestedLayer = string.IsNullOrWhiteSpace(layer)
+            ? AuthorizationOperationExtensions.Wildcard
+            : layer.Trim();
+
+        foreach (var grant in effectivePermissions.Permissions)
+        {
+            if (Matches(grant, service, requestedLayer, operation))
+            {
+                return PermissionDecision.Allow(grant);
+            }
+        }
+
+        return PermissionDecision.NoMatch();
+    }
+
+    /// <inheritdoc />
+    public async Task<PermissionDecision> AuthorizeAsync(
+        string userId,
+        IReadOnlyList<string> roles,
+        string service,
+        string? layer,
+        AuthorizationOperation operation,
+        bool isAuthenticated,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(service);
+        ArgumentNullException.ThrowIfNull(roles);
+
+        var effective = await _roleStore
+            .GetEffectivePermissionsAsync(userId ?? string.Empty, roles, cancellationToken)
+            .ConfigureAwait(false);
+
+        var decision = Authorize(effective, service, layer, operation);
+        if (decision.IsAllowed)
+        {
+            return decision;
+        }
+
+        // No grant matched. If the principal is anonymous, surface a
+        // requires-authentication signal so the caller can challenge rather than
+        // forbid; otherwise let the caller decide on its coarse fallback.
+        return isAuthenticated
+            ? PermissionDecision.NoMatch()
+            : PermissionDecision.RequiresAuthentication();
+    }
+
+    private static bool Matches(
+        PermissionGrant grant,
+        string service,
+        string requestedLayer,
+        AuthorizationOperation operation)
+    {
+        if (!MatchesScope(grant.Service, service))
+        {
+            return false;
+        }
+
+        if (!MatchesScope(grant.Layer, requestedLayer))
+        {
+            return false;
+        }
+
+        return AuthorizationOperationExtensions.Satisfies(grant.Operation, operation);
+    }
+
+    private static bool MatchesScope(string? grantValue, string requested)
+    {
+        if (string.IsNullOrWhiteSpace(grantValue))
+        {
+            return false;
+        }
+
+        var grant = grantValue.Trim();
+        return grant == AuthorizationOperationExtensions.Wildcard
+            || string.Equals(grant, requested, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Honua.Hosting/Features/Authentication/AccessPolicyHelpers.cs
+++ b/src/Honua.Hosting/Features/Authentication/AccessPolicyHelpers.cs
@@ -1,12 +1,15 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Security.Domain;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Validation;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using System.Security.Claims;
 using AccessDecision = Honua.Core.Features.Security.Domain.AccessDecision;
 
@@ -70,6 +73,131 @@ internal static class AccessPolicyHelpers
     {
         ArgumentNullException.ThrowIfNull(resource);
         return RequireAccess(context, resource.AccessPolicy, service?.AccessPolicy, scope);
+    }
+
+    /// <summary>
+    /// Resource access check that first consults the canonical per-operation
+    /// permission resolver (#1375) over the principal's RBAC grants, then falls
+    /// back to the coarse <see cref="AccessPolicy"/> seam when no grant matches.
+    /// This is the live wiring of the resolver into an enforced read/write path;
+    /// services with no per-operation grants behave exactly as before.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <param name="resource">The resource (layer) being accessed.</param>
+    /// <param name="service">The owning service, when known.</param>
+    /// <param name="scope">The requested access scope (read/write).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An error result when denied, otherwise <see langword="null"/>.</returns>
+    public static async Task<IResult?> RequireResourceAccessAsync(
+        HttpContext context,
+        MetadataV2Resource resource,
+        MetadataV2Service? service = null,
+        AccessScope scope = AccessScope.Read,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        var serviceName = service?.Metadata.Name;
+        if (!string.IsNullOrWhiteSpace(serviceName))
+        {
+            var grantDecision = await EvaluateGrantAsync(
+                context,
+                serviceName,
+                resource.Metadata.Name,
+                scope,
+                cancellationToken).ConfigureAwait(false);
+
+            // An explicit per-operation grant authorizes the request directly.
+            if (grantDecision == GrantOutcome.Allow)
+            {
+                return null;
+            }
+        }
+
+        // No matching grant (or no service context): preserve current behavior
+        // by falling back to the coarse AccessPolicy evaluation.
+        return RequireAccess(context, resource.AccessPolicy, service?.AccessPolicy, scope);
+    }
+
+    /// <summary>
+    /// Consults the per-operation permission resolver for the supplied
+    /// <c>(service, layer, operation)</c> tuple, mapping the request principal's
+    /// claims to roles. Returns whether an explicit grant allows the request.
+    /// </summary>
+    private static async Task<GrantOutcome> EvaluateGrantAsync(
+        HttpContext context,
+        string serviceName,
+        string? layerName,
+        AccessScope scope,
+        CancellationToken cancellationToken)
+    {
+        var resolver = context.RequestServices.GetService<IPermissionResolver>();
+        if (resolver is null)
+        {
+            return GrantOutcome.NoGrant;
+        }
+
+        var principal = context.User;
+        var options = context.RequestServices.GetRequiredService<IOptions<RbacOptions>>().Value;
+        var roles = EnumeratePrincipalRoles(principal, options);
+        if (roles.Count == 0)
+        {
+            // No roles to resolve grants from — defer to the coarse policy.
+            return GrantOutcome.NoGrant;
+        }
+
+        var userId = principal.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? principal.FindFirstValue("sub")
+            ?? string.Empty;
+        var isAuthenticated = principal.Identity?.IsAuthenticated == true;
+
+        var operation = scope == AccessScope.Write
+            ? AuthorizationOperation.Update
+            : AuthorizationOperation.Query;
+
+        var decision = await resolver.AuthorizeAsync(
+            userId,
+            roles,
+            serviceName,
+            layerName,
+            operation,
+            isAuthenticated,
+            cancellationToken).ConfigureAwait(false);
+
+        return decision.IsAllowed ? GrantOutcome.Allow : GrantOutcome.NoGrant;
+    }
+
+    private static List<string> EnumeratePrincipalRoles(ClaimsPrincipal principal, RbacOptions options)
+    {
+        var roles = new List<string>();
+
+        foreach (var claim in principal.FindAll(ClaimTypes.Role))
+        {
+            if (!string.IsNullOrWhiteSpace(claim.Value))
+            {
+                roles.Add(claim.Value);
+            }
+        }
+
+        var roleClaimType = options.EffectiveRoleClaimType;
+        if (!string.Equals(roleClaimType, ClaimTypes.Role, StringComparison.OrdinalIgnoreCase))
+        {
+            foreach (var claim in principal.FindAll(roleClaimType))
+            {
+                if (!string.IsNullOrWhiteSpace(claim.Value))
+                {
+                    roles.Add(claim.Value);
+                }
+            }
+        }
+
+        return roles;
+    }
+
+    private enum GrantOutcome
+    {
+        NoGrant = 0,
+        Allow = 1,
     }
 
     public static IResult? RequireServiceAccess(

--- a/src/Honua.Postgres/Features/Authorization/PostgresRoleStore.cs
+++ b/src/Honua.Postgres/Features/Authorization/PostgresRoleStore.cs
@@ -237,15 +237,32 @@ internal sealed class PostgresRoleStore : IRoleStore
             await using var command = new NpgsqlCommand(sql, connection);
             command.Parameters.AddWithValue("role_names", NpgsqlDbType.Array | NpgsqlDbType.Text, loweredNames);
 
-            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            try
             {
-                grants.Add(new PermissionGrant
+                await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
                 {
-                    Service = reader.GetString(0),
-                    Layer = reader.GetString(1),
-                    Operation = reader.GetString(2),
-                });
+                    grants.Add(new PermissionGrant
+                    {
+                        Service = reader.GetString(0),
+                        Layer = reader.GetString(1),
+                        Operation = reader.GetString(2),
+                    });
+                }
+            }
+            catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UndefinedTable)
+            {
+                // Fresh/legacy DB where migration 041 has not created the
+                // rbac_roles / rbac_role_permissions tables. Treat as "no grants"
+                // so PermissionResolver yields NoMatch and AccessPolicyHelpers
+                // falls back to the coarse AccessPolicy instead of 500ing
+                // enforced query paths (honua-server#1341 pattern).
+                return new EffectivePermissions
+                {
+                    UserId = userId ?? string.Empty,
+                    Roles = roles,
+                    Permissions = [],
+                };
             }
         }
 
@@ -273,8 +290,9 @@ internal sealed class PostgresRoleStore : IRoleStore
         var roles = new List<RoleDefinition>();
         var permissionsByRole = new Dictionary<Guid, List<PermissionGrant>>();
 
-        await using (var command = new NpgsqlCommand(sql, connection))
+        try
         {
+            await using var command = new NpgsqlCommand(sql, connection);
             if (roleId.HasValue)
             {
                 command.Parameters.AddWithValue("role_id", NpgsqlDbType.Uuid, roleId.Value);
@@ -296,6 +314,11 @@ internal sealed class PostgresRoleStore : IRoleStore
                     Permissions = [],
                 });
             }
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UndefinedTable)
+        {
+            // RBAC tables absent (migration 041 not applied): no roles defined.
+            return [];
         }
 
         if (roles.Count == 0)
@@ -363,15 +386,23 @@ internal sealed class PostgresRoleStore : IRoleStore
         command.Parameters.AddWithValue("role_id", NpgsqlDbType.Uuid, roleId);
 
         var grants = new List<PermissionGrant>();
-        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        try
         {
-            grants.Add(new PermissionGrant
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
-                Service = reader.GetString(0),
-                Layer = reader.GetString(1),
-                Operation = reader.GetString(2),
-            });
+                grants.Add(new PermissionGrant
+                {
+                    Service = reader.GetString(0),
+                    Layer = reader.GetString(1),
+                    Operation = reader.GetString(2),
+                });
+            }
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UndefinedTable)
+        {
+            // RBAC tables absent (migration 041 not applied): no grants.
+            return [];
         }
 
         return grants;

--- a/src/Honua.Postgres/Features/Authorization/PostgresRoleStore.cs
+++ b/src/Honua.Postgres/Features/Authorization/PostgresRoleStore.cs
@@ -1,0 +1,415 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Infrastructure;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.Authorization;
+
+/// <summary>
+/// PostgreSQL-backed <see cref="IRoleStore"/> (#1374). Persists role
+/// definitions, their per-operation permission grants, and role memberships to
+/// the <c>honua.rbac_*</c> tables created by migration 041, so RBAC survives
+/// process restart and is shared across scaled nodes. Replaces the process-local
+/// <c>InMemoryRoleStore</c> as the registered implementation.
+/// </summary>
+internal sealed class PostgresRoleStore : IRoleStore
+{
+    private readonly IDatabaseConnectionProvider _connectionProvider;
+    private readonly string _rolesTable;
+    private readonly string _permissionsTable;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgresRoleStore"/> class.
+    /// </summary>
+    /// <param name="connectionProvider">The database connection provider.</param>
+    /// <param name="schemaName">Optional schema override (used by tests for
+    /// isolated schemas); defaults to the application schema.</param>
+    public PostgresRoleStore(IDatabaseConnectionProvider connectionProvider, string? schemaName = null)
+    {
+        ArgumentNullException.ThrowIfNull(connectionProvider);
+        _connectionProvider = connectionProvider;
+        _rolesTable = SchemaSearchPath.QualifyTable("rbac_roles", schemaName);
+        _permissionsTable = SchemaSearchPath.QualifyTable("rbac_role_permissions", schemaName);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<RoleDefinition>> ListRolesAsync(CancellationToken cancellationToken = default)
+    {
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        var roles = await ReadRolesAsync(connection, roleId: null, cancellationToken).ConfigureAwait(false);
+        return roles;
+    }
+
+    /// <inheritdoc />
+    public async Task<RoleDefinition?> GetRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+    {
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        var roles = await ReadRolesAsync(connection, roleId, cancellationToken).ConfigureAwait(false);
+        return roles.Count == 0 ? null : roles[0];
+    }
+
+    /// <inheritdoc />
+    public async Task<RoleDefinition> CreateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(role);
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.Connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        var insertRole = $"""
+            INSERT INTO {_rolesTable} (role_id, name, description, is_built_in, created_at, updated_at)
+            VALUES (@role_id, @name, @description, @is_built_in, @created_at, @updated_at)
+            """;
+
+        try
+        {
+            await using (var command = new NpgsqlCommand(insertRole, connection.Connection, transaction))
+            {
+                command.Parameters.AddWithValue("role_id", NpgsqlDbType.Uuid, role.RoleId);
+                command.Parameters.AddWithValue("name", NpgsqlDbType.Varchar, role.Name);
+                command.Parameters.AddWithValue("description", NpgsqlDbType.Text, (object?)role.Description ?? DBNull.Value);
+                command.Parameters.AddWithValue("is_built_in", NpgsqlDbType.Boolean, role.IsBuiltIn);
+                command.Parameters.AddWithValue("created_at", NpgsqlDbType.TimestampTz, role.CreatedAt);
+                command.Parameters.AddWithValue("updated_at", NpgsqlDbType.TimestampTz, role.UpdatedAt);
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await ReplacePermissionsAsync(connection.Connection, transaction, role.RoleId, role.Permissions, cancellationToken).ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
+        {
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException($"Role with ID '{role.RoleId}' or name '{role.Name}' already exists.", ex);
+        }
+
+        return role;
+    }
+
+    /// <inheritdoc />
+    public async Task<RoleDefinition?> UpdateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(role);
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.Connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        // Built-in roles' name/description may be updated, but the is_built_in
+        // flag is immutable so a built-in role can never be demoted to deletable.
+        var updateRole = $"""
+            UPDATE {_rolesTable}
+            SET name = @name, description = @description, updated_at = NOW()
+            WHERE role_id = @role_id
+            RETURNING created_at, is_built_in
+            """;
+
+        DateTimeOffset createdAt;
+        bool isBuiltIn;
+
+        await using (var command = new NpgsqlCommand(updateRole, connection.Connection, transaction))
+        {
+            command.Parameters.AddWithValue("role_id", NpgsqlDbType.Uuid, role.RoleId);
+            command.Parameters.AddWithValue("name", NpgsqlDbType.Varchar, role.Name);
+            command.Parameters.AddWithValue("description", NpgsqlDbType.Text, (object?)role.Description ?? DBNull.Value);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                await reader.DisposeAsync().ConfigureAwait(false);
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                return null;
+            }
+
+            createdAt = reader.GetFieldValue<DateTimeOffset>(0);
+            isBuiltIn = reader.GetBoolean(1);
+        }
+
+        await ReplacePermissionsAsync(connection.Connection, transaction, role.RoleId, role.Permissions, cancellationToken).ConfigureAwait(false);
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+        return new RoleDefinition
+        {
+            RoleId = role.RoleId,
+            Name = role.Name,
+            Description = role.Description,
+            IsBuiltIn = isBuiltIn,
+            Permissions = role.Permissions,
+            CreatedAt = createdAt,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+    {
+        // Built-in roles are protected: the DELETE only affects non-built-in
+        // rows, so a built-in id deletes 0 rows and returns false.
+        var sql = $"DELETE FROM {_rolesTable} WHERE role_id = @role_id AND is_built_in = FALSE";
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("role_id", NpgsqlDbType.Uuid, roleId);
+        var affected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return affected > 0;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<PermissionGrant>> GetPermissionsAsync(Guid roleId, CancellationToken cancellationToken = default)
+    {
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        return await ReadPermissionsAsync(connection.Connection, transaction: null, roleId, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<PermissionGrant>> SetPermissionsAsync(
+        Guid roleId,
+        IReadOnlyList<PermissionGrant> permissions,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(permissions);
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.Connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        // No-op (return empty) when the role does not exist, matching the
+        // in-memory store's contract.
+        var exists = $"SELECT 1 FROM {_rolesTable} WHERE role_id = @role_id";
+        await using (var existsCommand = new NpgsqlCommand(exists, connection.Connection, transaction))
+        {
+            existsCommand.Parameters.AddWithValue("role_id", NpgsqlDbType.Uuid, roleId);
+            var found = await existsCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            if (found is null)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                return [];
+            }
+        }
+
+        await ReplacePermissionsAsync(connection.Connection, transaction, roleId, permissions, cancellationToken).ConfigureAwait(false);
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return permissions;
+    }
+
+    /// <inheritdoc />
+    public async Task<EffectivePermissions> GetEffectivePermissionsAsync(
+        string userId,
+        IReadOnlyList<string> roles,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(roles);
+
+        if (roles.Count == 0)
+        {
+            return new EffectivePermissions
+            {
+                UserId = userId ?? string.Empty,
+                Roles = roles,
+                Permissions = [],
+            };
+        }
+
+        // Resolve grants across every role whose name matches one of the
+        // supplied roles (case-insensitive), de-duplicated. A single set-based
+        // query keeps this correct and cheap under concurrent writes.
+        var sql = $"""
+            SELECT DISTINCT p.service, p.layer, p.operation
+            FROM {_rolesTable} r
+            JOIN {_permissionsTable} p ON p.role_id = r.role_id
+            WHERE LOWER(r.name) = ANY(@role_names)
+            """;
+
+        var loweredNames = roles
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Select(static name => name.Trim().ToLowerInvariant())
+            .Distinct()
+            .ToArray();
+
+        var grants = new List<PermissionGrant>();
+
+        if (loweredNames.Length > 0)
+        {
+            await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.Parameters.AddWithValue("role_names", NpgsqlDbType.Array | NpgsqlDbType.Text, loweredNames);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                grants.Add(new PermissionGrant
+                {
+                    Service = reader.GetString(0),
+                    Layer = reader.GetString(1),
+                    Operation = reader.GetString(2),
+                });
+            }
+        }
+
+        return new EffectivePermissions
+        {
+            UserId = userId ?? string.Empty,
+            Roles = roles,
+            Permissions = grants,
+        };
+    }
+
+    private async Task<IReadOnlyList<RoleDefinition>> ReadRolesAsync(
+        NpgsqlConnection connection,
+        Guid? roleId,
+        CancellationToken cancellationToken)
+    {
+        var filter = roleId.HasValue ? "WHERE role_id = @role_id" : string.Empty;
+        var sql = $"""
+            SELECT role_id, name, description, is_built_in, created_at, updated_at
+            FROM {_rolesTable}
+            {filter}
+            ORDER BY name
+            """;
+
+        var roles = new List<RoleDefinition>();
+        var permissionsByRole = new Dictionary<Guid, List<PermissionGrant>>();
+
+        await using (var command = new NpgsqlCommand(sql, connection))
+        {
+            if (roleId.HasValue)
+            {
+                command.Parameters.AddWithValue("role_id", NpgsqlDbType.Uuid, roleId.Value);
+            }
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var id = reader.GetGuid(0);
+                permissionsByRole[id] = [];
+                roles.Add(new RoleDefinition
+                {
+                    RoleId = id,
+                    Name = reader.GetString(1),
+                    Description = reader.IsDBNull(2) ? null : reader.GetString(2),
+                    IsBuiltIn = reader.GetBoolean(3),
+                    CreatedAt = reader.GetFieldValue<DateTimeOffset>(4),
+                    UpdatedAt = reader.GetFieldValue<DateTimeOffset>(5),
+                    Permissions = [],
+                });
+            }
+        }
+
+        if (roles.Count == 0)
+        {
+            return roles;
+        }
+
+        var permissionFilter = roleId.HasValue ? "WHERE role_id = @role_id" : string.Empty;
+        var permissionSql = $"""
+            SELECT role_id, service, layer, operation
+            FROM {_permissionsTable}
+            {permissionFilter}
+            """;
+
+        await using (var permissionCommand = new NpgsqlCommand(permissionSql, connection))
+        {
+            if (roleId.HasValue)
+            {
+                permissionCommand.Parameters.AddWithValue("role_id", NpgsqlDbType.Uuid, roleId.Value);
+            }
+
+            await using var reader = await permissionCommand.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var id = reader.GetGuid(0);
+                if (permissionsByRole.TryGetValue(id, out var list))
+                {
+                    list.Add(new PermissionGrant
+                    {
+                        Service = reader.GetString(1),
+                        Layer = reader.GetString(2),
+                        Operation = reader.GetString(3),
+                    });
+                }
+            }
+        }
+
+        return roles
+            .Select(role => new RoleDefinition
+            {
+                RoleId = role.RoleId,
+                Name = role.Name,
+                Description = role.Description,
+                IsBuiltIn = role.IsBuiltIn,
+                CreatedAt = role.CreatedAt,
+                UpdatedAt = role.UpdatedAt,
+                Permissions = permissionsByRole[role.RoleId],
+            })
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<PermissionGrant>> ReadPermissionsAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        Guid roleId,
+        CancellationToken cancellationToken)
+    {
+        var sql = $"""
+            SELECT service, layer, operation
+            FROM {_permissionsTable}
+            WHERE role_id = @role_id
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("role_id", NpgsqlDbType.Uuid, roleId);
+
+        var grants = new List<PermissionGrant>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            grants.Add(new PermissionGrant
+            {
+                Service = reader.GetString(0),
+                Layer = reader.GetString(1),
+                Operation = reader.GetString(2),
+            });
+        }
+
+        return grants;
+    }
+
+    private async Task ReplacePermissionsAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        Guid roleId,
+        IReadOnlyList<PermissionGrant> permissions,
+        CancellationToken cancellationToken)
+    {
+        var delete = $"DELETE FROM {_permissionsTable} WHERE role_id = @role_id";
+        await using (var deleteCommand = new NpgsqlCommand(delete, connection, transaction))
+        {
+            deleteCommand.Parameters.AddWithValue("role_id", NpgsqlDbType.Uuid, roleId);
+            await deleteCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        if (permissions.Count == 0)
+        {
+            return;
+        }
+
+        var insert = $"""
+            INSERT INTO {_permissionsTable} (role_id, service, layer, operation)
+            VALUES (@role_id, @service, @layer, @operation)
+            ON CONFLICT (role_id, service, layer, operation) DO NOTHING
+            """;
+
+        foreach (var grant in permissions)
+        {
+            await using var command = new NpgsqlCommand(insert, connection, transaction);
+            command.Parameters.AddWithValue("role_id", NpgsqlDbType.Uuid, roleId);
+            command.Parameters.AddWithValue("service", NpgsqlDbType.Varchar, grant.Service);
+            command.Parameters.AddWithValue("layer", NpgsqlDbType.Varchar, grant.Layer);
+            command.Parameters.AddWithValue("operation", NpgsqlDbType.Varchar, grant.Operation);
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -202,6 +202,15 @@ internal static class ServiceCollectionExtensions
                 serviceProvider.GetRequiredService<IDatabaseConnectionProvider>(),
                 configuration["Database:Schema"]));
 
+        // Register Postgres-backed RBAC role/permission store (#1374). Durable
+        // storage wins over the in-memory default registered in Program.cs, so
+        // roles, per-operation grants, and memberships survive restart and are
+        // shared across scaled nodes.
+        services.AddScoped<Honua.Core.Features.Authorization.Abstractions.IRoleStore>(serviceProvider =>
+            new Features.Authorization.PostgresRoleStore(
+                serviceProvider.GetRequiredService<IDatabaseConnectionProvider>(),
+                configuration["Database:Schema"]));
+
         // Register layer style catalog for MapLibre/GeoServices styling
         services.AddScoped<ILayerStyleCatalog>(serviceProvider =>
             new PostgresLayerStyleCatalog(

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerQueryHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerQueryHandler.cs
@@ -160,7 +160,16 @@ internal sealed partial class FeatureServerQueryHandler(
         var publication = resourceValidationResult.Publication!;
         var resource = resourceValidationResult.Resource!;
 
-        var accessError = AccessPolicyHelpers.RequireResourceAccess(context, resource, service);
+        // Per-operation RBAC grants are consulted first (#1375); the coarse
+        // AccessPolicy seam is the fallback when no grant matches. This is the
+        // enforced read path wired to the resolver for this PR — the remaining
+        // protocol adapters are re-wired in #1376.
+        var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+            context,
+            resource,
+            service,
+            AccessScope.Read,
+            cancellationToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return (null, accessError);

--- a/src/Honua.Server/Migrations/041_CreateRbacRoleStore.sql
+++ b/src/Honua.Server/Migrations/041_CreateRbacRoleStore.sql
@@ -1,0 +1,116 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Persistent RBAC role/permission store (#1374).
+--
+-- Backs the canonical IRoleStore so role definitions, their per-operation
+-- permission grants, and role memberships survive process restart and are
+-- shared across scaled nodes. Replaces the process-local InMemoryRoleStore.
+--
+-- Idempotent: every statement is CREATE ... IF NOT EXISTS / ON CONFLICT so the
+-- script is safe to re-run and matches the established migration pattern.
+
+CREATE SCHEMA IF NOT EXISTS honua;
+
+-- Role definitions. role_id is a client-assigned UUID (the application owns id
+-- generation so built-in roles can use stable well-known ids).
+CREATE TABLE IF NOT EXISTS honua.rbac_roles (
+    role_id       UUID         PRIMARY KEY,
+    name          VARCHAR(128) NOT NULL,
+    description   TEXT,
+    is_built_in   BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- Role names are unique (case-insensitive) so group->role mapping and effective
+-- permission resolution can look up by name deterministically.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_rbac_roles_name_lower
+    ON honua.rbac_roles (LOWER(name));
+
+-- Per-operation permission grants. A grant is the (service, layer, operation)
+-- tuple consumed by the permission resolver. "*" is the wildcard for any of the
+-- three dimensions.
+CREATE TABLE IF NOT EXISTS honua.rbac_role_permissions (
+    role_id       UUID         NOT NULL,
+    service       VARCHAR(256) NOT NULL,
+    layer         VARCHAR(256) NOT NULL,
+    operation     VARCHAR(64)  NOT NULL,
+
+    CONSTRAINT rbac_role_permissions_role_fk
+        FOREIGN KEY (role_id) REFERENCES honua.rbac_roles(role_id) ON DELETE CASCADE,
+    -- A grant tuple is unique within a role; SetPermissions replaces the set.
+    CONSTRAINT rbac_role_permissions_unique
+        UNIQUE (role_id, service, layer, operation)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rbac_role_permissions_role
+    ON honua.rbac_role_permissions (role_id);
+
+-- Role memberships: which principal (user id / external subject) is in which
+-- role. GetEffectivePermissionsAsync currently resolves by role name supplied
+-- from claims, but the membership table is the durable source SCIM (#510) and
+-- OIDC group sync (#348) write into.
+CREATE TABLE IF NOT EXISTS honua.rbac_role_memberships (
+    role_id       UUID         NOT NULL,
+    user_id       VARCHAR(256) NOT NULL,
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT rbac_role_memberships_role_fk
+        FOREIGN KEY (role_id) REFERENCES honua.rbac_roles(role_id) ON DELETE CASCADE,
+    CONSTRAINT rbac_role_memberships_pk PRIMARY KEY (role_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rbac_role_memberships_user
+    ON honua.rbac_role_memberships (user_id);
+
+-- Keep updated_at fresh on role edits (reuses the shared trigger function when
+-- present; defined defensively here so this migration is self-contained).
+CREATE OR REPLACE FUNCTION honua.rbac_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_rbac_roles_updated_at ON honua.rbac_roles;
+CREATE TRIGGER trg_rbac_roles_updated_at
+    BEFORE UPDATE ON honua.rbac_roles
+    FOR EACH ROW
+    EXECUTE FUNCTION honua.rbac_set_updated_at();
+
+-- Seed built-in roles idempotently with stable well-known ids (these match the
+-- ids the InMemoryRoleStore used so existing references stay valid). Built-in
+-- roles cannot be deleted (enforced in the store + by is_built_in).
+INSERT INTO honua.rbac_roles (role_id, name, description, is_built_in)
+VALUES
+    ('00000000-0000-0000-0000-000000000001', 'admin',  'Full administrative access', TRUE),
+    ('00000000-0000-0000-0000-000000000003', 'editor', 'Read and write access to all services and layers', TRUE),
+    ('00000000-0000-0000-0000-000000000002', 'viewer', 'Read-only access to all services and layers', TRUE)
+ON CONFLICT (role_id) DO NOTHING;
+
+-- Seed built-in grants. admin => everything; editor => read + the write
+-- operations; viewer => read only. ON CONFLICT keeps re-runs idempotent.
+INSERT INTO honua.rbac_role_permissions (role_id, service, layer, operation)
+VALUES
+    -- admin: wildcard operation on everything.
+    ('00000000-0000-0000-0000-000000000001', '*', '*', '*'),
+    -- editor: read + insert/update/delete + export on everything.
+    ('00000000-0000-0000-0000-000000000003', '*', '*', 'query'),
+    ('00000000-0000-0000-0000-000000000003', '*', '*', 'insert'),
+    ('00000000-0000-0000-0000-000000000003', '*', '*', 'update'),
+    ('00000000-0000-0000-0000-000000000003', '*', '*', 'delete'),
+    ('00000000-0000-0000-0000-000000000003', '*', '*', 'export'),
+    ('00000000-0000-0000-0000-000000000003', '*', '*', 'metadata'),
+    -- viewer: read only.
+    ('00000000-0000-0000-0000-000000000002', '*', '*', 'query'),
+    ('00000000-0000-0000-0000-000000000002', '*', '*', 'metadata')
+ON CONFLICT (role_id, service, layer, operation) DO NOTHING;
+
+COMMENT ON TABLE honua.rbac_roles IS
+    'RBAC role definitions (#1374). Built-in roles (is_built_in) cannot be deleted.';
+COMMENT ON TABLE honua.rbac_role_permissions IS
+    'Per-operation permission grants: (service, layer, operation) tuples consumed by the permission resolver (#1375).';
+COMMENT ON TABLE honua.rbac_role_memberships IS
+    'Durable principal->role memberships written by OIDC group sync (#348) and SCIM (#510).';

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -430,6 +430,11 @@ builder.Services.AddSingleton<Honua.Core.Features.Identity.Abstractions.IUserSto
     Honua.Server.Features.Admin.Services.InMemoryUserStore>();
 builder.Services.AddSingleton<Honua.Core.Features.Authorization.Abstractions.IRoleStore,
     Honua.Server.Features.Admin.Services.InMemoryRoleStore>();
+// Canonical per-operation permission resolver (#1375): the shared authorization
+// seam over EffectivePermissions. Scoped so it can consume the (scoped) Postgres
+// role store when durable RBAC is active.
+builder.Services.AddScoped<Honua.Core.Features.Authorization.Abstractions.IPermissionResolver,
+    Honua.Core.Features.Authorization.PermissionResolver>();
 builder.Services.AddSingleton<Honua.Infrastructure.Authentication.IAdminApiKeyStore>(sp =>
     new Honua.Infrastructure.Authentication.InMemoryAdminApiKeyStore(sp.GetService<TimeProvider>()));
 // v1 metadata-resource / manifest-approval / gitops-watch admin surface removed in #1035 cutover.

--- a/tests/dotnet/Honua.Core.Tests/Features/Authorization/PermissionResolverTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Authorization/PermissionResolverTests.cs
@@ -1,0 +1,212 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Authorization;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+
+namespace Honua.Core.Tests.Features.Authorization;
+
+/// <summary>
+/// Unit tests for <see cref="PermissionResolver"/> — the canonical per-operation
+/// permission resolver (#1375). Locks in the grant-resolution decision matrix:
+/// wildcard precedence, per-layer / per-operation granularity, read/query
+/// synonym handling, the no-matching-grant fallback signal, and the anonymous
+/// requires-authentication signal.
+/// </summary>
+public sealed class PermissionResolverTests
+{
+    private static EffectivePermissions Effective(params PermissionGrant[] grants)
+        => new()
+        {
+            UserId = "user-1",
+            Roles = ["role-a"],
+            Permissions = grants,
+        };
+
+    private static PermissionGrant Grant(string service, string layer, string operation)
+        => new() { Service = service, Layer = layer, Operation = operation };
+
+    [Fact]
+    public void Authorize_WildcardGrant_AllowsEveryOperation()
+    {
+        var resolver = new PermissionResolver(new FakeRoleStore());
+        var effective = Effective(Grant("*", "*", "*"));
+
+        resolver.Authorize(effective, "svc", "layer-1", AuthorizationOperation.Delete)
+            .IsAllowed.Should().BeTrue();
+        resolver.Authorize(effective, "any", "any", AuthorizationOperation.Query)
+            .IsAllowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Authorize_ServiceLevelGrant_ImpliesAllLayers()
+    {
+        var resolver = new PermissionResolver(new FakeRoleStore());
+        var effective = Effective(Grant("svc", "*", "query"));
+
+        resolver.Authorize(effective, "svc", "layer-1", AuthorizationOperation.Query)
+            .IsAllowed.Should().BeTrue();
+        resolver.Authorize(effective, "svc", "layer-99", AuthorizationOperation.Query)
+            .IsAllowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Authorize_PerLayerGrant_DeniesOtherLayers()
+    {
+        var resolver = new PermissionResolver(new FakeRoleStore());
+        var effective = Effective(Grant("svc", "layer-A", "query"));
+
+        resolver.Authorize(effective, "svc", "layer-A", AuthorizationOperation.Query)
+            .IsAllowed.Should().BeTrue();
+
+        var denied = resolver.Authorize(effective, "svc", "layer-B", AuthorizationOperation.Query);
+        denied.IsAllowed.Should().BeFalse();
+        denied.HasNoMatchingGrant.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Authorize_PerOperationGrant_DeniesOtherOperations()
+    {
+        var resolver = new PermissionResolver(new FakeRoleStore());
+        var effective = Effective(Grant("svc", "layer-A", "query"));
+
+        resolver.Authorize(effective, "svc", "layer-A", AuthorizationOperation.Query)
+            .IsAllowed.Should().BeTrue();
+        resolver.Authorize(effective, "svc", "layer-A", AuthorizationOperation.Delete)
+            .HasNoMatchingGrant.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Authorize_LegacyReadGrant_SatisfiesQuery()
+    {
+        var resolver = new PermissionResolver(new FakeRoleStore());
+        var effective = Effective(Grant("svc", "*", "read"));
+
+        // The historic "read" grant must cover the canonical Query operation so
+        // existing seeded grants keep working after the taxonomy expansion.
+        resolver.Authorize(effective, "svc", "layer-1", AuthorizationOperation.Query)
+            .IsAllowed.Should().BeTrue();
+        resolver.Authorize(effective, "svc", "layer-1", AuthorizationOperation.Read)
+            .IsAllowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Authorize_NullLayer_TreatedAsWildcardLayer()
+    {
+        var resolver = new PermissionResolver(new FakeRoleStore());
+        var effective = Effective(Grant("svc", "*", "metadata"));
+
+        resolver.Authorize(effective, "svc", layer: null, AuthorizationOperation.Metadata)
+            .IsAllowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Authorize_NoGrants_ReturnsNoMatch()
+    {
+        var resolver = new PermissionResolver(new FakeRoleStore());
+
+        resolver.Authorize(Effective(), "svc", "layer-1", AuthorizationOperation.Query)
+            .HasNoMatchingGrant.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_AnonymousWithNoGrant_RequiresAuthentication()
+    {
+        var resolver = new PermissionResolver(new FakeRoleStore());
+
+        var decision = await resolver.AuthorizeAsync(
+            userId: string.Empty,
+            roles: [],
+            service: "svc",
+            layer: "layer-1",
+            operation: AuthorizationOperation.Query,
+            isAuthenticated: false);
+
+        decision.Result.Should().Be(PermissionResult.RequiresAuthentication);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_AuthenticatedWithNoGrant_ReturnsNoMatchForFallback()
+    {
+        var resolver = new PermissionResolver(new FakeRoleStore());
+
+        var decision = await resolver.AuthorizeAsync(
+            userId: "user-1",
+            roles: ["unknown-role"],
+            service: "svc",
+            layer: "layer-1",
+            operation: AuthorizationOperation.Query,
+            isAuthenticated: true);
+
+        decision.HasNoMatchingGrant.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_RoleWithGrant_Allows()
+    {
+        var store = new FakeRoleStore
+        {
+            GrantsByRole =
+            {
+                ["editor"] = [Grant("svc", "*", "query")],
+            },
+        };
+        var resolver = new PermissionResolver(store);
+
+        var decision = await resolver.AuthorizeAsync(
+            userId: "user-1",
+            roles: ["editor"],
+            service: "svc",
+            layer: "layer-1",
+            operation: AuthorizationOperation.Query,
+            isAuthenticated: true);
+
+        decision.IsAllowed.Should().BeTrue();
+    }
+
+    private sealed class FakeRoleStore : IRoleStore
+    {
+        public Dictionary<string, IReadOnlyList<PermissionGrant>> GrantsByRole { get; } =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<EffectivePermissions> GetEffectivePermissionsAsync(
+            string userId,
+            IReadOnlyList<string> roles,
+            CancellationToken cancellationToken = default)
+        {
+            var grants = roles
+                .SelectMany(role => GrantsByRole.TryGetValue(role, out var g) ? g : [])
+                .Distinct()
+                .ToList();
+
+            return Task.FromResult(new EffectivePermissions
+            {
+                UserId = userId,
+                Roles = roles,
+                Permissions = grants,
+            });
+        }
+
+        public Task<IReadOnlyList<RoleDefinition>> ListRolesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<RoleDefinition>>([]);
+
+        public Task<RoleDefinition?> GetRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult<RoleDefinition?>(null);
+
+        public Task<RoleDefinition> CreateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+            => Task.FromResult(role);
+
+        public Task<RoleDefinition?> UpdateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+            => Task.FromResult<RoleDefinition?>(role);
+
+        public Task<bool> DeleteRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<IReadOnlyList<PermissionGrant>> GetPermissionsAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<PermissionGrant>>([]);
+
+        public Task<IReadOnlyList<PermissionGrant>> SetPermissionsAsync(Guid roleId, IReadOnlyList<PermissionGrant> permissions, CancellationToken cancellationToken = default)
+            => Task.FromResult(permissions);
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Authorization/PostgresRoleStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Authorization/PostgresRoleStoreTests.cs
@@ -212,6 +212,38 @@ public sealed class PostgresRoleStoreTests(PostgresFixture fixture)
         }
     }
 
+    [IntegrationTest]
+    public async Task GetEffectivePermissions_RbacTablesAbsent_ReturnsNoGrants_DoesNotThrow()
+    {
+        // Regression (#1385): integration-test fixtures and fresh/legacy DBs that
+        // never ran migration 041 lack the rbac_* tables. The store must treat the
+        // missing relation (42P01) as "no grants" so PermissionResolver yields
+        // NoMatch and AccessPolicyHelpers falls back to the coarse AccessPolicy,
+        // instead of surfacing a Postgres 42P01 as an HTTP 500 on enforced query
+        // and OGC Features paths.
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRoleStoreTests));
+        try
+        {
+            // Deliberately do NOT call EnsureRbacTablesAsync: the schema exists but
+            // the RBAC tables do not.
+            var store = CreateStore(schema);
+
+            var effective = await store.GetEffectivePermissionsAsync("user-1", ["viewer", "admin"]);
+            effective.Should().NotBeNull();
+            effective.UserId.Should().Be("user-1");
+            effective.Permissions.Should().BeEmpty();
+
+            // Sibling read paths must be resilient too (admin list / get-permissions).
+            (await store.ListRolesAsync()).Should().BeEmpty();
+            (await store.GetRoleAsync(AdminRoleId)).Should().BeNull();
+            (await store.GetPermissionsAsync(ViewerRoleId)).Should().BeEmpty();
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
     private PostgresRoleStore CreateStore(string schema)
         => new(new TestConnectionProvider(fixture.DataSource, schema), schemaName: schema);
 

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Authorization/PostgresRoleStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Authorization/PostgresRoleStoreTests.cs
@@ -1,0 +1,301 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using FluentAssertions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Authorization;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Npgsql;
+
+namespace Honua.Postgres.Tests.Features.Authorization;
+
+/// <summary>
+/// Integration tests for <see cref="PostgresRoleStore"/> (#1374) using the shared
+/// Testcontainers Postgres fixture. Exercises CRUD parity with the in-memory
+/// store, built-in role protection, multi-role effective-permission resolution,
+/// and restart durability against an isolated per-test schema mirroring
+/// migration 041.
+/// </summary>
+[Collection("Database")]
+public sealed class PostgresRoleStoreTests(PostgresFixture fixture)
+{
+    private static readonly Guid AdminRoleId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private static readonly Guid ViewerRoleId = Guid.Parse("00000000-0000-0000-0000-000000000002");
+
+    [IntegrationTest]
+    public async Task ListRoles_ReturnsSeededBuiltInRoles()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRoleStoreTests));
+        try
+        {
+            await EnsureRbacTablesAsync(schema);
+            var store = CreateStore(schema);
+
+            var roles = await store.ListRolesAsync();
+
+            roles.Select(r => r.Name).Should().Contain(["admin", "editor", "viewer"]);
+            roles.Where(r => r.IsBuiltIn).Should().HaveCountGreaterThanOrEqualTo(3);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task CreateRole_PersistsRoleAndGrants_AndIsReadable()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRoleStoreTests));
+        try
+        {
+            await EnsureRbacTablesAsync(schema);
+            var store = CreateStore(schema);
+
+            var role = new RoleDefinition
+            {
+                RoleId = Guid.NewGuid(),
+                Name = "field-worker",
+                Description = "Field collection editor",
+                IsBuiltIn = false,
+                Permissions =
+                [
+                    new PermissionGrant { Service = "parcels", Layer = "*", Operation = "query" },
+                    new PermissionGrant { Service = "parcels", Layer = "edits", Operation = "update" },
+                ],
+            };
+
+            await store.CreateRoleAsync(role);
+
+            var fetched = await store.GetRoleAsync(role.RoleId);
+            fetched.Should().NotBeNull();
+            fetched!.Name.Should().Be("field-worker");
+            fetched.Permissions.Should().HaveCount(2);
+            fetched.Permissions.Should().ContainSingle(p =>
+                p.Service == "parcels" && p.Layer == "edits" && p.Operation == "update");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task DeleteRole_BuiltIn_IsRejected_NonBuiltIn_Succeeds()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRoleStoreTests));
+        try
+        {
+            await EnsureRbacTablesAsync(schema);
+            var store = CreateStore(schema);
+
+            // Built-in role cannot be deleted.
+            var deletedBuiltIn = await store.DeleteRoleAsync(AdminRoleId);
+            deletedBuiltIn.Should().BeFalse();
+            (await store.GetRoleAsync(AdminRoleId)).Should().NotBeNull();
+
+            // A custom role can be deleted.
+            var custom = new RoleDefinition { RoleId = Guid.NewGuid(), Name = "temp", IsBuiltIn = false };
+            await store.CreateRoleAsync(custom);
+            (await store.DeleteRoleAsync(custom.RoleId)).Should().BeTrue();
+            (await store.GetRoleAsync(custom.RoleId)).Should().BeNull();
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task SetPermissions_ReplacesGrants()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRoleStoreTests));
+        try
+        {
+            await EnsureRbacTablesAsync(schema);
+            var store = CreateStore(schema);
+
+            var role = new RoleDefinition
+            {
+                RoleId = Guid.NewGuid(),
+                Name = "analyst",
+                IsBuiltIn = false,
+                Permissions = [new PermissionGrant { Service = "a", Layer = "*", Operation = "query" }],
+            };
+            await store.CreateRoleAsync(role);
+
+            var replaced = await store.SetPermissionsAsync(role.RoleId,
+            [
+                new PermissionGrant { Service = "b", Layer = "*", Operation = "query" },
+                new PermissionGrant { Service = "b", Layer = "*", Operation = "export" },
+            ]);
+
+            replaced.Should().HaveCount(2);
+            var grants = await store.GetPermissionsAsync(role.RoleId);
+            grants.Should().HaveCount(2);
+            grants.Should().NotContain(p => p.Service == "a");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task GetEffectivePermissions_ResolvesAcrossMultipleRoles_Deduplicated()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRoleStoreTests));
+        try
+        {
+            await EnsureRbacTablesAsync(schema);
+            var store = CreateStore(schema);
+
+            // viewer (seeded) grants query+metadata; add a custom role granting export.
+            var exporter = new RoleDefinition
+            {
+                RoleId = Guid.NewGuid(),
+                Name = "exporter",
+                IsBuiltIn = false,
+                Permissions =
+                [
+                    new PermissionGrant { Service = "*", Layer = "*", Operation = "export" },
+                    // duplicate of a viewer grant — must be de-duplicated.
+                    new PermissionGrant { Service = "*", Layer = "*", Operation = "query" },
+                ],
+            };
+            await store.CreateRoleAsync(exporter);
+
+            var effective = await store.GetEffectivePermissionsAsync("user-1", ["viewer", "exporter"]);
+
+            effective.Permissions.Select(p => p.Operation).Should().Contain(["query", "metadata", "export"]);
+            effective.Permissions.Where(p => p.Operation == "query").Should().HaveCount(1);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task Roles_SurviveStoreReinstantiation()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRoleStoreTests));
+        try
+        {
+            await EnsureRbacTablesAsync(schema);
+
+            var roleId = Guid.NewGuid();
+            var first = CreateStore(schema);
+            await first.CreateRoleAsync(new RoleDefinition
+            {
+                RoleId = roleId,
+                Name = "durable",
+                IsBuiltIn = false,
+                Permissions = [new PermissionGrant { Service = "*", Layer = "*", Operation = "query" }],
+            });
+
+            // A brand-new store instance (simulating a process restart / second
+            // node) must see the persisted role and its grants.
+            var second = CreateStore(schema);
+            var fetched = await second.GetRoleAsync(roleId);
+
+            fetched.Should().NotBeNull();
+            fetched!.Name.Should().Be("durable");
+            fetched.Permissions.Should().ContainSingle();
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    private PostgresRoleStore CreateStore(string schema)
+        => new(new TestConnectionProvider(fixture.DataSource, schema), schemaName: schema);
+
+    private async Task EnsureRbacTablesAsync(string schema)
+    {
+        // Mirrors migration 041 inside the per-test isolated schema (so the
+        // suite runs in parallel) and seeds the built-in roles the store relies
+        // on for the built-in-protection and effective-permission assertions.
+        await fixture.ExecuteAsync($"""
+            CREATE TABLE IF NOT EXISTS "{schema}".rbac_roles (
+                role_id       UUID         PRIMARY KEY,
+                name          VARCHAR(128) NOT NULL,
+                description   TEXT,
+                is_built_in   BOOLEAN      NOT NULL DEFAULT FALSE,
+                created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+                updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_rbac_roles_name_lower_{schema}
+                ON "{schema}".rbac_roles (LOWER(name));
+
+            CREATE TABLE IF NOT EXISTS "{schema}".rbac_role_permissions (
+                role_id       UUID         NOT NULL REFERENCES "{schema}".rbac_roles(role_id) ON DELETE CASCADE,
+                service       VARCHAR(256) NOT NULL,
+                layer         VARCHAR(256) NOT NULL,
+                operation     VARCHAR(64)  NOT NULL,
+                CONSTRAINT rbac_role_permissions_unique_{schema} UNIQUE (role_id, service, layer, operation)
+            );
+
+            CREATE TABLE IF NOT EXISTS "{schema}".rbac_role_memberships (
+                role_id       UUID         NOT NULL REFERENCES "{schema}".rbac_roles(role_id) ON DELETE CASCADE,
+                user_id       VARCHAR(256) NOT NULL,
+                created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+                CONSTRAINT rbac_role_memberships_pk_{schema} PRIMARY KEY (role_id, user_id)
+            );
+
+            INSERT INTO "{schema}".rbac_roles (role_id, name, description, is_built_in)
+            VALUES
+                ('00000000-0000-0000-0000-000000000001', 'admin',  'Full administrative access', TRUE),
+                ('00000000-0000-0000-0000-000000000003', 'editor', 'Read and write', TRUE),
+                ('00000000-0000-0000-0000-000000000002', 'viewer', 'Read-only', TRUE)
+            ON CONFLICT (role_id) DO NOTHING;
+
+            INSERT INTO "{schema}".rbac_role_permissions (role_id, service, layer, operation)
+            VALUES
+                ('00000000-0000-0000-0000-000000000001', '*', '*', '*'),
+                ('00000000-0000-0000-0000-000000000002', '*', '*', 'query'),
+                ('00000000-0000-0000-0000-000000000002', '*', '*', 'metadata')
+            ON CONFLICT (role_id, service, layer, operation) DO NOTHING;
+            """);
+    }
+
+    private sealed class TestConnectionProvider(NpgsqlDataSource dataSource, string schemaName) : IDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => dataSource.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            var conn = await dataSource.OpenConnectionAsync(cancellationToken);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SET search_path TO \"{schemaName}\", public;";
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+            return conn;
+        }
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var conn = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var tx = await conn.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (conn, tx);
+            }
+            catch
+            {
+                await conn.DisposeAsync();
+                throw;
+            }
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken = default) => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(Func<Task> operation, CancellationToken cancellationToken = default) => operation();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/PermissionResolverQuerySmokeTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/PermissionResolverQuerySmokeTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using FluentAssertions;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Security.Domain;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
+using Honua.TestKit.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Tests.Features.Security;
+
+/// <summary>
+/// Cross-protocol smoke proving the canonical permission resolver (#1375) is
+/// LIVE on an already-enforced path: the GeoServices FeatureServer layer-query
+/// read seam now consults per-operation RBAC grants and the legacy coarse
+/// <see cref="AccessPolicy"/> only as a fallback.
+/// </summary>
+public sealed class PermissionResolverQuerySmokeTests
+{
+    private const string GrantedRole = "alpha-query-grant";
+    private const string QueryUrl =
+        "/rest/services/" + ServiceRbacTestFixture.AlphaService +
+        "/FeatureServer/" + "0" + "/query?where=1=1&f=json";
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task Query_PerOperationGrant_OverridesCoarseReadPolicyDeny()
+    {
+        // Alpha service requires a coarse read role the user does NOT hold, so
+        // the legacy AccessPolicy seam would 403. The user instead holds a role
+        // whose RBAC store grants the "query" operation on service "alpha", which
+        // the resolver must honor → 200.
+        using var factory = ServiceRbacTestFixture.CreateFactory(
+            layerCatalogFactory: static () => new RbacTestLayerCatalog(
+                alphaServiceMetadata: ServiceRbacTestFixture.CreateServiceMetadata(readRoles: ["coarse-only-role"])),
+            configureServices: static services =>
+            {
+                services.RemoveAll<ICrsDetectionService>();
+                services.AddSingleton<ICrsDetectionService, NoopCrsDetectionService>();
+                services.RemoveAll<IRoleStore>();
+                services.AddSingleton<IRoleStore>(new StubRoleStore(GrantedRole,
+                    new PermissionGrant { Service = ServiceRbacTestFixture.AlphaService, Layer = "*", Operation = "query" }));
+            });
+
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.GetAsync(QueryUrl);
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task Query_NoGrant_FallsBackToCoarsePolicyDeny()
+    {
+        // Same coarse deny, but the user's role carries NO matching grant, so the
+        // resolver returns no-match and the coarse AccessPolicy fallback applies
+        // → 403 (proving no behavior regression for ungranted principals).
+        using var factory = ServiceRbacTestFixture.CreateFactory(
+            layerCatalogFactory: static () => new RbacTestLayerCatalog(
+                alphaServiceMetadata: ServiceRbacTestFixture.CreateServiceMetadata(readRoles: ["coarse-only-role"])),
+            configureServices: static services =>
+            {
+                services.RemoveAll<ICrsDetectionService>();
+                services.AddSingleton<ICrsDetectionService, NoopCrsDetectionService>();
+                services.RemoveAll<IRoleStore>();
+                services.AddSingleton<IRoleStore>(new StubRoleStore("some-other-role",
+                    new PermissionGrant { Service = "beta", Layer = "*", Operation = "query" }));
+            });
+
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.GetAsync(QueryUrl);
+
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IRoleStore"/> that resolves the supplied grant for a
+    /// single named role; everything else is empty.
+    /// </summary>
+    private sealed class StubRoleStore(string roleName, PermissionGrant grant) : IRoleStore
+    {
+        public Task<EffectivePermissions> GetEffectivePermissionsAsync(
+            string userId,
+            IReadOnlyList<string> roles,
+            CancellationToken cancellationToken = default)
+        {
+            var grants = roles.Any(r => string.Equals(r, roleName, StringComparison.OrdinalIgnoreCase))
+                ? new[] { grant }
+                : [];
+
+            return Task.FromResult(new EffectivePermissions
+            {
+                UserId = userId,
+                Roles = roles,
+                Permissions = grants,
+            });
+        }
+
+        public Task<IReadOnlyList<RoleDefinition>> ListRolesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<RoleDefinition>>([]);
+
+        public Task<RoleDefinition?> GetRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult<RoleDefinition?>(null);
+
+        public Task<RoleDefinition> CreateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+            => Task.FromResult(role);
+
+        public Task<RoleDefinition?> UpdateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+            => Task.FromResult<RoleDefinition?>(role);
+
+        public Task<bool> DeleteRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<IReadOnlyList<PermissionGrant>> GetPermissionsAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<PermissionGrant>>([]);
+
+        public Task<IReadOnlyList<PermissionGrant>> SetPermissionsAsync(Guid roleId, IReadOnlyList<PermissionGrant> permissions, CancellationToken cancellationToken = default)
+            => Task.FromResult(permissions);
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #1374
Fixes #1375

Also delivers the ADR from #1377 and unblocks the Beta RBAC gate (#349), the ArcGIS Portal facade (#1240), and the OAuth2 bridge (#1242).

## Summary
Implements the auth keystone: a durable Postgres-backed RBAC store (#1374), the canonical per-operation permission resolver as the single shared authorization seam (#1375), and the foundation ADR (#1377). The resolver is made **live** — not another orphan — by routing the existing enforced GeoServices FeatureServer layer-query read decision through it, falling back to the coarse `AccessPolicy` when no per-operation grant matches (no behavior change for unconfigured services).

## Changes Made
- **ADR (#1377):** `docs/contributor/adr/0048-single-auth-identity-token-foundation.md` records the single foundation — OIDC for identity, `IPortalTokenIssuer` for ArcGIS tokens, this RBAC resolver for per-operation authorization — and the RBAC-resolver-first ordering constraint for #1242/#1240. (Also resolved a stale merge-conflict marker in the ADR `README.md` index while adding the 0048 row.)
- **Persistent store (#1374):** `PostgresRoleStore` (`Honua.Postgres`) over new `honua.rbac_roles` / `rbac_role_permissions` / `rbac_role_memberships` tables — migration `041_CreateRbacRoleStore.sql` (idempotent, seeds protected built-in `admin`/`editor`/`viewer`). Registered as the durable `IRoleStore` in `AddPostgreSqlServices`, overriding the in-memory default; `InMemoryRoleStore` retained for Community/no-DB mode and tests. Core stays abstraction-only.
- **Canonical resolver (#1375):** `IPermissionResolver` + `PermissionResolver` (`Honua.Core`) — `(principal, service, layer, operation) → allow / deny / requires-auth` over `EffectivePermissions`, with the documented `AuthorizationOperation` taxonomy (query/insert/update/delete/export/metadata/admin; `read`==`query` synonym for legacy grants). Service-level grant implies all layers; wildcard `*` supported on every dimension.
- **Live wiring:** `AccessPolicyHelpers.RequireResourceAccessAsync` consults the resolver first, then the coarse `AccessPolicy`; the FeatureServer query path (`FeatureServerQueryHandler.ResolveQueryLayerContextV2Async`) now calls it. **Exactly one enforced path wired** this PR.
- **Deferred to #1376:** re-wiring the remaining protocol adapters (FeatureServer edits/maintenance/related-records, OData, WFS, OGC API, MVT, gRPC, MCP) to per-operation checks + the cross-protocol conformance matrix.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Local results (Release, warnings-as-errors):
- `dotnet build Honua.sln` — succeeded, 0 warnings.
- Resolver decision-matrix unit tests — **10/10** (`Honua.Core.Tests`).
- `PostgresRoleStore` Testcontainers + PostGIS integration tests (CRUD parity, built-in protection, multi-role dedup resolution, restart durability) — **6/6** (`Honua.Postgres.Tests`).
- Cross-protocol smoke: per-operation grant overrides a coarse read deny on the FeatureServer query path → 200; no-grant falls back to coarse deny → 403 — **2/2** (`Honua.Server.Tests`).
- Existing FeatureServer RBAC suite (regression) — **16/16**.
- Architecture tests — **101 passed / 1 pre-existing skip**.
- `dotnet format Honua.sln --verify-no-changes` — clean.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

ADR added; no OpenAPI/proto/SDK surface change. The per-operation permission semantics are new shared behavior consumed by #1376/#1240/#1242.

## Release/Deploy Impact
- [x] Requires database migration

Migration `041_CreateRbacRoleStore.sql` runs on boot (idempotent). **Compatibility:** for already-deployed services that have no per-operation grants, the resolver returns no-match and the existing coarse `AccessPolicy` decision is preserved unchanged — no authorization regression. Built-in roles are seeded with the same well-known ids the in-memory store used.

## Breaking Changes
None.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent during implementation (dotnet build warnings-as-errors + targeted dotnet test + dotnet format --verify-no-changes); full matrix gated by CI below
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

