### PR TITLE
feat: persist Esri coded-value/range domains through import-publish-serve (#1255)

### DIFF
--- a/src/Honua.Core/Features/Admin/Domain/LayerPublishingModels.cs
+++ b/src/Honua.Core/Features/Admin/Domain/LayerPublishingModels.cs
@@ -67,6 +67,17 @@ public sealed class LayerPublishRequest
     /// Whether the layer should be enabled after publishing.
     /// </summary>
     public bool Enabled { get; init; } = true;
+
+    /// <summary>
+    /// Optional per-field value domains captured from the migration source,
+    /// keyed by source field name (case-insensitive). When a published column
+    /// matches a key, the domain is carried into the Metadata v2 field so it
+    /// persists into the graph and is served via the FeatureServer field
+    /// <c>domain</c> and <c>queryDomains</c> surfaces. Fields without an entry
+    /// publish without a domain.
+    /// </summary>
+    public IReadOnlyDictionary<string, Honua.Core.Features.Metadata.Domain.V2.MetadataV2FieldDomain> FieldDomains { get; init; }
+        = new Dictionary<string, Honua.Core.Features.Metadata.Domain.V2.MetadataV2FieldDomain>(StringComparer.OrdinalIgnoreCase);
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Migration/Domain/GeoservicesServiceInfo.cs
+++ b/src/Honua.Core/Features/Migration/Domain/GeoservicesServiceInfo.cs
@@ -149,6 +149,15 @@ public sealed record GeoservicesLayerInfo
 public sealed record GeoservicesFieldInfo : FieldDefinitionBase
 {
     /// <summary>
+    /// Canonical value domain (coded values or numeric range) captured from the
+    /// source field, or <c>null</c> when the field carries no domain. Carried
+    /// through the auto-publish pipeline so the domain persists into the
+    /// Metadata v2 graph and is served via the FeatureServer field <c>domain</c>
+    /// and <c>queryDomains</c> surfaces.
+    /// </summary>
+    public Honua.Core.Features.Metadata.Domain.V2.MetadataV2FieldDomain? Domain { get; init; }
+
+    /// <summary>
     /// Whether this is the ObjectID field.
     /// </summary>
     public bool IsObjectId => Type.Equals("esriFieldTypeOID", StringComparison.OrdinalIgnoreCase);

--- a/src/Honua.Core/Features/Migration/Services/ArcGisRestClient.cs
+++ b/src/Honua.Core/Features/Migration/Services/ArcGisRestClient.cs
@@ -774,7 +774,11 @@ internal sealed partial class ArcGisRestClient
             Type = f.Type ?? "esriFieldTypeString",
             Alias = f.Alias,
             Length = f.Length,
-            Nullable = f.Nullable ?? true
+            Nullable = f.Nullable ?? true,
+            // Persisted through publish so coded-value/range domains survive to the
+            // served FeatureServer surface. A coded-value domain over the cap is
+            // reported via the inventory warning path and intentionally not persisted.
+            Domain = EsriFieldDomainParser.ParseDomain(f.Domain).Domain
         }).ToArray();
     }
 
@@ -1012,6 +1016,9 @@ internal sealed record ArcGisField
 
     [JsonPropertyName("nullable")]
     public bool? Nullable { get; init; }
+
+    [JsonPropertyName("domain")]
+    public JsonElement? Domain { get; init; }
 }
 
 internal sealed record ArcGisCountResponse

--- a/src/Honua.Core/Features/Migration/Services/EsriFieldDomainParser.cs
+++ b/src/Honua.Core/Features/Migration/Services/EsriFieldDomainParser.cs
@@ -1,0 +1,243 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Core.Features.Migration.Services;
+
+/// <summary>
+/// Shared, deterministic parser that converts an Esri field <c>domain</c> JSON
+/// fragment into the canonical <see cref="MetadataV2FieldDomain"/> model.
+/// <para>
+/// This is the single source of truth for Esri domain capture so the migration
+/// inventory artifact and the import/publish field builder agree on cap
+/// semantics (<see cref="CodedValueDomainCap"/>). Coded-value domains larger than
+/// the cap are reported as truncated and not persisted, so a large domain is
+/// surfaced as a review warning rather than being silently halved or
+/// false-failing later reconciliation against a capped artifact.
+/// </para>
+/// </summary>
+public static class EsriFieldDomainParser
+{
+    /// <summary>
+    /// Maximum number of coded-value entries captured for a single domain. Domains
+    /// that exceed this cap are reported via <see cref="EsriFieldDomainParseResult.Truncated"/>
+    /// and are not persisted, keeping artifacts deterministic and bounded.
+    /// </summary>
+    public const int CodedValueDomainCap = 100;
+
+    /// <summary>
+    /// Canonical domain-kind token for an enumerated coded-value domain.
+    /// </summary>
+    public const string CodedValueDomainType = "codedValue";
+
+    /// <summary>
+    /// Canonical domain-kind token for a numeric range domain.
+    /// </summary>
+    public const string RangeDomainType = "range";
+
+    /// <summary>
+    /// Parses the Esri <c>domain</c> object on a field element into the canonical
+    /// <see cref="MetadataV2FieldDomain"/> model.
+    /// </summary>
+    /// <param name="fieldElement">The Esri field element (the object that may carry a <c>domain</c> property).</param>
+    /// <returns>
+    /// A <see cref="EsriFieldDomainParseResult"/> describing the parsed domain (or
+    /// <c>null</c> when the field carries no usable domain) and whether a coded-value
+    /// domain was truncated by the cap.
+    /// </returns>
+    public static EsriFieldDomainParseResult Parse(JsonElement fieldElement)
+    {
+        if (fieldElement.ValueKind != JsonValueKind.Object ||
+            !fieldElement.TryGetProperty("domain", out var domainElement))
+        {
+            return EsriFieldDomainParseResult.None;
+        }
+
+        return ParseDomain(domainElement);
+    }
+
+    /// <summary>
+    /// Parses an Esri <c>domain</c> object directly (already extracted from a field).
+    /// </summary>
+    /// <param name="domainElement">The Esri <c>domain</c> object, or any non-object value when the field has no domain.</param>
+    /// <returns>The parsed domain result; <see cref="EsriFieldDomainParseResult.None"/> when there is no usable domain.</returns>
+    public static EsriFieldDomainParseResult ParseDomain(JsonElement? domainElement)
+    {
+        if (domainElement is not { ValueKind: JsonValueKind.Object } domain)
+        {
+            return EsriFieldDomainParseResult.None;
+        }
+
+        var type = GetString(domain, "type");
+        var name = GetString(domain, "name");
+        var mergePolicy = GetString(domain, "mergePolicy");
+        var splitPolicy = GetString(domain, "splitPolicy");
+
+        if (string.Equals(type, CodedValueDomainType, StringComparison.Ordinal))
+        {
+            return ParseCodedValueDomain(domain, name, mergePolicy, splitPolicy);
+        }
+
+        if (string.Equals(type, RangeDomainType, StringComparison.Ordinal))
+        {
+            return ParseRangeDomain(domain, name, mergePolicy, splitPolicy);
+        }
+
+        // Unknown domain kind: capture identity only so downstream review still
+        // sees that a domain existed without inventing coded values or a range.
+        if (string.IsNullOrEmpty(type))
+        {
+            return EsriFieldDomainParseResult.None;
+        }
+
+        return new EsriFieldDomainParseResult(
+            new MetadataV2FieldDomain
+            {
+                Name = name,
+                Type = type!,
+                MergePolicy = mergePolicy,
+                SplitPolicy = splitPolicy
+            },
+            Truncated: false);
+    }
+
+    private static EsriFieldDomainParseResult ParseCodedValueDomain(
+        JsonElement domainElement,
+        string? name,
+        string? mergePolicy,
+        string? splitPolicy)
+    {
+        if (!domainElement.TryGetProperty("codedValues", out var codedValuesElement) ||
+            codedValuesElement.ValueKind != JsonValueKind.Array)
+        {
+            return new EsriFieldDomainParseResult(
+                new MetadataV2FieldDomain
+                {
+                    Name = name,
+                    Type = CodedValueDomainType,
+                    CodedValues = [],
+                    MergePolicy = mergePolicy,
+                    SplitPolicy = splitPolicy
+                },
+                Truncated: false);
+        }
+
+        var entries = new List<MetadataV2CodedValue>();
+        var truncated = false;
+        foreach (var entry in codedValuesElement.EnumerateArray())
+        {
+            if (entry.ValueKind != JsonValueKind.Object ||
+                !entry.TryGetProperty("code", out var codeElement))
+            {
+                continue;
+            }
+
+            var entryName = GetString(entry, "name");
+            if (string.IsNullOrWhiteSpace(entryName) || !IsSupportedCode(codeElement))
+            {
+                continue;
+            }
+
+            if (entries.Count >= CodedValueDomainCap)
+            {
+                truncated = true;
+                break;
+            }
+
+            entries.Add(new MetadataV2CodedValue
+            {
+                Code = codeElement.Clone(),
+                Name = entryName!
+            });
+        }
+
+        // A truncated domain is not persisted: keeping a half-domain would let an
+        // Esri client believe the lookup is complete. Report the cap instead.
+        if (truncated)
+        {
+            return new EsriFieldDomainParseResult(Domain: null, Truncated: true, DomainName: name);
+        }
+
+        var ordered = entries
+            .OrderBy(static value => value.Code.GetRawText(), StringComparer.Ordinal)
+            .ThenBy(static value => value.Name, StringComparer.Ordinal)
+            .ToArray();
+
+        return new EsriFieldDomainParseResult(
+            new MetadataV2FieldDomain
+            {
+                Name = name,
+                Type = CodedValueDomainType,
+                CodedValues = ordered,
+                MergePolicy = mergePolicy,
+                SplitPolicy = splitPolicy
+            },
+            Truncated: false);
+    }
+
+    private static EsriFieldDomainParseResult ParseRangeDomain(
+        JsonElement domainElement,
+        string? name,
+        string? mergePolicy,
+        string? splitPolicy)
+    {
+        JsonElement[]? range = null;
+        if (domainElement.TryGetProperty("range", out var rangeElement) &&
+            rangeElement.ValueKind == JsonValueKind.Array)
+        {
+            var values = new List<JsonElement>(capacity: 2);
+            foreach (var value in rangeElement.EnumerateArray())
+            {
+                values.Add(value.Clone());
+            }
+
+            // A well-formed Esri range domain carries exactly [min, max]. Anything
+            // else is left null so serving omits an ambiguous range.
+            if (values.Count == 2)
+            {
+                range = [.. values];
+            }
+        }
+
+        return new EsriFieldDomainParseResult(
+            new MetadataV2FieldDomain
+            {
+                Name = name,
+                Type = RangeDomainType,
+                Range = range,
+                MergePolicy = mergePolicy,
+                SplitPolicy = splitPolicy
+            },
+            Truncated: false);
+    }
+
+    private static bool IsSupportedCode(JsonElement codeElement)
+        => codeElement.ValueKind is JsonValueKind.String
+            or JsonValueKind.Number
+            or JsonValueKind.True
+            or JsonValueKind.False;
+
+    private static string? GetString(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}
+
+/// <summary>
+/// Outcome of parsing an Esri field domain into the canonical model.
+/// </summary>
+/// <param name="Domain">The parsed canonical domain, or <c>null</c> when there is no usable domain or it was truncated.</param>
+/// <param name="Truncated">True when a coded-value domain exceeded <see cref="EsriFieldDomainParser.CodedValueDomainCap"/> and was omitted.</param>
+/// <param name="DomainName">The source domain name when known (used for truncation reporting).</param>
+public readonly record struct EsriFieldDomainParseResult(
+    MetadataV2FieldDomain? Domain,
+    bool Truncated,
+    string? DomainName = null)
+{
+    /// <summary>
+    /// Shared result for a field that carries no domain.
+    /// </summary>
+    public static readonly EsriFieldDomainParseResult None = new(Domain: null, Truncated: false);
+}

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.MetadataV2Graph.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.MetadataV2Graph.cs
@@ -443,7 +443,11 @@ internal sealed partial class PostgreSqlLayerPublishingService
             SemanticRoles = semanticRoles.ToArray(),
             Alias = field.Name,
             Editable = field.Type != MetadataV2FieldType.Geometry,
-            Length = field.MaxLength
+            Length = field.MaxLength,
+            // Carry the captured Esri coded-value/range domain into the canonical
+            // graph so it survives the compat-compile snapshot and is served via the
+            // FeatureServer field domain and queryDomains surfaces (honua-server#1255).
+            Domain = field.Domain
         };
     }
 

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.TableIntrospection.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.TableIntrospection.cs
@@ -241,11 +241,14 @@ internal sealed partial class PostgreSqlLayerPublishingService
     private static List<LayerFieldInsert> BuildLayerFields(
         List<ColumnInfo> selectedColumns,
         ColumnInfo primaryKeyColumn,
-        string geometryColumn)
+        string geometryColumn,
+        IReadOnlyDictionary<string, MetadataV2FieldDomain> fieldDomains)
     {
         var fields = new List<LayerFieldInsert>();
         var added = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        // The object-id column is identity, never a domain-bearing attribute, so it
+        // intentionally publishes without a domain even if the source advertised one.
         var primaryKeyType = MapPostgresType(primaryKeyColumn.DataType);
         fields.Add(new LayerFieldInsert(
             primaryKeyColumn.Name,
@@ -268,7 +271,8 @@ internal sealed partial class PostgreSqlLayerPublishingService
                 fieldType,
                 column.MaxLength,
                 column.IsNullable,
-                null));
+                null,
+                Domain: fieldDomains.TryGetValue(column.Name, out var domain) ? domain : null));
             _ = added.Add(column.Name);
         }
 

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
@@ -255,7 +255,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
                 "Primary key must be an integer column.");
         }
 
-        var fields = BuildLayerFields(selectedColumns, primaryKeyColumn, geometryColumn);
+        var fields = BuildLayerFields(selectedColumns, primaryKeyColumn, geometryColumn, request.FieldDomains);
 
         await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync(cancellationToken);
@@ -639,7 +639,8 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         int? MaxLength,
         bool Nullable,
         string? Description,
-        object? DefaultValue = null);
+        object? DefaultValue = null,
+        MetadataV2FieldDomain? Domain = null);
 
     private sealed record LayerExtentInsert(
         double MinX,

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Metadata.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Metadata.cs
@@ -18,7 +18,10 @@ namespace Honua.Postgres.Features.Migration;
 
 internal sealed partial class GeoservicesImportService
 {
-    private const int CodedValueDomainCap = 100;
+    // Single source of truth for the coded-value capture cap, shared with the
+    // publish-path capture (EsriFieldDomainParser) so persistence and the inventory
+    // artifact agree and a large domain does not later false-fail reconciliation.
+    private const int CodedValueDomainCap = EsriFieldDomainParser.CodedValueDomainCap;
 
     private async Task<MigrationSpatialReferenceInfo[]> BuildArcGisSpatialReferencesAsync(
         JsonElement resourceElement,

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.cs
@@ -179,7 +179,8 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
                 PrimaryKey = FieldNames.ObjectId,
                 Fields = [],
                 ServiceName = request.ServiceName,
-                Enabled = true
+                Enabled = true,
+                FieldDomains = BuildFieldDomainMap(layerInfo)
             };
 
             var published = await _layerPublishingService.PublishLayerAsync(
@@ -209,6 +210,26 @@ internal sealed partial class GeoservicesImportService : IGeoservicesImportServi
             warnings.Add("AutoPublish was requested, but publishing did not complete.");
             return null;
         }
+    }
+
+    // Projects the captured per-field Esri domains onto the publish request, keyed
+    // by source field name. Coded-value domains over the capture cap are not present
+    // here (the source parser omitted them and the inventory raised the truncation
+    // warning), so they intentionally publish without a domain rather than as a
+    // misleading partial lookup.
+    private static Dictionary<string, MetadataV2FieldDomain> BuildFieldDomainMap(
+        GeoservicesLayerInfo layerInfo)
+    {
+        var map = new Dictionary<string, MetadataV2FieldDomain>(StringComparer.OrdinalIgnoreCase);
+        foreach (var field in layerInfo.Fields)
+        {
+            if (field.Domain is { } domain && !string.IsNullOrWhiteSpace(field.Name))
+            {
+                map[field.Name] = domain;
+            }
+        }
+
+        return map;
     }
 
     private async Task TryAttachLayerStyleAsync(

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/EsriFieldDomainParserTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/EsriFieldDomainParserTests.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Migration.Services;
+
+namespace Honua.Core.Tests.Features.Import;
+
+/// <summary>
+/// Unit coverage for the shared Esri domain parser (honua-server#1255). The parser is
+/// the single source of truth for coded-value/range capture and the 100-entry cap, so
+/// the import inventory and the publish-path field builder agree on cap semantics.
+/// </summary>
+public sealed class EsriFieldDomainParserTests
+{
+    [Fact]
+    public void Parse_CodedValueDomain_ProducesCanonicalCodedValues()
+    {
+        var field = ParseField("""
+            {
+              "name": "status",
+              "domain": {
+                "type": "codedValue",
+                "name": "StatusDomain",
+                "codedValues": [
+                  { "name": "Active", "code": "A" },
+                  { "name": "Closed", "code": "C" }
+                ]
+              }
+            }
+            """);
+
+        var result = EsriFieldDomainParser.Parse(field);
+
+        result.Truncated.Should().BeFalse();
+        result.Domain.Should().NotBeNull();
+        result.Domain!.Type.Should().Be("codedValue");
+        result.Domain.Name.Should().Be("StatusDomain");
+        result.Domain.CodedValues.Should().HaveCount(2);
+        result.Domain.CodedValues.Select(v => v.Name).Should().BeEquivalentTo(["Active", "Closed"]);
+    }
+
+    [Fact]
+    public void Parse_RangeDomain_ProducesTwoElementRange()
+    {
+        var field = ParseField("""
+            {
+              "name": "score",
+              "domain": { "type": "range", "name": "ScoreRange", "range": [0, 100] }
+            }
+            """);
+
+        var result = EsriFieldDomainParser.Parse(field);
+
+        result.Truncated.Should().BeFalse();
+        result.Domain.Should().NotBeNull();
+        result.Domain!.Type.Should().Be("range");
+        result.Domain.Name.Should().Be("ScoreRange");
+        result.Domain.Range.Should().NotBeNull();
+        result.Domain.Range!.Should().HaveCount(2);
+        result.Domain.Range![0].GetInt32().Should().Be(0);
+        result.Domain.Range![1].GetInt32().Should().Be(100);
+    }
+
+    [Fact]
+    public void Parse_CodedValueDomainOverCap_ReportsTruncatedAndOmitsDomain()
+    {
+        var entries = new StringBuilder();
+        for (var i = 0; i < EsriFieldDomainParser.CodedValueDomainCap + 1; i++)
+        {
+            if (i > 0)
+            {
+                entries.Append(',');
+            }
+
+            entries.Append(System.Globalization.CultureInfo.InvariantCulture, $"{{\"name\":\"Value{i}\",\"code\":{i}}}");
+        }
+
+        var field = ParseField($$"""
+            {
+              "name": "huge",
+              "domain": { "type": "codedValue", "name": "HugeDomain", "codedValues": [{{entries}}] }
+            }
+            """);
+
+        var result = EsriFieldDomainParser.Parse(field);
+
+        // An over-cap domain is not persisted as a half-domain; it is reported truncated.
+        result.Truncated.Should().BeTrue();
+        result.Domain.Should().BeNull();
+        result.DomainName.Should().Be("HugeDomain");
+    }
+
+    [Fact]
+    public void Parse_FieldWithoutDomain_ReturnsNone()
+    {
+        var field = ParseField("""{ "name": "plain", "type": "esriFieldTypeString" }""");
+
+        var result = EsriFieldDomainParser.Parse(field);
+
+        result.Should().Be(EsriFieldDomainParseResult.None);
+    }
+
+    [Fact]
+    public void Parse_DomainAtCapBoundary_PersistsFully()
+    {
+        var entries = new StringBuilder();
+        for (var i = 0; i < EsriFieldDomainParser.CodedValueDomainCap; i++)
+        {
+            if (i > 0)
+            {
+                entries.Append(',');
+            }
+
+            entries.Append(System.Globalization.CultureInfo.InvariantCulture, $"{{\"name\":\"Value{i}\",\"code\":{i}}}");
+        }
+
+        var field = ParseField($$"""
+            {
+              "name": "atcap",
+              "domain": { "type": "codedValue", "name": "AtCap", "codedValues": [{{entries}}] }
+            }
+            """);
+
+        var result = EsriFieldDomainParser.Parse(field);
+
+        result.Truncated.Should().BeFalse();
+        result.Domain.Should().NotBeNull();
+        result.Domain!.CodedValues.Should().HaveCount(EsriFieldDomainParser.CodedValueDomainCap);
+    }
+
+    private static JsonElement ParseField(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportDomainPersistenceTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesImportDomainPersistenceTests.cs
@@ -1,0 +1,302 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Migration.Domain;
+using Honua.Core.Features.Migration.Services;
+using Honua.Core.Features.Shared.Models;
+using Honua.Postgres.Features.Admin;
+using Honua.Postgres.Features.Infrastructure;
+using Honua.Postgres.Features.Metadata;
+using Honua.Postgres.Features.Migration;
+using Honua.TestKit;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Honua.Postgres.Tests.Features.Import;
+
+/// <summary>
+/// Integration coverage for honua-server#1255: Esri coded-value and range domains
+/// captured on import must persist through publish into the Metadata v2 graph,
+/// survive the compat-compile (activated current snapshot), and surface on the
+/// canonical field the FeatureServer field <c>domain</c> and <c>queryDomains</c>
+/// surfaces read from (<see cref="MetadataV2Field.Domain"/>).
+/// </summary>
+[Collection("Database")]
+public sealed class GeoservicesImportDomainPersistenceTests(PostgresFixture fixture)
+{
+    [Fact]
+    public async Task ImportLayerAsync_WithCodedValueAndRangeDomains_PersistsThemOntoPublishedMetadataV2Field()
+    {
+        const string tableName = "geoservices_import_domains";
+        var serviceName = $"domains_{Guid.NewGuid():N}";
+        // Keep the test-class component short: the generated schema name appends a GUID and
+        // PostgreSQL truncates identifiers at 63 chars, which would otherwise desync the
+        // publish-path schema lookup from the stored (truncated) schema name.
+        var schemaName = await fixture.CreateIsolatedSchemaAsync("ImportDomains");
+        var environment = $"DomainTest-{Guid.NewGuid():N}";
+
+        // Ensure the shared 'honua' catalog + metadata_v2 tables the publishing service
+        // and graph store write to exist (idempotent; isolated-schema seeding does not
+        // guarantee them in this collection).
+        await EnsureCatalogSchemaAsync();
+
+        var graphStore = new PostgresMetadataV2GraphStore(
+            new FixtureConnectionProvider(fixture),
+            environment);
+
+        try
+        {
+            var service = CreateService(graphStore, schemaName);
+
+            var result = await service.ImportLayerAsync(new GeoservicesImportRequest
+            {
+                ServiceUrl = "https://example.com/arcgis/rest/services/Domains/FeatureServer",
+                LayerId = 0,
+                TableName = tableName,
+                TargetSchema = schemaName,
+                TargetSrid = 4326,
+                BatchSize = 10,
+                RequestTimeoutSeconds = 5,
+                MaxRetries = 0,
+                AutoPublish = true,
+                ServiceName = serviceName
+            });
+
+            result.Success.Should().BeTrue();
+            result.Warnings.Should().NotContain(warning =>
+                warning.Contains("publishing did not complete", StringComparison.OrdinalIgnoreCase));
+
+            // Read the activated current snapshot — exactly the compat-compiled graph
+            // the serving side reads. If domains were dropped at publish (the #1255
+            // gap) this assertion fails.
+            var snapshot = await graphStore.GetCurrentAsync();
+            var resource = snapshot.Graph.Resources
+                .SingleOrDefault(r => r.SchemaFields.Any(f =>
+                    f.Name.Equals("status", StringComparison.OrdinalIgnoreCase)));
+            resource.Should().NotBeNull("the imported layer should be projected into the Metadata v2 graph");
+
+            var statusField = resource!.SchemaFields
+                .Single(f => f.Name.Equals("status", StringComparison.OrdinalIgnoreCase));
+            statusField.Domain.Should().NotBeNull("the coded-value domain must survive import → publish → compat-compile");
+            statusField.Domain!.Type.Should().Be(EsriFieldDomainParser.CodedValueDomainType);
+            statusField.Domain.Name.Should().Be("StatusDomain");
+            statusField.Domain.CodedValues.Select(v => v.Name)
+                .Should().BeEquivalentTo(["Active", "Closed", "Pending"]);
+
+            var scoreField = resource.SchemaFields
+                .Single(f => f.Name.Equals("score", StringComparison.OrdinalIgnoreCase));
+            scoreField.Domain.Should().NotBeNull("the range domain must survive import → publish → compat-compile");
+            scoreField.Domain!.Type.Should().Be(EsriFieldDomainParser.RangeDomainType);
+            scoreField.Domain.Name.Should().Be("ScoreRange");
+            scoreField.Domain.Range.Should().NotBeNull();
+            scoreField.Domain.Range!.Should().HaveCount(2);
+            scoreField.Domain.Range![0].GetInt32().Should().Be(0);
+            scoreField.Domain.Range![1].GetInt32().Should().Be(100);
+
+            // A field without a source domain must publish without one (no invented lookup).
+            var nameField = resource.SchemaFields
+                .Single(f => f.Name.Equals("name", StringComparison.OrdinalIgnoreCase));
+            nameField.Domain.Should().BeNull();
+
+            // queryDomains projection: serving enumerates SchemaFields where Domain is set.
+            resource.SchemaFields
+                .Where(f => !f.Hidden && f.Domain is not null)
+                .Select(f => f.Name)
+                .Should().BeEquivalentTo(["status", "score"]);
+        }
+        finally
+        {
+            await CleanupCatalogAsync(serviceName);
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
+    private GeoservicesImportService CreateService(PostgresMetadataV2GraphStore graphStore, string dataSchema)
+    {
+        var restClient = new ArcGisRestClient(
+            new HttpClient(new DomainFeatureServerHandler()),
+            NullLogger<ArcGisRestClient>.Instance,
+            (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+
+        var crsRegistry = new Mock<ICrsRegistry>(MockBehavior.Loose);
+
+        var connectionProvider = new FixtureConnectionProvider(fixture);
+
+        // The imported data table lives in the isolated test schema; include it in the
+        // discovery operational schemas so the publish-path geometry discovery finds it.
+        var schemaConfiguration = new PostgresSchemaConfiguration(
+            PostgresSchemaConfiguration.DefaultMetadataSchema,
+            dataSchema,
+            [dataSchema, "public"]);
+
+        var publishingService = new PostgreSqlLayerPublishingService(
+            new PostgreSqlTableDiscoveryService(
+                NullLogger<PostgreSqlTableDiscoveryService>.Instance,
+                schemaContext: null,
+                schemaConfiguration: schemaConfiguration),
+            graphStore,
+            NullLogger<PostgreSqlLayerPublishingService>.Instance);
+
+        return new GeoservicesImportService(
+            restClient,
+            connectionProvider,
+            crsRegistry.Object,
+            new EsriConstructCapabilityRegistry(EsriConstructCapabilityRegistry.BuiltInDescriptors),
+            NullLogger<GeoservicesImportService>.Instance,
+            layerPublishingService: publishingService);
+    }
+
+    private async Task EnsureCatalogSchemaAsync()
+    {
+        var sql = await File.ReadAllTextAsync(RepositoryPaths.Resolve("tests", "seed", "base-schema.sql"));
+        await using var connection = await fixture.GetConnectionAsync();
+        await using var command = connection.CreateCommand();
+        // base-schema.sql qualifies catalog tables as honua.* but creates 'features'
+        // unqualified; route the unqualified create into the honua schema too.
+        command.CommandText = $"SET search_path TO honua, public;\n{sql}";
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private async Task CleanupCatalogAsync(string serviceName)
+    {
+        await using var connection = await fixture.GetConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            DELETE FROM honua.layer_fields
+            WHERE layer_id IN (
+                SELECT layer_id FROM honua.service_layers WHERE service_name = @serviceName);
+            DELETE FROM honua.service_layers WHERE service_name = @serviceName;
+            DELETE FROM honua.services WHERE service_name = @serviceName;
+            """;
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "serviceName";
+        parameter.Value = serviceName;
+        command.Parameters.Add(parameter);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    // Minimal ArcGIS FeatureServer mock that advertises a coded-value domain on
+    // 'status' and a range domain on 'score', plus a plain 'name' field.
+    private sealed class DomainFeatureServerHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var pathAndQuery = request.RequestUri?.PathAndQuery ?? string.Empty;
+
+            var payload = pathAndQuery switch
+            {
+                "/arcgis/rest/services/Domains/FeatureServer/0?f=json" => """
+                    {
+                      "id": 0,
+                      "name": "Domain Layer",
+                      "geometryType": "esriGeometryPoint",
+                      "maxRecordCount": 10,
+                      "fields": [
+                        { "name": "OBJECTID", "type": "esriFieldTypeOID", "nullable": false },
+                        { "name": "name", "type": "esriFieldTypeString", "nullable": true },
+                        {
+                          "name": "status",
+                          "type": "esriFieldTypeString",
+                          "nullable": true,
+                          "domain": {
+                            "type": "codedValue",
+                            "name": "StatusDomain",
+                            "codedValues": [
+                              { "name": "Active", "code": "A" },
+                              { "name": "Closed", "code": "C" },
+                              { "name": "Pending", "code": "P" }
+                            ]
+                          }
+                        },
+                        {
+                          "name": "score",
+                          "type": "esriFieldTypeInteger",
+                          "nullable": true,
+                          "domain": {
+                            "type": "range",
+                            "name": "ScoreRange",
+                            "range": [0, 100]
+                          }
+                        }
+                      ]
+                    }
+                    """,
+                "/arcgis/rest/services/Domains/FeatureServer/0/query?where=1=1&returnCountOnly=true&f=json" => """{"count":1}""",
+                _ when pathAndQuery.Contains("resultOffset=0", StringComparison.Ordinal) => """
+                    {
+                      "features": [
+                        {
+                          "attributes": { "OBJECTID": 1, "name": "Alpha", "status": "A", "score": 42 },
+                          "geometry": { "x": -157.1, "y": 21.3 }
+                        }
+                      ],
+                      "exceededTransferLimit": false,
+                      "spatialReference": { "wkid": 4326 }
+                    }
+                    """,
+                _ when pathAndQuery.Contains("resultOffset=", StringComparison.Ordinal) => """
+                    {
+                      "features": [],
+                      "exceededTransferLimit": false,
+                      "spatialReference": { "wkid": 4326 }
+                    }
+                    """,
+                _ => throw new InvalidOperationException($"Unexpected ArcGIS request path: {pathAndQuery}")
+            };
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class FixtureConnectionProvider(PostgresFixture postgresFixture) : IDatabaseConnectionProvider
+    {
+        // The publishing service opens a raw connection from this string and references
+        // the shared 'features' table unqualified; route the search path to the 'honua'
+        // catalog schema so that resolves (the data table is always schema-qualified).
+        public string GetConnectionString()
+            => new Npgsql.NpgsqlConnectionStringBuilder(postgresFixture.ConnectionString)
+            {
+                SearchPath = "honua,public"
+            }.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+            => await postgresFixture.DataSource.OpenConnectionAsync(cancellationToken);
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var connection = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var transaction = await connection.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (connection, transaction);
+            }
+            catch
+            {
+                await connection.DisposeAsync();
+                throw;
+            }
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(
+            Func<Task<T>> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(
+            Func<Task> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #1255

References epic #1254 and the migration-fidelity plan in #1244.

## Summary
Esri coded-value and range domains were captured into the import inventory artifact but dropped at publish: the publish-path field builder never set `MetadataV2Field.Domain`, so the metadata-v2 graph (and therefore the FeatureServer field `domain` and `queryDomains` surfaces, which read it) served no domains. This PR carries the captured domains through import → publish into `MetadataV2Field.Domain`, so they persist into the graph, survive the compat-compile snapshot, and are served.

## Changes Made
- Add `EsriFieldDomainParser` (`Honua.Core`) as the single source of truth for capturing Esri coded-value and range domains into the canonical `MetadataV2FieldDomain`, applying the shared 100-entry `CodedValueDomainCap`.
- Capture the canonical domain on `GeoservicesFieldInfo` during ArcGIS field parsing (`ArcGisRestClient.ParseFields`) and carry it through a new `LayerPublishRequest.FieldDomains` map into the publish-path field builder. `BuildLayerFields` attaches the domain per column and `MapLayerFieldToMetadataV2` now sets `MetadataV2Field.Domain` — the concrete gap.
- Reuse the shared cap constant in the inventory extraction path (`GeoservicesImportService.Metadata.cs`) so capture and persistence agree on cap semantics.
- Cap handling: a coded-value domain larger than 100 entries is reported as truncated and **not** persisted (never a partial/misleading lookup), matching the existing inventory truncation warning. Range and at-or-under-cap coded-value domains persist fully. This keeps persistence consistent with the capped inventory artifact so large domains don't later false-fail reconciliation.

## Testing
- [x] Unit tests added/updated — `EsriFieldDomainParserTests` (coded-value, range, cap boundary, over-cap truncation, no-domain).
- [x] Integration tests added/updated — `GeoservicesImportDomainPersistenceTests` (Testcontainers + PostGIS): imports a layer with a coded-value domain and a range domain with AutoPublish, then asserts the domains survive into the activated (compat-compiled) Metadata v2 graph and the `queryDomains` projection (`SchemaFields` where `Domain is not null`), while a domain-free field stays domain-free.
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

The served FeatureServer field `domain` and `queryDomains` shapes are unchanged; they now carry real definitions instead of being empty. `LayerPublishRequest.FieldDomains` is an additive, optional input.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
