### PR TITLE
feat: OIDC-backed portal credential verifier + RBAC access projection (#1370)

### DIFF
--- a/src/Honua.Core/Features/Authorization/Abstractions/IPortalAccessProjection.cs
+++ b/src/Honua.Core/Features/Authorization/Abstractions/IPortalAccessProjection.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Security.Domain;
+
+namespace Honua.Core.Features.Authorization.Abstractions;
+
+/// <summary>
+/// The single shared projection (#1370) that turns a canonical authorization
+/// outcome into the ArcGIS Portal facade's notion of item/service
+/// <see cref="PortalAccessLevel"/> and per-principal visibility.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the seam consumed by both the Portal/Sharing read surface (#1243) and
+/// the OAuth2 named-user bridge (#1242). Implementing it once here guarantees the
+/// <c>access</c> a Portal item reports always reflects the real RBAC decision
+/// (<see cref="IPermissionResolver"/>) and the coarse <c>AccessPolicy</c> seam
+/// (#349) — no parallel ACL model is introduced.
+/// </para>
+/// <para>
+/// The projection is intentionally pure: it operates on resolved
+/// <see cref="AccessPolicy"/> values and a precomputed
+/// <see cref="PermissionDecision"/>, so it carries no <c>HttpContext</c> or
+/// provider dependency and is safe to call from any protocol slice.
+/// </para>
+/// </remarks>
+public interface IPortalAccessProjection
+{
+    /// <summary>
+    /// Gets a value indicating whether the Portal access projection is enabled.
+    /// When <see langword="false"/> the facade must not surface a discovery
+    /// surface and consumers should treat every item as not visible.
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
+    /// Projects the effective access policy of a resource onto the Portal
+    /// <see cref="PortalAccessLevel"/>. This is the level reported on the item
+    /// regardless of who is asking (Esri's <c>access</c> field).
+    /// </summary>
+    /// <param name="layerPolicy">The resource (layer/item) access policy, or
+    /// <see langword="null"/> when none is configured.</param>
+    /// <param name="servicePolicy">The owning service access policy, or
+    /// <see langword="null"/>.</param>
+    /// <returns>The projected access level.</returns>
+    PortalAccessLevel ProjectAccessLevel(AccessPolicy? layerPolicy, AccessPolicy? servicePolicy);
+
+    /// <summary>
+    /// Computes whether a specific principal may see/open a Portal item, folding
+    /// the per-operation RBAC decision over the coarse access policy. This is the
+    /// per-item visibility used to filter <c>search</c> results and authorize
+    /// <c>content/items/{id}</c>.
+    /// </summary>
+    /// <param name="grantDecision">The per-operation decision produced by
+    /// <see cref="IPermissionResolver"/> for the (principal, service, layer,
+    /// query) tuple, or <see langword="null"/> when no resolver was consulted.</param>
+    /// <param name="coarseDecision">The coarse <see cref="AccessDecision"/> from
+    /// the <c>AccessPolicy</c> seam for the same principal/resource.</param>
+    /// <returns>The resolved item visibility for the principal.</returns>
+    PortalItemVisibility ProjectVisibility(PermissionDecision? grantDecision, AccessDecision coarseDecision);
+}
+
+/// <summary>
+/// The per-principal visibility of a Portal item, the projection of an
+/// authorization decision onto the facade's discovery/open semantics.
+/// </summary>
+/// <param name="IsVisible"><see langword="true"/> when the principal may see the
+/// item in listings and open its metadata.</param>
+/// <param name="RequiresAuthentication"><see langword="true"/> when the item is
+/// hidden only because the caller is anonymous and authenticating could reveal
+/// it; lets the facade emit a 401 challenge rather than silently omitting it.</param>
+public readonly record struct PortalItemVisibility(bool IsVisible, bool RequiresAuthentication)
+{
+    /// <summary>Item is visible to the principal.</summary>
+    public static PortalItemVisibility Visible => new(true, false);
+
+    /// <summary>Item is hidden; the principal is forbidden.</summary>
+    public static PortalItemVisibility Hidden => new(false, false);
+
+    /// <summary>Item is hidden because authentication is required first.</summary>
+    public static PortalItemVisibility AuthenticationRequired => new(false, true);
+}

--- a/src/Honua.Core/Features/Authorization/Domain/PortalAccessLevel.cs
+++ b/src/Honua.Core/Features/Authorization/Domain/PortalAccessLevel.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Authorization.Domain;
+
+/// <summary>
+/// The ArcGIS Portal/Sharing notion of item and service <c>access</c> (#1370).
+/// This is a projection of the canonical RBAC decision
+/// (<see cref="PermissionDecision"/>) and the coarse
+/// <c>AccessPolicy</c> seam onto the three values Esri clients expect from a
+/// Portal facade; it is <b>not</b> a new access-control model.
+/// </summary>
+/// <remarks>
+/// The string forms (<see cref="PortalAccessLevelExtensions.ToWireName"/>) are
+/// the exact lowercase tokens ArcGIS Pro / Field Maps expect in
+/// <c>content/items/{id}</c> and <c>search</c> responses. The shared
+/// <c>IPortalAccessProjection</c> is the single helper the Portal read surface
+/// (#1243) and the OAuth2 bridge (#1242) consume so the reported access never
+/// drifts from the real authorization decision.
+/// </remarks>
+public enum PortalAccessLevel
+{
+    /// <summary>
+    /// Visible only to the owner / explicitly granted principals; anonymous and
+    /// general authenticated users cannot see or open the item (wire name
+    /// <c>"private"</c>).
+    /// </summary>
+    Private = 0,
+
+    /// <summary>
+    /// Visible to authenticated members of the organization (any signed-in
+    /// principal that the policy/grant authorizes), but not to anonymous callers
+    /// (wire name <c>"org"</c>).
+    /// </summary>
+    Organization = 1,
+
+    /// <summary>
+    /// Visible to everyone, including anonymous callers (wire name
+    /// <c>"public"</c>).
+    /// </summary>
+    Public = 2,
+}
+
+/// <summary>
+/// Wire-name helpers for <see cref="PortalAccessLevel"/>.
+/// </summary>
+public static class PortalAccessLevelExtensions
+{
+    /// <summary>
+    /// Returns the lowercase ArcGIS Portal wire token for an access level
+    /// (<c>"private"</c>, <c>"org"</c>, or <c>"public"</c>).
+    /// </summary>
+    /// <param name="level">The access level.</param>
+    /// <returns>The Esri-compatible wire token.</returns>
+    public static string ToWireName(this PortalAccessLevel level) => level switch
+    {
+        PortalAccessLevel.Public => "public",
+        PortalAccessLevel.Organization => "org",
+        _ => "private",
+    };
+}

--- a/src/Honua.Core/Features/Authorization/PortalAccessProjection.cs
+++ b/src/Honua.Core/Features/Authorization/PortalAccessProjection.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Security.Domain;
+
+namespace Honua.Core.Features.Authorization;
+
+/// <summary>
+/// Default <see cref="IPortalAccessProjection"/> (#1370): a pure projection from
+/// the canonical RBAC decision and the coarse <see cref="AccessPolicy"/> seam onto
+/// the ArcGIS Portal <see cref="PortalAccessLevel"/> and per-item visibility.
+/// </summary>
+/// <remarks>
+/// <para>Access-level rules (most-open wins between layer and service policy):</para>
+/// <list type="bullet">
+/// <item>Anonymous read allowed (<see cref="AccessPolicy.AllowAnonymous"/>) projects
+/// to <see cref="PortalAccessLevel.Public"/>.</item>
+/// <item>Authenticated access with no role restriction
+/// (<see cref="AccessPolicy.AllowedRoles"/> empty/absent) projects to
+/// <see cref="PortalAccessLevel.Organization"/> — any signed-in org member.</item>
+/// <item>Access restricted to specific roles (or no policy at all) projects to
+/// <see cref="PortalAccessLevel.Private"/>.</item>
+/// </list>
+/// <para>
+/// Visibility folds the per-operation grant over the coarse decision: an explicit
+/// <see cref="PermissionResult.Allow"/> grant makes the item visible; otherwise the
+/// coarse <see cref="AccessDecision"/> governs, mapping
+/// <see cref="AccessDecision.RequiresAuthentication"/> to an authentication
+/// challenge so anonymous callers can sign in rather than silently losing the item.
+/// </para>
+/// </remarks>
+public sealed class PortalAccessProjection : IPortalAccessProjection
+{
+    private readonly bool _enabled;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PortalAccessProjection"/> class.
+    /// </summary>
+    /// <param name="enabled">
+    /// Whether the Portal access projection is enabled. Defaults to
+    /// <see langword="false"/> so the facade stays off-by-default and never
+    /// exposes a discovery surface unless an operator opts in (#1370).
+    /// </param>
+    public PortalAccessProjection(bool enabled = false)
+    {
+        _enabled = enabled;
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabled => _enabled;
+
+    /// <inheritdoc />
+    public PortalAccessLevel ProjectAccessLevel(AccessPolicy? layerPolicy, AccessPolicy? servicePolicy)
+    {
+        var layer = ProjectSingle(layerPolicy);
+        var service = ProjectSingle(servicePolicy);
+
+        // A layer can only narrow what the service exposes: the effective level is
+        // the more restrictive of the two when both are configured. When the layer
+        // has no policy of its own it inherits the service level.
+        if (layerPolicy is null)
+        {
+            return service;
+        }
+
+        if (servicePolicy is null)
+        {
+            return layer;
+        }
+
+        return layer < service ? layer : service;
+    }
+
+    /// <inheritdoc />
+    public PortalItemVisibility ProjectVisibility(PermissionDecision? grantDecision, AccessDecision coarseDecision)
+    {
+        // An explicit per-operation grant authorizes discovery/open directly.
+        if (grantDecision is { Result: PermissionResult.Allow })
+        {
+            return PortalItemVisibility.Visible;
+        }
+
+        // The resolver can also surface a hard "authenticate first" signal for an
+        // anonymous principal even before the coarse policy is consulted.
+        if (grantDecision is { Result: PermissionResult.RequiresAuthentication })
+        {
+            return PortalItemVisibility.AuthenticationRequired;
+        }
+
+        // No matching grant (or resolver not consulted): the coarse policy governs.
+        if (coarseDecision.IsAllowed)
+        {
+            return PortalItemVisibility.Visible;
+        }
+
+        return coarseDecision.RequiresAuthentication
+            ? PortalItemVisibility.AuthenticationRequired
+            : PortalItemVisibility.Hidden;
+    }
+
+    private static PortalAccessLevel ProjectSingle(AccessPolicy? policy)
+    {
+        if (policy is null)
+        {
+            // No policy means the resource is not exposed publicly; the facade
+            // treats it as owner/grant-only until a policy opens it.
+            return PortalAccessLevel.Private;
+        }
+
+        if (policy.AllowAnonymous)
+        {
+            return PortalAccessLevel.Public;
+        }
+
+        // Authenticated access with no role restriction is "org": any signed-in
+        // member of the organization may read it.
+        var hasRoleRestriction = policy.AllowedRoles is { Length: > 0 };
+        return hasRoleRestriction ? PortalAccessLevel.Private : PortalAccessLevel.Organization;
+    }
+}

--- a/src/Honua.Hosting/Features/Authentication/CompositePortalCredentialVerifier.cs
+++ b/src/Honua.Hosting/Features/Authentication/CompositePortalCredentialVerifier.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Authorization.Abstractions;
+
+namespace Honua.Infrastructure.Authentication;
+
+/// <summary>
+/// Chains <see cref="IPortalCredentialVerifier"/> implementations, returning the
+/// first non-null projection (#1370). Used when the OIDC-backed verifier is enabled
+/// with admin fallback so a named-user OIDC token <i>and</i> an admin password /
+/// admin API key can both authenticate against <c>/sharing/rest/generateToken</c>.
+/// </summary>
+internal sealed class CompositePortalCredentialVerifier : IPortalCredentialVerifier
+{
+    private readonly IReadOnlyList<IPortalCredentialVerifier> _verifiers;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CompositePortalCredentialVerifier"/> class.
+    /// </summary>
+    /// <param name="verifiers">The verifiers to consult in order; the first that
+    /// returns a non-null principal wins.</param>
+    public CompositePortalCredentialVerifier(params IPortalCredentialVerifier[] verifiers)
+    {
+        ArgumentNullException.ThrowIfNull(verifiers);
+        _verifiers = verifiers;
+    }
+
+    /// <inheritdoc />
+    public async Task<PortalCredentialPrincipal?> VerifyAsync(
+        string username,
+        string password,
+        CancellationToken cancellationToken)
+    {
+        foreach (var verifier in _verifiers)
+        {
+            var result = await verifier.VerifyAsync(username, password, cancellationToken).ConfigureAwait(false);
+            if (result is not null)
+            {
+                return result;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Honua.Hosting/Features/Authentication/OidcAuthenticationLog.cs
+++ b/src/Honua.Hosting/Features/Authentication/OidcAuthenticationLog.cs
@@ -134,4 +134,24 @@ internal static partial class OidcAuthenticationLog
         Message = "OIDC token replay protection is enabled but no replay cache is available. Allowing token to avoid permanent lockout.")]
     public static partial void TokenReplayCacheUnavailable(ILogger logger);
 
+    /// <summary>
+    /// Logs when the OIDC-backed portal credential verifier rejects a named-user
+    /// login (#1370).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 4215,
+        Level = LogLevel.Information,
+        Message = "Portal named-user credential rejected by OIDC verifier: {Reason}")]
+    public static partial void PortalCredentialRejected(ILogger logger, string reason);
+
+    /// <summary>
+    /// Logs when OIDC discovery metadata cannot be retrieved during portal
+    /// credential verification (#1370).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 4216,
+        Level = LogLevel.Warning,
+        Message = "OIDC discovery metadata unavailable for portal credential verification: {Reason}")]
+    public static partial void PortalCredentialMetadataUnavailable(ILogger logger, string reason);
+
 }

--- a/src/Honua.Hosting/Features/Authentication/OidcPortalCredentialVerifier.cs
+++ b/src/Honua.Hosting/Features/Authentication/OidcPortalCredentialVerifier.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using Honua.Core.Features.Authorization.Abstractions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Honua.Infrastructure.Authentication;
+
+/// <summary>
+/// OIDC-backed <see cref="IPortalCredentialVerifier"/> (#1370). A Portal named-user
+/// login presents an OIDC token (id/access JWT issued by the operator's IdP) as the
+/// <c>password</c> to <c>/sharing/rest/generateToken</c>; this verifier validates it
+/// against the shared OIDC core (#348) and projects the resulting
+/// <see cref="ClaimsPrincipal"/> onto a <see cref="PortalCredentialPrincipal"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Authentication therefore routes through the same identity pipeline as a direct
+/// OIDC session: the token is validated with
+/// <see cref="OidcTokenValidationParametersFactory"/> (the JwtBearer scheme's
+/// issuer/audience/signing rules) and the claims are normalized by the shared
+/// <see cref="OidcClaimsTransformation"/>. No Portal-local user store is introduced.
+/// </para>
+/// <para>
+/// This avoids the deprecated Resource-Owner-Password-Credentials grant (which most
+/// IdPs disable): the client obtains its token from the IdP via the normal OIDC
+/// flow and relays it through <c>generateToken</c>. The issued portal token then
+/// carries the same <c>PrincipalId</c>/<c>TenantId</c>/<c>Roles</c>, so
+/// <c>AccessPolicyHelpers</c>/<c>IPermissionResolver</c> (#349) reach the identical
+/// RBAC decision.
+/// </para>
+/// </remarks>
+internal sealed class OidcPortalCredentialVerifier : IPortalCredentialVerifier
+{
+    private const string TenantIdClaimType = "tenant_id";
+    private const string AzureTenantClaimType = "tid";
+
+    private readonly OidcAuthenticationOptions _oidcOptions;
+    private readonly IClaimsTransformation _claimsTransformation;
+    private readonly ILogger<OidcPortalCredentialVerifier> _logger;
+    private readonly TokenValidationParameters _baseParameters;
+    private readonly ConfigurationManager<OpenIdConnectConfiguration>? _configurationManager;
+    private readonly JsonWebTokenHandler _handler = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OidcPortalCredentialVerifier"/> class.
+    /// </summary>
+    /// <param name="oidcOptions">The OIDC authentication options.</param>
+    /// <param name="claimsTransformation">The shared OIDC claims transformation
+    /// used to normalize provider claims into application claims.</param>
+    /// <param name="logger">Diagnostics logger.</param>
+    public OidcPortalCredentialVerifier(
+        IOptions<OidcAuthenticationOptions> oidcOptions,
+        IClaimsTransformation claimsTransformation,
+        ILogger<OidcPortalCredentialVerifier> logger)
+    {
+        ArgumentNullException.ThrowIfNull(oidcOptions);
+        _oidcOptions = oidcOptions.Value ?? throw new ArgumentNullException(nameof(oidcOptions));
+        _claimsTransformation = claimsTransformation ?? throw new ArgumentNullException(nameof(claimsTransformation));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var (parameters, authority) = OidcTokenValidationParametersFactory.Build(_oidcOptions);
+        _baseParameters = parameters;
+
+        if (!string.IsNullOrWhiteSpace(authority))
+        {
+            var metadataAddress = authority.TrimEnd('/') + "/.well-known/openid-configuration";
+            _configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                metadataAddress,
+                new OpenIdConnectConfigurationRetriever(),
+                new HttpDocumentRetriever { RequireHttps = _oidcOptions.RequireHttps });
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<PortalCredentialPrincipal?> VerifyAsync(
+        string username,
+        string password,
+        CancellationToken cancellationToken)
+    {
+        if (!_oidcOptions.Enabled || string.IsNullOrWhiteSpace(password))
+        {
+            return null;
+        }
+
+        var parameters = await ResolveParametersAsync(cancellationToken).ConfigureAwait(false);
+        if (parameters is null)
+        {
+            return null;
+        }
+
+        var result = await _handler.ValidateTokenAsync(password, parameters).ConfigureAwait(false);
+        if (!result.IsValid || result.ClaimsIdentity is null)
+        {
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+#pragma warning disable CA1873 // Reason string only evaluated inside the IsEnabled gate above.
+                OidcAuthenticationLog.PortalCredentialRejected(_logger, result.Exception?.GetType().Name ?? "invalid token");
+#pragma warning restore CA1873
+            }
+
+            return null;
+        }
+
+        // Normalize provider claims through the shared OIDC transformation so the
+        // projected roles/name match a direct OIDC session exactly.
+        var principal = new ClaimsPrincipal(result.ClaimsIdentity);
+        principal = await _claimsTransformation.TransformAsync(principal).ConfigureAwait(false);
+
+        var principalId = principal.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? principal.FindFirstValue("sub")
+            ?? principal.FindFirstValue("oid")
+            ?? (string.IsNullOrWhiteSpace(username) ? null : username);
+
+        if (string.IsNullOrWhiteSpace(principalId))
+        {
+            OidcAuthenticationLog.PortalCredentialRejected(_logger, "no subject claim");
+            return null;
+        }
+
+        var displayName = principal.FindFirstValue(ClaimTypes.Name)
+            ?? principal.FindFirstValue("name")
+            ?? principal.FindFirstValue("preferred_username");
+
+        var tenantId = principal.FindFirstValue(TenantIdClaimType)
+            ?? principal.FindFirstValue(AzureTenantClaimType);
+
+        var roles = principal.FindAll(ClaimTypes.Role)
+            .Select(static c => c.Value)
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return new PortalCredentialPrincipal(principalId, displayName, tenantId, roles);
+    }
+
+    private async Task<TokenValidationParameters?> ResolveParametersAsync(CancellationToken cancellationToken)
+    {
+        if (_configurationManager is null)
+        {
+            // Static symmetric signing key path: the base parameters already carry
+            // the issuer signing key and need no metadata discovery.
+            return _baseParameters.IssuerSigningKey is null ? null : _baseParameters;
+        }
+
+        OpenIdConnectConfiguration configuration;
+        try
+        {
+            configuration = await _configurationManager.GetConfigurationAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            OidcAuthenticationLog.PortalCredentialMetadataUnavailable(_logger, ex.Message);
+            return null;
+        }
+
+        var parameters = _baseParameters.Clone();
+        parameters.IssuerSigningKeys = configuration.SigningKeys;
+        if (parameters.ValidIssuers is null || !parameters.ValidIssuers.Any())
+        {
+            parameters.ValidIssuer = configuration.Issuer;
+        }
+
+        return parameters;
+    }
+}

--- a/src/Honua.Hosting/Features/Authentication/OidcTokenValidationParametersFactory.cs
+++ b/src/Honua.Hosting/Features/Authentication/OidcTokenValidationParametersFactory.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+
+namespace Honua.Infrastructure.Authentication;
+
+/// <summary>
+/// Builds <see cref="TokenValidationParameters"/> from
+/// <see cref="OidcAuthenticationOptions"/> so server-side OIDC token validation
+/// (the named-user portal credential verifier, #1370) uses the same issuer,
+/// audience, signing-key, and claims-mapping rules as the interactive JwtBearer
+/// scheme configured in <see cref="OidcAuthenticationExtensions"/>.
+/// </summary>
+/// <remarks>
+/// Centralizing the rules keeps the portal verifier's decision identical to a
+/// direct OIDC Bearer session: the issuers/audiences derived here mirror
+/// <c>ConfigureJwtBearerAuthentication</c>. The authority returned alongside the
+/// parameters is the metadata endpoint the caller should configure on a
+/// <c>ConfigurationManager&lt;OpenIdConnectConfiguration&gt;</c> for signing-key
+/// discovery when no static symmetric key is set.
+/// </remarks>
+internal static class OidcTokenValidationParametersFactory
+{
+    /// <summary>
+    /// Builds validation parameters and resolves the metadata authority.
+    /// </summary>
+    /// <param name="options">The OIDC authentication options.</param>
+    /// <returns>The validation parameters and the resolved authority (or
+    /// <see langword="null"/> when a static symmetric signing key is configured
+    /// and metadata discovery is not required).</returns>
+    public static (TokenValidationParameters Parameters, string? Authority) Build(OidcAuthenticationOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var parameters = new TokenValidationParameters
+        {
+            ValidateIssuer = options.TokenValidation.ValidateIssuer,
+            ValidateAudience = options.TokenValidation.ValidateAudience,
+            ValidateLifetime = options.TokenValidation.ValidateLifetime,
+            ValidateIssuerSigningKey = options.TokenValidation.ValidateIssuerSigningKey,
+            ClockSkew = options.TokenValidation.ClockSkew,
+            NameClaimType = options.ClaimsMapping.NameClaimType,
+            RoleClaimType = options.ClaimsMapping.RoleClaimType,
+        };
+
+        parameters.ValidIssuers = BuildIssuers(options);
+        parameters.ValidAudiences = BuildAudiences(options);
+
+        var staticSigningKey = options.TokenValidation.SymmetricSigningKey;
+        if (!string.IsNullOrWhiteSpace(staticSigningKey))
+        {
+            parameters.IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(staticSigningKey));
+            return (parameters, null);
+        }
+
+        return (parameters, ResolveAuthority(options));
+    }
+
+    private static string[] BuildIssuers(OidcAuthenticationOptions options)
+    {
+        var issuers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (options.AzureAd?.IsValid == true)
+        {
+            var tenantId = options.AzureAd.TenantId!;
+            issuers.Add($"{options.AzureAd.Instance}{tenantId}/v2.0");
+            issuers.Add($"https://sts.windows.net/{tenantId}/");
+        }
+
+        if (options.Google?.IsValid == true)
+        {
+            issuers.Add("https://accounts.google.com");
+        }
+
+        if (options.Generic?.IsValid == true && !string.IsNullOrEmpty(options.Generic.Authority))
+        {
+            issuers.Add(options.Generic.Authority);
+        }
+
+        if (options.Okta?.IsValid == true)
+        {
+            issuers.Add(options.Okta.GetAuthority());
+        }
+
+        if (options.Auth0?.IsValid == true)
+        {
+            issuers.Add(options.Auth0.GetAuthority());
+        }
+
+        foreach (var issuer in options.TokenValidation.ValidIssuers)
+        {
+            issuers.Add(issuer);
+        }
+
+        return [.. issuers];
+    }
+
+    private static string[] BuildAudiences(OidcAuthenticationOptions options)
+    {
+        var audiences = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (options.AzureAd?.IsValid == true)
+        {
+            var clientId = options.AzureAd.ClientId!;
+            audiences.Add(clientId);
+            audiences.Add($"api://{clientId}");
+        }
+
+        if (options.Google?.IsValid == true)
+        {
+            audiences.Add(options.Google.ClientId!);
+        }
+
+        if (options.Generic?.IsValid == true)
+        {
+            audiences.Add(options.Generic.ClientId!);
+        }
+
+        if (options.Okta?.IsValid == true)
+        {
+            audiences.Add(options.Okta.ClientId!);
+        }
+
+        if (options.Auth0?.IsValid == true)
+        {
+            audiences.Add(options.Auth0.ClientId!);
+            if (!string.IsNullOrWhiteSpace(options.Auth0.Audience))
+            {
+                audiences.Add(options.Auth0.Audience);
+            }
+        }
+
+        foreach (var audience in options.TokenValidation.ValidAudiences)
+        {
+            audiences.Add(audience);
+        }
+
+        return [.. audiences];
+    }
+
+    private static string? ResolveAuthority(OidcAuthenticationOptions options)
+    {
+        if (options.AzureAd?.IsValid == true)
+        {
+            return $"{options.AzureAd.Instance}{options.AzureAd.TenantId}/v2.0";
+        }
+
+        if (options.Generic?.IsValid == true)
+        {
+            return options.Generic.Authority;
+        }
+
+        if (options.Okta?.IsValid == true)
+        {
+            return options.Okta.GetAuthority();
+        }
+
+        if (options.Auth0?.IsValid == true)
+        {
+            return options.Auth0.GetAuthority();
+        }
+
+        if (options.Google?.IsValid == true)
+        {
+            return "https://accounts.google.com";
+        }
+
+        return null;
+    }
+}

--- a/src/Honua.Hosting/Features/Authentication/PortalCredentialVerifierOptions.cs
+++ b/src/Honua.Hosting/Features/Authentication/PortalCredentialVerifierOptions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Authentication;
+
+/// <summary>
+/// Selects and configures the <c>IPortalCredentialVerifier</c> used by the
+/// ArcGIS-compatible <c>/sharing/rest/generateToken</c> endpoint (#1370).
+/// </summary>
+/// <remarks>
+/// The default verifier remains <c>AdminPortalCredentialVerifier</c> (admin
+/// password / admin API key) — the community/fallback option. Operators that run
+/// an external IdP can opt into the OIDC-backed verifier, which authenticates a
+/// named-user login against the shared OIDC core (#348) instead of a Portal-local
+/// user store. Both projections feed the same <c>IPortalTokenIssuer</c>, so the
+/// hydrated principal yields the same RBAC decision as a direct OIDC session.
+/// </remarks>
+public sealed class PortalCredentialVerifierOptions
+{
+    /// <summary>
+    /// Configuration section binding root.
+    /// </summary>
+    public const string SectionName = "Authentication:PortalCredentialVerifier";
+
+    /// <summary>
+    /// Whether the OIDC-backed verifier is enabled. Defaults to
+    /// <see langword="false"/> so the admin verifier stays the default and named-
+    /// user OIDC login is strictly opt-in (#1370 acceptance criteria).
+    /// </summary>
+    public bool UseOidc { get; set; }
+
+    /// <summary>
+    /// When the OIDC verifier is enabled, whether to fall back to the admin
+    /// verifier if the supplied credential is not a valid OIDC token. Defaults to
+    /// <see langword="true"/> so an operator can keep admin/API-key access working
+    /// alongside named-user login during a migration.
+    /// </summary>
+    public bool FallBackToAdminVerifier { get; set; } = true;
+}

--- a/src/Honua.Hosting/Features/Authentication/PortalTokenAuthenticationExtensions.cs
+++ b/src/Honua.Hosting/Features/Authentication/PortalTokenAuthenticationExtensions.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Authorization;
 using Honua.Core.Features.Authorization.Abstractions;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Infrastructure.Authentication;
@@ -44,8 +46,14 @@ public static class PortalTokenAuthenticationExtensions
             .Bind(configuration.GetSection(PortalTokenAuthenticationOptions.SectionName))
             .ValidateOnStart();
 
+        services
+            .AddOptions<PortalCredentialVerifierOptions>()
+            .Bind(configuration.GetSection(PortalCredentialVerifierOptions.SectionName))
+            .ValidateOnStart();
+
         services.TryAddSingletonPortalTokenIssuer();
-        services.TryAddDefaultPortalCredentialVerifier();
+        services.TryAddPortalCredentialVerifier();
+        services.TryAddPortalAccessProjection(configuration);
 
         services.AddAuthentication()
             .AddScheme<AuthenticationSchemeOptions, PortalTokenAuthenticationHandler>(
@@ -77,13 +85,62 @@ public static class PortalTokenAuthenticationExtensions
         }
     }
 
-    private static void TryAddDefaultPortalCredentialVerifier(this IServiceCollection services)
+    private static void TryAddPortalCredentialVerifier(this IServiceCollection services)
     {
-        if (!services.Any(d => d.ServiceType == typeof(IPortalCredentialVerifier)))
+        if (services.Any(d => d.ServiceType == typeof(IPortalCredentialVerifier)))
         {
-            services.AddScoped<IPortalCredentialVerifier, AdminPortalCredentialVerifier>();
+            // An operator-supplied custom verifier takes precedence over the
+            // built-in admin/OIDC selection.
+            return;
         }
+
+        // The admin verifier (admin password / admin API key) remains the default
+        // and community option. The OIDC-backed verifier is opt-in and, when
+        // enabled, may fall back to the admin verifier so admin/API-key access
+        // keeps working alongside named-user login.
+        services.AddScoped<AdminPortalCredentialVerifier>();
+        services.AddScoped<OidcPortalCredentialVerifier>();
+        services.AddScoped<IPortalCredentialVerifier>(static provider =>
+        {
+            var options = provider.GetRequiredService<IOptions<PortalCredentialVerifierOptions>>().Value;
+            var admin = provider.GetRequiredService<AdminPortalCredentialVerifier>();
+
+            if (!options.UseOidc)
+            {
+                return admin;
+            }
+
+            var oidc = provider.GetRequiredService<OidcPortalCredentialVerifier>();
+            return options.FallBackToAdminVerifier
+                ? new CompositePortalCredentialVerifier(oidc, admin)
+                : oidc;
+        });
     }
+
+    private static void TryAddPortalAccessProjection(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.TryAddSingleton<IPortalAccessProjection>(_ =>
+        {
+            // The Portal access/visibility projection is off-by-default so the
+            // facade never exposes a discovery surface unless an operator opts in,
+            // consistent with the entitlement-gated generateToken surface (#1370).
+            var enabled = configuration.GetValue(
+                $"{PortalAccessProjectionConfiguration.SectionName}:Enabled",
+                defaultValue: false);
+            return new PortalAccessProjection(enabled);
+        });
+    }
+}
+
+/// <summary>
+/// Configuration keys for the Portal access/visibility projection (#1370).
+/// </summary>
+public static class PortalAccessProjectionConfiguration
+{
+    /// <summary>
+    /// Configuration section binding root for the projection gate.
+    /// </summary>
+    public const string SectionName = "Authentication:PortalAccessProjection";
 }
 
 /// <summary>

--- a/tests/dotnet/Honua.Core.Tests/Features/Authorization/PortalAccessProjectionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Authorization/PortalAccessProjectionTests.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Authorization;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Security.Domain;
+
+namespace Honua.Core.Tests.Features.Authorization;
+
+/// <summary>
+/// Unit tests for <see cref="PortalAccessProjection"/> — the shared seam (#1370)
+/// that turns a canonical RBAC decision and the coarse <see cref="AccessPolicy"/>
+/// into the ArcGIS Portal <see cref="PortalAccessLevel"/> and per-item visibility
+/// consumed by the read surface (#1243) and OAuth2 bridge (#1242). Locks in the
+/// access-level mapping, the layer-narrows-service rule, the grant-over-policy
+/// visibility fold, and the off-by-default gate.
+/// </summary>
+public sealed class PortalAccessProjectionTests
+{
+    private static readonly PortalAccessProjection Enabled = new(enabled: true);
+
+    private static PermissionDecision Allow()
+        => PermissionDecision.Allow(new PermissionGrant { Service = "svc", Layer = "*", Operation = "query" });
+
+    [Fact]
+    public void IsEnabled_DefaultsToFalse_SoTheFacadeStaysOffByDefault()
+    {
+        var projection = new PortalAccessProjection();
+
+        projection.IsEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ProjectAccessLevel_AnonymousReadAllowed_IsPublic()
+    {
+        var policy = new AccessPolicy { AllowAnonymous = true };
+
+        Enabled.ProjectAccessLevel(policy, null).Should().Be(PortalAccessLevel.Public);
+    }
+
+    [Fact]
+    public void ProjectAccessLevel_AuthenticatedNoRoleRestriction_IsOrg()
+    {
+        var policy = new AccessPolicy { AllowAnonymous = false };
+
+        Enabled.ProjectAccessLevel(policy, null).Should().Be(PortalAccessLevel.Organization);
+    }
+
+    [Fact]
+    public void ProjectAccessLevel_RoleRestricted_IsPrivate()
+    {
+        var policy = new AccessPolicy { AllowAnonymous = false, AllowedRoles = ["editor"] };
+
+        Enabled.ProjectAccessLevel(policy, null).Should().Be(PortalAccessLevel.Private);
+    }
+
+    [Fact]
+    public void ProjectAccessLevel_NoPolicyAtAll_IsPrivate()
+    {
+        Enabled.ProjectAccessLevel(null, null).Should().Be(PortalAccessLevel.Private);
+    }
+
+    [Fact]
+    public void ProjectAccessLevel_LayerNarrowsService_TakesMoreRestrictiveLevel()
+    {
+        var service = new AccessPolicy { AllowAnonymous = true }; // public
+        var layer = new AccessPolicy { AllowAnonymous = false, AllowedRoles = ["editor"] }; // private
+
+        Enabled.ProjectAccessLevel(layer, service).Should().Be(PortalAccessLevel.Private);
+    }
+
+    [Fact]
+    public void ProjectAccessLevel_LayerWithoutPolicy_InheritsServiceLevel()
+    {
+        var service = new AccessPolicy { AllowAnonymous = true };
+
+        Enabled.ProjectAccessLevel(null, service).Should().Be(PortalAccessLevel.Public);
+    }
+
+    [Fact]
+    public void ProjectVisibility_ExplicitGrant_IsVisible()
+    {
+        var visibility = Enabled.ProjectVisibility(Allow(), AccessDecision.Forbidden());
+
+        visibility.IsVisible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ProjectVisibility_ResolverRequiresAuth_RequestsAuthentication()
+    {
+        var visibility = Enabled.ProjectVisibility(
+            PermissionDecision.RequiresAuthentication(),
+            AccessDecision.Forbidden());
+
+        visibility.IsVisible.Should().BeFalse();
+        visibility.RequiresAuthentication.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ProjectVisibility_NoGrant_FallsBackToCoarseAllow()
+    {
+        var visibility = Enabled.ProjectVisibility(PermissionDecision.NoMatch(), AccessDecision.Allowed());
+
+        visibility.IsVisible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ProjectVisibility_NoGrantAndCoarseRequiresAuth_RequestsAuthentication()
+    {
+        var visibility = Enabled.ProjectVisibility(null, AccessDecision.RequiresAuth());
+
+        visibility.IsVisible.Should().BeFalse();
+        visibility.RequiresAuthentication.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ProjectVisibility_NoGrantAndCoarseForbidden_IsHidden()
+    {
+        var visibility = Enabled.ProjectVisibility(null, AccessDecision.Forbidden());
+
+        visibility.IsVisible.Should().BeFalse();
+        visibility.RequiresAuthentication.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(PortalAccessLevel.Public, "public")]
+    [InlineData(PortalAccessLevel.Organization, "org")]
+    [InlineData(PortalAccessLevel.Private, "private")]
+    public void ToWireName_EmitsEsriTokens(PortalAccessLevel level, string expected)
+    {
+        level.ToWireName().Should().Be(expected);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/OidcPortalCredentialVerifierTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/OidcPortalCredentialVerifierTests.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using FluentAssertions;
+using Honua.Infrastructure.Authentication;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Honua.Server.Tests.Infrastructure.Authentication;
+
+/// <summary>
+/// Unit tests for <see cref="OidcPortalCredentialVerifier"/> — the OIDC-backed
+/// portal credential verifier (#1370). Proves a named-user OIDC token validated by
+/// the shared OIDC core projects onto the same <c>PrincipalId</c> / <c>DisplayName</c>
+/// / <c>TenantId</c> / <c>Roles</c> that a direct OIDC session yields, and that the
+/// verifier is off-by-default and rejects invalid tokens. Uses a static symmetric
+/// signing key so validation runs without IdP metadata discovery.
+/// </summary>
+[SecurityTest]
+[Protocol(TestProtocols.FeatureServer)]
+[Operation(Operations.Security)]
+public sealed class OidcPortalCredentialVerifierTests
+{
+    private const string SigningKey = "ThisIsATestSigningKeyThatIsLongEnoughForHS256Algorithm!";
+    private const string Issuer = "https://idp.example.com";
+    private const string Audience = "honua-portal-client";
+
+    [UnitTest]
+    public async Task VerifyAsync_ValidOidcToken_ProjectsPrincipalIdNameTenantAndRoles()
+    {
+        var verifier = CreateVerifier(enabled: true);
+        var token = CreateToken(
+            subject: "user-123",
+            name: "Ada Lovelace",
+            roles: ["editor", "viewer"],
+            tenantId: "tenant-A");
+
+        var result = await verifier.VerifyAsync("ada", token, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.PrincipalId.Should().Be("user-123");
+        result.DisplayName.Should().Be("Ada Lovelace");
+        result.TenantId.Should().Be("tenant-A");
+        result.Roles.Should().Contain("editor").And.Contain("viewer");
+    }
+
+    [UnitTest]
+    public async Task VerifyAsync_Disabled_ReturnsNull()
+    {
+        var verifier = CreateVerifier(enabled: false);
+        var token = CreateToken(subject: "user-123", name: "Ada", roles: ["editor"], tenantId: null);
+
+        var result = await verifier.VerifyAsync("ada", token, CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task VerifyAsync_WrongSigningKey_ReturnsNull()
+    {
+        var verifier = CreateVerifier(enabled: true);
+        var token = CreateToken(
+            subject: "user-123",
+            name: "Ada",
+            roles: ["editor"],
+            tenantId: null,
+            signingKey: "AnEntirelyDifferentSigningKeyThatIsAlsoLongEnoughForHS256!");
+
+        var result = await verifier.VerifyAsync("ada", token, CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task VerifyAsync_GarbageCredential_ReturnsNull()
+    {
+        var verifier = CreateVerifier(enabled: true);
+
+        var result = await verifier.VerifyAsync("ada", "not-a-jwt", CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    private static OidcPortalCredentialVerifier CreateVerifier(bool enabled)
+    {
+        var options = new OidcAuthenticationOptions
+        {
+            Enabled = enabled,
+            RequireHttps = false,
+            Generic = new GenericOidcProviderOptions
+            {
+                Enabled = true,
+                Authority = Issuer,
+                ClientId = Audience,
+            },
+            TokenValidation = new TokenValidationOptions
+            {
+                SymmetricSigningKey = SigningKey,
+                ValidIssuers = [Issuer],
+                ValidAudiences = [Audience],
+                // The replay/lifetime defaults are fine; metadata discovery is
+                // bypassed by the static symmetric key.
+            },
+        };
+
+        var wrapped = Options.Create(options);
+        var transformation = new OidcClaimsTransformation(wrapped, NullLogger<OidcClaimsTransformation>.Instance);
+        return new OidcPortalCredentialVerifier(
+            wrapped,
+            transformation,
+            NullLogger<OidcPortalCredentialVerifier>.Instance);
+    }
+
+    private static string CreateToken(
+        string subject,
+        string name,
+        string[] roles,
+        string? tenantId,
+        string? signingKey = null)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey ?? SigningKey));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var claims = new List<Claim>
+        {
+            new("sub", subject),
+            new("name", name),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+        };
+
+        foreach (var role in roles)
+        {
+            claims.Add(new Claim("roles", role));
+        }
+
+        if (tenantId is not null)
+        {
+            claims.Add(new Claim("tenant_id", tenantId));
+        }
+
+        var token = new JwtSecurityToken(
+            issuer: Issuer,
+            audience: Audience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(30),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #1370

## Summary
Establishes the Portal/Sharing facade's **shared auth seam** (epic #1240): a named-user Portal login authenticates against the existing OIDC core (#348) and item/service `access` is a projection of the canonical RBAC decision (#349 / #1375) — not a Portal-local identity store or ACL. This is the load-bearing seam the read surface (#1243) and the OAuth2 bridge (#1242) build on.

Stacked on **#1385** (`feat/rbac-persistent-store-resolver`), which adds the RBAC `IPermissionResolver` / `PermissionDecision` this PR projects.

## Changes Made
- **OIDC-backed `IPortalCredentialVerifier`** (`OidcPortalCredentialVerifier`): a named-user OIDC token presented as the `generateToken` password is validated against the same issuer/audience/signing rules as the JwtBearer scheme and normalized by the shared `OidcClaimsTransformation`, then projected onto `PrincipalId`/`DisplayName`/`TenantId`/`Roles`. Avoids the deprecated ROPC grant and introduces no user store. The issued portal token therefore yields the same RBAC decision as a direct OIDC session.
- **`AdminPortalCredentialVerifier` remains the default**; OIDC is opt-in via `Authentication:PortalCredentialVerifier:UseOidc` (off-by-default) with optional admin fallback (`CompositePortalCredentialVerifier`).
- **`IPortalAccessProjection` / `PortalAccessProjection`** (Core abstraction + pure impl): turns an `AccessPolicy` + `PermissionDecision` into Portal `access` (`private`/`org`/`public`) and per-item visibility — the single helper #1243 and #1242 consume. Off-by-default via `Authentication:PortalAccessProjection:Enabled`.
- `OidcTokenValidationParametersFactory` centralizes the OIDC issuer/audience/signing-key rules shared by the verifier and the JwtBearer scheme.

### Scoped here vs deferred
- **Here:** the verifier (OIDC principal → portal identity) and the access/visibility projection (RBAC decision → Portal access level), both entitlement/gate-consistent and off-by-default.
- **Deferred to #1243:** the read-surface endpoints (`info`, `portals/self`, `search`, `content/items/{id}`) and `IPortalItemProjector`.
- **Deferred to #1242:** the OAuth2 `authorize`/`token` endpoints and the OIDC-challenge bridge.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

`OidcPortalCredentialVerifierTests` (OIDC principal → portal identity, off-by-default, wrong-key/garbage rejection) and `PortalAccessProjectionTests` (decision → access level, layer-narrows-service, grant-over-policy visibility, gate). Local: `dotnet build` (warnings-as-errors) clean; Core.Tests authorization 25/25; verifier 4/4; Architecture.Tests 101/102 (1 unrelated skip); `dotnet format --verify-no-changes` clean.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [ ] None — no new public endpoints; new config keys are off-by-default.

## Release/Deploy Impact
- [x] Requires environment variable or secret changes
<!-- OIDC verifier opt-in needs the existing Oidc:* provider config; new keys default off. -->

## Breaking Changes
None — additive and off-by-default; the default verifier is unchanged.

### Assumption on the #1385 resolver API (reconcile if it changes in review)
This PR depends on the #1385 surface: `IPermissionResolver`, `PermissionDecision` with `PermissionResult { NoMatchingGrant, Allow, RequiresAuthentication }` and the `Allow/NoMatch/RequiresAuthentication` factories, and `EffectivePermissions`/`PermissionGrant`. The access projection consumes `PermissionDecision` directly; if those names/shapes shift in #1385 review, `PortalAccessProjection.ProjectVisibility` and `IPortalAccessProjection` need a matching tweak.

Refs #1240, #1242, #1243, #1385.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent (rebase pass: dotnet build warnings-as-errors + targeted tests + dotnet format verified); full matrix via CI below
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract

