### PR TITLE
feat: RBAC-aware MetadataV2 to ArcGIS Portal item projector (#1371)

### DIFF
--- a/src/Honua.Core.Abstractions/Features/Portal/Abstractions/IPortalItemProjector.cs
+++ b/src/Honua.Core.Abstractions/Features/Portal/Abstractions/IPortalItemProjector.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Portal.Domain;
+
+namespace Honua.Core.Features.Portal.Abstractions;
+
+/// <summary>
+/// Projects the canonical Metadata v2 graph into ArcGIS Portal / Sharing REST
+/// item documents (<see cref="PortalItem"/>). This is the single, RBAC-aware
+/// projection seam consumed by the Portal read endpoints (#1243) so the
+/// service → item mapping, item URL emission, and the <c>access</c> decision
+/// never diverge across <c>search</c> and <c>content/items/{id}</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The projector is wire-neutral: it takes a resolved <see cref="ClaimsPrincipal"/>
+/// and an already-resolved public base URL (callers derive this from the shared
+/// forwarded-scheme/host helper so item URLs are correct behind a proxy), and
+/// returns plain <see cref="PortalItem"/> records. It does not touch
+/// <c>HttpContext</c>, which keeps it testable in isolation and reusable from any
+/// adapter.
+/// </para>
+/// <para>
+/// RBAC visibility is enforced here, not by caller discipline: an item is only
+/// returned when the supplied principal is permitted to read the underlying
+/// service/resource, evaluated through the shared access-policy seam over the
+/// resource/service <c>AccessPolicy</c>.
+/// </para>
+/// </remarks>
+public interface IPortalItemProjector
+{
+    /// <summary>
+    /// Projects every Esri-shaped service in the snapshot that the principal can
+    /// read into a Portal item. Services the principal cannot access are omitted,
+    /// which is exactly the filtering the Portal <c>search</c> endpoint needs.
+    /// </summary>
+    /// <param name="snapshot">The current Metadata v2 graph snapshot.</param>
+    /// <param name="principal">The calling principal.</param>
+    /// <param name="baseUrl">
+    /// The public base URL (scheme + authority + optional path base) item URLs are
+    /// built from. Callers resolve this via the shared forwarded-scheme/host helper.
+    /// </param>
+    /// <returns>The projected, access-filtered Portal items.</returns>
+    IReadOnlyList<PortalItem> ProjectVisibleItems(
+        MetadataV2GraphSnapshot snapshot,
+        ClaimsPrincipal principal,
+        string baseUrl);
+
+    /// <summary>
+    /// Projects a single Portal item by its item id (the Metadata v2 service id),
+    /// honouring RBAC. Returns <see langword="null"/> when no Esri-shaped service
+    /// matches the id <em>or</em> when the principal is not permitted to read it —
+    /// the endpoint (#1243) maps both to the Esri-shaped 403/404 so the projector
+    /// never leaks the existence of a hidden item.
+    /// </summary>
+    /// <param name="snapshot">The current Metadata v2 graph snapshot.</param>
+    /// <param name="principal">The calling principal.</param>
+    /// <param name="itemId">The requested Portal item id.</param>
+    /// <param name="baseUrl">
+    /// The public base URL item URLs are built from (see
+    /// <see cref="ProjectVisibleItems"/>).
+    /// </param>
+    /// <returns>The projected item, or <see langword="null"/> when not visible.</returns>
+    PortalItem? ProjectItem(
+        MetadataV2GraphSnapshot snapshot,
+        ClaimsPrincipal principal,
+        string itemId,
+        string baseUrl);
+}

--- a/src/Honua.Core.Abstractions/Features/Portal/Domain/PortalItem.cs
+++ b/src/Honua.Core.Abstractions/Features/Portal/Domain/PortalItem.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Portal.Domain;
+
+/// <summary>
+/// An ArcGIS Portal / Sharing REST item document projected from a Metadata v2
+/// service/resource. The shape matches what the Esri Portal
+/// <c>content/items/{id}</c> and <c>search</c> endpoints return so packaged Esri
+/// clients (ArcGIS Pro "Add Portal", Field Maps) can discover and open Honua
+/// content as portal items.
+/// </summary>
+/// <remarks>
+/// This is the wire-neutral projection produced by <c>IPortalItemProjector</c>.
+/// The Portal HTTP read endpoints (#1243) consume this directly; they own the
+/// <c>info</c>/<c>portals/self</c>/<c>search</c>/<c>content/items/{id}</c> route
+/// surface and any response envelope wrapping (search result paging, etc.).
+/// </remarks>
+public sealed record PortalItem
+{
+    /// <summary>
+    /// Stable Portal item identifier. Derived from the Metadata v2 service id so it
+    /// is stable across requests and across the search / item-detail endpoints.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Owner username of the item. Derived from the service publisher / owner; falls
+    /// back to the deployment's portal owner when unset.
+    /// </summary>
+    [JsonPropertyName("owner")]
+    public required string Owner { get; init; }
+
+    /// <summary>
+    /// Epoch-millisecond creation timestamp.
+    /// </summary>
+    [JsonPropertyName("created")]
+    public long Created { get; init; }
+
+    /// <summary>
+    /// Epoch-millisecond last-modified timestamp.
+    /// </summary>
+    [JsonPropertyName("modified")]
+    public long Modified { get; init; }
+
+    /// <summary>
+    /// Esri item type, e.g. <c>Feature Service</c>, <c>Map Service</c>, or
+    /// <c>Image Service</c>.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Esri item type keywords used by clients to refine capability detection.
+    /// </summary>
+    [JsonPropertyName("typeKeywords")]
+    public IReadOnlyList<string> TypeKeywords { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Human-readable item title.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Item snippet (short description).
+    /// </summary>
+    [JsonPropertyName("snippet")]
+    public string? Snippet { get; init; }
+
+    /// <summary>
+    /// Item long-form description.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Discovery tags.
+    /// </summary>
+    [JsonPropertyName("tags")]
+    public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// The service URL the item resolves to, pointing at the existing
+    /// <c>/rest/services/...</c> endpoint. Honours the forwarded scheme/host so
+    /// links remain correct behind a reverse proxy.
+    /// </summary>
+    [JsonPropertyName("url")]
+    public required string Url { get; init; }
+
+    /// <summary>
+    /// Item access level — <c>public</c>, <c>org</c>, or <c>private</c>. A
+    /// projection of the RBAC <c>AccessPolicy</c>: <c>public</c> when anonymous
+    /// read is allowed; <c>org</c> when any authenticated principal is allowed;
+    /// <c>private</c> when access is role-restricted.
+    /// </summary>
+    [JsonPropertyName("access")]
+    public required string Access { get; init; }
+
+    /// <summary>
+    /// Item extent as <c>[[xmin, ymin], [xmax, ymax]]</c> in WGS84, or an empty
+    /// array when the resource declares no extent. Matches the Esri item-extent
+    /// shape.
+    /// </summary>
+    [JsonPropertyName("extent")]
+    public IReadOnlyList<IReadOnlyList<double>> Extent { get; init; } =
+        Array.Empty<IReadOnlyList<double>>();
+
+    /// <summary>
+    /// Spatial reference well-known id (WKID) the item's extent is expressed in.
+    /// </summary>
+    [JsonPropertyName("spatialReference")]
+    public string? SpatialReference { get; init; }
+
+    /// <summary>
+    /// Culture / language tag for the item.
+    /// </summary>
+    [JsonPropertyName("culture")]
+    public string? Culture { get; init; }
+
+    /// <summary>
+    /// Accumulated number of comments (always 0 — comments are out of scope per
+    /// #1243). Present for client-shape fidelity.
+    /// </summary>
+    [JsonPropertyName("numComments")]
+    public int NumComments { get; init; }
+
+    /// <summary>
+    /// Number of views (always 0 — view tracking is out of scope). Present for
+    /// client-shape fidelity.
+    /// </summary>
+    [JsonPropertyName("numViews")]
+    public int NumViews { get; init; }
+}
+
+/// <summary>
+/// Portal access tiers projected from the RBAC <c>AccessPolicy</c>.
+/// </summary>
+public static class PortalAccessLevels
+{
+    /// <summary>Anonymous read is permitted.</summary>
+    public const string Public = "public";
+
+    /// <summary>Any authenticated principal is permitted, but not anonymous.</summary>
+    public const string Org = "org";
+
+    /// <summary>Access is restricted to specific roles.</summary>
+    public const string Private = "private";
+}
+
+/// <summary>
+/// Esri Portal item type strings used by the projector.
+/// </summary>
+public static class PortalItemTypes
+{
+    /// <summary>Feature Service item type.</summary>
+    public const string FeatureService = "Feature Service";
+
+    /// <summary>Map Service item type.</summary>
+    public const string MapService = "Map Service";
+
+    /// <summary>Image Service item type.</summary>
+    public const string ImageService = "Image Service";
+}

--- a/src/Honua.Core.Abstractions/Features/Portal/Domain/PortalItemJsonContext.cs
+++ b/src/Honua.Core.Abstractions/Features/Portal/Domain/PortalItemJsonContext.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.Portal.Domain;
+
+/// <summary>
+/// Source-generated JSON serialization context for Portal item DTOs. Keeps the
+/// Portal read surface AOT-safe (no reflection in the hot path).
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(PortalItem))]
+[JsonSerializable(typeof(IReadOnlyList<PortalItem>))]
+[JsonSerializable(typeof(PortalItem[]))]
+public sealed partial class PortalItemJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Core/Features/Portal/PortalServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Portal/PortalServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Portal.Abstractions;
+using Honua.Core.Features.Portal.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Core.Features.Portal;
+
+/// <summary>
+/// Service collection extensions for registering the ArcGIS Portal projection
+/// services consumed by the Portal/Sharing REST read surface (#1243).
+/// </summary>
+public static class PortalServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the RBAC-aware <see cref="IPortalItemProjector"/>. The projector
+    /// depends on the shared <c>IAccessPolicyEvaluator</c>, which the host registers
+    /// as part of the authentication/RBAC pipeline.
+    /// </summary>
+    /// <param name="services">The service collection to add services to.</param>
+    /// <returns>The same service collection for chaining.</returns>
+    public static IServiceCollection AddPortalItemProjection(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.TryAddSingleton<IPortalItemProjector, PortalItemProjector>();
+        return services;
+    }
+}

--- a/src/Honua.Core/Features/Portal/Services/PortalItemProjector.cs
+++ b/src/Honua.Core/Features/Portal/Services/PortalItemProjector.cs
@@ -1,0 +1,296 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Security.Claims;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Portal.Abstractions;
+using Honua.Core.Features.Portal.Domain;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.Core.Features.Security.Domain;
+
+namespace Honua.Core.Features.Portal.Services;
+
+/// <summary>
+/// Default <see cref="IPortalItemProjector"/> implementation. Maps Esri-shaped
+/// Metadata v2 services (FeatureServer / MapServer / ImageServer) to Portal item
+/// documents, deriving the item <c>url</c> from the caller-supplied base URL and
+/// the <c>access</c> tier from the resource/service <see cref="AccessPolicy"/> via
+/// the shared <see cref="IAccessPolicyEvaluator"/>.
+/// </summary>
+public sealed class PortalItemProjector : IPortalItemProjector
+{
+    // A throwaway authenticated principal used purely to probe the access tier:
+    // if an authenticated-but-role-less principal is allowed, the item is "org";
+    // otherwise it is "private" (role-restricted).
+    private static readonly ClaimsPrincipal AnonymousPrincipal = new(new ClaimsIdentity());
+    private static readonly ClaimsPrincipal AuthenticatedNoRolePrincipal =
+        new(new ClaimsIdentity(authenticationType: "PortalAccessProbe"));
+
+    private readonly IAccessPolicyEvaluator _accessPolicyEvaluator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PortalItemProjector"/> class.
+    /// </summary>
+    /// <param name="accessPolicyEvaluator">
+    /// The shared access-policy evaluator that decides whether a principal may read
+    /// a resource/service. This is the same seam the protocol endpoints enforce
+    /// through, so the Portal <c>access</c> tier cannot drift from the real RBAC
+    /// decision.
+    /// </param>
+    public PortalItemProjector(IAccessPolicyEvaluator accessPolicyEvaluator)
+    {
+        ArgumentNullException.ThrowIfNull(accessPolicyEvaluator);
+        _accessPolicyEvaluator = accessPolicyEvaluator;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<PortalItem> ProjectVisibleItems(
+        MetadataV2GraphSnapshot snapshot,
+        ClaimsPrincipal principal,
+        string baseUrl)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        ArgumentNullException.ThrowIfNull(principal);
+        ArgumentNullException.ThrowIfNull(baseUrl);
+
+        var items = new List<PortalItem>();
+        foreach (var service in snapshot.Graph.Services)
+        {
+            var item = TryProjectService(snapshot, service, principal, baseUrl);
+            if (item is not null)
+            {
+                items.Add(item);
+            }
+        }
+
+        items.Sort(static (a, b) => string.Compare(a.Title, b.Title, StringComparison.OrdinalIgnoreCase));
+        return items;
+    }
+
+    /// <inheritdoc />
+    public PortalItem? ProjectItem(
+        MetadataV2GraphSnapshot snapshot,
+        ClaimsPrincipal principal,
+        string itemId,
+        string baseUrl)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        ArgumentNullException.ThrowIfNull(principal);
+        ArgumentNullException.ThrowIfNull(baseUrl);
+
+        if (string.IsNullOrWhiteSpace(itemId))
+        {
+            return null;
+        }
+
+        foreach (var service in snapshot.Graph.Services)
+        {
+            if (!string.Equals(service.Metadata.Id, itemId, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            return TryProjectService(snapshot, service, principal, baseUrl);
+        }
+
+        return null;
+    }
+
+    private PortalItem? TryProjectService(
+        MetadataV2GraphSnapshot snapshot,
+        MetadataV2Service service,
+        ClaimsPrincipal principal,
+        string baseUrl)
+    {
+        if (!TryMapItemType(service.PrimaryProtocol, out var itemType, out var urlType))
+        {
+            return null;
+        }
+
+        // Collect the resources published through this service so RBAC and extent
+        // can be computed from the resource + service policy composition.
+        var publications = snapshot.PublicationsForService(service.Metadata.Id);
+        MetadataV2Resource? firstVisibleResource = null;
+        var anyResource = false;
+        var anyVisible = false;
+
+        foreach (var publication in publications)
+        {
+            var resource = snapshot.ResolveResource(publication);
+            if (resource is null)
+            {
+                continue;
+            }
+
+            anyResource = true;
+            if (IsAllowed(principal, resource.AccessPolicy, service.AccessPolicy))
+            {
+                anyVisible = true;
+                firstVisibleResource ??= resource;
+            }
+        }
+
+        // A service with no resolvable publications is gated on the service policy
+        // alone; one with publications must have at least one the principal can read.
+        if (anyResource)
+        {
+            if (!anyVisible)
+            {
+                return null;
+            }
+        }
+        else if (!IsAllowed(principal, layerPolicy: null, service.AccessPolicy))
+        {
+            return null;
+        }
+
+        var access = DeriveAccessTier(firstVisibleResource?.AccessPolicy, service.AccessPolicy);
+        return BuildItem(service, firstVisibleResource, itemType, urlType, access, baseUrl);
+    }
+
+    private bool IsAllowed(ClaimsPrincipal principal, AccessPolicy? layerPolicy, AccessPolicy? servicePolicy)
+        => _accessPolicyEvaluator.Evaluate(principal, layerPolicy, servicePolicy, scope: null).IsAllowed;
+
+    /// <summary>
+    /// Projects the composed (resource, service) access policy into the Esri
+    /// <c>public</c>/<c>org</c>/<c>private</c> tier by probing the shared evaluator
+    /// with synthetic principals — no second ACL model.
+    /// </summary>
+    private string DeriveAccessTier(AccessPolicy? layerPolicy, AccessPolicy? servicePolicy)
+    {
+        if (_accessPolicyEvaluator.Evaluate(AnonymousPrincipal, layerPolicy, servicePolicy, scope: null).IsAllowed)
+        {
+            return PortalAccessLevels.Public;
+        }
+
+        return _accessPolicyEvaluator
+            .Evaluate(AuthenticatedNoRolePrincipal, layerPolicy, servicePolicy, scope: null).IsAllowed
+            ? PortalAccessLevels.Org
+            : PortalAccessLevels.Private;
+    }
+
+    private static PortalItem BuildItem(
+        MetadataV2Service service,
+        MetadataV2Resource? resource,
+        string itemType,
+        string urlType,
+        string access,
+        string baseUrl)
+    {
+        var metadata = service.Metadata;
+        var title = FirstNonEmpty(metadata.Title, metadata.Name, metadata.Id);
+        var owner = FirstNonEmpty(metadata.Publisher, "honua");
+        var created = ToEpochMilliseconds(metadata.CreatedAt);
+        var modified = ToEpochMilliseconds(metadata.UpdatedAt ?? metadata.CreatedAt);
+
+        var (extent, spatialReference) = BuildExtent(resource);
+
+        return new PortalItem
+        {
+            Id = metadata.Id,
+            Owner = owner,
+            Created = created,
+            Modified = modified,
+            Type = itemType,
+            TypeKeywords = BuildTypeKeywords(itemType),
+            Title = title,
+            Snippet = metadata.Description,
+            Description = metadata.Description,
+            Tags = metadata.Keywords.Count > 0 ? metadata.Keywords : metadata.Tags,
+            Url = BuildServiceUrl(baseUrl, metadata.Name, urlType),
+            Access = access,
+            Extent = extent,
+            SpatialReference = spatialReference,
+            Culture = metadata.Language,
+        };
+    }
+
+    /// <summary>
+    /// Builds the item URL pointing at the existing GeoServices service endpoint,
+    /// mirroring <c>GeoservicesCatalogEndpoints</c> so the Portal item and the
+    /// services directory always agree on host/scheme and route shape.
+    /// </summary>
+    private static string BuildServiceUrl(string baseUrl, string serviceName, string urlType)
+    {
+        var trimmedBase = baseUrl.TrimEnd('/');
+        var escapedName = Uri.EscapeDataString(serviceName);
+        return $"{trimmedBase}/rest/services/{escapedName}/{urlType}";
+    }
+
+    /// <summary>
+    /// Maps a Metadata v2 primary protocol to the Esri Portal item type and the
+    /// GeoServices URL route segment. Returns <see langword="false"/> for
+    /// non-Esri protocols (OGC API, STAC, OData, …) which are not Portal items.
+    /// </summary>
+    private static bool TryMapItemType(string? primaryProtocol, out string itemType, out string urlType)
+    {
+        switch (primaryProtocol)
+        {
+            case ServiceProtocols.FeatureServer:
+                itemType = PortalItemTypes.FeatureService;
+                urlType = ServiceProtocols.FeatureServer;
+                return true;
+            case ServiceProtocols.MapServer:
+                itemType = PortalItemTypes.MapService;
+                urlType = ServiceProtocols.MapServer;
+                return true;
+            case ServiceProtocols.ImageServer:
+                itemType = PortalItemTypes.ImageService;
+                urlType = ServiceProtocols.ImageServer;
+                return true;
+            default:
+                itemType = string.Empty;
+                urlType = string.Empty;
+                return false;
+        }
+    }
+
+    private static IReadOnlyList<string> BuildTypeKeywords(string itemType)
+    {
+        // Esri clients key capability detection off these tokens. "Data" + "Service"
+        // are common to all hosted service items; the type-specific token follows.
+        return itemType switch
+        {
+            PortalItemTypes.FeatureService => ["Data", "Service", "Feature Service", "ArcGIS Server", "Hosted Service"],
+            PortalItemTypes.MapService => ["Data", "Service", "Map Service", "ArcGIS Server"],
+            PortalItemTypes.ImageService => ["Data", "Service", "Image Service", "ArcGIS Server"],
+            _ => ["Data", "Service"],
+        };
+    }
+
+    private static (IReadOnlyList<IReadOnlyList<double>> Extent, string? SpatialReference) BuildExtent(
+        MetadataV2Resource? resource)
+    {
+        var bbox = resource?.Spatial?.Bbox;
+        if (bbox is null)
+        {
+            return (Array.Empty<IReadOnlyList<double>>(), null);
+        }
+
+        var wkid = resource?.Spatial?.SpatialReference?.ResolveSrid();
+        var extent = new IReadOnlyList<double>[]
+        {
+            new[] { bbox.West, bbox.South },
+            new[] { bbox.East, bbox.North },
+        };
+
+        return (extent, wkid?.ToString(CultureInfo.InvariantCulture));
+    }
+
+    private static long ToEpochMilliseconds(DateTimeOffset? timestamp)
+        => timestamp.HasValue ? timestamp.Value.ToUnixTimeMilliseconds() : 0L;
+
+    private static string FirstNonEmpty(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return string.Empty;
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -3,6 +3,7 @@
 
 using Honua.Core.Features.Compliance;
 using Honua.Core.Features.Metadata;
+using Honua.Core.Features.Portal;
 using Honua.Core.Features.Temporal;
 using Honua.Server.Features.Temporal;
 using Honua.Postgres.Features.Scene;
@@ -119,6 +120,9 @@ internal static class FeatureRegistrationExtensions
         services.AddSpec(configuration);
         services.AddEnhancedAdminServices();
         services.AddMetadataReleaseServices();
+        // RBAC-aware ArcGIS Portal item projector consumed by the Portal/Sharing
+        // REST read surface (#1371 → #1243).
+        services.AddPortalItemProjection();
         services.AddStudioPackageLifecycle();
         // Durable Studio map collaboration: comment threads + activity feed (#1278, slice 1).
         // In-memory store is the default; AddPostgreSqlServices overrides it with durable storage.

--- a/tests/dotnet/Honua.Core.Tests/Features/Portal/PortalItemProjectorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Portal/PortalItemProjectorTests.cs
@@ -1,0 +1,337 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Portal.Domain;
+using Honua.Core.Features.Portal.Services;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.Core.Features.Security.Domain;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using AccessDecision = Honua.Core.Features.Security.Domain.AccessDecision;
+
+namespace Honua.Core.Tests.Features.Portal;
+
+/// <summary>
+/// Unit tests for the RBAC-aware Metadata v2 → ArcGIS Portal item projector.
+/// Covers service-type mapping, item URL emission (including behind-proxy base
+/// URLs), access-tier derivation, and the RBAC visibility rule.
+/// </summary>
+[Protocol(ProtocolNames.TestQuality)]
+public sealed class PortalItemProjectorTests
+{
+    private const string ProxyBaseUrl = "https://maps.example.gov/honua";
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void ProjectVisibleItems_FeatureService_MapsEsriItemShape()
+    {
+        var snapshot = BuildSnapshot(
+            BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: true),
+            resourceAccess: AnonymousPolicy());
+        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+
+        var items = projector.ProjectVisibleItems(snapshot, Anonymous(), ProxyBaseUrl);
+
+        items.Should().ContainSingle();
+        var item = items[0];
+        item.Id.Should().Be("service.parcels");
+        item.Type.Should().Be(PortalItemTypes.FeatureService);
+        item.Title.Should().Be("Parcels Title");
+        item.TypeKeywords.Should().Contain("Feature Service");
+        item.Access.Should().Be(PortalAccessLevels.Public);
+        item.Tags.Should().Contain("cadastre");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void ProjectVisibleItems_BuildsUrlBehindProxyAndEscapesName()
+    {
+        var snapshot = BuildSnapshot(
+            BuildService("service.basemap", "City Basemap", ServiceProtocols.MapServer, publicAccess: true),
+            resourceAccess: AnonymousPolicy());
+        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+
+        var items = projector.ProjectVisibleItems(snapshot, Anonymous(), ProxyBaseUrl + "/");
+
+        items.Should().ContainSingle();
+        // Base URL is honoured verbatim (caller resolves forwarded scheme/host),
+        // trailing slash is trimmed, service name is URL-escaped, route segment is
+        // the GeoServices type — agreeing with the services directory emission.
+        items[0].Url.Should().Be("https://maps.example.gov/honua/rest/services/City%20Basemap/MapServer");
+        items[0].Type.Should().Be(PortalItemTypes.MapService);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void ProjectVisibleItems_ProjectsExtentFromResourceBbox()
+    {
+        var resource = new MetadataV2Resource
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "resource.parcels", Name = "parcels" },
+            Type = MetadataV2ResourceType.FeatureDataset,
+            AccessPolicy = AnonymousPolicy(),
+            Spatial = new MetadataV2ResourceSpatial
+            {
+                SpatialReference = MetadataV2SpatialReference.Wgs84,
+                GeometryType = MetadataV2GeometryType.Polygon,
+                Bbox = new MetadataV2Bbox { West = -10, South = -20, East = 30, North = 40 },
+            },
+        };
+        var snapshot = BuildSnapshotWithResource(
+            BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: true),
+            resource);
+        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+
+        var item = projector.ProjectVisibleItems(snapshot, Anonymous(), ProxyBaseUrl).Single();
+
+        item.Extent.Should().HaveCount(2);
+        item.Extent[0].Should().Equal(-10d, -20d);
+        item.Extent[1].Should().Equal(30d, 40d);
+        item.SpatialReference.Should().Be("4326");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void ProjectVisibleItems_SkipsNonEsriServiceTypes()
+    {
+        var snapshot = BuildSnapshot(
+            BuildService("service.ogc", "OgcFeatures", ServiceProtocols.OgcFeatures, publicAccess: true),
+            resourceAccess: AnonymousPolicy());
+        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+
+        var items = projector.ProjectVisibleItems(snapshot, Anonymous(), ProxyBaseUrl);
+
+        items.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void DeriveAccess_AuthenticatedOnly_YieldsOrg()
+    {
+        // Resource requires authentication (no anonymous, no role restriction).
+        var snapshot = BuildSnapshot(
+            BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: false),
+            resourceAccess: new AccessPolicy { AllowAnonymous = false });
+        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+
+        var item = projector.ProjectVisibleItems(snapshot, AuthenticatedUser("editor"), ProxyBaseUrl).Single();
+
+        item.Access.Should().Be(PortalAccessLevels.Org);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void DeriveAccess_RoleRestricted_YieldsPrivate()
+    {
+        var snapshot = BuildSnapshot(
+            BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: false),
+            resourceAccess: new AccessPolicy { AllowedRoles = ["admin"] });
+        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+
+        var item = projector.ProjectVisibleItems(snapshot, AuthenticatedUser("admin"), ProxyBaseUrl).Single();
+
+        item.Access.Should().Be(PortalAccessLevels.Private);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void ProjectVisibleItems_UnpermittedPrincipal_OmitsItem()
+    {
+        // Resource is restricted to "admin"; the caller has only "viewer".
+        var snapshot = BuildSnapshot(
+            BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: false),
+            resourceAccess: new AccessPolicy { AllowedRoles = ["admin"] });
+        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+
+        var items = projector.ProjectVisibleItems(snapshot, AuthenticatedUser("viewer"), ProxyBaseUrl);
+
+        items.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void ProjectItem_UnpermittedPrincipal_ReturnsNull()
+    {
+        var snapshot = BuildSnapshot(
+            BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: false),
+            resourceAccess: new AccessPolicy { AllowedRoles = ["admin"] });
+        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+
+        var item = projector.ProjectItem(snapshot, AuthenticatedUser("viewer"), "service.parcels", ProxyBaseUrl);
+
+        item.Should().BeNull();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void ProjectItem_PermittedPrincipal_ReturnsItem()
+    {
+        var snapshot = BuildSnapshot(
+            BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: false),
+            resourceAccess: new AccessPolicy { AllowedRoles = ["admin"] });
+        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+
+        var item = projector.ProjectItem(snapshot, AuthenticatedUser("admin"), "service.parcels", ProxyBaseUrl);
+
+        item.Should().NotBeNull();
+        item!.Id.Should().Be("service.parcels");
+        item.Access.Should().Be(PortalAccessLevels.Private);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Metadata)]
+    public void ProjectItem_UnknownId_ReturnsNull()
+    {
+        var snapshot = BuildSnapshot(
+            BuildService("service.parcels", "Parcels", ServiceProtocols.FeatureServer, publicAccess: true),
+            resourceAccess: AnonymousPolicy());
+        var projector = new PortalItemProjector(new FakeAccessPolicyEvaluator());
+
+        projector.ProjectItem(snapshot, Anonymous(), "service.missing", ProxyBaseUrl).Should().BeNull();
+    }
+
+    private static MetadataV2Service BuildService(string id, string name, string protocol, bool publicAccess)
+        => new()
+        {
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Id = id,
+                Name = name,
+                Title = $"{name} Title",
+                Description = $"{name} description",
+                Publisher = "gis-team",
+                Keywords = ["cadastre"],
+            },
+            Protocols = [protocol],
+            AccessPolicy = publicAccess ? AnonymousPolicy() : null,
+        };
+
+    private static AccessPolicy AnonymousPolicy() => new() { AllowAnonymous = true };
+
+    private static MetadataV2GraphSnapshot BuildSnapshot(MetadataV2Service service, AccessPolicy? resourceAccess)
+    {
+        var resource = new MetadataV2Resource
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "resource.parcels", Name = "parcels" },
+            Type = MetadataV2ResourceType.FeatureDataset,
+            AccessPolicy = resourceAccess,
+        };
+        return BuildSnapshotWithResource(service, resource);
+    }
+
+    private static MetadataV2GraphSnapshot BuildSnapshotWithResource(
+        MetadataV2Service service,
+        MetadataV2Resource resource)
+    {
+        var graph = new MetadataV2Graph
+        {
+            Revision = 1,
+            Environment = "test",
+            Resources = [resource],
+            Services = [service],
+            Publications =
+            [
+                new MetadataV2Publication
+                {
+                    Metadata = new MetadataV2ObjectMetadata { Id = "pub.parcels", Name = "parcels" },
+                    ResourceId = resource.Metadata.Id,
+                    ServiceId = service.Metadata.Id,
+                    PublicationType = MetadataV2PublicationType.EsriFeatureLayer,
+                    Identifier = new MetadataV2PublicationIdentifier { Value = "0", IsNumeric = true },
+                }
+            ],
+        };
+        return new MetadataV2GraphSnapshot(graph, "\"etag\"", DateTimeOffset.UnixEpoch);
+    }
+
+    private static ClaimsPrincipal Anonymous() => new(new ClaimsIdentity());
+
+    private static ClaimsPrincipal AuthenticatedUser(params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, "user-1") };
+        claims.AddRange(roles.Select(static r => new Claim(ClaimTypes.Role, r)));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "Test"));
+    }
+
+    /// <summary>
+    /// Faithful test double for the host's access-policy evaluator. Reproduces the
+    /// deny-wins composition of the production <c>AccessPolicyEvaluator</c>
+    /// (anonymous flag → authenticated → role membership) so the projector's RBAC
+    /// behaviour is exercised end to end without referencing Honua.Hosting.
+    /// </summary>
+    private sealed class FakeAccessPolicyEvaluator : IAccessPolicyEvaluator
+    {
+        public Task<AccessDecision> EvaluateAsync(ClaimsPrincipal principal, string resource, string action)
+            => Task.FromResult(Evaluate(principal, resource, action));
+
+        public AccessDecision Evaluate(ClaimsPrincipal principal, string resource, string action)
+            => principal.Identity?.IsAuthenticated == true
+                ? AccessDecision.Allowed()
+                : AccessDecision.RequiresAuth();
+
+        public Task<AccessDecision> EvaluateAsync(
+            ClaimsPrincipal principal,
+            AccessPolicy? layerPolicy,
+            AccessPolicy? servicePolicy,
+            object? scope = null)
+            => Task.FromResult(Evaluate(principal, layerPolicy, servicePolicy, scope));
+
+        public AccessDecision Evaluate(
+            ClaimsPrincipal principal,
+            AccessPolicy? layerPolicy,
+            AccessPolicy? servicePolicy,
+            object? scope = null)
+        {
+            var layer = EvaluateSingle(principal, layerPolicy);
+            var service = EvaluateSingle(principal, servicePolicy);
+
+            if (layer is null && service is null)
+            {
+                return principal.Identity?.IsAuthenticated == true
+                    ? AccessDecision.Allowed()
+                    : AccessDecision.RequiresAuth();
+            }
+
+            if (layer is { IsAllowed: false })
+            {
+                return layer.Value;
+            }
+
+            if (service is { IsAllowed: false })
+            {
+                return service.Value;
+            }
+
+            return AccessDecision.Allowed();
+        }
+
+        private static AccessDecision? EvaluateSingle(ClaimsPrincipal principal, AccessPolicy? policy)
+        {
+            if (policy is null)
+            {
+                return null;
+            }
+
+            if (policy.AllowAnonymous)
+            {
+                return AccessDecision.Allowed();
+            }
+
+            if (principal.Identity?.IsAuthenticated != true)
+            {
+                return AccessDecision.RequiresAuth();
+            }
+
+            if (policy.AllowedRoles is { Length: > 0 } roles &&
+                !roles.Any(principal.IsInRole))
+            {
+                return AccessDecision.Forbidden();
+            }
+
+            return AccessDecision.Allowed();
+        }
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #1371

## Summary
Adds an RBAC-aware projector that maps the Metadata v2 graph into ArcGIS Portal/Sharing REST item JSON. This is the reusable, single-source projection the Portal read surface (#1243) consumes so the service-to-item mapping, item URL emission, and the `access` decision never diverge across `search` and `content/items/{id}`.

Stacked on #1385 (`feat/rbac-persistent-store-resolver`, the RBAC `IPermissionResolver` / persistent store). Part of epic #1240; directly enables #1243.

## Changes Made
- New neutral abstraction `IPortalItemProjector` + `PortalItem` DTO + `PortalItemJsonContext` (source-generated, AOT-safe) in `Honua.Core.Abstractions/Features/Portal`.
- `PortalItemProjector` implementation in `Honua.Core/Features/Portal/Services`. Maps Esri-shaped services (`FeatureServer`/`MapServer`/`ImageServer`) to Portal items (`id`, `owner`, `type`, `title`, `url`, `access`, `typeKeywords`, `extent`, `spatialReference`, tags, timestamps). Non-Esri service types (OGC API, STAC, OData, ...) are not projected.
- Item `url` points at the existing `/rest/services/{name}/{Type}` endpoint and is built from a caller-supplied base URL (callers pass the result of the shared forwarded-scheme/host helper), so links are correct behind a reverse proxy. Matches `GeoservicesCatalogEndpoints` route/escaping.
- `access` (`public`/`org`/`private`) is a projection of the resource + service `AccessPolicy` through the shared `IAccessPolicyEvaluator` — no second ACL. `public` = anonymous read allowed; `org` = any authenticated principal allowed; `private` = role-restricted.
- RBAC visibility enforced in the projector: unpermitted principals get the item omitted from the search-style projection and `null` from item-by-id (which #1243 maps to the Esri-shaped 403/404).
- Registered via `AddPortalItemProjection()` in the host (`FeatureRegistrationExtensions`).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

10 unit tests in `Honua.Core.Tests/Features/Portal/PortalItemProjectorTests.cs` cover service-type mapping, item shape, URL-behind-proxy + name escaping, extent projection, access-tier derivation (`public`/`org`/`private`), and the RBAC cases (unpermitted principal yields no item from `ProjectVisibleItems` and `null` from `ProjectItem`). Architecture suite: 101 passed / 1 skipped.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` equivalent (rebase pass: dotnet build warnings-as-errors + targeted tests + dotnet format verified); full matrix via CI below
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

## Deferred to #1243
The `/sharing/rest` read endpoints (`info`, `portals/self`, `community/self`, `search`, `content/items/{id}` (+`/data`), users items), the response envelopes/paging, entitlement gating, and the Esri-shaped 403/404 mapping for hidden items.

## Resolver / #1370-seam assumptions to reconcile
- The access-projection seam (#1370) has NOT landed on this base (only #1374/#1375 RBAC store + permission resolver). Per the issue guidance, the projector depends on the shared `IAccessPolicyEvaluator` directly (which itself consults the `IPermissionResolver`-backed grants in `AccessPolicyHelpers` on enforced paths). If #1370 introduces a dedicated access-projection abstraction before this lands, the `DeriveAccessTier`/visibility calls should be re-pointed at it; the projector seam stays the same.
- The projector is intentionally `HttpContext`-free; the #1243 endpoints resolve the base URL via the existing `BaseUrlResolver` (Honua.Hosting) and the `ClaimsPrincipal` from `HttpContext.User`, then call the projector.

