### PR TITLE
feat(forms): add repeatable-section support to field form packages

### DIFF
--- a/src/Honua.Core/Features/Forms/Packages/FormPackageContracts.cs
+++ b/src/Honua.Core/Features/Forms/Packages/FormPackageContracts.cs
@@ -128,6 +128,22 @@ public sealed class FormSectionDefinition
     /// <summary>Field ids included in this section.</summary>
     [JsonPropertyName("fieldIds")]
     public string[] FieldIds { get; init => field = value ?? []; } = [];
+
+    /// <summary>
+    /// Whether this section can be captured multiple times per record (a
+    /// Survey123 "repeat" / Fulcrum "repeatable section"). Each captured row
+    /// carries its own values and attachments.
+    /// </summary>
+    [JsonPropertyName("repeatable")]
+    public bool Repeatable { get; init; }
+
+    /// <summary>Minimum number of rows required when <see cref="Repeatable"/> is set.</summary>
+    [JsonPropertyName("minInstances")]
+    public int? MinInstances { get; init; }
+
+    /// <summary>Maximum number of rows allowed when <see cref="Repeatable"/> is set.</summary>
+    [JsonPropertyName("maxInstances")]
+    public int? MaxInstances { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Forms/Packages/FormPackageValidator.cs
+++ b/src/Honua.Core/Features/Forms/Packages/FormPackageValidator.cs
@@ -434,6 +434,8 @@ public sealed class FormPackageValidator
                 AddError(issues, "sectionLabelRequired", $"Section '{section.SectionId}' requires a label.", path: "sections.label");
             }
 
+            ValidateRepeatBounds(section, issues);
+
             foreach (var fieldId in section.FieldIds)
             {
                 if (!fieldIds.Contains(fieldId))
@@ -441,6 +443,35 @@ public sealed class FormPackageValidator
                     AddError(issues, "sectionFieldNotFound", $"Section '{section.SectionId}' references unknown field '{fieldId}'.", fieldId);
                 }
             }
+        }
+    }
+
+    private static void ValidateRepeatBounds(FormSectionDefinition section, List<FormValidationIssue> issues)
+    {
+        // Instance bounds only apply to repeatable sections.
+        if (!section.Repeatable)
+        {
+            if (section.MinInstances is not null || section.MaxInstances is not null)
+            {
+                AddError(issues, "sectionRepeatBoundsWithoutRepeatable", $"Section '{section.SectionId}' specifies instance bounds but is not repeatable.", path: "sections.repeatable");
+            }
+
+            return;
+        }
+
+        if (section.MinInstances is < 0)
+        {
+            AddError(issues, "sectionMinInstancesInvalid", $"Section '{section.SectionId}' minInstances must be zero or greater.", path: "sections.minInstances");
+        }
+
+        if (section.MaxInstances is < 1)
+        {
+            AddError(issues, "sectionMaxInstancesInvalid", $"Section '{section.SectionId}' maxInstances must be one or greater.", path: "sections.maxInstances");
+        }
+
+        if (section.MinInstances is { } min && section.MaxInstances is { } max && min > max)
+        {
+            AddError(issues, "sectionInstanceBoundsInverted", $"Section '{section.SectionId}' minInstances ({min}) cannot exceed maxInstances ({max}).", path: "sections.minInstances");
         }
     }
 

--- a/tests/dotnet/Honua.Core.Tests/Features/Forms/FormPackageValidatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Forms/FormPackageValidatorTests.cs
@@ -531,6 +531,78 @@ public sealed class FormPackageValidatorTests
         ]);
     }
 
+    [UnitTest]
+    public async Task ValidateForPublish_WithValidRepeatableSection_ReturnsValidResult()
+    {
+        var validator = CreateValidator();
+
+        var result = await validator.ValidateForPublishAsync(CreateRepeatablePackage(repeatable: true, min: 1, max: 3));
+
+        result.IsValid.Should().BeTrue();
+        result.Issues.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public async Task ValidateForPublish_WithInstanceBoundsButNotRepeatable_ReturnsError()
+    {
+        var validator = CreateValidator();
+
+        var result = await validator.ValidateForPublishAsync(CreateRepeatablePackage(repeatable: false, min: 1, max: 3));
+
+        result.IsValid.Should().BeFalse();
+        result.Issues.Select(static issue => issue.Code).Should().Contain("sectionRepeatBoundsWithoutRepeatable");
+    }
+
+    [UnitTest]
+    public async Task ValidateForPublish_WithInvertedInstanceBounds_ReturnsError()
+    {
+        var validator = CreateValidator();
+
+        var result = await validator.ValidateForPublishAsync(CreateRepeatablePackage(repeatable: true, min: 5, max: 2));
+
+        result.IsValid.Should().BeFalse();
+        result.Issues.Select(static issue => issue.Code).Should().Contain("sectionInstanceBoundsInverted");
+    }
+
+    [UnitTest]
+    public Task RepeatableSection_RoundTripsThroughJson()
+    {
+        var package = CreateRepeatablePackage(repeatable: true, min: 1, max: 3);
+
+        var json = JsonSerializer.Serialize(package, FormPackageJsonContext.Default.FormPackageDocument);
+        var restored = JsonSerializer.Deserialize(json, FormPackageJsonContext.Default.FormPackageDocument)!;
+
+        var section = restored.Sections.Single();
+        section.Repeatable.Should().BeTrue();
+        section.MinInstances.Should().Be(1);
+        section.MaxInstances.Should().Be(3);
+        return Task.CompletedTask;
+    }
+
+    private static FormPackageDocument CreateRepeatablePackage(bool repeatable, int? min, int? max)
+        => new()
+        {
+            Title = "Inspection Form",
+            Target = new FormTargetDefinition { ServiceId = "test", LayerId = 0 },
+            Sections =
+            [
+                new FormSectionDefinition
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    FieldIds = ["name"],
+                    Repeatable = repeatable,
+                    MinInstances = min,
+                    MaxInstances = max
+                }
+            ],
+            Fields = [CreateNameField()],
+            SubmitPolicy = new FormSubmitPolicy
+            {
+                AllowedOperations = [FormSubmissionOperations.Create]
+            }
+        };
+
     private static FormPackageValidator CreateValidator(
         string[]? serviceCapabilities = null,
         MetadataV2SpatialReference? spatialReference = null)


### PR DESCRIPTION
## Issue Link
N/A — no tracking issue (cross-repo parity work supporting Honua Collect).

## Summary
The form package is what the server authors, distributes to field devices, and validates submissions against — but `FormSectionDefinition` could not express a repeatable section, so Survey123/Fulcrum-style repeats could not be authored or validated server-side. This adds repeatable-section support and its validation.

## Changes Made
- Add `Repeatable`, `MinInstances`, `MaxInstances` to `FormSectionDefinition` (JSON: `repeatable` / `minInstances` / `maxInstances`).
- `FormPackageValidator` validates the bounds: instance bounds require `Repeatable`; `min >= 0`; `max >= 1`; `min <= max`.
- Mirrors the native `FieldRecord.Repeats` support added in honua-sdk-dotnet so a repeatable form round-trips to the capture client and back.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — additive; new optional members on `FormSectionDefinition`.

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Tests added for new functionality

Note: verified locally — `Honua.Core` builds clean (0/0) and the `FormPackageValidator` test suite passes (13 existing + 4 new = 17).
