### PR TITLE
feat(imageserver): support orderByFields and outFields on Query

### DIFF
--- a/docs/gis/image-server-matrix.md
+++ b/docs/gis/image-server-matrix.md
@@ -20,14 +20,17 @@ Sources:
 | --- | --- | --- | --- | --- | --- |
 | Service metadata | `/rest/services/{serviceName}/ImageServer` | GET | Implemented | `GET /rest/services/{id}/ImageServer` | Returns metadata for the addressed layer mosaic, including aggregate extent/time metadata when multiple rasters are present. Metadata responses are cached with the `ImageServerMetadata` output-cache policy. |
 | Image tile | `/rest/services/{serviceName}/ImageServer/tile/{level}/{row}/{col}` | GET | Implemented | `GET /rest/services/{id}/ImageServer/tile/{level}/{row}/{col}` | Returns raster map tiles. Supports `png` (default), `jpeg`, and `tiff` output; zoom levels are limited to `0-28`. When multiple PostGIS rasters overlap the requested tile, Honua renders a mosaic using the resolved merge strategy. If no PostGIS tile is produced, instances with the active `raster.cloud-cog-serving` entitlement can fall back to a registered cloud-hosted COG for the layer. |
+| Compute Histograms | `/rest/services/{serviceName}/ImageServer/computeHistograms` | GET, POST | Implemented | `GET\|POST /rest/services/{id}/ImageServer/computeHistograms` | Returns per-band histograms for the rasters intersecting the AOI. Requires `geometry` and `geometryType` (`esriGeometryEnvelope` or `esriGeometryPolygon`); shares the `computeStatisticsHistograms` core (`rasterIds`, `bandIds`, `mosaicRule`, single-instant `time`, `histogramParameters.size`). |
+| Get Samples | `/rest/services/{serviceName}/ImageServer/getSamples` | GET, POST | Implemented | `GET\|POST /rest/services/{id}/ImageServer/getSamples` | Samples pixel values at the points of (or vertices along) the supplied geometry, reusing the shared raster identify/mosaic pipeline. Supports `sampleCount` (capped at 1000), `mosaicRule`, single-instant `time`, and per-point SRID. Each sample carries `location`, `value`, per-band `attributes`, and `resolution`. |
 
 ### Partial
 
 | Esri operation | Esri path | Methods | Honua status | Honua endpoint(s) | Notes |
 | --- | --- | --- | --- | --- | --- |
+| Compute Class Statistics | `/rest/services/{serviceName}/ImageServer/computeClassStatistics` | GET, POST | Partial | `GET\|POST /rest/services/{id}/ImageServer/computeClassStatistics` | Route is wired and validates `classDescriptions` (must be a JSON object with a `classes` array) and the response `f` format. Class-signature computation is not yet implemented — valid requests return `501 Not Implemented` until the signature pipeline lands. |
 | Export Image | `/rest/services/{serviceName}/ImageServer/exportImage` | GET | Partial | `GET /rest/services/{id}/ImageServer/exportImage` | Default response is a JSON envelope with a temporary `href` to the rendered image. `f=image` returns the rendered bytes inline with the format-specific media type. Spatially intersecting rasters are exported as a mosaic, with optional `mosaicRule` and single-instant `time` support. |
 | Identify | `/rest/services/{serviceName}/ImageServer/identify` | GET | Partial | `GET /rest/services/{id}/ImageServer/identify` | Supports point-only identify requests and JSON responses. When multiple rasters overlap the identify point, Honua returns the mosaic value and can include all participating catalog items. Several Esri response-shaping and raster-processing parameters remain unsupported. |
-| Query | `/rest/services/{serviceName}/ImageServer/query` | GET, POST | Partial | `GET\|POST /rest/services/{id}/ImageServer/query` | Returns the layer's raster catalog as Esri-compatible features with `OBJECTID`, footprint geometry, pixel-size attributes, `BandCount`, `PixelType`, `AcquisitionDate`, and `CreatedAt`. Supports `where`, `objectIds`, `outSR`, `time`, `resultOffset`, `resultRecordCount`, and the `returnGeometry`/`returnIdsOnly`/`returnCountOnly`/`returnExtentOnly` shaping flags. The MVP applies WHERE filters via the GeoServices SQL parser in-memory and does not reproject footprint geometry — `outSR` is honoured for the response envelope only. |
+| Query | `/rest/services/{serviceName}/ImageServer/query` | GET, POST | Partial | `GET\|POST /rest/services/{id}/ImageServer/query` | Returns the layer's raster catalog as Esri-compatible features with `OBJECTID`, footprint geometry, pixel-size attributes, `BandCount`, `PixelType`, `AcquisitionDate`, and `CreatedAt`. Supports `where`, `objectIds`, `outSR`, `time`, `orderByFields`, `outFields`, `resultOffset`, `resultRecordCount`, and the `returnGeometry`/`returnIdsOnly`/`returnCountOnly`/`returnExtentOnly` shaping flags. The MVP applies WHERE filters via the GeoServices SQL parser in-memory and does not reproject footprint geometry — `outSR` is honoured for the response envelope only. |
 | Compute Statistics and Histograms | `/rest/services/{serviceName}/ImageServer/computeStatisticsHistograms` | GET, POST | Partial | `GET\|POST /rest/services/{id}/ImageServer/computeStatisticsHistograms` | Returns per-band statistics and histograms for one or more rasters in the catalog. Supports `rasterIds` (catalog object IDs), the Honua-specific `bandIds` selector, `mosaicRule`, single-instant `time`, and `histogramParameters.size` for bin count. AOI clipping via `geometry`/`geometryType` is not yet honoured — analysis always covers the full selected raster or mosaic. |
 
 ### Not implemented
@@ -37,8 +40,6 @@ Sources:
 | Add Rasters | `/rest/services/{serviceName}/ImageServer/addRasters` | POST | Not implemented | |
 | Calculate Volume | `/rest/services/{serviceName}/ImageServer/calculateVolume` | GET, POST | Not implemented | |
 | Compute Cache Info | `/rest/services/{serviceName}/ImageServer/computeCacheInfo` | GET, POST | Not implemented | |
-| Compute Class Statistics | `/rest/services/{serviceName}/ImageServer/computeClassStatistics` | GET, POST | Not implemented | |
-| Compute Histograms | `/rest/services/{serviceName}/ImageServer/computeHistograms` | GET, POST | Not implemented | |
 | Compute Multidimensional Info | `/rest/services/{serviceName}/ImageServer/computeMultidimensionalInfo` | GET, POST | Not implemented | |
 | Compute Pixel Location | `/rest/services/{serviceName}/ImageServer/computePixelLocation` | GET, POST | Not implemented | |
 | Compute Tie Points | `/rest/services/{serviceName}/ImageServer/computeTiePoints` | GET, POST | Not implemented | |
@@ -46,7 +47,6 @@ Sources:
 | Download Rasters | `/rest/services/{serviceName}/ImageServer/downloadRasters` | GET, POST | Not implemented | |
 | Export Tiles | `/rest/services/{serviceName}/ImageServer/exportTiles` | POST | Not implemented | |
 | Find | `/rest/services/{serviceName}/ImageServer/find` | GET, POST | Not implemented | |
-| Get Samples | `/rest/services/{serviceName}/ImageServer/getSamples` | GET, POST | Not implemented | |
 | Measure | `/rest/services/{serviceName}/ImageServer/measure` | GET, POST | Not implemented | |
 | Project | `/rest/services/{serviceName}/ImageServer/project` | GET, POST | Not implemented | |
 | Query Boundary | `/rest/services/{serviceName}/ImageServer/queryBoundary` | GET, POST | Not implemented | |
@@ -55,6 +55,13 @@ Sources:
 | Validate | `/rest/services/{serviceName}/ImageServer/validate` | GET, POST | Not implemented | |
 
 ## Image Service child resources
+
+### Implemented
+
+| Esri child resource | Esri path | Honua status | Notes |
+| --- | --- | --- | --- |
+| Key Properties | `.../ImageServer/keyProperties` | Implemented | `GET\|POST /rest/services/{id}/ImageServer/keyProperties` returns the canonical Esri raster key-properties document (per-band `BandProperties`, `DataType`, `BandCount`, `NoDataValue`, `LowCellSize`/`HighCellSize`/`MaxCellSize`) for the layer's primary raster, sourced from the shared raster store metadata. A POST mirror exists because the ArcGIS API for Python `ImageryLayer.key_properties()` issues an HTTP POST. |
+| Multidimensional Info | `.../ImageServer/multidimensionalInfo` | Implemented | `GET\|POST /rest/services/{id}/ImageServer/multidimensionalInfo` returns the Esri `multidimensionalInfo` document (variables with dimensions). Non-multidimensional layers return a spec-correct empty document (`{ "variables": [] }`) rather than a 404, matching ArcGIS behaviour for non-cube rasters. |
 
 ### Partial
 
@@ -71,9 +78,7 @@ Sources:
 | Histograms | `.../ImageServer/histograms` | Not implemented | |
 | Image Service Info (`iteminfo`, `metadata`, `thumbnail`) | `.../ImageServer/info/*` | Not implemented | |
 | Image Support Data | `.../ImageServer/imageSupportData` | Not implemented | |
-| Key Properties | `.../ImageServer/keyProperties` | Not implemented | |
 | KML Image | `.../ImageServer/kml` | Not implemented | |
-| Multidimensional Info | `.../ImageServer/multiDimensionalInfo` | Not implemented | |
 | Raster Attribute Table | `.../ImageServer/rasterAttributeTable` | Not implemented | |
 | Raster Catalog Item and nested raster resources | `.../ImageServer/{rasterId}/*` | Not implemented | |
 | Raster File | `.../ImageServer/rasterFile` | Not implemented | |
@@ -170,6 +175,8 @@ Sources:
 | `returnIdsOnly` | Implemented | Returns `objectIdFieldName` + `objectIds[]` shape. |
 | `returnCountOnly` | Implemented | Returns `count`-only response. |
 | `returnExtentOnly` | Implemented | Returns the aggregate extent (computed after `where`/`objectIds` filters but before pagination). |
+| `orderByFields` | Implemented | Comma-separated `field [ASC\|DESC]` terms applied after filtering and before pagination, so paging walks the requested ordering. Multiple terms break ties left-to-right. Numbers and dates sort naturally; other fields use ordinal string comparison; nulls sort first. Unknown field names or sort directions return `400 Bad Request`. |
+| `outFields` | Implemented | Comma-separated field selector (or `*` for all). Projects both the feature `attributes` and the `fields[]` schema to the requested set in canonical field order. `OBJECTID` is always retained so clients can correlate features. Unknown field names return `400 Bad Request`. |
 
 #### Partial or behavior differences
 
@@ -182,8 +189,6 @@ Sources:
 | Esri parameter | Notes |
 | --- | --- |
 | `geometry` / `geometryType` / `inSR` / `spatialRel` | Spatial filtering against arbitrary client geometries is not yet supported by the catalog reader. |
-| `outFields` | Catalog responses always include the full attribute set; per-field projection is not yet honoured. |
-| `orderByFields` | Ordering is currently the catalog's natural order. |
 | `pixelSize` | Not honoured. |
 
 ### Compute Statistics and Histograms (`GET|POST .../ImageServer/computeStatisticsHistograms`)
@@ -314,8 +319,11 @@ Merge strategy resolution is request `mosaicRule` first, then the layer's admin 
 - Export implementation: [ImageServerExportHandler](../../src/Honua.Server/Features/Protocols/GeoServices/ImageServer/Handlers/ImageServerExportHandler.cs)
 - Identify implementation: [ImageServerIdentifyHandler](../../src/Honua.Server/Features/Protocols/GeoServices/ImageServer/Handlers/ImageServerIdentifyHandler.cs)
 - Tile implementation: [ImageServerTileHandler](../../src/Honua.Server/Features/Protocols/GeoServices/ImageServer/Handlers/ImageServerTileHandler.cs)
-- Catalog query implementation: [ImageServerCatalogQueryHandler](../../src/Honua.Server/Features/Protocols/GeoServices/ImageServer/Handlers/ImageServerCatalogQueryHandler.cs), [ImageServerCatalogReader](../../src/Honua.Server/Features/Protocols/GeoServices/ImageServer/Services/ImageServerCatalogReader.cs)
-- Statistics/histograms implementation: [ImageServerStatisticsHistogramsHandler](../../src/Honua.Server/Features/Protocols/GeoServices/ImageServer/Handlers/ImageServerStatisticsHistogramsHandler.cs)
+- Catalog query implementation: [ImageServerCatalogQueryHandler](../../src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerCatalogQueryHandler.cs), [ImageServerCatalogReader](../../src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerCatalogReader.cs), [ImageServerCatalogFields](../../src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerCatalogFields.cs) (the shared field surface used by WHERE/`orderByFields`/`outFields`)
+- Statistics/histograms implementation: [ImageServerStatisticsHistogramsHandler](../../src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerStatisticsHistogramsHandler.cs) (also serves `computeHistograms`)
+- Get Samples implementation: [ImageServerSamplesHandler](../../src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerSamplesHandler.cs)
+- Key Properties implementation: [ImageServerKeyPropertiesHandler](../../src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerKeyPropertiesHandler.cs)
+- Multidimensional Info implementation: [ImageServerMultidimensionalInfoHandler](../../src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerMultidimensionalInfoHandler.cs), [ImageServerMultidimensionalInfoBuilder](../../src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerMultidimensionalInfoBuilder.cs)
 - Legend implementation: [ImageServerLegendHandler](../../src/Honua.Server/Features/Protocols/GeoServices/ImageServer/Handlers/ImageServerLegendHandler.cs)
 - Raster function chain analysis (`computeClass`): [ImageServerAnalyzeHandler](../../src/Honua.Server/Features/Protocols/GeoServices/ImageServer/Handlers/ImageServerAnalyzeHandler.cs), [ImageServerRasterFunctionPlanner](../../src/Honua.Server/Features/Protocols/GeoServices/ImageServer/Services/ImageServerRasterFunctionPlanner.cs)
 - Request/response models: [ImageServerModels](../../src/Honua.Server/Features/Protocols/GeoServices/ImageServer/Models/ImageServerModels.cs)

--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerCatalogQueryHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerCatalogQueryHandler.cs
@@ -184,6 +184,16 @@ internal sealed class ImageServerCatalogQueryHandler
         var returnCountOnly = ParseBool(GetString(values, "returnCountOnly"), defaultValue: false);
         var returnExtentOnly = ParseBool(GetString(values, "returnExtentOnly"), defaultValue: false);
 
+        if (!TryParseOrderByFields(GetString(values, "orderByFields"), out var orderBy, out error))
+        {
+            return false;
+        }
+
+        if (!TryParseOutFields(GetString(values, "outFields"), out var outFields, out error))
+        {
+            return false;
+        }
+
         query = new ImageServerCatalogQuery
         {
             Where = where,
@@ -192,11 +202,101 @@ internal sealed class ImageServerCatalogQueryHandler
             Time = time,
             Offset = offset,
             Limit = limit,
+            OrderBy = orderBy,
+            OutFields = outFields,
             ReturnGeometry = returnGeometry,
             ReturnIdsOnly = returnIdsOnly,
             ReturnCountOnly = returnCountOnly,
             ReturnExtentOnly = returnExtentOnly,
         };
+        return true;
+    }
+
+    /// <summary>
+    /// Parses the Esri <c>orderByFields</c> parameter: a comma-separated list of
+    /// <c>field [ASC|DESC]</c> terms. Unknown field names are rejected with a 400.
+    /// </summary>
+    private static bool TryParseOrderByFields(
+        string? raw,
+        out IReadOnlyList<ImageServerCatalogOrderBy> orderBy,
+        out string? error)
+    {
+        error = null;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            orderBy = [];
+            return true;
+        }
+
+        var terms = new List<ImageServerCatalogOrderBy>();
+        foreach (var part in raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var tokens = part.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            var fieldName = tokens.Length > 0 ? tokens[0] : string.Empty;
+            var canonical = ImageServerCatalogFields.ResolveCanonicalName(fieldName);
+            if (canonical is null)
+            {
+                error = $"Unknown orderByFields field '{fieldName}'.";
+                orderBy = [];
+                return false;
+            }
+
+            var descending = false;
+            if (tokens.Length > 1)
+            {
+                if (tokens[1].Equals("DESC", StringComparison.OrdinalIgnoreCase))
+                {
+                    descending = true;
+                }
+                else if (!tokens[1].Equals("ASC", StringComparison.OrdinalIgnoreCase))
+                {
+                    error = $"Invalid sort direction '{tokens[1]}' in orderByFields. Use ASC or DESC.";
+                    orderBy = [];
+                    return false;
+                }
+            }
+
+            terms.Add(new ImageServerCatalogOrderBy(canonical, descending));
+        }
+
+        orderBy = terms;
+        return true;
+    }
+
+    /// <summary>
+    /// Parses the Esri <c>outFields</c> parameter into a canonical field set.
+    /// <c>*</c> (or omitted) selects all fields. <c>OBJECTID</c> is always
+    /// retained. Unknown field names are rejected with a 400.
+    /// </summary>
+    private static bool TryParseOutFields(
+        string? raw,
+        out IReadOnlyList<string>? outFields,
+        out string? error)
+    {
+        error = null;
+        outFields = null;
+        if (string.IsNullOrWhiteSpace(raw) || raw.Trim() == "*")
+        {
+            return true;
+        }
+
+        var selected = new List<string> { "OBJECTID" };
+        foreach (var part in raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var canonical = ImageServerCatalogFields.ResolveCanonicalName(part);
+            if (canonical is null)
+            {
+                error = $"Unknown outFields field '{part}'.";
+                return false;
+            }
+
+            if (!selected.Contains(canonical, StringComparer.Ordinal))
+            {
+                selected.Add(canonical);
+            }
+        }
+
+        outFields = selected;
         return true;
     }
 
@@ -259,7 +359,7 @@ internal sealed class ImageServerCatalogQueryHandler
                 Wkid = responseSrid,
                 LatestWkid = responseSrid,
             },
-            Fields = BuildCatalogFields(),
+            Fields = BuildCatalogFields(query.OutFields),
             Features = page.Items.Select(item => BuildFeature(item, query)).ToArray(),
             ExceededTransferLimit = page.ExceededTransferLimit,
         };
@@ -288,6 +388,16 @@ internal sealed class ImageServerCatalogQueryHandler
             ["CreatedAt"] = item.CreatedAt.ToUnixTimeMilliseconds(),
         };
 
+        // Project to the requested outFields when supplied. OBJECTID is always
+        // retained by TryParseOutFields so the projected set is never empty.
+        if (query.OutFields is { Count: > 0 })
+        {
+            var allowed = new HashSet<string>(query.OutFields, StringComparer.OrdinalIgnoreCase);
+            attributes = attributes
+                .Where(pair => allowed.Contains(pair.Key))
+                .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+        }
+
         CatalogQueryGeometry? geometry = null;
         if (query.ReturnGeometry && item.FootprintRings is { Length: > 0 })
         {
@@ -313,9 +423,9 @@ internal sealed class ImageServerCatalogQueryHandler
         };
     }
 
-    internal static Field[] BuildCatalogFields()
+    internal static Field[] BuildCatalogFields(IReadOnlyList<string>? outFields = null)
     {
-        return
+        Field[] allFields =
         [
             new Field { Name = "OBJECTID", Type = "esriFieldTypeOID", Alias = "OBJECTID" },
             new Field { Name = "Name", Type = "esriFieldTypeString", Alias = "Name", Nullable = true },
@@ -333,6 +443,16 @@ internal sealed class ImageServerCatalogQueryHandler
             new Field { Name = "AcquisitionDate", Type = "esriFieldTypeDate", Alias = "AcquisitionDate", Nullable = true },
             new Field { Name = "CreatedAt", Type = "esriFieldTypeDate", Alias = "CreatedAt" },
         ];
+
+        if (outFields is not { Count: > 0 })
+        {
+            return allFields;
+        }
+
+        // Preserve the canonical field order rather than the caller's order so the
+        // schema stays stable and matches the attribute emit order.
+        var allowed = new HashSet<string>(outFields, StringComparer.OrdinalIgnoreCase);
+        return allFields.Where(field => allowed.Contains(field.Name)).ToArray();
     }
 
     private static List<long>? ParseObjectIds(string? raw)

--- a/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerCatalogFields.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerCatalogFields.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Protocols.GeoServices.ImageServer.Services;
+
+/// <summary>
+/// Central knowledge of the Esri raster-catalog field surface exposed by the
+/// Image Server <c>query</c> endpoint. WHERE evaluation, <c>orderByFields</c>
+/// ordering, and <c>outFields</c> projection all resolve field names through
+/// this helper so the supported set stays in lockstep across the operation.
+/// </summary>
+internal static class ImageServerCatalogFields
+{
+    /// <summary>
+    /// Canonical, response-facing field names in their natural emit order. These
+    /// are the names stamped onto query feature attributes and the field schema.
+    /// </summary>
+    public static readonly IReadOnlyList<string> CanonicalNames =
+    [
+        "OBJECTID",
+        "Name",
+        "MinPS",
+        "MaxPS",
+        "LowPS",
+        "HighPS",
+        "CenterX",
+        "CenterY",
+        "ZOrder",
+        "Shape_Length",
+        "Shape_Area",
+        "BandCount",
+        "PixelType",
+        "AcquisitionDate",
+        "CreatedAt",
+    ];
+
+    /// <summary>
+    /// Resolves a catalog field value for WHERE evaluation, accepting the Esri
+    /// field aliases (for example <c>NUM_BANDS</c>) that the SQL surface allows.
+    /// Date fields resolve to <see cref="DateTime"/> for comparison.
+    /// </summary>
+    public static bool TryResolve(string propertyName, ImageServerCatalogItem item, out object? value)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        switch (Normalize(propertyName))
+        {
+            case "OBJECTID":
+                value = item.ObjectId;
+                return true;
+            case "NAME":
+                value = item.Name;
+                return true;
+            case "MINPS":
+                value = item.MinPixelSize;
+                return true;
+            case "MAXPS":
+                value = item.MaxPixelSize;
+                return true;
+            case "LOWPS":
+                value = item.LowPixelSize;
+                return true;
+            case "HIGHPS":
+                value = item.HighPixelSize;
+                return true;
+            case "CENTERX":
+                value = item.CenterX;
+                return true;
+            case "CENTERY":
+                value = item.CenterY;
+                return true;
+            case "ZORDER":
+                value = item.ZOrder;
+                return true;
+            case "SHAPE_LENGTH":
+                value = item.ShapeLength;
+                return true;
+            case "SHAPE_AREA":
+                value = item.ShapeArea;
+                return true;
+            case "BANDCOUNT":
+            case "NUM_BANDS":
+                value = item.BandCount;
+                return true;
+            case "PIXELTYPE":
+            case "PIXEL_TYPE":
+                value = item.PixelType;
+                return true;
+            case "ACQUISITIONDATE":
+                value = item.AcquisitionDate?.UtcDateTime;
+                return true;
+            case "CREATEDAT":
+            case "CREATED_AT":
+                value = item.CreatedAt.UtcDateTime;
+                return true;
+            default:
+                value = null;
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Maps a caller-supplied field name (any documented alias, case-insensitive)
+    /// to its canonical response-facing name, or <c>null</c> when the field is
+    /// not part of the catalog surface.
+    /// </summary>
+    public static string? ResolveCanonicalName(string fieldName)
+    {
+        if (string.IsNullOrWhiteSpace(fieldName))
+        {
+            return null;
+        }
+
+        var normalized = Normalize(fieldName);
+        foreach (var canonical in CanonicalNames)
+        {
+            if (string.Equals(Normalize(canonical), normalized, StringComparison.Ordinal))
+            {
+                return canonical;
+            }
+        }
+
+        return normalized switch
+        {
+            "NUM_BANDS" => "BandCount",
+            "PIXEL_TYPE" => "PixelType",
+            "CREATED_AT" => "CreatedAt",
+            _ => null,
+        };
+    }
+
+    private static string Normalize(string fieldName)
+        => fieldName.Trim().ToUpperInvariant();
+}

--- a/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerCatalogFilterEvaluator.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerCatalogFilterEvaluator.cs
@@ -123,29 +123,10 @@ internal sealed class ImageServerCatalogFilterEvaluator : IImageServerCatalogFil
     }
 
     private static object? ResolveProperty(string propertyName, ImageServerCatalogItem item)
-    {
-        // Esri raster catalog field names are case-insensitive.
-        return propertyName.ToUpperInvariant() switch
-        {
-            "OBJECTID" => item.ObjectId,
-            "NAME" => item.Name,
-            "MINPS" => item.MinPixelSize,
-            "MAXPS" => item.MaxPixelSize,
-            "LOWPS" => item.LowPixelSize,
-            "HIGHPS" => item.HighPixelSize,
-            "CENTERX" => item.CenterX,
-            "CENTERY" => item.CenterY,
-            "ZORDER" => item.ZOrder,
-            "SHAPE_LENGTH" => item.ShapeLength,
-            "SHAPE_AREA" => item.ShapeArea,
-            "BANDCOUNT" or "NUM_BANDS" => item.BandCount,
-            "PIXELTYPE" or "PIXEL_TYPE" => item.PixelType,
-            "ACQUISITIONDATE" => item.AcquisitionDate?.UtcDateTime,
-            "CREATEDAT" or "CREATED_AT" => item.CreatedAt.UtcDateTime,
-            _ => throw new ImageServerCatalogFilterException(
-                $"Unknown raster catalog field '{propertyName}'.")
-        };
-    }
+        => ImageServerCatalogFields.TryResolve(propertyName, item, out var value)
+            ? value
+            : throw new ImageServerCatalogFilterException(
+                $"Unknown raster catalog field '{propertyName}'.");
 
     private static bool CompareEquality(object? left, object? right)
     {

--- a/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerCatalogReader.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerCatalogReader.cs
@@ -103,6 +103,20 @@ internal sealed class ImageServerCatalogQuery
 
     public DateTimeOffset? Time { get; init; }
 
+    /// <summary>
+    /// Ordering specification applied after filtering and before pagination.
+    /// Each entry is a canonical catalog field name plus a descending flag.
+    /// Empty means the catalog's natural order is preserved.
+    /// </summary>
+    public IReadOnlyList<ImageServerCatalogOrderBy> OrderBy { get; init; } = [];
+
+    /// <summary>
+    /// Canonical field names to include in feature attributes and the field
+    /// schema. <c>null</c> means all catalog fields are returned. <c>OBJECTID</c>
+    /// is always included so clients can correlate features.
+    /// </summary>
+    public IReadOnlyList<string>? OutFields { get; init; }
+
     public bool ReturnGeometry { get; init; } = true;
 
     public bool ReturnIdsOnly { get; init; }
@@ -111,6 +125,12 @@ internal sealed class ImageServerCatalogQuery
 
     public bool ReturnExtentOnly { get; init; }
 }
+
+/// <summary>
+/// A single <c>orderByFields</c> term: the canonical catalog field name and
+/// whether it sorts descending.
+/// </summary>
+internal sealed record ImageServerCatalogOrderBy(string Field, bool Descending);
 
 /// <summary>
 /// Default <see cref="IImageServerCatalogReader"/> built on <see cref="IRasterStore"/>.
@@ -201,6 +221,13 @@ internal sealed class ImageServerCatalogReader : IImageServerCatalogReader
             projected = projected.Where(p => filteredObjectIds.Contains(p.Item.ObjectId)).ToList();
         }
 
+        // Apply orderByFields after filtering and before pagination, so paging
+        // walks the requested ordering rather than the catalog's natural order.
+        if (query.OrderBy is { Count: > 0 })
+        {
+            projected = ApplyOrdering(projected, query.OrderBy);
+        }
+
         // Compute aggregate extent BEFORE pagination but AFTER filtering, so returnExtentOnly
         // honours objectIds/where filters per Esri spec.
         RasterExtent? aggregateExtent = null;
@@ -267,6 +294,105 @@ internal sealed class ImageServerCatalogReader : IImageServerCatalogReader
             AggregateExtent = aggregateExtent,
             NativeSrid = nativeSrid,
         };
+    }
+
+    /// <summary>
+    /// Applies the requested <c>orderByFields</c> terms in priority order. The
+    /// first term is the primary sort key; subsequent terms break ties. Values
+    /// are compared via <see cref="FieldValueComparer"/>, which orders numbers
+    /// and dates naturally and falls back to ordinal string comparison.
+    /// </summary>
+    private static List<(ImageServerCatalogItem Item, RasterInfo Source)> ApplyOrdering(
+        List<(ImageServerCatalogItem Item, RasterInfo Source)> projected,
+        IReadOnlyList<ImageServerCatalogOrderBy> orderBy)
+    {
+        IOrderedEnumerable<(ImageServerCatalogItem Item, RasterInfo Source)>? ordered = null;
+        foreach (var term in orderBy)
+        {
+            var localTerm = term;
+            object? KeySelector((ImageServerCatalogItem Item, RasterInfo Source) entry)
+                => ImageServerCatalogFields.TryResolve(localTerm.Field, entry.Item, out var value) ? value : null;
+
+            if (ordered is null)
+            {
+                ordered = localTerm.Descending
+                    ? projected.OrderByDescending(KeySelector, FieldValueComparer.Instance)
+                    : projected.OrderBy(KeySelector, FieldValueComparer.Instance);
+            }
+            else
+            {
+                ordered = localTerm.Descending
+                    ? ordered.ThenByDescending(KeySelector, FieldValueComparer.Instance)
+                    : ordered.ThenBy(KeySelector, FieldValueComparer.Instance);
+            }
+        }
+
+        return ordered is null ? projected : ordered.ToList();
+    }
+
+    /// <summary>
+    /// Comparer used for <c>orderByFields</c>. Numbers and dates compare
+    /// naturally; everything else falls back to ordinal string comparison.
+    /// Nulls sort first.
+    /// </summary>
+    private sealed class FieldValueComparer : IComparer<object?>
+    {
+        public static readonly FieldValueComparer Instance = new();
+
+        public int Compare(object? x, object? y)
+        {
+            if (x is null && y is null)
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
+            if (TryToDouble(x, out var xd) && TryToDouble(y, out var yd))
+            {
+                return xd.CompareTo(yd);
+            }
+
+            if (x is DateTime xDate && y is DateTime yDate)
+            {
+                return DateTime.Compare(xDate, yDate);
+            }
+
+            return string.Compare(x.ToString(), y.ToString(), StringComparison.Ordinal);
+        }
+
+        private static bool TryToDouble(object value, out double result)
+        {
+            switch (value)
+            {
+                case double d:
+                    result = d;
+                    return true;
+                case float f:
+                    result = f;
+                    return true;
+                case long l:
+                    result = l;
+                    return true;
+                case int i:
+                    result = i;
+                    return true;
+                case decimal m:
+                    result = (double)m;
+                    return true;
+                default:
+                    result = 0;
+                    return false;
+            }
+        }
     }
 
     private static ImageServerCatalogItem ProjectRaster(RasterInfo raster, bool includeGeometry)

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerCatalogQueryHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerCatalogQueryHandlerTests.cs
@@ -516,6 +516,210 @@ public class ImageServerCatalogQueryHandlerTests
 
     [UnitTest]
     [Operation(Operations.Query)]
+    public async Task QueryCatalogAsync_OrderByFieldsAscending_SortsByField()
+    {
+        SetupLayerWithRasters([
+            CreateRaster(300, "c-scene"),
+            CreateRaster(100, "a-scene"),
+            CreateRaster(200, "b-scene"),
+        ]);
+
+        var values = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["orderByFields"] = "Name ASC",
+        };
+
+        var context = CreateImageServerContext();
+        var result = await _handler.QueryCatalogAsync(context, 1, values, CancellationToken.None);
+
+        var jsonResult = result as JsonHttpResult<CatalogQueryResponse>;
+        jsonResult.Should().NotBeNull();
+        jsonResult!.Value!.Features.Select(f => f.Attributes["OBJECTID"])
+            .Should().ContainInOrder(100L, 200L, 300L);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public async Task QueryCatalogAsync_OrderByFieldsDescending_SortsByFieldDescending()
+    {
+        SetupLayerWithRasters([
+            CreateRaster(100, "a-scene"),
+            CreateRaster(300, "c-scene"),
+            CreateRaster(200, "b-scene"),
+        ]);
+
+        var values = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["orderByFields"] = "OBJECTID DESC",
+        };
+
+        var context = CreateImageServerContext();
+        var result = await _handler.QueryCatalogAsync(context, 1, values, CancellationToken.None);
+
+        var jsonResult = result as JsonHttpResult<CatalogQueryResponse>;
+        jsonResult.Should().NotBeNull();
+        jsonResult!.Value!.Features.Select(f => f.Attributes["OBJECTID"])
+            .Should().ContainInOrder(300L, 200L, 100L);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public async Task QueryCatalogAsync_OrderByFieldsMultiKey_BreaksTiesWithSecondaryField()
+    {
+        SetupLayerWithRasters([
+            CreateRaster(100, "shared", bandCount: 3),
+            CreateRaster(300, "shared", bandCount: 1),
+            CreateRaster(200, "shared", bandCount: 1),
+        ]);
+
+        var values = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Primary key (Name) is identical for all rows, so the secondary key
+            // (OBJECTID ascending) determines the order.
+            ["orderByFields"] = "Name ASC, OBJECTID ASC",
+        };
+
+        var context = CreateImageServerContext();
+        var result = await _handler.QueryCatalogAsync(context, 1, values, CancellationToken.None);
+
+        var jsonResult = result as JsonHttpResult<CatalogQueryResponse>;
+        jsonResult.Should().NotBeNull();
+        jsonResult!.Value!.Features.Select(f => f.Attributes["OBJECTID"])
+            .Should().ContainInOrder(100L, 200L, 300L);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public async Task QueryCatalogAsync_OrderByFieldsAppliesBeforePagination()
+    {
+        SetupLayerWithRasters([
+            CreateRaster(100, "a-scene"),
+            CreateRaster(400, "d-scene"),
+            CreateRaster(200, "b-scene"),
+            CreateRaster(300, "c-scene"),
+        ]);
+
+        var values = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["orderByFields"] = "OBJECTID DESC",
+            ["resultOffset"] = "1",
+            ["resultRecordCount"] = "2",
+        };
+
+        var context = CreateImageServerContext();
+        var result = await _handler.QueryCatalogAsync(context, 1, values, CancellationToken.None);
+
+        var jsonResult = result as JsonHttpResult<CatalogQueryResponse>;
+        jsonResult.Should().NotBeNull();
+        // Sorted desc => 400,300,200,100; offset 1, count 2 => 300,200.
+        jsonResult!.Value!.Features.Select(f => f.Attributes["OBJECTID"])
+            .Should().ContainInOrder(300L, 200L);
+        jsonResult.Value.ExceededTransferLimit.Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public async Task QueryCatalogAsync_OrderByFieldsUnknownField_ReturnsBadRequest()
+    {
+        SetupLayerWithRasters([CreateRaster(100, "first")]);
+
+        var values = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["orderByFields"] = "BogusField",
+        };
+
+        var context = CreateImageServerContext();
+        var result = await _handler.QueryCatalogAsync(context, 1, values, CancellationToken.None);
+        await result.ExecuteAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public async Task QueryCatalogAsync_OrderByFieldsInvalidDirection_ReturnsBadRequest()
+    {
+        SetupLayerWithRasters([CreateRaster(100, "first")]);
+
+        var values = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["orderByFields"] = "OBJECTID SIDEWAYS",
+        };
+
+        var context = CreateImageServerContext();
+        var result = await _handler.QueryCatalogAsync(context, 1, values, CancellationToken.None);
+        await result.ExecuteAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public async Task QueryCatalogAsync_OutFields_ProjectsAttributesAndSchema()
+    {
+        SetupLayerWithRasters([CreateRaster(100, "scene-a")]);
+
+        var values = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["outFields"] = "Name,BandCount",
+        };
+
+        var context = CreateImageServerContext();
+        var result = await _handler.QueryCatalogAsync(context, 1, values, CancellationToken.None);
+
+        var jsonResult = result as JsonHttpResult<CatalogQueryResponse>;
+        jsonResult.Should().NotBeNull();
+
+        // OBJECTID is always retained alongside the requested fields.
+        jsonResult!.Value!.Fields.Select(f => f.Name)
+            .Should().BeEquivalentTo(["OBJECTID", "Name", "BandCount"]);
+
+        var attributes = jsonResult.Value.Features[0].Attributes;
+        attributes.Keys.Should().BeEquivalentTo(["OBJECTID", "Name", "BandCount"]);
+        attributes.Should().NotContainKey("PixelType");
+        attributes.Should().NotContainKey("CenterX");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public async Task QueryCatalogAsync_OutFieldsWildcard_ReturnsAllFields()
+    {
+        SetupLayerWithRasters([CreateRaster(100, "scene-a")]);
+
+        var values = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["outFields"] = "*",
+        };
+
+        var context = CreateImageServerContext();
+        var result = await _handler.QueryCatalogAsync(context, 1, values, CancellationToken.None);
+
+        var jsonResult = result as JsonHttpResult<CatalogQueryResponse>;
+        jsonResult.Should().NotBeNull();
+        jsonResult!.Value!.Fields.Should().HaveCount(15);
+        jsonResult.Value.Features[0].Attributes.Should().ContainKey("PixelType");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    public async Task QueryCatalogAsync_OutFieldsUnknownField_ReturnsBadRequest()
+    {
+        SetupLayerWithRasters([CreateRaster(100, "first")]);
+
+        var values = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["outFields"] = "BogusField",
+        };
+
+        var context = CreateImageServerContext();
+        var result = await _handler.QueryCatalogAsync(context, 1, values, CancellationToken.None);
+        await result.ExecuteAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
     public async Task QueryCatalogAsync_RasterStoreThrows_ReturnsServerError()
     {
         _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
@@ -104,6 +104,30 @@ public class ImageServerEndpointsTests
         return store;
     }
 
+    private static IRasterStore CreateMultiRasterStoreSubstitute()
+    {
+        var store = Substitute.For<IRasterStore>();
+        RasterInfo Build(long id, string name) => new()
+        {
+            Id = id,
+            LayerId = TestLayerId,
+            Name = name,
+            Width = 256,
+            Height = 256,
+            BandCount = 1,
+            PixelType = "8BUI",
+            Srid = 4326,
+            GeoTransform = [-180, 1.40625, 0, 90, 0, -0.703125],
+            Extent = new RasterExtent { XMin = -180, YMin = -90, XMax = 180, YMax = 90, Srid = 4326 },
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        // Returned in deliberately unsorted order so orderByFields has work to do.
+        var rasters = new[] { Build(200, "b"), Build(100, "a"), Build(300, "c") };
+        store.ListRastersAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(rasters);
+        return store;
+    }
+
     private static async Task<WebAppFixture> CreateFixtureAsync(IRasterStore rasterStore)
     {
         var fixture = new WebAppFixture()
@@ -180,6 +204,74 @@ public class ImageServerEndpointsTests
                 "/rest/services/99999/ImageServer/query?f=json");
 
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /rest/services/{id}/ImageServer/query")]
+    [Operation(Operations.Query)]
+    public async Task QueryCatalog_Get_OrderByFieldsDescending_SortsFeatures()
+    {
+        var fixture = await CreateFixtureAsync(CreateMultiRasterStoreSubstitute());
+        try
+        {
+            var response = await fixture.Client.GetAsync(
+                $"/rest/services/{TestLayerId}/ImageServer/query?f=json&orderByFields=OBJECTID%20DESC");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var ids = json.RootElement.GetProperty("features").EnumerateArray()
+                .Select(f => f.GetProperty("attributes").GetProperty("OBJECTID").GetInt64())
+                .ToArray();
+            ids.Should().ContainInOrder(300L, 200L, 100L);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /rest/services/{id}/ImageServer/query")]
+    [Operation(Operations.Query)]
+    public async Task QueryCatalog_Get_OutFields_ProjectsAttributes()
+    {
+        var fixture = await CreateFixtureAsync(CreateRasterStoreSubstitute());
+        try
+        {
+            var response = await fixture.Client.GetAsync(
+                $"/rest/services/{TestLayerId}/ImageServer/query?f=json&outFields=Name,BandCount");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var attributes = json.RootElement.GetProperty("features")[0].GetProperty("attributes");
+            attributes.TryGetProperty("OBJECTID", out _).Should().BeTrue();
+            attributes.TryGetProperty("Name", out _).Should().BeTrue();
+            attributes.TryGetProperty("BandCount", out _).Should().BeTrue();
+            attributes.TryGetProperty("PixelType", out _).Should().BeFalse();
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /rest/services/{id}/ImageServer/query")]
+    [Operation(Operations.Query)]
+    public async Task QueryCatalog_Get_OutFieldsUnknownField_ReturnsBadRequest()
+    {
+        var fixture = await CreateFixtureAsync(CreateRasterStoreSubstitute());
+        try
+        {
+            var response = await fixture.Client.GetAsync(
+                $"/rest/services/{TestLayerId}/ImageServer/query?f=json&outFields=Bogus");
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         }
         finally
         {


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #1398

## Summary
Completes two previously-ignored Esri parameters on the ImageServer `query` (raster catalog) operation — `orderByFields` and `outFields` — and refreshes `docs/gis/image-server-matrix.md` to reflect ImageServer operations that already shipped on trunk but were stale in the matrix. This is part of the Stream 3 effort to raise ImageServer Esri coverage by completing the closest-to-done partials first.

Both new parameters are pure in-memory transforms over the already-read catalog page, reusing the existing shared catalog reader/filter pipeline — no new rendering, geodesy, or SQL surface was introduced.

## Changes Made
- `orderByFields`: comma-separated `field [ASC|DESC]` terms, applied after filtering and **before** pagination so paging walks the requested order. Multiple terms break ties left-to-right; numbers/dates sort naturally, other fields fall back to ordinal comparison, nulls first. Unknown fields or directions return `400`.
- `outFields`: comma-separated selector (or `*`); projects both the feature `attributes` and the `fields[]` schema in canonical field order. `OBJECTID` is always retained. Unknown fields return `400`.
- New `ImageServerCatalogFields` helper centralizes the catalog field surface so the WHERE evaluator, ordering, and projection all resolve field names through one place and stay in lockstep.
- Matrix doc refresh: `getSamples` and `computeHistograms` moved to Implemented operations; `keyProperties` and `multidimensionalInfo` moved to Implemented child resources; `computeClassStatistics` documented as Partial (validate-only / 501). These were already on trunk but mismarked `Not implemented`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

9 new handler unit tests (ordering asc/desc/multi-key/before-pagination/unknown-field/invalid-direction; projection subset/wildcard/unknown-field) and 3 new endpoint integration tests (orderByFields desc, outFields projection, outFields unknown-field => 400). All 140 fast-tier ImageServer tests pass; architecture tests pass except the pre-existing, known-failing `PublicInterfaceProofLedgerTests.SdkCompatibilityWorkflow_ShouldConvertSmokeTimeoutsIntoCellEvidence` (Windows CRLF artifact in a workflow yml, unrelated to this change).

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

> Pre-PR-check transparency note: `scripts/ci/pre-pr-check.sh` cannot run unmodified under Git Bash on this host (MSYS mangles `/p:` MSBuild args, and `CLAUDE.md` is materialized as a file here vs the repo's symlink). The substantive checks it runs were executed directly and pass: `dotnet build -c Release -p:TreatWarningsAsErrors=true` (0/0) for `Honua.Protocols.GeoServices` and its test project, the new + existing ImageServer unit/integration tests, and the architecture suite (only the known-failing CRLF workflow test fails). Both blockers are host-only artifacts absent on Linux CI.
